### PR TITLE
[EWS] Move EWS bots to iOS 15 / watchOS 8 / tvOS 15

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -42,12 +42,12 @@
     { "name": "ews118", "platform": "mac-catalina" },
     { "name": "ews119", "platform": "mac-catalina" },
     { "name": "ews120", "platform": "mac-catalina" },
-    { "name": "ews121", "platform": "ios-simulator-14" },
-    { "name": "ews122", "platform": "ios-simulator-14" },
-    { "name": "ews123", "platform": "ios-simulator-14" },
-    { "name": "ews124", "platform": "ios-simulator-14" },
-    { "name": "ews125", "platform": "ios-simulator-14" },
-    { "name": "ews126", "platform": "ios-simulator-14" },
+    { "name": "ews121", "platform": "ios-simulator-15" },
+    { "name": "ews122", "platform": "ios-simulator-15" },
+    { "name": "ews123", "platform": "ios-simulator-15" },
+    { "name": "ews124", "platform": "ios-simulator-15" },
+    { "name": "ews125", "platform": "ios-simulator-15" },
+    { "name": "ews126", "platform": "ios-simulator-15" },
     { "name": "ews127", "platform": "mac-catalina" },
     { "name": "ews128", "platform": "mac-catalina" },
     { "name": "ews150", "platform": "*" },
@@ -70,7 +70,7 @@
     { "name": "ews167", "platform": "*" },
     { "name": "ews168", "platform": "*" },
     { "name": "ews169", "platform": "mac-bigsur" },
-    { "name": "ews170", "platform": "tvos-simulator-14" },
+    { "name": "ews170", "platform": "tvos-simulator-15" },
     { "name": "ews171", "platform": "mac-bigsur" },
     { "name": "ews172", "platform": "mac-bigsur" },
     { "name": "ews173", "platform": "mac-bigsur" },
@@ -118,23 +118,23 @@
       "workernames": ["igalia5-gtk-wk2-ews", "igalia6-gtk-wk2-ews", "igalia7-gtk-wk2-ews", "igalia8-gtk-wk2-ews", "igalia9-gtk-wk2-ews"]
     },
     {
-      "name": "iOS-14-Build-EWS", "shortname": "ios", "icon": "buildOnly",
-      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-14",
+      "name": "iOS-15-Build-EWS", "shortname": "ios", "icon": "buildOnly",
+      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-15",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews152", "ews154", "ews108", "ews109"]
     },
     {
-      "name": "iOS-14-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
-      "factory": "iOSBuildFactory", "platform": "ios-simulator-14",
+      "name": "iOS-15-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
+      "factory": "iOSBuildFactory", "platform": "ios-simulator-15",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggers": ["api-tests-ios-sim-ews", "ios-14-sim-wk2-tests-ews"],
+      "triggers": ["api-tests-ios-sim-ews", "ios-15-sim-wk2-tests-ews"],
       "workernames": ["ews152", "ews154", "ews156", "ews157", "ews108", "ews109"]
     },
     {
-      "name": "iOS-14-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
-      "factory": "iOSTestsFactory", "platform": "ios-simulator-14",
+      "name": "iOS-15-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-15",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggered_by": ["ios-14-sim-build-ews"],
+      "triggered_by": ["ios-15-sim-build-ews"],
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126"]
     },
     {
@@ -194,26 +194,26 @@
       "workernames": ["ews112", "ews113", "ews115", "ews117"]
     },
     {
-      "name": "watchOS-7-Build-EWS", "shortname": "watch", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-7",
+      "name": "watchOS-8-Build-EWS", "shortname": "watch", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-8",
       "configuration": "release", "architectures": ["arm64_32", "armv7k"],
       "workernames": ["ews163", "ews164", "ews165"]
     },
     {
-      "name": "watchOS-7-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-7",
+      "name": "watchOS-8-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-8",
       "configuration": "release", "architectures": ["i386"],
       "workernames": ["ews164", "ews165", "ews166"]
     },
     {
-      "name": "tvOS-14-Build-EWS", "shortname": "tv", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-14",
+      "name": "tvOS-15-Build-EWS", "shortname": "tv", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-15",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews167", "ews168"]
     },
     {
-      "name": "tvOS-14-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-14",
+      "name": "tvOS-15-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-15",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews168", "ews170"]
     },
