### PR TITLE
[Speedometer] Avoid emitting stack checks.

### DIFF
--- a/JSTests/stress/stack-overflow-simple.js
+++ b/JSTests/stress/stack-overflow-simple.js
@@ -1,0 +1,52 @@
+var level = 0;
+var stackLevel = 0;
+var gotWrongCatch = false;
+
+function test1()
+{
+    var myLevel = level;
+    var dummy;
+
+    print($vm.callFrame().ptr)
+
+    try {
+        level = level + 1;
+        // Dummy code to make this funciton different from test2()
+        dummy = level * level + 1;
+        if (dummy == 0)
+            debug('Should never get here!!!!');
+    } catch(err) {
+        gotWrongCatch = true;
+    }
+
+    try {
+        test2();
+    } catch(err) {
+        stackLevel = myLevel;
+    }
+}
+
+function test2()
+{
+    var myLevel = level;
+
+    // Dummy code to make this funciton different from test1()
+    if (gotWrongCatch)
+        debug('Should never get here!!!!');
+
+    try {
+        level = level + 1;
+    } catch(err) {
+        gotWrongCatch = true;
+    }
+
+    try {
+        test1();
+    } catch(err) {
+        stackLevel = myLevel;
+    }
+}
+
+test1();
+
+print(stackLevel, level, gotWrongCatch);

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1163,6 +1163,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/SparseArrayValueMap.h
     runtime/StackAlignment.h
     runtime/StackFrame.h
+    runtime/StackOverflowFaultSignalHandler.h
     runtime/StringObject.h
     runtime/StringPrototype.h
     runtime/Structure.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -872,6 +872,7 @@
 		451539B912DC994500EF7AC4 /* Yarr.h in Headers */ = {isa = PBXBuildFile; fileRef = 451539B812DC994500EF7AC4 /* Yarr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		473DA4A4764C45FE871B0485 /* DefinePropertyAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4BAA07CEB81F49A296E02203 /* WasmTypeDefinitionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4BF1CD2A281B0F7600432D6F /* StackOverflowFaultSignalHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BF1CD29281B0F7500432D6F /* StackOverflowFaultSignalHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		520D99F12388CC81000509A3 /* GetByValHistory.h in Headers */ = {isa = PBXBuildFile; fileRef = 520D99F02388CC78000509A3 /* GetByValHistory.h */; };
 		521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 521131F61F82BF11007CCEEE /* PolyProtoAccessChain.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		521322461ECBCE8200F65615 /* WebAssemblyFunctionBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 521322441ECBCE8200F65615 /* WebAssemblyFunctionBase.h */; };
@@ -3807,6 +3808,8 @@
 		442FBD852149D1E00073519C /* hasher.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = hasher.py; path = yarr/hasher.py; sourceTree = "<group>"; };
 		451539B812DC994500EF7AC4 /* Yarr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Yarr.h; path = yarr/Yarr.h; sourceTree = "<group>"; };
 		45E12D8806A49B0F00E9DF84 /* jsc.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsc.cpp; sourceTree = "<group>"; tabWidth = 4; };
+		4BF1CD27281B0F1600432D6F /* StackOverflowFaultSignalHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackOverflowFaultSignalHandler.cpp; sourceTree = "<group>"; };
+		4BF1CD29281B0F7500432D6F /* StackOverflowFaultSignalHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackOverflowFaultSignalHandler.h; sourceTree = "<group>"; };
 		4CE978E385A8498199052153 /* ModuleNamespaceAccessCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleNamespaceAccessCase.h; sourceTree = "<group>"; };
 		51F0EB6105C86C6B00E6DF1B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		51F0EC0705C86C9A00E6DF1B /* libobjc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libobjc.dylib; path = /usr/lib/libobjc.dylib; sourceTree = "<absolute>"; };
@@ -8103,6 +8106,8 @@
 				4340A4821A9051AF00D73CCA /* MathCommon.cpp */,
 				4340A4831A9051AF00D73CCA /* MathCommon.h */,
 				F692A86A0255597D01FF60F7 /* MathObject.cpp */,
+				4BF1CD27281B0F1600432D6F /* StackOverflowFaultSignalHandler.cpp */,
+				4BF1CD29281B0F7500432D6F /* StackOverflowFaultSignalHandler.h */,
 				F692A86B0255597D01FF60F7 /* MathObject.h */,
 				90213E3B123A40C200D422F3 /* MemoryStatistics.cpp */,
 				90213E3C123A40C200D422F3 /* MemoryStatistics.h */,
