### PR TITLE
[webkitscmpy] Ensure empty line before canonicalization

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,23 @@
+2021-10-27  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Ensure empty line before canonicalization
+        https://bugs.webkit.org/show_bug.cgi?id=232103
+        <rdar://problem/84521382>
+
+        Reviewed by Stephanie Lewis.
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
+        (main): Handle empty lines around identifier links, add empty line before identifier links.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
+        (TestCanonicalize.test_formated_identifier):
+        (TestCanonicalize.test_existing_identifier):
+        (TestCanonicalize.test_git_svn):
+        (TestCanonicalize.test_git_svn_existing):
+        (TestCanonicalize.test_branch_commits):
+        (TestCanonicalize.test_number):
+
 2021-10-27  Alexey Proskuryakov  <ap@apple.com>
 
         webkitdirs.pm should use JSON::XS when available

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.16',
+    version='2.2.17',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 16)
+version = Version(2, 2, 17)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
@@ -56,10 +56,28 @@ def main(inputfile, identifier_template):
     if identifier_index and repository.GIT_SVN_REVISION.match(lines[-1]):
         identifier_index -= 1
 
+    # We're trying to cover cases where there is a space between link and git-svn-id:
+    #     <commit message content>
+    #
+    #     Canonical link: ...
+    #     git-svn-id: ...
+    # OR
+    #     <commit message content>
+    #     Canonical link: ...
+    #
+    #     git-svn-id: ...
     if identifier_index and lines[identifier_index - 1].startswith(identifier_template.format('').split(':')[0]):
         lines[identifier_index - 1] = identifier_template.format(commit)
+        identifier_index = identifier_index - 2
+    elif identifier_index and lines[identifier_index - 2].startswith(identifier_template.format('').split(':')[0]):
+        del lines[identifier_index - 2]
+        lines.insert(identifier_index - 1, identifier_template.format(commit))
+        identifier_index = identifier_index - 2
     else:
         lines.insert(identifier_index, identifier_template.format(commit))
+
+    if lines[identifier_index]:
+        lines.insert(identifier_index, '')
 
     for line in lines:
         print(line)


### PR DESCRIPTION
#### db3b432ba7fc95bd5838df7b2fca18965cfb5b95
<pre>
[webkitscmpy] Ensure empty line before canonicalization
<a href="https://bugs.webkit.org/show_bug.cgi?id=232103">https://bugs.webkit.org/show_bug.cgi?id=232103</a>
&lt;rdar://problem/84521382 &gt;

Reviewed by Stephanie Lewis.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
(main): Handle empty lines around identifier links, add empty line before identifier links.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
(TestCanonicalize.test_formated_identifier):
(TestCanonicalize.test_existing_identifier):
(TestCanonicalize.test_git_svn):
(TestCanonicalize.test_git_svn_existing):
(TestCanonicalize.test_branch_commits):
(TestCanonicalize.test_number):
</pre>