### PR TITLE
Modernize Text::replaceWholeText()

### DIFF
--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -116,27 +116,25 @@ String Text::wholeText() const
     return result.toString();
 }
 
-RefPtr<Text> Text::replaceWholeText(const String& newText)
+// Remove all adjacent text nodes, and replace the contents of this one.
+void Text::replaceWholeText(const String& newText)
 {
-    // Remove all adjacent text nodes, and replace the contents of this one.
-
     // Protect startText and endText against mutation event handlers removing the last ref
-    RefPtr<Text> startText = const_cast<Text*>(earliestLogicallyAdjacentTextNode(this));
-    RefPtr<Text> endText = const_cast<Text*>(latestLogicallyAdjacentTextNode(this));
+    RefPtr startText = const_cast<Text*>(earliestLogicallyAdjacentTextNode(this));
+    RefPtr endText = const_cast<Text*>(latestLogicallyAdjacentTextNode(this));
 
-    RefPtr<Text> protectedThis(this); // Mutation event handlers could cause our last ref to go away
-    RefPtr<ContainerNode> parent = parentNode(); // Protect against mutation handlers moving this node during traversal
-    for (RefPtr<Node> n = startText; n && n != this && n->isTextNode() && n->parentNode() == parent;) {
-        Ref<Node> nodeToRemove(n.releaseNonNull());
-        n = nodeToRemove->nextSibling();
+    RefPtr parent = parentNode(); // Protect against mutation handlers moving this node during traversal
+    for (RefPtr<Node> node = WTFMove(startText); is<Text>(node) && node != this && node->parentNode() == parent;) {
+        auto nodeToRemove = node.releaseNonNull();
+        node = nodeToRemove->nextSibling();
         parent->removeChild(nodeToRemove);
     }
 
     if (this != endText) {
-        Node* onePastEndText = endText->nextSibling();
-        for (RefPtr<Node> n = nextSibling(); n && n != onePastEndText && n->isTextNode() && n->parentNode() == parent;) {
-            Ref<Node> nodeToRemove(n.releaseNonNull());
-            n = nodeToRemove->nextSibling();
+        auto* onePastEndText = endText->nextSibling();
+        for (RefPtr node = nextSibling(); is<Text>(node) && node != onePastEndText && node->parentNode() == parent;) {
+            Ref nodeToRemove = node.releaseNonNull();
+            node = nodeToRemove->nextSibling();
             parent->removeChild(nodeToRemove);
         }
     }
@@ -144,11 +142,10 @@ RefPtr<Text> Text::replaceWholeText(const String& newText)
     if (newText.isEmpty()) {
         if (parent && parentNode() == parent)
             parent->removeChild(*this);
-        return nullptr;
+        return;
     }
 
     setData(newText);
-    return protectedThis;
 }
 
 String Text::nodeName() const

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -45,7 +45,7 @@ public:
     // DOM Level 3: http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-1312295772
 
     WEBCORE_EXPORT String wholeText() const;
-    WEBCORE_EXPORT RefPtr<Text> replaceWholeText(const String&);
+    WEBCORE_EXPORT void replaceWholeText(const String&);
     
     RenderPtr<RenderText> createTextRenderer(const RenderStyle&);
     

--- a/Source/WebCore/html/BaseCheckableInputType.h
+++ b/Source/WebCore/html/BaseCheckableInputType.h
@@ -36,6 +36,9 @@ namespace WebCore {
 
 // Base of checkbox and radio types.
 class BaseCheckableInputType : public InputType {
+public:
+    bool canSetStringValue() const override;
+
 protected:
     explicit BaseCheckableInputType(Type type, HTMLInputElement& element) : InputType(type, element) { }
     ShouldCallBaseEventHandler handleKeydownEvent(KeyboardEvent&) override;
@@ -46,7 +49,6 @@ private:
     void restoreFormControlState(const FormControlState&) override;
     bool appendFormData(DOMFormData&) const override;
     void handleKeypressEvent(KeyboardEvent&) override;
-    bool canSetStringValue() const override;
     bool accessKeyAction(bool sendMouseEvents) override;
     String fallbackValue() const override;
     bool storesValueSeparateFromAttribute() override;

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -48,6 +48,10 @@ struct DateTimeChooserParameters;
 
 // A super class of date, datetime, datetime-local, month, time, and week types.
 class BaseDateAndTimeInputType : public InputType, private DateTimeChooserClient, private DateTimeEditElement::EditControlOwner {
+public:
+    bool typeMismatchFor(const String&) const final;
+    bool valueMissing(const String&) const final;
+
 protected:
     enum class DateTimeFormatValidationResults : uint8_t {
         HasYear = 1 << 0,
@@ -74,9 +78,8 @@ protected:
 
     bool shouldHaveSecondField(const DateComponents&) const;
     bool shouldHaveMillisecondField(const DateComponents&) const;
-    bool typeMismatchFor(const String&) const final;
+
     bool typeMismatch() const final;
-    bool valueMissing(const String&) const final;
 
 private:
     class DateTimeFormatValidator final : public DateTimeFormat::TokenHandler {

--- a/Source/WebCore/html/BaseTextInputType.h
+++ b/Source/WebCore/html/BaseTextInputType.h
@@ -37,10 +37,12 @@ namespace WebCore {
 // Base of email, password, search, tel, text, and URL types.
 // They support maxlength, selection functions, and so on.
 class BaseTextInputType : public TextFieldInputType {
+public:
+    bool patternMismatch(const String&) const override;
+
 protected:
     explicit BaseTextInputType(Type type, HTMLInputElement& element) : TextFieldInputType(type, element) { }
 
-    bool patternMismatch(const String&) const override;
     bool supportsPlaceholder() const override;
     bool supportsSelectionAPI() const override;
 };

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -39,9 +39,10 @@ class CheckboxInputType final : public BaseCheckableInputType {
 public:
     explicit CheckboxInputType(HTMLInputElement& element) : BaseCheckableInputType(Type::Checkbox, element) { }
 
+    bool valueMissing(const String&) const final;
+
 private:
     const AtomString& formControlType() const final;
-    bool valueMissing(const String&) const final;
     String valueMissingText() const final;
     void handleKeyupEvent(KeyboardEvent&) final;
     void willDispatchClick(InputElementClickState&) final;

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -49,6 +49,7 @@ public:
     }
 
     virtual ~ColorInputType();
+    bool typeMismatchFor(const String&) const final;
 
 private:
     void didChooseColor(const Color&) final;
@@ -71,7 +72,6 @@ private:
     void detach() final;
     void elementDidBlur() final;
     bool shouldRespectListAttribute() final;
-    bool typeMismatchFor(const String&) const final;
     bool shouldResetOnDocumentActivation() final;
     Color valueAsColor() const final;
     void selectColor(StringView) final;

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -38,10 +38,10 @@ class EmailInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     explicit EmailInputType(HTMLInputElement& element) : BaseTextInputType(Type::Email, element) { }
+    bool typeMismatchFor(const String&) const override;
 
 private:
     const AtomString& formControlType() const override;
-    bool typeMismatchFor(const String&) const override;
     bool typeMismatch() const override;
     String typeMismatchText() const override;
     bool supportsSelectionAPI() const override;

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -51,17 +51,17 @@ public:
     virtual ~FileInputType();
 
     static Vector<FileChooserFileInfo> filesFromFormControlState(const FormControlState&);
+    bool canSetStringValue() const final;
+    bool valueMissing(const String&) const final;
 
 private:
     const AtomString& formControlType() const final;
     FormControlState saveFormControlState() const final;
     void restoreFormControlState(const FormControlState&) final;
     bool appendFormData(DOMFormData&) const final;
-    bool valueMissing(const String&) const final;
     String valueMissingText() const final;
     void handleDOMActivateEvent(Event&) final;
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) final;
-    bool canSetStringValue() const final;
     FileList* files() final;
     void setFiles(RefPtr<FileList>&&, WasSetByJavaScript) final;
     enum class RequestIcon { Yes, No };

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -265,20 +265,14 @@ bool HTMLInputElement::shouldAutocomplete() const
     return HTMLTextFormControlElement::shouldAutocomplete();
 }
 
+
+
 bool HTMLInputElement::isValidValue(const String& value) const
 {
-    if (!m_inputType->canSetStringValue()) {
-        ASSERT_NOT_REACHED();
+    if (!m_inputType->isValidValue(value))
         return false;
-    }
-    return !m_inputType->typeMismatchFor(value)
-        && !m_inputType->stepMismatch(value)
-        && !m_inputType->rangeUnderflow(value)
-        && !m_inputType->rangeOverflow(value)
-        && !tooShort(value, IgnoreDirtyFlag)
-        && !tooLong(value, IgnoreDirtyFlag)
-        && !m_inputType->patternMismatch(value)
-        && !m_inputType->valueMissing(value);
+
+    return !tooShort(value, IgnoreDirtyFlag) && !tooLong(value, IgnoreDirtyFlag);
 }
 
 bool HTMLInputElement::tooShort() const

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -169,6 +169,72 @@ bool InputType::themeSupportsDataListUI(InputType* type)
     return RenderTheme::singleton().supportsDataListUI(type->formControlType());
 }
 
+template<typename T> static bool validateInputType(const T& inputType, const String& value)
+{
+    if (!inputType.canSetStringValue()) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+    return !inputType.typeMismatchFor(value)
+        && !inputType.stepMismatch(value)
+        && !inputType.rangeUnderflow(value)
+        && !inputType.rangeOverflow(value)
+        && !inputType.patternMismatch(value)
+        && !inputType.valueMissing(value);
+}
+
+bool InputType::isValidValue(const String& value) const
+{
+    switch (m_type) {
+    case Type::Button:
+        return validateInputType(static_cast<const ButtonInputType&>(*this), value);
+    case Type::Checkbox:
+        return validateInputType(static_cast<const CheckboxInputType&>(*this), value);
+    case Type::Color:
+        return validateInputType(static_cast<const ColorInputType&>(*this), value);
+    case Type::Date:
+        return validateInputType(static_cast<const DateInputType&>(*this), value);
+    case Type::DateTimeLocal:
+        return validateInputType(static_cast<const DateTimeLocalInputType&>(*this), value);
+    case Type::Email:
+        return validateInputType(static_cast<const EmailInputType&>(*this), value);
+    case Type::File:
+        return validateInputType(static_cast<const FileInputType&>(*this), value);
+    case Type::Hidden:
+        return validateInputType(static_cast<const HiddenInputType&>(*this), value);
+    case Type::Image:
+        return validateInputType(static_cast<const ImageInputType&>(*this), value);
+    case Type::Month:
+        return validateInputType(static_cast<const MonthInputType&>(*this), value);
+    case Type::Number:
+        return validateInputType(static_cast<const NumberInputType&>(*this), value);
+    case Type::Password:
+        return validateInputType(static_cast<const PasswordInputType&>(*this), value);
+    case Type::Radio:
+        return validateInputType(static_cast<const RadioInputType&>(*this), value);
+    case Type::Range:
+        return validateInputType(static_cast<const RangeInputType&>(*this), value);
+    case Type::Reset:
+        return validateInputType(static_cast<const ResetInputType&>(*this), value);
+    case Type::Search:
+        return validateInputType(static_cast<const SearchInputType&>(*this), value);
+    case Type::Submit:
+        return validateInputType(static_cast<const SubmitInputType&>(*this), value);
+    case Type::Telephone:
+        return validateInputType(static_cast<const TelephoneInputType&>(*this), value);
+    case Type::Time:
+        return validateInputType(static_cast<const TimeInputType&>(*this), value);
+    case Type::URL:
+        return validateInputType(static_cast<const URLInputType&>(*this), value);
+    case Type::Week:
+        return validateInputType(static_cast<const WeekInputType&>(*this), value);
+    case Type::Text:
+        return validateInputType(static_cast<const TextInputType&>(*this), value);
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 bool InputType::shouldSaveAndRestoreFormControlState() const
 {
     return true;

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -164,6 +164,8 @@ public:
 
     virtual const AtomString& formControlType() const = 0;
 
+    bool isValidValue(const String&) const;
+
     // Type query functions.
 
     // Any time we are using one of these functions it's best to refactor

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -39,6 +39,7 @@ class NumberInputType final : public TextFieldInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     explicit NumberInputType(HTMLInputElement& element) : TextFieldInputType(Type::Number, element) { }
+    bool typeMismatchFor(const String&) const final;
 
 private:
     const AtomString& formControlType() const final;
@@ -46,7 +47,6 @@ private:
     double valueAsDouble() const final;
     ExceptionOr<void> setValueAsDouble(double, TextFieldEventBehavior) const final;
     ExceptionOr<void> setValueAsDecimal(const Decimal&, TextFieldEventBehavior) const final;
-    bool typeMismatchFor(const String&) const final;
     bool typeMismatch() const final;
     bool sizeShouldIncludeDecoration(int defaultSize, int& preferredSize) const final;
     float decorationWidth() const final;

--- a/Source/WebCore/html/RadioInputType.h
+++ b/Source/WebCore/html/RadioInputType.h
@@ -42,9 +42,10 @@ public:
 
     static void forEachButtonInDetachedGroup(ContainerNode& rootName, const String& groupName, const Function<bool(HTMLInputElement&)>&);
 
+    bool valueMissing(const String&) const final;
+
 private:
     const AtomString& formControlType() const final;
-    bool valueMissing(const String&) const final;
     String valueMissingText() const final;
     void handleClickEvent(MouseEvent&) final;
     ShouldCallBaseEventHandler handleKeydownEvent(KeyboardEvent&) final;

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -41,12 +41,12 @@ class RangeInputType final : public InputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     explicit RangeInputType(HTMLInputElement&);
+    bool typeMismatchFor(const String&) const final;
 
 private:
     const AtomString& formControlType() const final;
     double valueAsDouble() const final;
     ExceptionOr<void> setValueAsDecimal(const Decimal&, TextFieldEventBehavior) const final;
-    bool typeMismatchFor(const String&) const final;
     bool supportsRequired() const final;
     StepRange createStepRange(AnyStepHandling) const final;
     void handleMouseDownEvent(MouseEvent&) final;

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -50,6 +50,9 @@ class TextFieldInputType : public InputType, protected SpinButtonElement::SpinBu
     , private DataListSuggestionsClient, protected DataListButtonElement::DataListButtonOwner
 #endif
 {
+public:
+    bool valueMissing(const String&) const final;
+
 protected:
     explicit TextFieldInputType(Type, HTMLInputElement&);
     virtual ~TextFieldInputType();
@@ -81,7 +84,6 @@ protected:
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) override;
     void updateInnerTextValue() final;
     String sanitizeValue(const String&) const override;
-    bool valueMissing(const String&) const final;
 
     virtual String convertFromVisibleValue(const String&) const;
     virtual void didSetValueByUserEdit();

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -38,10 +38,10 @@ class URLInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     explicit URLInputType(HTMLInputElement& element) : BaseTextInputType(Type::URL, element) { }
+    bool typeMismatchFor(const String&) const override;
 
 private:
     const AtomString& formControlType() const override;
-    bool typeMismatchFor(const String&) const override;
     bool typeMismatch() const override;
     String typeMismatchText() const override;
     String sanitizeValue(const String&) const override;

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -190,10 +190,10 @@ void DateTimeFieldElement::updateVisibleValue(EventBehavior eventBehavior)
     if (!firstChild())
         appendChild(Text::create(document(), String { emptyString() }));
 
-    auto& textNode = downcast<Text>(*firstChild());
+    Ref textNode = downcast<Text>(*firstChild());
     String newVisibleValue = visibleValue();
-    if (textNode.wholeText() != newVisibleValue)
-        textNode.replaceWholeText(newVisibleValue);
+    if (textNode->wholeText() != newVisibleValue)
+        textNode->replaceWholeText(newVisibleValue);
 
     if (eventBehavior == DispatchInputAndChangeEvents && m_fieldOwner)
         m_fieldOwner->fieldValueChanged();

--- a/Source/WebKitLegacy/mac/DOM/DOMText.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMText.mm
@@ -53,7 +53,9 @@
 - (DOMText *)replaceWholeText:(NSString *)content
 {
     WebCore::JSMainThreadNullState state;
-    return kit(IMPL->replaceWholeText(content).get());
+    RefPtr protectedImpl = IMPL;
+    protectedImpl->replaceWholeText(content);
+    return self;
 }
 
 @end


### PR DESCRIPTION
#### f3d3f591b6baeff6fc098e245f399ee2711eb360
<pre>
Modernize Text::replaceWholeText()
<a href="https://bugs.webkit.org/show_bug.cgi?id=239637">https://bugs.webkit.org/show_bug.cgi?id=239637</a>

Reviewed by NOBODY (OOPS!).

Modernize Text::replaceWholeText():
- Drop unnecessary return value
- Ref the Text node at call sites instead of using an internal protectedThis variable
- Use node instead of n for variable name
- Use modern template deduction for Ref / RefPtr

* Source/WebKitLegacy/mac/DOM/DOMText.mm:
(-[DOMText replaceWholeText:]):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::replaceWholeText):
* Source/WebCore/dom/Text.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::updateVisibleValue):
</pre>
----------------------------------------------------------------------
#### fd1b354a965ffba197abb33647cc303e59714f4b
<pre>
devitualize_input_validation
</pre>