### PR TITLE
Prepare the rest of WebCore for making the AtomString(const String&) constructor explicit

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,11 @@
+2022-05-01  Arcady Goldmints-Orlov  <agoldmints@igalia.com>
+
+        [GLIB] Update test expectations. Unreviewed test gardening.
+        https://bugs.webkit.org/show_bug.cgi?id=239945
+
+        * platform/glib/TestExpectations:
+        * platform/gtk/TestExpectations:
+
 2022-05-01  Philippe Normand  <philn@igalia.com>
 
         [GStreamer] tests gardening

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -441,9 +441,6 @@ webkit.org/b/232256 accessibility/auto-fill-crash.html [ Timeout ]
 # Cairo-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
 
-# This one needs a [Pass] after fixed, due to root expectation being ImageOnlyFailure. Was passing after r277073.
-webkit.org/b/233611 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-percentage-root.html [ ImageOnlyFailure ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Cairo-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -2394,7 +2391,6 @@ webkit.org/b/207574 [ Debug ] imported/w3c/web-platform-tests/css/css-background
 webkit.org/b/207574 [ Debug ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-omitted-height-viewbox.html [ Crash ]
 webkit.org/b/207574 [ Debug ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-percent-height.html [ Crash ]
 webkit.org/b/207574 [ Debug ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-percent-height-viewbox.html [ Crash ]
-webkit.org/b/207624 imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html [ Failure ]
 webkit.org/b/207678 imported/w3c/web-platform-tests/url/a-element.html [ Failure ]
 webkit.org/b/207678 imported/w3c/web-platform-tests/url/a-element-origin.html [ Failure ]
 webkit.org/b/207678 imported/w3c/web-platform-tests/url/a-element-origin-xhtml.xhtml [ Failure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1813,7 +1813,7 @@ webkit.org/b/224076 imported/w3c/web-platform-tests/css/css-text/white-space/whi
 
 webkit.org/b/230277 imported/w3c/web-platform-tests/css/css-transforms/3dtransform-and-filter-no-perspective-001.html [ ImageOnlyFailure ]
 
-webkit.org/b/234726 imported/w3c/web-platform-tests/css/css-color/color-mix-non-srgb-001.html [ Failure ]
+webkit.org/b/234726 imported/w3c/web-platform-tests/css/css-color/color-mix-non-srgb-001.html [ ImageOnlyFailure ]
 webkit.org/b/234726 imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-computed.html  [ Failure ]
 webkit.org/b/234726 imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-valid.html [ Failure ]
 webkit.org/b/234726 imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-computed.html [ Failure ]

--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,5 +1,30 @@
 2022-05-01  Zan Dobersek  <zdobersek@igalia.com>
 
+        [RISCV64] Implement MacroAssembler::probe(), ctiMasmProbeTrampoline
+        https://bugs.webkit.org/show_bug.cgi?id=239938
+
+        Reviewed by Yusuke Suzuki.
+
+        Implement MacroAssembler::probe() for RISCV64, along with the
+        ctiMasmProbeTrampoline operation. The implementation follows the process
+        of implementations for other platforms, with incoming, outgoing and
+        return-address-restoration records used to store register values during
+        setup and breakdown of the probe.
+
+        Going into the probe and back out of it, the general-purpose and
+        floating-point registers are stored, with the exception of global and
+        thread registers (x3 and x4). After the probe, if the probe state on the
+        stack is broken, the complete state is re-established before the
+        registers are reloaded, with the stack pointer and return address
+        registers set up last.
+
+        Covered by probing-related unit tests in testmasm.
+
+        * assembler/MacroAssemblerRISCV64.cpp:
+        (JSC::MacroAssembler::probe):
+
+2022-05-01  Zan Dobersek  <zdobersek@igalia.com>
+
         [RISCV64] Enable testmasm execution
         https://bugs.webkit.org/show_bug.cgi?id=239937
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.cpp
@@ -29,12 +29,489 @@
 #if ENABLE(ASSEMBLER) && CPU(RISCV64)
 
 #include "ProbeContext.h"
+#include <wtf/InlineASM.h>
 
 namespace JSC {
 
-void MacroAssembler::probe(Probe::Function, void*)
+JSC_DECLARE_JIT_OPERATION(ctiMasmProbeTrampoline, void, ());
+JSC_ANNOTATE_JIT_OPERATION_PROBE(ctiMasmProbeTrampoline);
+
+using namespace RISCV64Registers;
+
+#define PTR_SIZE 8
+#define GPREG_SIZE 8
+#define FPREG_SIZE 8
+
+#define PROBE_PROBE_FUNCTION_OFFSET (0 * PTR_SIZE)
+#define PROBE_ARG_OFFSET (1 * PTR_SIZE)
+#define PROBE_INITIALIZE_STACK_FUNCTION_OFFSET (2 * PTR_SIZE)
+#define PROBE_INITIALIZE_STACK_ARG_OFFSET (3 * PTR_SIZE)
+#define PROBE_CONTEXT_STATE_SIZE (4 * PTR_SIZE)
+
+#define PROBE_FIRST_GPREG_OFFSET PROBE_CONTEXT_STATE_SIZE
+#define PROBE_CPU_X0_OFFSET (PROBE_FIRST_GPREG_OFFSET + (0 * GPREG_SIZE))
+#define PROBE_CPU_X1_OFFSET (PROBE_FIRST_GPREG_OFFSET + (1 * GPREG_SIZE))
+#define PROBE_CPU_X2_OFFSET (PROBE_FIRST_GPREG_OFFSET + (2 * GPREG_SIZE))
+#define PROBE_CPU_X3_OFFSET (PROBE_FIRST_GPREG_OFFSET + (3 * GPREG_SIZE))
+#define PROBE_CPU_X4_OFFSET (PROBE_FIRST_GPREG_OFFSET + (4 * GPREG_SIZE))
+#define PROBE_CPU_X5_OFFSET (PROBE_FIRST_GPREG_OFFSET + (5 * GPREG_SIZE))
+#define PROBE_CPU_X6_OFFSET (PROBE_FIRST_GPREG_OFFSET + (6 * GPREG_SIZE))
+#define PROBE_CPU_X7_OFFSET (PROBE_FIRST_GPREG_OFFSET + (7 * GPREG_SIZE))
+#define PROBE_CPU_X8_OFFSET (PROBE_FIRST_GPREG_OFFSET + (8 * GPREG_SIZE))
+#define PROBE_CPU_X9_OFFSET (PROBE_FIRST_GPREG_OFFSET + (9 * GPREG_SIZE))
+#define PROBE_CPU_X10_OFFSET (PROBE_FIRST_GPREG_OFFSET + (10 * GPREG_SIZE))
+#define PROBE_CPU_X11_OFFSET (PROBE_FIRST_GPREG_OFFSET + (11 * GPREG_SIZE))
+#define PROBE_CPU_X12_OFFSET (PROBE_FIRST_GPREG_OFFSET + (12 * GPREG_SIZE))
+#define PROBE_CPU_X13_OFFSET (PROBE_FIRST_GPREG_OFFSET + (13 * GPREG_SIZE))
+#define PROBE_CPU_X14_OFFSET (PROBE_FIRST_GPREG_OFFSET + (14 * GPREG_SIZE))
+#define PROBE_CPU_X15_OFFSET (PROBE_FIRST_GPREG_OFFSET + (15 * GPREG_SIZE))
+#define PROBE_CPU_X16_OFFSET (PROBE_FIRST_GPREG_OFFSET + (16 * GPREG_SIZE))
+#define PROBE_CPU_X17_OFFSET (PROBE_FIRST_GPREG_OFFSET + (17 * GPREG_SIZE))
+#define PROBE_CPU_X18_OFFSET (PROBE_FIRST_GPREG_OFFSET + (18 * GPREG_SIZE))
+#define PROBE_CPU_X19_OFFSET (PROBE_FIRST_GPREG_OFFSET + (19 * GPREG_SIZE))
+#define PROBE_CPU_X20_OFFSET (PROBE_FIRST_GPREG_OFFSET + (20 * GPREG_SIZE))
+#define PROBE_CPU_X21_OFFSET (PROBE_FIRST_GPREG_OFFSET + (21 * GPREG_SIZE))
+#define PROBE_CPU_X22_OFFSET (PROBE_FIRST_GPREG_OFFSET + (22 * GPREG_SIZE))
+#define PROBE_CPU_X23_OFFSET (PROBE_FIRST_GPREG_OFFSET + (23 * GPREG_SIZE))
+#define PROBE_CPU_X24_OFFSET (PROBE_FIRST_GPREG_OFFSET + (24 * GPREG_SIZE))
+#define PROBE_CPU_X25_OFFSET (PROBE_FIRST_GPREG_OFFSET + (25 * GPREG_SIZE))
+#define PROBE_CPU_X26_OFFSET (PROBE_FIRST_GPREG_OFFSET + (26 * GPREG_SIZE))
+#define PROBE_CPU_X27_OFFSET (PROBE_FIRST_GPREG_OFFSET + (27 * GPREG_SIZE))
+#define PROBE_CPU_X28_OFFSET (PROBE_FIRST_GPREG_OFFSET + (28 * GPREG_SIZE))
+#define PROBE_CPU_X29_OFFSET (PROBE_FIRST_GPREG_OFFSET + (29 * GPREG_SIZE))
+#define PROBE_CPU_X30_OFFSET (PROBE_FIRST_GPREG_OFFSET + (30 * GPREG_SIZE))
+#define PROBE_CPU_X31_OFFSET (PROBE_FIRST_GPREG_OFFSET + (31 * GPREG_SIZE))
+#define PROBE_CPU_GPREG_ARRAY_SIZE (32 * GPREG_SIZE)
+
+#define PROBE_FIRST_SPREG_OFFSET PROBE_CONTEXT_STATE_SIZE + PROBE_CPU_GPREG_ARRAY_SIZE
+#define PROBE_CPU_PC_OFFSET (PROBE_FIRST_SPREG_OFFSET + (0 * GPREG_SIZE))
+#define PROBE_CPU_SPREG_ARRAY_SIZE (1 * GPREG_SIZE)
+
+#define PROBE_FIRST_FPREG_OFFSET PROBE_CONTEXT_STATE_SIZE + PROBE_CPU_GPREG_ARRAY_SIZE + PROBE_CPU_SPREG_ARRAY_SIZE
+#define PROBE_CPU_F0_OFFSET (PROBE_FIRST_FPREG_OFFSET + (0 * FPREG_SIZE))
+#define PROBE_CPU_F1_OFFSET (PROBE_FIRST_FPREG_OFFSET + (1 * FPREG_SIZE))
+#define PROBE_CPU_F2_OFFSET (PROBE_FIRST_FPREG_OFFSET + (2 * FPREG_SIZE))
+#define PROBE_CPU_F3_OFFSET (PROBE_FIRST_FPREG_OFFSET + (3 * FPREG_SIZE))
+#define PROBE_CPU_F4_OFFSET (PROBE_FIRST_FPREG_OFFSET + (4 * FPREG_SIZE))
+#define PROBE_CPU_F5_OFFSET (PROBE_FIRST_FPREG_OFFSET + (5 * FPREG_SIZE))
+#define PROBE_CPU_F6_OFFSET (PROBE_FIRST_FPREG_OFFSET + (6 * FPREG_SIZE))
+#define PROBE_CPU_F7_OFFSET (PROBE_FIRST_FPREG_OFFSET + (7 * FPREG_SIZE))
+#define PROBE_CPU_F8_OFFSET (PROBE_FIRST_FPREG_OFFSET + (8 * FPREG_SIZE))
+#define PROBE_CPU_F9_OFFSET (PROBE_FIRST_FPREG_OFFSET + (9 * FPREG_SIZE))
+#define PROBE_CPU_F10_OFFSET (PROBE_FIRST_FPREG_OFFSET + (10 * FPREG_SIZE))
+#define PROBE_CPU_F11_OFFSET (PROBE_FIRST_FPREG_OFFSET + (11 * FPREG_SIZE))
+#define PROBE_CPU_F12_OFFSET (PROBE_FIRST_FPREG_OFFSET + (12 * FPREG_SIZE))
+#define PROBE_CPU_F13_OFFSET (PROBE_FIRST_FPREG_OFFSET + (13 * FPREG_SIZE))
+#define PROBE_CPU_F14_OFFSET (PROBE_FIRST_FPREG_OFFSET + (14 * FPREG_SIZE))
+#define PROBE_CPU_F15_OFFSET (PROBE_FIRST_FPREG_OFFSET + (15 * FPREG_SIZE))
+#define PROBE_CPU_F16_OFFSET (PROBE_FIRST_FPREG_OFFSET + (16 * FPREG_SIZE))
+#define PROBE_CPU_F17_OFFSET (PROBE_FIRST_FPREG_OFFSET + (17 * FPREG_SIZE))
+#define PROBE_CPU_F18_OFFSET (PROBE_FIRST_FPREG_OFFSET + (18 * FPREG_SIZE))
+#define PROBE_CPU_F19_OFFSET (PROBE_FIRST_FPREG_OFFSET + (19 * FPREG_SIZE))
+#define PROBE_CPU_F20_OFFSET (PROBE_FIRST_FPREG_OFFSET + (20 * FPREG_SIZE))
+#define PROBE_CPU_F21_OFFSET (PROBE_FIRST_FPREG_OFFSET + (21 * FPREG_SIZE))
+#define PROBE_CPU_F22_OFFSET (PROBE_FIRST_FPREG_OFFSET + (22 * FPREG_SIZE))
+#define PROBE_CPU_F23_OFFSET (PROBE_FIRST_FPREG_OFFSET + (23 * FPREG_SIZE))
+#define PROBE_CPU_F24_OFFSET (PROBE_FIRST_FPREG_OFFSET + (24 * FPREG_SIZE))
+#define PROBE_CPU_F25_OFFSET (PROBE_FIRST_FPREG_OFFSET + (25 * FPREG_SIZE))
+#define PROBE_CPU_F26_OFFSET (PROBE_FIRST_FPREG_OFFSET + (26 * FPREG_SIZE))
+#define PROBE_CPU_F27_OFFSET (PROBE_FIRST_FPREG_OFFSET + (27 * FPREG_SIZE))
+#define PROBE_CPU_F28_OFFSET (PROBE_FIRST_FPREG_OFFSET + (28 * FPREG_SIZE))
+#define PROBE_CPU_F29_OFFSET (PROBE_FIRST_FPREG_OFFSET + (29 * FPREG_SIZE))
+#define PROBE_CPU_F30_OFFSET (PROBE_FIRST_FPREG_OFFSET + (30 * FPREG_SIZE))
+#define PROBE_CPU_F31_OFFSET (PROBE_FIRST_FPREG_OFFSET + (31 * FPREG_SIZE))
+#define PROBE_CPU_FPREG_ARRAY_SIZE (32 * FPREG_SIZE)
+
+#define PROBE_SIZE (PROBE_CONTEXT_STATE_SIZE + PROBE_CPU_GPREG_ARRAY_SIZE + PROBE_CPU_SPREG_ARRAY_SIZE + PROBE_CPU_FPREG_ARRAY_SIZE)
+
+#define PROBE_SAVED_RETURN_PC_OFFSET PROBE_SIZE
+#define PROBE_SAVED_RETURN_PC_SIZE (1 * GPREG_SIZE)
+
+#define PROBE_OFFSETOF(x) offsetof(struct Probe::State, x)
+
+static_assert(PROBE_OFFSETOF(probeFunction) == PROBE_PROBE_FUNCTION_OFFSET);
+static_assert(PROBE_OFFSETOF(arg) == PROBE_ARG_OFFSET);
+static_assert(PROBE_OFFSETOF(initializeStackFunction) == PROBE_INITIALIZE_STACK_FUNCTION_OFFSET);
+static_assert(PROBE_OFFSETOF(initializeStackArg) == PROBE_INITIALIZE_STACK_ARG_OFFSET);
+
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x0]) == PROBE_CPU_X0_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x1]) == PROBE_CPU_X1_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x2]) == PROBE_CPU_X2_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x3]) == PROBE_CPU_X3_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x4]) == PROBE_CPU_X4_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x5]) == PROBE_CPU_X5_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x6]) == PROBE_CPU_X6_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x7]) == PROBE_CPU_X7_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x8]) == PROBE_CPU_X8_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x9]) == PROBE_CPU_X9_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x10]) == PROBE_CPU_X10_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x11]) == PROBE_CPU_X11_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x12]) == PROBE_CPU_X12_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x13]) == PROBE_CPU_X13_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x14]) == PROBE_CPU_X14_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x15]) == PROBE_CPU_X15_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x16]) == PROBE_CPU_X16_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x17]) == PROBE_CPU_X17_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x18]) == PROBE_CPU_X18_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x19]) == PROBE_CPU_X19_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x20]) == PROBE_CPU_X20_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x21]) == PROBE_CPU_X21_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x22]) == PROBE_CPU_X22_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x23]) == PROBE_CPU_X23_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x24]) == PROBE_CPU_X24_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x25]) == PROBE_CPU_X25_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x26]) == PROBE_CPU_X26_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x27]) == PROBE_CPU_X27_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x28]) == PROBE_CPU_X28_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x29]) == PROBE_CPU_X29_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x30]) == PROBE_CPU_X30_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.gprs[RISCV64Registers::x31]) == PROBE_CPU_X31_OFFSET);
+
+static_assert(PROBE_OFFSETOF(cpu.sprs[RISCV64Registers::pc]) == PROBE_CPU_PC_OFFSET);
+
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f0]) == PROBE_CPU_F0_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f1]) == PROBE_CPU_F1_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f2]) == PROBE_CPU_F2_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f3]) == PROBE_CPU_F3_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f4]) == PROBE_CPU_F4_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f5]) == PROBE_CPU_F5_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f6]) == PROBE_CPU_F6_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f7]) == PROBE_CPU_F7_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f8]) == PROBE_CPU_F8_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f9]) == PROBE_CPU_F9_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f10]) == PROBE_CPU_F10_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f11]) == PROBE_CPU_F11_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f12]) == PROBE_CPU_F12_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f13]) == PROBE_CPU_F13_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f14]) == PROBE_CPU_F14_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f15]) == PROBE_CPU_F15_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f16]) == PROBE_CPU_F16_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f17]) == PROBE_CPU_F17_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f18]) == PROBE_CPU_F18_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f19]) == PROBE_CPU_F19_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f20]) == PROBE_CPU_F20_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f21]) == PROBE_CPU_F21_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f22]) == PROBE_CPU_F22_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f23]) == PROBE_CPU_F23_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f24]) == PROBE_CPU_F24_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f25]) == PROBE_CPU_F25_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f26]) == PROBE_CPU_F26_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f27]) == PROBE_CPU_F27_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f28]) == PROBE_CPU_F28_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f29]) == PROBE_CPU_F29_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f30]) == PROBE_CPU_F30_OFFSET);
+static_assert(PROBE_OFFSETOF(cpu.fprs[RISCV64Registers::f31]) == PROBE_CPU_F31_OFFSET);
+
+static_assert(sizeof(Probe::State) == PROBE_SIZE);
+
+#define PROBE_ALIGNED_STACK_SIZE (PROBE_SIZE + PROBE_SAVED_RETURN_PC_SIZE)
+static_assert(!(PROBE_ALIGNED_STACK_SIZE & 0xf));
+
+struct IncomingProbeRecord {
+    UCPURegister x1;
+    UCPURegister x25;
+    UCPURegister x26;
+    UCPURegister x27;
+};
+
+#define IN_X1_OFFSET  (0 * GPREG_SIZE)
+#define IN_X25_OFFSET (1 * GPREG_SIZE)
+#define IN_X26_OFFSET (2 * GPREG_SIZE)
+#define IN_X27_OFFSET (3 * GPREG_SIZE)
+#define IN_SIZE       (4 * GPREG_SIZE)
+
+static_assert(offsetof(IncomingProbeRecord, x1) == IN_X1_OFFSET);
+static_assert(offsetof(IncomingProbeRecord, x25) == IN_X25_OFFSET);
+static_assert(offsetof(IncomingProbeRecord, x26) == IN_X26_OFFSET);
+static_assert(offsetof(IncomingProbeRecord, x27) == IN_X27_OFFSET);
+static_assert(sizeof(IncomingProbeRecord) == IN_SIZE);
+static_assert(!(IN_SIZE & 0xf));
+
+struct OutgoingProbeRecord {
+    UCPURegister x25;
+    UCPURegister x26;
+    UCPURegister x27;
+    UCPURegister x8;
+    UCPURegister x1;
+    UCPURegister padding;
+};
+
+#define OUT_X25_OFFSET (0 * GPREG_SIZE)
+#define OUT_X26_OFFSET (1 * GPREG_SIZE)
+#define OUT_X27_OFFSET (2 * GPREG_SIZE)
+#define OUT_X8_OFFSET  (3 * GPREG_SIZE)
+#define OUT_X1_OFFSET  (4 * GPREG_SIZE)
+#define OUT_SIZE       (6 * GPREG_SIZE)
+
+static_assert(offsetof(OutgoingProbeRecord, x25) == OUT_X25_OFFSET);
+static_assert(offsetof(OutgoingProbeRecord, x26) == OUT_X26_OFFSET);
+static_assert(offsetof(OutgoingProbeRecord, x27) == OUT_X27_OFFSET);
+static_assert(offsetof(OutgoingProbeRecord, x8) == OUT_X8_OFFSET);
+static_assert(offsetof(OutgoingProbeRecord, x1) == OUT_X1_OFFSET);
+static_assert(sizeof(OutgoingProbeRecord) == OUT_SIZE);
+static_assert(!(OUT_SIZE & 0xf));
+
+struct RARestorationRecord {
+    UCPURegister ra;
+    UCPURegister padding;
+};
+
+#define RA_RESTORATION_RA_OFFSET (0 * GPREG_SIZE)
+#define RA_RESTORATION_SIZE      (2 * GPREG_SIZE)
+
+static_assert(offsetof(RARestorationRecord, ra) == RA_RESTORATION_RA_OFFSET);
+static_assert(sizeof(RARestorationRecord) == RA_RESTORATION_SIZE);
+static_assert(!(RA_RESTORATION_SIZE & 0xf));
+
+asm(
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
+    HIDE_SYMBOL(ctiMasmProbeTrampoline) "\n"
+    SYMBOL_STRING(ctiMasmProbeTrampoline) ":" "\n"
+
+    "mv x27, sp" "\n"
+    "addi sp, sp, " STRINGIZE_VALUE_OF(-(PROBE_ALIGNED_STACK_SIZE + OUT_SIZE)) "\n"
+
+    "sd x25, " STRINGIZE_VALUE_OF(PROBE_PROBE_FUNCTION_OFFSET) "(sp)" "\n"
+    "sd x26, " STRINGIZE_VALUE_OF(PROBE_ARG_OFFSET) "(sp)" "\n"
+
+    "addi x26, x27, " STRINGIZE_VALUE_OF(IN_SIZE) "\n"
+
+    // Move over the link register
+    "ld x25, " STRINGIZE_VALUE_OF(IN_X1_OFFSET) "(x27)" "\n"
+    "sd x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X1_OFFSET) "(sp)" "\n"
+
+    // Insert the original sp value
+    "sd x26, " STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "(sp)" "\n"
+
+    // Also handle x25, x26 and x27
+    "ld x25, " STRINGIZE_VALUE_OF(IN_X25_OFFSET) "(x27)" "\n"
+    "sd x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X25_OFFSET) "(sp)" "\n"
+    "ld x25, " STRINGIZE_VALUE_OF(IN_X26_OFFSET) "(x27)" "\n"
+    "sd x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X26_OFFSET) "(sp)" "\n"
+    "ld x25, " STRINGIZE_VALUE_OF(IN_X27_OFFSET) "(x27)" "\n"
+    "sd x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X27_OFFSET) "(sp)" "\n"
+
+    // x0 -- zero register, stored for completeness
+    "sd x0, " STRINGIZE_VALUE_OF(PROBE_CPU_X0_OFFSET) "(sp)" "\n"
+    // x1 -- return address register, handled above
+    // x2 -- stack pointer register, handled above
+    // x3 -- global pointer, not stored
+    // x4 -- thread pointer, not stored
+    "sd x5, " STRINGIZE_VALUE_OF(PROBE_CPU_X5_OFFSET) "(sp)" "\n"
+    "sd x6, " STRINGIZE_VALUE_OF(PROBE_CPU_X6_OFFSET) "(sp)" "\n"
+    "sd x7, " STRINGIZE_VALUE_OF(PROBE_CPU_X7_OFFSET) "(sp)" "\n"
+    "sd x8, " STRINGIZE_VALUE_OF(PROBE_CPU_X8_OFFSET) "(sp)" "\n"
+    "sd x9, " STRINGIZE_VALUE_OF(PROBE_CPU_X9_OFFSET) "(sp)" "\n"
+    "sd x10, " STRINGIZE_VALUE_OF(PROBE_CPU_X10_OFFSET) "(sp)" "\n"
+    "sd x11, " STRINGIZE_VALUE_OF(PROBE_CPU_X11_OFFSET) "(sp)" "\n"
+    "sd x12, " STRINGIZE_VALUE_OF(PROBE_CPU_X12_OFFSET) "(sp)" "\n"
+    "sd x13, " STRINGIZE_VALUE_OF(PROBE_CPU_X13_OFFSET) "(sp)" "\n"
+    "sd x14, " STRINGIZE_VALUE_OF(PROBE_CPU_X14_OFFSET) "(sp)" "\n"
+    "sd x15, " STRINGIZE_VALUE_OF(PROBE_CPU_X15_OFFSET) "(sp)" "\n"
+    "sd x16, " STRINGIZE_VALUE_OF(PROBE_CPU_X16_OFFSET) "(sp)" "\n"
+    "sd x17, " STRINGIZE_VALUE_OF(PROBE_CPU_X17_OFFSET) "(sp)" "\n"
+    "sd x18, " STRINGIZE_VALUE_OF(PROBE_CPU_X18_OFFSET) "(sp)" "\n"
+    "sd x19, " STRINGIZE_VALUE_OF(PROBE_CPU_X19_OFFSET) "(sp)" "\n"
+    "sd x20, " STRINGIZE_VALUE_OF(PROBE_CPU_X20_OFFSET) "(sp)" "\n"
+    "sd x21, " STRINGIZE_VALUE_OF(PROBE_CPU_X21_OFFSET) "(sp)" "\n"
+    "sd x22, " STRINGIZE_VALUE_OF(PROBE_CPU_X22_OFFSET) "(sp)" "\n"
+    "sd x23, " STRINGIZE_VALUE_OF(PROBE_CPU_X23_OFFSET) "(sp)" "\n"
+    "sd x24, " STRINGIZE_VALUE_OF(PROBE_CPU_X24_OFFSET) "(sp)" "\n"
+    // x25 -- incoming probe member, handled above
+    // x26 -- incoming probe member, handled above
+    // x27 -- incoming probe member, handled above
+    "sd x28, " STRINGIZE_VALUE_OF(PROBE_CPU_X28_OFFSET) "(sp)" "\n"
+    "sd x29, " STRINGIZE_VALUE_OF(PROBE_CPU_X29_OFFSET) "(sp)" "\n"
+    "sd x30, " STRINGIZE_VALUE_OF(PROBE_CPU_X30_OFFSET) "(sp)" "\n"
+    "sd x31, " STRINGIZE_VALUE_OF(PROBE_CPU_X31_OFFSET) "(sp)" "\n"
+
+    "fsd f0, " STRINGIZE_VALUE_OF(PROBE_CPU_F0_OFFSET) "(sp)" "\n"
+    "fsd f1, " STRINGIZE_VALUE_OF(PROBE_CPU_F1_OFFSET) "(sp)" "\n"
+    "fsd f2, " STRINGIZE_VALUE_OF(PROBE_CPU_F2_OFFSET) "(sp)" "\n"
+    "fsd f3, " STRINGIZE_VALUE_OF(PROBE_CPU_F3_OFFSET) "(sp)" "\n"
+    "fsd f4, " STRINGIZE_VALUE_OF(PROBE_CPU_F4_OFFSET) "(sp)" "\n"
+    "fsd f5, " STRINGIZE_VALUE_OF(PROBE_CPU_F5_OFFSET) "(sp)" "\n"
+    "fsd f6, " STRINGIZE_VALUE_OF(PROBE_CPU_F6_OFFSET) "(sp)" "\n"
+    "fsd f7, " STRINGIZE_VALUE_OF(PROBE_CPU_F7_OFFSET) "(sp)" "\n"
+    "fsd f8, " STRINGIZE_VALUE_OF(PROBE_CPU_F8_OFFSET) "(sp)" "\n"
+    "fsd f9, " STRINGIZE_VALUE_OF(PROBE_CPU_F9_OFFSET) "(sp)" "\n"
+    "fsd f10, " STRINGIZE_VALUE_OF(PROBE_CPU_F10_OFFSET) "(sp)" "\n"
+    "fsd f11, " STRINGIZE_VALUE_OF(PROBE_CPU_F11_OFFSET) "(sp)" "\n"
+    "fsd f12, " STRINGIZE_VALUE_OF(PROBE_CPU_F12_OFFSET) "(sp)" "\n"
+    "fsd f13, " STRINGIZE_VALUE_OF(PROBE_CPU_F13_OFFSET) "(sp)" "\n"
+    "fsd f14, " STRINGIZE_VALUE_OF(PROBE_CPU_F14_OFFSET) "(sp)" "\n"
+    "fsd f15, " STRINGIZE_VALUE_OF(PROBE_CPU_F15_OFFSET) "(sp)" "\n"
+    "fsd f16, " STRINGIZE_VALUE_OF(PROBE_CPU_F16_OFFSET) "(sp)" "\n"
+    "fsd f17, " STRINGIZE_VALUE_OF(PROBE_CPU_F17_OFFSET) "(sp)" "\n"
+    "fsd f18, " STRINGIZE_VALUE_OF(PROBE_CPU_F18_OFFSET) "(sp)" "\n"
+    "fsd f19, " STRINGIZE_VALUE_OF(PROBE_CPU_F19_OFFSET) "(sp)" "\n"
+    "fsd f20, " STRINGIZE_VALUE_OF(PROBE_CPU_F20_OFFSET) "(sp)" "\n"
+    "fsd f21, " STRINGIZE_VALUE_OF(PROBE_CPU_F21_OFFSET) "(sp)" "\n"
+    "fsd f22, " STRINGIZE_VALUE_OF(PROBE_CPU_F22_OFFSET) "(sp)" "\n"
+    "fsd f23, " STRINGIZE_VALUE_OF(PROBE_CPU_F23_OFFSET) "(sp)" "\n"
+    "fsd f24, " STRINGIZE_VALUE_OF(PROBE_CPU_F24_OFFSET) "(sp)" "\n"
+    "fsd f25, " STRINGIZE_VALUE_OF(PROBE_CPU_F25_OFFSET) "(sp)" "\n"
+    "fsd f26, " STRINGIZE_VALUE_OF(PROBE_CPU_F26_OFFSET) "(sp)" "\n"
+    "fsd f27, " STRINGIZE_VALUE_OF(PROBE_CPU_F27_OFFSET) "(sp)" "\n"
+    "fsd f28, " STRINGIZE_VALUE_OF(PROBE_CPU_F28_OFFSET) "(sp)" "\n"
+    "fsd f29, " STRINGIZE_VALUE_OF(PROBE_CPU_F29_OFFSET) "(sp)" "\n"
+    "fsd f30, " STRINGIZE_VALUE_OF(PROBE_CPU_F30_OFFSET) "(sp)" "\n"
+    "fsd f31, " STRINGIZE_VALUE_OF(PROBE_CPU_F31_OFFSET) "(sp)" "\n"
+
+    "sd ra, " STRINGIZE_VALUE_OF(PROBE_SAVED_RETURN_PC_OFFSET) "(sp)" "\n"
+    "sd ra, " STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "(sp)" "\n"
+
+    "mv x27, sp" "\n"
+
+    "mv x10, sp" "\n"
+    "la ra, " SYMBOL_STRING(executeJSCJITProbe) "\n"
+    "jalr ra" "\n"
+
+    "ld x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "(x27)" "\n"
+    "addi x26, x27, " STRINGIZE_VALUE_OF(PROBE_ALIGNED_STACK_SIZE + OUT_SIZE) "\n"
+    "bge x25, x26, " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) "\n"
+
+    "addi x25, x25, " STRINGIZE_VALUE_OF(-(PROBE_ALIGNED_STACK_SIZE + OUT_SIZE)) "\n"
+    "andi x25, x25, -16" "\n"
+    "mv sp, x25" "\n"
+
+    "mv x28, x27" "\n"
+    "mv x29, x25" "\n"
+    "addi x30, x28, " STRINGIZE_VALUE_OF(PROBE_ALIGNED_STACK_SIZE) "\n"
+
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) ":" "\n"
+    "ld x31, 0(x28)" "\n"
+    "sd x31, 0(x29)" "\n"
+    "addi x28, x28, " STRINGIZE_VALUE_OF(GPREG_SIZE) "\n"
+    "addi x29, x29, " STRINGIZE_VALUE_OF(GPREG_SIZE) "\n"
+    "blt x28, x30, " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineCopyLoop) "\n"
+
+    "mv x27, x25" "\n"
+
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineProbeStateIsSafe) ":" "\n"
+
+    // Call initializeStackFunction, if present
+    "ld x26, " STRINGIZE_VALUE_OF(PROBE_INITIALIZE_STACK_FUNCTION_OFFSET) "(x27)" "\n"
+    "beqz x26, " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) "\n"
+    "mv x10, x27" "\n"
+    "jalr x26" "\n"
+
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineRestoreRegisters) ":" "\n"
+    "mv sp, x27" "\n"
+
+    "fld f0, " STRINGIZE_VALUE_OF(PROBE_CPU_F0_OFFSET) "(sp)" "\n"
+    "fld f1, " STRINGIZE_VALUE_OF(PROBE_CPU_F1_OFFSET) "(sp)" "\n"
+    "fld f2, " STRINGIZE_VALUE_OF(PROBE_CPU_F2_OFFSET) "(sp)" "\n"
+    "fld f3, " STRINGIZE_VALUE_OF(PROBE_CPU_F3_OFFSET) "(sp)" "\n"
+    "fld f4, " STRINGIZE_VALUE_OF(PROBE_CPU_F4_OFFSET) "(sp)" "\n"
+    "fld f5, " STRINGIZE_VALUE_OF(PROBE_CPU_F5_OFFSET) "(sp)" "\n"
+    "fld f6, " STRINGIZE_VALUE_OF(PROBE_CPU_F6_OFFSET) "(sp)" "\n"
+    "fld f7, " STRINGIZE_VALUE_OF(PROBE_CPU_F7_OFFSET) "(sp)" "\n"
+    "fld f8, " STRINGIZE_VALUE_OF(PROBE_CPU_F8_OFFSET) "(sp)" "\n"
+    "fld f9, " STRINGIZE_VALUE_OF(PROBE_CPU_F9_OFFSET) "(sp)" "\n"
+    "fld f10, " STRINGIZE_VALUE_OF(PROBE_CPU_F10_OFFSET) "(sp)" "\n"
+    "fld f11, " STRINGIZE_VALUE_OF(PROBE_CPU_F11_OFFSET) "(sp)" "\n"
+    "fld f12, " STRINGIZE_VALUE_OF(PROBE_CPU_F12_OFFSET) "(sp)" "\n"
+    "fld f13, " STRINGIZE_VALUE_OF(PROBE_CPU_F13_OFFSET) "(sp)" "\n"
+    "fld f14, " STRINGIZE_VALUE_OF(PROBE_CPU_F14_OFFSET) "(sp)" "\n"
+    "fld f15, " STRINGIZE_VALUE_OF(PROBE_CPU_F15_OFFSET) "(sp)" "\n"
+    "fld f16, " STRINGIZE_VALUE_OF(PROBE_CPU_F16_OFFSET) "(sp)" "\n"
+    "fld f17, " STRINGIZE_VALUE_OF(PROBE_CPU_F17_OFFSET) "(sp)" "\n"
+    "fld f18, " STRINGIZE_VALUE_OF(PROBE_CPU_F18_OFFSET) "(sp)" "\n"
+    "fld f19, " STRINGIZE_VALUE_OF(PROBE_CPU_F19_OFFSET) "(sp)" "\n"
+    "fld f20, " STRINGIZE_VALUE_OF(PROBE_CPU_F20_OFFSET) "(sp)" "\n"
+    "fld f21, " STRINGIZE_VALUE_OF(PROBE_CPU_F21_OFFSET) "(sp)" "\n"
+    "fld f22, " STRINGIZE_VALUE_OF(PROBE_CPU_F22_OFFSET) "(sp)" "\n"
+    "fld f23, " STRINGIZE_VALUE_OF(PROBE_CPU_F23_OFFSET) "(sp)" "\n"
+    "fld f24, " STRINGIZE_VALUE_OF(PROBE_CPU_F24_OFFSET) "(sp)" "\n"
+    "fld f25, " STRINGIZE_VALUE_OF(PROBE_CPU_F25_OFFSET) "(sp)" "\n"
+    "fld f26, " STRINGIZE_VALUE_OF(PROBE_CPU_F26_OFFSET) "(sp)" "\n"
+    "fld f27, " STRINGIZE_VALUE_OF(PROBE_CPU_F27_OFFSET) "(sp)" "\n"
+    "fld f28, " STRINGIZE_VALUE_OF(PROBE_CPU_F28_OFFSET) "(sp)" "\n"
+    "fld f29, " STRINGIZE_VALUE_OF(PROBE_CPU_F29_OFFSET) "(sp)" "\n"
+    "fld f30, " STRINGIZE_VALUE_OF(PROBE_CPU_F30_OFFSET) "(sp)" "\n"
+    "fld f31, " STRINGIZE_VALUE_OF(PROBE_CPU_F31_OFFSET) "(sp)" "\n"
+
+    // x0 -- zero register, loaded for completeness
+    "ld x0, " STRINGIZE_VALUE_OF(PROBE_CPU_X0_OFFSET) "(sp)" "\n"
+    // x1 -- return address register, loaded at the end
+    // x2 -- stack pointer register, loaded at the end
+    // x3 -- global pointer, not loaded
+    // x4 -- thread pointer, not loaded
+    "ld x5, " STRINGIZE_VALUE_OF(PROBE_CPU_X5_OFFSET) "(sp)" "\n"
+    "ld x6, " STRINGIZE_VALUE_OF(PROBE_CPU_X6_OFFSET) "(sp)" "\n"
+    "ld x7, " STRINGIZE_VALUE_OF(PROBE_CPU_X7_OFFSET) "(sp)" "\n"
+    "ld x8, " STRINGIZE_VALUE_OF(PROBE_CPU_X8_OFFSET) "(sp)" "\n"
+    "ld x9, " STRINGIZE_VALUE_OF(PROBE_CPU_X9_OFFSET) "(sp)" "\n"
+    "ld x10, " STRINGIZE_VALUE_OF(PROBE_CPU_X10_OFFSET) "(sp)" "\n"
+    "ld x11, " STRINGIZE_VALUE_OF(PROBE_CPU_X11_OFFSET) "(sp)" "\n"
+    "ld x12, " STRINGIZE_VALUE_OF(PROBE_CPU_X12_OFFSET) "(sp)" "\n"
+    "ld x13, " STRINGIZE_VALUE_OF(PROBE_CPU_X13_OFFSET) "(sp)" "\n"
+    "ld x14, " STRINGIZE_VALUE_OF(PROBE_CPU_X14_OFFSET) "(sp)" "\n"
+    "ld x15, " STRINGIZE_VALUE_OF(PROBE_CPU_X15_OFFSET) "(sp)" "\n"
+    "ld x16, " STRINGIZE_VALUE_OF(PROBE_CPU_X16_OFFSET) "(sp)" "\n"
+    "ld x17, " STRINGIZE_VALUE_OF(PROBE_CPU_X17_OFFSET) "(sp)" "\n"
+    "ld x18, " STRINGIZE_VALUE_OF(PROBE_CPU_X18_OFFSET) "(sp)" "\n"
+    "ld x19, " STRINGIZE_VALUE_OF(PROBE_CPU_X19_OFFSET) "(sp)" "\n"
+    "ld x20, " STRINGIZE_VALUE_OF(PROBE_CPU_X20_OFFSET) "(sp)" "\n"
+    "ld x21, " STRINGIZE_VALUE_OF(PROBE_CPU_X21_OFFSET) "(sp)" "\n"
+    "ld x22, " STRINGIZE_VALUE_OF(PROBE_CPU_X22_OFFSET) "(sp)" "\n"
+    "ld x23, " STRINGIZE_VALUE_OF(PROBE_CPU_X23_OFFSET) "(sp)" "\n"
+    "ld x24, " STRINGIZE_VALUE_OF(PROBE_CPU_X24_OFFSET) "(sp)" "\n"
+    "ld x28, " STRINGIZE_VALUE_OF(PROBE_CPU_X28_OFFSET) "(sp)" "\n"
+    "ld x29, " STRINGIZE_VALUE_OF(PROBE_CPU_X29_OFFSET) "(sp)" "\n"
+    "ld x30, " STRINGIZE_VALUE_OF(PROBE_CPU_X30_OFFSET) "(sp)" "\n"
+    "ld x31, " STRINGIZE_VALUE_OF(PROBE_CPU_X31_OFFSET) "(sp)" "\n"
+
+    "ld x25, " STRINGIZE_VALUE_OF(PROBE_CPU_X2_OFFSET) "(sp)" "\n"
+    "ld x26, " STRINGIZE_VALUE_OF(PROBE_SAVED_RETURN_PC_OFFSET) "(sp)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "(sp)" "\n"
+    "bne x26, x27, " LOCAL_LABEL_STRING(ctiMasmProbeTrampolineEnd) "\n"
+
+    "addi x25, x25, " STRINGIZE_VALUE_OF(-RA_RESTORATION_SIZE) "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_X1_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(RA_RESTORATION_RA_OFFSET) "(x25)" "\n"
+
+    LOCAL_LABEL_STRING(ctiMasmProbeTrampolineEnd) ":" "\n"
+
+    "addi x25, x25, " STRINGIZE_VALUE_OF(-OUT_SIZE) "\n"
+
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_X25_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(OUT_X25_OFFSET) "(x25)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_X26_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(OUT_X26_OFFSET) "(x25)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_X27_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(OUT_X27_OFFSET) "(x25)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_X8_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(OUT_X8_OFFSET) "(x25)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(PROBE_CPU_PC_OFFSET) "(sp)" "\n"
+    "sd x27, " STRINGIZE_VALUE_OF(OUT_X1_OFFSET) "(x25)" "\n"
+
+    "mv sp, x25" "\n"
+    "ld x25, " STRINGIZE_VALUE_OF(OUT_X25_OFFSET) "(sp)" "\n"
+    "ld x26, " STRINGIZE_VALUE_OF(OUT_X26_OFFSET) "(sp)" "\n"
+    "ld x27, " STRINGIZE_VALUE_OF(OUT_X27_OFFSET) "(sp)" "\n"
+    "ld ra, " STRINGIZE_VALUE_OF(OUT_X1_OFFSET) "(sp)" "\n"
+    "addi sp, sp, " STRINGIZE_VALUE_OF(OUT_SIZE) "\n"
+
+    "ret" "\n");
+
+void MacroAssembler::probe(Probe::Function function, void* arg)
 {
-    // TODO
+    sub64(TrustedImm32(sizeof(IncomingProbeRecord)), sp);
+    store64(ra, Address(sp, offsetof(IncomingProbeRecord, x1)));
+    store64(x25, Address(sp, offsetof(IncomingProbeRecord, x25)));
+    store64(x26, Address(sp, offsetof(IncomingProbeRecord, x26)));
+    store64(x27, Address(sp, offsetof(IncomingProbeRecord, x27)));
+
+    move(TrustedImmPtr(tagCFunction<OperationPtrTag>(ctiMasmProbeTrampoline)), x27);
+    move(TrustedImmPtr(reinterpret_cast<void*>(function)), x25);
+    move(TrustedImmPtr(arg), x26);
+    call(x27, OperationPtrTag);
+
+    load64(Address(sp, offsetof(RARestorationRecord, ra)), ra);
+    add64(TrustedImm32(sizeof(RARestorationRecord)), sp);
 }
 
 } // namespace JSC

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -52,6 +52,12 @@ public:
             return nullptr;
         return add(*string);
     }
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(RefPtr<StringImpl>&& string)
+    {
+        if (!string)
+            return nullptr;
+        return add(string.releaseNonNull());
+    }
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const StaticStringImpl*);
     WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(const char* characters, unsigned length);
 
