### PR TITLE
Git setup svn command should fetch commits from git before running git-svn fetch

### DIFF
--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -1,3 +1,17 @@
+2022-04-15  Keith Miller  <keith_miller@apple.com>
+
+        Git setup svn command should fetch commits from git before running git-svn fetch
+        https://bugs.webkit.org/show_bug.cgi?id=239392
+
+        Reviewed by NOBODY (OOPS!).
+
+        git-svn fetch pulls commits one at a time rather than gathering all the commits at once.
+        This means if someone is far behind the HEAD of tree running setup-git-svn could take a long
+        time. Instead we should fetch commits via `git fetch` then rebuild the mapping.
+
+        * Scripts/libraries/webkitscmpy/webkitscmpy/program/setup_git_svn.py:
+        (SetupGitSvn.main):
+
 2022-04-15  J Pascoe  <j_pascoe@apple.com>
 
         [WebAuthn] Implement getTransports() and getAuthenticatorData() on AuthenticatorAttestationResponse 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup_git_svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup_git_svn.py
@@ -92,4 +92,6 @@ class SetupGitSvn(Command):
                     config.write('\tfetch = branches/{branch}:refs/remotes/origin/{branch}\n'.format(branch=branch))
 
         print('Populating svn commit mapping (will take a few minutes)...')
+        # Run `git fetch` first since fetching actual content over git-svn is not batched.
+        run([repository.executable(), 'fetch'], cwd=repository.root_path)
         return run([repository.executable(), 'svn', 'fetch', '--log-window-size=5000', '-r', '1:HEAD'], cwd=repository.root_path).returncode


### PR DESCRIPTION
#### 8207e9de8b5c4186b26bbdc3b7451c5a2d4eb2d2
<pre>
Git setup svn command should fetch commits from git before running git-svn fetch
</pre>
----------------------------------------------------------------------
#### 8a1a58205996615f0dfd60c8300d75a19f7c68f0
<pre>
Git setup svn command should fetch commits from git before running git-svn fetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=239392">https://bugs.webkit.org/show_bug.cgi?id=239392</a>

Reviewed by NOBODY (OOPS!).

    git-svn fetch pulls commits one at a time rather than gathering all the commits at once.
    This means if someone is far behind the HEAD of tree running setup-git-svn could take a long
    time. Instead we should fetch commits via `git fetch` then rebuild the mapping.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup_git_svn.py:
(SetupGitSvn.main):
</pre>