### PR TITLE
[Merge-Queue] Run `git svn fetch`

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,7 +27,7 @@ from buildbot.steps import trigger
 from steps import (AddAuthorToCommitMessage, AddReviewerToCommitMessage, AddReviewerToChangeLog, ApplyPatch, ApplyWatchList, Canonicalize,
                    CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                    CheckPatchStatusOnEWSQueues, CheckStyle, CleanGitRepo, CompileJSC, CompileWebKit, ConfigureBuild, CreateLocalGITCommit,
-                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedChangeLogs, FindModifiedLayoutTests,
+                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedChangeLogs, FindModifiedLayoutTests, GitSvnFetch,
                    InstallGtkDependencies, InstallWpeDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                    RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                    RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
@@ -326,6 +326,7 @@ class MergeQueueFactory(factory.BuildFactory):
         self.addStep(PrintConfiguration())
         self.addStep(CleanGitRepo())
         self.addStep(CheckOutSource())
+        self.addStep(GitSvnFetch())  # FIXME: Remove when migrating to pure git
         self.addStep(FetchBranches())
         self.addStep(ShowIdentifier())
         self.addStep(VerifyGitHubIntegrity())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -633,6 +633,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'configuration',
             'clean-up-git-repo',
             'clean-and-update-working-directory',
+            'git-svn-fetch',
             'fetch-branch-references',
             'show-identifier',
             'verify-github-integrity',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5056,3 +5056,20 @@ class UpdatePullRequest(shell.ShellCommand, GitHubMixin):
 
     def hideStepIf(self, results, step):
         return not self.doStepIf(step)
+
+
+class GitSvnFetch(shell.ShellCommand):
+    name = 'git-svn-fetch'
+    haltOnFailure = False
+    flunkOnFailure = False
+    command = ['git', 'svn', 'fetch']
+
+    def __init__(self, **kwargs):
+        super(GitSvnFetch, self).__init__(logEnviron=False, timeout=600, **kwargs)
+
+    def getResultSummary(self):
+        if self.results == SUCCESS:
+            return {'step': 'Paired recent SVN commits with GitHub record'}
+        if self.results == FAILURE:
+            return {'step': 'Recent SVN commits did not match GitHub record'}
+        return super(GitSvnFetch, self).getResultSummary()

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,24 @@
+2022-04-04  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Run `git svn fetch`
+        https://bugs.webkit.org/show_bug.cgi?id=238759
+        <rdar://problem/91258277>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/factories.py:
+        (MergeQueueFactory.__init__): Add GitSvnFetch step.
+        * CISupport/ews-build/factories_unittest.py:
+        (TestExpectedBuildSteps): Ditto.
+        * CISupport/ews-build/steps.py:
+        (UpdatePullRequest.hideStepIf):
+        (GitSvnFetch):
+        (GitSvnFetch.__init__): `git svn fetch` will have a non-zero exit code if the Subversion
+        record of changes does not match the git one, which will happen imiediately after committing.
+        (GitSvnFetch.getResultSummary):
+        (GitSvnFetch.evaluateCommand): Support expected failure.
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-06  J Pascoe  <j_pascoe@apple.com>
 
         Fix expected, actual links for variant-based imported wpt tests


### PR DESCRIPTION
#### 81729c491c0a0702b84a9ea309eaf6ee8046d7d9
<pre>
[Merge-Queue] Run `git svn fetch`
<a href="https://bugs.webkit.org/show_bug.cgi?id=238759">https://bugs.webkit.org/show_bug.cgi?id=238759</a>
&lt;rdar://problem/91258277 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/factories.py:
(MergeQueueFactory.__init__): Add GitSvnFetch step.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps): Ditto.
* Tools/CISupport/ews-build/steps.py:
(UpdatePullRequest.hideStepIf):
(GitSvnFetch):
(GitSvnFetch.__init__): `git svn fetch` will have a non-zero exit code if the Subversion
record of changes does not match the git one, which will happen imiediately after committing.
(GitSvnFetch.getResultSummary):
(GitSvnFetch.evaluateCommand): Support expected failure.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249352@main">https://commits.webkit.org/249352@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292509">https://svn.webkit.org/repository/webkit/trunk@292509</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
