### PR TITLE
[webkitscmpy] Refactor PR branch management

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -795,7 +795,7 @@ class Git(Scm):
                     ), 'HEAD...{}'.format('{}/{}'.format(remote, branch)),
                 ], cwd=self.root_path, env={'FILTER_BRANCH_SQUELCH_WARNING': '1'}).returncode
 
-        if not code and self.is_svn:
+        if not code and self.is_svn and commit.revision:
             return run([
                 self.executable(), 'svn', 'fetch', '--log-window-size=5000', '-r', '{}:HEAD'.format(commit.revision),
             ], cwd=self.root_path).returncode

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
@@ -22,8 +22,8 @@
 
 import sys
 
+from .branch import Branch
 from .command import Command
-from .pull_request import PullRequest
 from webkitscmpy import local
 
 
@@ -39,6 +39,6 @@ class Pull(Command):
             return 1
 
         if isinstance(repository, local.Git):
-            branch_point = PullRequest.branch_point(args, repository, **kwargs)
+            branch_point = Branch.branch_point(repository)
             return repository.pull(rebase=True, branch=branch_point.branch)
         return repository.pull()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -25,7 +25,7 @@ import sys
 from .command import Command
 from .branch import Branch
 
-from webkitcorepy import arguments, run, string_utils
+from webkitcorepy import arguments, run
 from webkitscmpy import local, log, remote
 
 
@@ -82,23 +82,12 @@ class PullRequest(Command):
         return 0
 
     @classmethod
-    def branch_point(cls, args, repository, **kwargs):
-        cnt = 0
-        commit = None
-        while not commit or commit.branch.startswith(Branch.PREFIX):
-            cnt += 1
-            commit = repository.find(argument='HEAD~{}'.format(cnt), include_log=False, include_identifier=False)
-            log.warning('    Found {}...'.format(string_utils.pluralize(cnt, 'commit')))
-
-        return commit
-
-    @classmethod
     def main(cls, args, repository, **kwargs):
         if not isinstance(repository, local.Git):
             sys.stderr.write("Can only '{}' on a native Git repository\n".format(cls.name))
             return 1
 
-        if not repository.branch.startswith(Branch.PREFIX):
+        if not repository.DEV_BRANCHES.match(repository.branch):
             if Branch.main(args, repository, **kwargs):
                 sys.stderr.write("Abandoning pushing pull-request because '{}' could not be created\n".format(args.issue))
                 return 1
@@ -110,7 +99,7 @@ class PullRequest(Command):
         if result:
             return result
 
-        branch_point = cls.branch_point(args, repository, **kwargs)
+        branch_point = Branch.branch_point(repository)
         if args.rebase or (args.rebase is None and repository.config().get('pull.rebase')):
             log.warning("Rebasing '{}' on '{}'...".format(repository.branch, branch_point.branch))
             if repository.pull(rebase=True, branch=branch_point.branch):


### PR DESCRIPTION
#### 5ae7ce23a8e317929a0d8e6077eff6627948772a
```
[webkitscmpy] Refactor PR branch management
https://bugs.webkit.org/show_bug.cgi?id=230432
<rdar://problem/83258413>

Reviewed by NOBODY (OOPS!).

* Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch): Specify that the 'eng' prefix is for pull-requests.
(Branch.normalize_branch_name): Normalized branch names should consider other developement prefixes.
(Branch.editable): Check if a branch is editable. Only includes development branches at the moment,
will include commit-queue in the near future.
(Branch.branch_point): Moved from pull_request.py.
(Branch.main):
(Branch.normalize_issue): Renamed normalize_branch_name.
* Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py:
(Pull.main): branch_point is now owned Branch command.
* Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.main): Match DEV_BRANCHES instead of PREFIX, branch_point is now owned Branch command.
(PullRequest.branch_point): Moved to branch.py.
```