### PR TITLE
[git-webkit] Prompt user for bugzilla credentials during setup

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,17 @@
+2022-02-15  Jonathan Bedard  <jbedard@apple.com>
+
+        [git-webkit] Prompt user for bugzilla credentials during setup
+        https://bugs.webkit.org/show_bug.cgi?id=236659
+        <rdar://problem/88980650>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitcorepy/webkitcorepy/credentials.py:
+        (credentials): Store credentials under "bugs.webkit.org" instead of "https://bugs.webkit.org"
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
+        (Setup.git): Prompt user for bugzilla credentials.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
+
 2022-03-29  Alex Christensen  <achristensen@webkit.org>
 
         Don't create directories on iOS if we are only using ephemeral storages

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/credentials.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/credentials.py
@@ -33,6 +33,7 @@ def credentials(url, required=True, name=None, prompt=None, key_name='password',
     global _cache
 
     name = name or url.split('/')[2].replace('.', '_')
+    hostname = url.split('//')[-1]
     if _cache.get(name):
         return _cache.get(name)
 
@@ -58,7 +59,7 @@ def credentials(url, required=True, name=None, prompt=None, key_name='password',
         if not username:
             try:
                 if keyring and not attempt:
-                    username = keyring.get_password(url, 'username')
+                    username = keyring.get_password(hostname, 'username')
             except (RuntimeError, AttributeError):
                 pass
 
@@ -75,7 +76,7 @@ def credentials(url, required=True, name=None, prompt=None, key_name='password',
         if not key and username:
             try:
                 if keyring and not attempt:
-                    key = keyring.get_password(url, username)
+                    key = keyring.get_password(hostname, username)
             except (RuntimeError, AttributeError):
                 pass
 
@@ -103,12 +104,12 @@ def credentials(url, required=True, name=None, prompt=None, key_name='password',
 
     if keyring and (username_prompted or key_prompted):
         if save_in_keyring or (save_in_keyring is None and Terminal.choose(
-            'Store username and {} in system keyring for {}?'.format(key_name, url),
+            'Store username and {} in system keyring for {}?'.format(key_name, hostname),
             default='Yes',
         ) == 'Yes'):
             sys.stderr.write('Storing credentials...\n')
-            keyring.set_password(url, 'username', username)
-            keyring.set_password(url, username, key)
+            keyring.set_password(hostname, 'username', username)
+            keyring.set_password(hostname, username, key)
         else:
             sys.stderr.write('Credentials cached in process.\n')
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -26,6 +26,7 @@ import sys
 
 from .command import Command
 from requests.auth import HTTPBasicAuth
+from webkitbugspy import Tracker
 from webkitcorepy import arguments, run, Editor, Terminal
 from webkitscmpy import log, local, remote
 
@@ -249,6 +250,15 @@ class Setup(Command):
             else:
                 # Force reset cache
                 repository.url(cached=False)
+
+        # Bug trackers often require credentials, prompt the user for those if applicable
+        default_tracker = Tracker.instance()
+        if default_tracker and hasattr(default_tracker, 'credentials') and hasattr(default_tracker, 'url'):
+            log.info("Verifying {} credentials...".format(default_tracker.url.split('\\')[-1]))
+            try:
+                default_tracker.credentials(required=True, validate=True)
+            except SystemExit:
+                sys.stderr.write('Failed to determine {} credentials, continuing\n'.format(default_tracker.url.split('\\')[-1]))
 
         # Any additional setup passed to main
         if additional_setup:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -24,6 +24,8 @@ import logging
 import os
 import sys
 
+from mock import patch
+from webkitbugspy import bugzilla
 from webkitcorepy import Editor, OutputCapture, testing, mocks as wkmocks
 from webkitcorepy.mocks import Terminal as MockTerminal
 from webkitscmpy import local, program, mocks
@@ -78,7 +80,7 @@ Created a private fork of 'WebKit' belonging to 'username'!
     def test_git(self):
         self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, \
-            mocks.local.Svn(), wkmocks.Environment(EMAIL_ADDRESS=''):
+            mocks.local.Svn(), wkmocks.Environment(EMAIL_ADDRESS=''), patch('webkitbugspy.Tracker._trackers', []):
 
             self.assertEqual(0, program.main(
                 args=('setup', '--defaults', '-v'),
@@ -120,7 +122,9 @@ Using the default git editor for this repository
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, \
             MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'disabled', '1', 'y', 'y'), \
             mocks.local.Git(self.path, remote='https://{}.git'.format(remote.remote)) as repo, \
-            wkmocks.Environment(EMAIL_ADDRESS=''):
+            wkmocks.Environment(
+                EMAIL_ADDRESS='', BUGS_EXAMPLE_COM_USERNAME='username', BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker('https://bugs.example.com')]):
 
             self.assertEqual('https://github.example.com/WebKit/WebKit.git', local.Git(self.path).url())
 
@@ -175,6 +179,7 @@ Set better Objective-C diffing behavior for this repository!
 Using a rebase merge strategy for this repository
 Setting git editor for {repository}...
 Using the default git editor for this repository
+Verifying https://bugs.example.com credentials...
 Saving GitHub credentials in system credential store...
 GitHub credentials saved via Keyring!
 Verifying user owned fork...


### PR DESCRIPTION
#### 1957c7470eb18d40f7b32969e9146d1af91b76ad
<pre>
[git-webkit] Prompt user for bugzilla credentials during setup
<a href="https://bugs.webkit.org/show_bug.cgi?id=236659">https://bugs.webkit.org/show_bug.cgi?id=236659</a>
&lt;rdar://problem/88980650 &gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/credentials.py:
(credentials): Store credentials under &quot;bugs.webkit.org&quot; instead of &quot;<a href="https://bugs.webkit.org&quot">https://bugs.webkit.org&quot</a>;
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Prompt user for bugzilla credentials.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
</pre>