### PR TITLE
Fix typo in domain.endsWith() check for hulu.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -184,7 +184,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
         || domain == "youtube.com"
         || domain.endsWith(".youtube.com")
         || domain == "hulu.com"
-        || domain.endsWith("hulu.com");
+        || domain.endsWith(".hulu.com");
 
     return m_hasBrokenEncryptedMediaAPISupportQuirk.value();
 }


### PR DESCRIPTION
Missing period after the subdomain.