### PR TITLE
Remove Catalina references in TestExpectations

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,15 @@
+2022-04-06  Jonathan Bedard  <jbedard@apple.com>
+
+        Remove Catalina references in TestExpectations
+        https://bugs.webkit.org/show_bug.cgi?id=238886
+        <rdar://problem/91373532>
+
+        Unreviewed test gardening.
+
+        * platform/mac-wk1/TestExpectations: Remove Catalina references.
+        * platform/mac-wk2/TestExpectations: Ditto.
+        * platform/mac/TestExpectations: Ditto.
+
 2022-04-06  J Pascoe  <j_pascoe@apple.com>
 
         pbkdf2.https.any.worker.html fails on WPE, GTK2 ports

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -454,7 +454,7 @@ webkit.org/b/155196 security/contentSecurityPolicy/video-with-blob-url-allowed-b
 storage/websql/sql-error-codes.html [ Failure ]
 
 # <rdar://problem/52689856> storage/websql/test-authorizer.html is failing
-[ Catalina+ ] storage/websql/test-authorizer.html [ Failure ]
+storage/websql/test-authorizer.html [ Failure ]
 
 # <rdar://problem/11187491> storage/websql/quota-tracking.html is failing on Mountain Lion
 storage/websql/quota-tracking.html
@@ -947,8 +947,6 @@ media/track/track-cues-enter-exit.html [ Pass Crash ]
 # <rdar://problem/61744994> media/track/track-cues-cuechange.html is flaky timing out.
 media/track/track-cues-cuechange.html [ Pass Crash Timeout ]
 
-webkit.org/b/229765 [ Catalina Debug ] media/track/track-disabled-addcue.html [ Pass Crash ]
-
 webkit.org/b/229478 [ Release ] media/track/track-in-band.html [ Pass Timeout ]
 
 webkit.org/b/167127 pointer-lock/locked-element-removed-from-dom.html
@@ -1360,23 +1358,6 @@ fast/dom/Window/window-open-self-disallow-close.html [ Pass Crash Timeout ]
 # rdar://66866579 ([ Layout Tests ] REGRESSION: [ MacOS wk1 release ] compositing/animation/matrix-animation.html is a flaky failure)
 compositing/animation/matrix-animation.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/206945 [ Catalina ] compositing/repaint/become-overlay-composited-layer.html [ Pass Failure ]
