### PR TITLE
[webkitscmpy] Linkify http urls in pull-requests

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,21 @@
+2021-09-29  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Linkify http urls in pull-requests
+        https://bugs.webkit.org/show_bug.cgi?id=230655
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
+        (PullRequest): 
+        (PullRequest.escape_html): Escape any html and linkify http urls.
+        (PullRequest.unescape_html): Unescape escaped html and strip links from http urls.
+        (PullRequest.create_body): Use <pre> and escape html in commit messages.
+        (PullRequest.parse_body): Match both <pre> and ```, escape html if <pre> was used.
+        * Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
+        (BitBucket.PRGenerator.create): Opt out of linkifying http in comment body.
+        (BitBucket.PRGenerator.update): Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+
 2021-09-29  Alex Christensen  <achristensen@webkit.org>
 
         Update PCM Daemon name

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -74,7 +74,7 @@ class BitBucket(Scm):
 
             if len(title) > self.TITLE_CHAR_LIMIT:
                 raise ValueError('Title length too long. Limit is: {}'.format(self.TITLE_CHAR_LIMIT))
-            description = PullRequest.create_body(body, commits)
+            description = PullRequest.create_body(body, commits, linkify=False)
             if description and len(description) > self.BODY_CHAR_LIMIT:
                 raise ValueError('Body length too long. Limit is: {}'.format(self.BODY_CHAR_LIMIT))
             response = requests.post(
@@ -84,7 +84,7 @@ class BitBucket(Scm):
                     name=self.repository.name,
                 ), json=dict(
                     title=title,
-                    description=PullRequest.create_body(body, commits),
+                    description=PullRequest.create_body(body, commits, linkify=False),
                     fromRef=dict(
                         id='refs/heads/{}'.format(head),
                         repository=dict(
@@ -125,7 +125,7 @@ class BitBucket(Scm):
             if title:
                 to_change['title'] = title
             if body or commits:
-                to_change['description'] = PullRequest.create_body(body, commits)
+                to_change['description'] = PullRequest.create_body(body, commits, linkify=False)
             if head:
                 to_change['fromRef'] = dict(
                     id='refs/heads/{}'.format(head),


### PR DESCRIPTION
#### 389b2003930433799f541bfc058f7b1cb139847c
<pre>
[webkitscmpy] Linkify http urls in pull-requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=230655">https://bugs.webkit.org/show_bug.cgi?id=230655</a>

Reviewed by NOBODY (OOPS!).

* Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest):
(PullRequest.escape_html): Escape any html and linkify http urls.
(PullRequest.unescape_html): Unescape escaped html and strip links from http urls.
(PullRequest.create_body): Use &lt;pre &gt; and escape html in commit messages, unless opted out.
(PullRequest.parse_body): Match both &lt;pre &gt; and ```, escape html if &lt;pre &gt; was used.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.create): Opt out of linkifying http in comment body.
(BitBucket.PRGenerator.update): Ditto.
* Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
</pre>