@@ -86,6 +92,15 @@ private:
         return addSlowCase(string);
     }
 
+    ALWAYS_INLINE static Ref<AtomStringImpl> add(Ref<StringImpl>&& string)
+    {
+        if (string->isAtom()) {
+            ASSERT_WITH_MESSAGE(!string->length() || isInAtomStringTable(string.ptr()), "The atom string comes from an other thread!");
+            return static_reference_cast<AtomStringImpl>(WTFMove(string));
+        }
+        return addSlowCase(WTFMove(string));
+    }
+
     ALWAYS_INLINE static Ref<AtomStringImpl> add(AtomStringTable& stringTable, StringImpl& string)
     {
         if (string.isAtom()) {
@@ -96,6 +111,7 @@ private:
     }
 
     WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addSlowCase(StringImpl&);
+    WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addSlowCase(Ref<StringImpl>&&);
     WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addSlowCase(AtomStringTable&, StringImpl&);
 
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUpSlowCase(StringImpl&);

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -153,6 +153,8 @@ public:
     WTF_EXPORT_PRIVATE static String numberToStringFixedWidth(float, unsigned decimalPlaces);
     WTF_EXPORT_PRIVATE static String numberToStringFixedWidth(double, unsigned decimalPlaces);
 
+    AtomString toExistingAtomString() const;
+
     // Find a single character or string, also with match function & latin1 forms.
     size_t find(UChar character, unsigned start = 0) const { return m_impl ? m_impl->find(character, start) : notFound; }
 

--- a/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl
+++ b/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl
@@ -28,7 +28,7 @@
     Conditional=WIRELESS_PLAYBACK_TARGET,
     Exposed=Window
 ] interface WebKitPlaybackTargetAvailabilityEvent : Event {
-    constructor(DOMString type, optional WebKitPlaybackTargetAvailabilityEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitPlaybackTargetAvailabilityEventInit eventInitDict);
 
     readonly attribute DOMString availability;
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl
@@ -32,7 +32,7 @@
     DisabledByQuirk=hasBrokenEncryptedMediaAPISupport,
     Exposed=Window
 ] interface MediaKeyMessageEvent : Event {
-    constructor(DOMString type, MediaKeyMessageEventInit eventInitDict);
+    constructor([AtomString] DOMString type, MediaKeyMessageEventInit eventInitDict);
 
     readonly attribute MediaKeyMessageType messageType;
     readonly attribute ArrayBuffer message;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.idl
@@ -40,7 +40,7 @@
     readonly attribute MediaKeyStatusMap keyStatuses;
     attribute EventHandler onkeystatuseschange;
     attribute EventHandler onmessage;
-    Promise<undefined> generateRequest(DOMString initDataType, BufferSource initData);
+    Promise<undefined> generateRequest([AtomString] DOMString initDataType, BufferSource initData);
     Promise<boolean> load(DOMString sessionId);
     Promise<undefined> update(BufferSource response);
     Promise<undefined> close();

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=LegacyEncryptedMediaAPIEnabled,
     Exposed=Window
 ] interface WebKitMediaKeyMessageEvent : Event {
-    constructor(DOMString type, optional WebKitMediaKeyMessageEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitMediaKeyMessageEventInit eventInitDict);
 
     readonly attribute Uint8Array message;
     readonly attribute DOMString destinationURL;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=LegacyEncryptedMediaAPIEnabled,
     Exposed=Window
 ] interface WebKitMediaKeyNeededEvent : Event {
-    constructor(DOMString type, optional WebKitMediaKeyNeededEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitMediaKeyNeededEventInit eventInitDict);
 
     readonly attribute Uint8Array initData;
 };

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl
@@ -31,7 +31,7 @@ dictionary MediaRecorderErrorEventInit : EventInit {
     Exposed=Window,
     EnabledBySetting=MediaRecorderEnabled
 ] interface MediaRecorderErrorEvent : Event {
-    constructor(DOMString type, MediaRecorderErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, MediaRecorderErrorEventInit eventInitDict);
 
     [SameObject] readonly attribute DOMException error;
 };

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
@@ -26,7 +26,7 @@
     Conditional=MEDIA_STREAM,
     Exposed=Window
 ] interface MediaStreamTrackEvent : Event {
-    constructor(DOMString type, MediaStreamTrackEventInit eventInitDict);
+    constructor([AtomString] DOMString type, MediaStreamTrackEventInit eventInitDict);
 
     [SameObject] readonly attribute MediaStreamTrack track;
 };

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
@@ -30,7 +30,7 @@
     Conditional=MEDIA_STREAM,
     Exposed=Window
 ] interface OverconstrainedErrorEvent : Event {
-    constructor(DOMString type, optional OverconstrainedErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional OverconstrainedErrorEventInit eventInitDict);
 
     readonly attribute OverconstrainedError? error;
 };

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCErrorEvent : Event {
-    constructor(DOMString type, RTCErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, RTCErrorEventInit eventInitDict);
     [SameObject] readonly attribute RTCError error;
 };
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl
@@ -36,7 +36,7 @@ dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCPeerConnectionIceErrorEvent : Event {
-    constructor(DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict);
 
     readonly attribute DOMString? address;
     readonly attribute unsigned short? port;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
@@ -33,7 +33,7 @@ dictionary RTCPeerConnectionIceEventInit : EventInit {
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCPeerConnectionIceEvent : Event {
-    constructor(DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict);
 
     readonly attribute RTCIceCandidate? candidate;
     readonly attribute DOMString? url;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
@@ -40,7 +40,7 @@ dictionary RTCRtpSFrameTransformErrorEventInit : EventInit {
     Exposed=(Window,DedicatedWorker),
     InterfaceName=SFrameTransformErrorEvent
 ] interface RTCRtpSFrameTransformErrorEvent : Event {
-    constructor(DOMString type, RTCRtpSFrameTransformErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, RTCRtpSFrameTransformErrorEventInit eventInitDict);
 
     readonly attribute RTCRtpSFrameTransformErrorEventType errorType;
     // FIXME: Add below fields

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
@@ -33,7 +33,7 @@
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCTrackEvent : Event {
-    constructor(DOMString type, RTCTrackEventInit eventInitDict);
+    constructor([AtomString] DOMString type, RTCTrackEventInit eventInitDict);
 
     readonly attribute RTCRtpReceiver receiver;
     readonly attribute MediaStreamTrack track;

--- a/Source/WebCore/Modules/mediastream/RTCTransformEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCTransformEvent.idl
@@ -28,7 +28,7 @@
     Exposed=Worker,
     InterfaceName=RTCTransformEvent,
 ] interface RTCTransformEvent : Event {
-    constructor(DOMString type, RTCRtpScriptTransformer transformer);
+    constructor([AtomString] DOMString type, RTCRtpScriptTransformer transformer);
 
     readonly attribute RTCRtpScriptTransformer transformer;
 };

--- a/Source/WebCore/Modules/notifications/NotificationEvent.idl
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.idl
@@ -29,7 +29,7 @@
     EnabledAtRuntime=NotificationEventEnabled,
 ]
 interface NotificationEvent : ExtendableEvent {
-    constructor(DOMString type, NotificationEventInit eventInitDict);
+    constructor([AtomString] DOMString type, NotificationEventInit eventInitDict);
 
     readonly attribute Notification notification;
     readonly attribute DOMString action;

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
@@ -29,7 +29,7 @@
     Exposed=Window,
     SecureContext,
 ] interface MerchantValidationEvent : Event {
-    [CallWith=CurrentDocument] constructor(DOMString type, optional MerchantValidationEventInit eventInitDict);
+    [CallWith=CurrentDocument] constructor([AtomString] DOMString type, optional MerchantValidationEventInit eventInitDict);
 
     readonly attribute DOMString methodName;
     readonly attribute USVString validationURL;

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
@@ -30,7 +30,7 @@
     JSCustomMarkFunction,
     SecureContext,
 ] interface PaymentMethodChangeEvent : PaymentRequestUpdateEvent {
-    constructor(DOMString type, optional PaymentMethodChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PaymentMethodChangeEventInit eventInitDict);
 
     readonly attribute DOMString methodName;
     [CustomGetter] readonly attribute object? methodDetails;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl
@@ -29,7 +29,7 @@
     Exposed=Window,
     SecureContext
 ] interface PaymentRequestUpdateEvent : Event {
-    constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PaymentRequestUpdateEventInit eventInitDict);
 
     undefined updateWith(Promise<PaymentDetailsUpdate> detailsPromise);
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=SpeechRecognitionEnabled,
     Exposed=Window
 ] interface SpeechRecognitionErrorEvent : Event {
-    constructor(DOMString type, SpeechRecognitionErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, SpeechRecognitionErrorEventInit eventInitDict);
     readonly attribute SpeechRecognitionErrorCode error;
     readonly attribute DOMString message;
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=SpeechRecognitionEnabled,
     Exposed=Window
 ] interface SpeechRecognitionEvent : Event {
-    constructor(DOMString type, SpeechRecognitionEventInit eventInitDict);
+    constructor([AtomString] DOMString type, SpeechRecognitionEventInit eventInitDict);
     readonly attribute unsigned long resultIndex;
     readonly attribute SpeechRecognitionResultList results;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
@@ -28,7 +28,7 @@
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window
 ] interface SpeechSynthesisEvent : Event {
-    constructor(DOMString type, SpeechSynthesisEventInit eventInitDict);
+    constructor([AtomString] DOMString type, SpeechSynthesisEventInit eventInitDict);
 
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.idl
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.idl
@@ -39,7 +39,7 @@
     SecureContext,
     Exposed=Window
 ] interface XRInputSourceEvent : Event {
-    constructor(DOMString type, XRInputSourceEventInit eventInitDict);
+    constructor([AtomString] DOMString type, XRInputSourceEventInit eventInitDict);
     [SameObject] readonly attribute WebXRFrame frame;
     [SameObject] readonly attribute WebXRInputSource inputSource;
 };

--- a/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.idl
+++ b/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.idl
@@ -40,7 +40,7 @@
     SecureContext,
     Exposed=Window
 ] interface XRInputSourcesChangeEvent : Event {
-    constructor(DOMString type, XRInputSourcesChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, XRInputSourcesChangeEventInit eventInitDict);
     [SameObject] readonly attribute WebXRSession session;
     [CachedAttribute, SameObject] readonly attribute FrozenArray<WebXRInputSource> added;
     [CachedAttribute, SameObject] readonly attribute FrozenArray<WebXRInputSource> removed;

--- a/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.idl
+++ b/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.idl
@@ -39,7 +39,7 @@
     SecureContext,
     Exposed=Window
 ] interface XRReferenceSpaceEvent : Event {
-    constructor(DOMString type, XRReferenceSpaceEventInit eventInitDict);
+    constructor([AtomString] DOMString type, XRReferenceSpaceEventInit eventInitDict);
     [SameObject] readonly attribute WebXRReferenceSpace referenceSpace;
     [SameObject] readonly attribute WebXRRigidTransform? transform;
 };

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.idl
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.idl
@@ -38,6 +38,6 @@
     SecureContext,
     Exposed=Window
 ] interface XRSessionEvent : Event {
-    constructor(DOMString type, XRSessionEventInit eventInitDict);
+    constructor([AtomString] DOMString type, XRSessionEventInit eventInitDict);
     [SameObject] readonly attribute WebXRSession session;
 };

