### PR TITLE
[Merge-Queue] Remove custom summaries when skipped

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4637,11 +4637,11 @@ class ValidateSquashed(shell.ShellCommand):
         return shell.ShellCommand.start(self)
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'Patches are always squashed'}
-        elif self.results == SUCCESS:
+        if self.results == FAILURE:
+            return {'step': 'Can only land squashed branches'}
+        if self.results == SUCCESS:
             return {'step': 'Verified branch is squashed'}
-        return {'step': 'Can only land squashed branches'}
+        return super(ValidateSquashed, self).getResultSummary()
 
     def evaluateCommand(self, cmd):
         rc = shell.ShellCommand.evaluateCommand(self, cmd)
@@ -4714,11 +4714,11 @@ class AddReviewerToCommitMessage(shell.ShellCommand, AddReviewerMixin):
         return super(AddReviewerToCommitMessage, self).start()
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'No reviewer defined' if self.getProperty('github.number') else 'Patches have no commit message'}
-        elif self.results == SUCCESS:
+        if self.results == FAILURE:
+            return {'step': 'Failed to apply reviewers'}
+        if self.results == SUCCESS:
             return {'step': f'Reviewed by {self.reviewers()}'}
-        return {'step': 'Failed to apply reviewers'}
+        return super(AddReviewerToCommitMessage, self).getResultSummary()
 
     def doStepIf(self, step):
         return self.getProperty('github.number') and self.getProperty('reviewers_full_names')
@@ -4762,11 +4762,11 @@ class AddReviewerToChangeLog(steps.ShellSequence, ShellMixin, AddReviewerMixin):
         return super(AddReviewerToChangeLog, self).run()
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'No reviewer defined' if self.getProperty('github.number') else 'Patches are edited upon application'}
-        elif self.results == SUCCESS:
+        if self.results == FAILURE:
+            return {'step': 'Failed to add reviewers to ChangeLogs'}
+        if self.results == SUCCESS:
             return {'step': f'Reviewed by {self.reviewers()}'}
-        return {'step': 'Failed to add reviewers to ChangeLogs'}
+        return super(AddReviewerToChangeLog, self).getResultSummary()
 
     def doStepIf(self, step):
         return self.getProperty('github.number') and self.getProperty('reviewers_full_names')
@@ -4794,7 +4794,9 @@ class ValidateCommitMessage(shell.ShellCommand):
         return super(ValidateCommitMessage, self).start()
 
     def getResultSummary(self):
-        return {'step': self.summary}
+        if self.results in (SUCCESS, FAILURE):
+            return {'step': self.summary}
+        return super(ValidateCommitMessage, self).getResultSummary()
 
     def evaluateCommand(self, cmd):
         rc = super(ValidateCommitMessage, self).evaluateCommand(cmd)
@@ -4853,11 +4855,11 @@ class Canonicalize(steps.ShellSequence, ShellMixin):
         return super(Canonicalize, self).run()
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'Cannot canonicalize patches'}
-        if self.results != SUCCESS:
+        if self.results == SUCCESS:
+            return {'step': 'Canonicalized commit'}
+        if self.results == FAILURE:
             return {'step': 'Failed to canonicalize commit'}
-        return {'step': 'Canonicalized commit'}
+        return super(Canonicalize, self).getResultSummary()
 
     def doStepIf(self, step):
         return self.getProperty('github.number', False)
@@ -4885,11 +4887,11 @@ class PushPullRequestBranch(shell.ShellCommand):
         return super(PushPullRequestBranch, self).start()
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'No pull request branch to push to'}
-        if self.results != SUCCESS:
+        if self.results == SUCCESS:
+            return {'step': 'Pushed to pull request branch'}
+        if self.results == FAILURE:
             return {'step': 'Failed to push to pull request branch'}
-        return {'step': 'Pushed to pull request branch'}
+        return super(PushPullRequestBranch, self).getResultSummary()
 
     def doStepIf(self, step):
         return CURRENT_HOSTNAME == EWS_BUILD_HOSTNAME and self.getProperty('github.number') and self.getProperty('github.head.ref') and self.getProperty('github.head.repo.full_name')
