### PR TITLE
[steps.py] Update macOS versions in build_to_name_mapping

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1207,18 +1207,9 @@ class PrintConfiguration(steps.ShellSequence):
             return 'Unknown'
 
         build_to_name_mapping = {
+            '12': 'Monterey',
             '11': 'Big Sur',
             '10.15': 'Catalina',
-            '10.14': 'Mojave',
-            '10.13': 'High Sierra',
-            '10.12': 'Sierra',
-            '10.11': 'El Capitan',
-            '10.10': 'Yosemite',
-            '10.9': 'Maverick',
-            '10.8': 'Mountain Lion',
-            '10.7': 'Lion',
-            '10.6': 'Snow Leopard',
-            '10.5': 'Leopard',
         }
 
         for key, value in build_to_name_mapping.items():

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1104,8 +1104,8 @@ class TestPrintConfiguration(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_success_mac(self):
         self.setupStep(PrintConfiguration())
-        self.setProperty('buildername', 'macOS-High-Sierra-Release-WK2-Tests-EWS')
-        self.setProperty('platform', 'mac-highsierra')
+        self.setProperty('buildername', 'macOS-Monterey-Release-WK2-Tests-EWS')
+        self.setProperty('platform', 'mac-monterey')
 
         self.expectRemoteCommands(
             ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
@@ -1118,34 +1118,35 @@ class TestPrintConfiguration(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
             + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
             ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.13.4
-BuildVersion:	17E199'''),
+            + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+ProductVersion:	12.0.1
+BuildVersion:	21A558'''),
             ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
-            + ExpectShell.log('stdio', stdout='''MacOSX10.13.sdk - macOS 10.13 (macosx10.13)
-SDKVersion: 10.13
-Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
-PlatformVersion: 1.1
+            + ExpectShell.log('stdio', stdout='''MacOSX12.0.sdk - macOS 12.0 (macosx12.0)
+SDKVersion: 12.0
+Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk
+PlatformVersion: 12.0
 PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
-ProductBuildVersion: 17E189
-ProductCopyright: 1983-2018 Apple Inc.
-ProductName: Mac OS X
-ProductUserVisibleVersion: 10.13.4
-ProductVersion: 10.13.4
+ProductBuildVersion: 21A344
+ProductCopyright: 1983-2021 Apple Inc.
+ProductName: macOS
+ProductUserVisibleVersion: 12.0
+ProductVersion: 12.0
+iOSSupportVersion: 15.0
 
-Xcode 9.4.1
-Build version 9F2000''')
+Xcode 13.1
+Build version 13A1030d''')
             + 0,
             ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
             + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
         )
-        self.expectOutcome(result=SUCCESS, state_string='OS: High Sierra (10.13.4), Xcode: 9.4.1')
+        self.expectOutcome(result=SUCCESS, state_string='OS: Monterey (12.0.1), Xcode: 13.1')
         return self.runStep()
 
     def test_success_ios_simulator(self):
         self.setupStep(PrintConfiguration())
-        self.setProperty('buildername', 'macOS-Sierra-Release-WK2-Tests-EWS')
-        self.setProperty('platform', 'ios-simulator-12')
+        self.setProperty('buildername', 'Apple-iOS-15-Simulator-Release-WK2-Tests')
+        self.setProperty('platform', 'ios-simulator-15')
 
         self.expectRemoteCommands(
             ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
@@ -1158,28 +1159,28 @@ Build version 9F2000''')
             ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
             + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
             ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.15.6
-BuildVersion:	19H2'''),
+            + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+ProductVersion:	11.6
+BuildVersion:	20G165'''),
             ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
-            + ExpectShell.log('stdio', stdout='''iPhoneSimulator13.4.sdk - Simulator - iOS 13.4 (iphonesimulator13.4)
-SDKVersion: 13.4
-Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk
-PlatformVersion: 13.4
+            + ExpectShell.log('stdio', stdout='''iPhoneSimulator15.0.sdk - Simulator - iOS 15.0 (iphonesimulator15.0)
+SDKVersion: 15.0
+Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.0.sdk
+PlatformVersion: 15.0
 PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform
-BuildID: BB4C82AE-5F8A-11EA-A1A5-838AD03DDE06
-ProductBuildVersion: 17E255
-ProductCopyright: 1983-2020 Apple Inc.
+BuildID: 84856584-0587-11EC-B99C-6807972BB3D4
+ProductBuildVersion: 19A339
+ProductCopyright: 1983-2021 Apple Inc.
 ProductName: iPhone OS
-ProductVersion: 13.4
+ProductVersion: 15.0
 
-Xcode 11.7
-Build version 10E125''')
+Xcode 13.0
+Build version 13A233''')
             + 0,
             ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
             + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
         )
-        self.expectOutcome(result=SUCCESS, state_string='OS: Catalina (10.15.6), Xcode: 11.7')
+        self.expectOutcome(result=SUCCESS, state_string='OS: Big Sur (11.6), Xcode: 13.0')
         return self.runStep()
 
     def test_success_webkitpy(self):
@@ -1191,15 +1192,15 @@ Build version 10E125''')
             ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
             ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
             ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.13.6