--- a/Source/WebCore/PAL/pal/FileSizeFormatter.cpp
+++ b/Source/WebCore/PAL/pal/FileSizeFormatter.cpp
@@ -32,17 +32,17 @@ namespace PAL {
 
 #if !PLATFORM(COCOA)
 
-String fileSizeDescription(uint64_t size)
+AtomString fileSizeDescription(uint64_t size)
 {
     // FIXME: These strings should be localized, but that would require bringing LocalizedStrings into PAL.
     // See <https://bugs.webkit.org/show_bug.cgi?id=179019> for more details.
     if (size < 1000)
-        return makeString(size, " bytes");
+        return makeAtomString(size, " bytes");
     if (size < 1000000)
-        return makeString(FormattedNumber::fixedWidth(size / 1000., 1), " KB");
+        return makeAtomString(FormattedNumber::fixedWidth(size / 1000., 1), " KB");
     if (size < 1000000000)
-        return makeString(FormattedNumber::fixedWidth(size / 1000000., 1), " MB");
-    return makeString(FormattedNumber::fixedWidth(size / 1000000000., 1), " GB");
+        return makeAtomString(FormattedNumber::fixedWidth(size / 1000000., 1), " MB");
+    return makeAtomString(FormattedNumber::fixedWidth(size / 1000000000., 1), " GB");
 }
 
 #endif

--- a/Source/WebCore/PAL/pal/FileSizeFormatter.h
+++ b/Source/WebCore/PAL/pal/FileSizeFormatter.h
@@ -29,6 +29,6 @@
 
 namespace PAL {
 
-PAL_EXPORT String fileSizeDescription(uint64_t);
+PAL_EXPORT AtomString fileSizeDescription(uint64_t);
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/cocoa/FileSizeFormatterCocoa.mm
+++ b/Source/WebCore/PAL/pal/cocoa/FileSizeFormatterCocoa.mm
@@ -30,7 +30,7 @@
 
 namespace PAL {
 
-String fileSizeDescription(uint64_t size)
+AtomString fileSizeDescription(uint64_t size)
 {
     return NSLocalizedFileSizeDescription(size, 0, 0);
 }

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -139,7 +139,8 @@ template<typename StringType> struct IDLString : IDLType<StringType> {
 
     using NullableType = StringType;
     static StringType nullValue() { return StringType(); }
-    static bool isNullValue(const StringType& value) { return value.isNull(); }
+    static bool isNullValue(const String& value) { return value.isNull(); }
+    static bool isNullValue(const AtomString& value) { return value.isNull(); }
     static bool isNullValue(const UncachedString& value) { return value.string.isNull(); }
     static bool isNullValue(const OwnedString& value) { return value.string.isNull(); }
     static bool isNullValue(const URL& value) { return value.isNull(); }
@@ -150,6 +151,10 @@ struct IDLByteString : IDLString<String> { };
 struct IDLUSVString : IDLString<String> { };
 
 template<typename T> struct IDLLegacyNullToEmptyStringAdaptor : IDLString<String> {
+    using InnerType = T;
+};
+
+template<typename T> struct IDLLegacyNullToEmptyAtomStringAdaptor : IDLString<AtomString> {
     using InnerType = T;
 };
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
@@ -236,7 +236,7 @@ static inline JSValue jsTestCEReactions_reflectAttributeWithCEReactionsGetter(JS
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestCEReactions_reflectAttributeWithCEReactions, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -250,7 +250,7 @@ static inline bool setJSTestCEReactions_reflectAttributeWithCEReactionsSetter(JS
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     CustomElementReactionStack customElementReactionStack(lexicalGlobalObject);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsAttr, WTFMove(nativeValue));
@@ -336,7 +336,7 @@ static inline JSValue jsTestCEReactions_reflectAttributeWithCEReactionsNotNeeded
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsnotneededAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsnotneededAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestCEReactions_reflectAttributeWithCEReactionsNotNeeded, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -350,7 +350,7 @@ static inline bool setJSTestCEReactions_reflectAttributeWithCEReactionsNotNeeded
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     CustomElementReactionDisallowedScope customElementReactionDisallowedScope;
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectattributewithcereactionsnotneededAttr, WTFMove(nativeValue));

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -836,7 +836,7 @@ static inline JSValue jsTestInterface_reflectAttributeGetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributeAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectattributeAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestInterface_reflectAttribute, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -852,7 +852,7 @@ static inline bool setJSTestInterface_reflectAttributeSetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectattributeAttr, WTFMove(nativeValue));

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -3768,7 +3768,7 @@ static inline JSValue jsTestObj_reflectedStringAttrGetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedstringattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedstringattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -3781,7 +3781,7 @@ static inline bool setJSTestObj_reflectedStringAttrSetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedstringattrAttr, WTFMove(nativeValue));
@@ -3799,7 +3799,7 @@ static inline JSValue jsTestObj_reflectedUSVStringAttrGetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedusvstringattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::reflectedusvstringattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedUSVStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -3812,7 +3812,7 @@ static inline bool setJSTestObj_reflectedUSVStringAttrSetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedusvstringattrAttr, WTFMove(nativeValue));
@@ -3923,7 +3923,7 @@ static inline JSValue jsTestObj_reflectedURLAttrGetter(JSGlobalObject& lexicalGl
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedurlattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedurlattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -3936,7 +3936,7 @@ static inline bool setJSTestObj_reflectedURLAttrSetter(JSGlobalObject& lexicalGl
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedurlattrAttr, WTFMove(nativeValue));
@@ -3954,7 +3954,7 @@ static inline JSValue jsTestObj_reflectedUSVURLAttrGetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedusvurlattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedusvurlattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -3967,7 +3967,7 @@ static inline bool setJSTestObj_reflectedUSVURLAttrSetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedusvurlattrAttr, WTFMove(nativeValue));
@@ -3985,7 +3985,7 @@ static inline JSValue jsTestObj_reflectedStringAttrGetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::customContentStringAttrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.attributeWithoutSynchronization(WebCore::HTMLNames::customContentStringAttrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -3998,7 +3998,7 @@ static inline bool setJSTestObj_reflectedStringAttrSetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentStringAttrAttr, WTFMove(nativeValue));
@@ -4078,7 +4078,7 @@ static inline JSValue jsTestObj_reflectedCustomURLAttrGetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::customContentURLAttrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::customContentURLAttrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4091,7 +4091,7 @@ static inline bool setJSTestObj_reflectedCustomURLAttrSetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    auto nativeValue = convert<IDLDOMString>(lexicalGlobalObject, value);
+    auto nativeValue = convert<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
         return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentURLAttrAttr, WTFMove(nativeValue));

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -177,7 +177,7 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTestPromiseRejectionEventDO
     if (UNLIKELY(callFrame->argumentCount() < 2))
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    auto type = convert<IDLDOMString>(*lexicalGlobalObject, argument0.value());
+    auto type = convert<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto eventInitDict = convert<IDLDictionary<TestPromiseRejectionEvent::Init>>(*lexicalGlobalObject, argument1.value());

--- a/Source/WebCore/bindings/scripts/test/TestPromiseRejectionEvent.idl
+++ b/Source/WebCore/bindings/scripts/test/TestPromiseRejectionEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=(Window,Worker),
 ] interface TestPromiseRejectionEvent : Event {
-    [CallWith=CurrentGlobalObject] constructor(DOMString type, TestPromiseRejectionEventInit eventInitDict);
+    [CallWith=CurrentGlobalObject] constructor([AtomString] DOMString type, TestPromiseRejectionEventInit eventInitDict);
     readonly attribute Promise<any> promise;
     readonly attribute any reason;
 };

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -4510,7 +4510,7 @@ CSSRule* CSSComputedStyleDeclaration::parentRule() const
 RefPtr<DeprecatedCSSOMValue> CSSComputedStyleDeclaration::getPropertyCSSValue(const String& propertyName)
 {
     if (isCustomPropertyName(propertyName)) {
-        auto value = ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementSpecifier).customPropertyValue(propertyName);
+        auto value = ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementSpecifier).customPropertyValue(AtomString { propertyName });
         if (!value)
             return nullptr;
         return value->createDeprecatedCSSOMWrapper(*this);
