### PR TITLE
[Merge-Queue] Canonicalize commit without rebase

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6008,6 +6008,28 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 timeout=300,
                 logEnviron=False,
+                command=['git', 'checkout', 'main'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                command=['python3', 'Tools/Scripts/git-webkit', 'canonicalize', '-n', '1'],
+            ) + 0,
+        )
+        self.expectOutcome(result=SUCCESS, state_string='Canonicalized commit')
+        return self.runStep()
+
+    def test_success_no_rebase(self):
+        self.setupStep(Canonicalize(rebase_enabled=False))
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
                 command=['python3', 'Tools/Scripts/git-webkit', 'canonicalize', '-n', '1'],
             ) + 0,
         )
@@ -6031,6 +6053,11 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 logEnviron=False,
                 command=['git', 'branch', '-f', 'main', 'eng/pull-request-branch'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                command=['git', 'checkout', 'main'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=300,

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,19 @@
+2022-03-31  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Canonicalize commit without rebase
+        https://bugs.webkit.org/show_bug.cgi?id=238614
+        <rdar://problem/91113465>
+
+        Reviewed by Aakash Jain.
+
+        This is helpful immiediatly after landing a subversion commit
+        and allows us to bypass the 60 second sleep in PushCommitToWebKitRepo.
+
+        * CISupport/ews-build/steps.py:
+        (Canonicalize.__init__): Allow caller to opt out of rebasing.
+        (Canonicalize.run): Ditto.
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-01  Tim Horton  <timothy_horton@apple.com>
 
         Add a debug overlay for interaction regions


### PR DESCRIPTION
#### 982cb855332505a205085636b8fbab4f989d2a86
<pre>
[Merge-Queue] Canonicalize commit without rebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=238614">https://bugs.webkit.org/show_bug.cgi?id=238614</a>
&lt;rdar://problem/91113465 &gt;

Reviewed by Aakash Jain.

This is helpful immiediatly after landing a subversion commit
and allows us to bypass the 60 second sleep in PushCommitToWebKitRepo.

* Tools/CISupport/ews-build/steps.py:
(Canonicalize.__init__): Allow caller to opt out of rebasing.
(Canonicalize.run): Ditto.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249136@main">https://commits.webkit.org/249136@main</a>



Canonical link: <a href="https://commits.webkit.org/249136@main">https://commits.webkit.org/249136@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292235">https://svn.webkit.org/repository/webkit/trunk@292235</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
