### PR TITLE
[git-webkit] Provide https credentialing program

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,24 @@
 2022-04-06  Jonathan Bedard  <jbedard@apple.com>
 
+        [git-webkit] Provide https credentialing program
+        https://bugs.webkit.org/show_bug.cgi?id=238679
+        <rdar://problem/91177114>
+
+        Reviewed by Stephanie Lewis and Dewei Zhu.
+
+        * Scripts/libraries/webkitscmpy/setup.py: Bump version.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add Credentials program.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/credentials.py: Added.
+        (Credentials.main): Return credentials for remote.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
+        (Setup.git): Set credential helper if remote is an http remote.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
+        (BitBucket.credentials): Stub function to be replace by child classes.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
+
+2022-04-06  Jonathan Bedard  <jbedard@apple.com>
+
         [git-webkit] Add automation to assist in branch cleanup
         https://bugs.webkit.org/show_bug.cgi?id=238637
         <rdar://problem/91127828>

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='4.8.0',
+    version='4.9.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(4, 8, 0)
+version = Version(4, 9, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -31,6 +31,7 @@ from .canonicalize import Canonicalize
 from .clean import Clean
 from .command import Command
 from .checkout import Checkout
+from .credentials import Credentials
 from .find import Find, Info
 from .install_git_lfs import InstallGitLFS
 from .land import Land
@@ -72,7 +73,7 @@ def main(
     )
 
     subparsers = parser.add_subparsers(help='sub-command help')
-    programs = [Blame, Branch, Canonicalize, Checkout, Clean, Find, Info, Land, Log, Pull, PullRequest, Setup, InstallGitLFS]
+    programs = [Blame, Branch, Canonicalize, Checkout, Clean, Find, Info, Land, Log, Pull, PullRequest, Setup, InstallGitLFS, Credentials]
     if subversion:
         programs.append(SetupGitSvn)
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/credentials.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/credentials.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .command import Command
+from webkitcorepy import arguments
+from webkitscmpy import local
+
+
+class Credentials(Command):
+    name = 'credentials'
+    help = 'Return https credentials for a repository in a format digestable by git'
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not repository:
+            sys.stderr.write('No repository defined\n')
+            return 1
+        if repository.is_svn and not repository.is_git:
+            sys.stderr.write('Cannot extract credentials from subversion repository\n')
+            return 1
+
+        if repository.path:
+            rmt = repository.remote()
+        else:
+            rmt = repository
+
+        username = None
+        password = None
+
+        if rmt and getattr(rmt, 'credentials', None):
+            username, password = rmt.credentials()
+
+        print('username={}'.format(username or ''))
+        print('password={}'.format(password or ''))
+
+        return 0 if username and password else 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -284,6 +284,9 @@ class BitBucket(Scm):
 
         self.pull_requests = self.PRGenerator(self)
 
+    def credentials(self):
+        return None, None
+
     @property
     def is_git(self):
         return True

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -116,9 +116,8 @@ Using the default git editor for this repository
         )
 
     def test_github_checkout(self):
-        self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, \
-            MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'disabled', '1', 'y', 'y'), \
+            MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'disabled', '1', 'y'), \
             mocks.local.Git(self.path, remote='https://{}.git'.format(remote.remote)) as repo, \
             wkmocks.Environment(EMAIL_ADDRESS=''):
 
@@ -133,7 +132,8 @@ Using the default git editor for this repository
             self.assertNotIn('color.status', config)
             self.assertEqual('Committer', config.get('user.name', ''))
             self.assertEqual('committer@webkit.org', config.get('user.email', ''))
-            self.assertEqual('git@github.example.com:WebKit/WebKit.git', local.Git(self.path).url())
+            self.assertEqual('!f()', config.get('credential.https://github.example.com.helper', ''))
+            self.assertEqual('https://github.example.com/WebKit/WebKit.git', local.Git(self.path).url())
 
         programs = ['default'] + [p.name for p in Editor.programs()]
         self.assertEqual(
@@ -153,8 +153,6 @@ a pull request branch? ([when-user-owned]/disabled/always/never):
 Pick a commit message editor for this repository:
     {}
 : 
-http(s) based remotes will prompt for your password every time when pushing,
-it is recommended to convert to a ssh remote, would you like to convert to a ssh remote? ([Yes]/No): 
 Create a private fork of 'WebKit' belonging to 'username' ([Yes]/No): 
 Setup succeeded!
 '''.format('\n    '.join([
@@ -182,7 +180,7 @@ Created a private fork of 'WebKit' belonging to 'username'!
 Adding forked remote as 'username' and 'fork'...
 Added remote 'username'
 Added remote 'fork'
-Fetching 'git@github.example.com:username/WebKit.git'
+Fetching 'https://github.example.com/username/WebKit.git'
 '''.format(repository=self.path),
         )
 


### PR DESCRIPTION
#### eb4bb8f4da391c2a9f4b93844930b77ff298b1d9
<pre>
[git-webkit] Provide https credentialing program
<a href="https://bugs.webkit.org/show_bug.cgi?id=238679">https://bugs.webkit.org/show_bug.cgi?id=238679</a>
&lt;rdar://problem/91177114 &gt;

Reviewed by Stephanie Lewis and Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add Credentials program.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/credentials.py: Added.
(Credentials.main): Return credentials for remote.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Set credential helper if remote is an http remote.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.credentials): Stub function to be replace by child classes.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249340@main">https://commits.webkit.org/249340@main</a>
</pre>