-
-# rdar://65287528 (CrashTracer: DumpRenderTree at com.apple.QuartzCore: CA::OGL::MetalContext::create_pipeline_state (SC crash on SC_SCCVN::MakeBufferIntrinsicProp))
-[ Catalina ] fast/canvas/canvas-currentColor.html [ Skip ]
-[ Catalina ] fast/canvas/canvas-radial-gradient-spreadMethod.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.behind.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.bottom.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.cylinder.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.front.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.shape1.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.shape2.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.top.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch1.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch2.html [ Skip ]
-[ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch3.html [ Skip ]
-
 webkit.org/b/214388 [ Mojave ] compositing/repaint/iframes [ Pass Failure ]
 webkit.org/b/206178 [ Mojave ] editing/spelling/spellcheck-attribute.html [ Pass Crash ]
 webkit.org/b/190350 [ Mojave ] storage/indexeddb/database-odd-names.html [ Failure ]
@@ -1471,7 +1452,7 @@ webkit.org/b/215926 svg/custom/object-sizing.xhtml [ Pass Failure ]
 [ BigSur+ ] platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html [ Skip ]
 
 # <rdar://problem/32800095> REGRESSION: LayoutTest imported/blink/fast/gradients/gradient-transparency.html is failing
-[ Mojave Catalina ] imported/blink/fast/gradients/gradient-transparency.html [ ImageOnlyFailure ]
+[ Mojave ] imported/blink/fast/gradients/gradient-transparency.html [ ImageOnlyFailure ]
 
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/collapse-45.html [ Slow ]
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/collapse-15.html [ Slow ]
@@ -1522,7 +1503,6 @@ webkit.org/b/222693 [ BigSur Release ] media/video-aspect-ratio.html [ Failure T
 
 webkit.org/b/223104 compositing/visibility/iframe-visibility-hidden.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/223193 [ Catalina ] imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.scale2.html [ Failure ]
 webkit.org/b/223193 [ BigSur ] imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.scale2.html [ Failure ]
 
 webkit.org/b/223271 [ BigSur Debug ] imported/w3c/web-platform-tests/xhr/send-response-event-order.htm [ Pass Failure ]
@@ -1597,8 +1577,6 @@ webkit.org/b/223770 media/video-playback-quality.html [ Pass Failure ]
 
 webkit.org/b/224144 storage/websql/alter-to-info-table.html [ Skip ]
 
-webkit.org/b/226229 [ Catalina ] imported/w3c/web-platform-tests/css/css-backgrounds/hidpi/simple-bg-color.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/226360 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html [ Pass Failure ]
 
 webkit.org/b/226377 [ BigSur ] imported/w3c/web-platform-tests/css/css-contain/contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html [ Pass Failure ]
@@ -1640,7 +1618,6 @@ webkit.org/b/228091 [ Release ] media/modern-media-controls/scrubber-support/scr
 webkit.org/b/227845 [ Debug ] webaudio/audioworket-out-of-memory.html [ Pass Timeout DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/228796 [ BigSur+ ] webaudio/silent-audio-interrupted-in-background.html [ Pass Timeout ]
-webkit.org/b/228796 [ Catalina Debug ] webaudio/silent-audio-interrupted-in-background.html [ Pass Timeout ]
 
 webkit.org/b/227136 media/video-pause-immediately.html [ Pass Failure ]
 
@@ -1708,66 +1685,15 @@ webkit.org/b/231102 [ BigSur ] printing/css2.1/page-break-after-000.html [ Pass 
 # webkit.org/b/214448 Web Share API is not implemented for mac-wk1
 http/tests/webshare/ [ Skip ]
 
-#WebGL Tests Timing Out on Catalina Debug WK1 EWS webkit.org/b/230774
-[ Catalina Debug ] webgl/1.0.3/conformance/canvas/drawingbuffer-static-canvas-test.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/ogles/GL/notEqual/notEqual_009_to_012.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/ogles/GL/step/step_001_to_006.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/ogles/GL/exp/exp_001_to_008.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/ogles/GL/struct/struct_049_to_056.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-r8ui-red_integer-unsigned_byte.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/canvas/viewport-unchanged-upon-resize.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/canvas/tex-2d-rg8-rg-unsigned_byte.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/image_bitmap_from_image_data/tex-2d-rgb5_a1-rgba-unsigned_byte.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/uniforms/out-of-bounds-uniform-array-access.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/max-active-contexts-gc.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/extensions/ext-sRGB.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/glsl/misc/shader-with-undefined-preprocessor-symbol.frag.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/misc/expando-loss-2.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/image_data/tex-2d-r11f_g11f_b10f-rgb-half_float.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/extensions/get-extension.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance2/textures/canvas/tex-2d-r11f_g11f_b10f-rgb-half_float.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/attribs/gl-vertex-attrib-zero-issues.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/webgl2-primitive-restart.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/1.0.3/conformance/programs/program-test.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/pending/conformance/glsl/misc/swizzle-as-lvalue.html [ Pass Timeout ]
-[ Catalina Debug ] webgl/2.0.0/conformance/rendering/draw-elements-out-of-bounds.html [ Pass Timeout ]
+webkit.org/b/230835 [ BigSur Debug ] webgl/2.0.y/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html [ Pass Crash ]
+webkit.org/b/230835 [ BigSur Debug ] webgl/1.0.3/conformance/extensions/oes-texture-float.html [ Pass Crash ]
+webkit.org/b/230835 [ BigSur Debug ] webgl/2.0.0/conformance/extensions/ext-blend-minmax.html [ Pass Crash ]
 
-webkit.org/b/230777 [ Catalina Debug ] transitions/transition-end-event-destroy-renderer.html [ Pass Crash ]
+webkit.org/b/230842 [ BigSur Debug ] media/track/audio-track.html [ Pass Crash ]
 
-webkit.org/b/230808 [ Catalina Debug ] media/modern-media-controls/media-controls/media-controls-placard-compressed-metrics.html [ Pass Crash ]
+webkit.org/b/230848 [ BigSur Debug ] webrtc/datachannel/datachannel-gc.html [ Pass Crash ]
 
-webkit.org/b/230831 [ Catalina Debug ] storage/websql/multiple-transactions-on-different-handles.html [ Pass Crash ]
-
-webkit.org/b/230833 [ Catalina Debug ] performance-api/performance-observer-order.html [ Pass Crash ]
-
-webkit.org/b/230835 [ Catalina BigSur Debug ] webgl/2.0.y/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html [ Pass Crash ]
-webkit.org/b/230835 [ Catalina BigSur Debug ] webgl/1.0.3/conformance/extensions/oes-texture-float.html [ Pass Crash ]
-webkit.org/b/230835 [ Catalina BigSur Debug ] webgl/2.0.0/conformance/extensions/ext-blend-minmax.html [ Pass Crash ]
-
-webkit.org/b/230842 [ Catalina BigSur Debug ] media/track/audio-track.html [ Pass Crash ]
-
-webkit.org/b/230844 [ Catalina Debug ] storage/indexeddb/mozilla/cursor-mutation.html [ Pass Crash ]
-
-webkit.org/b/230846 [ Catalina Debug ] svg/filters/big-height-filter.svg [ Pass Crash ]
-
-webkit.org/b/230848 [ Catalina BigSur Debug ] webrtc/datachannel/datachannel-gc.html [ Pass Crash ]
-
-webkit.org/b/230905 [ Catalina BigSur ] imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override.html [ Pass Failure ]
-
-webkit.org/b/231684 [ Catalina Debug ] requestidlecallback/requestidlecallback-document-gc.html [ Pass Crash ]
-
-webkit.org/b/232277 [ Catalina ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document.html [ Pass Failure ]
-webkit.org/b/232277 [ Catalina ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-different-load.html [ Pass Failure ]
-
-webkit.org/b/232315 [ Catalina Debug ] media/track/track-disabled.html [ Pass Crash ]
-
-webkit.org/b/232446 [ Catalina Debug ] media/track/track-element-dom-change-crash.html [ Pass Crash ]
-
-webkit.org/b/232585 [ Catalina Debug ] media/track/track-element-load-event.html [ Pass Crash ]
+webkit.org/b/230905 [ BigSur ] imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override.html [ Pass Failure ]
 
 # DumpRenderTree doesn't invoke inspector instrumentation when repainting.
 webkit.org/b/232852 inspector/page/setShowPaintRects.html [ Skip ]
@@ -1778,8 +1704,8 @@ webanimations/frame-rate/document-timeline-maximum-frame-rate.html [ Skip ]
 webkit.org/b/231918 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus-multiple-times.html [ Pass Failure ]
 
 # webkit.org/b/234105 Skip 2 imported/w3c/web-platform-tests/speech-api/SpeechSynthesis in mac wk1. 
-[ Catalina+ ] imported/w3c/web-platform-tests/speech-api/SpeechSynthesis-speak-events.html [ Skip ]
-[ Catalina+ ] imported/w3c/web-platform-tests/speech-api/SpeechSynthesis-pause-resume.tentative.html [ Skip ] 
+imported/w3c/web-platform-tests/speech-api/SpeechSynthesis-speak-events.html [ Skip ]
+imported/w3c/web-platform-tests/speech-api/SpeechSynthesis-pause-resume.tentative.html [ Skip ] 
 
 fast/scrolling/rtl-scrollbars-alternate-iframe-body-dir-attr-does-not-update-scrollbar-placement.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -689,7 +689,7 @@ webkit.org/b/141085 http/tests/media/video-query-url.html [ Pass Timeout ]
 ########################################
 
 # Accessibility isolated tree mode is enabled in Big Sur and beyond, no in Catalina and before.
-[ Mojave Catalina ] accessibility/mac/isolated-tree-mode-on-off.html [ Skip ]
+[ Mojave ] accessibility/mac/isolated-tree-mode-on-off.html [ Skip ]
 
 # Network interception with a mapped file is only mac-wk2 for now.
 http/tests/inspector/network/local-resource-override-mapped-to-file.html [ Pass ]
@@ -719,7 +719,7 @@ webkit.org/b/157589 fast/text-autosizing/ios/text-autosizing-after-back.html [ P
 
 # PiP tests are only enabled for Sierra WebKit2.
 # rdar://problem/27574303
-[ Catalina BigSur Monterey ] media/element-containing-pip-video-going-into-fullscreen.html [ Pass ]
+[ BigSur Monterey ] media/element-containing-pip-video-going-into-fullscreen.html [ Pass ]
 media/fullscreen-api-enabled-media-with-presentation-mode.html [ Pass ]
 webkit.org/b/173199 media/navigate-with-pip-should-not-crash.html [ Pass Failure ]
 media/picture-in-picture [ Pass ]
@@ -840,7 +840,7 @@ webkit.org/b/173861 [ Release ] http/tests/webrtc/filtering-ice-candidate-cross-
 webkit.org/b/172148 tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-mainframe-vertical.html [ Pass Failure ]
 
 webkit.org/b/228930 [ BigSur+ arm64 ] tiled-drawing/scrolling/scroll-snap/scroll-snap-momentum-in-non-snapping-axis.html [ Pass Failure ]
-webkit.org/b/228930 [ Catalina Debug ] tiled-drawing/scrolling/scroll-snap/scroll-snap-momentum-in-non-snapping-axis.html [ Pass Failure ]
+webkit.org/b/228930 [ Debug ] tiled-drawing/scrolling/scroll-snap/scroll-snap-momentum-in-non-snapping-axis.html [ Pass Failure ]
 
 webkit.org/b/173779 [ Debug ] fast/scrolling/arrow-key-scroll-in-rtl-document.html [ Pass Failure ]
 
@@ -880,8 +880,8 @@ http/tests/resourceLoadStatistics/strip-referrer-to-origin-for-third-party-reque
 http/tests/resourceLoadStatistics/cap-cache-max-age-for-prevalent-resource.html [ Pass ]
 
 # The SameSite cookie API is only available in macOS Catalina and above.
-[ Catalina+ ] http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Pass ]
-[ Catalina+ ] http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html [ Pass ]
+http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Pass ]
+http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html [ Pass ]
 
 # The CNAME and cookie transform SPIs are only available in macOS Big Sur and above.
 [ BigSur+ ] http/tests/resourceLoadStatistics/cname-cloaking-top-cname-sub-1p-cname.html [ Pass ]
@@ -1083,8 +1083,6 @@ webkit.org/b/209564 svg/as-image/svg-image-with-data-uri-background.html [ Pass 
 
 webkit.org/b/209624 tiled-drawing/scrolling/fixed/four-bars-zoomed.html [ Pass Failure ]
 
-webkit.org/b/209769 [ Catalina ] tiled-drawing/scrolling/frames/frameset-nested-frame-scrollability.html [ Pass Failure ]
-
 webkit.org/b/68278 http/tests/history/back-with-fragment-change.py [ Pass Failure ]
 
 webkit.org/b/210433 swipe/basic-cached-back-swipe.html [ Pass Crash Timeout ]
@@ -1171,24 +1169,6 @@ media/modern-media-controls/scrubber-support/scrubber-support-media-api.html [ P
 # <rdar://problem/63626512> REGRESSION(20A279-20A291a): webrtc/simulcast-h264.html is a constant timeout
 webrtc/simulcast-h264.html [ Pass Timeout ]
 
-# <rdar://problem/60642539> [ macOS wk2 ] inspector/unit-tests/async-test-suite.html is flaky timing out
-[ Catalina ] inspector/unit-tests/async-test-suite.html [ Slow ]
-
-# <rdar://problem/61177257> [ wk2 Debug ] ASSERTION FAILED: m_uncommittedState.state == State::Committed on http/tests/referrer-policy-anchor/unsafe-url/cross-origin-http-http.html
-[ Catalina Debug ] http/tests/referrer-policy-anchor/unsafe-url/cross-origin-http-http.html [ Pass Crash ]
-
-# <rdar://problem/61736265> fast/scrolling/latching/scroll-div-no-latching.html is flaky failing.
-[ Catalina Release ] fast/scrolling/latching/scroll-div-no-latching.html [ Pass Failure ]
-
-# <rdar://problem/63730309> accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html is a flaky failure
-[ Catalina ] accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html [ Pass Failure ]
-
-# <rdar://problem/64816037> REGRESSION: media/media-source/media-source-unnecessary-seek-seeked.html is a flaky failure
-[ Catalina ] media/media-source/media-source-unnecessary-seek-seeked.html [ Pass Failure ]
-
-#  <rdar://problem/64816527> swipe/pushState-cached-back-swipe.html is a flaky failure
-[ Catalina ] swipe/pushState-cached-back-swipe.html [ Pass Failure ]
-
 # <rdar://problem/63554249> [20A279] DQ bots are seeing http/tests/cache/disk-cache/disk-cache-validation-back-navigation-policy.html and http/tests/cache/disk-cache/disk-cache-validation-no-body.html are timing out
 webkit.org/b/179796 http/tests/cache/disk-cache/disk-cache-validation-back-navigation-policy.html [ Pass Failure Timeout ]
 [ BigSur+ Release ] http/tests/cache/disk-cache/disk-cache-validation-no-body.html [ Pass Timeout ]
@@ -1254,8 +1234,6 @@ webkit.org/b/214997 [ Release ] http/tests/workers/service/basic-install-event-w
 webkit.org/b/215809 [ Debug ] media/W3C/video/events/event_order_canplay_canplaythrough.html [ Pass Timeout ]
 
 webkit.org/b/216159 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-restartIce.https.html [ Pass Failure ]
-
-webkit.org/b/216164 [ Catalina Debug ] html5lib/generated/run-template-data.html [ Pass Crash ]
 
 webkit.org/b/216292 imported/w3c/web-platform-tests/css/css-flexbox/quirks-auto-block-size-with-percentage-item.html [ Pass Failure ]
 
@@ -1430,7 +1408,6 @@ webkit.org/b/224633 media/presentationmodechanged-fired-once.html [ Pass Timeout
 
 webkit.org/b/224690 compositing/video/video-border-radius-clipping.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/228713 [ Catalina Release ] compositing/video/video-object-fit.html [ Pass Timeout ] 
 webkit.org/b/228713 [ BigSur Debug arm64 ] compositing/video/video-object-fit.html [ Pass Timeout ] 
 
 webkit.org/b/224698 [ BigSur Release arm64 ] inspector/console/console-oom.html [ Pass Crash ]
@@ -1493,11 +1470,9 @@ webkit.org/b/227639 [ BigSur Release ] fast/history/visited-href-mutation.html [
 
 # Behavior of navigator-language-ru changed in Monterey
 [ Monterey+ ] fast/text/international/system-language/navigator-language/navigator-language-ru.html [ Failure ]
-[ BigSur Catalina Mojave ] fast/text/international/system-language/navigator-language/navigator-language-ru-2.html [ Failure ]
+[ BigSur Mojave ] fast/text/international/system-language/navigator-language/navigator-language-ru-2.html [ Failure ]
 
 webkit.org/b/227776 [ BigSur Release arm64 ] scrollbars/corner-resizer-window-inactive.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/227776 [ Catalina Release ] scrollbars/corner-resizer-window-inactive.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/227805 [ Debug ] fast/canvas/canvas-composite-image.html [ Pass Crash ]
 
@@ -1571,8 +1546,6 @@ imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.html [ Pass Failure
 #rdar://82044002 ([Monterey] imported/w3c/web-platform-tests/service-workers/service-worker/fetch-canvas-tainting-double-write.https.html is a constant failure)
 [ Monterey ]  imported/w3c/web-platform-tests/service-workers/service-worker/fetch-canvas-tainting-double-write.https.html [ Pass Failure ]
 
-webkit.org/b/226789 [ Catalina Release ] imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html [ Pass Failure ]
-
 webkit.org/b/230775 [ BigSur Release arm64 ] imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html [ Pass Failure ]
 
 webkit.org/b/229429 [ BigSur Debug ] http/tests/inspector/network/fetch-network-data.html [ Pass Failure ]
@@ -1594,7 +1567,7 @@ webkit.org/b/229472 [ BigSur Debug ] webgl/1.0.3/conformance/glsl/constructors/g
 [ BigSur+ ] media/modern-media-controls/tracks-support/hidden-tracks.html [ Pass Timeout ]
 [ BigSur+ ] media/modern-media-controls/tracks-support/off-text-track.html [ Pass Failure Timeout ]
 
-webkit.org/b/229478 [ Catalina BigSur ] media/track/track-in-band.html [ Pass Timeout ]
+webkit.org/b/229478 [ BigSur ] media/track/track-in-band.html [ Pass Timeout ]
 
 webkit.org/b/229502 [ BigSur Debug ] http/tests/inspector/paymentrequest/payment-request-internal-properties.https.html [ Pass Failure ]
 
@@ -1640,17 +1613,17 @@ webkit.org/b/230117 [ BigSur Debug ] http/tests/inspector/target/pause-on-inline
 
 webkit.org/b/230502 [ Debug ] storage/indexeddb/request-with-null-open-db-request.html [ Pass Crash ]
 
-webkit.org/b/230504 [ Catalina BigSur Release ] css3/masking/reference-clip-path-animate-transform-repaint.html [ Pass Failure ]
+webkit.org/b/230504 [ BigSur Release ] css3/masking/reference-clip-path-animate-transform-repaint.html [ Pass Failure ]
 
-webkit.org/b/230514 [ Catalina BigSur Release ] imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.html [ Pass Crash ]
+webkit.org/b/230514 [ BigSur Release ] imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.html [ Pass Crash ]
 
-webkit.org/b/230518 [ Catalina Release ]  accessibility/mac/button-shouldnot-have-axvalue.html [ Pass Crash ]
+webkit.org/b/230518 [ Release ]  accessibility/mac/button-shouldnot-have-axvalue.html [ Pass Crash ]
 
 webkit.org/b/230588 [ BigSur Debug ] imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-fixed.html [ Pass Crash ]
 
 webkit.org/b/230865 [ BigSur Debug arm64 ] webrtc/video-mute.html [ Pass Failure ]
 
-webkit.org/b/230866 [ Catalina BigSur ] imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-default-feature-policy.https.html [ Pass Failure DumpJSConsoleLogInStdErr ]
+webkit.org/b/230866 [ BigSur ] imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-default-feature-policy.https.html [ Pass Failure DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/231083 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/generic/policy-inherited-correctly-by-plznavigate.html [ Pass Failure ]
 
@@ -1659,8 +1632,6 @@ webkit.org/b/231386 [ BigSur ] http/tests/resourceLoadStatistics/website-data-re
 webkit.org/b/231765 [ Release ] http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration.html [ Pass Timeout ]
 
 webkit.org/b/231780 [ Debug ] imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html [ Pass Failure ]
-
-webkit.org/b/229569 [ Catalina Release ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-perfect-negotiation-stress-glare.https.html [ Pass Crash ]
 
 webkit.org/b/235605 [ arm64 ] fast/scrolling/mac/j-shaped-scroll-rubberband.html [ Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -817,8 +817,8 @@ webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-err
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-is-type-supported.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-removesourcebuffer.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-seek-beyond-duration.html [ Skip ]
-webkit.org/b/161725 [ Mojave Catalina ] imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html [ Skip ]
-webkit.org/b/161725 [ Mojave Catalina ] imported/w3c/web-platform-tests/media-source/mediasource-seekable.html [ Skip ]
+webkit.org/b/161725 [ Mojave ] imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html [ Skip ]
+webkit.org/b/161725 [ Mojave ] imported/w3c/web-platform-tests/media-source/mediasource-seekable.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-mode-timestamps.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-mode.html [ Skip ]
@@ -829,9 +829,9 @@ imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-a-bi
 imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-audio-bitrate.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-framesize.html [ Skip ]
 imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Skip ]
-[ Mojave Catalina ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-bitrate.html [ Skip ]
-[ Mojave Catalina ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framerate.html [ Skip ]
-[ Mojave Catalina ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framesize.html [ Skip ]
+[ Mojave ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-bitrate.html [ Skip ]
+[ Mojave ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framerate.html [ Skip ]
+[ Mojave ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framesize.html [ Skip ]
 
 # Skipped in W3C Web Platform Test manifest
 imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html [ Skip ]
@@ -1360,8 +1360,6 @@ webkit.org/b/183258 imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-
 webkit.org/b/183258 imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-line-break-opclns-115.html [ ImageOnlyFailure ]
 webkit.org/b/183258 imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-line-break-opclns-116.html [ ImageOnlyFailure ]
 
-[ Catalina ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-001.html [ ImageOnlyFailure ]
-
 http/tests/cookies/same-site [ Pass ]
 
 # FIXME: Mark as Pass once <rdar://problem/47165939> is fixed.
@@ -1380,7 +1378,7 @@ fast/dom/HTMLMeterElement/meter-styles.html [ Failure ]
 
 # <rdar://problem/41103260> REGRESSION (Mojave): Three text tests failing with small antialiasing(?) diffs
 [ Mojave ] fast/inline/break-between-nobr.html [ ImageOnlyFailure ]
-[ Mojave Catalina ] imported/blink/fast/text/international/text-shaping-arabic.html [ ImageOnlyFailure ]
+[ Mojave ] imported/blink/fast/text/international/text-shaping-arabic.html [ ImageOnlyFailure ]
 imported/blink/fast/text/international/vertical-positioning-with-combining-marks.html [ ImageOnlyFailure ]
 
 # < Mojave doesn't support the CG needed for Conic Gradients
@@ -1474,38 +1472,37 @@ webaudio/oscillator-sine.html [ Skip ]
 webkit.org/b/190882 animations/change-one-anim.html [ Pass Failure ]
 
 # <rdar://problem/88980849>
-[ Catalina+ ] fast/images/animated-heics-draw.html [ Skip ]
-[ Catalina+ ] fast/images/animated-heics-verify.html [ Skip ]
+fast/images/animated-heics-draw.html [ Skip ]
+fast/images/animated-heics-verify.html [ Skip ]
 
 # <rdar://problem/40172428>
-webkit.org/b/212172 [ Catalina ] fast/text/font-collection.html [ ImageOnlyFailure ]
-[ Catalina+ ] fast/text/woff2.html [ Pass ImageOnlyFailure ]
+fast/text/woff2.html [ Pass ImageOnlyFailure ]
 
 # <rdar://problem/45056204>
-[ Catalina+ ] http/wpt/beacon/cors/cors-preflight-cookie.html [ Failure ]
+http/wpt/beacon/cors/cors-preflight-cookie.html [ Failure ]
 
 # <rdar://problem/51762717>
-[ Catalina+ ] http/wpt/resource-timing/rt-cors.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-cors.worker.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-initiatorType-css.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-initiatorType.worker.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-initiatorType-script-module.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-initiatorType-element.html [ Pass Failure ]
-[ Catalina+ ] http/wpt/resource-timing/rt-initiatorType-xmlhttprequest.html [ Pass Failure ]
+http/wpt/resource-timing/rt-cors.html [ Pass Failure ]
+http/wpt/resource-timing/rt-cors.worker.html [ Pass Failure ]
+http/wpt/resource-timing/rt-initiatorType-css.html [ Pass Failure ]
+http/wpt/resource-timing/rt-initiatorType.worker.html [ Pass Failure ]
+http/wpt/resource-timing/rt-initiatorType-script-module.html [ Pass Failure ]
+http/wpt/resource-timing/rt-initiatorType-element.html [ Pass Failure ]
+http/wpt/resource-timing/rt-initiatorType-xmlhttprequest.html [ Pass Failure ]
 
 # These tests require the design system ui fonts to be installed.
-[ Catalina+ ] fast/text/design-system-ui-11.html [ Pass ]
-[ Catalina+ ] fast/text/design-system-ui-12.html [ Pass ]
-[ Catalina+ ] fast/text/design-system-ui-13.html [ Pass ]
-[ Catalina+ ] fast/text/design-system-ui-14.html [ Pass ]
-[ Catalina+ ] fast/text/design-system-ui-15.html [ Pass ]
-[ Catalina+ ] fast/text/design-system-ui-16.html [ Pass ]
+fast/text/design-system-ui-11.html [ Pass ]
+fast/text/design-system-ui-12.html [ Pass ]
+fast/text/design-system-ui-13.html [ Pass ]
+fast/text/design-system-ui-14.html [ Pass ]
+fast/text/design-system-ui-15.html [ Pass ]
+fast/text/design-system-ui-16.html [ Pass ]
 
 [ Mojave ] http/wpt/mediarecorder [ Skip ]
 [ Mojave ] imported/w3c/web-platform-tests/mediacapture-record [ Skip ]
 [ Mojave ] fast/history/page-cache-media-recorder.html [ Skip ]
 
-[ Catalina+ ] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Pass Failure ]
 
 webkit.org/b/200128 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html [ Timeout Pass ]
 
@@ -1527,12 +1524,12 @@ platform/mac/media/encrypted-media/fps-multiple-pssh.html [ Skip ]
 webkit.org/b/204756 imported/w3c/web-platform-tests/fetch/content-encoding/bad-gzip-body.any.worker.html [ Pass Failure ]
 
 # <rdar://problem/55667423> REGRESSION: [19E136] fast/text/emoji-gender* tests are failing.
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-3.html [ ImageOnlyFailure ]
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-4.html [ ImageOnlyFailure ]
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-5.html [ ImageOnlyFailure ]
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-6.html [ ImageOnlyFailure ]
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-8.html [ ImageOnlyFailure ]
-webkit.org/b/204820 [ Catalina+ ] fast/text/emoji-gender-9.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-3.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-4.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-5.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-6.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-8.html [ ImageOnlyFailure ]
+webkit.org/b/204820 fast/text/emoji-gender-9.html [ ImageOnlyFailure ]
 
 webkit.org/b/205216 imported/w3c/web-platform-tests/content-security-policy/reporting/report-same-origin-with-cookies.html [ Pass Failure DumpJSConsoleLogInStdErr ]
 
@@ -1550,8 +1547,8 @@ webkit.org/b/205756 webgl/2.0.0/conformance2/glsl3/no-attribute-vertex-shader.ht
 webkit.org/b/204312 imported/w3c/web-platform-tests/svg/import/struct-dom-06-b-manual.svg [ Failure Pass ]
 
 # Locale-specific shaping is only enabled on certain OSes.
-webkit.org/b/77568 [ Mojave Catalina ] fast/text/locale-shaping.html [ ImageOnlyFailure ]
-webkit.org/b/77568 [ Mojave Catalina ] fast/text/locale-shaping-complex.html [ ImageOnlyFailure ]
+webkit.org/b/77568 [ Mojave ] fast/text/locale-shaping.html [ ImageOnlyFailure ]
+webkit.org/b/77568 [ Mojave ] fast/text/locale-shaping-complex.html [ ImageOnlyFailure ]
 
 webkit.org/b/203222 svg/wicd/rightsizing-grid.xhtml [ Pass Failure ]
 
@@ -1566,7 +1563,7 @@ webkit.org/b/206883 [ Mojave ] imported/w3c/web-platform-tests/css/css-fonts/fon
 webkit.org/b/206883 [ Mojave ] imported/w3c/web-platform-tests/css/css-fonts/font-default-02.html [ ImageOnlyFailure ]
 webkit.org/b/206883 [ Mojave ] imported/w3c/web-platform-tests/css/css-fonts/font-default-03.html [ ImageOnlyFailure ]
 webkit.org/b/206883 [ Mojave ] imported/w3c/web-platform-tests/css/css-fonts/variations/font-weight-matching.html [ Failure ]
-webkit.org/b/206881 [ Catalina BigSur ] imported/w3c/web-platform-tests/css/css-fonts/first-available-font-003.html [ ImageOnlyFailure ]
+webkit.org/b/206881 [ BigSur ] imported/w3c/web-platform-tests/css/css-fonts/first-available-font-003.html [ ImageOnlyFailure ]
 
 webkit.org/b/205729 webrtc/captureCanvas-webrtc.html [ Pass Failure ]
 
@@ -1622,8 +1619,6 @@ webkit.org/b/238469 imported/w3c/web-platform-tests/fetch/metadata/download.http
 
 webkit.org/b/208467 [ Debug ] imported/w3c/IndexedDB-private-browsing/idbobjectstore_createIndex6-event_order.html [ Pass Failure ]
 
-webkit.org/b/208519 [ Catalina ] webanimations/accelerated-animation-slot-invalidation.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/208722 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm [ Pass Failure ]
 
 webkit.org/b/208592 svg/custom/object-sizing-explicit-height.xhtml [ Pass Failure ]
@@ -1636,10 +1631,9 @@ webkit.org/b/207150 platform/mac/webrtc/captureCanvas-webrtc-software-encoder.ht
 
 # The line breaking rules changed in ICU 66. We've updated the tests to match, but old platforms won't get updated line breaking rules.
 webkit.org/b/216315 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-normal-015a.xht [ ImageOnlyFailure ]
-webkit.org/b/209250 [ Mojave Catalina ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-normal-015b.xht [ ImageOnlyFailure ]
+webkit.org/b/209250 [ Mojave ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-normal-015b.xht [ ImageOnlyFailure ]
 webkit.org/b/216315 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-strict-015a.xht [ ImageOnlyFailure ]
-webkit.org/b/209250 [ Mojave Catalina ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-strict-015b.xht [ ImageOnlyFailure ]
-webkit.org/b/183258 [ Catalina ] imported/w3c/web-platform-tests/css/css-text/word-break/word-break-break-all-008.html [ ImageOnlyFailure ]
+webkit.org/b/209250 [ Mojave ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-strict-015b.xht [ ImageOnlyFailure ]
 
 webkit.org/b/207858 fast/canvas/webgl/simulated-vertexAttrib0-invalid-indicies.html [ Skip ]
 
@@ -1652,7 +1646,7 @@ webkit.org/b/210046 [ Release ] storage/indexeddb/value-cursor-cycle.html [ Pass
 webkit.org/b/207160 css2.1/20110323/replaced-intrinsic-ratio-001.htm [ Pass Failure ]
 
 # Certain versions of macOS use different text security characters.
-webkit.org/b/209692 [ Mojave Catalina ] platform/mac/fast/text/text-security-disc-bullet-pua-mac.html [ ImageOnlyFailure ]
+webkit.org/b/209692 [ Mojave ] platform/mac/fast/text/text-security-disc-bullet-pua-mac.html [ ImageOnlyFailure ]
 
 webkit.org/b/210517 storage/indexeddb/result-request-cycle.html [ Pass Failure ]
 
@@ -1677,21 +1671,21 @@ fast/text/text-styles/-apple-system [ Pass ]
 webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Failure ]
 
 # These test requires system platform support.
-[ Catalina Mojave ] media/media-source/media-source-webm.html [ Skip ]
-[ Catalina Mojave ] media/media-source/media-source-webm-append-buffer-after-abort.html [ Skip ]
-[ Catalina Mojave ] media/media-source/media-source-webm-init-inside-segment.html [ Skip ]
-[ Catalina Mojave ] platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html [ Skip ]
-[ Catalina Mojave ] platform/mac/media/media-source/is-type-supported-vp9-codec-check.html [ Skip ]
+[ Mojave ] media/media-source/media-source-webm.html [ Skip ]
+[ Mojave ] media/media-source/media-source-webm-append-buffer-after-abort.html [ Skip ]
+[ Mojave ] media/media-source/media-source-webm-init-inside-segment.html [ Skip ]
+[ Mojave ] platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html [ Skip ]
+[ Mojave ] platform/mac/media/media-source/is-type-supported-vp9-codec-check.html [ Skip ]
 
 # These tests require macOS Monterey.
-[ Catalina Mojave BigSur ] media/media-source/media-webm-vorbis-partial.html [ Skip ]
-[ Catalina Mojave BigSur ] media/media-source/media-source-webm-vorbis-partial.html [ Skip ]
-[ Catalina Mojave BigSur ] media/media-source/media-webm-opus-partial.html [ Skip ]
-[ Catalina Mojave BigSur ] media/media-source/media-webm-opus-partial-abort.html [ Skip ]
-[ Catalina Mojave BigSur ] webaudio/decode-audio-data-webm-opus.html [ Skip ]
-[ Catalina Mojave BigSur ] webaudio/decode-audio-data-webm-opus-resample.html [ Skip ]
-[ Catalina Mojave BigSur ] webaudio/decode-audio-data-webm-vorbis.html [ Skip ]
-[ Catalina Mojave BigSur ] http/tests/model/model-document.html [ Skip ]
+[ Mojave BigSur ] media/media-source/media-webm-vorbis-partial.html [ Skip ]
+[ Mojave BigSur ] media/media-source/media-source-webm-vorbis-partial.html [ Skip ]
+[ Mojave BigSur ] media/media-source/media-webm-opus-partial.html [ Skip ]
+[ Mojave BigSur ] media/media-source/media-webm-opus-partial-abort.html [ Skip ]
+[ Mojave BigSur ] webaudio/decode-audio-data-webm-opus.html [ Skip ]
+[ Mojave BigSur ] webaudio/decode-audio-data-webm-opus-resample.html [ Skip ]
+[ Mojave BigSur ] webaudio/decode-audio-data-webm-vorbis.html [ Skip ]
+[ Mojave BigSur ] http/tests/model/model-document.html [ Skip ]
 
 webkit.org/b/214422 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/suspend-after-construct.html [ Pass Failure ]
 
@@ -1966,7 +1960,7 @@ webkit.org/b/219448 [ Debug ] webgl/2.0.0/conformance/rendering/multisample-corr
 [ BigSur+ ] imported/w3c/web-platform-tests/css/css-fonts/font-language-override-02.html [ ImageOnlyFailure ]
 
 # This test requires the OS to have a font that supports the Ahom language.
-webkit.org/b/216024 [ Mojave Catalina ] fast/text/ahom.html [ ImageOnlyFailure ]
+webkit.org/b/216024 [ Mojave ] fast/text/ahom.html [ ImageOnlyFailure ]
 
 # rdar://68364365 [ Big Sur ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html is a flaky failure/timeout)
 [ BigSur+ ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure Timeout ]
@@ -2033,17 +2027,17 @@ webkit.org/b/220332 [ BigSur+ ] imported/w3c/web-platform-tests/mimesniff/mime-t
 [ BigSur ] fast/text/system-font-width-7.html [ ImageOnlyFailure ]
 [ BigSur ] fast/text/system-font-width-8.html [ ImageOnlyFailure ]
 [ BigSur ] fast/text/system-font-width-9.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-2.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-3.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-4.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-6.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-7.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-8.html [ ImageOnlyFailure ]
-[ Catalina Mojave ] fast/text/system-font-width-9.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-2.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-3.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-4.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-6.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-7.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-8.html [ ImageOnlyFailure ]
+[ Mojave ] fast/text/system-font-width-9.html [ ImageOnlyFailure ]
 
 # WebM support is on Monterey and later
-[ Catalina Mojave BigSur ] http/tests/media/video-webm-stall.html [ Skip ]
+[ Mojave BigSur ] http/tests/media/video-webm-stall.html [ Skip ]
 
 webkit.org/b/221152 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-automatic-pull.https.html [ Pass Failure ]
 
@@ -2058,14 +2052,14 @@ webkit.org/b/221218 [ BigSur+ ] imported/w3c/web-platform-tests/media-source/med
 webkit.org/b/221100 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-channel-count.https.html [ Pass Failure ]
 
 # @counter-style WPT failures specific to Mac platforms
-[ Mojave Catalina ] imported/w3c/web-platform-tests/css/css-counter-styles/lower-armenian/css3-counter-styles-112.html [ ImageOnlyFailure ]
+[ Mojave ] imported/w3c/web-platform-tests/css/css-counter-styles/lower-armenian/css3-counter-styles-112.html [ ImageOnlyFailure ]
 
 webkit.org/b/222205 css3/calc/transforms-translate.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/222422 imported/w3c/web-platform-tests/media-source/mediasource-duration.html [ Pass Failure Slow ]
 
 # Not all OSes support the same set of emoji.
-[ Mojave Catalina BigSur ] fast/text/mending-heart.html [ Failure ]
+[ Mojave BigSur ] fast/text/mending-heart.html [ Failure ]
 
 webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
@@ -2121,14 +2115,7 @@ webkit.org/b/222844 imported/blink/compositing/draws-content/webgl-simple-backgr
 fast/canvas/webgl/webgl-compressed-texture-astc.html [ Skip ]
 
 # This fails on Catalina, but not Big Sur.
-[ Catalina Mojave ] inspector/canvas/updateShader-webgl.html [ Skip ]
-
-webkit.org/b/224016 [ Catalina ] webgl/2.0.0/conformance2/buffers/one-large-uniform-buffer.html [ Failure ]
-webkit.org/b/224016 [ Catalina ] webgl/2.0.0/conformance2/buffers/uniform-buffers.html [ Failure ]
-webkit.org/b/224016 [ Catalina ] webgl/1.0.3/conformance/ogles/GL/all/all_001_to_004.html [ Skip ]
-webkit.org/b/224016 [ Catalina ] webgl/1.0.3/conformance/ogles/GL/any/any_001_to_004.html [ Skip ]
-webkit.org/b/224016 [ Catalina ] webgl/2.0.0/conformance/ogles/GL/all/all_001_to_004.html [ Skip ]
-webkit.org/b/224016 [ Catalina ] webgl/2.0.0/conformance/ogles/GL/any/any_001_to_004.html [ Skip ]
+[ Mojave ] inspector/canvas/updateShader-webgl.html [ Skip ]
 
 webkit.org/b/223820 inspector/debugger/csp-exceptions.html [ Pass Failure Timeout ]
 
@@ -2250,10 +2237,8 @@ webkit.org/b/229291 imported/w3c/web-platform-tests/html/rendering/replaced-elem
 
 #rdar://82146367 ([Mac, iOS Release] imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html is a flaky failure) imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html [ Pass Failure ] 
 
-webkit.org/b/228176 [ Mojave Catalina BigSur ] fast/text/variable-system-font.html [ ImageOnlyFailure ]
+webkit.org/b/228176 [ Mojave BigSur ] fast/text/variable-system-font.html [ ImageOnlyFailure ]
 webkit.org/b/228176 [ Monterey ] fast/text/variable-system-font.html [ Pass ]
-
-webkit.org/b/168961 [ Catalina ] fast/events/wheelevent-in-frame.html [ Pass Timeout ]
 
 #rdar://80333935 (REGRESSION (Star21A236a-21A254): [ Monterey wk2 arm64 ] fast/animation/request-animation-frame-throttling-detached-iframe.html and request-animation-frame-throttling-lowPowerMode.html failing) [ Monterey ] fast/animation/request-animation-frame-throttling-detached-iframe.html [ Pass Failure ]
 
@@ -2312,15 +2297,13 @@ webkit.org/b/231463 fast/css/accent-color/range.html [ ImageOnlyFailure ]
 
 webkit.org/b/229521 pointer-lock/lock-already-locked.html [ Pass Failure ]
 
-webkit.org/b/189672 [ Catalina ] webgl/2.0.0/conformance2/rendering/uniform-block-buffer-size.html  [ Pass Failure ]
-
 webkit.org/b/229588 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Pass Crash Failure Timeout ]
 
-webkit.org/b/228176 [ Mojave Catalina BigSur Monterey ] fast/text/variable-system-font-2.html [ Pass ]
+webkit.org/b/228176 [ Mojave BigSur Monterey ] fast/text/variable-system-font-2.html [ Pass ]
 
 # These tests open apparently unskippable prompts on Catalina.
-webkit.org/b/229391 [ Mojave Catalina ] fast/text/mobileasset-font.html [ Skip ]
-webkit.org/b/189448 [ Mojave Catalina ] fast/text/osaka-synthetic-bold.html [ Skip ]
+webkit.org/b/229391 [ Mojave ] fast/text/mobileasset-font.html [ Skip ]
+webkit.org/b/189448 [ Mojave ] fast/text/osaka-synthetic-bold.html [ Skip ]
 
 webkit.org/b/230327 imported/w3c/web-platform-tests/css/css-transforms/crashtests/transform-marquee-resize-div-image-001.html [ Pass Failure ]
 
@@ -2362,9 +2345,9 @@ webkit.org/b/170629  memory/memory-pressure-simulation.html [ Pass Failure Crash
 
 webkit.org/b/230711 [ BigSur ] http/tests/inspector/network/resource-initiatorNode.html [ Pass Failure Crash ]
 
-webkit.org/b/230780 [ Catalina BigSur Debug ] fast/workers/use-machine-stack.html [ Pass Crash ]
+webkit.org/b/230780 [ BigSur Debug ] fast/workers/use-machine-stack.html [ Pass Crash ]
 
-webkit.org/b/230862 [ Catalina BigSur ] imported/w3c/web-platform-tests/resource-timing/sizes-redirect-img.html [ Pass Failure ]
+webkit.org/b/230862 [ BigSur ] imported/w3c/web-platform-tests/resource-timing/sizes-redirect-img.html [ Pass Failure ]
 
 webkit.org/b/230984 [ BigSur Debug arm64 ] streams/readableStream-then.html [ Pass Crash ]
 
@@ -2388,26 +2371,20 @@ webkit.org/b/226826 [ Monterey ] http/tests/ssl/applepay/ApplePayButton.html [ F
 webkit.org/b/235660 [ Debug ] fast/replaced/encrypted-pdf-as-object-and-embed.html [ Skip ]
 
 # <model> tests involving the ready promise can only work on Monterey and up
-[ Catalina BigSur ] model-element/model-element-ready.html [ Skip ]
-
-# OT-SVG is not implemented on Catalina.
-[ Catalina ] fast/text/otsvg-canvas.html [ ImageOnlyFailure ]
+[ BigSur ] model-element/model-element-ready.html [ Skip ]
 
 # This test is specific to Core Text.
 fast/text/font-lookup-dot-prefix-case-sensitive.html [ Pass ]
 
 # These tests require platform support.
 # <rdar://problem/87944426>
-[ Catalina BigSur Monterey ] fast/text/locale-shaping-2.html [ Pass ImageOnlyFailure ]
-[ Catalina BigSur Monterey ] fast/text/locale-shaping-3.html [ Pass ImageOnlyFailure ]
+[ BigSur Monterey ] fast/text/locale-shaping-2.html [ Pass ImageOnlyFailure ]
+[ BigSur Monterey ] fast/text/locale-shaping-3.html [ Pass ImageOnlyFailure ]
 
 #rdar://80333071
 [ BigSur+ ] compositing/iframes/border-radius-composited-frame.html [ ImageOnlyFailure ]
 
-# rdar://84556831 
-[ Catalina ] media/media-allowed-containers.html [ Skip ]
-
-[ Catalina BigSur ] imported/w3c/web-platform-tests/url/toascii.window.html [ Skip ]
+[ BigSur ] imported/w3c/web-platform-tests/url/toascii.window.html [ Skip ]
 
 # Was in LayoutTests/Expectations, now only happening on Mac
 imported/w3c/web-platform-tests/xhr/event-timeout-order.any.worker.html [ Failure ]


### PR DESCRIPTION
#### de8155720405d18abf8032fc738a1369adc9b57c
<pre>
Remove Catalina references in TestExpectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=238886">https://bugs.webkit.org/show_bug.cgi?id=238886</a>
&lt;rdar://problem/91373532 &gt;

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations: Remove Catalina references.
* LayoutTests/platform/mac-wk2/TestExpectations: Ditto.
* LayoutTests/platform/mac/TestExpectations: Ditto.

Canonical link: <a href="https://commits.webkit.org/249346@main">https://commits.webkit.org/249346@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292502">https://svn.webkit.org/repository/webkit/trunk@292502</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
