### PR TITLE
[webkitscmpy] Only respect the latest review

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,21 @@
+2021-11-01  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Only respect the latest review
+        https://bugs.webkit.org/show_bug.cgi?id=231987
+        <rdar://problem/84434991>
+
+        Reviewed by Dewei Zhu.
+
+        GitHub will report the entire history of a review, we should only
+        respect the latest review state.
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
+        (GitHub.PRGenerator.reviewers):
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+        (TestNetworkPullRequestGitHub.test_approved_edits):
+
 2021-11-01  Sam Sneddon  <gsnedders@apple.com>
 
         Improve LayoutTestFinder test coverage

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.21',
+    version='2.2.22',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 21)
+version = Version(2, 2, 22)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -507,6 +507,15 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
             self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
 
+    def test_approved_edits(self):
+        with self.webserver() as server:
+            server.pull_requests[0]['reviews'].append(dict(user=dict(login='sreviewer'), state='APPROVED'))
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(sorted(pr.approvers), sorted([
+                Contributor('Eager Reviewer', ['ereviewer@webkit.org']),
+                Contributor('Suspicious Reviewer', ['sreviewer@webkit.org']),
+            ]))
+
     def test_approvers_status(self):
         with self.webserver():
             repo = remote.GitHub(self.remote)


### PR DESCRIPTION
#### 3bced9d602295f75e2c637f4ccc6d1e733a6af0a
<pre>
[webkitscmpy] Only respect the latest review
<a href="https://bugs.webkit.org/show_bug.cgi?id=231987">https://bugs.webkit.org/show_bug.cgi?id=231987</a>
&lt;rdar://problem/84434991 &gt;

Reviewed by Dewei Zhu.

GitHub will report the entire history of a review, we should only
respect the latest review state.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.reviewers):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestNetworkPullRequestGitHub.test_approved_edits):
</pre>