@@ -4528,7 +4528,7 @@ RefPtr<DeprecatedCSSOMValue> CSSComputedStyleDeclaration::getPropertyCSSValue(co
 String CSSComputedStyleDeclaration::getPropertyValue(const String &propertyName)
 {
     if (isCustomPropertyName(propertyName))
-        return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementSpecifier).customPropertyText(propertyName);
+        return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementSpecifier).customPropertyText(AtomString { propertyName });
 
     CSSPropertyID propertyID = cssPropertyID(propertyName);
     if (!propertyID)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6275,7 +6275,7 @@
             "inherited": true,
             "codegen-properties": {
                 "name-for-methods": "HyphenationString",
-                "converter": "StringOrAuto"
+                "converter": "StringOrAutoAtom"
             },
             "status": {
                 "status": "experimental"
@@ -6411,7 +6411,7 @@
         "-webkit-line-grid": {
             "inherited": true,
             "codegen-properties": {
-                "converter": "StringOrNone"
+                "converter": "StringOrNoneAtom"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h
+++ b/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 struct DOMCSSCustomPropertyDescriptor {
-    String name;
+    AtomString name;
     String syntax { "*"_s };
     bool inherits;
     String initialValue;

--- a/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl
+++ b/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl
@@ -27,7 +27,7 @@
     JSGenerateToJSObject,
     EnabledBySetting=CSSCustomPropertiesAndValuesEnabled
 ] dictionary DOMCSSCustomPropertyDescriptor {
-    required DOMString name;
+    required [AtomString] DOMString name;
              DOMString syntax       = "*";
     required boolean   inherits;
              DOMString initialValue;

--- a/Source/WebCore/css/MediaQueryExpression.cpp
+++ b/Source/WebCore/css/MediaQueryExpression.cpp
@@ -218,7 +218,7 @@ inline RefPtr<CSSPrimitiveValue> consumeFirstValue(const String& mediaFeature, C
     if (auto value = CSSPropertyParserHelpers::consumeIntegerZeroAndGreater(range))
         return value;
 
-    if (!featureExpectingPositiveInteger(mediaFeature) && !isAspectRatioFeature(mediaFeature)) {
+    if (!featureExpectingPositiveInteger(mediaFeature) && !isAspectRatioFeature(AtomString { mediaFeature })) {
         if (auto value = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::NonNegative))
             return value;
     }

--- a/Source/WebCore/css/MediaQueryListEvent.idl
+++ b/Source/WebCore/css/MediaQueryListEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface MediaQueryListEvent : Event {
-    constructor(DOMString type, optional MediaQueryListEventInit mediaQueryListEventInit);
+    constructor([AtomString] DOMString type, optional MediaQueryListEventInit mediaQueryListEventInit);
 
     readonly attribute DOMString media;
     readonly attribute boolean matches;

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1287,7 +1287,7 @@ bool MutableStyleProperties::setCustomProperty(const Document* document, const S
 
     // When replacing an existing property value, this moves the property to the end of the list.
     // Firefox preserves the position, and MSIE moves the property to the beginning.
-    return CSSParser::parseCustomPropertyValue(*this, propertyName, value, important, parserContext) == CSSParser::ParseResult::Changed;
+    return CSSParser::parseCustomPropertyValue(*this, AtomString { propertyName }, value, important, parserContext) == CSSParser::ParseResult::Changed;
 }
 
 void MutableStyleProperties::setProperty(CSSPropertyID propertyID, RefPtr<CSSValue>&& value, bool important)

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -240,7 +240,7 @@ RefPtr<CSSValue> CSSParser::parseValueWithVariableReferences(CSSPropertyID propI
     for (auto id : dependencies)
         builderState.builder().applyProperty(id);
 
-    return CSSPropertyParser::parseTypedCustomPropertyValue(name, syntax, resolvedData->tokens(), builderState, valueWithReferences.context());
+    return CSSPropertyParser::parseTypedCustomPropertyValue(AtomString { name }, syntax, resolvedData->tokens(), builderState, valueWithReferences.context());
 }
 
 Vector<double> CSSParser::parseKeyframeKeyList(const String& selector)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -297,7 +297,7 @@ bool CSSPropertyParser::canParseTypedCustomPropertyValue(const String& syntax, c
     return parser.canParseTypedCustomPropertyValue(syntax);
 }
 
-RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const String& name, const String& syntax, const CSSParserTokenRange& tokens, const Style::BuilderState& builderState, const CSSParserContext& context)
+RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange& tokens, const Style::BuilderState& builderState, const CSSParserContext& context)
 {
     CSSPropertyParser parser(tokens, context, nullptr, false);
     RefPtr<CSSCustomPropertyValue> value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
@@ -4804,7 +4804,7 @@ void CSSPropertyParser::collectParsedCustomPropertyValueDependencies(const Strin
     }
 }
 
-RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const String& name, const String& syntax, const Style::BuilderState& builderState)
+RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const Style::BuilderState& builderState)
 {
     if (syntax != "*") {
         m_range.consumeWhitespace();

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -53,7 +53,7 @@ public:
     // Parses a non-shorthand CSS property
     static RefPtr<CSSValue> parseSingleValue(CSSPropertyID, const CSSParserTokenRange&, const CSSParserContext&);
     static bool canParseTypedCustomPropertyValue(const String& syntax, const CSSParserTokenRange&, const CSSParserContext&);
-    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const String& name, const String& syntax, const CSSParserTokenRange&, const Style::BuilderState&, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const CSSParserTokenRange&, const Style::BuilderState&, const CSSParserContext&);
     static void collectParsedCustomPropertyValueDependencies(const String& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies, const CSSParserTokenRange&, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
@@ -66,7 +66,7 @@ private:
     bool consumeCSSWideKeyword(CSSPropertyID, bool important);
     RefPtr<CSSValue> parseSingleValue(CSSPropertyID, CSSPropertyID = CSSPropertyInvalid);
     bool canParseTypedCustomPropertyValue(const String& syntax);
-    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const String& name, const String& syntax, const Style::BuilderState&);
+    RefPtr<CSSCustomPropertyValue> parseTypedCustomPropertyValue(const AtomString& name, const String& syntax, const Style::BuilderState&);
     void collectParsedCustomPropertyValueDependencies(const String& syntax, bool isRoot, HashSet<CSSPropertyID>& dependencies);
 
     bool inQuirksMode() const { return m_context.mode == HTMLQuirksMode; }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4370,7 +4370,7 @@ AtomString consumeFamilyNameRaw(CSSParserTokenRange& range)
     if (range.peek().type() == StringToken)
         return range.consumeIncludingWhitespace().value().toAtomString();
     if (range.peek().type() != IdentToken)
-        return String();
+        return nullAtom();
     return concatenateFamilyName(range);
 }
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -74,7 +74,7 @@ DOMImplementation::DOMImplementation(Document& document)
 {
 }
 
-ExceptionOr<Ref<DocumentType>> DOMImplementation::createDocumentType(const String& qualifiedName, const String& publicId, const String& systemId)
+ExceptionOr<Ref<DocumentType>> DOMImplementation::createDocumentType(const AtomString& qualifiedName, const String& publicId, const String& systemId)
 {
     auto parseResult = Document::parseQualifiedName(qualifiedName);
     if (parseResult.hasException())
@@ -91,7 +91,7 @@ static inline Ref<XMLDocument> createXMLDocument(const String& namespaceURI, con
     return XMLDocument::create(nullptr, settings, URL());
 }
 
-ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const String& namespaceURI, const String& qualifiedName, DocumentType* documentType)
+ExceptionOr<Ref<XMLDocument>> DOMImplementation::createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType* documentType)
 {
     auto document = createXMLDocument(namespaceURI, m_document.settings());
     document->setContextDocument(m_document.contextDocument());

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -38,8 +38,8 @@ public:
     void deref() { m_document.deref(); }
     Document& document() { return m_document; }
 
-    WEBCORE_EXPORT ExceptionOr<Ref<DocumentType>> createDocumentType(const String& qualifiedName, const String& publicId, const String& systemId);
-    WEBCORE_EXPORT ExceptionOr<Ref<XMLDocument>> createDocument(const String& namespaceURI, const String& qualifiedName, DocumentType*);
+    WEBCORE_EXPORT ExceptionOr<Ref<DocumentType>> createDocumentType(const AtomString& qualifiedName, const String& publicId, const String& systemId);
+    WEBCORE_EXPORT ExceptionOr<Ref<XMLDocument>> createDocument(const AtomString& namespaceURI, const AtomString& qualifiedName, DocumentType*);
     WEBCORE_EXPORT Ref<HTMLDocument> createHTMLDocument(String&& title);
     static bool hasFeature() { return true; }
     WEBCORE_EXPORT static Ref<CSSStyleSheet> createCSSStyleSheet(const String& title, const String& media);

--- a/Source/WebCore/dom/DOMImplementation.idl
+++ b/Source/WebCore/dom/DOMImplementation.idl
@@ -23,8 +23,8 @@
     GenerateIsReachable=ImplDocument,
     Exposed=Window
 ] interface DOMImplementation {
-    [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
-    [NewObject] XMLDocument createDocument(DOMString? namespaceURI, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
+    [NewObject] DocumentType createDocumentType([AtomString] DOMString qualifiedName, DOMString publicId, DOMString systemId);
+    [NewObject] XMLDocument createDocument([AtomString] DOMString? namespaceURI, [LegacyNullToEmptyString, AtomString] DOMString qualifiedName, optional DocumentType? doctype = null);
     [NewObject] HTMLDocument createHTMLDocument(optional DOMString title);
 
     boolean hasFeature(); // Useless; always returns true.

--- a/Source/WebCore/dom/Document+HTMLObsolete.idl
+++ b/Source/WebCore/dom/Document+HTMLObsolete.idl
@@ -25,11 +25,11 @@
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#Document-partial
 partial interface Document {
-    [CEReactions] attribute [LegacyNullToEmptyString] DOMString fgColor;
-    [CEReactions, ImplementedAs=linkColorForBindings] attribute [LegacyNullToEmptyString] DOMString linkColor;
-    [CEReactions] attribute [LegacyNullToEmptyString] DOMString vlinkColor;
-    [CEReactions] attribute [LegacyNullToEmptyString] DOMString alinkColor;
-    [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+    [CEReactions] attribute [LegacyNullToEmptyString, AtomString] DOMString fgColor;
+    [CEReactions, ImplementedAs=linkColorForBindings] attribute [LegacyNullToEmptyString, AtomString] DOMString linkColor;
+    [CEReactions] attribute [LegacyNullToEmptyString, AtomString] DOMString vlinkColor;
+    [CEReactions] attribute [LegacyNullToEmptyString, AtomString] DOMString alinkColor;
+    [CEReactions] attribute [LegacyNullToEmptyString, AtomString] DOMString bgColor;
 
     [SameObject] readonly attribute HTMLCollection anchors;
     [SameObject] readonly attribute HTMLCollection applets;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1339,7 +1339,7 @@ CustomElementNameValidationStatus Document::validateCustomElementName(const Atom
     return CustomElementNameValidationStatus::Valid;
 }
 
-ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceURI, const String& qualifiedName)
+ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName)
 {
     auto parseResult = parseQualifiedName(namespaceURI, qualifiedName);
     if (parseResult.hasException())
@@ -1927,14 +1927,14 @@ FormController& Document::formController()
     return *m_formController;
 }
 
-Vector<String> Document::formElementsState() const
+Vector<AtomString> Document::formElementsState() const
 {
     if (!m_formController)
-        return Vector<String>();
+        return { };
     return m_formController->formElementsState(*this);
 }
 
-void Document::setStateForNewFormElements(const Vector<String>& stateVector)
+void Document::setStateForNewFormElements(const Vector<AtomString>& stateVector)
 {
     if (!stateVector.size() && !m_formController)
         return;
@@ -5537,7 +5537,7 @@ bool Document::isValidName(const String& name)
     return isValidNameNonASCII(characters, length);
 }
 
-ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(const String& qualifiedName)
+ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(const AtomString& qualifiedName)
 {
     unsigned length = qualifiedName.length();
 
@@ -5576,7 +5576,7 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
     return std::pair<AtomString, AtomString> { StringView { qualifiedName }.left(colonPosition).toAtomString(), StringView { qualifiedName }.substring(colonPosition + 1).toAtomString() };
 }
 
-ExceptionOr<QualifiedName> Document::parseQualifiedName(const AtomString& namespaceURI, const String& qualifiedName)
+ExceptionOr<QualifiedName> Document::parseQualifiedName(const AtomString& namespaceURI, const AtomString& qualifiedName)
 {
     auto parseResult = parseQualifiedName(qualifiedName);
     if (parseResult.hasException())
@@ -6069,7 +6069,7 @@ ExceptionOr<Ref<Attr>> Document::createAttribute(const AtomString& localName)
     return Attr::create(*this, QualifiedName { nullAtom(), isHTMLDocument() ? localName.convertToASCIILowercase() : localName, nullAtom() }, emptyAtom());
 }
 
-ExceptionOr<Ref<Attr>> Document::createAttributeNS(const AtomString& namespaceURI, const String& qualifiedName, bool shouldIgnoreNamespaceChecks)
+ExceptionOr<Ref<Attr>> Document::createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks)
 {
     auto parseResult = parseQualifiedName(namespaceURI, qualifiedName);
     if (parseResult.hasException())
@@ -7517,7 +7517,7 @@ Locale& Document::getCachedLocale(const AtomString& locale)
 {
     AtomString localeKey = locale;
     if (locale.isEmpty() || !settings().langAttributeAwareFormControlUIEnabled())
-        localeKey = defaultLanguage();
+        localeKey = AtomString { defaultLanguage() };
     LocaleIdentifierToLocaleMap::AddResult result = m_localeCache.add(localeKey, nullptr);
     if (result.isNewEntry)
         result.iterator->value = Locale::create(localeKey);
@@ -8337,7 +8337,7 @@ const AtomString& Document::bgColor() const
     return bodyElement->attributeWithoutSynchronization(bgcolorAttr);
 }
 
-void Document::setBgColor(const String& value)
+void Document::setBgColor(const AtomString& value)
 {
     if (RefPtr bodyElement = body())
         bodyElement->setAttributeWithoutSynchronization(bgcolorAttr, value);
@@ -8351,7 +8351,7 @@ const AtomString& Document::fgColor() const
     return bodyElement->attributeWithoutSynchronization(textAttr);
 }
 
-void Document::setFgColor(const String& value)
+void Document::setFgColor(const AtomString& value)
 {
     if (RefPtr bodyElement = body())
         bodyElement->setAttributeWithoutSynchronization(textAttr, value);
@@ -8365,7 +8365,7 @@ const AtomString& Document::alinkColor() const
     return bodyElement->attributeWithoutSynchronization(alinkAttr);
 }
 
-void Document::setAlinkColor(const String& value)
+void Document::setAlinkColor(const AtomString& value)
 {
     if (RefPtr bodyElement = body())
         bodyElement->setAttributeWithoutSynchronization(alinkAttr, value);
@@ -8379,7 +8379,7 @@ const AtomString& Document::linkColorForBindings() const
     return bodyElement->attributeWithoutSynchronization(linkAttr);
 }
 
-void Document::setLinkColorForBindings(const String& value)
+void Document::setLinkColorForBindings(const AtomString& value)
 {
     if (RefPtr bodyElement = body())
         bodyElement->setAttributeWithoutSynchronization(linkAttr, value);
@@ -8393,7 +8393,7 @@ const AtomString& Document::vlinkColor() const
     return bodyElement->attributeWithoutSynchronization(vlinkAttr);
 }
 
-void Document::setVlinkColor(const String& value)
+void Document::setVlinkColor(const AtomString& value)
 {
     if (RefPtr bodyElement = body())
         bodyElement->setAttributeWithoutSynchronization(vlinkAttr, value);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -440,9 +440,9 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<CDATASection>> createCDATASection(String&& data);
     WEBCORE_EXPORT ExceptionOr<Ref<ProcessingInstruction>> createProcessingInstruction(String&& target, String&& data);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttribute(const AtomString& name);
-    WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const String& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
+    WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, bool deep);
-    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const String& qualifiedName);
+    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser);
 
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
@@ -583,8 +583,8 @@ public:
     void evaluateMediaQueriesAndReportChanges();
 
     FormController& formController();
-    Vector<String> formElementsState() const;
-    void setStateForNewFormElements(const Vector<String>&);
+    Vector<AtomString> formElementsState() const;
+    void setStateForNewFormElements(const Vector<AtomString>&);
 
     WEBCORE_EXPORT FrameView* view() const; // Can be null.
     WEBCORE_EXPORT Page* page() const; // Can be null.
@@ -1029,8 +1029,8 @@ public:
 
     // The following breaks a qualified name into a prefix and a local name.
     // It also does a validity check, and returns an error if the qualified name is invalid.
-    static ExceptionOr<std::pair<AtomString, AtomString>> parseQualifiedName(const String& qualifiedName);
-    static ExceptionOr<QualifiedName> parseQualifiedName(const AtomString& namespaceURI, const String& qualifiedName);
+    static ExceptionOr<std::pair<AtomString, AtomString>> parseQualifiedName(const AtomString& qualifiedName);
+    static ExceptionOr<QualifiedName> parseQualifiedName(const AtomString& namespaceURI, const AtomString& qualifiedName);
 
     // Checks to make sure prefix and namespace do not conflict (per DOM Core 3)
     static bool hasValidNamespaceForElements(const QualifiedName&);
@@ -1511,15 +1511,15 @@ public:
     OrientationNotifier& orientationNotifier() { return m_orientationNotifier; }
 
     WEBCORE_EXPORT const AtomString& bgColor() const;
-    WEBCORE_EXPORT void setBgColor(const String&);
+    WEBCORE_EXPORT void setBgColor(const AtomString&);
     WEBCORE_EXPORT const AtomString& fgColor() const;
-    WEBCORE_EXPORT void setFgColor(const String&);
+    WEBCORE_EXPORT void setFgColor(const AtomString&);
     WEBCORE_EXPORT const AtomString& alinkColor() const;
-    WEBCORE_EXPORT void setAlinkColor(const String&);
+    WEBCORE_EXPORT void setAlinkColor(const AtomString&);
     WEBCORE_EXPORT const AtomString& linkColorForBindings() const;
-    WEBCORE_EXPORT void setLinkColorForBindings(const String&);
+    WEBCORE_EXPORT void setLinkColorForBindings(const AtomString&);
     WEBCORE_EXPORT const AtomString& vlinkColor() const;
-    WEBCORE_EXPORT void setVlinkColor(const String&);
+    WEBCORE_EXPORT void setVlinkColor(const AtomString&);
 
     // Per https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-clear, this method does nothing.
     void clear() { }

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -70,7 +70,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     [CEReactions] Node adoptNode(Node node);
 
     [NewObject] Attr createAttribute([AtomString] DOMString localName);
-    [NewObject] Attr createAttributeNS([AtomString] DOMString? namespaceURI, DOMString qualifiedName);
+    [NewObject] Attr createAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
 
     [NewObject] Event createEvent(DOMString type);
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1814,7 +1814,7 @@ ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std:
     unsigned index = elementData() ? elementData()->findAttributeIndexByName(caseAdjustedQualifiedName, false) : ElementData::attributeNotFound;
     if (index == ElementData::attributeNotFound) {
         if (!force || *force) {
-            setAttributeInternal(index, QualifiedName { nullAtom(), caseAdjustedQualifiedName, nullAtom() }, emptyString(), NotInSynchronizationOfLazyAttribute);
+            setAttributeInternal(index, QualifiedName { nullAtom(), caseAdjustedQualifiedName, nullAtom() }, emptyAtom(), NotInSynchronizationOfLazyAttribute);
             return true;
         }
         return false;
@@ -4285,21 +4285,21 @@ void Element::willModifyAttribute(const QualifiedName& name, const AtomString& o
 void Element::didAddAttribute(const QualifiedName& name, const AtomString& value)
 {
     attributeChanged(name, nullAtom(), value);
-    InspectorInstrumentation::didModifyDOMAttr(document(), *this, name.toString(), value);
+    InspectorInstrumentation::didModifyDOMAttr(document(), *this, name.toAtomString(), value);
     dispatchSubtreeModifiedEvent();
 }
 
 void Element::didModifyAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue)
 {
     attributeChanged(name, oldValue, newValue);
-    InspectorInstrumentation::didModifyDOMAttr(document(), *this, name.toString(), newValue);
+    InspectorInstrumentation::didModifyDOMAttr(document(), *this, name.toAtomString(), newValue);
     // Do not dispatch a DOMSubtreeModified event here; see bug 81141.
 }
 
 void Element::didRemoveAttribute(const QualifiedName& name, const AtomString& oldValue)
 {
     attributeChanged(name, oldValue, nullAtom());
-    InspectorInstrumentation::didRemoveDOMAttr(document(), *this, name.toString());
+    InspectorInstrumentation::didRemoveDOMAttr(document(), *this, name.toAtomString());
     dispatchSubtreeModifiedEvent();
 }
 

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -52,7 +52,7 @@
 
     // FIXME: this does not match the version in the DOM spec.
     undefined initKeyboardEvent([AtomString] DOMString type, optional boolean canBubble = false, optional boolean cancelable = false,
-        optional WindowProxy? view = null, optional DOMString keyIdentifier = "undefined", optional unsigned long location = 0,
+        optional WindowProxy? view = null, optional [AtomString] DOMString keyIdentifier = "undefined", optional unsigned long location = 0,
         optional boolean ctrlKey = false, optional boolean altKey = false, optional boolean shiftKey = false, optional boolean metaKey = false, optional boolean altGraphKey = false);
 };
 

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -86,7 +86,7 @@ public:
         bool subtree;
         std::optional<bool> attributeOldValue;
         std::optional<bool> characterDataOldValue;
-        std::optional<Vector<String>> attributeFilter;
+        std::optional<Vector<AtomString>> attributeFilter;
     };
 
     ExceptionOr<void> observe(Node&, const Init&);

--- a/Source/WebCore/dom/MutationObserver.idl
+++ b/Source/WebCore/dom/MutationObserver.idl
@@ -48,5 +48,5 @@ dictionary MutationObserverInit {
     boolean subtree = false;
     boolean attributeOldValue;
     boolean characterDataOldValue;
-    sequence<DOMString> attributeFilter;
+    sequence<[AtomString] DOMString> attributeFilter;
 };

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -101,6 +101,7 @@ public:
     const AtomString& localNameUpper() const;
 
     String toString() const;
+    AtomString toAtomString() const;
 
     QualifiedNameImpl* impl() const { return m_impl.get(); }
 #if ENABLE(JIT)
@@ -159,6 +160,14 @@ inline String QualifiedName::toString() const
         return localName();
 
     return prefix().string() + ':' + localName().string();
+}
+
+inline AtomString QualifiedName::toAtomString() const
+{
+    if (!hasPrefix())
+        return localName();
+
+    return makeAtomString(prefix(), ':', localName());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -351,7 +351,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         return true;
     }
 
-    auto script = LoadableModuleScript::create(nonce, emptyString(), referrerPolicy(), crossOriginMode, scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree());
+    auto script = LoadableModuleScript::create(nonce, emptyAtom(), referrerPolicy(), crossOriginMode, scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree());
 
     TextPosition position = m_element.document().isInDocumentWrite() ? TextPosition() : scriptStartPosition;
     ScriptSourceCode sourceCode(scriptContent(), URL(m_element.document().url()), position, JSC::SourceProviderSourceType::Module, script.copyRef());

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1370,13 +1370,13 @@ bool ApplyStyleCommand::surroundNodeRangeWithElement(Node& startNode, Node& endN
     return true;
 }
 
-static String joinWithSpace(const String& a, const String& b)
+static AtomString joinWithSpace(const String& a, const AtomString& b)
 {
     if (a.isEmpty())
         return b;
     if (b.isEmpty())
-        return a;
-    return makeString(a, ' ', b);
+        return AtomString { a };
+    return makeAtomString(a, ' ', b);
 }
 
 void ApplyStyleCommand::addBlockStyle(const StyleChange& styleChange, HTMLElement& block)

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -475,7 +475,7 @@ void CompositeEditCommand::setShouldRetainAutocorrectionIndicator(bool)
 {
 }
 
-String CompositeEditCommand::inputEventTypeName() const
+AtomString CompositeEditCommand::inputEventTypeName() const
 {
     return inputTypeNameForEditingAction(editingAction());
 }

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -120,7 +120,7 @@ public:
     virtual bool shouldRetainAutocorrectionIndicator() const;
     virtual void setShouldRetainAutocorrectionIndicator(bool);
     virtual bool shouldStopCaretBlinking() const { return false; }
-    virtual String inputEventTypeName() const;
+    virtual AtomString inputEventTypeName() const;
     virtual String inputEventData() const { return { }; }
     virtual bool isBeforeInputEventCancelable() const { return true; }
     virtual bool shouldDispatchInputEvents() const { return true; }

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -44,7 +44,7 @@ void CreateLinkCommand::doApply()
         return;
 
     auto anchorElement = HTMLAnchorElement::create(document());
-    anchorElement->setHref(m_url);
+    anchorElement->setHref(AtomString { m_url });
     
     if (endingSelection().isRange())
         applyStyledElement(WTFMove(anchorElement));

--- a/Source/WebCore/editing/EditCommand.cpp
+++ b/Source/WebCore/editing/EditCommand.cpp
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-String inputTypeNameForEditingAction(EditAction action)
+ASCIILiteral inputTypeNameForEditingAction(EditAction action)
 {
     switch (action) {
     case EditAction::Justify:
@@ -117,7 +117,7 @@ String inputTypeNameForEditingAction(EditAction action)
     case EditAction::CreateLink:
         return "insertLink"_s;
     default:
-        return emptyString();
+        return ""_s;
     }
 }
 

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -40,7 +40,7 @@ class CompositeEditCommand;
 class Document;
 class Element;
 
-String inputTypeNameForEditingAction(EditAction);
+ASCIILiteral inputTypeNameForEditingAction(EditAction);
 
 class EditCommand : public RefCounted<EditCommand> {
 public:

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1846,13 +1846,13 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
     if (style.getPropertyCSSValue(CSSPropertyColor)) {
         auto color = textColorFromStyle(style);
         if (color.isOpaque()) {
-            m_applyFontColor = serializationForHTML(color);
+            m_applyFontColor = AtomString { serializationForHTML(color) };
             style.removeProperty(CSSPropertyColor);
         }
     }
 
     // Remove quotes for Outlook 2007 compatibility. See https://bugs.webkit.org/show_bug.cgi?id=79448
-    m_applyFontFace = makeStringByReplacingAll(style.getPropertyValue(CSSPropertyFontFamily), '\"', ""_s);
+    m_applyFontFace = AtomString { makeStringByReplacingAll(style.getPropertyValue(CSSPropertyFontFamily), '\"', ""_s) };
     style.removeProperty(CSSPropertyFontFamily);
 
     if (RefPtr<CSSValue> fontSize = style.getPropertyCSSValue(CSSPropertyFontSize)) {
@@ -1860,7 +1860,7 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
             style.removeProperty(CSSPropertyFontSize); // Can't make sense of the number. Put no font size.
         else if (int legacyFontSize = legacyFontSizeFromCSSValue(document, downcast<CSSPrimitiveValue>(fontSize.get()),
                 shouldUseFixedFontDefaultSize, UseLegacyFontSizeOnlyIfPixelValuesMatch)) {
-            m_applyFontSize = String::number(legacyFontSize);
+            m_applyFontSize = AtomString::number(legacyFontSize);
             style.removeProperty(CSSPropertyFontSize);
         }
     }

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -215,9 +215,9 @@ public:
     bool applyFontFace() const { return m_applyFontFace.length() > 0; }
     bool applyFontSize() const { return m_applyFontSize.length() > 0; }
 
-    String fontColor() { return m_applyFontColor; }
-    String fontFace() { return m_applyFontFace; }
-    String fontSize() { return m_applyFontSize; }
+    const AtomString& fontColor() { return m_applyFontColor; }
+    const AtomString& fontFace() { return m_applyFontFace; }
+    const AtomString& fontSize() { return m_applyFontSize; }
 
     bool operator==(const StyleChange&);
     bool operator!=(const StyleChange& other)
@@ -234,9 +234,9 @@ private:
     bool m_applyLineThrough = false;
     bool m_applySubscript = false;
     bool m_applySuperscript = false;
-    String m_applyFontColor;
-    String m_applyFontFace;
-    String m_applyFontSize;
+    AtomString m_applyFontColor;
+    AtomString m_applyFontFace;
+    AtomString m_applyFontSize;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -978,7 +978,7 @@ void Editor::applyStyle(RefPtr<EditingStyle>&& style, EditAction editingAction, 
     if (m_document.selection().isNone())
         return;
 
-    String inputTypeName = inputTypeNameForEditingAction(editingAction);
+    AtomString inputTypeName = inputTypeNameForEditingAction(editingAction);
     String inputEventData = inputEventDataForEditingStyleAndAction(*style, editingAction);
     RefPtr element { m_document.selection().selection().rootEditableElement() };
 
@@ -1013,7 +1013,7 @@ void Editor::applyParagraphStyle(StyleProperties* style, EditAction editingActio
     if (m_document.selection().isNone())
         return;
 
-    String inputTypeName = inputTypeNameForEditingAction(editingAction);
+    AtomString inputTypeName = inputTypeNameForEditingAction(editingAction);
     String inputEventData = inputEventDataForEditingStyleAndAction(style, editingAction);
     RefPtr element { m_document.selection().selection().rootEditableElement() };
     if (element && !dispatchBeforeInputEvent(*element, inputTypeName, inputEventData))
@@ -4275,7 +4275,7 @@ void Editor::notifyClientOfAttachmentUpdates()
     }
 }
 
-void Editor::insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const String& fileName, const String& contentType)
+void Editor::insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const AtomString& fileName, const AtomString& contentType)
 {
     auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document());
     attachment->setUniqueIdentifier(identifier);
@@ -4359,7 +4359,7 @@ const RenderStyle* Editor::styleForSelectionStart(RefPtr<Node>& nodeToRemove)
 
     auto styleElement = HTMLSpanElement::create(document());
 
-    String styleText = typingStyle->style()->asText() + " display: inline";
+    auto styleText = makeAtomString(typingStyle->style()->asText(), " display: inline"_s);
     styleElement->setAttribute(HTMLNames::styleAttr, styleText);
 
     styleElement->appendChild(document().createEditingTextNode(String { emptyString() }));

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -574,7 +574,7 @@ public:
     bool isGettingDictionaryPopupInfo() const { return m_isGettingDictionaryPopupInfo; }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    WEBCORE_EXPORT void insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const String& fileName, const String& contentType);
+    WEBCORE_EXPORT void insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const AtomString& fileName, const AtomString& contentType);
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& fileData);
     void registerAttachments(Vector<SerializedAttachmentData>&&);
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& filePath);

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -408,9 +408,12 @@ static bool executeForeColor(Frame& frame, Event*, EditorCommandSource source, c
 
 static bool executeFormatBlock(Frame& frame, Event*, EditorCommandSource, const String& value)
 {
-    String tagName = value.convertToASCIILowercase();
-    if (tagName[0] == '<' && tagName[tagName.length() - 1] == '>')
-        tagName = tagName.substring(1, tagName.length() - 2);
+    String lowercaseValue = value.convertToASCIILowercase();
+    AtomString tagName;
+    if (lowercaseValue[0] == '<' && lowercaseValue[lowercaseValue.length() - 1] == '>')
+        tagName = StringView(lowercaseValue).substring(1, lowercaseValue.length() - 2).toAtomString();
+    else
+        tagName = AtomString { WTFMove(lowercaseValue) };
 
     auto qualifiedTagName = Document::parseQualifiedName(xhtmlNamespaceURI, tagName);
     if (qualifiedTagName.hasException())
@@ -462,7 +465,7 @@ static bool executeInsertHorizontalRule(Frame& frame, Event*, EditorCommandSourc
 {
     Ref<HTMLHRElement> rule = HTMLHRElement::create(*frame.document());
     if (!value.isEmpty())
-        rule->setIdAttribute(value);
+        rule->setIdAttribute(AtomString { value });
     return executeInsertNode(frame, WTFMove(rule));
 }
 
@@ -476,7 +479,7 @@ static bool executeInsertImage(Frame& frame, Event*, EditorCommandSource, const 
     // FIXME: If userInterface is true, we should display a dialog box and let the user choose a local image.
     Ref<HTMLImageElement> image = HTMLImageElement::create(*frame.document());
     if (!value.isEmpty())
-        image->setSrc(value);
+        image->setSrc(AtomString { value });
     return executeInsertNode(frame, WTFMove(image));
 }
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -309,7 +309,7 @@ static bool shouldAddNamespaceElement(const Element& element)
     auto& prefix = element.prefix();
     if (prefix.isEmpty())
         return !element.hasAttribute(xmlnsAtom());
-    return !element.hasAttribute("xmlns:" + prefix);
+    return !element.hasAttribute(makeAtomString("xmlns:"_s, prefix));
 }
 
 static bool shouldAddNamespaceAttribute(const Attribute& attribute, Namespaces& namespaces)
@@ -466,7 +466,7 @@ void MarkupAccumulator::generateUniquePrefix(QualifiedName& prefixedName, const 
     AtomString name;
     do {
         // FIXME: We should create makeAtomString, which would be more efficient.
-        name = makeString("NS", ++m_prefixLevel);
+        name = makeAtomString("NS"_s, ++m_prefixLevel);
     } while (namespaces.get(name.impl()));
     prefixedName.setPrefix(name);
 }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -774,7 +774,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         else if (item.attributeName == HTMLNames::valueAttr && is<HTMLInputElement>(*element))
             downcast<HTMLInputElement>(*element).setValue(newValue.toString());
         else
-            element->setAttribute(item.attributeName, newValue.toString());
+            element->setAttribute(item.attributeName, newValue.toAtomString());
 
         m_manipulatedNodes.add(*element);
         return std::nullopt;

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -384,7 +384,7 @@ void TypingCommand::doApply()
     ASSERT_NOT_REACHED();
 }
 
-String TypingCommand::inputEventTypeName() const
+AtomString TypingCommand::inputEventTypeName() const
 {
     return inputTypeNameForEditingAction(m_currentTypingEditAction);
 }

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -117,7 +117,7 @@ private:
     bool shouldStopCaretBlinking() const final { return true; }
     void setShouldPreventSpellChecking(bool prevent) { m_shouldPreventSpellChecking = prevent; }
 
-    String inputEventTypeName() const final;
+    AtomString inputEventTypeName() const final;
     String inputEventData() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
     bool isBeforeInputEventCancelable() const final;

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -81,7 +81,7 @@ private:
     bool readWebArchive(SharedBuffer&) override;
     bool readRTFD(SharedBuffer&) override;
     bool readRTF(SharedBuffer&) override;
-    bool readDataBuffer(SharedBuffer&, const String& type, const String& name, PresentationSize preferredPresentationSize = { }) override;
+    bool readDataBuffer(SharedBuffer&, const String& type, const AtomString& name, PresentationSize preferredPresentationSize = { }) override;
 #endif
 };
 
