### PR TITLE
[webkitcorepy] six is part of the Python standard library

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,16 @@
 2021-11-02  Jonathan Bedard  <jbedard@apple.com>
 
+        [webkitcorepy] six is part of the Python standard library
+        https://bugs.webkit.org/show_bug.cgi?id=232625
+        <rdar://problem/84931857>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitcorepy/setup.py: Exclude six, bump version.
+        * Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
+
+2021-11-02  Jonathan Bedard  <jbedard@apple.com>
+
         [webkitscmpy] Generalize pull-request title generation.
         https://bugs.webkit.org/show_bug.cgi?id=232463
         <rdar://problem/84784354>

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.11.3',
+    version='0.11.4',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[
@@ -56,7 +56,6 @@ setup(
     install_requires=[
         'mock',
         'requests',
-        'six',
         'tblib',
         'whichcraft',
     ],

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -43,7 +43,7 @@ from webkitcorepy.call_by_need import CallByNeed
 from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 
-version = Version(0, 11, 3)
+version = Version(0, 11, 4)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):
@@ -66,7 +66,6 @@ AutoInstall.register(Package('pyparsing', Version(2, 4, 7)))
 AutoInstall.register(Package('requests', Version(2, 24)))
 AutoInstall.register(Package('setuptools_scm', Version(5, 0, 2), pypi_name='setuptools-scm'))
 AutoInstall.register(Package('socks', Version(1, 7, 1), pypi_name='PySocks'))
-AutoInstall.register(Package('six', Version(1, 15, 0)))
 AutoInstall.register(Package('tblib', Version(1, 7, 0)))
 AutoInstall.register(Package('urllib3', Version(1, 25, 10)))
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))


### PR DESCRIPTION
#### 55f4a9ce14e9eba0a6894b3b67a32c644be95858
<pre>
[webkitcorepy] six is part of the Python standard library
<a href="https://bugs.webkit.org/show_bug.cgi?id=232625">https://bugs.webkit.org/show_bug.cgi?id=232625</a>
&lt;rdar://problem/84931857 &gt;

Reviewed by NOBODY (OOPS!).

* Scripts/libraries/webkitcorepy/setup.py: Exclude six, bump version.
* Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
</pre>