### PR TITLE
Add GitHub info to contributors.json

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2022-04-15  Justin Michaud  <justin_michaud@apple.com>
+
+        Add GitHub info to contributors.json
+        https://bugs.webkit.org/show_bug.cgi?id=239410
+
+        Reviewed by Yusuke Suzuki.
+
+        * metadata/contributors.json:
+
 2022-04-15  Saam Barati  <sbarati@apple.com>
 
         Unreviewed. Add my github into to contributors.json.

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -3860,6 +3860,8 @@
          "justin_michaud@apple.com",
          "justin@justinmichaud.com"
       ],
+      "expertise" : "JavaScriptCore",
+      "github" : "justinmichaud",
       "name" : "Justin Michaud",
       "status" : "committer"
    },
@@ -5854,11 +5856,11 @@
          "sbarati@apple.com",
          "saambarati1@gmail.com"
       ],
+      "github" : "saambarati",
       "name" : "Saam Barati",
       "nicks" : [
          "saamyjoon"
       ],
-      "github" : "saambarati",
       "status" : "reviewer"
    },
    {


### PR DESCRIPTION
#### 525eb8d0f287abb6796dc904ae25ac487bd80857
<pre>
Add GitHub info to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=239410">https://bugs.webkit.org/show_bug.cgi?id=239410</a>

Reviewed by NOBODY (OOPS!).

* metadata/contributors.json:
</pre>