@@ -108,7 +108,7 @@ private:
     bool readWebArchive(SharedBuffer&) override;
     bool readRTFD(SharedBuffer&) override;
     bool readRTF(SharedBuffer&) override;
-    bool readDataBuffer(SharedBuffer&, const String&, const String&, PresentationSize = { }) override { return false; }
+    bool readDataBuffer(SharedBuffer&, const String&, const AtomString&, PresentationSize = { }) override { return false; }
 #endif
 };
 

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -282,12 +282,12 @@ void HistoryItem::setPageScaleFactor(float scaleFactor)
     m_pageScaleFactor = scaleFactor;
 }
 
-void HistoryItem::setDocumentState(const Vector<String>& state)
+void HistoryItem::setDocumentState(const Vector<AtomString>& state)
 {
     m_documentState = state;
 }
 
-const Vector<String>& HistoryItem::documentState() const
+const Vector<AtomString>& HistoryItem::documentState() const
 {
     return m_documentState;
 }

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -122,8 +122,8 @@ public:
     WEBCORE_EXPORT float pageScaleFactor() const;
     WEBCORE_EXPORT void setPageScaleFactor(float);
     
-    WEBCORE_EXPORT const Vector<String>& documentState() const;
-    WEBCORE_EXPORT void setDocumentState(const Vector<String>&);
+    WEBCORE_EXPORT const Vector<AtomString>& documentState() const;
+    WEBCORE_EXPORT void setDocumentState(const Vector<AtomString>&);
     void clearDocumentState();
 
     WEBCORE_EXPORT void setShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy);
@@ -237,7 +237,7 @@ private:
     
     IntPoint m_scrollPosition;
     float m_pageScaleFactor { 0 }; // 0 indicates "unset".
-    Vector<String> m_documentState;
+    Vector<AtomString> m_documentState;
 
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy { ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -140,14 +140,15 @@ Ref<Element> FTPDirectoryDocumentParser::createTDForFilename(String&& filename)
 {
     auto& document = *this->document();
 
-    String fullURL = document.baseURL().string();
-    if (fullURL.endsWith('/'))
-        fullURL = fullURL + filename;
+    auto baseURL = document.baseURL().string();
+    AtomString fullURL;
+    if (baseURL.endsWith('/'))
+        fullURL = makeAtomString(baseURL, filename);
     else
-        fullURL = fullURL + '/' + filename;
+        fullURL = makeAtomString(baseURL, '/', filename);
 
     auto anchorElement = HTMLAnchorElement::create(document);
-    anchorElement->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, fullURL);
+    anchorElement->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, WTFMove(fullURL));
     anchorElement->appendChild(Text::create(document, WTFMove(filename)));
 
     auto tdElement = HTMLTableCellElement::create(tdTag, document);

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -144,11 +144,11 @@ FormControlState FileInputType::saveFormControlState() const
 
     auto length = Checked<size_t>(m_fileList->files().size()) * Checked<size_t>(2);
 
-    Vector<String> stateVector;
+    Vector<AtomString> stateVector;
     stateVector.reserveInitialCapacity(length);
     for (auto& file : m_fileList->files()) {
-        stateVector.uncheckedAppend(file->path());
-        stateVector.uncheckedAppend(file->name());
+        stateVector.uncheckedAppend(AtomString { file->path() });
+        stateVector.uncheckedAppend(AtomString { file->name() });
     }
     return FormControlState { WTFMove(stateVector) };
 }

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -41,22 +41,22 @@ static HTMLFormElement* ownerForm(const HTMLFormControlElementWithState& control
     return control.hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
 }
 
-struct StringVectorReader {
-    const Vector<String>& vector;
+struct AtomStringVectorReader {
+    const Vector<AtomString>& vector;
     size_t index { 0 };
 
-    const String& consumeString();
-    Vector<String> consumeSubvector(size_t subvectorSize);
+    const AtomString& consumeString();
+    Vector<AtomString> consumeSubvector(size_t subvectorSize);
 };
 
-const String& StringVectorReader::consumeString()
+const AtomString& AtomStringVectorReader::consumeString()
 {
     if (index == vector.size())
-        return nullString();
+        return nullAtom();
     return vector[index++];
 }
 
-Vector<String> StringVectorReader::consumeSubvector(size_t subvectorSize)
+Vector<AtomString> AtomStringVectorReader::consumeSubvector(size_t subvectorSize)
 {
     if (subvectorSize > vector.size() - index)
         return { };
@@ -78,14 +78,14 @@ Vector<String> StringVectorReader::consumeSubvector(size_t subvectorSize)
 //
 // The UnsignedNumber in RestoreState is the length of the sequence of ControlValues.
 
-static void appendSerializedFormControlState(Vector<String>& vector, const FormControlState& state)
+static void appendSerializedFormControlState(Vector<AtomString>& vector, const FormControlState& state)
 {
-    vector.append(String::number(state.size()));
+    vector.append(AtomString::number(state.size()));
     for (auto& value : state)
-        vector.append(value.isNull() ? emptyString() : value);
+        vector.append(value.isNull() ? emptyAtom() : value);
 }
 
-static std::optional<FormControlState> consumeSerializedFormControlState(StringVectorReader& reader)
+static std::optional<FormControlState> consumeSerializedFormControlState(AtomStringVectorReader& reader)
 {
     auto sizeString = reader.consumeString();
     if (sizeString.isNull())
@@ -99,7 +99,7 @@ static std::optional<FormControlState> consumeSerializedFormControlState(StringV
 
 class FormController::SavedFormState {
 public:
-    static SavedFormState consumeSerializedState(StringVectorReader&);
+    static SavedFormState consumeSerializedState(AtomStringVectorReader&);
 
     bool isEmpty() const { return m_map.isEmpty(); }
 
@@ -112,7 +112,7 @@ private:
     HashMap<FormElementKey, Deque<FormControlState>> m_map;
 };
 
-FormController::SavedFormState FormController::SavedFormState::consumeSerializedState(StringVectorReader& reader)
+FormController::SavedFormState FormController::SavedFormState::consumeSerializedState(AtomStringVectorReader& reader)
 {
     auto isNotFormControlTypeCharacter = [](UChar character) {
         return !(character == '-' || isASCIILower(character));
@@ -242,7 +242,7 @@ static String formStateSignature()
     return signature;
 }
 
-Vector<String> FormController::formElementsState(const Document& document) const
+Vector<AtomString> FormController::formElementsState(const Document& document) const
 {
     struct Control {
         Ref<const HTMLFormControlElementWithState> control;
@@ -267,14 +267,14 @@ Vector<String> FormController::formElementsState(const Document& document) const
         return a.control->insertionIndex() < b.control->insertionIndex();
     });
 
-    Vector<String> stateVector;
+    Vector<AtomString> stateVector;
     stateVector.append(formStateSignature());
     for (size_t i = 0, size = controls.size(); i < size; ) {
         auto formStart = i;
         auto formKey = controls[formStart].formKey;
         while (++i < size && controls[i].formKey == formKey) { }
-        stateVector.append(formKey);
-        stateVector.append(String::number(i - formStart));
+        stateVector.append(AtomString { formKey });
+        stateVector.append(AtomString::number(i - formStart));
         for (size_t j = formStart; j < i; ++j) {
             auto& control = controls[j].control.get();
             stateVector.append(control.name());
@@ -286,7 +286,7 @@ Vector<String> FormController::formElementsState(const Document& document) const
     return stateVector;
 }
 
-void FormController::setStateForNewFormElements(const Vector<String>& stateVector)
+void FormController::setStateForNewFormElements(const Vector<AtomString>& stateVector)
 {
     m_savedFormStateMap = parseStateVector(stateVector);
 }
@@ -306,9 +306,9 @@ FormControlState FormController::takeStateForFormElement(const HTMLFormControlEl
     return state;
 }
 
-FormController::SavedFormStateMap FormController::parseStateVector(const Vector<String>& stateVector)
+FormController::SavedFormStateMap FormController::parseStateVector(const Vector<AtomString>& stateVector)
 {
-    StringVectorReader reader { stateVector };
+    AtomStringVectorReader reader { stateVector };
 
     if (reader.consumeString() != formStateSignature())
         return { };
@@ -362,7 +362,7 @@ bool FormController::hasFormStateToRestore() const
     return !m_savedFormStateMap.isEmpty();
 }
 
-Vector<String> FormController::referencedFilePaths(const Vector<String>& stateVector)
+Vector<String> FormController::referencedFilePaths(const Vector<AtomString>& stateVector)
 {
     Vector<String> paths;
     auto parsedState = parseStateVector(stateVector);

--- a/Source/WebCore/html/FormController.h
+++ b/Source/WebCore/html/FormController.h
@@ -30,7 +30,7 @@ class Document;
 class HTMLFormControlElementWithState;
 class HTMLFormElement;
 
-using FormControlState = Vector<String>;
+using FormControlState = Vector<AtomString>;
 
 class FormController {
     WTF_MAKE_FAST_ALLOCATED;
@@ -39,15 +39,15 @@ public:
     FormController();
     ~FormController();
 
-    Vector<String> formElementsState(const Document&) const;
-    void setStateForNewFormElements(const Vector<String>& stateVector);
+    Vector<AtomString> formElementsState(const Document&) const;
+    void setStateForNewFormElements(const Vector<AtomString>& stateVector);
 
     void willDeleteForm(HTMLFormElement&);
     void restoreControlStateFor(HTMLFormControlElementWithState&);
     void restoreControlStateIn(HTMLFormElement&);
     bool hasFormStateToRestore() const;
 
-    WEBCORE_EXPORT static Vector<String> referencedFilePaths(const Vector<String>& stateVector);
+    WEBCORE_EXPORT static Vector<String> referencedFilePaths(const Vector<AtomString>& stateVector);
 
 private:
     class FormKeyGenerator;
@@ -55,7 +55,7 @@ private:
     using SavedFormStateMap = HashMap<String, SavedFormState>;
 
     FormControlState takeStateForFormElement(const HTMLFormControlElementWithState&);
-    static SavedFormStateMap parseStateVector(const Vector<String>&);
+    static SavedFormStateMap parseStateVector(const Vector<AtomString>&);
 
     SavedFormStateMap m_savedFormStateMap;
     std::unique_ptr<FormKeyGenerator> m_formKeyGenerator;

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -576,13 +576,13 @@ void HTMLAnchorElement::handleClick(Event& event)
     }
 #endif
 
-    String downloadAttribute;
+    AtomString downloadAttribute;
 #if ENABLE(DOWNLOAD_ATTRIBUTE)
     if (document().settings().downloadAttributeEnabled()) {
         // Ignore the download attribute completely if the href URL is cross origin.
         bool isSameOrigin = completedURL.protocolIsData() || document().securityOrigin().canRequest(completedURL);
         if (isSameOrigin)
-            downloadAttribute = ResourceResponse::sanitizeSuggestedFilename(attributeWithoutSynchronization(downloadAttr));
+            downloadAttribute = AtomString { ResourceResponse::sanitizeSuggestedFilename(attributeWithoutSynchronization(downloadAttr)) };
         else if (hasAttributeWithoutSynchronization(downloadAttr))
             document().addConsoleMessage(MessageSource::Security, MessageLevel::Warning, "The download attribute on anchor was ignored because its href URL has a different security origin."_s);
     }

--- a/Source/WebCore/html/HTMLAreaElement.idl
+++ b/Source/WebCore/html/HTMLAreaElement.idl
@@ -21,16 +21,16 @@
 [
     Exposed=Window
 ] interface HTMLAreaElement : HTMLElement {
-    [CEReactions=NotNeeded, Reflect] attribute [AtomString] DOMString alt;
-    [CEReactions=NotNeeded, Reflect] attribute [AtomString] DOMString coords;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString coords;
     [CEReactions=NotNeeded, Reflect] attribute boolean noHref;
-    [CEReactions=NotNeeded, Reflect] attribute [AtomString] USVString ping;
+    [CEReactions=NotNeeded, Reflect] attribute USVString ping;
     [CEReactions=NotNeeded, Reflect] attribute DOMString rel;
     [CEReactions=NotNeeded, Reflect] attribute DOMString shape;
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;
 
     [CEReactions=NotNeeded, Conditional=DOWNLOAD_ATTRIBUTE, EnabledBySetting=DownloadAttributeEnabled, Reflect] attribute DOMString download;
-    [EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings, CEReactions=NotNeeded] attribute DOMString referrerPolicy;
+    [EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings, CEReactions=NotNeeded] attribute [AtomString] DOMString referrerPolicy;
 
     [PutForwards=value] readonly attribute DOMTokenList relList;
 };

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -117,9 +117,9 @@ void HTMLAttachmentElement::setFile(RefPtr<File>&& file, UpdateDisplayAttributes
 
     if (updateAttributes == UpdateDisplayAttributes::Yes) {
         if (m_file) {
-            setAttributeWithoutSynchronization(HTMLNames::titleAttr, m_file->name());
+            setAttributeWithoutSynchronization(HTMLNames::titleAttr, AtomString { m_file->name() });
             setAttributeWithoutSynchronization(HTMLNames::subtitleAttr, PAL::fileSizeDescription(m_file->size()));
-            setAttributeWithoutSynchronization(HTMLNames::typeAttr, m_file->type());
+            setAttributeWithoutSynchronization(HTMLNames::typeAttr, AtomString { m_file->type() });
         } else {
             removeAttribute(HTMLNames::titleAttr);
             removeAttribute(HTMLNames::subtitleAttr);
@@ -205,7 +205,7 @@ String HTMLAttachmentElement::attachmentPath() const
     return attributeWithoutSynchronization(webkitattachmentpathAttr);
 }
 
-void HTMLAttachmentElement::updateAttributes(std::optional<uint64_t>&& newFileSize, const String& newContentType, const String& newFilename)
+void HTMLAttachmentElement::updateAttributes(std::optional<uint64_t>&& newFileSize, const AtomString& newContentType, const AtomString& newFilename)
 {
     if (!newFilename.isNull()) {
         if (auto enclosingImage = enclosingImageElement())
@@ -254,7 +254,7 @@ void HTMLAttachmentElement::updateEnclosingImageWithData(const String& contentTy
     if (!mimeTypeIsSuitableForInlineImageAttachment(mimeType))
         return;
 
-    enclosingImage->setAttributeWithoutSynchronization(HTMLNames::srcAttr, DOMURL::createObjectURL(document(), Blob::create(&document(), buffer->extractData(), mimeType)));
+    enclosingImage->setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(document(), Blob::create(&document(), buffer->extractData(), mimeType)) });
 }
 
 void HTMLAttachmentElement::updateThumbnail(const RefPtr<Image>& thumbnail)

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -56,7 +56,7 @@ public:
 
     void copyNonAttributePropertiesFromElement(const Element&) final;
 
-    WEBCORE_EXPORT void updateAttributes(std::optional<uint64_t>&& newFileSize, const String& newContentType, const String& newFilename);
+    WEBCORE_EXPORT void updateAttributes(std::optional<uint64_t>&& newFileSize, const AtomString& newContentType, const AtomString& newFilename);
     WEBCORE_EXPORT void updateEnclosingImageWithData(const String& contentType, Ref<FragmentedSharedBuffer>&& data);
     WEBCORE_EXPORT void updateThumbnail(const RefPtr<Image>& thumbnail);
     WEBCORE_EXPORT void updateIcon(const RefPtr<Image>& icon, const WebCore::FloatSize&);

--- a/Source/WebCore/html/HTMLBaseElement.idl
+++ b/Source/WebCore/html/HTMLBaseElement.idl
@@ -20,7 +20,7 @@
 [
     Exposed=Window
 ] interface HTMLBaseElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute USVString href;
+    [CEReactions=NotNeeded] attribute [AtomString] USVString href;
 
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;
 };

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -23,10 +23,10 @@
 ] interface HTMLButtonElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement form;
-    [CEReactions=NotNeeded] attribute USVString formAction;
+    [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
 
     [CEReactions=NotNeeded] attribute [AtomString] DOMString formEnctype;
-    [CEReactions=NotNeeded] attribute DOMString formMethod;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString formMethod;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString type;
 
     [CEReactions=NotNeeded, Reflect] attribute boolean formNoValidate;

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -186,7 +186,7 @@ const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
     return m_namedElementCache->propertyNames();
 }
 
-bool HTMLCollection::isSupportedPropertyName(const String& name)
+bool HTMLCollection::isSupportedPropertyName(const AtomString& name)
 {
     updateNamedElementCache();
     ASSERT(m_namedElementCache);

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -69,7 +69,7 @@ public:
     Element* item(unsigned index) const override = 0; // Tighten return type from NodeList::item().
     virtual Element* namedItem(const AtomString& name) const = 0;
     const Vector<AtomString>& supportedPropertyNames();
-    bool isSupportedPropertyName(const String& name);
+    bool isSupportedPropertyName(const AtomString& name);
 
     // Non-DOM API
     Vector<Ref<Element>> namedItems(const AtomString& name) const;

--- a/Source/WebCore/html/HTMLFormControlElementWithState.h
+++ b/Source/WebCore/html/HTMLFormControlElementWithState.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-using FormControlState = Vector<String>;
+using FormControlState = Vector<AtomString>;
 
 class HTMLFormControlElementWithState : public HTMLFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFormControlElementWithState);

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -54,7 +54,7 @@ Ref<HTMLFormControlsCollection> HTMLFormControlsCollection::create(ContainerNode
 
 HTMLFormControlsCollection::~HTMLFormControlsCollection() = default;
 
-std::optional<std::variant<RefPtr<RadioNodeList>, RefPtr<Element>>> HTMLFormControlsCollection::namedItemOrItems(const String& name) const
+std::optional<std::variant<RefPtr<RadioNodeList>, RefPtr<Element>>> HTMLFormControlsCollection::namedItemOrItems(const AtomString& name) const
 {
     auto namedItems = this->namedItems(name);
 

--- a/Source/WebCore/html/HTMLFormControlsCollection.h
+++ b/Source/WebCore/html/HTMLFormControlsCollection.h
@@ -41,7 +41,7 @@ public:
     virtual ~HTMLFormControlsCollection();
 
     HTMLElement* item(unsigned offset) const override;
-    std::optional<std::variant<RefPtr<RadioNodeList>, RefPtr<Element>>> namedItemOrItems(const String&) const;
+    std::optional<std::variant<RefPtr<RadioNodeList>, RefPtr<Element>>> namedItemOrItems(const AtomString&) const;
 
     HTMLFormElement& ownerNode() const;
 

--- a/Source/WebCore/html/HTMLFormElement.idl
+++ b/Source/WebCore/html/HTMLFormElement.idl
@@ -25,7 +25,7 @@
     Exposed=Window
 ] interface HTMLFormElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect=accept_charset] attribute DOMString acceptCharset;
-    [CEReactions=NotNeeded] attribute USVString action;
+    [CEReactions=NotNeeded] attribute [AtomString] USVString action;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString enctype;
     [CEReactions=NotNeeded, ImplementedAs=enctype] attribute [AtomString] DOMString encoding;

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -88,7 +88,7 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
         return;
 
     if (m_frameURL.isEmpty())
-        m_frameURL = aboutBlankURL().string();
+        m_frameURL = AtomString { aboutBlankURL().string() };
 
     if (shouldLoadFrameLazily())
         return;
@@ -99,7 +99,7 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
 
     document().willLoadFrameElement(document().completeURL(m_frameURL));
 
-    String frameName = getNameAttribute();
+    auto frameName = getNameAttribute();
     if (frameName.isNull() && UNLIKELY(document().settings().needsFrameNameFallbackToIdQuirk()))
         frameName = getIdAttribute();
 

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -183,7 +183,7 @@ bool HTMLIFrameElement::shouldLoadFrameLazily()
         URL completeURL = document().completeURL(frameURL());
         if (isFrameLazyLoadable(document(), completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
             auto currentReferrerPolicy = referrerPolicy();
-            lazyLoadFrameObserver().observe(completeURL.string(), currentReferrerPolicy);
+            lazyLoadFrameObserver().observe(AtomString { completeURL.string() }, currentReferrerPolicy);
             return true;
         }
     }

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -22,22 +22,22 @@
     Exposed=Window,
     JSGenerateToNativeObject
 ] interface HTMLIFrameElement : HTMLElement {
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString align;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString frameBorder;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString height;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString align;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString frameBorder;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString height;
     [Reflect, URL, CEReactions=NotNeeded] attribute USVString longDesc;
-    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString, AtomString] DOMString marginHeight;
-    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString, AtomString] DOMString marginWidth;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString name;
+    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginHeight;
+    [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString name;
 
     [PutForwards=value] readonly attribute DOMTokenList sandbox;
     [Reflect, CEReactions=NotNeeded] attribute boolean allowFullscreen;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString allow;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString allow;
 
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString scrolling;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString scrolling;
     [Reflect, URL, CEReactions=NotNeeded] attribute USVString src;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString srcdoc;
-    [Reflect, CEReactions=NotNeeded] attribute [AtomString] DOMString width;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString srcdoc;
+    [Reflect, CEReactions=NotNeeded] attribute DOMString width;
 
     [CheckSecurityForNode] readonly attribute Document contentDocument;
 
@@ -45,7 +45,7 @@
 
     [CheckSecurityForNode] Document getSVGDocument();
 
-    [EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings, CEReactions=NotNeeded] attribute DOMString referrerPolicy;
+    [EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings, CEReactions=NotNeeded] attribute [AtomString] DOMString referrerPolicy;
 
     [CEReactions, EnabledBySetting=LazyIframeLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
 };

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -27,9 +27,9 @@
     LegacyFactoryFunctionCallWith=CurrentDocument,
     LegacyFactoryFunction=Image(optional unsigned long width, optional unsigned long height)
 ] interface HTMLImageElement : HTMLElement {
-    [CEReactions=NotNeeded, Reflect] attribute [AtomString] DOMString alt;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
-    [CEReactions=NotNeeded, Reflect] attribute [AtomString] USVString srcset;
+    [CEReactions=NotNeeded, Reflect] attribute USVString srcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString sizes;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
     [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -558,7 +558,7 @@ void HTMLInputElement::updateType()
     bool wasSuccessfulSubmitButtonCandidate = m_inputType->canBeSuccessfulSubmitButton();
 
     if (didStoreValue && !willStoreValue && hasDirtyValue()) {
-        setAttributeWithoutSynchronization(valueAttr, m_valueIfDirty);
+        setAttributeWithoutSynchronization(valueAttr, AtomString { m_valueIfDirty });
         m_valueIfDirty = String();
     }
 

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -33,7 +33,7 @@
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement form;
     [ImplementedAs=filesForBindings] attribute FileList? files;
-    [CEReactions=NotNeeded] attribute USVString formAction;
+    [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
 
     [CEReactions=NotNeeded] attribute [AtomString] DOMString formEnctype;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString formMethod;

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -97,7 +97,7 @@ void HTMLMapElement::parseAttribute(const QualifiedName& name, const AtomString&
         }
         if (isConnected())
             treeScope().removeImageMap(*this);
-        String mapName = value;
+        AtomString mapName = value;
         if (mapName[0] == '#')
             mapName = StringView(mapName).substring(1).toAtomString();
         m_name = WTFMove(mapName);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3666,7 +3666,7 @@ String HTMLMediaElement::preload() const
     return String();
 }
 
-void HTMLMediaElement::setPreload(const String& preload)
+void HTMLMediaElement::setPreload(const AtomString& preload)
 {
     ALWAYS_LOG(LOGIDENTIFIER, preload);
 #if ENABLE(MEDIA_STREAM)
@@ -4375,7 +4375,7 @@ void HTMLMediaElement::forgetResourceSpecificTracks()
         removeVideoTrack(*m_videoTracks->lastItem());
 }
 
-ExceptionOr<TextTrack&> HTMLMediaElement::addTextTrack(const String& kind, const String& label, const String& language)
+ExceptionOr<TextTrack&> HTMLMediaElement::addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language)
 {
     // 4.8.10.12.4 Text track API
     // The addTextTrack(kind, label, language) method of media elements, when invoked, must run the following steps:
@@ -4390,7 +4390,7 @@ ExceptionOr<TextTrack&> HTMLMediaElement::addTextTrack(const String& kind, const
 
     // 5. Create a new text track corresponding to the new object, and set its text track kind to kind, its text
     // track label to label, its text track language to language...
-    auto track = TextTrack::create(&document(), kind, emptyString(), label, language);
+    auto track = TextTrack::create(&document(), kind, emptyAtom(), label, language);
     auto& trackReference = track.get();
 #if !RELEASE_LOG_DISABLED
     trackReference.setLogger(logger(), logIdentifier());

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -229,7 +229,7 @@ public:
     WEBCORE_EXPORT NetworkState networkState() const;
 
     WEBCORE_EXPORT String preload() const;
-    WEBCORE_EXPORT void setPreload(const String&);
+    WEBCORE_EXPORT void setPreload(const AtomString&);
 
     Ref<TimeRanges> buffered() const override;
     WEBCORE_EXPORT void load();
@@ -350,7 +350,7 @@ public:
 
     bool shouldForceControlsDisplay() const;
 
-    ExceptionOr<TextTrack&> addTextTrack(const String& kind, const String& label, const String& language);
+    ExceptionOr<TextTrack&> addTextTrack(const AtomString& kind, const AtomString& label, const AtomString& language);
 
     AudioTrackList& ensureAudioTracks();
     TextTrackList& ensureTextTracks();

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -54,7 +54,7 @@ typedef (
     const unsigned short NETWORK_LOADING = 2;
     const unsigned short NETWORK_NO_SOURCE = 3;
     readonly attribute unsigned short networkState;
-    [CEReactions=NotNeeded] attribute DOMString preload;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString preload;
 
     readonly attribute TimeRanges buffered;
     undefined load();
@@ -109,7 +109,7 @@ typedef (
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] attribute EventHandler onwaitingforkey;
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] Promise<undefined> setMediaKeys(MediaKeys? mediaKeys);
 
-    TextTrack addTextTrack(DOMString kind, optional DOMString label = "", optional DOMString language = "");
+    TextTrack addTextTrack([AtomString] DOMString kind, optional [AtomString] DOMString label = "", optional [AtomString] DOMString language = "");
     [ImplementedAs=ensureAudioTracks] readonly attribute AudioTrackList audioTracks;
     [ImplementedAs=ensureTextTracks] readonly attribute TextTrackList textTracks;
     [ImplementedAs=ensureVideoTracks] readonly attribute VideoTrackList videoTracks;

--- a/Source/WebCore/html/HTMLOrForeignElement.idl
+++ b/Source/WebCore/html/HTMLOrForeignElement.idl
@@ -28,7 +28,7 @@
 // https://github.com/whatwg/html/issues/4702
 interface mixin HTMLOrForeignElement {
     [SameObject] readonly attribute DOMStringMap dataset;
-    attribute DOMString nonce; // intentionally no [CEReactions]
+    attribute [AtomString] DOMString nonce; // intentionally no [CEReactions]
 
     [CEReactions=NotNeeded, Reflect] attribute boolean autofocus;
     [CEReactions, ImplementedAs=tabIndexForBindings] attribute long tabIndex;

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -23,7 +23,7 @@
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface HTMLSelectElement : HTMLElement {
-    [CEReactions] attribute DOMString autocomplete;
+    [CEReactions] attribute [AtomString] DOMString autocomplete;
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;
     [CEReactions] attribute boolean multiple;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -121,7 +121,7 @@ const AtomString& HTMLTextAreaElement::formControlType() const
 
 FormControlState HTMLTextAreaElement::saveFormControlState() const
 {
-    return m_isDirty ? FormControlState { { value() } } : FormControlState { };
+    return m_isDirty ? FormControlState { { AtomString { value() } } } : FormControlState { };
 }
 
 void HTMLTextAreaElement::restoreFormControlState(const FormControlState& state)

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -59,5 +59,5 @@
 
     undefined setSelectionRange(optional unsigned long start = 0, optional unsigned long end = 0, optional DOMString direction);
 
-    [CEReactions=NotNeeded] attribute DOMString autocomplete;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
 };

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -70,7 +70,7 @@ inline HTMLVideoElement::HTMLVideoElement(const QualifiedName& tagName, Document
 {
     ASSERT(hasTagName(videoTag));
     setHasCustomStyleResolveCallbacks();
-    m_defaultPosterURL = document.settings().defaultVideoPosterURL();
+    m_defaultPosterURL = AtomString { document.settings().defaultVideoPosterURL() };
 }
 
 Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)

--- a/Source/WebCore/html/HiddenInputType.cpp
+++ b/Source/WebCore/html/HiddenInputType.cpp
@@ -53,13 +53,13 @@ FormControlState HiddenInputType::saveFormControlState() const
     // valueAttributeWasUpdatedAfterParsing() never be true for form controls create by createElement() or cloneNode().
     // It's OK for now because we restore values only to form controls created by parsing.
     ASSERT(element());
-    return element()->valueAttributeWasUpdatedAfterParsing() ? FormControlState { { element()->value() } } : FormControlState { };
+    return element()->valueAttributeWasUpdatedAfterParsing() ? FormControlState { { AtomString { element()->value() } } } : FormControlState { };
 }
 
 void HiddenInputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, state[0]);
+    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { state[0] });
 }
 
 RenderPtr<RenderElement> HiddenInputType::createInputRenderer(RenderStyle&&)
@@ -86,7 +86,7 @@ bool HiddenInputType::storesValueSeparateFromAttribute()
 void HiddenInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, sanitizedValue);
+    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 bool HiddenInputType::appendFormData(DOMFormData& formData) const

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -241,7 +241,7 @@ void ImageDocument::createDocumentStructure()
     else
         imageElement->setAttribute(styleAttr, "-webkit-user-select:none; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     imageElement->setLoadManually(true);
-    imageElement->setSrc(url().string());
+    imageElement->setSrc(AtomString { url().string() });
     imageElement->cachedImage()->setResponse(loader()->response());
     body->appendChild(imageElement);
     imageElement->setLoadManually(false);

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -255,7 +255,7 @@ FormControlState InputType::saveFormControlState() const
     auto currentValue = element()->value();
     if (currentValue == element()->defaultValue())
         return { };
-    return { { currentValue } };
+    return { { AtomString { currentValue } } };
 }
 
 void InputType::restoreFormControlState(const FormControlState& state)

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -111,9 +111,9 @@ void MediaDocumentParser::createDocumentStructure()
     m_mediaElement = videoElement.ptr();
     videoElement->setAttributeWithoutSynchronization(controlsAttr, emptyAtom());
     videoElement->setAttributeWithoutSynchronization(autoplayAttr, emptyAtom());
-    videoElement->setAttributeWithoutSynchronization(srcAttr, document.url().string());
+    videoElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document.url().string() });
     if (RefPtr loader = document.loader())
-        videoElement->setAttributeWithoutSynchronization(typeAttr, loader->responseMIMEType());
+        videoElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->responseMIMEType() });
 
 #if !ENABLE(MODERN_MEDIA_CONTROLS)
     videoElement->setAttribute(styleAttr, "max-width: 100%; max-height: 100%;"_s);