@@ -10362,6 +10367,7 @@
 				522927D5235FD0B9005CB169 /* GCMemoryOperations.h in Headers */,
 				0F9715311EB28BEE00A1645D /* GCRequest.h in Headers */,
 				A54E8EB018BFFBBB00556D28 /* GCSegmentedArray.h in Headers */,
+				4BF1CD2A281B0F7600432D6F /* StackOverflowFaultSignalHandler.h in Headers */,
 				A54E8EB118BFFBBE00556D28 /* GCSegmentedArrayInlines.h in Headers */,
 				0F86A26F1D6F7B3300CB0C92 /* GCTypeMap.h in Headers */,
 				9959E9311BD18272001AA413 /* generate-combined-inspector-json.py in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -966,6 +966,7 @@ runtime/RandomizingFuzzerAgent.cpp
 runtime/ShadowRealmObject.cpp
 runtime/ShadowRealmConstructor.cpp
 runtime/ShadowRealmPrototype.cpp
+runtime/StackOverflowFaultSignalHandler.cpp
 runtime/ReflectObject.cpp
 runtime/RegExp.cpp
 runtime/RegExpCache.cpp

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -290,6 +290,12 @@ public:
                 unsigned ftlFrameSize = params.proc().frameSize();
                 unsigned maxFrameSize = std::max(exitFrameSize, ftlFrameSize);
 
+                if (Options::useFastStackOverflowChecks() && maxFrameSize < pageSize()) {
+                    jit.addPtr(MacroAssembler::TrustedImm32(-maxFrameSize), fp, scratch);
+                    jit.load64(MacroAssembler::Address(scratch), scratch);
+                    return; // TODO move this up?
+                }
+
                 jit.jitAssertCodeBlockOnCallFrameWithType(scratch, JITType::FTLJIT);
 
                 jit.addPtr(MacroAssembler::TrustedImm32(-maxFrameSize), fp, scratch);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -68,6 +68,7 @@
 #include "ReleaseHeapAccessScope.h"
 #include "SamplingProfiler.h"
 #include "SimpleTypedArrayController.h"
+#include "StackOverflowFaultSignalHandler.h"
 #include "StackVisitor.h"
 #include "StructureInlines.h"
 #include "SuperSampler.h"
@@ -3629,9 +3630,11 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
     VM& vm = VM::create(HeapType::Large).leakRef();
     if (!isWorker && options.m_canBlockIsFalse)
         vm.m_typedArrayController = adoptRef(new JSC::SimpleTypedArrayController(false));
+    enableFastStackOverflow(vm);
 #if ENABLE(WEBASSEMBLY)
     Wasm::enableFastMemory();
 #endif
+    activateSignalHandlersFor(Signal::AccessFault);
 
     int result;
     bool success = true;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -36,6 +36,7 @@
 #include "LLIntData.h"
 #include "Options.h"
 #include "SigillCrashAnalyzer.h"
+#include "StackOverflowFaultSignalHandler.h"
 #include "StructureAlignedMemoryAllocator.h"
 #include "SuperSampler.h"
 #include "VMTraps.h"
@@ -111,6 +112,7 @@ void initialize()
         WTF::startMachExceptionHandlerThread();
 #endif
         VMTraps::initializeSignals();
+        prepareFastStackOverflow();
 #if ENABLE(WEBASSEMBLY)
         Wasm::prepareFastMemory();
 #endif

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -484,6 +484,7 @@ bool canUseWebAssemblyFastMemory();
     v(Int32, omgTierUpCounterIncrementForEntry, 15, Normal, "The amount the tier up counter is incremented on each function entry.") \
     /* FIXME: enable fast memories on iOS and pre-allocate them. https://bugs.webkit.org/show_bug.cgi?id=170774 */ \
     v(Bool, useWebAssemblyFastMemory, canUseWebAssemblyFastMemory(), Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory.") \
+    v(Bool, useFastStackOverflowChecks, canUseWebAssemblyFastMemory(), Normal, "If true, we will use a guard page to avoid stack overflow checks for frames that are smaller than a page.") \
     v(Bool, logWebAssemblyMemory, false, Normal, nullptr) \
     v(Unsigned, webAssemblyFastMemoryRedzonePages, 128, Normal, "WebAssembly fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB WebAssembly pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked") \
     v(Bool, crashIfWebAssemblyCantFastMemory, false, Normal, "If true, we will crash if we can't obtain fast memory for wasm.") \

--- a/Source/JavaScriptCore/runtime/StackOverflowFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/runtime/StackOverflowFaultSignalHandler.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StackOverflowFaultSignalHandler.h"
+
+#include "LLIntData.h"
+#include "LLIntPCRanges.h"
+#include "MachineContext.h"
+#include "VM.h"
+#include "VMInlines.h"
+#include "wtf/Assertions.h"
+#include "wtf/DataLog.h"
+#include "wtf/Lock.h"
+#include "wtf/NeverDestroyed.h"
+#include "wtf/RawPointer.h"
+#include "wtf/StdLibExtras.h"
+#include <_types/_uint64_t.h>
+#include <sys/mman.h>
+#include <wtf/threads/Signals.h>
+
+namespace JSC {
+
+namespace {
+namespace StackOverflowSignalHandlerInternal {
+static constexpr bool verbose = true;
+}
+}
+
+static Lock contextLock = { };
+static LazyNeverDestroyed<HashMap<void*, VM*>> activeVMs;
+
+static void* pageForAddress(void* addr)
+{
+    uint64_t pageMask = ~(pageSize() - 1);
+    uint64_t asInt = reinterpret_cast<uint64_t>(addr);
+    uint64_t result = asInt & pageMask;
+    ASSERT(asInt >= result && asInt - result < pageSize());
+    return reinterpret_cast<void*>(result);
+}
+
+static void* findVM(VM* v) WTF_REQUIRES_LOCK(contextLock)
+{
+    for (auto pair : activeVMs.get()) {
+        if (pair.value == v)
+            return pair.key;
+    }
+    return nullptr;
+}
+
+static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegisters& context)
+{
+    RELEASE_ASSERT(signal == Signal::AccessFault);
+
+    auto instructionPointer = MachineContext::instructionPointer(context);
+    void* stackPointer = MachineContext::stackPointer(context);
+    void* framePointer = MachineContext::framePointer(context);
+    void* faultingAddress = sigInfo.faultingAddress;
+    if (!instructionPointer || !stackPointer || !faultingAddress)
+        return SignalAction::NotHandled;
+    void* faultingInstruction = instructionPointer->untaggedExecutableAddress();    
+    assertIsNotTagged(faultingInstruction);
+    assertIsNotTagged(faultingAddress);
+    assertIsNotTagged(stackPointer);
+    assertIsNotTagged(framePointer);
+    void* faultingPage = pageForAddress(faultingAddress);
+
+    dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "starting stack overflow handler for fault at insn: ", RawPointer(faultingInstruction), " sp: ", RawPointer(stackPointer), " fp: ", RawPointer(framePointer));
+    dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "JIT memory start: ", RawPointer(startOfFixedExecutableMemoryPool()), " end: ", RawPointer(endOfFixedExecutableMemoryPool()));
+    dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "Faulting address: ", RawPointer(faultingAddress), " page: ", RawPointer(faultingPage));
+    LockHolder holder { contextLock };
+    if (StackOverflowSignalHandlerInternal::verbose) {
+        for (auto& pair : activeVMs.get())
+            dataLogLn("Active VM: ", RawPointer(pair.value), " guard page:", RawPointer(pair.key), " -> ", RawPointer(static_cast<char*>(pair.key) + pageSize()));
+    }
+
+    if (!activeVMs->contains(faultingPage)) {
+        dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "Faulting address is not a stack guard page, ignoring.");
+        return SignalAction::NotHandled;
+    }
+
+    VM* vm = activeVMs->get(faultingPage);
+    if (!vm) {
+        dataLogLn("The VM appears to have been destroyed?");
+        RELEASE_ASSERT_NOT_REACHED();
+        return SignalAction::NotHandled;
+    }
+
+    if (stackPointer < faultingPage || stackPointer > static_cast<char*>(faultingPage) + 2*pageSize()) {
+        dataLogLn("The stack pointer appears to be beyond the guard page, or too far before(above) it.");
+        RELEASE_ASSERT_NOT_REACHED();
+        return SignalAction::NotHandled;
+    }
+
+    if (framePointer < faultingPage || framePointer > static_cast<char*>(faultingPage) + 3*pageSize()) {
+        dataLogLn("The frame pointer appears to be beyond the guard page, or too far before(above) it.");
+        RELEASE_ASSERT_NOT_REACHED();
+        return SignalAction::NotHandled;
+    }
+
+    if (isJITPC(faultingInstruction) || LLInt::isLLIntPC(faultingInstruction) || LLInt::isWasmLLIntPC(faultingInstruction)) {
+        dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "JIT/LLint/WasmLLint?: ", isJITPC(faultingInstruction), LLInt::isLLIntPC(faultingInstruction), LLInt::isWasmLLIntPC(faultingInstruction));
+        MachineContext::setInstructionPointer(context,
+            LLInt::getCodePtr<CFunctionPtrTag>(llint_throw_from_slow_path_trampoline));
+        __asm(".inst 0xd4200000");
+        return SignalAction::Handled;
+    }
+
+    dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "C++ has used more than the js stack limit");
+    __asm(".inst 0xd4200000");
+    return SignalAction::Handled;
+}
+
+void prepareFastStackOverflow()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        if (!Options::useFastStackOverflowChecks())
+            return;
+        
+        addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& ucontext) {
+            return trapHandler(signal, sigInfo, ucontext);
+        });
+        activateSignalHandlersFor(Signal::AccessFault);
+        activeVMs.construct();
+    });
+}
+
+void enableFastStackOverflow(VM& vm)
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        activateSignalHandlersFor(Signal::AccessFault);
+    });
+
+    if (activeVMs->contains(&vm)) {
+        dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "Called enableFastStackOverflow twice on the same VM");
+        RELEASE_ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (activeVMs->size()) {
+        dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "We have more than one vm, I didn't expect this");
+        RELEASE_ASSERT_NOT_REACHED();
+        return;
+    }
+
+    LockHolder holder { contextLock };
+
+    void* guardPage = pageForAddress(vm.addressOfSoftStackLimit() + pageSize());
+    
+    if (!mmap(guardPage, pageSize(), PROT_NONE, MAP_ANON|MAP_PRIVATE|MAP_FIXED, 0, 0)) {
+        dataLogLn("mmap failed with result ", strerror(errno));
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    dataLogLnIf(StackOverflowSignalHandlerInternal::verbose, "Protected stack page: ", RawPointer(guardPage));
+    activeVMs->add(guardPage, &vm);
+}
+
+void disableFastStackOverflowForVMThatWillBeDestroyed(VM& vm)
+{
+    LockHolder holder { contextLock };
+    auto* key = findVM(&vm);
+    if (key)
+        activeVMs->set(key, nullptr);
+}
+
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/StackOverflowFaultSignalHandler.h
+++ b/Source/JavaScriptCore/runtime/StackOverflowFaultSignalHandler.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace JSC {
+
+class VM;
+
+JS_EXPORT_PRIVATE void prepareFastStackOverflow();
+JS_EXPORT_PRIVATE void enableFastStackOverflow(VM&);
+JS_EXPORT_PRIVATE void disableFastStackOverflowForVMThatWillBeDestroyed(VM&);
+
+}
+

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -97,6 +97,7 @@
 #include "ShadowChicken.h"
 #include "SimpleTypedArrayController.h"
 #include "SourceProviderCache.h"
