### PR TITLE
[results-safari] Replace bzero with memset, since bzero is deprecated

### DIFF
--- a/ManualTests/NPN_Invoke/main.c
+++ b/ManualTests/NPN_Invoke/main.c
@@ -6,7 +6,7 @@
  redistribute this Apple software.
  
  In consideration of your agreement to abide by the following terms, and subject to these 
- terms, Apple grants you a personal, non-exclusive license, under AppleÕs copyrights in 
+ terms, Apple grants you a personal, non-exclusive license, under Appleï¿½s copyrights in 
  this original Apple software (the "Apple Software"), to use, reproduce, modify and 
  redistribute the Apple Software, with or without modifications, in source and/or binary 
  forms; provided that if you redistribute the Apple Software in its entirety and without 
@@ -102,8 +102,7 @@ void NP_Shutdown(void)
 // For compatibility with CFM browsers.
 int main(NPNetscapeFuncs *browserFuncs, NPPluginFuncs *pluginFuncs, NPP_ShutdownProcPtr *shutdown)
 {
-    browser = malloc(sizeof(NPNetscapeFuncs));
-    bzero(browser, sizeof(NPNetscapeFuncs));
+    browser = calloc(1, sizeof(NPNetscapeFuncs));
     
     browser->size = browserFuncs->size;
     browser->version = browserFuncs->version;

--- a/PerformanceTests/JetStream2/wasm/TSF/tsf_fsdb.c
+++ b/PerformanceTests/JetStream2/wasm/TSF/tsf_fsdb.c
@@ -190,7 +190,7 @@ static tsf_fsdb_connection_t *create_first_connection(tsf_fsdb_t *fsdb,
     struct addrinfo *result,*cur;
     char buf[32];
     
-    bzero(&hints,sizeof(hints));
+    memset (&hints,0,sizeof(hints));
     hints.ai_family=AF_INET;
     hints.ai_socktype=SOCK_STREAM;
     
@@ -234,7 +234,7 @@ static tsf_fsdb_connection_t *create_first_connection(tsf_fsdb_t *fsdb,
             struct sockaddr_in addr;
             socklen_t slen=sizeof(addr);
             
-            bzero(&addr,slen);
+            memset(&addr,0,slen);
             addr.sin_family=AF_INET;
             addr.sin_port=htons(port);
             addr.sin_addr.s_addr=*(struct in_addr*)(hp->h_addr_list[i]);
@@ -277,7 +277,7 @@ static tsf_fsdb_connection_t *create_connection(tsf_fsdb_t *fsdb) {
     struct sockaddr_in addr;
     socklen_t slen=sizeof(addr);
     
-    bzero(&addr,slen);
+    memset(&addr,0,slen);
     addr.sin_family=AF_INET;
     addr.sin_port=htons(fsdb->u.remote.port);
     addr.sin_addr.s_addr=*(struct in_addr*)(&fsdb->u.remote.addr);
@@ -590,7 +590,7 @@ tsf_fsdb_t *tsf_fsdb_open_local(const char *dirname,
     
     free(marker_flnm);
     
-    bzero(buf,sizeof(buf));
+    memset(buf,0,sizeof(buf));
     fgets(buf,sizeof(buf),fin);
     
     fclose(fin);

--- a/PerformanceTests/JetStream2/wasm/TSF/tsf_reflect.c
+++ b/PerformanceTests/JetStream2/wasm/TSF/tsf_reflect.c
@@ -96,7 +96,7 @@ tsf_reflect_t *tsf_reflect_create(tsf_type_t *type) {
                           "tsf_reflect_create()");
             return NULL;
         }
-        bzero(ret->u.c.array, sizeof(tsf_reflect_t*) * ret->u.c.size);
+        memset(ret->u.c.array, 0, sizeof(tsf_reflect_t*) * ret->u.c.size);
         break;
     case TSF_TK_CHOICE:
         ret->u.h.choice = UINT32_MAX;
@@ -308,7 +308,7 @@ tsf_reflect_t *tsf_reflect_clone(tsf_reflect_t *data) {
         
         /* set the elements of the array to NULL so that destroy
          * works. */
-        bzero(ret->u.c.array,
+        memset(ret->u.c.array,0,
               sizeof(tsf_reflect_t*) * ret->u.c.size);
         
         for (i = 0; i < ret->u.c.size; ++i) {

--- a/PerformanceTests/MallocBench/MallocBench/Benchmark.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/Benchmark.cpp
@@ -112,7 +112,7 @@ static void*** allocateHeap(size_t heapSize, size_t chunkSize, size_t objectSize
         chunks[i] = (void**)mbmalloc(objectCount * sizeof(void*));
         for (size_t j = 0; j < objectCount; ++j) {
             chunks[i][j] = (void*)mbmalloc(objectSize);
-            bzero(chunks[i][j], objectSize);
+            memset(chunks[i][j], 0, objectSize);
         }
     }
     return chunks;

--- a/PerformanceTests/MallocBench/MallocBench/Interpreter.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/Interpreter.cpp
@@ -237,7 +237,7 @@ void Interpreter::doMallocOp(Op op, ThreadId)
         case op_malloc: {
             m_objects[op.slot] = { mbmalloc(op.size), op.size };
             assert(m_objects[op.slot].object);
-            bzero(m_objects[op.slot].object, op.size);
+            memset(m_objects[op.slot].object, 0, op.size);
             break;
         }
         case op_free: {
@@ -257,7 +257,7 @@ void Interpreter::doMallocOp(Op op, ThreadId)
             size_t alignment = compute2toPower(op.alignLog2);
             m_objects[op.slot] = { mbmemalign(alignment, op.size), op.size };
             assert(m_objects[op.slot].object);
-            bzero(m_objects[op.slot].object, op.size);
+            memset(m_objects[op.slot].object, 0, op.size);
             break;
         }
         default: {

--- a/PerformanceTests/MallocBench/MallocBench/balloon.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/balloon.cpp
@@ -47,7 +47,7 @@ void benchmark_balloon(CommandLine&)
 
     for (size_t i = 0; i < balloon.size(); ++i) {
         balloon[i] = mbmalloc(chunkSize);
-        bzero(balloon[i], chunkSize);
+        memset(balloon[i], 0, chunkSize);
     }
 
     for (size_t i = 0; i < balloon.size(); ++i)
@@ -66,7 +66,7 @@ void benchmark_balloon(CommandLine&)
         && std::chrono::steady_clock::now() - start < 8 * benchmarkTime) {
         for (size_t i = 0; i < steady.size(); ++i) {
             steady[i] = mbmalloc(chunkSize);
-            bzero(steady[i], chunkSize);
+            memset(steady[i], 0, chunkSize);
         }
 
         for (size_t i = 0; i < steady.size(); ++i)

--- a/PerformanceTests/MallocBench/MallocBench/big.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/big.cpp
@@ -59,12 +59,12 @@ void benchmark_big(CommandLine& commandLine)
 
     for (size_t i = 0; i < times; ++i) {
         Object* objects = (Object*)mbmalloc(objectCount * sizeof(Object));
-        bzero(objects, objectCount * sizeof(Object));
+        memset(objects, 0, objectCount * sizeof(Object));
 
         for (size_t i = 0, remaining = vmSize; remaining > objectSizeMin; ++i) {
             size_t size = min<size_t>(remaining, max<size_t>(objectSizeMin, random() % objectSizeMax));
             objects[i] = { (double*)mbmalloc(size), size };
-            bzero(objects[i].p, size);
+            memset(objects[i].p, 0, size);
             remaining -= size;
         }
 

--- a/PerformanceTests/MallocBench/MallocBench/list.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/list.cpp
@@ -51,7 +51,7 @@ struct Node {
     {
         if (m_next)
             m_next->ref();
-        bzero(m_payload, payloadSize);
+        memset(m_payload, 0, payloadSize);
     }
 
     ~Node()

--- a/PerformanceTests/MallocBench/MallocBench/medium.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/medium.cpp
@@ -55,12 +55,12 @@ void benchmark_medium(CommandLine& commandLine)
 
     for (size_t i = 0; i < times; ++i) {
         Object* objects = (Object*)mbmalloc(objectCount * sizeof(Object));
-        bzero(objects, objectCount * sizeof(Object));
+        memset(objects, 0, objectCount * sizeof(Object));
 
         for (size_t i = 0, remaining = vmSize; remaining > objectSizeMin; ++i) {
             size_t size = min<size_t>(remaining, max<size_t>(objectSizeMin, random() % objectSizeMax));
             objects[i] = { (double*)mbmalloc(size), size };
-            bzero(objects[i].p, size);
+            memset(objects[i].p, 0, size);
             remaining -= size;
         }
 

--- a/PerformanceTests/MallocBench/MallocBench/tree.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/tree.cpp
@@ -55,7 +55,7 @@ struct Node {
             m_left->ref();
         if (m_right)
             m_right->ref();
-        bzero(m_payload, payloadSize);
+        memset(m_payload, 0, payloadSize);
     }
 
     ~Node()

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -148,7 +148,7 @@ ObjcValue convertValueToObjcValue(JSGlobalObject* lexicalGlobalObject, JSValue v
             result.doubleValue = (double)d;
             break;
         case ObjcVoidType:
-            bzero(&result, sizeof(ObjcValue));
+            memset(&result, 0, sizeof(ObjcValue));
             break;
 
         case ObjcInvalidType:

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3033,7 +3033,7 @@ static inline IMP getMethod(id o, SEL s)
     id delegate = _private->resourceProgressDelegate;
 
     if (!delegate) {
-        bzero(cache, sizeof(WebResourceDelegateImplementationCache));
+        memset(cache, 0, sizeof(WebResourceDelegateImplementationCache));
         return;
     }
 
@@ -3073,7 +3073,7 @@ static inline IMP getMethod(id o, SEL s)
     id delegate = _private->frameLoadDelegate;
 
     if (!delegate) {
-        bzero(cache, sizeof(WebFrameLoadDelegateImplementationCache));
+        memset(cache, 0, sizeof(WebFrameLoadDelegateImplementationCache));
         return;
     }
 
@@ -3136,7 +3136,7 @@ static inline IMP getMethod(id o, SEL s)
     id delegate = _private->scriptDebugDelegate;
 
     if (!delegate) {
-        bzero(cache, sizeof(WebScriptDebugDelegateImplementationCache));
+        memset(cache, 0, sizeof(WebScriptDebugDelegateImplementationCache));
         return;
     }
 
@@ -3165,7 +3165,7 @@ static inline IMP getMethod(id o, SEL s)
     id delegate = _private->historyDelegate;
 
     if (!delegate) {
-        bzero(cache, sizeof(WebHistoryDelegateImplementationCache));
+        memset(cache, 0, sizeof(WebHistoryDelegateImplementationCache));
         return;
     }
 

--- a/Tools/TestWebKitAPI/mac/GamepadMappings/GoogleStadia.mm
+++ b/Tools/TestWebKitAPI/mac/GamepadMappings/GoogleStadia.mm
@@ -150,7 +150,7 @@ const char* StadiaName = "Virtual Stadia";
 static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& axisValues, HIDUserDevice *userDevice)
 {
     uint8_t reportData[StadiaReportSize];
-    bzero(reportData, StadiaReportSize);
+    memset(reportData, 0, StadiaReportSize);
     size_t reportIndex = 0;
 
     // Report ID (Normal input report is #3)

--- a/Tools/TestWebKitAPI/mac/GamepadMappings/SonyDualShock3.mm
+++ b/Tools/TestWebKitAPI/mac/GamepadMappings/SonyDualShock3.mm
@@ -132,7 +132,7 @@ const char* Dualshock3Name = "Virtual Dualshock3";
 static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& axisValues, HIDUserDevice *userDevice)
 {
     uint8_t reportData[Dualshock3ReportSize];
-    bzero(reportData, Dualshock3ReportSize);
+    memset(reportData, 0, Dualshock3ReportSize);
     size_t reportIndex = 0;
 
     // Report ID

--- a/Websites/browserbench.org/JetStream2.0/wasm/TSF/tsf_fsdb.c
+++ b/Websites/browserbench.org/JetStream2.0/wasm/TSF/tsf_fsdb.c
@@ -190,7 +190,7 @@ static tsf_fsdb_connection_t *create_first_connection(tsf_fsdb_t *fsdb,
     struct addrinfo *result,*cur;
     char buf[32];
     
-    bzero(&hints,sizeof(hints));
+    memset(&hints,0,sizeof(hints));
     hints.ai_family=AF_INET;
     hints.ai_socktype=SOCK_STREAM;
     
@@ -234,7 +234,7 @@ static tsf_fsdb_connection_t *create_first_connection(tsf_fsdb_t *fsdb,
             struct sockaddr_in addr;
             socklen_t slen=sizeof(addr);
             
-            bzero(&addr,slen);
+            memset(&addr,0,slen);
             addr.sin_family=AF_INET;
             addr.sin_port=htons(port);
             addr.sin_addr.s_addr=*(struct in_addr*)(hp->h_addr_list[i]);
@@ -277,7 +277,7 @@ static tsf_fsdb_connection_t *create_connection(tsf_fsdb_t *fsdb) {
     struct sockaddr_in addr;
     socklen_t slen=sizeof(addr);
     
-    bzero(&addr,slen);
+    memset(&addr,0,slen);
     addr.sin_family=AF_INET;
     addr.sin_port=htons(fsdb->u.remote.port);
     addr.sin_addr.s_addr=*(struct in_addr*)(&fsdb->u.remote.addr);
@@ -590,7 +590,7 @@ tsf_fsdb_t *tsf_fsdb_open_local(const char *dirname,
     
     free(marker_flnm);
     
-    bzero(buf,sizeof(buf));
+    memset(buf,0,sizeof(buf));
     fgets(buf,sizeof(buf),fin);
     
     fclose(fin);

--- a/Websites/browserbench.org/JetStream2.0/wasm/TSF/tsf_reflect.c
+++ b/Websites/browserbench.org/JetStream2.0/wasm/TSF/tsf_reflect.c
@@ -96,7 +96,7 @@ tsf_reflect_t *tsf_reflect_create(tsf_type_t *type) {
                           "tsf_reflect_create()");
             return NULL;
         }
-        bzero(ret->u.c.array, sizeof(tsf_reflect_t*) * ret->u.c.size);
+        memset(ret->u.c.array, 0, sizeof(tsf_reflect_t*) * ret->u.c.size);
         break;
     case TSF_TK_CHOICE:
         ret->u.h.choice = UINT32_MAX;
@@ -308,7 +308,7 @@ tsf_reflect_t *tsf_reflect_clone(tsf_reflect_t *data) {
         
         /* set the elements of the array to NULL so that destroy
          * works. */
-        bzero(ret->u.c.array,
+        memset(ret->u.c.array, 0,
               sizeof(tsf_reflect_t*) * ret->u.c.size);
         
         for (i = 0; i < ret->u.c.size; ++i) {


### PR DESCRIPTION
Since bzero has been deprecated in all BSD distributions, it would be better to just call the libc equivalent directly