@@ -236,11 +236,11 @@ void MediaDocument::replaceMediaElementTimerFired()
         embedElement->setAttributeWithoutSynchronization(widthAttr, "100%"_s);
         embedElement->setAttributeWithoutSynchronization(heightAttr, "100%"_s);
         embedElement->setAttributeWithoutSynchronization(nameAttr, "plugin"_s);
-        embedElement->setAttributeWithoutSynchronization(srcAttr, url().string());
+        embedElement->setAttributeWithoutSynchronization(srcAttr, AtomString { url().string() });
 
         ASSERT(loader());
         if (RefPtr loader = this->loader())
-            embedElement->setAttributeWithoutSynchronization(typeAttr, loader->writer().mimeType());
+            embedElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->writer().mimeType() });
 
         videoElement->parentNode()->replaceChild(embedElement, *videoElement);
     }

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -109,9 +109,9 @@ void ModelDocumentParser::createDocumentStructure()
     modelElement->setAttributeWithoutSynchronization(interactiveAttr, emptyAtom());
 
     auto sourceElement = HTMLSourceElement::create(HTMLNames::sourceTag, document);
-    sourceElement->setAttributeWithoutSynchronization(srcAttr, document.url().string());
+    sourceElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document.url().string() });
     if (RefPtr loader = document.loader())
-        sourceElement->setAttributeWithoutSynchronization(typeAttr, loader->responseMIMEType());
+        sourceElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->responseMIMEType() });
 
     modelElement->appendChild(sourceElement);
 

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -98,11 +98,11 @@ void PluginDocumentParser::createDocumentStructure()
     embedElement->setAttributeWithoutSynchronization(heightAttr, "100%"_s);
     
     embedElement->setAttributeWithoutSynchronization(nameAttr, "plugin"_s);
-    embedElement->setAttributeWithoutSynchronization(srcAttr, document.url().string());
+    embedElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document.url().string() });
     
     ASSERT(document.loader());
     if (RefPtr loader = document.loader())
-        m_embedElement->setAttributeWithoutSynchronization(typeAttr, loader->writer().mimeType());
+        m_embedElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->writer().mimeType() });
 
     document.setPluginElement(*m_embedElement);
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -840,7 +840,7 @@ void TextFieldInputType::createAutoFillButton(AutoFillButtonType autoFillButtonT
     m_autoFillButton = AutoFillButtonElement::create(element()->document(), *this);
     m_autoFillButton->setPseudo(autoFillButtonTypeToAutoFillButtonPseudoClassName(autoFillButtonType));
     m_autoFillButton->setAttributeWithoutSynchronization(roleAttr, HTMLNames::buttonTag->localName());
-    m_autoFillButton->setAttributeWithoutSynchronization(aria_labelAttr, autoFillButtonTypeToAccessibilityLabel(autoFillButtonType));
+    m_autoFillButton->setAttributeWithoutSynchronization(aria_labelAttr, AtomString { autoFillButtonTypeToAccessibilityLabel(autoFillButtonType) });
     m_autoFillButton->setTextContent(autoFillButtonTypeToAutoFillButtonText(autoFillButtonType));
     m_container->appendChild(*m_autoFillButton);
 }
@@ -866,7 +866,7 @@ void TextFieldInputType::updateAutoFillButton()
         bool shouldUpdateAutoFillButtonType = isAutoFillButtonTypeChanged(attribute, autoFillButtonType);
         if (shouldUpdateAutoFillButtonType) {
             m_autoFillButton->setPseudo(autoFillButtonTypeToAutoFillButtonPseudoClassName(autoFillButtonType));
-            m_autoFillButton->setAttributeWithoutSynchronization(aria_labelAttr, autoFillButtonTypeToAccessibilityLabel(autoFillButtonType));
+            m_autoFillButton->setAttributeWithoutSynchronization(aria_labelAttr, AtomString { autoFillButtonTypeToAccessibilityLabel(autoFillButtonType) });
             m_autoFillButton->setTextContent(autoFillButtonTypeToAutoFillButtonText(autoFillButtonType));
         }
         m_autoFillButton->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock, true);

