### PR TITLE
[git-webkit] Apply labels based on tracker

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,24 @@
+2022-04-06  Jonathan Bedard  <jbedard@apple.com>
+
+        [git-webkit] Apply labels based on tracker
+        https://bugs.webkit.org/show_bug.cgi?id=238640
+        <rdar://problem/91135356>
+
+        Reviewed by Stephanie Lewis.
+
+        * Scripts/libraries/webkitbugspy/setup.py: Bump version.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
+        * Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py:
+        (GitHub._issue): Handle case where empty assignee can be resolved.
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
+        (GitHub.__init__): Pass issues, projects and labels to base class.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
+        (PullRequest.main): If we have an associated issue and can apply labels to our pull request,
+        apply the issue's component and version labels to our pull request.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
+
 2022-04-06  Sihui Liu  <sihui_liu@apple.com>
 
         Remove test ResourceLoadStatistics.RemoveSessionID

--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.5.0',
+    version='0.5.1',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 5, 0)
+version = Version(0, 5, 1)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
@@ -122,7 +122,7 @@ class GitHub(Base, mocks.Requests):
             )
         issue = self.issues[id]
         if data:
-            if self.users.get(data.get('assignees', [None])[0]):
+            if data.get('assignees') and self.users.get(data.get('assignees', [None])[0]):
                 issue['assignee'] = self.users[data['assignees'][0]]
             if data.get('state') == 'opened':
                 issue['opened'] = True

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='4.6.0',
+    version='4.7.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(4, 6, 0)
+version = Version(4, 7, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -35,7 +35,7 @@ class GitHub(bmocks.GitHub):
     def __init__(
         self, remote='github.example.com/WebKit/WebKit', datafile=None,
         default_branch='main', git_svn=False, environment=None,
-        releases=None,
+        releases=None, issues=None, projects=None, labels=None,
     ):
         if not scmremote.GitHub.is_webserver('https://{}'.format(remote)):
             raise ValueError('"{}" is not a valid GitHub remote'.format(remote))
@@ -44,7 +44,7 @@ class GitHub(bmocks.GitHub):
         self.remote = remote
         self.forks = []
 
-        super(GitHub, self).__init__(remote, environment=environment)
+        super(GitHub, self).__init__(remote, environment=environment, issues=issues, projects=projects, labels=labels)
 
         with open(datafile or os.path.join(os.path.dirname(os.path.dirname(__file__)), 'git-repo.json')) as file:
             self.commits = jsonlib.load(file)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -270,6 +270,22 @@ class PullRequest(Command):
                     issue.open(why='Re-opening for pull request {}'.format(pr.url))
                 print('Posted pull request link to {}'.format(issue.link))
 
+        if issue and pr._metadata and pr._metadata.get('issue'):
+            log.info('Syncing PR labels with issue component...')
+            pr_issue = pr._metadata['issue']
+            project = pr_issue.tracker.name
+            component = issue.component
+            if pr_issue.component == component or component not in pr_issue.tracker.projects.get(project, {}).get('components', {}):
+                component = None
+            version = issue.version
+            if pr_issue.version == version or version not in pr_issue.tracker.projects.get(project, {}).get('versions', []):
+                version = None
+            if component or version:
+                pr_issue.set_component(component=component, version=version)
+                log.info('Synced PR labels with issue component!')
+            else:
+                log.info('No label syncing required')
+
         if pr.url:
             print(pr.url)
 


### PR DESCRIPTION
#### f31e86e910699627d6dd623e3cbad8de3bbb5369
<pre>
[git-webkit] Apply labels based on tracker
<a href="https://bugs.webkit.org/show_bug.cgi?id=238640">https://bugs.webkit.org/show_bug.cgi?id=238640</a>
&lt;rdar://problem/91135356 &gt;

Reviewed by Stephanie Lewis.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py:
(GitHub._issue): Handle case where empty assignee can be resolved.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.__init__): Pass issues, projects and labels to base class.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.main): If we have an associated issue and can apply labels to our pull request,
apply the issue&apos;s component and version labels to our pull request.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249325@main">https://commits.webkit.org/249325@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292474">https://svn.webkit.org/repository/webkit/trunk@292474</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
