### PR TITLE
[Merge-Queue] Comment on PR when failing validation

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6191,7 +6191,9 @@ https://bugs.webkit.org/show_bug.cgi?id=238172
 Reviewed by NOBODY (OOPS!)'''),
         )
         self.expectOutcome(result=FAILURE, state_string='Commit message contains (OOPS!)')
-        return self.runStep()
+        rc = self.runStep()
+        self.assertEqual(self.getProperty('comment_text'), 'Commit message contains (OOPS!), blocking PR #1234')
+        return rc
 
     def test_failure_no_reviewer(self):
         self.setupStep(ValidateCommitMessage())
@@ -6209,7 +6211,9 @@ https://bugs.webkit.org/show_bug.cgi?id=238172
 <rdar://problem/90602594>'''),
         )
         self.expectOutcome(result=FAILURE, state_string='No reviewer information in commit message')
-        return self.runStep()
+        rc = self.runStep()
+        self.assertEqual(self.getProperty('comment_text'), 'No reviewer information in commit message, blocking PR #1234')
+        return rc
 
 
 class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,5 +1,19 @@
 2022-04-07  Jonathan Bedard  <jbedard@apple.com>
 
+        [Merge-Queue] Comment on PR when failing validation
+        https://bugs.webkit.org/show_bug.cgi?id=238969
+        <rdar://problem/91451392>
+
+        Reviewed by Aakash Jain.
+
+        * CISupport/ews-build/steps.py:
+        (ValidateChangeLogAndReviewer.evaluateCommand): Add BlockPullRequest on failure.
+        (ValidateCommitMessage.evaluateCommand): Block and comment on pull request if
+        validation fails.
+        * CISupport/ews-build/steps_unittest.py:
+
+2022-04-07  Jonathan Bedard  <jbedard@apple.com>
+
         [Merge-Queue] Reset git-svn cache on commit failure
         https://bugs.webkit.org/show_bug.cgi?id=238975
         <rdar://problem/91454550>


### PR DESCRIPTION
#### 818a5466dfb48749d64a3568b7bb9c7a221bf511
<pre>
[Merge-Queue] Comment on PR when failing validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=238969">https://bugs.webkit.org/show_bug.cgi?id=238969</a>
&lt;rdar://problem/91451392 &gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ValidateChangeLogAndReviewer.evaluateCommand): Add BlockPullRequest on failure.
(ValidateCommitMessage.evaluateCommand): Block and comment on pull request if
validation fails.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/249437@main">https://commits.webkit.org/249437@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@292605">https://svn.webkit.org/repository/webkit/trunk@292605</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
