### PR TITLE
[Merge-Queue] Skip CloseBug if no bug defined

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1719,23 +1719,26 @@ class CloseBug(buildstep.BuildStep, BugzillaMixin):
     name = 'close-bugzilla-bug'
     flunkOnFailure = False
     haltOnFailure = False
+    bug_id = ''
 
     def start(self):
         self.bug_id = self.getProperty('bug_id', '')
-        if not self.bug_id:
-            self._addToLog('stdio', 'bug_id build property not found.\n')
-            self.descriptionDone = 'No bug id found'
-            self.finished(FAILURE)
-            return None
-
         rc = self.close_bug(self.bug_id)
         self.finished(rc)
         return None
 
     def getResultSummary(self):
+        if self.results == SKIPPED:
+            return buildstep.BuildStep.getResultSummary(self)
         if self.results == SUCCESS:
             return {'step': 'Closed bug {}'.format(self.bug_id)}
         return {'step': 'Failed to close bug {}'.format(self.bug_id)}
+
+    def doStepIf(self, step):
+        return self.getProperty('bug_id')
+
+    def hideStepIf(self, results, step):
+        return not self.doStepIf(step)
 
 
 class LeaveComment(buildstep.BuildStep, BugzillaMixin, GitHubMixin):

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,18 @@
+2022-03-31  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Skip CloseBug if no bug defined
+        https://bugs.webkit.org/show_bug.cgi?id=238612
+        <rdar://problem/91110116>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (CloseBug.__init__):
+        (CloseBug.start): Ignore unavailable bug_id case.
+        (CloseBug.getResultSummary): Use default summary for skip case.
+        (CloseBug.doStepIf): Do step if bug_id is available.
+        (CloseBug.hideStepIf): Hide step if skipped.
+
 2022-03-30  Jonathan Bedard  <jbedard@apple.com>
 
         [Merge-Queue] Update pull-request with landed content


### PR DESCRIPTION
#### 6ddf72853c64be73426bce0a14fafa00690b3499
<pre>
[Merge-Queue] Skip CloseBug if no bug defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=238612">https://bugs.webkit.org/show_bug.cgi?id=238612</a>
&lt;rdar://problem/91110116 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(CloseBug.start): Ignore unavailable bug_id case.
(CloseBug.getResultSummary): Use default summary for skip case.
(CloseBug.doStepIf): Do step if bug_id is available.
(CloseBug.hideStepIf): Hide step if skipped.

Canonical link: <a href="https://commits.webkit.org/249068@main">https://commits.webkit.org/249068@main</a>

From: Jonathan Bedard &lt;jbedard@apple.com &gt;


Canonical link: <a href="https://commits.webkit.org/249068@main">https://commits.webkit.org/249068@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292161">https://svn.webkit.org/repository/webkit/trunk@292161</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