@@ -294,7 +294,7 @@
     {
       "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
-      "triggered_by": ["ios-14-sim-build-ews"],
+      "triggered_by": ["ios-15-sim-build-ews"],
       "workernames": ["ews156", "ews157", "ews158", "ews159"]
     },
     {
@@ -325,11 +325,11 @@
     {
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
-            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-14-Build-EWS", "iOS-14-Simulator-Build-EWS",
+            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-15-Build-EWS", "iOS-15-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS",
             "macOS-AppleSilicon-Big-Sur-Debug-Build-EWS", "macOS-Catalina-Debug-Build-EWS", "macOS-Catalina-Release-Build-EWS",
-            "Services-EWS", "Style-EWS", "tvOS-14-Build-EWS", "tvOS-14-Simulator-Build-EWS", "watchOS-7-Build-EWS",
-            "watchOS-7-Simulator-Build-EWS", "WPE-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS", "Windows-EWS"
+            "Services-EWS", "Style-EWS", "tvOS-15-Build-EWS", "tvOS-15-Simulator-Build-EWS", "watchOS-8-Build-EWS",
+            "watchOS-8-Simulator-Build-EWS", "WPE-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS", "Windows-EWS"
       ]
     },
     {
@@ -369,12 +369,12 @@
       "builderNames": ["macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-14-sim-build-ews",
-      "builderNames": ["iOS-14-Simulator-Build-EWS"]
+      "type": "Triggerable", "name": "ios-15-sim-build-ews",
+      "builderNames": ["iOS-15-Simulator-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-14-sim-wk2-tests-ews",
-      "builderNames": ["iOS-14-Simulator-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "ios-15-sim-wk2-tests-ews",
+      "builderNames": ["iOS-15-Simulator-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "api-tests-ios-sim-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -83,7 +83,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'layout-tests',
             'set-build-summary'
         ],
-        'iOS-14-Build-EWS': [
+        'iOS-15-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -95,7 +95,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'iOS-14-Simulator-Build-EWS': [
+        'iOS-15-Simulator-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -107,7 +107,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'iOS-14-Simulator-WK2-Tests-EWS': [
+        'iOS-15-Simulator-WK2-Tests-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -259,7 +259,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'watchOS-7-Build-EWS': [
+        'watchOS-8-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -271,7 +271,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'watchOS-7-Simulator-Build-EWS': [
+        'watchOS-8-Simulator-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -283,7 +283,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'tvOS-14-Build-EWS': [
+        'tvOS-15-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',
@@ -295,7 +295,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'compile-webkit'
         ],
-        'tvOS-14-Simulator-Build-EWS': [
+        'tvOS-15-Simulator-Build-EWS': [
             'configure-build',
             'validate-patch',
             'configuration',

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,14 @@
+2021-10-19  Ryan Haddad  <ryanhaddad@apple.com>
+
+        [EWS] Move EWS bots to iOS 15 / watchOS 8 / tvOS 15
+        https://bugs.webkit.org/show_bug.cgi?id=231925
+
+        Reviewed by NOBODY (OOPS!).
+
+        * CISupport/ews-build/config.json:
+        * CISupport/ews-build/factories_unittest.py:
+        (TestExpectedBuildSteps):
+
 2021-10-19  Alex Christensen  <achristensen@webkit.org>
 
         Fix iOS API tests after r284304


### PR DESCRIPTION
#### 37d37a0b0ce792f9c02ab1126a9fcacd19370cc7
<pre>
[EWS] Move EWS bots to iOS 15 / watchOS 8 / tvOS 15
<a href="https://bugs.webkit.org/show_bug.cgi?id=231925">https://bugs.webkit.org/show_bug.cgi?id=231925</a>

Reviewed by NOBODY (OOPS!).

* CISupport/ews-build/config.json:
* CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
</pre>
----------------------------------------------------------------------
#### c474dc3da0f977de21105649a58db14864f92848
<pre>
[GTK] Update test expectations for still-failing CSS web platform tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=231964">https://bugs.webkit.org/show_bug.cgi?id=231964</a>

Unreviewed test gardening.

Patch by Arcady Goldmints-Orlov &lt;agoldmints@igalia.com &gt; on 2021-10-19

* platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/243234@main">https://commits.webkit.org/243234@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284475">https://svn.webkit.org/repository/webkit/trunk@284475</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 389f031e8bdee7ae3ff755f84e3f5666f68e4ff6
<pre>
Fix iOS API tests after r284304
<a href="https://bugs.webkit.org/show_bug.cgi?id=231829">https://bugs.webkit.org/show_bug.cgi?id=231829</a>

Part of the original commit that told the tests to continue doing what they were doing before was omitted.
This commits that.

* TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::TEST):
* TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm:
(webViewWithResourceLoadStatisticsEnabledInNetworkProcess):



Canonical link: <a href="https://commits.webkit.org/243233@main">https://commits.webkit.org/243233@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284474">https://svn.webkit.org/repository/webkit/trunk@284474</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 820c06d51adbc7b7737b6b3d1269ff3445693842
<pre>
http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=231379">https://bugs.webkit.org/show_bug.cgi?id=231379</a>
&lt;rdar://problem/83991245 &gt;

Reviewed by Chris Dumez.

* http/tests/resourceLoadStatistics/resources/redirect.py:
    Added the response header &apos;Cache-Control: no-cache, no-store&apos;.
    Historically, we&apos;ve had problems with redirects getting cached
    so that they don&apos;t hit the network. In this particular case,
    the same redirect is being done in different orders and might
    fall into the cache trap.
* platform/mac-wk2/TestExpectations:
    Removed [Pass Failure] expectation for sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html.


Canonical link: <a href="https://commits.webkit.org/243232@main">https://commits.webkit.org/243232@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284473">https://svn.webkit.org/repository/webkit/trunk@284473</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 53228c86672b2be6f2e52ee13810cc6a4fbf8c8e
<pre>
Guarantee order of WebSocket events in case of being resumed
<a href="https://bugs.webkit.org/show_bug.cgi?id=231664">https://bugs.webkit.org/show_bug.cgi?id=231664</a>

Reviewed by Chris Dumez.

LayoutTests/imported/w3c:

* web-platform-tests/websockets/interfaces/WebSocket/close/close-nested-expected.txt:
* web-platform-tests/websockets/interfaces/WebSocket/readyState/003-expected.txt:

Source/WebCore:

Introduce a WebSocket task source as per spec.
This aligns with <a href="https://html.spec.whatwg.org/multipage/web-sockets.html">https://html.spec.whatwg.org/multipage/web-sockets.html</a> where the user agent is expected to a queue task
when closing handshake is started and so on.

By queuing an event loop task to fire WebSocket events, we ensure ordering of events even in case of resuming, while simplifying the implementation.
This makes it use the event loop which is extra nice if we resolve promises in event listeners.

A follow-up patch should refactor code so that WebSocket::didReceiveMessageError can directly fire the close event without having to wait for a didClose call.

Covered by existing tests.

* Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::WebSocket):
(WebCore::WebSocket::suspend):
(WebCore::WebSocket::resume):
(WebCore::WebSocket::stop):
(WebCore::WebSocket::dispatchOrQueueEvent):
(WebCore::WebSocket::resumeTimerFired): Deleted.
* Modules/websockets/WebSocket.h:
* Modules/websockets/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::send):
* dom/TaskSource.h:

Source/WebKit:

We no longer need to handle resume/suspend in WebSocketChannel layer since WebSocket will deal with itself by enqueuing a task in the event loop.

* WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::disconnect):
(WebKit::WebSocketChannel::didConnect):
(WebKit::WebSocketChannel::didReceiveText):
(WebKit::WebSocketChannel::didReceiveBinaryData):
(WebKit::WebSocketChannel::didClose):
(WebKit::WebSocketChannel::didReceiveMessageError):
(WebKit::WebSocketChannel::suspend):
(WebKit::WebSocketChannel::resume):
(WebKit::WebSocketChannel::didSendHandshakeRequest):
(WebKit::WebSocketChannel::didReceiveHandshakeResponse):
(WebKit::WebSocketChannel::enqueueTask): Deleted.
* WebProcess/Network/WebSocketChannel.h:

LayoutTests:

* http/tests/websocket/tests/hybi/inspector/send-and-receive.html:
The WebSocket server was racing to close the connection with the User Agent.
The patch queueing a task to fire events is further amplifying this race.
To make the test non flaky, we use an echo server that waits for User Agent to close the connection.


Canonical link: <a href="https://commits.webkit.org/243231@main">https://commits.webkit.org/243231@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284472">https://svn.webkit.org/repository/webkit/trunk@284472</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### f78cdfd26f0c8d1f4be9efec82e02ca805438985
<pre>
Add AX team GitHub usernames to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=231966">https://bugs.webkit.org/show_bug.cgi?id=231966</a>

Patch by Tyler Wilcock &lt;tyler_w@apple.com &gt; on 2021-10-19
Reviewed by Chris Fleizach.

* metadata/contributors.json:
Add Chris Fleizach&apos;s and Andres Gonzalez&apos;s GitHub usernames. Add Tyler
Wilcock as a contributor. Run validate-committer-lists --canonicalize
to fix some style issues.

Canonical link: <a href="https://commits.webkit.org/243230@main">https://commits.webkit.org/243230@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284471">https://svn.webkit.org/repository/webkit/trunk@284471</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 8e5688bb62abe6c5a35dc0ce879a3a14576b11b2
<pre>
[ iOS ] http/tests/cache/disk-cache/redirect-chain-limits.html is a flaky timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=231630">https://bugs.webkit.org/show_bug.cgi?id=231630</a>

Unreviewed test gardening.

* platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/243229@main">https://commits.webkit.org/243229@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284469">https://svn.webkit.org/repository/webkit/trunk@284469</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 982f98fe4ed3ea0fe8f1adcad1daadaf8d24dc3c
<pre>
[ iOS ] imported/w3c/web-platform-tests/html/canvas/element/manual tests, fast/canvas/canvas-createPattern-video-modify.html and media/video-canvas-createPattern.html are failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=231959">https://bugs.webkit.org/show_bug.cgi?id=231959</a>

Unreviewed test gardening.

* platform/ipad/TestExpectations:
* platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/243228@main">https://commits.webkit.org/243228@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284468">https://svn.webkit.org/repository/webkit/trunk@284468</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 00a472dcc9e503cff62363ff5978f39d41b83288
<pre>
Wasm Table can take arbitrary default value
<a href="https://bugs.webkit.org/show_bug.cgi?id=231933">https://bugs.webkit.org/show_bug.cgi?id=231933</a>
rdar://84327812

Reviewed by Robin Morisset.

* wasm/WasmTable.cpp:
(JSC::Wasm::Table::grow):

Canonical link: <a href="https://commits.webkit.org/243227@main">https://commits.webkit.org/243227@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284467">https://svn.webkit.org/repository/webkit/trunk@284467</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### f4f1e11be3a8f3cc9499d540e1714ad4b5de678d
<pre>
REGRESSION(r284313): ::marker accelerated animations are broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=231906">https://bugs.webkit.org/show_bug.cgi?id=231906</a>
&lt;rdar://problem/84383279 &gt;

Reviewed by Antti Koivisto.

LayoutTests/imported/w3c:

WPT now reflect that we correctly do not animate the opacity property and correctly account for
other ineffective properties on ::marker, such as line-height.

* web-platform-tests/css/css-pseudo/marker-animate-expected.txt:
* web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation-expected.txt:

Source/WebCore:

Test: webanimations/marker-opacity-animation-no-effect.html

We incorrectly supported animations for all known CSS properties on a ::marker since we added
support for animation of ::marker, and with r284313 we started returning the correct renderer
for ::marker pseudo-elements which meant that accelerated opacity animations started running
for the first time.

We now correctly ignore disallowed properties for ::marker when animating with those changes.

First, in Style::Resolver::styleForKeyframe(), we pass the relevant allowlist to the MatchResult&apos;s
authorDeclarations when adding the keyframe properties.

Then, in KeyframeEffect::isCurrentlyAffectingProperty() we call isValidMarkerStyleProperty() in
case we&apos;re being called for a ::marker pseudo-element.

To be able to obtain the allowlist and call isValidMarkerStyleProperty() in those two questions,
we had to refactor the related code into a dedicated PropertyAllowlist file and enum.

* Sources.txt:
* WebCore.xcodeproj/project.pbxproj:
* animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::isCurrentlyAffectingProperty const):
* style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
* style/ElementRuleCollector.h:
* style/PropertyAllowlist.cpp: Added.
(WebCore::Style::propertyAllowlistForPseudoId):
(WebCore::Style::isValidMarkerStyleProperty):
(WebCore::Style::isValidCueStyleProperty):
* style/PropertyAllowlist.h: Added.
* style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::isValidMarkerStyleProperty): Deleted.
(WebCore::Style::isValidCueStyleProperty): Deleted.
* style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
(WebCore::Style::RuleData::RuleData):
(WebCore::Style::determinePropertyAllowlistType): Deleted.
* style/RuleData.h:
(WebCore::Style::RuleData::propertyAllowlist const):
(): Deleted.
(WebCore::Style::RuleData::propertyAllowlistType const): Deleted.
* style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):

