### PR TITLE
[webkitscmpy] Override http url with ssh url

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,17 @@
+2021-10-19  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Override http url with ssh url
+        https://bugs.webkit.org/show_bug.cgi?id=231965
+        <rdar://problem/84422393>
+
+        Reviewed by Ryan Haddad.
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
+        (Git): Exclude / from hostname.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
+        (Setup.git): Prompt user to switch to ssh checkout.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
+
 2021-10-19  Ryan Haddad  <ryanhaddad@apple.com>
 
         [EWS] Move EWS bots to iOS 15 / watchOS 8 / tvOS 15

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.14',
+    version='2.2.15',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 14)
+version = Version(2, 2, 15)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -275,7 +275,7 @@ class Git(Scm):
 
     GIT_COMMIT = re.compile(r'commit (?P<hash>[0-9a-f]+)')
     SSH_REMOTE = re.compile('(ssh://)?git@(?P<host>[^:/]+)[:/](?P<path>.+).git')
-    HTTP_REMOTE = re.compile('(?P<protocol>https?)://(?P<host>.+)/(?P<path>.+).git')
+    HTTP_REMOTE = re.compile(r'(?P<protocol>https?)://(?P<host>[^\/]+)/(?P<path>.+).git')
     REMOTE_BRANCH = re.compile(r'remotes\/(?P<remote>[^\/]+)\/(?P<branch>.+)')
 
     @classmethod


### PR DESCRIPTION
#### 0c02987007119a54db47172599cd6f1e266323a6
<pre>
[webkitscmpy] Override http url with ssh url
<a href="https://bugs.webkit.org/show_bug.cgi?id=231965">https://bugs.webkit.org/show_bug.cgi?id=231965</a>
&lt;rdar://problem/84422393 &gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git): Exclude / from hostname.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Prompt user to switch to ssh checkout.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
</pre>
----------------------------------------------------------------------
#### 1d76d6b98ff4aeaec929b69872d7f1a35e102c79
<pre>
Unreviewed, reverting r284099.
<a href="https://bugs.webkit.org/show_bug.cgi?id=231984">https://bugs.webkit.org/show_bug.cgi?id=231984</a>

Introduced build failure

Reverted changeset:

&quot;[iOS] Stop including &apos;util.sb&apos; in the WebContent process&apos;
sandbox&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=231570">https://bugs.webkit.org/show_bug.cgi?id=231570</a>
<a href="https://commits.webkit.org/r284099">https://commits.webkit.org/r284099</a>

Canonical link: <a href="https://commits.webkit.org/243249@main">https://commits.webkit.org/243249@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@284495">https://svn.webkit.org/repository/webkit/trunk@284495</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>