### PR TITLE
[ macOS Release arm64 ] imported/w3c/web-platform-tests/resource-timing/resource_timing.worker.html is a flakey text failure

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,14 @@
+2022-04-22  Karl Rackler  <rackler@apple.com>
+
+        [ macOS Release arm64 ] imported/w3c/web-platform-tests/resource-timing/resource_timing.worker.html is a flakey text failure
+        https://bugs.webkit.org/show_bug.cgi?id=223472
+
+        Unreviewed test gardening. 
+
+        Updated test expectation [ Release arm64 ]
+
+        * platform/mac/TestExpectations:
+
 2022-04-22  Andres Gonzalez  <andresg_22@apple.com>
 
         Fix for accessibility/aria-grid-with-aria-owns-rows.html in isolated tree mode.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2093,7 +2093,7 @@ webkit.org/b/238824 http/tests/workers/service/openwindow-from-notification-clic
 
 webkit.org/b/215335 [ Release ] webanimations/css-transition-retargeting-during-ready-promise.html [ Pass Failure ]
 
-webkit.org/b/223472 [ BigSur Release arm64 ] imported/w3c/web-platform-tests/resource-timing/resource_timing.worker.html [ Pass Failure ]
+webkit.org/b/223472 [ Release arm64 ] imported/w3c/web-platform-tests/resource-timing/resource_timing.worker.html [ Pass Failure ]
 
 webkit.org/b/227753 [ Debug ] fast/dom/Window/post-message-large-array-buffer-should-not-crash.html [ Pass Failure ]
 


### PR DESCRIPTION
#### c03ef17e9a7fb8f341462288238f88dca93873ea
<pre>
[ macOS Release arm64 ] imported/w3c/web-platform-tests/resource-timing/resource_timing.worker.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=223472">https://bugs.webkit.org/show_bug.cgi?id=223472</a>

Unreviewed test gardening.

Updated test expectation [ Release arm64 ]

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/249890@main">https://commits.webkit.org/249890@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@293221">https://svn.webkit.org/repository/webkit/trunk@293221</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