LayoutTests:

Add a new test that checks we do not visually account for an opacity animation on a ::marker
pseudo-element.

* webanimations/marker-opacity-animation-no-effect-expected.html: Added.
* webanimations/marker-opacity-animation-no-effect.html: Added.


Canonical link: <a href="https://commits.webkit.org/243226@main">https://commits.webkit.org/243226@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284466">https://svn.webkit.org/repository/webkit/trunk@284466</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 1f90e62735b5cf8f09870f49080ba2aeac3ead5a
<pre>
Use JSONValues instead of a JSC::VM to parse WKContentRuleLists
<a href="https://bugs.webkit.org/show_bug.cgi?id=231704">https://bugs.webkit.org/show_bug.cgi?id=231704</a>

Patch by Alex Christensen &lt;achristensen@webkit.org &gt; on 2021-10-19
Reviewed by Brady Eidson.

Source/WebCore:

This makes the parser much simpler and easier to see what is going on.
It probably also saves some memory because we don&apos;t need to make a VM just to parse JSON.
Covered by existing tests.  There are extensive tests for invalid input, and there is only
one change in the error reported: we used to say the top level has to be an object, then
we would say that it has to be an array.  JavaScript arrays are objects, but JSON arrays aren&apos;t.
Valid input continues to parse the same, and invalid input continues to fail to parse, but the
error is more accurate now.

