### PR TITLE
Support PKShippingMethods on iOS

### DIFF
--- a/Source/WebCore/PAL/ChangeLog
+++ b/Source/WebCore/PAL/ChangeLog
@@ -1,3 +1,13 @@
+2022-04-05  Jonathan Bedard  <jbedard@apple.com>
+
+        Support PKShippingMethods on iOS
+        https://bugs.webkit.org/show_bug.cgi?id=238845
+        <rdar://problem/91320467>
+
+        Reviewed by Devin Rousso.
+
+        * pal/spi/cocoa/PassKitSPI.h: Move PKShippingMethods SPI declarations out of MacOS specific #ifdefs.
+
 2022-04-05  Elliott Williams  <emw@apple.com>
 
         [XCBuild] PAL: Add headers-only dependency on WebGPU

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -320,12 +320,6 @@ typedef NSString * PKPaymentNetwork NS_EXTENSIBLE_STRING_ENUM;
 #endif
 @end
 
-#if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-@interface PKShippingMethods : NSObject
-- (instancetype)initWithMethods:(NSArray<PKShippingMethod *> *)methods defaultMethod:(nullable PKShippingMethod *)defaultMethod;
-@end
-#endif
-
 #if HAVE(PASSKIT_SHIPPING_CONTACT_EDITING_MODE)
 typedef NS_ENUM(NSUInteger, PKShippingContactEditingMode) {
     PKShippingContactEditingModeEnabled = 1,
@@ -354,10 +348,6 @@ typedef NS_ENUM(NSUInteger, PKShippingContactEditingMode) {
 #if HAVE(PASSKIT_COUPON_CODE)
 @property (nonatomic, assign) BOOL supportsCouponCode;
 @property (nonatomic, copy, nullable) NSString *couponCode;
-#endif
-
-#if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-@property (nonatomic, copy) PKShippingMethods *availableShippingMethods;
 #endif
 
 #if HAVE(PASSKIT_SHIPPING_CONTACT_EDITING_MODE)
@@ -522,9 +512,6 @@ NS_ASSUME_NONNULL_BEGIN
 #if HAVE(PASSKIT_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_SUMMARY_ITEMS)
 @property (nonatomic, copy) NSArray<PKShippingMethod *> *shippingMethods;
 #endif
-#if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
-@property (nonatomic, copy) PKShippingMethods *availableShippingMethods;
-#endif
 @end
 
 @interface PKPaymentRequestPaymentMethodUpdate : PKPaymentRequestUpdate
@@ -548,6 +535,24 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 #endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD) && !USE(APPLE_INTERNAL_SDK)
+@interface PKShippingMethods : NSObject
+- (instancetype)initWithMethods:(NSArray<PKShippingMethod *> *)methods defaultMethod:(nullable PKShippingMethod *)defaultMethod;
+@end
+
+@interface PKPaymentRequest ()
+@property (nonatomic, copy) PKShippingMethods *availableShippingMethods;
+@end
+
+@interface PKPaymentRequestUpdate ()
+@property (nonatomic, copy) PKShippingMethods *availableShippingMethods;
+@end
+#endif // HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD) && !USE(APPLE_INTERNAL_SDK)
+
+NS_ASSUME_NONNULL_END
 
 extern "C"
 void PKDrawApplePayButtonWithCornerRadius(_Nonnull CGContextRef, CGRect drawRect, CGFloat scale, CGFloat cornerRadius, PKPaymentButtonType, PKPaymentButtonStyle, NSString * _Nullable languageCode);


### PR DESCRIPTION
#### fe9ec83a70d003c1ebd159c4cc8fc268e4a6787e
<pre>
Support PKShippingMethods on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=238845">https://bugs.webkit.org/show_bug.cgi?id=238845</a>
&lt;rdar://problem/91320467 &gt;

Reviewed by Devin Rousso.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h: Move PKShippingMethods SPI declarations out of MacOS specific #ifdefs.

Canonical link: <a href="https://commits.webkit.org/249321@main">https://commits.webkit.org/249321@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292470">https://svn.webkit.org/repository/webkit/trunk@292470</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