--- a/Source/WebCore/html/canvas/WebGLContextEvent.idl
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=WebGLEnabled,
     Exposed=Window
 ] interface WebGLContextEvent : Event {
-    constructor(DOMString type, optional WebGLContextEventInit eventInit);
+    constructor([AtomString] DOMString type, optional WebGLContextEventInit eventInit);
 
     readonly attribute DOMString statusMessage;
 };

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -86,9 +86,7 @@ static StringView extractCharset(const String& value)
 bool HTMLMetaCharsetParser::processMeta(HTMLToken& token)
 {
     auto attributes = token.attributes().map([](auto& attribute) {
-        String attributeName = StringImpl::create8BitIfPossible(attribute.name);
-        String attributeValue = StringImpl::create8BitIfPossible(attribute.value);
-        return std::pair { WTFMove(attributeName), WTFMove(attributeValue) };
+        return std::pair { AtomString(attribute.name), AtomString(attribute.value) };
     });
 
     m_encoding = encodingFromMetaAttributes(attributes);
@@ -102,8 +100,8 @@ PAL::TextEncoding HTMLMetaCharsetParser::encodingFromMetaAttributes(const Attrib
     StringView charset;
 
     for (auto& attribute : attributes) {
-        const String& attributeName = attribute.first;
-        const String& attributeValue = attribute.second;
+        auto& attributeName = attribute.first;
+        auto& attributeValue = attribute.second;
 
         if (attributeName == http_equivAttr) {
             if (equalLettersIgnoringASCIICase(attributeValue, "content-type"_s))

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
@@ -46,7 +46,7 @@ public:
     const PAL::TextEncoding& encoding() { return m_encoding; }
 
     // The returned encoding might not be valid.
-    typedef Vector<std::pair<String, String>> AttributeList;
+    typedef Vector<std::pair<AtomString, AtomString>> AttributeList;
     static PAL::TextEncoding encodingFromMetaAttributes(const AttributeList&);
 
 private:

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -533,7 +533,7 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<AtomString, QualifiedName> create
         for (unsigned i = 0; i < length; ++i) {
             const QualifiedName& name = *names[i];
             const AtomString& localName = name.localName();
-            map.add(prefix + ':' + localName, QualifiedName(prefix, localName, name.namespaceURI()));
+            map.add(makeAtomString(prefix, ':', localName), QualifiedName(prefix, localName, name.namespaceURI()));
         }
     };
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -298,7 +298,7 @@ Ref<SearchFieldCancelButtonElement> SearchFieldCancelButtonElement::create(Docum
 
     element->setPseudo(ShadowPseudoIds::webkitSearchCancelButton());
 #if !PLATFORM(IOS_FAMILY)
-    element->setAttributeWithoutSynchronization(aria_labelAttr, AXSearchFieldCancelButtonText());
+    element->setAttributeWithoutSynchronization(aria_labelAttr, AtomString { AXSearchFieldCancelButtonText() });
 #endif
     element->setAttributeWithoutSynchronization(roleAttr, HTMLNames::buttonTag->localName());
     return element;

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -209,7 +209,7 @@ void AudioTrack::updateKindFromPrivate()
         setKind(commentaryAtom());
         break;
     case AudioTrackPrivate::None:
-        setKind(emptyString());
+        setKind(emptyAtom());
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -42,13 +42,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LoadableTextTrack);
 
-LoadableTextTrack::LoadableTextTrack(HTMLTrackElement& track, const String& kind, const String& label, const String& language)
-    : TextTrack(&track.document(), kind, emptyString(), label, language, TrackElement)
+LoadableTextTrack::LoadableTextTrack(HTMLTrackElement& track, const AtomString& kind, const AtomString& label, const AtomString& language)
+    : TextTrack(&track.document(), kind, emptyAtom(), label, language, TrackElement)
     , m_trackElement(&track)
 {
 }
 
-Ref<LoadableTextTrack> LoadableTextTrack::create(HTMLTrackElement& track, const String& kind, const String& label, const String& language)
+Ref<LoadableTextTrack> LoadableTextTrack::create(HTMLTrackElement& track, const AtomString& kind, const AtomString& label, const AtomString& language)
 {
     auto textTrack = adoptRef(*new LoadableTextTrack(track, kind, label, language));
     textTrack->suspendIfNeeded();

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -38,7 +38,7 @@ class HTMLTrackElement;
 class LoadableTextTrack final : public TextTrack, private TextTrackLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(LoadableTextTrack);
 public:
-    static Ref<LoadableTextTrack> create(HTMLTrackElement&, const String& kind, const String& label, const String& language);
+    static Ref<LoadableTextTrack> create(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
 
     void scheduleLoad(const URL&);
 
@@ -47,7 +47,7 @@ public:
     void clearElement() { m_trackElement = nullptr; }
 
 private:
-    LoadableTextTrack(HTMLTrackElement&, const String& kind, const String& label, const String& language);
+    LoadableTextTrack(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
 
     void newCuesAvailable(TextTrackLoader&) final;
     void cueLoadingCompleted(TextTrackLoader&, bool loadingFailed) final;

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -265,7 +265,7 @@ void TextTrackCue::setTrack(TextTrack* track)
     m_track = track;
 }
 
-void TextTrackCue::setId(const String& id)
+void TextTrackCue::setId(const AtomString& id)
 {
     if (m_id == id)
         return;

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -71,8 +71,8 @@ public:
     TextTrack* track() const;
     void setTrack(TextTrack*);
 
-    const String& id() const { return m_id; }
-    void setId(const String&);
+    const AtomString& id() const { return m_id; }
+    void setId(const AtomString&);
 
     double startTime() const { return startMediaTime().toDouble(); }
     void setStartTime(double);
@@ -147,7 +147,7 @@ private:
 
     void rebuildDisplayTree();
 
-    String m_id;
+    AtomString m_id;
     MediaTime m_startTime;
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };

--- a/Source/WebCore/html/track/TextTrackCue.idl
+++ b/Source/WebCore/html/track/TextTrackCue.idl
@@ -37,7 +37,7 @@
 
     readonly attribute TextTrack track;
 
-    attribute DOMString id;
+    attribute [AtomString] DOMString id;
     attribute double startTime;
     attribute double endTime;
     attribute boolean pauseOnExit;

--- a/Source/WebCore/html/track/TrackEvent.idl
+++ b/Source/WebCore/html/track/TrackEvent.idl
@@ -27,7 +27,7 @@
     Conditional=VIDEO,
     Exposed=Window
 ] interface TrackEvent : Event {
-    constructor(DOMString type, optional TrackEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional TrackEventInit eventInitDict);
 
     readonly attribute (VideoTrack or AudioTrack or TextTrack)? track;
 };

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -230,7 +230,7 @@ void VideoTrack::updateKindFromPrivate()
         setKind(commentaryAtom());
         return;
     case VideoTrackPrivate::None:
-        setKind(emptyString());
+        setKind(emptyAtom());
         return;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -280,7 +280,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
         if (!m_styleSheets.isEmpty())
             m_client.newStyleSheetsParsed();
         if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"))
-            m_currentId = m_previousLine;
+            m_currentId = AtomString { m_previousLine };
         
         return state;
     }
@@ -417,7 +417,7 @@ WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)
 {
     if (line.contains("-->"))
         return collectTimingsAndSettings(line);
-    m_currentId = line;
+    m_currentId = AtomString { line };
     return TimingsAndSettings;
 }
 
@@ -556,7 +556,7 @@ void WebVTTParser::createNewCue()
 
 void WebVTTParser::resetCueValues()
 {
-    m_currentId = emptyString();
+    m_currentId = emptyAtom();
     m_currentSettings = emptyString();
     m_currentStartTime = MediaTime::zeroTime();
     m_currentEndTime = MediaTime::zeroTime();

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -73,14 +73,14 @@ public:
     MediaTime endTime() const { return m_endTime; }
     void setEndTime(const MediaTime& endTime) { m_endTime = endTime; }
 
-    String id() const { return m_id; }
-    void setId(String id) { m_id = id; }
+    AtomString id() const { return m_id; }
+    void setId(const AtomString& id) { m_id = id; }
 
     String content() const { return m_content; }
-    void setContent(String content) { m_content = content; }
+    void setContent(const String& content) { m_content = content; }
 
     String settings() const { return m_settings; }
-    void setSettings(String settings) { m_settings = settings; }
+    void setSettings(const String& settings) { m_settings = settings; }
 
     MediaTime originalStartTime() const { return m_originalStartTime; }
     void setOriginalStartTime(const MediaTime& time) { m_originalStartTime = time; }
@@ -91,7 +91,7 @@ private:
     MediaTime m_startTime;
     MediaTime m_endTime;
     MediaTime m_originalStartTime;
-    String m_id;
+    AtomString m_id;
     String m_content;
     String m_settings;
 };
@@ -185,7 +185,7 @@ private:
 
     BufferedLineReader m_lineReader;
     RefPtr<TextResourceDecoder> m_decoder;
-    String m_currentId;
+    AtomString m_currentId;
     MediaTime m_currentStartTime;
     MediaTime m_currentEndTime;
     StringBuilder m_currentContent;

--- a/Source/WebCore/inspector/DOMEditor.cpp
+++ b/Source/WebCore/inspector/DOMEditor.cpp
@@ -126,7 +126,7 @@ private:
 class DOMEditor::RemoveAttributeAction final : public InspectorHistory::Action {
     WTF_MAKE_NONCOPYABLE(RemoveAttributeAction);
 public:
-    RemoveAttributeAction(Element& element, const String& name)
+    RemoveAttributeAction(Element& element, const AtomString& name)
         : InspectorHistory::Action()
         , m_element(element)
         , m_name(name)
@@ -152,8 +152,8 @@ private:
     }
 
     Ref<Element> m_element;
-    String m_name;
-    String m_value;
+    AtomString m_name;
+    AtomString m_value;
 };
 
 class DOMEditor::SetAttributeAction final : public InspectorHistory::Action {
@@ -395,12 +395,12 @@ ExceptionOr<void> DOMEditor::removeChild(Node& parentNode, Node& node)
     return m_history.perform(makeUnique<RemoveChildAction>(parentNode, node));
 }
 
-ExceptionOr<void> DOMEditor::setAttribute(Element& element, const String& name, const String& value)
+ExceptionOr<void> DOMEditor::setAttribute(Element& element, const AtomString& name, const AtomString& value)
 {
     return m_history.perform(makeUnique<SetAttributeAction>(element, name, value));
 }
 
-ExceptionOr<void> DOMEditor::removeAttribute(Element& element, const String& name)
+ExceptionOr<void> DOMEditor::removeAttribute(Element& element, const AtomString& name)
 {
     return m_history.perform(makeUnique<RemoveAttributeAction>(element, name));
 }
@@ -453,12 +453,12 @@ bool DOMEditor::removeChild(Node& parentNode, Node& node, ErrorString& errorStri
     return populateErrorString(removeChild(parentNode, node), errorString);
 }
 
-bool DOMEditor::setAttribute(Element& element, const String& name, const String& value, ErrorString& errorString)
+bool DOMEditor::setAttribute(Element& element, const AtomString& name, const AtomString& value, ErrorString& errorString)
 {
     return populateErrorString(setAttribute(element, name, value), errorString);
 }
 
-bool DOMEditor::removeAttribute(Element& element, const String& name, ErrorString& errorString)
+bool DOMEditor::removeAttribute(Element& element, const AtomString& name, ErrorString& errorString)
 {
     return populateErrorString(removeAttribute(element, name), errorString);
 }

--- a/Source/WebCore/inspector/DOMEditor.h
+++ b/Source/WebCore/inspector/DOMEditor.h
@@ -49,8 +49,8 @@ public:
 
     ExceptionOr<void> insertBefore(Node& parentNode, Ref<Node>&&, Node* anchorNode);
     ExceptionOr<void> removeChild(Node& parentNode, Node&);
-    ExceptionOr<void> setAttribute(Element&, const String& name, const String& value);
-    ExceptionOr<void> removeAttribute(Element&, const String& name);
+    ExceptionOr<void> setAttribute(Element&, const AtomString& name, const AtomString& value);
+    ExceptionOr<void> removeAttribute(Element&, const AtomString& name);
     ExceptionOr<void> setOuterHTML(Node&, const String& html, Node*& newNode);
     ExceptionOr<void> replaceWholeText(Text&, const String& text);
     ExceptionOr<void> replaceChild(Node& parentNode, Ref<Node>&& newNode, Node& oldNode);
@@ -59,8 +59,8 @@ public:
 
     bool insertBefore(Node& parentNode, Ref<Node>&&, Node* anchorNode, ErrorString&);
     bool removeChild(Node& parentNode, Node&, ErrorString&);
-    bool setAttribute(Element&, const String& name, const String& value, ErrorString&);
-    bool removeAttribute(Element&, const String& name, ErrorString&);
+    bool setAttribute(Element&, const AtomString& name, const AtomString& value, ErrorString&);
+    bool removeAttribute(Element&, const AtomString& name, ErrorString&);
     bool setOuterHTML(Node&, const String& html, Node*& newNode, ErrorString&);
     bool replaceWholeText(Text&, const String& text, ErrorString&);
     bool insertAdjacentHTML(Element&, const String& where, const String& html, ErrorString&);

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -199,11 +199,11 @@ ExceptionOr<std::optional<InspectorAuditAccessibilityObject::ComputedProperties>
             String ariaRelevantAttrValue = axObject->liveRegionRelevant();
             if (!ariaRelevantAttrValue.isEmpty()) {
                 Vector<String> liveRegionRelevant;
-                String ariaRelevantAdditions = "additions"_s;
-                String ariaRelevantRemovals = "removals"_s;
-                String ariaRelevantText = "text"_s;
+                AtomString ariaRelevantAdditions = "additions"_s;
+                AtomString ariaRelevantRemovals = "removals"_s;
+                AtomString ariaRelevantText = "text"_s;
 
-                const auto& values = SpaceSplitString(ariaRelevantAttrValue, SpaceSplitString::ShouldFoldCase::Yes);
+                const auto& values = SpaceSplitString(AtomString { ariaRelevantAttrValue }, SpaceSplitString::ShouldFoldCase::Yes);
                 if (values.contains("all"_s)) {
                     liveRegionRelevant.append(ariaRelevantAdditions);
                     liveRegionRelevant.append(ariaRelevantRemovals);

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -873,7 +873,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw lines.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(m_page.settings().sansSerifFontFamily());
+        fontDescription.setOneFamily(AtomString { m_page.settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(10);
 
         FontCascade font(WTFMove(fontDescription), 0, 0);
@@ -963,7 +963,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
     // Draw viewport size.
     {
         FontCascadeDescription fontDescription;
-        fontDescription.setOneFamily(m_page.settings().sansSerifFontFamily());
+        fontDescription.setOneFamily(AtomString { m_page.settings().sansSerifFontFamily() });
         fontDescription.setComputedSize(12);
 
         FontCascade font(WTFMove(fontDescription), 0, 0);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1620,7 +1620,7 @@ ExceptionOr<void> InspectorStyleSheetForInlineStyle::setStyleText(CSSStyleDeclar
 
     {
         InspectorCSSAgent::InlineStyleOverrideScope overrideScope(m_element->document());
-        m_element->setAttribute(HTMLNames::styleAttr, text);
+        m_element->setAttribute(HTMLNames::styleAttr, AtomString { text });
     }
 
     m_styleText = text;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1233,9 +1233,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const
     if (status)
         overrideResponse.setHTTPStatusCode(*status);
     if (!!statusText)
-        overrideResponse.setHTTPStatusText(statusText);
+        overrideResponse.setHTTPStatusText(AtomString { statusText });
     if (!!mimeType)
-        overrideResponse.setMimeType(mimeType);
+        overrideResponse.setMimeType(AtomString { mimeType });
     if (headers) {
         HTTPHeaderMap explicitHeaders;
         for (auto& header : *headers) {
@@ -1291,7 +1291,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
     ResourceResponse response(pendingRequest->m_loader->url(), mimeType, data->size(), String());
     response.setSource(ResourceResponse::Source::InspectorOverride);
     response.setHTTPStatusCode(status);
-    response.setHTTPStatusText(statusText);
+    response.setHTTPStatusText(AtomString { statusText });
     HTTPHeaderMap explicitHeaders;
     for (auto& header : headers.get()) {
         auto headerValue = header.value->asString();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1380,7 +1380,7 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
             openerPolicy = NewFrameOpenerPolicy::Suppress;
         }
 
-        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(request), WTFMove(formState), effectiveFrameName, [this, allowNavigationToInvalidURL, openerPolicy, completionHandler = completionHandlerCaller.release()] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const String& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) mutable {
+        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(request), WTFMove(formState), effectiveFrameName, [this, allowNavigationToInvalidURL, openerPolicy, completionHandler = completionHandlerCaller.release()] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const AtomString& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) mutable {
             continueLoadAfterNewWindowPolicy(request, formState.get(), frameName, action, shouldContinue, allowNavigationToInvalidURL, openerPolicy);
             completionHandler();
         });
@@ -1463,7 +1463,7 @@ void FrameLoader::load(FrameLoadRequest&& request)
 
     if (request.shouldCheckNewWindowPolicy()) {
         NavigationAction action { request.requester(), request.resourceRequest(), InitiatedByMainFrame::Unknown, NavigationType::Other, request.shouldOpenExternalURLsPolicy() };
-        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(request.resourceRequest()), { }, request.frameName(), [this] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const String& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) {
+        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(request.resourceRequest()), { }, request.frameName(), [this] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const AtomString& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) {
             continueLoadAfterNewWindowPolicy(request, formState.get(), frameName, action, shouldContinue, AllowNavigationToInvalidURL::Yes, NewFrameOpenerPolicy::Suppress);
         });
 
@@ -3096,7 +3096,7 @@ void FrameLoader::loadPostRequest(FrameLoadRequest&& request, const String& refe
             openerPolicy = NewFrameOpenerPolicy::Suppress;
         }
 
-        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(workingResourceRequest), WTFMove(formState), frameName, [this, allowNavigationToInvalidURL, openerPolicy, completionHandler = WTFMove(completionHandler)] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const String& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) mutable {
+        policyChecker().checkNewWindowPolicy(WTFMove(action), WTFMove(workingResourceRequest), WTFMove(formState), frameName, [this, allowNavigationToInvalidURL, openerPolicy, completionHandler = WTFMove(completionHandler)] (const ResourceRequest& request, WeakPtr<FormState>&& formState, const AtomString& frameName, const NavigationAction& action, ShouldContinuePolicyCheck shouldContinue) mutable {
             continueLoadAfterNewWindowPolicy(request, formState.get(), frameName, action, shouldContinue, allowNavigationToInvalidURL, openerPolicy);
             completionHandler();
         });

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -737,7 +737,7 @@ void FrameLoader::HistoryController::recursiveSetProvisionalItem(HistoryItem& it
     m_provisionalItem = &item;
 
     for (auto& childItem : item.children()) {
-        const String& childFrameName = childItem->target();
+        auto& childFrameName = childItem->target();
 
         HistoryItem* fromChildItem = fromItem->childItemWithTarget(childFrameName);
         ASSERT(fromChildItem);

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -249,7 +249,7 @@ void FrameLoader::PolicyChecker::checkNavigationPolicy(ResourceRequest&& request
         m_frame.loader().client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), policyDecisionMode, requestIdentifier, WTFMove(decisionHandler));
 }
 
-void FrameLoader::PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigationAction, ResourceRequest&& request, RefPtr<FormState>&& formState, const String& frameName, NewWindowPolicyDecisionFunction&& function)
+void FrameLoader::PolicyChecker::checkNewWindowPolicy(NavigationAction&& navigationAction, ResourceRequest&& request, RefPtr<FormState>&& formState, const AtomString& frameName, NewWindowPolicyDecisionFunction&& function)
 {
     if (m_frame.document() && m_frame.document()->isSandboxed(SandboxPopups))
         return function({ }, nullptr, { }, { }, ShouldContinuePolicyCheck::No);

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -68,11 +68,11 @@ public:
     explicit PolicyChecker(Frame&);
 
     using NavigationPolicyDecisionFunction = CompletionHandler<void(ResourceRequest&&, WeakPtr<FormState>&&, NavigationPolicyDecision)>;
-    using NewWindowPolicyDecisionFunction = CompletionHandler<void(const ResourceRequest&, WeakPtr<FormState>&&, const String& frameName, const NavigationAction&, ShouldContinuePolicyCheck)>;
+    using NewWindowPolicyDecisionFunction = CompletionHandler<void(const ResourceRequest&, WeakPtr<FormState>&&, const AtomString& frameName, const NavigationAction&, ShouldContinuePolicyCheck)>;
 
     void checkNavigationPolicy(ResourceRequest&&, const ResourceResponse& redirectResponse, DocumentLoader*, RefPtr<FormState>&&, NavigationPolicyDecisionFunction&&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous);
     void checkNavigationPolicy(ResourceRequest&&, const ResourceResponse& redirectResponse, NavigationPolicyDecisionFunction&&);
-    void checkNewWindowPolicy(NavigationAction&&, ResourceRequest&&, RefPtr<FormState>&&, const String& frameName, NewWindowPolicyDecisionFunction&&);
+    void checkNewWindowPolicy(NavigationAction&&, ResourceRequest&&, RefPtr<FormState>&&, const AtomString& frameName, NewWindowPolicyDecisionFunction&&);
 
     void stopCheck();
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -78,7 +78,7 @@ static bool isCharsetSpecifyingNode(const Node& node)
     if (element.hasAttributes()) {
         for (const Attribute& attribute : element.attributesIterator()) {
             // FIXME: We should deal appropriately with the attribute if they have a namespace.
-            attributes.append(std::make_pair(attribute.name().toString(), attribute.value().string()));
+            attributes.append({ attribute.name().toAtomString(), attribute.value() });
         }
     }
     return HTMLMetaCharsetParser::encodingFromMetaAttributes(attributes).isValid();

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -168,7 +168,7 @@ public:
     virtual bool readWebArchive(SharedBuffer&) = 0;
     virtual bool readRTFD(SharedBuffer&) = 0;
     virtual bool readRTF(SharedBuffer&) = 0;
-    virtual bool readDataBuffer(SharedBuffer&, const String& type, const String& name, PresentationSize preferredPresentationSize = { }) = 0;
+    virtual bool readDataBuffer(SharedBuffer&, const String& type, const AtomString& name, PresentationSize preferredPresentationSize = { }) = 0;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/InbandGenericCue.h
+++ b/Source/WebCore/platform/graphics/InbandGenericCue.h
@@ -39,7 +39,7 @@ struct GenericCueData {
     enum class Status : uint8_t { Uninitialized, Partial, Complete };
 
     GenericCueData() = default;
-    GenericCueData(InbandGenericCueIdentifier uniqueId, const MediaTime& startTime, const MediaTime& endTime, const String& id, const String& content, const String& fontName, double line, double position, double size, double baseFontSize, double relativeFontSize, const Color& foregroundColor, const Color& backgroundColor, const Color& highlightColor, GenericCueData::Alignment align, GenericCueData::Status status)
+    GenericCueData(InbandGenericCueIdentifier uniqueId, const MediaTime& startTime, const MediaTime& endTime, const AtomString& id, const String& content, const String& fontName, double line, double position, double size, double baseFontSize, double relativeFontSize, const Color& foregroundColor, const Color& backgroundColor, const Color& highlightColor, GenericCueData::Alignment align, GenericCueData::Status status)
         : m_uniqueId(uniqueId)
         , m_startTime(startTime)
         , m_endTime(endTime)
@@ -66,7 +66,7 @@ struct GenericCueData {
     InbandGenericCueIdentifier m_uniqueId;
     MediaTime m_startTime;
     MediaTime m_endTime;
-    String m_id;
+    AtomString m_id;
     String m_content;
     String m_fontName;
     double m_line { -1 };
@@ -102,7 +102,7 @@ std::optional<GenericCueData> GenericCueData::decode(Decoder& decoder)
     if (!endTime)
         return std::nullopt;
 
-    std::optional<String> identifier;
+    std::optional<AtomString> identifier;
     decoder >> identifier;
     if (!identifier)
         return std::nullopt;
@@ -233,8 +233,8 @@ public:
     MediaTime endTime() const { return m_cueData.m_endTime; }
     void setEndTime(const MediaTime& endTime) { m_cueData.m_endTime = endTime; }
 
-    const String& id() const { return m_cueData.m_id; }
-    void setId(const String& id) { m_cueData.m_id = id; }
+    const AtomString& id() const { return m_cueData.m_id; }
+    void setId(const AtomString& id) { m_cueData.m_id = id; }
 
     const String& content() const { return m_cueData.m_content; }
     void setContent(const String& content) { m_cueData.m_content = content; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
@@ -61,7 +61,7 @@ void InbandChapterTrackPrivateAVFObjC::processChapters(RetainPtr<NSArray<AVTimed
             return;
         m_processedChapters.append(chapterData);
 
-        ISOWebVTTCue cueData = ISOWebVTTCue(PAL::toMediaTime([item time]), PAL::toMediaTime([item duration]), String::number(chapterNumber), [item stringValue]);
+        ISOWebVTTCue cueData = ISOWebVTTCue(PAL::toMediaTime([item time]), PAL::toMediaTime([item duration]), AtomString::number(chapterNumber), [item stringValue]);
         INFO_LOG(identifier, "created cue ", cueData);
         client()->parseWebVTTCueData(WTFMove(cueData));
     });

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
@@ -80,7 +80,7 @@ ISOWebVTTCue::ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& d
 {
 }
 
-ISOWebVTTCue::ISOWebVTTCue(MediaTime&& presentationTime, MediaTime&& duration, String&& cueID, String&& cueText, String&& settings, String&& sourceID, String&& originalStartTime)
+ISOWebVTTCue::ISOWebVTTCue(MediaTime&& presentationTime, MediaTime&& duration, AtomString&& cueID, String&& cueText, String&& settings, String&& sourceID, String&& originalStartTime)
     : m_presentationTime(WTFMove(presentationTime))
     , m_duration(WTFMove(duration))
     , m_sourceID(WTFMove(sourceID))
@@ -105,7 +105,7 @@ bool ISOWebVTTCue::parse(DataView& view, unsigned& offset)
         if (stringBox.boxType() == vttCueSourceIDBoxType())
             m_sourceID = stringBox.contents();
         else if (stringBox.boxType() == vttIdBoxType())
-            m_identifier = stringBox.contents();
+            m_identifier = AtomString { stringBox.contents() };
         else if (stringBox.boxType() == vttCurrentTimeBoxType())
             m_originalStartTime = stringBox.contents();
         else if (stringBox.boxType() == vttSettingsBoxType())

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -42,7 +42,7 @@ namespace WebCore {
 class ISOWebVTTCue final : public ISOBox {
 public:
     ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration);
-    WEBCORE_EXPORT ISOWebVTTCue(MediaTime&& presentationTime, MediaTime&& duration, String&& cueID, String&& cueText, String&& settings = { }, String&& sourceID = { }, String&& originalStartTime = { });
+    WEBCORE_EXPORT ISOWebVTTCue(MediaTime&& presentationTime, MediaTime&& duration, AtomString&& cueID, String&& cueText, String&& settings = { }, String&& sourceID = { }, String&& originalStartTime = { });
     ISOWebVTTCue(const ISOWebVTTCue&) = default;
     WEBCORE_EXPORT ISOWebVTTCue(ISOWebVTTCue&&);
     WEBCORE_EXPORT ~ISOWebVTTCue();
@@ -56,7 +56,7 @@ public:
     const MediaTime& duration() const { return m_duration; }
 
     const String& sourceID() const { return m_sourceID; }
-    const String& id() const { return m_identifier; }
+    const AtomString& id() const { return m_identifier; }
     const String& originalStartTime() const { return m_originalStartTime; }
     const String& settings() const { return m_settings; }
     const String& cueText() const { return m_cueText; }
@@ -93,7 +93,7 @@ public:
         if (!sourceID)
             return std::nullopt;
 
-        std::optional<String> identifier;
+        std::optional<AtomString> identifier;
         decoder >> identifier;
         if (!identifier)
             return std::nullopt;
@@ -131,7 +131,7 @@ private:
     MediaTime m_duration;
 
     String m_sourceID;
-    String m_identifier;
+    AtomString m_identifier;
     String m_originalStartTime;
     String m_settings;
     String m_cueText;

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -351,7 +351,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
             auto typeForFileUpload = info->contentTypeForHighestFidelityItem();
             if (auto buffer = strategy.readBufferFromPasteboard(i, typeForFileUpload, m_pasteboardName, context())) {
                 readURLAlongsideAttachmentIfNecessary(reader, strategy, typeForFileUpload, m_pasteboardName, i, context());
-                reader.readDataBuffer(*buffer, typeForFileUpload, info->suggestedFileName, info->preferredPresentationSize);
+                reader.readDataBuffer(*buffer, typeForFileUpload, AtomString { info->suggestedFileName }, info->preferredPresentationSize);
                 continue;
             }
         }

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-RealtimeVideoCaptureSource::RealtimeVideoCaptureSource(String&& name, String&& id, String&& hashSalt, PageIdentifier pageIdentifier)
+RealtimeVideoCaptureSource::RealtimeVideoCaptureSource(AtomString&& name, String&& id, String&& hashSalt, PageIdentifier pageIdentifier)
     : RealtimeMediaSource(Type::Video, WTFMove(name), WTFMove(id), WTFMove(hashSalt), pageIdentifier)
 {
 }

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -55,7 +55,7 @@ public:
     const VideoPreset* currentPreset() const { return m_currentPreset.get(); }
 
 protected:
-    RealtimeVideoCaptureSource(String&& name, String&& id, String&& hashSalt, PageIdentifier);
+    RealtimeVideoCaptureSource(AtomString&& name, String&& id, String&& hashSalt, PageIdentifier);
 
     void setSizeAndFrameRate(std::optional<int> width, std::optional<int> height, std::optional<double>) override;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, String&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier)
+CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomString&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier)
 {
 #ifndef NDEBUG
     auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(deviceID);
@@ -52,7 +52,7 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, String&&
 
 CaptureSourceOrError MockDisplayCaptureSourceGStreamer::create(const CaptureDevice& device, String&& hashSalt, const MediaConstraints* constraints)
 {
-    auto mockSource = adoptRef(*new MockRealtimeVideoSourceGStreamer(String { device.persistentId() }, String { device.label() }, String { hashSalt }));
+    auto mockSource = adoptRef(*new MockRealtimeVideoSourceGStreamer(String { device.persistentId() }, AtomString { device.label() }, String { hashSalt }));
 
     if (constraints) {
         if (auto error = mockSource->applyConstraints(*constraints))
@@ -64,7 +64,7 @@ CaptureSourceOrError MockDisplayCaptureSourceGStreamer::create(const CaptureDevi
 }
 
 MockDisplayCaptureSourceGStreamer::MockDisplayCaptureSourceGStreamer(RealtimeMediaSource::Type type, Ref<MockRealtimeVideoSourceGStreamer>&& source, String&& hashSalt, CaptureDevice::DeviceType deviceType)
-    : RealtimeMediaSource(type, source->name().string().isolatedCopy(), source->persistentID().isolatedCopy(), WTFMove(hashSalt))
+    : RealtimeMediaSource(type, AtomString { source->name().string().isolatedCopy() }, source->persistentID().isolatedCopy(), WTFMove(hashSalt))
     , m_source(WTFMove(source))
     , m_deviceType(deviceType)
 {
@@ -145,7 +145,7 @@ const RealtimeMediaSourceSettings& MockDisplayCaptureSourceGStreamer::settings()
     return m_currentSettings.value();
 }
 
-MockRealtimeVideoSourceGStreamer::MockRealtimeVideoSourceGStreamer(String&& deviceID, String&& name, String&& hashSalt)
+MockRealtimeVideoSourceGStreamer::MockRealtimeVideoSourceGStreamer(String&& deviceID, AtomString&& name, String&& hashSalt)
     : MockRealtimeVideoSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalt), { })
 {
     ensureGStreamerInitialized();

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
@@ -30,7 +30,7 @@ namespace WebCore {
 
 class MockRealtimeVideoSourceGStreamer final : public MockRealtimeVideoSource {
 public:
-    MockRealtimeVideoSourceGStreamer(String&& deviceID, String&& name, String&& hashSalt);
+    MockRealtimeVideoSourceGStreamer(String&& deviceID, AtomString&& name, String&& hashSalt);
     ~MockRealtimeVideoSourceGStreamer() = default;
 
 private:

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -126,7 +126,7 @@ CaptureSourceOrError AVVideoCaptureSource::create(const CaptureDevice& device, S
 }
 
 AVVideoCaptureSource::AVVideoCaptureSource(AVCaptureDevice* avDevice, const CaptureDevice& device, String&& hashSalt, PageIdentifier pageIdentifier)
-    : RealtimeVideoCaptureSource(String(device.label()), String(device.persistentId()), WTFMove(hashSalt), pageIdentifier)
+    : RealtimeVideoCaptureSource(AtomString(device.label()), String(device.persistentId()), WTFMove(hashSalt), pageIdentifier)
     , m_objcObserver(adoptNS([[WebCoreAVVideoCaptureSourceObserver alloc] initWithCallback:this]))
     , m_device(avDevice)
     , m_verifyCapturingTimer(*this, &AVVideoCaptureSource::verifyIsCapturing)

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
@@ -47,13 +47,13 @@ class ImageTransferSessionVT;
 
 class MockRealtimeVideoSourceMac final : public MockRealtimeVideoSource {
 public:
-    static Ref<MockRealtimeVideoSource> createForMockDisplayCapturer(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier);
+    static Ref<MockRealtimeVideoSource> createForMockDisplayCapturer(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier);
 
     ~MockRealtimeVideoSourceMac() = default;
 
 private:
     friend class MockRealtimeVideoSource;
-    MockRealtimeVideoSourceMac(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier);
+    MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier);
 
     PlatformLayer* platformLayer() const;
     void updateSampleBuffer() final;

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -51,7 +51,7 @@
 
 namespace WebCore {
 
-CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, String&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier pageIdentifier)
+CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomString&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier pageIdentifier)
 {
 #ifndef NDEBUG
     auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(deviceID);
@@ -69,12 +69,12 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, String&&
     return CaptureSourceOrError(RealtimeVideoSource::create(WTFMove(source)));
 }
 
-Ref<MockRealtimeVideoSource> MockRealtimeVideoSourceMac::createForMockDisplayCapturer(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier pageIdentifier)
+Ref<MockRealtimeVideoSource> MockRealtimeVideoSourceMac::createForMockDisplayCapturer(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier pageIdentifier)
 {
     return adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalt), pageIdentifier));
 }
 
-MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier pageIdentifier)
+MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier pageIdentifier)
     : MockRealtimeVideoSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalt), pageIdentifier)
     , m_workQueue(WorkQueue::create("MockRealtimeVideoSource Render Queue", WorkQueue::QOS::UserInteractive))
 {

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -107,7 +107,7 @@ public:
         if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(CaptureDevice::DeviceType::Camera, device.persistentId()))
             return { "Unable to find mock camera device with given persistentID"_s };
 
-        return MockRealtimeVideoSource::create(String { device.persistentId() }, String { device.label() }, WTFMove(hashSalt), constraints, pageIdentifier);
+        return MockRealtimeVideoSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalt), constraints, pageIdentifier);
     }
 
 private:
@@ -135,7 +135,7 @@ private:
 };
 
 MockDisplayCapturer::MockDisplayCapturer(const CaptureDevice& device, PageIdentifier pageIdentifier)
-    : m_source(MockRealtimeVideoSourceMac::createForMockDisplayCapturer(String { device.persistentId() }, String { device.label() }, String { }, pageIdentifier))
+    : m_source(MockRealtimeVideoSourceMac::createForMockDisplayCapturer(String { device.persistentId() }, AtomString { device.label() }, String { }, pageIdentifier))
 {
 }
 
@@ -218,7 +218,7 @@ public:
         if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(CaptureDevice::DeviceType::Microphone, device.persistentId()))
             return { "Unable to find mock microphone device with given persistentID"_s };
 
-        return MockRealtimeAudioSource::create(String { device.persistentId() }, String { device.label() }, WTFMove(hashSalt), constraints, pageIdentifier);
+        return MockRealtimeAudioSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalt), constraints, pageIdentifier);
     }
 private:
     CaptureDeviceManager& audioCaptureDeviceManager() final { return MockRealtimeMediaSourceCenter::singleton().audioCaptureDeviceManager(); }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -50,7 +50,7 @@
 namespace WebCore {
 
 #if !PLATFORM(MAC) && !PLATFORM(IOS_FAMILY) && !USE(GSTREAMER)
-CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, String&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier pageIdentifier)
+CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomString&& name, String&& hashSalt, const MediaConstraints* constraints, PageIdentifier pageIdentifier)
 {
 #ifndef NDEBUG
     auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(deviceID);
@@ -73,7 +73,7 @@ static HashSet<MockRealtimeVideoSource*>& allMockRealtimeVideoSource()
     return videoSources;
 }
 
-MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier pageIdentifier)
+MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier pageIdentifier)
     : RealtimeVideoCaptureSource(WTFMove(name), WTFMove(deviceID), WTFMove(hashSalt), pageIdentifier)
     , m_emitFrameTimer(RunLoop::current(), this, &MockRealtimeVideoSource::generateFrame)
 {

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -48,7 +48,7 @@ class GraphicsContext;
 
 class MockRealtimeVideoSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
-    static CaptureSourceOrError create(String&& deviceID, String&& name, String&& hashSalt, const MediaConstraints*, PageIdentifier);
+    static CaptureSourceOrError create(String&& deviceID, AtomString&& name, String&& hashSalt, const MediaConstraints*, PageIdentifier);
     ~MockRealtimeVideoSource();
 
     static void setIsInterrupted(bool);
@@ -56,7 +56,7 @@ public:
     ImageBuffer* imageBuffer() const;
 
 protected:
-    MockRealtimeVideoSource(String&& deviceID, String&& name, String&& hashSalt, PageIdentifier);
+    MockRealtimeVideoSource(String&& deviceID, AtomString&& name, String&& hashSalt, PageIdentifier);
 
     virtual void updateSampleBuffer() = 0;
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -100,7 +100,9 @@ public:
 #endif
     static String convertString(BuilderState&, const CSSValue&);
     static String convertStringOrAuto(BuilderState&, const CSSValue&);
+    static AtomString convertStringOrAutoAtom(BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrAuto(state, value) }; }
     static String convertStringOrNone(BuilderState&, const CSSValue&);
