### PR TITLE
[Merge-Queue] Support multiple reviewers names

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -722,9 +722,9 @@ class ApplyPatch(shell.ShellCommand, CompositeStepMixin, ShellMixin):
             shell.ShellCommand.start(self)
             return None
 
-        reviewer_name = self.getProperty('reviewer_full_name', '')
-        if reviewer_name:
-            self.command.extend(['--reviewer', reviewer_name])
+        reviewers_names = self.getProperty('reviewers_full_names', [])
+        if reviewers_names:
+            self.command.extend(['--reviewer', reviewers_names[0]])
         d = self.downloadFileContentToWorker('.buildbot-diff', patch)
         d.addCallback(lambda res: shell.ShellCommand.start(self))
 
@@ -1516,7 +1516,7 @@ class ValidateCommiterAndReviewer(buildstep.BuildStep):
             self.finished(SUCCESS)
             return None
 
-        self.setProperty('reviewer_full_name', self.full_name_from_email(reviewer))
+        self.setProperty('reviewers_full_names', [self.full_name_from_email(reviewer)])
         if not self.is_reviewer(reviewer):
             self.fail_build(reviewer, 'reviewer')
             return None

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,15 @@
+2022-03-18  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Support multiple reviewers names
+        https://bugs.webkit.org/show_bug.cgi?id=238095
+        <rdar://problem/90503503>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (ApplyPatch.start): Only apply the first reviewer name.
+        (ValidateCommiterAndReviewer.start): Support a list of reviewers.
+
 2022-03-21  Diego Pino Garcia  <dpino@igalia.com>
 
         Unreviewed, fix Debian Stable build after r291543


### PR DESCRIPTION
#### aa3111984a78c6d43f0d1a6f2a6723ddca299dde
<pre>
[Merge-Queue] Support multiple reviewers names
<a href="https://bugs.webkit.org/show_bug.cgi?id=238095">https://bugs.webkit.org/show_bug.cgi?id=238095</a>
&lt;rdar://problem/90503503 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ApplyPatch.start): Only apply the first reviewer name.
(ValidateCommiterAndReviewer.start): Support a list of reviewers.
</pre>