### PR TITLE
[run-webkit-websocketserver] Replace `/usr/bin/python` with `/usr/bin/env python`

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,15 @@
+2021-11-04  Jonathan Bedard  <jbedard@apple.com>
+
+        [run-webkit-websocketserver] Replace `/usr/bin/python` with `/usr/bin/env python`
+        https://bugs.webkit.org/show_bug.cgi?id=232713
+        <rdar://problem/85019074>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/run-webkit-websocketserver:
+        (openWebSocketServer):
+        (closeWebSocketServer):
+
 2021-11-04  Andres Gonzalez  <andresg_22@apple.com>
 
         Fix for crashes in layout tests in AX isolated tree mode.

--- a/Tools/Scripts/run-webkit-websocketserver
+++ b/Tools/Scripts/run-webkit-websocketserver
@@ -71,7 +71,7 @@ sub openWebSocketServer()
         "--root", "$webSocketHandlerDir",
         "--pidfile", "$webSocketServerPidFile"
     );
-    system "/usr/bin/python", @args;
+    system "/usr/bin/env python", @args;
 }
 
 sub closeWebSocketServer()
@@ -81,7 +81,7 @@ sub closeWebSocketServer()
         "--server", "stop",
         "--pidfile", "$webSocketServerPidFile"
     );
-    system "/usr/bin/python", @args;
+    system "/usr/bin/env python", @args;
     unlink "$webSocketServerPidFile";
 }
 


### PR DESCRIPTION
#### 384ac3db68beaccedd4f4818752c7e9c63384fae
<pre>
[run-webkit-websocketserver] Replace `/usr/bin/python` with `/usr/bin/env python`
<a href="https://bugs.webkit.org/show_bug.cgi?id=232713">https://bugs.webkit.org/show_bug.cgi?id=232713</a>
&lt;rdar://problem/85019074 &gt;

Reviewed by NOBODY (OOPS!).

* Scripts/run-webkit-websocketserver:
(openWebSocketServer):
(closeWebSocketServer):
</pre>