### PR TITLE
[git-webkit] Add automation to assist in branch cleanup

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,32 @@
 2022-04-06  Jonathan Bedard  <jbedard@apple.com>
 
+        [git-webkit] Add automation to assist in branch cleanup
+        https://bugs.webkit.org/show_bug.cgi?id=238637
+        <rdar://problem/91127828>
+
+        Reviewed by NOBODY (OOPS!).
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add branch deletion and reset mocks.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py:
+        (Svn.__init__): Add `svn revert` mock.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py:
+        (Clean):
+        (Clean.parser): Allow caller to specify branch or pull request.
+        (Clean.cleanup): Delete a branch or branches associated with a pull request.
+        (Clean.main): Differentiate calls with branches and pull requests specified from those without.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py: Added.
+        (TestClean):
+        (TestClean.setUp):
+        (TestClean.test_checkout_none):
+        (TestClean.test_clean_git):
+        (TestClean.test_clean_svn):
+        (TestClean.test_clean_branch):
+        (TestClean.test_clean_pr):
+
+2022-04-06  Jonathan Bedard  <jbedard@apple.com>
+
         [git-webkit] Apply labels based on tracker
         https://bugs.webkit.org/show_bug.cgi?id=238640
         <rdar://problem/91135356>

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='4.7.0',
+    version='4.8.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(4, 7, 0)
+version = Version(4, 8, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
@@ -150,6 +150,10 @@ class Svn(mocks.Subprocess):
                 cwd=self.path,
                 completion=mocks.ProcessCompletion(returncode=0),
             ), mocks.Subprocess.Route(
+                self.executable, 'revert', '-R',
+                cwd=self.path,
+                completion=mocks.ProcessCompletion(returncode=0),
+            ), mocks.Subprocess.Route(
                 self.executable,
                 cwd=self.path,
                 completion=mocks.ProcessCompletion(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Time as MockTime, Terminal as MockTerminal
+from webkitscmpy import program, mocks
+
+
+class TestClean(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestClean, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_checkout_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), MockTime:
+            self.assertEqual(1, program.main(
+                args=('clean',),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), 'No repository provided\n')
+
+    def test_clean_git(self):
+        with OutputCapture(), mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime:
+            repo.modified['some/file'] = 'diff contnet'
+            self.assertEqual(0, program.main(
+                args=('clean',),
+                path=self.path,
+            ))
+            self.assertDictEqual({}, repo.modified)
+
+    def test_clean_svn(self):
+        with OutputCapture(), mocks.local.Git(), mocks.local.Svn(self.path), MockTime:
+            self.assertEqual(0, program.main(
+                args=('clean',),
+                path=self.path,
+            ))
+
+    def test_clean_branch(self):
+        with OutputCapture(), mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime:
+            self.assertIn('branch-a', repo.commits)
+            self.assertEqual(0, program.main(
+                args=('clean', 'branch-a'),
+                path=self.path,
+            ))
+            self.assertNotIn('branch-a', repo.commits)
+
+    def test_clean_pr(self):
+        with OutputCapture(), mocks.remote.GitHub() as remote, mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn():
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-i', 'pr-branch'),
+                path=self.path,
+            ))
+
+            self.assertIn('eng/pr-branch', repo.commits)
+            with MockTerminal.input('y'):
+                self.assertEqual(0, program.main(
+                    args=('clean', 'pr-1'),
+                    path=self.path,
+                ))
+            self.assertNotIn('eng/pr-branch', repo.commits)


### PR DESCRIPTION
#### 23ca71549eeb4d958388b58a8e322d9f90d66eb5
<pre>
[git-webkit] Add automation to assist in branch cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=238637">https://bugs.webkit.org/show_bug.cgi?id=238637</a>
&lt;rdar://problem/91127828 &gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add branch deletion and reset mocks.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py:
(Svn.__init__): Add `svn revert` mock.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py:
(Clean):
(Clean.parser): Allow caller to specify branch or pull request.
(Clean.cleanup): Delete a branch or branches associated with a pull request.
(Clean.main): Differentiate calls with branches and pull requests specified from those without.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py: Added.
(TestClean):
(TestClean.setUp):
(TestClean.test_checkout_none):
(TestClean.test_clean_git):
(TestClean.test_clean_svn):
(TestClean.test_clean_branch):
(TestClean.test_clean_pr):
</pre>