@@ -4932,11 +4934,11 @@ class UpdatePullRequest(shell.ShellCommand, GitHubMixin):
         return super(UpdatePullRequest, self).start()
 
     def getResultSummary(self):
-        if self.results == SKIPPED:
-            return {'step': 'No pull request to update'}
-        if self.results != SUCCESS:
+        if self.results == SUCCESS:
+            return {'step': 'Updated pull request'}
+        if self.results == FAILURE:
             return {'step': 'Failed to update pull request'}
-        return {'step': 'Updated pull request'}
+        return super(UpdatePullRequest, self).getResultSummary()
 
     def evaluateCommand(self, cmd):
         rc = super(UpdatePullRequest, self).evaluateCommand(cmd)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -5621,7 +5621,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(ValidateSquashed())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='Patches are always squashed')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -5694,7 +5694,7 @@ class TestAddReviewerToCommitMessage(BuildStepMixinAdditions, unittest.TestCase)
     def test_skipped_patch(self):
         self.setupStep(AddReviewerToCommitMessage())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='Patches have no commit message')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -5761,7 +5761,7 @@ class TestAddReviewerToCommitMessage(BuildStepMixinAdditions, unittest.TestCase)
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
         self.setProperty('reviewers_full_names', [])
-        self.expectOutcome(result=SKIPPED, state_string='No reviewer defined')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
 
@@ -5783,7 +5783,7 @@ class TestAddReviewerToChangeLog(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(AddReviewerToChangeLog())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='Patches are edited upon application')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -5876,7 +5876,7 @@ class TestAddReviewerToChangeLog(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
         self.setProperty('reviewers_full_names', [])
-        self.expectOutcome(result=SKIPPED, state_string='No reviewer defined')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
 
@@ -5891,7 +5891,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(ValidateCommitMessage())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='Patches have no commit message')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -5984,7 +5984,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(Canonicalize())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='Cannot canonicalize patches')
+        self.expectOutcome(result=SKIPPED, state_string='Canonicalize Commit (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -6080,7 +6080,7 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(PushPullRequestBranch())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='No pull request branch to push to')
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
     def test_success(self):
@@ -6133,7 +6133,7 @@ class TestUpdatePullRequest(BuildStepMixinAdditions, unittest.TestCase):
     def test_skipped_patch(self):
         self.setupStep(UpdatePullRequest())
         self.setProperty('patch_id', '1234')
-        self.expectOutcome(result=SKIPPED, state_string='No pull request to update')
+        self.expectOutcome(result=SKIPPED, state_string="'git log ...' (skipped)")
         return self.runStep()
 
     def test_success(self):

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,21 @@
+2022-03-31  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Remove custom summaries when skipped
+        https://bugs.webkit.org/show_bug.cgi?id=238633
+        <rdar://problem/91125435>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (ValidateSquashed.getResultSummary):
+        (AddReviewerToCommitMessage.getResultSummary):
+        (AddReviewerToChangeLog.getResultSummary):
+        (ValidateCommitMessage.getResultSummary):
+        (Canonicalize.getResultSummary):
+        (PushPullRequestBranch.getResultSummary):
+        (UpdatePullRequest.getResultSummary):
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-04  Sam Sneddon  <gsnedders@apple.com>
 
         WPT export broken under Python 3


### PR DESCRIPTION
#### ddae38dc02f060f94cb0b3776863289d62a39421
<pre>
[Merge-Queue] Remove custom summaries when skipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=238633">https://bugs.webkit.org/show_bug.cgi?id=238633</a>
&lt;rdar://problem/91125435 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ValidateSquashed.getResultSummary):
(AddReviewerToCommitMessage.getResultSummary):
(AddReviewerToChangeLog.getResultSummary):
(ValidateCommitMessage.getResultSummary):
(Canonicalize.getResultSummary):
(PushPullRequestBranch.getResultSummary):
(UpdatePullRequest.getResultSummary):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249189@main">https://commits.webkit.org/249189@main</a>



Canonical link: <a href="https://commits.webkit.org/249189@main">https://commits.webkit.org/249189@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292291">https://svn.webkit.org/repository/webkit/trunk@292291</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
