### PR TITLE
[Merge-Queue] Add author to commit message

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -24,8 +24,8 @@
 from buildbot.process import factory
 from buildbot.steps import trigger
 
-from steps import (AddReviewerToCommitMessage, AddReviewerToChangeLog, ApplyPatch, ApplyWatchList, Canonicalize, CheckOutPullRequest,
-                   CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
+from steps import (AddAuthorToCommitMessage, AddReviewerToCommitMessage, AddReviewerToChangeLog, ApplyPatch, ApplyWatchList, Canonicalize,
+                   CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                    CheckPatchStatusOnEWSQueues, CheckStyle, CleanGitRepo, CompileJSC, CompileWebKit, ConfigureBuild, CreateLocalGITCommit,
                    DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedChangeLogs, FindModifiedLayoutTests,
                    InstallGtkDependencies, InstallWpeDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
@@ -333,6 +333,7 @@ class MergeQueueFactory(factory.BuildFactory):
         self.addStep(CheckOutPullRequest())
         self.addStep(ValidateSquashed())
         self.addStep(AddReviewerToCommitMessage())
+        self.addStep(AddAuthorToCommitMessage())
         self.addStep(AddReviewerToChangeLog())
         self.addStep(ValidateCommitMessage())
         self.addStep(ValidateChangeLogAndReviewer())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -640,6 +640,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-pull-request',
             'validate-squashed',
             'add-reviewer-to-commit-message',
+            'add-author-to-commit-message',
             'add-reviewer-to-changelog',
             'validate-commit-message',
             'validate-changelog-and-reviewer',

--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -56,6 +56,7 @@ if not is_test_mode_enabled:
                 'github.base.ref',
                 'github.base.sha',
                 'github.head.repo.full_name',
+                'github.head.user.login',
             ], 'token': load_password('GITHUB_COM_ACCESS_TOKEN'),
         },
     )

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,30 @@
+2022-04-04  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Add author to commit message
+        https://bugs.webkit.org/show_bug.cgi?id=238752
+        <rdar://problem/91254339>
+
+        Reviewed by Aakash Jain.
+
+        svn.webkit.org will attribute a change to a specific author
+        if "Patch by" is in the commit message.
+
+        * CISupport/ews-build/factories.py:
+        (MergeQueueFactory.__init__): Add AddAuthorToCommitMessage step.
+        * CISupport/ews-build/factories_unittest.py:
+        (TestExpectedBuildSteps): Ditto.
+        * CISupport/ews-build/master.cfg: Determine commit author from github.head.user.login.
+        * CISupport/ews-build/steps.py:
+        (AddAuthorToCommitMessage):
+        (AddAuthorToCommitMessage.__init__):
+        (AddAuthorToCommitMessage.author): Return commit author's name and email, falling back
+        to the committers name and email if those cannot be determined.
+        (AddAuthorToCommitMessage.start): Insert "Patch by" into commit message.
+        (AddAuthorToCommitMessage.getResultSummary):
+        (AddAuthorToCommitMessage.doStepIf): Only do step if the author can be determined.
+        (AddAuthorToCommitMessage.hideStepIf): Hide step if skipped.
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-05  Eric Carlson  <eric.carlson@apple.com>
 
         5 Media API tests are flakily timing out on iOS14


### PR DESCRIPTION
#### 1e8eb307daa055dde54e7c11f60d4153ac9bd325
<pre>
[Merge-Queue] Add author to commit message
<a href="https://bugs.webkit.org/show_bug.cgi?id=238752">https://bugs.webkit.org/show_bug.cgi?id=238752</a>
&lt;rdar://problem/91254339 &gt;

Reviewed by Aakash Jain.

svn.webkit.org will attribute a change to a specific author
if &quot;Patch by&quot; is in the commit message.

* Tools/CISupport/ews-build/factories.py:
(MergeQueueFactory.__init__): Add AddAuthorToCommitMessage step.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps): Ditto.
* Tools/CISupport/ews-build/master.cfg: Determine commit author from github.head.user.login.
* Tools/CISupport/ews-build/steps.py:
(AddAuthorToCommitMessage):
(AddAuthorToCommitMessage.__init__):
(AddAuthorToCommitMessage.author): Return commit author&apos;s name and email, falling back
to the committers name and email if those cannot be determined.
(AddAuthorToCommitMessage.start): Insert &quot;Patch by&quot; into commit message.
(AddAuthorToCommitMessage.getResultSummary):
(AddAuthorToCommitMessage.doStepIf): Only do step if the author can be determined.
(AddAuthorToCommitMessage.hideStepIf): Hide step if skipped.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249265@main">https://commits.webkit.org/249265@main</a>
</pre>
