### PR TITLE
[webkitscmpy] Generate commit message template

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,25 @@
+2021-10-14  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Generate commit message template
+        https://bugs.webkit.org/show_bug.cgi?id=231023
+        <rdar://problem/83722871>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/git-webkit: Use prepare-ChangeLog to generate commit messages.
+        * Scripts/hooks/prepare-commit-msg: Added.
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version, add jinja.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
+        (Git.__init__): Add unbound status mock.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
+        (main): Pass hooks to sub-programs.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
+        (Setup.git): iterate through the directory of provided hooks and render with jinja2.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg: Added.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
+        (TestSetup.test_commit_message):
+
 2021-10-18  Alex Christensen  <achristensen@webkit.org>
 
         Regression (r284304) : [ iOS 15 Release ] http/tests/privateClickMeasurement tests are failing

--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -71,5 +71,6 @@ if '__main__' == __name__:
         identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
         additional_setup=is_webkit_filter(additional_setup),
+        hooks=os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'hooks'),
     ))
 

--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -1,0 +1,76 @@
+#!/usr/bin/env {{ python }}
+
+import os
+import subprocess
+import sys
+
+LOCATION = '{{ location }}'
+SPACING = 8
+SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+
+
+def message(source=None, sha=None):
+    dirname = None
+    commit_message = []
+
+    try:
+        for line in subprocess.check_output(
+            [os.path.join(SCRIPTS, 'prepare-ChangeLog'), '--no-write', '--only-files', '--delimiters'],
+            **(dict(encoding='utf-8') if sys.version_info > (3, 0) else dict())
+        ).splitlines():
+            if line == '~':
+                dirname = None
+                continue
+            if line.startswith(' ' * SPACING):
+                if dirname:
+                    line = line.replace('* ', '* {}/'.format(dirname))
+                commit_message.append(line[SPACING:])
+                continue
+            if line.endswith(':'):
+                dirname = line.split(':')[0]
+                continue
+
+        return '''Need a short description (OOPS!).
+Need the bug URL (OOPS!).
+
+Reviewed by NOBODY (OOPS!).
+
+{}
+'''.format('\n'.join(commit_message))
+
+    except subprocess.CalledProcessError:
+        return ''
+
+def main(file_name=None, source=None, sha=None):
+    if source and source != 'commit':
+        return 0
+
+    with open(file_name, 'w') as commit_message_file:
+        if sha:
+            commit_message_file.write(subprocess.check_output(
+                ['{{ git }}', 'log', 'HEAD', '-1', '--pretty=format:%B'],
+                **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+            ))
+        else:
+            commit_message_file.write(message(source=source, sha=sha))
+
+        commit_message_file.write('''
+# Please populate the above commit message. Lines starting
+# with '#' will be ignored
+
+''')
+        if sha:
+            for line in message(source=source, sha=sha).splitlines():
+                commit_message_file.write('# {}\n'.format(line))
+            commit_message_file.write('\n')
+        for line in subprocess.check_output(
+            ['{{ git }}', 'status'],
+            **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+        ).splitlines():
+            commit_message_file.write('# {}\n'.format(line))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(*sys.argv[1:]))

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -58,7 +58,7 @@ setup(
         'webkitscmpy.test',
     ],
     scripts=['git-webkit'],
