### PR TITLE
[Merge-Queue] Use rebase over merge when canonicalizing commit

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4912,7 +4912,7 @@ class Canonicalize(steps.ShellSequence, ShellMixin):
         commands = []
         if self.rebase_enabled:
             commands = [
-                ['git', 'pull', 'origin', base_ref],
+                ['git', 'pull', 'origin', base_ref, '--rebase'],
                 ['git', 'branch', '-f', base_ref, head_ref],
                 ['git', 'checkout', base_ref],
             ]

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6115,7 +6115,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 timeout=300,
                 logEnviron=False,
-                command=['git', 'pull', 'origin', 'main'],
+                command=['git', 'pull', 'origin', 'main', '--rebase'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=300,
@@ -6164,7 +6164,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 workdir='wkdir',
                 timeout=300,
                 logEnviron=False,
-                command=['git', 'pull', 'origin', 'main'],
+                command=['git', 'pull', 'origin', 'main', '--rebase'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=300,

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,15 @@
+2022-04-06  Jonathan Bedard  <jbedard@apple.com>
+
+        [Merge-Queue] Use rebase over merge when canonicalizing commit
+        https://bugs.webkit.org/show_bug.cgi?id=238877
+        <rdar://problem/91363334>
+
+        Reviewed by Ryan Haddad and Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (Canonicalize.run): Specify rebase workflow instead of merge workflow.
+        * CISupport/ews-build/steps_unittest.py:
+
 2022-04-06  Lauro Moura  <lmoura@igalia.com>
 
         [Flatpak SDK] Avoid termination if gdbus is not installed after 249303@main


### PR DESCRIPTION
#### 0474084e98944608d2639420de2177724bdc8698
<pre>
[Merge-Queue] Use rebase over merge when canonicalizing commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=238877">https://bugs.webkit.org/show_bug.cgi?id=238877</a>
&lt;rdar://problem/91363334 &gt;

Reviewed by Ryan Haddad and Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(Canonicalize.run): Specify rebase workflow instead of merge workflow.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249344@main">https://commits.webkit.org/249344@main</a>
</pre>
