### PR TITLE
[git-webkit canonicalize] Support multiple empty lines

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,17 @@
+2022-04-04  Jonathan Bedard  <jbedard@apple.com>
+
+        [git-webkit canonicalize] Support multiple empty lines
+        https://bugs.webkit.org/show_bug.cgi?id=238744
+        <rdar://problem/91246947>
+
+        Reviewed by Stephanie Lewis and Dewei Zhu.
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
+        (main): When committing a change with 'Patch by' in it, SVN adds an
+        extra empty line in the commit message.
+        * Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
+        (TestCanonicalize.test_git_svn_existing_merge_queue): Added.
+
 2022-04-04  Chris Dumez  <cdumez@apple.com>
 
         Drop mostly unused String(const LChar*) constructor

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020, 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -69,15 +69,27 @@ def main(inputfile, identifier_template):
     if identifier_index and lines[identifier_index - 1].startswith(identifier_template.format('').split(':')[0]):
         lines[identifier_index - 1] = identifier_template.format(commit)
         identifier_index = identifier_index - 2
-    elif identifier_index and lines[identifier_index - 2].startswith(identifier_template.format('').split(':')[0]):
-        del lines[identifier_index - 2]
-        lines.insert(identifier_index - 1, identifier_template.format(commit))
-        identifier_index = identifier_index - 2
     else:
-        lines.insert(identifier_index, identifier_template.format(commit))
+        for index in [2, 3]:
+            if identifier_index - index > 0 and lines[identifier_index - index].startswith(identifier_template.format('').split(':')[0]):
+                del lines[identifier_index - index]
+                lines.insert(identifier_index - 1, identifier_template.format(commit))
+                identifier_index = identifier_index - 2
+                break
+        else:
+            lines.insert(identifier_index, identifier_template.format(commit))
 
     if lines[identifier_index]:
         lines.insert(identifier_index, '')
+
+    # Turn multiple empty lines at the end of a commit into a single one
+    index = len(lines) - 1
+    while index and lines[index]:
+        index -= 1
+    index -= 1
+    while index and not lines[index]:
+        del lines[index]
+        index -= 1
 
     for line in lines:
         print(line)


### PR DESCRIPTION
#### adcaeb7d203d7d889777eeb1750d104406f6df02
<pre>
[git-webkit canonicalize] Support multiple empty lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=238744">https://bugs.webkit.org/show_bug.cgi?id=238744</a>
&lt;rdar://problem/91246947 &gt;

Reviewed by Stephanie Lewis and Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
(main): When committing a change with &apos;Patch by&apos; in it, SVN adds an
extra empty line in the commit message.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
(TestCanonicalize.test_git_svn_existing_merge_queue): Added.

Canonical link: <a href="https://commits.webkit.org/249197@main">https://commits.webkit.org/249197@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292304">https://svn.webkit.org/repository/webkit/trunk@292304</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
