### PR TITLE
[ iOS ] http/tests/websocket/tests/hybi/bufferedAmount-after-close-in-busy.html is failing

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,12 @@
+2022-04-21  Truitt Savell  <tsavell@apple.com>
+
+        [ iOS ] http/tests/websocket/tests/hybi/bufferedAmount-after-close-in-busy.html is failing
+        https://bugs.webkit.org/show_bug.cgi?id=239630
+
+        Unreviwed test gardening.
+
+        * platform/ios/TestExpectations:
+
 2022-04-21  Karl Rackler  <rackler@apple.com>
 
         [ macOS wk2 arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html is a flaky failure

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3587,5 +3587,7 @@ webkit.org/b/239564 http/tests/app-privacy-report/user-attribution-cors-prefligh
 
 webkit.org/b/239625 imported/w3c/web-platform-tests/css/css-color/opacity-overlapping-letters.html [ ImageOnlyFailure ]
 
+webkit.org/b/239630 http/tests/websocket/tests/hybi/bufferedAmount-after-close-in-busy.html [ Failure ]
+
 # iOS has a WebGPU implementation.
 http/tests/webgpu [ Pass ]


### PR DESCRIPTION
#### a8c601cdf1365590f3f60939773abebbc6b60bd9
<pre>
[ iOS ] http/tests/websocket/tests/hybi/bufferedAmount-after-close-in-busy.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=239630">https://bugs.webkit.org/show_bug.cgi?id=239630</a>

Unreviwed test gardening.

* LayoutTests/platform/ios/TestExpectations:
</pre>