### PR TITLE
[Merge-Queue] Extract bug_id when updating pull-request

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6344,7 +6344,9 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to update pull request')
         with current_hostname(EWS_BUILD_HOSTNAME):
-            return self.runStep()
+            rc = self.runStep()
+            self.assertEqual(self.getProperty('bug_id'), '238553')
+            return rc
 
 
 if __name__ == '__main__':

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,19 @@
+2022-04-05  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Extract bug_id when updating pull-request
+        https://bugs.webkit.org/show_bug.cgi?id=238772
+        <rdar://problem/91263398>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (LeaveComment.start): Leave comment on both bugzilla and pull request.
+        (LeaveComment.getResultSummary): Ditto.
+        (UpdatePullRequest):
+        (UpdatePullRequest.bug_id_from_log): Extract bug_id from commit message.
+        (UpdatePullRequest.evaluateCommand): Set bug_id property
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-05  Yury Semikhatsky  <yurys@chromium.org>
 
         Do not create network process in ~WebsiteDataStore destructor


### PR DESCRIPTION
#### 2207fa9fc0025529b5c8821513f9e541f671e931
<pre>
[Merge-Queue] Extract bug_id when updating pull-request
<a href="https://bugs.webkit.org/show_bug.cgi?id=238772">https://bugs.webkit.org/show_bug.cgi?id=238772</a>
&lt;rdar://problem/91263398 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(LeaveComment.start): Leave comment on both bugzilla and pull request.
(LeaveComment.getResultSummary): Ditto.
(UpdatePullRequest):
(UpdatePullRequest.bug_id_from_log): Extract bug_id from commit message.
(UpdatePullRequest.evaluateCommand): Set bug_id property
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249268@main">https://commits.webkit.org/249268@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292405">https://svn.webkit.org/repository/webkit/trunk@292405</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
