### PR TITLE
[git-webkit] Support callbacks as main arguments

### DIFF
--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -26,7 +26,23 @@ import os
 import sys
 
 from webkitpy.common.config.committers import CommitterList
-from webkitscmpy import program, Contributor
+from webkitscmpy import local, program, remote, Contributor
+
+
+def is_webkit_filter(to_return):
+    def callback(repository):
+        if isinstance(repository, local.Scm):
+            repository = repository.remote()
+        if not isinstance(repository, remote.Scm):
+            return None
+        if getattr(repository, 'name', None) == 'WebKit':
+            return to_return
+        url = getattr(repository, 'url', '')
+        if 'svn.webkit.org' in url or 'git.webkit.org' in url:
+            return to_return
+        return None
+
+    return callback
 
 
 if '__main__' == __name__:
@@ -44,8 +60,8 @@ if '__main__' == __name__:
 
     sys.exit(program.main(
         path=os.path.dirname(__file__),
-        contributors=contributors,
-        identifier_template='Canonical link: https://commits.webkit.org/{}',
-        subversion='https://svn.webkit.org/repository/webkit',
+        contributors=is_webkit_filter(contributors),
+        identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
+        subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
     ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -99,9 +99,16 @@ def main(args=None, path=None, loggers=None, contributors=None, identifier_templ
             parsed = parser.parse_args(args=args)
 
     if parsed.repository.startswith(('https://', 'http://')):
-        repository = remote.Scm.from_url(parsed.repository, contributors=contributors)
+        repository = remote.Scm.from_url(parsed.repository, contributors=None if callable(contributors) else contributors)
     else:
-        repository = local.Scm.from_path(path=parsed.repository, contributors=contributors)
+        repository = local.Scm.from_path(path=parsed.repository, contributors=None if callable(contributors) else contributors)
+
+    if callable(contributors):
+        repository.contributors = contributors(repository)
+    if callable(identifier_template):
+        identifier_template = identifier_template(repository)
+    if callable(subversion):
+        subversion = subversion(repository)
 
     if not getattr(parsed, 'main', None):
         parser.print_help()


### PR DESCRIPTION
#### 4790532f26b0c40db73d2f04d7d2989ef89be2b3
```
[git-webkit] Support callbacks as main arguments
https://bugs.webkit.org/show_bug.cgi?id=229739
<rdar://problem/82597266>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/git-webkit:
(is_webkit_filter): Return item if repository is Webkit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main): Pass repository to contributors, identifier_template and subversion
to dynamically generate values if those arguments are callable.
```