+#include "StackOverflowFaultSignalHandler.h"
 #include "StrongInlines.h"
 #include "StructureChain.h"
 #include "StructureInlines.h"
@@ -418,6 +419,7 @@ VM::~VM()
 {
     Locker destructionLocker { s_destructionLock.read() };
     
+    disableFastStackOverflowForVMThatWillBeDestroyed(*this);
     Gigacage::removePrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
     deferredWorkTimer->stopRunningTasks();
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -174,6 +174,7 @@ public:
                 return StackVisitor::Continue;
 
             addProperty(vm, "name"_s, jsString(vm, visitor->functionName()));
+            addProperty(vm, "ptr"_s, jsString(vm, makeString(reinterpret_cast<uint64_t>(visitor->callFrame()->addressOfCodeBlock()))));
 
             if (visitor->callee().isCell())
                 addProperty(vm, "callee"_s, visitor->callee().asCell());

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -94,6 +94,7 @@
 #include "WebsiteDataType.h"
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/MemoryStatistics.h>
+#include <JavaScriptCore/StackOverflowFaultSignalHandler.h>
 #include <JavaScriptCore/WasmFaultSignalHandler.h>
 #include <WebCore/AXObjectCache.h>
 #include <WebCore/ApplicationCacheStorage.h>
@@ -594,6 +595,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
 #endif
     SharedWorkerProvider::setSharedProvider(WebSharedWorkerProvider::singleton());
 
+    JSC::enableFastStackOverflow(commonVM());
 #if ENABLE(WEBASSEMBLY)
     JSC::Wasm::enableFastMemory();
 #endif


### PR DESCRIPTION
#### 3aef51032ec278c2bb0aa25c7b11bd95bb95008b
<pre>
[Speedometer] Avoid emitting stack checks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=239878">https://bugs.webkit.org/show_bug.cgi?id=239878</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::emitStackOverflowCheck):
(JSC::DFG::JITCompiler::compile):
(JSC::DFG::JITCompiler::compileFunction):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::lower):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileAndLinkWithoutFinalizing):
* Source/JavaScriptCore/jsc.cpp:
(runJSC):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::~VM):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
No new tests (OOPS!).
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
</pre>