### PR TITLE
[webkitscmpy] Add fetch and rebase

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,32 @@
+2021-10-29  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Add fetch and rebase
+        https://bugs.webkit.org/show_bug.cgi?id=232447
+        <rdar://problem/84770221>
+
+        Reviewed by Dewei Zhu.
+
+        To land commits, we need to be able to rebase a branch against another.
+        Additionally, when rebasing, we need to discard stale cache bits. This
+        is also true when pulling and rebasing against main.
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
+        (Git.Cache.clear): Clear cache of a specific branch.
+        (Git.rebase): Rebase a branch on top of another.
+        (Git.fetch): Fetch specific branch ref.
+        (Git.pull): Use generalized fetch command, clear cache for updated branch
+        if that branch is not the default branch.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
+        (Git.__init__): Add rebase mock.
+        (Git.rebase):
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
+        (PullRequest.main): Recompute branch-point after rebase.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
+        (test_rebase):
+
 2021-10-29  Takashi Komori  <Takashi.Komori@sony.com>
 
         WKAPI does not have any APIs to set cookie path to WKWebsiteDataStoreConfigurationRef

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='2.2.19',
+    version='2.2.20',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(2, 2, 19)
+version = Version(2, 2, 20)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -198,6 +198,29 @@ class Git(Scm):
             except (IOError, OSError):
                 self.repo.log("Failed to write identifier cache to '{}'".format(self.path))
 
+        def clear(self, branch):
+            for d in [self._ordered_commits, self._ordered_revisions, self._last_populated]:
+                if branch in d:
+                    del d[branch]
+
+            self._hash_to_identifiers = NestedFuzzyDict(primary_size=6)
+            self._revisions_to_identifiers = {}
+
+            self._fill(self.repo.default_branch)
+            for branch in self._ordered_commits.keys():
+                if branch == self.repo.default_branch:
+                    continue
+                self._fill(branch)
+
+            try:
+                with open(self.path, 'w') as file:
+                    json.dump(dict(
+                        hashes=self._ordered_commits,
+                        revisions=self._ordered_revisions,
+                    ), file, indent=4)
+            except (IOError, OSError):
+                self.repo.log("Failed to write identifier cache to '{}'".format(self.path))
+
         def to_hash(self, revision=None, identifier=None, populate=True, branch=None):
             if revision:
                 identifier = self.to_identifier(revision=revision, populate=populate, branch=branch)
@@ -802,6 +825,28 @@ class Git(Scm):
             cwd=self.root_path,
         ).returncode else self.commit()
 
+    def rebase(self, target, base=None, head='HEAD', recommit=True):
+        if head == self.default_branch or self.prod_branches.match(head):
+            raise RuntimeError("Rebasing production branch '{}' banned in tooling!".format(head))
+
+        code = run([self.executable(), 'rebase', '--onto', target, base or target, head], cwd=self.root_path).returncode
+        if self.cache:
+            self.cache.clear(head if head != 'HEAD' else self.branch)
+        if code or not recommit:
+            return code
+        return run([
+            self.executable(), 'filter-branch', '-f',
+            '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(
+                date='{} -{}'.format(int(time.time()), int(time.localtime().tm_gmtoff * 100 / (60 * 60)))
+            ), '{}...{}'.format(target, head),
+        ], cwd=self.root_path, env={'FILTER_BRANCH_SQUELCH_WARNING': '1'}, capture_output=True).returncode
+
+    def fetch(self, branch, remote='origin'):
+        return run(
+            [self.executable(), 'fetch', remote, '{}:{}'.format(branch, branch)],
+            cwd=self.root_path,
+        ).returncode
+
     def pull(self, rebase=None, branch=None, remote='origin'):
         commit = self.commit() if self.is_svn or branch else None
         code = run(
@@ -811,12 +856,11 @@ class Git(Scm):
                 [] if rebase is None else ['--rebase={}'.format('True' if rebase else 'False')]
             ), cwd=self.root_path,
         ).returncode
+        if self.cache and rebase and branch != self.branch:
+            self.cache.clear(self.branch)
 
         if not code and branch:
