### PR TITLE
[webkitbugspy] Get and set issue component data

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,59 @@
+2022-03-30  Jonathan Bedard  <jbedard@apple.com>
+
+        [webkitbugspy] Get and set issue component data
+        https://bugs.webkit.org/show_bug.cgi?id=238514
+        <rdar://problem/90994542>
+
+        Reviewed by Dewei Zhu.
+
+        * Scripts/libraries/webkitbugspy/setup.py: Bump version.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
+        (Tracker.populate): Populate project, component and version.
+        (Tracker.set): Set project, component and version.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
+        (Tracker.request): github.Tracker has no Exception member. Use RuntimeError instead.
+        (Tracker.populate): Populate labels and then extract component and version.
+        (Tracker.set): Set labels associated with components and versions.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
+        (Issue.__init__): Set _labels, _project, _component and _version values.
+        (Issue.labels): Populate and return labels.
+        (Issue.set_labels): Set labels associated with issue.
+        (Issue.project): Populate and return project.
+        (Issue.component): Populate and return component.
+        (Issue.version): Populate and return version.
+        (Issue.set_component): Set the project, component and version of an issue.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
+        (Bugzilla._issue): Mock setting and returning project, component and version.
+        (Bugzilla._create): Populate project, component and version on creation.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Set values for
+        project, component and version.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py:
+        (GitHub._labels_for_issue): Given an issue, return a list of labels. Take into
+        consideration component and version.
+        (GitHub._issue): Mock label editing and returning.
+        (GitHub._create): Ditto.
+        (GitHub.request): Support request to update labels.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
+        (RadarModel.__init__): Set component.
+        (RadarModel.commit_changes): Commit component changes.
+        (RadarClient.find_components): Implement version filter.
+        (RadarClient.create_radar): Create radar with component details.
+        (Radar.Component.get): Implement dict-like API.
+        (Radar.Component.__getitem__): Ditto.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
+        (Tracker.populate): Get project, component and version.
+        (Tracker.set): Set component information.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
+        (TestBugzilla.test_create):
+        (TestBugzilla.test_create_prompt):
+        * Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
+        (TestGitHub.test_projects):
+        (TestGitHub.test_create_projects):
+        * Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
+        (TestRadar.test_create):
+        (TestRadar.test_create_prompt):
+
 2022-03-30  Sihui Liu  <sihui_liu@apple.com>
 
         Remove -[WKWebsiteDataStore _indexedDBDatabaseDirectory]

