### PR TITLE
[EWS] Never retry no-change build for pull-requests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -59,6 +59,7 @@ Interpolate = properties.Interpolate
 GITHUB_URL = 'https://github.com/'
 GITHUB_PROJECTS = ['WebKit/WebKit']
 HASH_LENGTH_TO_DISPLAY = 8
+RETRY_PRS = False
 
 
 class BufferLogHeaderObserver(logobserver.BufferLogObserver):
@@ -2766,7 +2767,7 @@ class ReRunWebKitTests(RunWebKitTests):
                                                 UnApplyPatch(),
                                                 RevertPullRequestChanges(),
                                                 ValidateChange(verifyBugClosed=False, addURLs=False),
-                                                CompileWebKitWithoutChange(retry_build_on_failure=True),
+                                                CompileWebKitWithoutChange(retry_build_on_failure=bool(self.getProperty('patch_id')) or RETRY_PRS),
                                                 ValidateChange(verifyBugClosed=False, addURLs=False),
                                                 KillOldProcesses(),
                                                 RunWebKitTestsWithoutChange()])
@@ -3116,7 +3117,7 @@ class RunWebKitTestsRedTree(RunWebKitTests):
                 next_steps.extend([
                     UnApplyPatch(),
                     RevertPullRequestChanges(),
-                    CompileWebKitWithoutChange(retry_build_on_failure=True),
+                    CompileWebKitWithoutChange(retry_build_on_failure=bool(self.getProperty('patch_id')) or RETRY_PRS),
                     ValidateChange(verifyBugClosed=False, addURLs=False),
                     RunWebKitTestsWithoutChangeRedTree(),
                 ])
@@ -3153,7 +3154,7 @@ class RunWebKitTestsRepeatFailuresRedTree(RunWebKitTestsRedTree):
                 KillOldProcesses(),
                 UnApplyPatch(),
                 RevertPullRequestChanges(),
-                CompileWebKitWithoutChange(retry_build_on_failure=True),
+                CompileWebKitWithoutChange(retry_build_on_failure=bool(self.getProperty('patch_id')) or RETRY_PRS),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
                 RunWebKitTestsRepeatFailuresWithoutPatchRedTree(),
             ])
@@ -3580,7 +3581,7 @@ class ReRunAPITests(RunAPITests):
                 steps_to_add.append(InstallWpeDependencies())
             elif platform == 'gtk':
                 steps_to_add.append(InstallGtkDependencies())
-            steps_to_add.append(CompileWebKitWithoutChange(retry_build_on_failure=True))
+            steps_to_add.append(CompileWebKitWithoutChange(retry_build_on_failure=bool(self.getProperty('patch_id')) or RETRY_PRS))
             steps_to_add.append(ValidateChange(verifyBugClosed=False, addURLs=False))
             steps_to_add.append(KillOldProcesses())
             steps_to_add.append(RunAPITestsWithoutPatch())

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,20 @@
+2022-02-02  Jonathan Bedard  <jbedard@apple.com>
+
+        [EWS] Never retry no-change build for pull-requests
+        https://bugs.webkit.org/show_bug.cgi?id=236046
+        <rdar://problem/88408671>
+
+        Reviewed by NOBODY (OOPS!).
+
+        Pull-requests are not automatically rebased in EWS, so if a build fails on a specific
+        commit, a retry is unlikely to rectify the situation.
+
+        * CISupport/ews-build/steps.py:
+        (ReRunWebKitTests.evaluateCommand):
+        (RunWebKitTestsRedTree.evaluateCommand):
+        (RunWebKitTestsRepeatFailuresRedTree.evaluateCommand):
+        (ReRunAPITests.evaluateCommand):
+
 2022-02-08  Philippe Normand  <pnormand@igalia.com>
 
         [GStreamer] Test webkit/WebKitWebView/display-usermedia-permission-request times out


### PR DESCRIPTION
#### 61fdbc23a37f16473180863ad571bfa5b754361f
<pre>
[EWS] Never retry no-change build for pull-requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=236046">https://bugs.webkit.org/show_bug.cgi?id=236046</a>
&lt;rdar://problem/88408671 &gt;

Reviewed by NOBODY (OOPS!).

Pull-requests are not automatically rebased in EWS, so if a build fails on a specific
commit, a retry is unlikely to rectify the situation.

* Tools/CISupport/ews-build/steps.py:
(ReRunWebKitTests.evaluateCommand):
(RunWebKitTestsRedTree.evaluateCommand):
(RunWebKitTestsRepeatFailuresRedTree.evaluateCommand):
(ReRunAPITests.evaluateCommand):
</pre>