### PR TITLE
[webkitscmpy] Assign PR to author

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,22 @@
 2021-10-29  Jonathan Bedard  <jbedard@apple.com>
 
+        [webkitscmpy] Assign PR to author
+        https://bugs.webkit.org/show_bug.cgi?id=232348
+        <rdar://problem/84685313>
+
+        Reviewed by Dewei Zhu.
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
+        (GitHub.request): Add assignees.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
+        (GitHub.PRGenerator.create): Assign created PR to it's author.
+        (GitHub.PRGenerator.update): Assign modified PR to it's editor.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py: Add assignees.
+
+2021-10-29  Jonathan Bedard  <jbedard@apple.com>
+
         [webkitscmpy] Add fetch and rebase
         https://bugs.webkit.org/show_bug.cgi?id=232447
         <rdar://problem/84770221>

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.20',
+    version='2.2.21',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 20)
+version = Version(2, 2, 21)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -411,6 +411,11 @@ class GitHub(mocks.Requests):
             pr['user'] = dict(login=auth.username)
             pr['_links'] = dict(issue=dict(href='https://{}/issues/{}'.format(self.api_remote, pr['number'])))
             self.pull_requests.append(pr)
+            if int(pr['number']) not in self.issues:
+                self.issues[int(pr['number'])] = dict(
+                    comments=[],
+                    assignees=[],
+                )
             return mocks.Response.fromJson(pr, url=url)
 
         # Update specifically
@@ -444,6 +449,9 @@ class GitHub(mocks.Requests):
                     body=json.get('body', ''),
                 ))
                 return mocks.Response.fromJson(issue['comments'], url=url)
+            if method == 'POST' and stripped_url.split('/')[6] == 'assignees':
+                self.issues[number]['assignees'] = {'login': name for name in json.get('assignees', [])}
+                return mocks.Response.fromJson(issue['assignees'], url=url)
             return mocks.Response.create404(url)
 
         return mocks.Response.create404(url)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -445,6 +445,12 @@ class TestNetworkPullRequestGitHub(unittest.TestCase):
             sreviewer=Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'], github='sreviewer'),
             tcontributor=Contributor('Tim Contributor', ['tcontributor@webkit.org']),
         )
+        result.issues = {
+            1: dict(
+                comments=[],
+                assignees=[],
+            )
+        }
         result.pull_requests = [dict(
             number=1,
             state='open',


### PR DESCRIPTION
#### c578df5c056ba795e5a856c36c257aa17d96b381
<pre>
[webkitscmpy] Assign PR to author
<a href="https://bugs.webkit.org/show_bug.cgi?id=232348">https://bugs.webkit.org/show_bug.cgi?id=232348</a>
&lt;rdar://problem/84685313 &gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.request): Add assignees.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.create): Assign created PR to it&apos;s author.
(GitHub.PRGenerator.update): Assign modified PR to it&apos;s editor.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py: Add assignees.
</pre>