### PR TITLE
[webkitscmpy] Filter approvers by status

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,26 @@
+2021-10-15  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Filter approvers by status
+        https://bugs.webkit.org/show_bug.cgi?id=231843
+        <rdar://problem/84320934>
+
+        Reviewed by Dewei Zhu.
+
+        If a project defines statuses for it's contributors, we only want
+        to allow reviewers to approve changes.
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py:
+        (Contributor): Add reviewer status.
+        (Contributor.Mapping.load): Keep track of possible statuses.
+        (Contributor.Mapping.__init__): Ditto.
+        (Contributor.Mapping.add): Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
+        (BitBucket.PRGenerator.PullRequest): If a project defines a reviewer status, enforce it.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
+        (GitHub.PRGenerator._contributor): Handle case where no name is defined.
+        (GitHub.PRGenerator.reviewers): If a project defines a reviewer status, enforce it.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+
 2021-10-19  Alex Christensen  <achristensen@webkit.org>
 
         Use JSONValues instead of a JSC::VM to parse WKContentRuleLists

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.12',
+    version='2.2.13',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 12)
+version = Version(2, 2, 13)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('monotonic', Version(1, 5)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
@@ -35,6 +35,7 @@ class Contributor(object):
     SVN_AUTHOR_RE = re.compile(r'r(?P<revision>\d+) \| (?P<email>.*) \| (?P<date>.*) \| \d+ lines?')
     SVN_AUTHOR_Q_RE = re.compile(r'r(?P<revision>\d+) \| (?P<email>.*) \| (?P<date>.*)')
     SVN_PATCH_FROM_RE = re.compile(r'Patch by (?P<author>.*) <(?P<email>.*)> on \d+-\d+-\d+')
+    REVIEWER = 'reviewer'
 
     class Encoder(json.JSONEncoder):
 
@@ -68,6 +69,8 @@ class Contributor(object):
                 created.github = contributor.get('github', created.github)
                 created.bitbucket = contributor.get('bitbucket', created.bitbucket)
 
+                result.statuses.add(created.status)
+
                 if created.github:
                     result[created.github] = created
                 if created.bitbucket:
@@ -85,6 +88,7 @@ class Contributor(object):
 
         def __init__(self):
             super(Contributor.Mapping, self).__init__(lambda: None)
+            self.statuses = set()
 
         def save(self, file):
             alias_to_name = defaultdict(list)
@@ -110,6 +114,8 @@ class Contributor(object):
             result.status = contributor.status or result.status
             result.github = contributor.github or result.github
             result.bitbucket = contributor.bitbucket or result.bitbucket
+
+            self.statuses.add(result.status)
 
             if result.github:
                 self[result.github] = result

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -25,10 +25,8 @@ import requests
 import six
 import sys
 
-import json
-
 from webkitcorepy import decorators
-from webkitscmpy import Commit, PullRequest
+from webkitscmpy import Commit, Contributor, PullRequest
 from webkitscmpy.remote.scm import Scm
 
 
@@ -58,13 +56,14 @@ class BitBucket(Scm):
             result._reviewers = []
             result._approvers = []
             result._blockers = []
+            needs_status = Contributor.REVIEWER in self.repository.contributors.statuses
             for rdata in data.get('reviewers', []):
                 reviewer = self.repository.contributors.create(
                     rdata['user']['displayName'],
                     rdata['user'].get('emailAddress', None),
                 )
                 result._reviewers.append(reviewer)
-                if rdata.get('approved', False):
+                if rdata.get('approved', False) and (not needs_status or reviewer.status == Contributor.REVIEWER):
                     result._approvers.append(reviewer)
                 if rdata.get('status') == 'NEEDS_WORK':
                     result._blockers.append(reviewer)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -493,6 +493,22 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
             self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
 
+    def test_approvers_status(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            repo.contributors.add(Contributor(
+                'Suspicious Reviewer', ['sreviewer@webkit.org'],
+                github='sreviewer', status=Contributor.REVIEWER,
+            ))
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.reviewers, [
+                Contributor('Eager Reviewer', ['ereviewer@webkit.org']),
+                Contributor('Reluctant Reviewer', ['rreviewer@webkit.org']),
+                Contributor('Suspicious Reviewer', ['sreviewer@webkit.org']),
+            ])
+            self.assertEqual(pr.approvers, [])
+            self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
+
 
 class TestNetworkPullRequestBitBucket(unittest.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
@@ -573,4 +589,20 @@ Reviewed by NOBODY (OOPS!).
                 Contributor('Suspicious Reviewer', ['sreviewer@webkit.org']),
             ])
             self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
+            self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
+
+    def test_approvers_status(self):
+        with self.webserver():
+            repo = remote.BitBucket(self.remote)
+            repo.contributors.add(Contributor(
+                'Suspicious Reviewer', ['sreviewer@webkit.org'],
+                github='sreviewer', status=Contributor.REVIEWER,
+            ))
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.reviewers, [
+                Contributor('Eager Reviewer', ['ereviewer@webkit.org']),
+                Contributor('Reluctant Reviewer', ['rreviewer@webkit.org']),
+                Contributor('Suspicious Reviewer', ['sreviewer@webkit.org']),
+            ])
+            self.assertEqual(pr.approvers, [])
             self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])


### PR DESCRIPTION
#### b7ef05a0c62a00a75a98ba185f1c61f956512b42
<pre>
[webkitscmpy] Filter approvers by status
<a href="https://bugs.webkit.org/show_bug.cgi?id=231843">https://bugs.webkit.org/show_bug.cgi?id=231843</a>
&lt;rdar://problem/84320934 &gt;

Reviewed by Dewei Zhu.

If a project defines statuses for it&apos;s contributors, we only want
to allow reviewers to approve changes.

* Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py:
(Contributor): Add reviewer status.
(Contributor.Mapping.load): Keep track of possible statuses.
(Contributor.Mapping.__init__): Ditto.
(Contributor.Mapping.add): Ditto.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.PullRequest): If a project defines a reviewer status, enforce it.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator._contributor): Handle case where no name is defined.
(GitHub.PRGenerator.reviewers): If a project defines a reviewer status, enforce it.
* Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
</pre>