* contentextensions/ContentExtensionError.cpp:
(WebCore::ContentExtensions::contentExtensionErrorCategory):
* contentextensions/ContentExtensionError.h:
* contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::getStringList):
(WebCore::ContentExtensions::getDomainList):
(WebCore::ContentExtensions::getTypeFlags):
(WebCore::ContentExtensions::loadTrigger):
(WebCore::ContentExtensions::loadAction):
(WebCore::ContentExtensions::loadRule):
(WebCore::ContentExtensions::loadEncodedRules):
(WebCore::ContentExtensions::parseRuleList):

Tools:

* TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/243225@main">https://commits.webkit.org/243225@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284465">https://svn.webkit.org/repository/webkit/trunk@284465</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 0e72e4a7ace7c53408a7eea0abb9416e0b30d44b
<pre>
[ iOS Win ] editing/selection/modal-dialog-select-paragraph.html is failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=231962">https://bugs.webkit.org/show_bug.cgi?id=231962</a>

Unreviewed test gardening.

* platform/ios-wk2/TestExpectations:
* platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/243224@main">https://commits.webkit.org/243224@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284464">https://svn.webkit.org/repository/webkit/trunk@284464</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 56ce69d9f204a13e245be0690547d32fec55dffc
<pre>
Re-disable WebKit.HTTPSProxy API test on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=231396">https://bugs.webkit.org/show_bug.cgi?id=231396</a>

