### PR TITLE
[reporelaypy] Support credentialed https repositories

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,20 @@
+2022-03-14  Jonathan Bedard  <jbedard@apple.com>
+
+        [reporelaypy] Support credentialed https repositories
+        https://bugs.webkit.org/show_bug.cgi?id=237853
+        <rdar://90252426>
+
+        Reviewed by Ryan Haddad, Dewei Zhu and Stephanie Lewis.
+
+        * Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
+        * Scripts/libraries/reporelaypy/reporelaypy/checkout.py:
+        (Checkout.Encoder.default): Pass credentials.
+        (Checkout.clone): Add credentials to local configuration.
+        (Checkout.add_credentials): Add username to .git/config and populate
+        .git-credentials file appropriately.
+        (Checkout.__init__): Re-add credentials.
+        * Scripts/libraries/reporelaypy/setup.py: Bump version.
+
 2022-03-15  Jonathan Bedard  <jbedard@apple.com>
 
         [Merge-Queue] Rename patch_reviewer

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 4, 1)
+version = Version(0, 4, 2)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
@@ -48,6 +48,7 @@ class Checkout(object):
                 url=obj.url,
                 sentinal=obj.sentinal,
                 remotes=obj.remotes,
+                credentials=obj.credentials,
             )
             if obj.fallback_repository:
                 result['fallback_url'] = obj.fallback_repository.url
@@ -61,11 +62,12 @@ class Checkout(object):
         return cls(**data, primary=False)
 
     @staticmethod
-    def clone(url, path, remotes, sentinal_file=None):
+    def clone(url, path, remotes, credentials, sentinal_file=None):
         run([local.Git.executable(), 'clone', url, path], cwd=os.path.dirname(path))
         run([local.Git.executable(), 'config', 'pull.ff', 'only'], cwd=path)
 
         Checkout.add_remotes(local.Git(path), remotes)
+        Checkout.add_credentials(local.Git(path), credentials)
 
         if sentinal_file:
             with open(sentinal_file, 'w') as cloned:
@@ -77,11 +79,35 @@ class Checkout(object):
         for name, url in (remotes or {}).items():
             run([repository.executable(), 'remote', 'add', name, url], cwd=repository.root_path)
 
-    def __init__(self, path, url=None, http_proxy=None, sentinal=True, fallback_url=None, primary=True, remotes=None):
+    @staticmethod
+    def add_credentials(repository, credentials):
+        git_credentials_content = ''
+
+        for url, creds in (credentials or {}).items():
+            username = creds.get('username')
+            password = creds.get('password')
+            if username:
+                run(
+                    [repository.executable(), 'config', '--local', 'credential.{}.username'.format(url), username],
+                    cwd=repository.root_path,
+                )
+            protocol, host = url.split('://')
+            if username and password and protocol and host:
+                git_credentials_content += '{}://{}:{}@{}\n'.format(protocol, username, password, host)
+
+        if not git_credentials_content:
+            return
+
+        run([repository.executable(), 'config', '--local', 'credential.helper', 'store'], cwd=repository.root_path)
+        with open(os.path.expanduser('~/.git-credentials'), 'w') as f:
+            f.write(git_credentials_content)
+
+    def __init__(self, path, url=None, http_proxy=None, sentinal=True, fallback_url=None, primary=True, remotes=None, credentials=None):
         self.sentinal = sentinal
         self.path = path
         self.url = url
         self.remotes = remotes or dict()
+        self.credentials = credentials or dict()
         self._repository = None
         self._child_process = None
         self.fallback_repository = remote.Scm.from_url(fallback_url) if fallback_url else None
@@ -110,6 +136,7 @@ class Checkout(object):
                     ))
                 if primary:
                     Checkout.add_remotes(self.repository, remotes)
+                    Checkout.add_credentials(self.repository, credentials)
                 return
         except FileNotFoundError:
             pass
@@ -132,7 +159,7 @@ class Checkout(object):
             )
             self._child_process.start()
         else:
-            self.clone(self.url, path, self.remotes)
+            self.clone(self.url, path, self.remotes, self.credentials)
 
     @property
     def sentinal_file(self):

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.4.1',
+    version='0.4.2',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 5f2ae0d4381be04f6ca78f8790a6ee5ae5fd5442
<pre>
[reporelaypy] Support credentialed https repositories
<a href="https://bugs.webkit.org/show_bug.cgi?id=237853">https://bugs.webkit.org/show_bug.cgi?id=237853</a>
&lt;rdar://90252426 &gt;

Reviewed by Ryan Haddad, Dewei Zhu and Stephanie Lewis.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py:
(Checkout.Encoder.default): Pass credentials.
(Checkout.clone): Add credentials to local configuration.
(Checkout.add_credentials): Add username to .git/config and populate
.git-credentials file appropriately.
(Checkout.__init__): Re-add credentials.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkout_unittest.py:
(CheckoutUnittest.test_json):
* Tools/Scripts/libraries/reporelaypy/setup.py: Bump version.


Canonical link: <a href="https://commits.webkit.org/248534@main">https://commits.webkit.org/248534@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@291404">https://svn.webkit.org/repository/webkit/trunk@291404</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>