+    static AtomString convertStringOrNoneAtom(BuilderState& state, const CSSValue& value) { return AtomString { convertStringOrNone(state, value) }; }
     static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(BuilderState&, const CSSValue&);
     static TextAlignMode convertTextAlign(BuilderState&, const CSSValue&);
     static RefPtr<PathOperation> convertPathOperation(BuilderState&, const CSSValue&);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1607,7 +1607,7 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             CSSValueID listStyleIdent = counterValue->listStyleIdent();
             if (listStyleIdent != CSSValueNone)
                 listStyleType = static_cast<ListStyleType>(listStyleIdent - CSSValueDisc);
-            auto counter = makeUnique<CounterContent>(counterValue->identifier(), listStyleType, counterValue->separator());
+            auto counter = makeUnique<CounterContent>(AtomString { counterValue->identifier() }, listStyleType, AtomString { counterValue->separator() });
             builderState.style().setContent(WTFMove(counter), didSet);
             didSet = true;
         } else {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1300,12 +1300,12 @@ ExceptionOr<String> Internals::shadowRootType(const Node& root) const
     }
 }
 
-String Internals::shadowPseudoId(Element& element)
+const AtomString& Internals::shadowPseudoId(Element& element)
 {
-    return element.shadowPseudoId().string();
+    return element.shadowPseudoId();
 }
 
-void Internals::setShadowPseudoId(Element& element, const String& id)
+void Internals::setShadowPseudoId(Element& element, const AtomString& id)
 {
     return element.setPseudo(id);
 }
@@ -1526,23 +1526,23 @@ void Internals::selectColorInColorChooser(HTMLInputElement& element, const Strin
     element.selectColor(colorValue);
 }
 
-ExceptionOr<Vector<String>> Internals::formControlStateOfPreviousHistoryItem()
+ExceptionOr<Vector<AtomString>> Internals::formControlStateOfPreviousHistoryItem()
 {
     HistoryItem* mainItem = frame()->loader().history().previousItem();
     if (!mainItem)
         return Exception { InvalidAccessError };
-    String uniqueName = frame()->tree().uniqueName();
+    auto uniqueName = frame()->tree().uniqueName();
     if (mainItem->target() != uniqueName && !mainItem->childItemWithTarget(uniqueName))
         return Exception { InvalidAccessError };
-    return Vector<String> { mainItem->target() == uniqueName ? mainItem->documentState() : mainItem->childItemWithTarget(uniqueName)->documentState() };
+    return Vector<AtomString> { mainItem->target() == uniqueName ? mainItem->documentState() : mainItem->childItemWithTarget(uniqueName)->documentState() };
 }
 
-ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vector<String>& state)
+ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vector<AtomString>& state)
 {
     HistoryItem* mainItem = frame()->loader().history().previousItem();
     if (!mainItem)
         return Exception { InvalidAccessError };
-    String uniqueName = frame()->tree().uniqueName();
+    auto uniqueName = frame()->tree().uniqueName();
     if (mainItem->target() == uniqueName)
         mainItem->setDocumentState(state);
     else if (HistoryItem* subItem = mainItem->childItemWithTarget(uniqueName))
@@ -2872,7 +2872,7 @@ RefPtr<WindowProxy> Internals::openDummyInspectorFrontend(const String& url)
 {
     auto* inspectedPage = contextDocument()->frame()->page();
     auto* window = inspectedPage->mainFrame().document()->domWindow();
-    auto frontendWindowProxy = window->open(*window, *window, url, emptyString(), emptyString()).releaseReturnValue();
+    auto frontendWindowProxy = window->open(*window, *window, url, emptyAtom(), emptyString()).releaseReturnValue();
     m_inspectorFrontend = makeUnique<InspectorStubFrontend>(*inspectedPage, downcast<DOMWindow>(frontendWindowProxy->window()));
     return frontendWindowProxy;
 }
@@ -6217,7 +6217,7 @@ void Internals::setIsPlayingToAutomotiveHeadUnit(bool isPlaying)
 #endif
 }
 
-String Internals::highlightPseudoElementColor(const String& highlightName, Element& element)
+String Internals::highlightPseudoElementColor(const AtomString& highlightName, Element& element)
 {
     element.document().updateStyleIfNeeded();
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -244,8 +244,8 @@ public:
     Node* ensureUserAgentShadowRoot(Element& host);
     Node* shadowRoot(Element& host);
     ExceptionOr<String> shadowRootType(const Node&) const;
-    String shadowPseudoId(Element&);
-    void setShadowPseudoId(Element&, const String&);
+    const AtomString& shadowPseudoId(Element&);
+    void setShadowPseudoId(Element&, const AtomString&);
 
     // CSS Deferred Parsing Testing
     unsigned deferredStyleRulesCount(StyleSheet&);
@@ -296,8 +296,8 @@ public:
     void removeTextPlaceholder(Element&);
 
     void selectColorInColorChooser(HTMLInputElement&, const String& colorValue);
-    ExceptionOr<Vector<String>> formControlStateOfPreviousHistoryItem();
-    ExceptionOr<void> setFormControlStateOfPreviousHistoryItem(const Vector<String>&);
+    ExceptionOr<Vector<AtomString>> formControlStateOfPreviousHistoryItem();
+    ExceptionOr<void> setFormControlStateOfPreviousHistoryItem(const Vector<AtomString>&);
 
     ExceptionOr<Ref<DOMRect>> absoluteLineRectFromPoint(int x, int y);
 
@@ -1208,7 +1208,7 @@ public:
     bool hasSandboxMachLookupAccessToXPCServiceName(const String& process, const String& service);
     bool hasSandboxIOKitOpenAccessToClass(const String& process, const String& ioKitClass);
 
-    String highlightPseudoElementColor(const String& highlightName, Element&);
+    String highlightPseudoElementColor(const AtomString& highlightName, Element&);
 
     String windowLocationHost(DOMWindow&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -385,7 +385,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     DOMString shadowRootType(Node root);
     DOMString shadowPseudoId(Element element);
-    undefined setShadowPseudoId(Element element, DOMString id);
+    undefined setShadowPseudoId(Element element, [AtomString] DOMString id);
     Node treeScopeRootNode(Node node);
     Node parentTreeScope(Node node);
 
@@ -412,8 +412,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     DOMString visiblePlaceholder(Element element);
     undefined selectColorInColorChooser(HTMLInputElement element, DOMString colorValue);
-    sequence<DOMString> formControlStateOfPreviousHistoryItem();
-    undefined setFormControlStateOfPreviousHistoryItem(sequence<DOMString> values);
+    sequence<[AtomString] DOMString> formControlStateOfPreviousHistoryItem();
+    undefined setFormControlStateOfPreviousHistoryItem(sequence<[AtomString] DOMString> values);
 
     DOMRect absoluteLineRectFromPoint(long x, long y);
 
@@ -796,11 +796,11 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setSelectionWithoutValidation(Node baseNode, unsigned long baseOffset, Node? extentNode, unsigned long extentOffset);
 
     [Conditional=MEDIA_SOURCE] undefined initializeMockMediaSource();
-    [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> bufferedSamplesForTrackId(SourceBuffer buffer, DOMString trackId);
-    [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> enqueuedSamplesForTrackID(SourceBuffer buffer, DOMString trackID);
+    [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> bufferedSamplesForTrackId(SourceBuffer buffer, [AtomString] DOMString trackId);
+    [Conditional=MEDIA_SOURCE] Promise<sequence<DOMString>> enqueuedSamplesForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID);
     [Conditional=MEDIA_SOURCE] undefined setShouldGenerateTimestamps(SourceBuffer buffer, boolean flag);
-    [Conditional=MEDIA_SOURCE] double minimumUpcomingPresentationTimeForTrackID(SourceBuffer buffer, DOMString trackID);
-    [Conditional=MEDIA_SOURCE] undefined setMaximumQueueDepthForTrackID(SourceBuffer buffer, DOMString trackID, unsigned long maxQueueDepth);
+    [Conditional=MEDIA_SOURCE] double minimumUpcomingPresentationTimeForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID);
+    [Conditional=MEDIA_SOURCE] undefined setMaximumQueueDepthForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID, unsigned long maxQueueDepth);
 
     [Conditional=VIDEO] undefined beginMediaSessionInterruption(DOMString interruptionType);
     [Conditional=VIDEO] undefined endMediaSessionInterruption(DOMString flags);
@@ -1076,7 +1076,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     InternalsMapLike createInternalsMapLike();
     InternalsSetLike createInternalsSetLike();
 
-    DOMString highlightPseudoElementColor(DOMString highlightName, Element element);
+    DOMString highlightPseudoElementColor([AtomString] DOMString highlightName, Element element);
 
     boolean hasSandboxMachLookupAccessToGlobalName(DOMString process, DOMString service);
     boolean hasSandboxMachLookupAccessToXPCServiceName(DOMString process, DOMString service);

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -98,11 +98,6 @@ void MockCDMFactory::setSupportedDataTypes(Vector<String>&& types)
         m_supportedDataTypes.append(type);
 }
 
-void MockCDMFactory::setSupportedRobustness(Vector<String>&& robustnesses)
-{
-    m_supportedRobustness = robustnesses.map([] (auto& robustness) -> AtomString { return robustness; });
-}
-
 std::unique_ptr<CDMPrivate> MockCDMFactory::createCDM(const String&, const CDMPrivateClient&)
 {
     return makeUnique<MockCDM>(*this);

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -53,7 +53,7 @@ public:
     void setSupportedSessionTypes(Vector<MediaKeySessionType>&& types) { m_supportedSessionTypes = WTFMove(types); }
 
     const Vector<AtomString>& supportedRobustness() const { return m_supportedRobustness; }
-    void setSupportedRobustness(Vector<String>&&);
+    void setSupportedRobustness(Vector<AtomString>&& supportedRobustness) { m_supportedRobustness = WTFMove(supportedRobustness); }
 
     MediaKeysRequirement distinctiveIdentifiersRequirement() const { return m_distinctiveIdentifiersRequirement; }
     void setDistinctiveIdentifiersRequirement(MediaKeysRequirement requirement) { m_distinctiveIdentifiersRequirement = requirement; }

--- a/Source/WebCore/testing/MockCDMFactory.idl
+++ b/Source/WebCore/testing/MockCDMFactory.idl
@@ -29,7 +29,7 @@
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
 ] interface MockCDMFactory {
     attribute sequence<DOMString> supportedDataTypes;
-    attribute sequence<DOMString> supportedRobustness;
+    attribute sequence<[AtomString] DOMString> supportedRobustness;
     attribute sequence<MediaKeySessionType> supportedSessionTypes;
     attribute MediaKeysRequirement distinctiveIdentifiersRequirement;
     attribute MediaKeysRequirement persistentStateRequirement;

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -282,7 +282,7 @@ void FrameState::validateDocumentState() const
     }
 }
 
-void FrameState::setDocumentState(const Vector<String>& documentState, ShouldValidate shouldValidate)
+void FrameState::setDocumentState(const Vector<AtomString>& documentState, ShouldValidate shouldValidate)
 {
     m_documentState = documentState;
 

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -91,9 +91,9 @@ public:
     FrameState& operator=(const FrameState&) = default;
     FrameState& operator=(FrameState&&) = default;
 
-    const Vector<String>& documentState() const { return m_documentState; }
+    const Vector<AtomString>& documentState() const { return m_documentState; }
     enum class ShouldValidate : bool { No, Yes };
-    void setDocumentState(const Vector<String>&, ShouldValidate = ShouldValidate::No);
+    void setDocumentState(const Vector<AtomString>&, ShouldValidate = ShouldValidate::No);
     void validateDocumentState() const;
 
     String urlString;
@@ -125,7 +125,7 @@ public:
     Vector<FrameState> children;
 
 private:
-    Vector<String> m_documentState;
+    Vector<AtomString> m_documentState;
 };
 
 struct PageState {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -171,7 +171,7 @@ static inline void encodeFrameState(GVariantBuilder* sessionBuilder, const Frame
     g_variant_builder_add(sessionBuilder, "s", frameState.target.utf8().data());
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("as"));
     for (const auto& state : frameState.documentState())
-        g_variant_builder_add(sessionBuilder, "s", state.utf8().data());
+        g_variant_builder_add(sessionBuilder, "s", state.string().utf8().data());
     g_variant_builder_close(sessionBuilder);
     if (!frameState.stateObjectData)
         g_variant_builder_add(sessionBuilder, "may", FALSE);
@@ -313,11 +313,11 @@ static inline void decodeFrameState(GVariant* frameStateVariant, FrameState& fra
         frameState.referrer = String::fromUTF8(referrer);
     frameState.target = String::fromUTF8(target);
     if (gsize documentStateLength = g_variant_iter_n_children(documentStateIter.get())) {
-        Vector<String> documentState;
+        Vector<AtomString> documentState;
         documentState.reserveInitialCapacity(documentStateLength);
         const char* documentStateString;
         while (g_variant_iter_next(documentStateIter.get(), "&s", &documentStateString))
-            documentState.uncheckedAppend(String::fromUTF8(documentStateString));
+            documentState.uncheckedAppend(AtomString::fromUTF8(documentStateString));
         frameState.setDocumentState(documentState);
     }
     if (stateObjectDataIter) {

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -611,6 +611,15 @@ public:
         return *this;
     }
 
+    HistoryEntryDataDecoder& operator>>(AtomString& value)
+    {
+        // FIXME: This could be more efficient but this matches what the IPC decoder currently does.
+        String string;
+        *this >> string;
+        value = AtomString { string };
+        return *this;
+    }
+
     HistoryEntryDataDecoder& operator>>(Vector<uint8_t>& value)
     {
         value = { };
@@ -902,9 +911,9 @@ static void decodeBackForwardTreeNode(HistoryEntryDataDecoder& decoder, FrameSta
     uint64_t documentStateVectorSize;
     decoder >> documentStateVectorSize;
 
-    Vector<String> documentState;
+    Vector<AtomString> documentState;
     for (uint64_t i = 0; i < documentStateVectorSize; ++i) {
-        String state;
+        AtomString state;
         decoder >> state;
 
         if (!decoder.isValid())


### PR DESCRIPTION
#### 636e305863afafacb8e2ee1f80e0a173e36762a1
<pre>
Prepare the rest of WebCore for making the AtomString(const String&amp;) constructor explicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=239917">https://bugs.webkit.org/show_bug.cgi?id=239917</a>

Reviewed by Darin Adler.

Prepare the rest of WebCore for making the AtomString(const String&amp;) constructor explicit.
This helps find suboptimal patterns in our code base, where we may be doing unnecessary
String allocations.

* Source/WebCore/PAL/pal/FileSizeFormatter.cpp:
(PAL::fileSizeDescription):
* Source/WebCore/PAL/pal/FileSizeFormatter.h:
* Source/WebCore/PAL/pal/cocoa/FileSizeFormatterCocoa.mm:
(PAL::fileSizeDescription):
* Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl:
* Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl:
* Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.idl:
* Source/WebCore/Modules/mediastream/RTCTransformEvent.idl:
* Source/WebCore/Modules/notifications/NotificationEvent.idl:
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl:
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl:
* Source/WebCore/Modules/webxr/XRInputSourceEvent.idl:
* Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.idl:
* Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.idl:
* Source/WebCore/Modules/webxr/XRSessionEvent.idl:
* Source/WebCore/bindings/IDLTypes.h:
(WebCore::IDLString::isNullValue):
* Source/WebCore/bindings/js/JSDOMConvertStrings.h:
(WebCore::propertyNameToString):
(WebCore::Converter&lt;IDLLegacyNullToEmptyAtomStringAdaptor&lt;T &gt; &gt;::convert):
(WebCore::JSConverter&lt;IDLLegacyNullToEmptyAtomStringAdaptor&lt;T &gt; &gt;::convert):
(WebCore::JSConverter&lt;IDLAtomStringAdaptor&lt;T &gt; &gt;::convert):
(WebCore::JSConverter&lt;IDLAtomStringAdaptor&lt;IDLUSVString &gt; &gt;::convert):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateAttributeGetterBodyDefinition):
(GetAnnotatedIDLType):
* Source/WebCore/bindings/scripts/test/TestPromiseRejectionEvent.idl:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue):
(WebCore::CSSComputedStyleDeclaration::getPropertyValue):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/DOMCSSCustomPropertyDescriptor.h:
* Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl:
* Source/WebCore/css/MediaQueryExpression.cpp:
(WebCore::consumeFirstValue):
* Source/WebCore/css/MediaQueryListEvent.idl:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::MutableStyleProperties::setCustomProperty):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseValueWithVariableReferences):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFamilyNameRaw):
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createDocumentType):
(WebCore::DOMImplementation::createDocument):
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/DOMImplementation.idl:
* Source/WebCore/dom/Document+HTMLObsolete.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createElementNS):
(WebCore::Document::formElementsState const):
(WebCore::Document::setStateForNewFormElements):
(WebCore::Document::parseQualifiedName):
(WebCore::Document::createAttributeNS):
(WebCore::Document::getCachedLocale):
(WebCore::Document::setBgColor):
(WebCore::Document::setFgColor):
(WebCore::Document::setAlinkColor):
(WebCore::Document::setLinkColorForBindings):
(WebCore::Document::setVlinkColor):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::toggleAttribute):
(WebCore::Element::didAddAttribute):
(WebCore::Element::didModifyAttribute):
(WebCore::Element::didRemoveAttribute):
* Source/WebCore/dom/KeyboardEvent.idl:
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/MutationObserver.idl:
* Source/WebCore/dom/QualifiedName.h:
(WebCore::QualifiedName::toAtomString const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestModuleScript):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::joinWithSpace):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::inputEventTypeName const):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/CreateLinkCommand.cpp:
(WebCore::CreateLinkCommand::doApply):
* Source/WebCore/editing/EditCommand.cpp:
(WebCore::inputTypeNameForEditingAction):
* Source/WebCore/editing/EditCommand.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::StyleChange::extractTextStyles):
* Source/WebCore/editing/EditingStyle.h:
(WebCore::StyleChange::fontColor):
(WebCore::StyleChange::fontFace):
(WebCore::StyleChange::fontSize):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::applyStyle):
(WebCore::Editor::applyParagraphStyle):
(WebCore::Editor::insertAttachment):
(WebCore::Editor::styleForSelectionStart):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeFormatBlock):
(WebCore::executeInsertHorizontalRule):
(WebCore::executeInsertImage):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::shouldAddNamespaceElement):
(WebCore::MarkupAccumulator::generateUniquePrefix):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::inputEventTypeName const):
* Source/WebCore/editing/TypingCommand.h:
* Source/WebCore/editing/WebContentReader.h:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::createFragmentForImageAttachment):
(WebCore::replaceRichContentWithAttachments):
(WebCore::createFragmentAndAddResources):
(WebCore::sanitizeMarkupWithArchive):
(WebCore::attachmentForFilePath):
(WebCore::attachmentForData):
(WebCore::WebContentReader::readURL):
(WebCore::WebContentReader::readDataBuffer):
* Source/WebCore/editing/markup.cpp:
(WebCore::AttributeChange::AttributeChange):
(WebCore::completeURLs):
(WebCore::replaceSubresourceURLs):
(WebCore::StyledMarkupAccumulator::appendCustomAttributes):
(WebCore::createFragmentForImageAndURL):
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::setDocumentState):
(WebCore::HistoryItem::documentState const):
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::createTDForFilename):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::saveFormControlState const):
* Source/WebCore/html/FormController.cpp:
(WebCore::StringVectorReader::consumeString):
(WebCore::StringVectorReader::consumeSubvector):
(WebCore::appendSerializedFormControlState):
(WebCore::FormController::formElementsState const):
(WebCore::FormController::setStateForNewFormElements):
(WebCore::FormController::parseStateVector):
(WebCore::FormController::referencedFilePaths):
* Source/WebCore/html/FormController.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/html/HTMLAreaElement.idl:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::setFile):
(WebCore::HTMLAttachmentElement::updateAttributes):
(WebCore::HTMLAttachmentElement::updateEnclosingImageWithData):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLBaseElement.idl:
* Source/WebCore/html/HTMLButtonElement.idl:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::isSupportedPropertyName):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLFormControlElementWithState.h:
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::namedItemOrItems const):
* Source/WebCore/html/HTMLFormControlsCollection.h:
* Source/WebCore/html/HTMLFormElement.idl:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):
* Source/WebCore/html/HTMLIFrameElement.idl:
* Source/WebCore/html/HTMLImageElement.idl:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::parseAttribute):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setPreload):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/html/HTMLOrForeignElement.idl:
* Source/WebCore/html/HTMLSelectElement.idl:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::saveFormControlState const):
* Source/WebCore/html/HTMLTextAreaElement.idl:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::HTMLVideoElement):
* Source/WebCore/html/HiddenInputType.cpp:
(WebCore::HiddenInputType::saveFormControlState const):
(WebCore::HiddenInputType::restoreFormControlState):
(WebCore::HiddenInputType::setValue):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::createDocumentStructure):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::saveFormControlState const):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocumentParser::createDocumentStructure):
(WebCore::MediaDocument::replaceMediaElementTimerFired):
* Source/WebCore/html/ModelDocument.cpp:
(WebCore::ModelDocumentParser::createDocumentStructure):
* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createDocumentStructure):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createAutoFillButton):
(WebCore::TextFieldInputType::updateAutoFillButton):
* Source/WebCore/html/canvas/WebGLContextEvent.idl:
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::processMeta):
(WebCore::HTMLMetaCharsetParser::encodingFromMetaAttributes):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::createForeignAttributesMap):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldCancelButtonElement::create):
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::updateKindFromPrivate):
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::LoadableTextTrack):
(WebCore::LoadableTextTrack::create):
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::setId):
* Source/WebCore/html/track/TextTrackCue.h:
(WebCore::TextTrackCue::id const):
* Source/WebCore/html/track/TextTrackCue.idl:
* Source/WebCore/html/track/TrackEvent.idl:
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::updateKindFromPrivate):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectWebVTTBlock):
(WebCore::WebVTTParser::collectCueId):
(WebCore::WebVTTParser::resetCueValues):
* Source/WebCore/html/track/WebVTTParser.h:
* Source/WebCore/inspector/DOMEditor.cpp:
(WebCore::DOMEditor::setAttribute):
(WebCore::DOMEditor::removeAttribute):
* Source/WebCore/inspector/DOMEditor.h:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::InspectorAuditAccessibilityObject::getComputedProperties):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawRulers):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheetForInlineStyle::setStyleText):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::setAttributeValue):
(WebCore::InspectorDOMAgent::setAttributesAsText):
(WebCore::InspectorDOMAgent::removeAttribute):
(WebCore::InspectorDOMAgent::setNodeName):
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::interceptWithResponse):
(WebCore::InspectorNetworkAgent::interceptRequestWithResponse):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadPostRequest):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::recursiveSetProvisionalItem):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::FrameLoader::PolicyChecker::checkNewWindowPolicy):
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::isCharsetSpecifyingNode):
* Source/WebCore/platform/Pasteboard.h:
(WebCore::PasteboardWebContentReader::readDataBuffer):
* Source/WebCore/platform/graphics/InbandGenericCue.h:
(WebCore::GenericCueData::GenericCueData):
(WebCore::GenericCueData::decode):
(WebCore::InbandGenericCue::id const):
(WebCore::InbandGenericCue::setId):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm:
(WebCore::InbandChapterTrackPrivateAVFObjC::processChapters):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp:
(WebCore::ISOWebVTTCue::ISOWebVTTCue):
(WebCore::ISOWebVTTCue::parse):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.h:
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::read):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::RealtimeVideoCaptureSource):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::AVVideoCaptureSource):
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h:
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSource::create):
(WebCore::MockRealtimeVideoSourceMac::createForMockDisplayCapturer):
(WebCore::MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockDisplayCapturer::MockDisplayCapturer):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::create):
(WebCore::MockRealtimeVideoSource::MockRealtimeVideoSource):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertStringOrAutoAtom):
(WebCore::Style::BuilderConverter::convertStringOrNoneAtom):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueContent):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::shadowPseudoId):
(WebCore::Internals::setShadowPseudoId):
(WebCore::Internals::formControlStateOfPreviousHistoryItem):
(WebCore::Internals::setFormControlStateOfPreviousHistoryItem):
(WebCore::Internals::openDummyInspectorFrontend):
(WebCore::Internals::highlightPseudoElementColor):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMFactory::setSupportedRobustness): Deleted.
* Source/WebCore/testing/MockCDMFactory.h:
(WebCore::MockCDMFactory::setSupportedRobustness):
* Source/WebCore/testing/MockCDMFactory.idl:

Canonical link: <a href="https://commits.webkit.org/250160@main">https://commits.webkit.org/250160@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@293656">https://svn.webkit.org/repository/webkit/trunk@293656</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
