### PR TITLE
[build.webkit.org] Update logic for archiving build products on Apple ports

### DIFF
--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -68,7 +68,7 @@ class BuildFactory(Factory):
 
             self.addStep(ArchiveBuiltProduct())
             self.addStep(UploadBuiltProduct())
-            if platform.startswith('mac') or platform.startswith('ios-simulator') or platform.startswith('tvos-simulator') or platform.startswith('watchos-simulator'):
+            if platform.startswith('mac') or platform.startswith('ios') or (platform.startswith('watchos') and not platform.startswith('watchos-simulator')):
                 self.addStep(ArchiveMinifiedBuiltProduct())
                 self.addStep(UploadMinifiedBuiltProduct())
             self.addStep(TransferToS3())

--- a/Tools/ChangeLog
+++ b/Tools/ChangeLog
@@ -20,6 +20,17 @@
         (Tracker.projects): Detect a failed login.
         * Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
 
+2022-04-28  Ryan Haddad  <ryanhaddad@apple.com>
+
+        [build.webkit.org] Update logic for archiving build products on Apple ports
+        https://bugs.webkit.org/show_bug.cgi?id=239855
+
+        Reviewed by NOBODY (OOPS!).
+
+        * CISupport/build-webkit-org/factories.py:
+        (BuildFactory.__init__): Upload macOS, iOS, and watchOS build products,
+        omitting watchOS and tvOS simulator.
+
 2022-04-28  Kimmo Kinnunen  <kkinnunen@apple.com>
 
         test-webkitperl outputs errors about uninitialized $platform variable


### PR DESCRIPTION
#### 8d045973ae8b2215e6303c569a1ffd3b755da1a3
<pre>
[build.webkit.org] Update logic for archiving build products on Apple ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=239855">https://bugs.webkit.org/show_bug.cgi?id=239855</a>

Reviewed by NOBODY (OOPS!).

* CISupport/build-webkit-org/factories.py:
(BuildFactory.__init__): Upload macOS, iOS, and watchOS build products,
omitting watchOS and tvOS simulator.
</pre>