### PR TITLE
[webkitscmpy] Reduce autoinstalls on import

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,18 @@
+2021-11-02  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitscmpy] Reduce autoinstalls on import
+        https://bugs.webkit.org/show_bug.cgi?id=232574
+        <rdar://problem/84894275>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Remove whichcraft (webkitcorepy registers it).
+        * Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py: Remove unused webkitscmpy imports.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py: Remote unused webkitcorepy import.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py: Move whichcraft to function.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py: Move jinja2 to function.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py: Move fasteners, xmltodict import to functions.
+
 2021-11-02  Tim Horton  <timothy_horton@apple.com>
 
         dumpAsText() tests don't get the ref-test treatment when using --self-compare-with-header

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -51,7 +51,6 @@ version = Version(2, 2, 23)
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
-AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
 AutoInstall.register(Package('markupsafe', Version(1, 1, 1), pypi_name='MarkupSafe'))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -35,7 +35,7 @@ from collections import defaultdict
 
 from webkitcorepy import run, decorators, NestedFuzzyDict
 from webkitscmpy.local import Scm
-from webkitscmpy import remote, Commit, Contributor, log
+from webkitscmpy import remote
 from webkitscmpy import Commit, Contributor, log
 
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -25,7 +25,6 @@ import os
 import re
 import six
 
-from webkitcorepy import run
 from webkitscmpy import ScmBase, Contributor
 
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -29,7 +29,6 @@ import time
 
 from webkitcorepy import Terminal
 from webkitscmpy.commit import Commit
-from whichcraft import which
 
 
 class Command(object):
@@ -104,6 +103,8 @@ class FilteredCommand(Command):
 
     @classmethod
     def pager(cls, args, repository, file=None, **kwargs):
+        from whichcraft import which
+
         if not repository.path:
             sys.stderr.write("Cannot run '{}' on remote repository\n".format(cls.name))
             return 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -25,7 +25,6 @@ import requests
 import sys
 
 from .command import Command
-from jinja2 import Template
 from requests.auth import HTTPBasicAuth
 from webkitcorepy import arguments, run, Editor, Terminal
 from webkitscmpy import log, local, remote
@@ -155,6 +154,7 @@ class Setup(Command):
                     continue
                 log.warning('Configuring and copying hook {}'.format(source_path))
                 with open(source_path, 'r') as f:
+                    from jinja2 import Template
                     contents = Template(f.read()).render(
                         git=local.Git.executable(),
                         location=source_path,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
@@ -22,13 +22,11 @@
 
 import bisect
 import calendar
-import fasteners
 import json
 import os
 import re
 import requests
 import tempfile
-import xmltodict
 
 from datetime import datetime
 
@@ -100,6 +98,8 @@ class Svn(Scm):
 
     @decorators.Memoize(cached=False)
     def info(self, branch=None, revision=None, tag=None):
+        import xmltodict
+
         if tag and branch:
             raise ValueError('Cannot specify both branch and tag')
         if tag and revision:
@@ -163,6 +163,8 @@ class Svn(Scm):
         return 'trunk'
 
     def list(self, category):
+        import xmltodict
+
         revision = self._latest()
         if not revision:
             return []
@@ -203,6 +205,7 @@ class Svn(Scm):
         return self.list('tags')
 
     def _cache_lock(self):
+        import fasteners
         return fasteners.InterProcessLock(os.path.join(os.path.dirname(self._cache_path), 'cache.lock'))
 
     def _cache_revisions(self, branch=None):
@@ -282,6 +285,8 @@ class Svn(Scm):
         return self._metadata_cache[branch]
 
     def _branch_for(self, revision):
+        import xmltodict
+
         response = requests.request(
             method='REPORT',
             url='{}!svn/rvr/{}'.format(self.url, revision),
@@ -332,6 +337,8 @@ class Svn(Scm):
         return self._commit_count(revision=self._metadata_cache[branch][0], branch=self.default_branch)
 
     def commit(self, hash=None, revision=None, identifier=None, branch=None, tag=None, include_log=True, include_identifier=True):
+        import xmltodict
+
         if hash:
             raise ValueError('SVN does not support Git hashes')
 
@@ -456,6 +463,8 @@ class Svn(Scm):
         )
 
     def _args_from_content(self, content, include_log=True):
+        import xmltodict
+
         xml = xmltodict.parse(content)
         date = datetime.strptime(string_utils.decode(xml['S:log-item']['S:date']).split('.')[0], '%Y-%m-%dT%H:%M:%S')
         name = string_utils.decode(xml['S:log-item']['D:creator-displayname'])


### PR DESCRIPTION
#### 7c8293e6d4d1879271b238a89607492c4acc6125
<pre>
[webkitscmpy] Reduce autoinstalls on import
<a href="https://bugs.webkit.org/show_bug.cgi?id=232574">https://bugs.webkit.org/show_bug.cgi?id=232574</a>
&lt;rdar://problem/84894275 &gt;

Reviewed by NOBODY (OOPS!).

* Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Remove whichcraft (webkitcorepy registers it).
* Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py: Remove unused webkitscmpy imports.
* Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py: Remote unused webkitcorepy import.
* Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py: Move whichcraft to function.
* Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py: Move jinja2 to function.
* Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py: Move fasteners, xmltodict import to functions.
</pre>