### PR TITLE
[Merge-Queue] Skip RemoveFlagsOnPatch if no patch defined

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1691,7 +1691,6 @@ class BlockPullRequest(buildstep.BuildStep, GitHubMixin):
         return not self.doStepIf(step)
 
 
-
 class RemoveFlagsOnPatch(buildstep.BuildStep, BugzillaMixin):
     name = 'remove-flags-from-patch'
     flunkOnFailure = False
@@ -1710,9 +1709,17 @@ class RemoveFlagsOnPatch(buildstep.BuildStep, BugzillaMixin):
         return None
 
     def getResultSummary(self):
+        if self.results == SKIPPED:
+            return buildstep.BuildStep.getResultSummary(self)
         if self.results == SUCCESS:
             return {'step': 'Removed flags on bugzilla patch'}
         return {'step': 'Failed to remove flags on bugzilla patch'}
+
+    def doStepIf(self, step):
+        return self.getProperty('patch_id')
+
+    def hideStepIf(self, results, step):
+        return not self.doStepIf(step)
 
 
 class CloseBug(buildstep.BuildStep, BugzillaMixin):

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,18 @@
 2022-03-31  Jonathan Bedard  <jbedard@apple.com>
 
+        [Merge-Queue] Skip RemoveFlagsOnPatch if no patch defined
+        https://bugs.webkit.org/show_bug.cgi?id=238613
+        <rdar://problem/91111541>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (RemoveFlagsOnPatch.getResultSummary): Use default summary for skip case.
+        (RemoveFlagsOnPatch.doStepIf): Do step if patch_id is available.
+        (RemoveFlagsOnPatch.hideStepIf): Hide step if skipped.
+
+2022-03-31  Jonathan Bedard  <jbedard@apple.com>
+
         [Merge-Queue] Skip CloseBug if no bug defined
         https://bugs.webkit.org/show_bug.cgi?id=238612
         <rdar://problem/91110116>


### PR DESCRIPTION
#### 55fe4a944835e9fc03e68acade411e7662be8fc5
<pre>
[Merge-Queue] Skip RemoveFlagsOnPatch if no patch defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=238613">https://bugs.webkit.org/show_bug.cgi?id=238613</a>
&lt;rdar://problem/91111541 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(RemoveFlagsOnPatch.getResultSummary): Use default summary for skip case.
(RemoveFlagsOnPatch.doStepIf): Do step if patch_id is available.
(RemoveFlagsOnPatch.hideStepIf): Hide step if skipped.


Canonical link: <a href="https://commits.webkit.org/249069@main">https://commits.webkit.org/249069@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292162">https://svn.webkit.org/repository/webkit/trunk@292162</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
