### PR TITLE
[webkitscmpy] List reviewers for pull-request

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,43 @@
+2021-10-12  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] List reviewers for pull-request
+        https://bugs.webkit.org/show_bug.cgi?id=231577
+        <rdar://problem/84146807>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
+        (BitBucket.request): Add state to created pull-reqest.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
+        (GitHub):
+        (GitHub._users): Vend json representation of user for username.
+        (GitHub.request): Filter review details, add users endpoint.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
+        (PullRequest.main): Match both closed and opened pull-requests.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
+        (PullRequest): Remove state.
+        (PullRequest.__init__): Add opened flag, reviewers and generator.
+        (PullRequest.reviewers): List the users who are reviewing this change.
+        (PullRequest.approvers): List the users who have aproved this change.
+        (PullRequest.blockers): List the users that are blocking this change from landing.
+        (PullRequest.opened): Check the pull-request is opened.
+        (PullRequest.State): Deleted.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
+        (BitBucket.PRGenerator.PullRequest): Set opened flag, specify reviewers.
+        (BitBucket.PRGenerator.find): Filter by opened flag instead of state.
+        (BitBucket.PRGenerator.update): Set generator.
+        (BitBucket.PRGenerator.reviewers): Set reviewer lists.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
+        (GitHub.PRGenerator.PullRequest): Set opened flag, pass generator.
+        (GitHub.PRGenerator.find): Filter by opened flag instead of state.
+        (GitHub.PRGenerator.update): Set generator and opened flag.
+        (GitHub.PRGenerator._contributor): Find contributor matching username.
+        (GitHub.PRGenerator.reviewers): Populate lists of reviewers for a pull-request.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
+        (Scm.PRGenerator.find): Filter via opened flag instead of state.
+        (Scm.PRGenerator.reviewers): Function which populates reviewer lists for a pull-request.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+
 2021-10-11  Diego Pino Garcia  <dpino@igalia.com>
 
         [GTK] Unreviewed build fix. Fix build for Debian 10 (Buster)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
@@ -222,6 +222,7 @@ class BitBucket(mocks.Requests):
             json['id'] = 1 + max([0] + [pr.get('id', 0) for pr in self.pull_requests])
             json['fromRef']['displayId'] = json['fromRef']['id'].split('/')[-2:]
             json['toRef']['displayId'] = json['toRef']['id'].split('/')[-2:]
+            json['state'] = 'OPEN'
             self.pull_requests.append(json)
             return mocks.Response.fromJson(json)
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -121,7 +121,7 @@ class PullRequest(Command):
             sys.stderr.write("'{}' cannot generate pull-requests\n".format(rmt.url))
             return 1
         user, _ = rmt.credentials(required=True) if isinstance(rmt, remote.GitHub) else (repository.config()['user.email'], None)
-        candidates = list(rmt.pull_requests.find(head=repository.branch))
+        candidates = list(rmt.pull_requests.find(opened=None, head=repository.branch))
         commits = list(repository.commits(begin=dict(hash=branch_point.hash), end=dict(branch=repository.branch)))
 
         title = commits[0].message.splitlines()[0]

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -44,10 +44,6 @@ class PullRequest(object):
         '&': '&amp;',
     }
 
-    class State(object):
-        OPENED = 'opened'
-        CLOSED = 'closed'
-
     @classmethod
     def escape_html(cls, message):
         message = ''.join(cls.ESCAPE_TABLE.get(c, c) for c in message)
@@ -103,13 +99,42 @@ class PullRequest(object):
                     body = part.rstrip().lstrip()
         return body or None, commits
 
-    def __init__(self, number, title=None, body=None, author=None, head=None, base=None):
+    def __init__(self, number, title=None, body=None, author=None, head=None, base=None, opened=None, generator=None):
         self.number = number
         self.title = title
         self.body, self.commits = self.parse_body(body)
         self.author = author
         self.head = head
         self.base = base
+        self._opened = opened
+        self._reviewers = None
+        self._approvers = None
+        self._blockers = None
+        self.generator = generator
+
+    @property
+    def reviewers(self):
+        if self._reviewers is None and self.generator:
+            self.generator.reviewers(self)
+        return self._reviewers
+
+    @property
+    def approvers(self):
+        if self._approvers is None and self.generator:
+            self.generator.reviewers(self)
+        return self._approvers
+
+    @property
+    def blockers(self):
+        if self._blockers is None and self.generator:
+            self.generator.reviewers(self)
+        return self._blockers
+
+    @property
+    def opened(self):
+        if self._opened is None:
+            return '?'
+        return self._opened
 
     def __repr__(self):
         return 'PR {}{}'.format(self.number, ' | {}'.format(self.title) if self.title else '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020, 2021 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,13 +33,16 @@ class Scm(ScmBase):
         def get(self, number):
             raise NotImplementedError()
 
-        def find(self, state=None, head=None, base=None):
+        def find(self, opened=True, head=None, base=None):
             raise NotImplementedError()
 
         def create(self, head, title, body=None, commits=None, base=None):
             raise NotImplementedError()
 
         def update(self, pull_request, head=None, title=None, body=None, commits=None, base=None):
+            raise NotImplementedError()
+
+        def reviewers(self, pull_request):
             raise NotImplementedError()
 
 


### PR DESCRIPTION
#### 0da82619282b07e4f49979366600ffefb9bd75ac
<pre>
[webkitscmpy] List reviewers for pull-request
<a href="https://bugs.webkit.org/show_bug.cgi?id=231577">https://bugs.webkit.org/show_bug.cgi?id=231577</a>
&lt;rdar://problem/84146807 &gt;

Reviewed by NOBODY (OOPS!).

* Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): Add state to created pull-reqest.
* Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub):
(GitHub._users): Vend json representation of user for username.
(GitHub.request): Filter review details, add users endpoint.
* Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.main): Match both closed and opened pull-requests.
* Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
(PullRequest): Remove state.
(PullRequest.__init__): Add opened flag, reviewers and generator.
(PullRequest.reviewers): List the users who are reviewing this change.
(PullRequest.approvers): List the users who have aproved this change.
(PullRequest.blockers): List the users that are blocking this change from landing.
(PullRequest.opened): Check the pull-request is opened.
(PullRequest.State): Deleted.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.PullRequest): Set opened flag, specify reviewers.
(BitBucket.PRGenerator.find): Filter by opened flag instead of state.
(BitBucket.PRGenerator.update): Set generator.
(BitBucket.PRGenerator.reviewers): Set reviewer lists.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.PullRequest): Set opened flag, pass generator.
(GitHub.PRGenerator.find): Filter by opened flag instead of state.
(GitHub.PRGenerator.update): Set generator and opened flag.
(GitHub.PRGenerator._contributor): Find contributor matching username.
(GitHub.PRGenerator.reviewers): Populate lists of reviewers for a pull-request.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.PRGenerator.find): Filter via opened flag instead of state.
(Scm.PRGenerator.reviewers): Function which populates reviewer lists for a pull-request.
* Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
</pre>