-            code = run(
-                [self.executable(), 'fetch', remote, '{}:{}'.format(branch, branch)],
-                cwd=self.root_path,
-            ).returncode
+            code = self.fetch(branch=branch, remote=remote)
 
         if not code and branch and rebase:
             result = run([self.executable(), 'rev-parse', 'HEAD'], cwd=self.root_path, capture_output=True, encoding='utf-8')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -435,6 +435,10 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: mocks.ProcessCompletion(returncode=0),
             ), mocks.Subprocess.Route(
+                self.executable, 'rebase', '--onto', re.compile(r'.+'), re.compile(r'.+'), re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.rebase(args[3], args[4], args[5]),
+            ), mocks.Subprocess.Route(
                 self.executable,
                 cwd=self.path,
                 completion=mocks.ProcessCompletion(
@@ -777,4 +781,13 @@ nothing to commit, working tree clean
         for key, value in self.modified.items():
             self.staged[key] = value
         self.modified = {}
+        return mocks.ProcessCompletion(returncode=0)
+
+    def rebase(self, target, base, head):
+        if target not in self.commits or base not in self.commits or head not in self.commits:
+            return mocks.ProcessCompletion(returncode=1)
+        for commit in self.commits[head]:
+            commit.branch_point = self.commits[target][-1].branch_point or self.commits[target][-1].identifier
+            if self.commits[target][-1].branch_point:
+                commit.identifier += self.commits[target][-1].identifier
         return mocks.ProcessCompletion(returncode=0)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -106,6 +106,7 @@ class PullRequest(Command):
                 sys.stderr.write("Failed to rebase '{}' on '{},' please resolve conflicts\n".format(repository.branch, branch_point.branch))
                 return 1
             log.warning("Rebased '{}' on '{}!'".format(repository.branch, branch_point.branch))
+            branch_point = Branch.branch_point(repository)
 
         rmt = repository.remote()
         if not rmt:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -476,6 +476,13 @@ CommitDate: {time_c}
             mrepo.staged['modified.txt'] = 'diff'
             self.assertEqual(repo.modified(staged=True), ['added.txt', 'modified.txt'])
 
+    def test_rebase(self):
+        with mocks.local.Git(self.path):
+            repo = local.Git(self.path)
+            self.assertEqual(str(repo.commit(branch='branch-a')), '2.2@branch-a')
+            self.assertEqual(repo.rebase(target='main', base='main', head='branch-a', recommit=False), 0)
+            self.assertEqual(str(repo.commit(branch='branch-a')), '5.2@branch-a')
+
 
 class TestGitHub(testing.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -288,7 +288,8 @@ class TestDoPullRequest(testing.PathTestCase):
 Creating commit...
     Found 1 commit...
 Rebasing 'eng/pr-branch' on 'main'...
-Rebased 'eng/pr-branch' on 'main!'""")
+Rebased 'eng/pr-branch' on 'main!'
+    Found 1 commit...""")
         self.assertEqual(captured.stderr.getvalue(), "'{}' doesn't have a recognized remote\n".format(self.path))
 
     def test_modified(self):
@@ -310,7 +311,8 @@ Rebased 'eng/pr-branch' on 'main!'""")
 Creating commit...
     Found 1 commit...
 Rebasing 'eng/pr-branch' on 'main'...
-Rebased 'eng/pr-branch' on 'main!'""")
+Rebased 'eng/pr-branch' on 'main!'
+    Found 1 commit...""")
 
     def test_github(self):
         with OutputCapture() as captured, mocks.remote.GitHub() as remote, \
@@ -331,6 +333,7 @@ Rebased 'eng/pr-branch' on 'main!'""")
                 '    Found 1 commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
+                "    Found 1 commit...",
                 "Pushing 'eng/pr-branch' to 'fork'...",
                 "Creating pull-request for 'eng/pr-branch'...",
                 "Created 'PR 1 | Created commit'!",
@@ -362,6 +365,7 @@ Rebased 'eng/pr-branch' on 'main!'""")
                 '    Found 1 commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
+                "    Found 1 commit...",
                 "Pushing 'eng/pr-branch' to 'fork'...",
                 "Updating pull-request for 'eng/pr-branch'...",
                 "Updated 'PR 1 | Amended commit'!",
@@ -388,6 +392,7 @@ Rebased 'eng/pr-branch' on 'main!'""")
                 '    Found 1 commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
+                "    Found 1 commit...",
                 "Pushing 'eng/pr-branch' to 'origin'...",
                 "Creating pull-request for 'eng/pr-branch'...",
                 "Created 'PR 1 | Created commit'!",
@@ -420,6 +425,7 @@ Rebased 'eng/pr-branch' on 'main!'""")
                 '    Found 1 commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
+                "    Found 1 commit...",
                 "Pushing 'eng/pr-branch' to 'origin'...",
                 "Updating pull-request for 'eng/pr-branch'...",
                 "Updated 'PR 1 | Amended commit'!",


### PR DESCRIPTION
#### bd80caa82ef1d6162ac1b69e33e3034a3c87694d
<pre>
[webkitscmpy] Add fetch and rebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=232447">https://bugs.webkit.org/show_bug.cgi?id=232447</a>
&lt;rdar://problem/84770221 &gt;

Reviewed by Dewei Zhu.

To land commits, we need to be able to rebase a branch against another.
Additionally, when rebasing, we need to discard stale cache bits. This
is also true when pulling and rebasing against main.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.Cache.clear): Clear cache of a specific branch.
(Git.rebase): Rebase a branch on top of another.
(Git.fetch): Fetch specific branch ref.
(Git.pull): Use generalized fetch command, clear cache for updated branch
if that branch is not the default branch.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Add rebase mock.
(Git.rebase):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.main): Recompute branch-point after rebase.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(test_rebase):
</pre>