--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.4.4',
+    version='0.5.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 4, 4)
+version = Version(0, 5, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -67,6 +67,11 @@ class Issue(object):
         self._comments = None
         self._references = None
 
+        self._labels = None
+        self._project = None
+        self._component = None
+        self._version = None
+
         self.tracker.populate(self, None)
 
     def __str__(self):
@@ -148,6 +153,36 @@ class Issue(object):
 
     def add_comment(self, text):
         return self.tracker.add_comment(self, text)
+
+    @property
+    def labels(self):
+        if self._labels is None:
+            self.tracker.populate(self, 'labels')
+        return self._labels
+
+    def set_labels(self, labels):
+        return self.tracker.set(labels=labels)
+
+    @property
+    def project(self):
+        if self._project is None:
+            self.tracker.populate(self, 'project')
+        return self._project
+
+    @property
+    def component(self):
+        if self._component is None:
+            self.tracker.populate(self, 'component')
+        return self._component
+
+    @property
+    def version(self):
+        if self._version is None:
+            self.tracker.populate(self, 'version')
+        return self._version
+
+    def set_component(self, project=None, component=None, version=None):
+        return self.tracker.set(self, project=project, component=component, version=version)
 
     def __hash__(self):
         return hash(self.link)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -136,6 +136,12 @@ class Bugzilla(Base, mocks.Requests):
                 issue['comments'].append(
                     Issue.Comment(user=user, timestamp=int(time.time()), content=data['comment']['body']),
                 )
+            if data.get('project'):
+                issue['product'] = data['project']
+            if data.get('component'):
+                issue['component'] = data['component']
+            if data.get('version'):
+                issue['version'] = data['version']
 
         return mocks.Response.fromJson(dict(
             bugs=[dict(
@@ -145,6 +151,9 @@ class Bugzilla(Base, mocks.Requests):
                 status='REOPENED' if issue['opened'] else 'RESOLVED',
                 resolution='' if issue['opened'] else 'FIXED',
                 creator=self.users[issue['creator'].name].username,
+                product=issue.get('project'),
+                component=issue.get('component'),
+                version=issue.get('version'),
                 creator_detail=dict(
                     email=issue['creator'].email,
                     name=self.users[issue['creator'].name].username,
@@ -296,6 +305,9 @@ class Bugzilla(Base, mocks.Requests):
             creator=user,
             assignee=assignee,
             description=data['description'],
+            project=data.get('product'),
+            component=data.get('component'),
+            version=data.get('version'),
             comments=[], watchers=[user, assignee] if assignee else [user],
         )
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -45,6 +45,9 @@ ISSUES = [
         creator=USERS['Felix Filer'],
         assignee=USERS['Tim Contributor'],
         description='An example issue for testing',
+        project='WebKit',
+        component='Text',
+        version='Other',
         comments=[
             Issue.Comment(
                 user=USERS['Felix Filer'],
@@ -63,6 +66,9 @@ ISSUES = [
         creator=USERS['Tim Contributor'],
         assignee=USERS['Tim Contributor'],
         description='We need to support a new feature',
+        project='WebKit',
+        component='Scrolling',
+        version='Safari 15',
         comments=[
             Issue.Comment(
                 user=USERS['Tim Contributor'],
@@ -78,6 +84,9 @@ ISSUES = [
         creator=USERS['Felix Filer'],
         assignee=USERS['Tim Contributor'],
         description='Another example issue for testing, example.com is broken',
+        project='WebKit',
+        component='SVG',
+        version='WebKit Local Build',
         comments=[
             Issue.Comment(
                 user=USERS['Tim Contributor'],

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -139,6 +139,16 @@ class RadarModel(object):
         self.cc_memberships = self.CollectionProperty(self, *[
             self.CCMembership(Radar.transform_user(watcher)) for watcher in issue.get('watchers', [])
         ])
+        components = []
+        if issue.get('project') and issue.get('component') and issue.get('version'):
+            components = self.client.find_components(dict(
+                name=dict(eq='{} {}'.format(issue['project'], issue['component'])),
+                version=dict(eq=issue['version']),
+            ))
+        if components:
+            self.component = components[0]
+        else:
+            self.component = None
 
     def related_radars(self):
         for reference in self._issue.get('references', []):
@@ -157,6 +167,18 @@ class RadarModel(object):
         self.client.parent.issues[self.id]['assignee'] = self.client.parent.users[self.assignee.dsid]
         self.client.parent.issues[self.id]['opened'] = self.state not in ('Verify', 'Closed')
 
+        if self.component:
+            project = ''
+            component = self.component.name
+            for candidate in self.client.parent.projects.keys():
+                if component.startswith(candidate):
+                    project = candidate
+                    component = component[len(project):].lstrip()
+
+            self.client.parent.issues[self.id]['project'] = project
+            self.client.parent.issues[self.id]['component'] = component
+            self.client.parent.issues[self.id]['version'] = self.component.version
+
 
 class RadarClient(object):
     def __init__(self, parent, authentication_strategy):
@@ -171,26 +193,27 @@ class RadarClient(object):
 
     def find_components(self, request_data):
         filters = []
-        if 'name' in request_data:
-            name_data = request_data['name']
-            action = list(name_data.keys())[0] if isinstance(name_data, dict) else 'eq'
-            name = name_data[action] if isinstance(name_data, dict) else name_data
-            filter = dict(
-                eq=lambda s: s == name,
-                like=lambda s: re.match(name.replace('%', '.*'), s),
-            ).get(action)
-            if not filter:
-                raise ValueError('{} is not a valid Radar filter'.format(action))
-            filters.append(filter)
+        for key in ('name', 'version'):
+            if key in request_data:
+                key_data = request_data[key]
+                action = list(key_data.keys())[0] if isinstance(key_data, dict) else 'eq'
+                key_value = key_data[action] if isinstance(key_data, dict) else key_data
+                filter = dict(
+                    eq=lambda key=key, key_value=key_value, **kwargs: not kwargs.get(key) or kwargs[key] == key_value,
+                    like=lambda key=key, key_value=key_value, **kwargs: not kwargs.get(key) or re.match(key_value.replace('%', '.*'), kwargs[key]),
+                ).get(action)
+                if not filter:
+                    raise ValueError('{} is not a valid Radar filter'.format(action))
+                filters.append(filter)
 
         result = []
         for project, project_details in self.parent.projects.items():
             for component, component_details in project_details.get('components', {}).items():
                 component_name = '{} {}'.format(project, component)
-                if any(not filter(component_name) for filter in filters):
+                if any(not filter(name=component_name) for filter in filters):
                     continue
                 for version in project_details.get('versions', ['All']):
-                    if 'version' in request_data and version != request_data['version']:
+                    if any(not filter(version=version) for filter in filters):
                         continue
                     result.append(Radar.Component(component_name, component_details['description'], version))
         return result
@@ -202,17 +225,24 @@ class RadarClient(object):
         )):
             raise Radar.exceptions.UnsuccessfulResponseException('Not enough parameters defined to create a radar')
 
-        if len(self.find_components(request_data['component'])) != 1:
+        components = self.find_components(request_data['component'])
+        if len(components) != 1:
             raise Radar.exceptions.UnsuccessfulResponseException('Provided component is not valid')
         if request_data['classification'] not in radar.Tracker.CLASSIFICATIONS:
             raise Radar.exceptions.UnsuccessfulResponseException("'{}' is not a valid classification".format(request_data['classification']))
         if request_data['reproducible'] not in radar.Tracker.REPRODUCIBILITY:
             raise Radar.exceptions.UnsuccessfulResponseException("'{}' is not a valid reproducibility value".format(request_data['reproducible']))
 
+        project = ''
+        component = components[0].name
+        for candidate in self.parent.projects.keys():
+            if component.startswith(candidate):
+                project = candidate
+                component = component[len(project):].lstrip()
+
         id = 1
         while id in self.parent.issues.keys():
             id += 1
-
         user = self.parent.users['{}@APPLECONNECT.APPLE.COM'.format(self.authentication_strategy.username())]
         issue = dict(
             id=id,
@@ -222,6 +252,9 @@ class RadarClient(object):
             creator=user,
             assignee=user,
             description=request_data['description'],
+            project=project,
+            component=component,
+            version=components[0].version,
             comments=[], watchers=[user],
         )
         self.parent.issues[id] = issue
@@ -253,6 +286,12 @@ class Radar(Base, ContextStack):
             self.name = name
             self.description = description
             self.version = version
+
+        def get(self, item, default=None):
+            return getattr(self, item, default)
+
+        def __getitem__(self, item):
+            return getattr(self, item)
 
     class DiagnosisEntry(object):
         def __init__(self, text=None, addedAt=None, addedBy=None):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -309,6 +309,10 @@ class TestBugzilla(unittest.TestCase):
                 dict(name='Tim Contributor', username='tcontributor@example.com', emails=['tcontributor@example.com']),
             )
 
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'Tables')
+            self.assertEqual(created.version, 'Other')
+
     def test_create_prompt(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
                 BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
@@ -327,6 +331,10 @@ class TestBugzilla(unittest.TestCase):
                 User.Encoder().default(created.assignee),
                 dict(name='Tim Contributor', username='tcontributor@example.com', emails=['tcontributor@example.com']),
             )
+
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'SVG')
+            self.assertEqual(created.version, 'Safari 15')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -348,3 +356,27 @@ What version of 'WebKit' should the bug be associated with?:
 : 
 ''',
         )
+
+    def test_get_component(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            issue = bugzilla.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Text')
+            self.assertEqual(issue.version, 'Other')
+
+    def test_set_component(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES):
+            bugzilla.Tracker(self.URL).issue(1).set_component(project='WebKit', component='Tables', version='Safari 15')
+
+            issue = bugzilla.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Tables')
+            self.assertEqual(issue.version, 'Safari 15')
+
+    def test_labels(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            issue = bugzilla.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.labels, [])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -268,7 +268,6 @@ class TestGitHub(unittest.TestCase):
             self.assertDictEqual(github.Tracker(self.URL).labels, mocked.DEFAULT_LABELS)
 
     def test_projects(self):
-        self.maxDiff = None
         with mocks.GitHub(self.URL.split('://')[1], projects=mocks.PROJECTS):
             self.assertDictEqual(
                 dict(
@@ -337,6 +336,10 @@ class TestGitHub(unittest.TestCase):
                 dict(name='Tim Contributor', username='tcontributor', emails=['tcontributor@example.com']),
             )
 
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'SVG')
+            self.assertEqual(created.version, 'Other')
+
         self.assertEqual(
             captured.stdout.getvalue(),
             '''What component in 'WebKit' should the bug be associated with?:
@@ -356,3 +359,27 @@ What version of 'WebKit' should the bug be associated with?:
 : 
 ''',
         )
+
+    def test_get_component(self):
+        with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            issue = github.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Text')
+            self.assertEqual(issue.version, 'Other')
+
+    def test_set_component(self):
+        with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS, environment=wkmocks.Environment(
+            GITHUB_EXAMPLE_COM_USERNAME='tcontributor',
+            GITHUB_EXAMPLE_COM_TOKEN='token',
+        )):
+            github.Tracker(self.URL).issue(1).set_component(component='Tables', version='Safari 15')
+
+            issue = github.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Tables')
+            self.assertEqual(issue.version, 'Safari 15')
+
+    def test_issue_label(self):
+        with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            issue = github.Tracker(self.URL).issue(1)
+            self.assertEqual(issue.labels, ['Other', 'Text'])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -270,6 +270,10 @@ class TestRadar(unittest.TestCase):
                 dict(name='Tim Contributor', username=504, emails=['tcontributor@example.com']),
             )
 
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'Tables')
+            self.assertEqual(created.version, 'Other')
+
     def test_create_prompt(self):
         with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS), \
             wkmocks.Terminal.input('2', '4', '4'), OutputCapture() as captured:
@@ -287,6 +291,10 @@ class TestRadar(unittest.TestCase):
                 User.Encoder().default(created.assignee),
                 dict(name='Tim Contributor', username=504, emails=['tcontributor@example.com']),
             )
+
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'Text')
+            self.assertEqual(created.version, 'WebKit Local Build')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -308,3 +316,24 @@ What version of 'WebKit Text' should the bug be associated with?:
 : 
 ''',
         )
+
+    def test_get_component(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            issue = radar.Tracker(project='WebKit').issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Text')
+            self.assertEqual(issue.version, 'Other')
+
+    def test_set_component(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            radar.Tracker(project='WebKit').issue(1).set_component(component='Tables', version='Safari 15')
+
+            issue = radar.Tracker(project='WebKit').issue(1)
+            self.assertEqual(issue.project, 'WebKit')
+            self.assertEqual(issue.component, 'Tables')
+            self.assertEqual(issue.version, 'Safari 15')
+
+    def test_labels(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES):
+            issue = radar.Tracker().issue(1)
+            self.assertEqual(issue.labels, [])


### PR DESCRIPTION
#### 61ca77011cb9ddc963017edb372dc4d97d7e4cd1
<pre>
[webkitbugspy] Get and set issue component data
<a href="https://bugs.webkit.org/show_bug.cgi?id=238514">https://bugs.webkit.org/show_bug.cgi?id=238514</a>
&lt;rdar://problem/90994542 &gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): Populate project, component and version.
(Tracker.set): Set project, component and version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.request): github.Tracker has no Exception member. Use RuntimeError instead.
(Tracker.populate): Populate labels and then extract component and version.
(Tracker.set): Set labels associated with components and versions.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__): Set _labels, _project, _component and _version values.
(Issue.labels): Populate and return labels.
(Issue.set_labels): Set labels associated with issue.
(Issue.project): Populate and return project.
(Issue.component): Populate and return component.
(Issue.version): Populate and return version.
(Issue.set_component): Set the project, component and version of an issue.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue): Mock setting and returning project, component and version.
(Bugzilla._create): Populate project, component and version on creation.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Set values for
project, component and version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py:
(GitHub._labels_for_issue): Given an issue, return a list of labels. Take into
consideration component and version.
(GitHub._issue): Mock label editing and returning.
(GitHub._create): Ditto.
(GitHub.request): Support request to update labels.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.__init__): Set component.
(RadarModel.commit_changes): Commit component changes.
(RadarClient.find_components): Implement version filter.
(RadarClient.create_radar): Create radar with component details.
(Radar.Component.get): Implement dict-like API.
(Radar.Component.__getitem__): Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate): Get project, component and version.
(Tracker.set): Set component information.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create):
(TestBugzilla.test_create_prompt):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_projects):
(TestGitHub.test_create_projects):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_create):
(TestRadar.test_create_prompt):


Canonical link: <a href="https://commits.webkit.org/249039@main">https://commits.webkit.org/249039@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292132">https://svn.webkit.org/repository/webkit/trunk@292132</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
