### PR TITLE
[generate-webkit-css-docs] Change shebang to Python 3

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,15 @@
+2021-11-04  Jonathan Bedard  <jbedard@apple.com>
+
+        [generate-webkit-css-docs] Change shebang to Python 3
+        https://bugs.webkit.org/show_bug.cgi?id=232714
+        <rdar://problem/85019719>
+
+        Reviewed by Ryan Haddad.
+
+        * Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py: Bump version.
+        * Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/generate-webkit-css-docs: Use Python 3 shebang.
+        * Scripts/libraries/resultsdbpy/setup.py: Bump version.
+
 2021-11-04  Andres Gonzalez  <andresg_22@apple.com>
 
         Fix for crashes in layout tests in AX isolated tree mode.

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(3, 1, 2)
+version = Version(3, 1, 3)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/generate-webkit-css-docs
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/generate-webkit-css-docs
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-# Copyright (C) 2019 Apple Inc. All rights reserved.
+#!/usr/bin/env python3
+# Copyright (C) 2019-2021 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Tools/Scripts/libraries/resultsdbpy/setup.py
+++ b/Tools/Scripts/libraries/resultsdbpy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='resultsdbpy',
-    version='3.1.2',
+    version='3.1.3',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 244d41322ba0cc46324b433484efed21e2d24101
<pre>
[generate-webkit-css-docs] Change shebang to Python 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=232714">https://bugs.webkit.org/show_bug.cgi?id=232714</a>
&lt;rdar://problem/85019719 &gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py: Bump version.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/library/css/generate-webkit-css-docs: Use Python 3 shebang.
* Tools/Scripts/libraries/resultsdbpy/setup.py: Bump version.
</pre>