### PR TITLE
[webkitscmpy] Allow repositories to define custom setup commands

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,20 @@
+2021-10-15  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Allow repositories to define custom setup commands
+        https://bugs.webkit.org/show_bug.cgi?id=231345
+        <rdar://problem/83960249>
+
+        Reviewed by Dewei Zhu.
+
+        * Scripts/git-webkit: Define changelog conflict resolver.
+        * Scripts/libraries/webkitscmpy/setup.py: Add inspect2 as dependency, bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
+        (main): Attempt to resolve additional_setup function.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
+        (Setup.github): Invoke additional_setup function, if it exists.
+        (Setup.git): Ditto.
+
 2021-10-15  BJ Burg  <bburg@apple.com>
 
         [Cocoa] Web Inspector: handle Promise objects returned from evaluateScriptInExtensionTab

--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -26,7 +26,8 @@ import os
 import sys
 
 import webkitpy
-from webkitscmpy import local, program, remote
+from webkitcorepy import run
+from webkitscmpy import local, program, remote, Contributor, log
 
 
 def is_webkit_filter(to_return):
@@ -45,10 +46,30 @@ def is_webkit_filter(to_return):
     return callback
 
 
+def additional_setup(args, repository):
+    if not isinstance(repository, local.Git):
+        return 0
+
+    log.warning('Setting merging behavior for changelogs...')
+    if run([
+        repository.executable(),
+        'config', 'merge.changelog.driver',
+        'perl {} --merge-driver -c %O %A %B'.format(os.path.join(
+            os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))),
+            'OpenSource', 'Tools', 'Scripts', 'resolve-ChangeLogs',
+        )),
+    ], capture_output=True, cwd=repository.root_path).returncode:
+        sys.stderr.write('Failed to set the git merging behaivor for changelogs...\n')
+        return 1
+    log.warning('Set merging behavior for changelogs!')
+    return 0
+
+
 if '__main__' == __name__:
     sys.exit(program.main(
         path=os.path.dirname(__file__),
         identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
+        additional_setup=is_webkit_filter(additional_setup),
     ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.11',
+    version='2.2.12',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[
@@ -58,7 +58,7 @@ setup(
         'webkitscmpy.test',
     ],
     scripts=['git-webkit'],
-    install_requires=['fasteners', 'monotonic', 'webkitcorepy', 'xmltodict'],
+    install_requires=['fasteners', 'inspect2', 'monotonic', 'webkitcorepy', 'xmltodict'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,12 +46,15 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 11)
+version = Version(2, 2, 12)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
+
+if sys.version_info < (3, 0):
+    AutoInstall.register(Package('inspect2', Version(0, 1, 2)))
 
 from webkitscmpy.contributor import Contributor
 from webkitscmpy.commit import Commit

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -42,7 +42,10 @@ from webkitcorepy import arguments, log as webkitcorepy_log
 from webkitscmpy import local, log, remote
 
 
-def main(args=None, path=None, loggers=None, contributors=None, identifier_template=None, subversion=None):
+def main(
+    args=None, path=None, loggers=None, contributors=None,
+    identifier_template=None, subversion=None, additional_setup=None,
+):
     logging.basicConfig(level=logging.WARNING)
 
     loggers = [logging.getLogger(), webkitcorepy_log,  log] + (loggers or [])
@@ -110,6 +113,13 @@ def main(args=None, path=None, loggers=None, contributors=None, identifier_templ
     if callable(subversion):
         subversion = subversion(repository)
 
+    if sys.version_info > (3, 0):
+        import inspect
+    else:
+        import inspect2 as inspect
+    if callable(additional_setup) and list(inspect.signature(additional_setup).parameters.keys()) == ['repository']:
+        additional_setup = additional_setup(repository)
+
     if not getattr(parsed, 'main', None):
         parser.print_help()
         return -1
@@ -119,4 +129,5 @@ def main(args=None, path=None, loggers=None, contributors=None, identifier_templ
         repository=repository,
         identifier_template=identifier_template,
         subversion=subversion,
+        additional_setup=additional_setup,
     )


### PR DESCRIPTION
#### 5a24f534edd68bf73e65b3d2b8c14ff0748bcc88
<pre>
[webkitscmpy] Allow repositories to define custom setup commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=231345">https://bugs.webkit.org/show_bug.cgi?id=231345</a>
&lt;rdar://problem/83960249 &gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/git-webkit: Define changelog conflict resolver.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Add inspect2 as dependency, bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main): Attempt to resolve additional_setup function.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.github): Invoke additional_setup function, if it exists.
(Setup.git): Ditto.
</pre>