Yesterday&apos;s attempt at making it not time out does not appear to have worked.

* TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:



Canonical link: <a href="https://commits.webkit.org/243223@main">https://commits.webkit.org/243223@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284463">https://svn.webkit.org/repository/webkit/trunk@284463</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 9def0e0f01434a564022caa08bc2f02f9cefdf41
<pre>
DumpRenderTree should not use WK methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=231910">https://bugs.webkit.org/show_bug.cgi?id=231910</a>

Reviewed by Alex Christensen.

DumpRenderTree functions can be called on WebThread if ios simulator is used.
If we first use WK functions on that, it causes WebKit initialization on non
main thread. We should not mix WK functions with DumpRenderTree.

* DumpRenderTree/mac/DumpRenderTree.mm:
(dumpFramesAsText):


Canonical link: <a href="https://commits.webkit.org/243222@main">https://commits.webkit.org/243222@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284462">https://svn.webkit.org/repository/webkit/trunk@284462</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### 68ebfe5f790ea6a693aca2f86dff6208d1d772d2
<pre>
[ iOS ] fast/inline/inline-background-clip-text-multiline.html is image failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=231961">https://bugs.webkit.org/show_bug.cgi?id=231961</a>

Unreviewed test gardening.

* platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/243221@main">https://commits.webkit.org/243221@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284461">https://svn.webkit.org/repository/webkit/trunk@284461</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
----------------------------------------------------------------------
#### fe0e6b49cf0deb09f6eccefa9b54080dae2d1ec1
<pre>
Unreviewed build fix.

* DerivedSources-input.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/243220@main">https://commits.webkit.org/243220@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284460">https://svn.webkit.org/repository/webkit/trunk@284460</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>