-    install_requires=['fasteners', 'inspect2', 'monotonic', 'webkitcorepy', 'xmltodict'],
+    install_requires=['fasteners', 'inspect2', 'jinja2', 'monotonic', 'webkitcorepy', 'xmltodict'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -49,9 +49,11 @@ except ImportError:
 version = Version(2, 2, 12)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
+AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
+AutoInstall.register(Package('MarkupSafe', Version(1, 1, 1)))
 
 if sys.version_info < (3, 0):
     AutoInstall.register(Package('inspect2', Version(0, 1, 2)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -442,6 +442,17 @@ nothing to commit, working tree clean
                     stderr='usage: git [--version] [--help]...\n',
                 ),
             ), mocks.Subprocess.Route(
+                self.executable, 'status',
+                generator=lambda *args, **kwargs:
+                    mocks.ProcessCompletion(
+                        returncode=0,
+                        stdout=''''On branch {branch}
+Your branch is up to date with 'origin/{branch}'.
+
+nothing to commit, working tree clean
+'''.format(branch=self.branch),
+                    ),
+            ), mocks.Subprocess.Route(
                 self.executable,
                 completion=mocks.ProcessCompletion(
                     returncode=128,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -44,7 +44,7 @@ from webkitscmpy import local, log, remote
 
 def main(
     args=None, path=None, loggers=None, contributors=None,
-    identifier_template=None, subversion=None, additional_setup=None,
+    identifier_template=None, subversion=None, additional_setup=None, hooks=None,
 ):
     logging.basicConfig(level=logging.WARNING)
 
@@ -112,6 +112,8 @@ def main(
         identifier_template = identifier_template(repository)
     if callable(subversion):
         subversion = subversion(repository)
+    if callable(hooks):
+        hooks = hooks(repository)
 
     if sys.version_info > (3, 0):
         import inspect
@@ -130,4 +132,5 @@ def main(
         identifier_template=identifier_template,
         subversion=subversion,
         additional_setup=additional_setup,
+        hooks=hooks,
     )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -20,10 +20,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import requests
 import sys
 
 from .command import Command
+from jinja2 import Template
 from requests.auth import HTTPBasicAuth
 from webkitcorepy import arguments, run, Editor, Terminal
 from webkitscmpy import log, local, remote
@@ -78,7 +80,7 @@ class Setup(Command):
         return result
 
     @classmethod
-    def git(cls, args, repository, additional_setup=None, **kwargs):
+    def git(cls, args, repository, additional_setup=None, hooks=None, **kwargs):
         global_config = local.Git.config()
         result = 0
 
@@ -145,6 +147,26 @@ class Setup(Command):
         ).returncode:
             sys.stderr.write('Failed to use {} as the merge strategy\n'.format('merge commits' if args.merge else 'rebase'))
             result += 1
+
+        if hooks:
+            for hook in os.listdir(hooks):
+                source_path = os.path.join(hooks, hook)
+                if not os.path.isfile(source_path):
+                    continue
+                log.warning('Configuring and copying hook {}'.format(source_path))
+                with open(source_path, 'r') as f:
+                    contents = Template(f.read()).render(
+                        git=local.Git.executable(),
+                        location=source_path,
+                        python=os.path.basename(sys.executable),
+                    )
+
+                target = os.path.join(repository.root_path, '.git', 'hooks', hook)
+                if not os.path.exists(os.path.dirname(target)):
+                    os.makedirs(os.path.dirname(target))
+                with open(target, 'w') as f:
+                    f.write(contents)
+                    f.write('\n')
 
         log.warning('Setting git editor for {}...'.format(repository.root_path))
         editor_name = 'default' if args.defaults else Terminal.choose(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg
@@ -1,0 +1,45 @@
+#!/usr/bin/env {{ python }}
+
+import os
+import subprocess
+import sys
+
+
+def message(source=None, sha=None):
+    return 'Generated commit message'
+
+
+def main(file_name=None, source=None, sha=None):
+    if source and source != 'commit':
+        return 0
+
+    with open(file_name, 'w') as commit_message_file:
+        if sha:
+            commit_message_file.write(subprocess.check_output(
+                ['{{ git }}', 'log', 'HEAD', '-1', '--pretty=format:%B'],
+                **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+            ))
+        else:
+            commit_message_file.write(message(source=source, sha=sha))
+
+        commit_message_file.write('''
+# Please populate the above commit message. Lines starting
+# with '#' will be ignored
+
+''')
+        if sha:
+            for line in message(source=source, sha=sha).splitlines():
+                commit_message_file.write('# {}\n'.format(line))
+            commit_message_file.write('\n')
+        for line in subprocess.check_output(
+            ['{{ git }}', 'status'],
+            **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+        ).splitlines():
+            commit_message_file.write('# {}\n'.format(line))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(*sys.argv[1:]))
+


### PR DESCRIPTION
#### 7dfc51593d68bc49bec3d73231f0171c3abf8139
<pre>
[webkitscmpy] Generate commit message template
<a href="https://bugs.webkit.org/show_bug.cgi?id=231023">https://bugs.webkit.org/show_bug.cgi?id=231023</a>
&lt;rdar://problem/83722871 &gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/git-webkit: Use prepare-ChangeLog to generate commit messages.
* Tools/Scripts/hooks/prepare-commit-msg: Added.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version, add jinja.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Add unbound status mock.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main): Pass hooks to sub-programs.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): iterate through the directory of provided hooks and render with jinja2.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg: Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
(TestSetup.test_commit_message):
</pre>