-BuildVersion:	17G7024'''),
+            + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+ProductVersion:	11.6
+BuildVersion:	20G165'''),
             ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''Xcode 10.2\nBuild version 10E125'''),
+            + ExpectShell.log('stdio', stdout='''Xcode 13.0\nBuild version 13A233'''),
             ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
             + ExpectShell.log('stdio', stdout=' 6:31  up 22 seconds, 12:05, 2 users, load averages: 3.17 7.23 5.45'),
         )
-        self.expectOutcome(result=SUCCESS, state_string='OS: High Sierra (10.13.6), Xcode: 10.2')
+        self.expectOutcome(result=SUCCESS, state_string='OS: Big Sur (11.6), Xcode: 13.0')
         return self.runStep()
 
     def test_success_linux_wpe(self):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3193,18 +3193,9 @@ class PrintConfiguration(steps.ShellSequence):
             return 'Unknown'
 
         build_to_name_mapping = {
+            '12': 'Monterey',
             '11': 'Big Sur',
             '10.15': 'Catalina',
-            '10.14': 'Mojave',
-            '10.13': 'High Sierra',
-            '10.12': 'Sierra',
-            '10.11': 'El Capitan',
-            '10.10': 'Yosemite',
-            '10.9': 'Maverick',
-            '10.8': 'Mountain Lion',
-            '10.7': 'Lion',
-            '10.6': 'Snow Leopard',
-            '10.5': 'Leopard',
         }
 
         for key, value in build_to_name_mapping.items():

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3800,105 +3800,108 @@ class TestPrintConfiguration(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
-    def test_success_mac(self):
-        self.setupStep(PrintConfiguration())
-        self.setProperty('buildername', 'macOS-High-Sierra-Release-WK2-Tests-EWS')
-        self.setProperty('platform', 'mac-highsierra')
+        def test_success_mac(self):
+            self.setupStep(PrintConfiguration())
+            self.setProperty('buildername', 'macOS-Monterey-Release-WK2-Tests-EWS')
+            self.setProperty('platform', 'mac-monterey')
 
-        self.expectRemoteCommands(
-            ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='ews150.apple.com'),
-            ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''Filesystem     Size   Used  Avail Capacity iused  ifree %iused  Mounted on
-/dev/disk1s1  119Gi   95Gi   23Gi    81%  937959 9223372036853837848    0%   /
-/dev/disk1s4  119Gi   20Ki   23Gi     1%       0 9223372036854775807    0%   /private/var/vm
-/dev/disk0s3  119Gi   22Gi   97Gi    19%  337595          4294629684    0%   /Volumes/Data'''),
-            ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
-            ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.13.4
-BuildVersion:	17E199'''),
-            ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
-            + ExpectShell.log('stdio', stdout='''MacOSX10.13.sdk - macOS 10.13 (macosx10.13)
-SDKVersion: 10.13
-Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
-PlatformVersion: 1.1
-PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
-ProductBuildVersion: 17E189
-ProductCopyright: 1983-2018 Apple Inc.
-ProductName: Mac OS X
-ProductUserVisibleVersion: 10.13.4
-ProductVersion: 10.13.4
+            self.expectRemoteCommands(
+                ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='ews150.apple.com'),
+                ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''Filesystem     Size   Used  Avail Capacity iused  ifree %iused  Mounted on
+    /dev/disk1s1  119Gi   95Gi   23Gi    81%  937959 9223372036853837848    0%   /
+    /dev/disk1s4  119Gi   20Ki   23Gi     1%       0 9223372036854775807    0%   /private/var/vm
+    /dev/disk0s3  119Gi   22Gi   97Gi    19%  337595          4294629684    0%   /Volumes/Data'''),
+                ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
+                ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+    ProductVersion:	12.0.1
+    BuildVersion:	21A558'''),
+                ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
+                + ExpectShell.log('stdio', stdout='''MacOSX12.0.sdk - macOS 12.0 (macosx12.0)
+    SDKVersion: 12.0
+    Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk
+    PlatformVersion: 12.0
+    PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
+    ProductBuildVersion: 21A344
+    ProductCopyright: 1983-2021 Apple Inc.
+    ProductName: macOS
+    ProductUserVisibleVersion: 12.0
+    ProductVersion: 12.0
+    iOSSupportVersion: 15.0
 
-Xcode 9.4.1
-Build version 9F2000''')
-            + 0,
-            ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
-        )
-        self.expectOutcome(result=SUCCESS, state_string='OS: High Sierra (10.13.4), Xcode: 9.4.1')
-        return self.runStep()
+    Xcode 13.1
+    Build version 13A1030d''')
+                + 0,
+                ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
+            )
+            self.expectOutcome(result=SUCCESS, state_string='OS: Monterey (12.0.1), Xcode: 13.1')
+            return self.runStep()
 
-    def test_success_ios_simulator(self):
-        self.setupStep(PrintConfiguration())
-        self.setProperty('buildername', 'macOS-Sierra-Release-WK2-Tests-EWS')
-        self.setProperty('platform', 'ios-simulator-12')
+        def test_success_ios_simulator(self):
+            self.setupStep(PrintConfiguration())
+            self.setProperty('buildername', 'Apple-iOS-15-Simulator-Release-WK2-Tests')
+            self.setProperty('platform', 'ios-simulator-15')
 
-        self.expectRemoteCommands(
-            ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='ews152.apple.com'),
-            ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''Filesystem     Size   Used  Avail Capacity iused  ifree %iused  Mounted on
-/dev/disk1s1  119Gi   95Gi   23Gi    81%  937959 9223372036853837848    0%   /
-/dev/disk1s4  119Gi   20Ki   23Gi     1%       0 9223372036854775807    0%   /private/var/vm
-/dev/disk0s3  119Gi   22Gi   97Gi    19%  337595          4294629684    0%   /Volumes/Data'''),
-            ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
-            ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.15.6
-BuildVersion:	19H2'''),
-            ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
-            + ExpectShell.log('stdio', stdout='''iPhoneSimulator13.4.sdk - Simulator - iOS 13.4 (iphonesimulator13.4)
-SDKVersion: 13.4
-Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk
-PlatformVersion: 13.4
-PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform
-BuildID: BB4C82AE-5F8A-11EA-A1A5-838AD03DDE06
-ProductBuildVersion: 17E255
-ProductCopyright: 1983-2020 Apple Inc.
-ProductName: iPhone OS
-ProductVersion: 13.4
+            self.expectRemoteCommands(
+                ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='ews152.apple.com'),
+                ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''Filesystem     Size   Used  Avail Capacity iused  ifree %iused  Mounted on
+    /dev/disk1s1  119Gi   95Gi   23Gi    81%  937959 9223372036853837848    0%   /
+    /dev/disk1s4  119Gi   20Ki   23Gi     1%       0 9223372036854775807    0%   /private/var/vm
+    /dev/disk0s3  119Gi   22Gi   97Gi    19%  337595          4294629684    0%   /Volumes/Data'''),
+                ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
+                ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+    ProductVersion:	11.6
+    BuildVersion:	20G165'''),
+                ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False)
+                + ExpectShell.log('stdio', stdout='''iPhoneSimulator15.0.sdk - Simulator - iOS 15.0 (iphonesimulator15.0)
+    SDKVersion: 15.0
+    Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.0.sdk
+    PlatformVersion: 15.0
+    PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform
+    BuildID: 84856584-0587-11EC-B99C-6807972BB3D4
+    ProductBuildVersion: 19A339
+    ProductCopyright: 1983-2021 Apple Inc.
+    ProductName: iPhone OS
+    ProductVersion: 15.0
 
-Xcode 11.7
-Build version 10E125''')
-            + 0,
-            ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
-        )
-        self.expectOutcome(result=SUCCESS, state_string='OS: Catalina (10.15.6), Xcode: 11.7')
-        return self.runStep()
+    Xcode 13.0
+    Build version 13A233''')
+                + 0,
+                ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout=' 6:31  up 1 day, 19:05, 24 users, load averages: 4.17 7.23 5.45'),
+            )
+            self.expectOutcome(result=SUCCESS, state_string='OS: Big Sur (11.6), Xcode: 13.0')
+            return self.runStep()
 
-    def test_success_webkitpy(self):
-        self.setupStep(PrintConfiguration())
-        self.setProperty('platform', '*')
+        def test_success_webkitpy(self):
+            self.setupStep(PrintConfiguration())
+            self.setProperty('platform', '*')
 
-        self.expectRemoteCommands(
-            ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
-            ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
-            ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
-            ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''ProductName:	Mac OS X
-ProductVersion:	10.13.6
-BuildVersion:	17G7024'''),
-            ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout='''Xcode 10.2\nBuild version 10E125'''),
-            ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
-            + ExpectShell.log('stdio', stdout=' 6:31  up 22 seconds, 12:05, 2 users, load averages: 3.17 7.23 5.45'),
-        )
-        self.expectOutcome(result=SUCCESS, state_string='OS: High Sierra (10.13.6), Xcode: 10.2')
-        return self.runStep()
+            self.expectRemoteCommands(
+                ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
+                ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
+                ExpectShell(command=['date'], workdir='wkdir', timeout=60, logEnviron=False) + 0,
+                ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''ProductName:	macOS
+    ProductVersion:	11.6
+    BuildVersion:	20G165'''),
+                ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60,
+                            logEnviron=False) + 0
+                + ExpectShell.log('stdio', stdout='''Xcode 13.0\nBuild version 13A233'''),
+                ExpectShell(command=['uptime'], workdir='wkdir', timeout=60, logEnviron=False) + 0
+                + ExpectShell.log('stdio',
+                                  stdout=' 6:31  up 22 seconds, 12:05, 2 users, load averages: 3.17 7.23 5.45'),
+            )
+            self.expectOutcome(result=SUCCESS, state_string='OS: Big Sur (11.6), Xcode: 13.0')
+            return self.runStep()
 
     def test_success_linux_wpe(self):
         self.setupStep(PrintConfiguration())

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,17 @@
+2021-11-04  Ryan Haddad  <ryanhaddad@apple.com>
+
+        [steps.py] Update macOS versions in build_to_name_mapping
+        https://bugs.webkit.org/show_bug.cgi?id=232732
+
+        Reviewed by NOBODY (OOPS!).
+
+        * CISupport/ews-build/steps.py:
+        (PrintConfiguration.convert_build_to_os_name):
+        * CISupport/ews-build/steps_unittest.py:
+        * CISupport/build-webkit-org/steps.py:
+        (PrintConfiguration.convert_build_to_os_name):
+        * CISupport/build-webkit-org/steps_unittest.py:
+
 2021-11-03  Jonathan Bedard  <jbedard@apple.com>
 
         [git-webkit] Add land command


### PR DESCRIPTION
#### caf08f3a4d242d8e6e36787b44da21e6c186acef
<pre>
[steps.py] Update macOS versions in build_to_name_mapping
<a href="https://bugs.webkit.org/show_bug.cgi?id=232732">https://bugs.webkit.org/show_bug.cgi?id=232732</a>

Reviewed by NOBODY (OOPS!).

* CISupport/ews-build/steps.py:
(PrintConfiguration.convert_build_to_os_name):
* CISupport/ews-build/steps_unittest.py:
* CISupport/build-webkit-org/steps.py:
(PrintConfiguration.convert_build_to_os_name):
* CISupport/build-webkit-org/steps_unittest.py:
</pre>