### PR TITLE
WebGL bot should run tests with GPU Process enabled

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -136,7 +136,7 @@
                       "platform": "mac-bigsur", "configuration": "release", "architectures": ["x86_64", "arm64"],
                       "triggers": [
                           "bigsur-applesilicon-release-tests-test262" ,"bigsur-release-tests-test262", "bigsur-release-tests-wk1", "bigsur-release-tests-wk2",
-                          "bigsur-release-applesilicon-tests-wk1", "bigsur-release-applesilicon-tests-wk2", "bigsur-applesilicon-release-tests-jsc", "bigsur-release-tests-wk2-webgl"
+                          "bigsur-release-applesilicon-tests-wk1", "bigsur-release-applesilicon-tests-wk2", "bigsur-applesilicon-release-tests-jsc", "bigsur-release-tests-wk2-webgl-gpuprocess"
                       ],
                       "workernames": ["bot121", "bot124"]
                     },
@@ -168,9 +168,9 @@
                       "additionalArguments": ["--no-retry-failures"],
                       "workernames": ["bot1022", "bot1023"]
                     },
-                    { "name": "Apple-BigSur-Release-WK2-WebGL-Tests", "factory": "TestAllButJSCFactory", "builddir": "bigsur-release-tests-wk2-webgl",
+                    { "name": "Apple-BigSur-Release-WK2-WebGL-GPUProcess-Tests", "factory": "TestAllButJSCFactory", "builddir": "bigsur-release-tests-wk2-webgl-gpuprocess",
                       "platform": "mac-bigsur", "configuration": "release", "architectures": ["x86_64", "arm64"],
-                      "additionalArguments": ["--no-retry-failures", "--webgl-test-suite"],
+                      "additionalArguments": ["--no-retry-failures", "--webgl-test-suite", "--use-gpu-process"],
                       "workernames": ["bot302"]
                     },
                     { "name": "Apple-BigSur-Debug-Build", "factory": "BuildFactory", "builddir": "bigsur-debug",
@@ -592,8 +592,8 @@
                     { "type": "Triggerable", "name": "bigsur-release-applesilicon-tests-wk2",
                       "builderNames": ["Apple-BigSur-Release-AppleSilicon-WK2-Tests"]
                     },
-                    { "type": "Triggerable", "name": "bigsur-release-tests-wk2-webgl",
-                      "builderNames": ["Apple-BigSur-Release-WK2-WebGL-Tests"]
+                    { "type": "Triggerable", "name": "bigsur-release-tests-wk2-webgl-gpuprocess",
+                      "builderNames": ["Apple-BigSur-Release-WK2-WebGL-GPUProcess-Tests"]
                     },
                     { "type": "Triggerable", "name": "bigsur-debug-tests-wk1",
                       "builderNames": ["Apple-BigSur-Debug-WK1-Tests"]

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,12 @@
+2021-10-21  Ryan Haddad  <ryanhaddad@apple.com>
+
+        WebGL bot should run tests with GPU Process enabled
+        https://bugs.webkit.org/show_bug.cgi?id=232107
+
+        Reviewed by NOBODY (OOPS!).
+
+        * CISupport/build-webkit-org/config.json:
+
 2021-10-21  Fujii Hironori  <Hironori.Fujii@sony.com>
 
         [Win] TestWTF.FileSystemTest.* are timing out if run-api-tests is run by a normal user


### PR DESCRIPTION
#### abbb58f5003e7f962fe5dea120caf3fca93dd2d1
<pre>
WebGL bot should run tests with GPU Process enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=232107">https://bugs.webkit.org/show_bug.cgi?id=232107</a>

Reviewed by NOBODY (OOPS!).

* CISupport/build-webkit-org/config.json:
</pre>