### PR TITLE
Move starAtom() / xmlAtom() / xmlnsAtom() from WTF to WebCore

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1159,7 +1159,7 @@ static StructHandlers* createStructHandlerMap()
             return;
         {
             auto type = adoptSystem<char[]>(method_copyArgumentType(method, 2));
-            structHandlers->add(StringImpl::create(type.get()), (StructTagHandler) { selector, 0 });
+            structHandlers->add(StringImpl::createFromCString(type.get()), (StructTagHandler) { selector, 0 });
         }
     });
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -755,7 +755,7 @@ public:
         if (!m_length) {
             if (m_isSymbol)
                 return &SymbolImpl::createNullSymbol().leakRef();
-            return AtomStringImpl::add("").leakRef();
+            return RefPtr { emptyAtom().impl() }.leakRef();
         }
 
         if (m_is8Bit)

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -27,14 +27,6 @@
 
 namespace JSC {
 
-Ref<AtomStringImpl> Identifier::addLiteral(VM& vm, const char* literal, size_t length)
-{
-    if (length == 1)
-        return vm.smallStrings.singleCharacterStringRep(literal[0]);
-
-    return AtomStringImpl::addLiteral(literal, length);
-}
-
 Ref<AtomStringImpl> Identifier::add8(VM& vm, const UChar* s, int length)
 {
     if (length == 1) {

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -169,7 +169,7 @@ private:
 
     Identifier(VM& vm, const LChar* s, int length) : m_string(add(vm, s, length)) { ASSERT(m_string.impl()->isAtom()); }
     Identifier(VM& vm, const UChar* s, int length) : m_string(add(vm, s, length)) { ASSERT(m_string.impl()->isAtom()); }
-    ALWAYS_INLINE Identifier(VM& vm, ASCIILiteral literal) : m_string(addLiteral(vm, literal.characters(), literal.length())) { ASSERT(m_string.impl()->isAtom()); }
+    ALWAYS_INLINE Identifier(VM& vm, ASCIILiteral literal) : m_string(add(vm, literal)) { ASSERT(m_string.impl()->isAtom()); }
     Identifier(VM&, AtomStringImpl*);
     Identifier(VM&, const AtomString&);
     Identifier(VM& vm, const String& string) : m_string(add(vm, string.impl())) { ASSERT(m_string.impl()->isAtom()); }
@@ -194,7 +194,7 @@ private:
     template <typename T> ALWAYS_INLINE static constexpr bool canUseSingleCharacterString(T);
 
     static Ref<AtomStringImpl> add(VM&, StringImpl*);
-    JS_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(VM&, const char*, size_t length);
+    static Ref<AtomStringImpl> add(VM&, ASCIILiteral);
 
 #ifndef NDEBUG
     JS_EXPORT_PRIVATE static void checkCurrentAtomStringTable(VM&);
@@ -226,6 +226,13 @@ Ref<AtomStringImpl> Identifier::add(VM& vm, const T* s, int length)
         return *static_cast<AtomStringImpl*>(StringImpl::empty());
 
     return *AtomStringImpl::add(s, length);
+}
+
+inline Ref<AtomStringImpl> Identifier::add(VM& vm, ASCIILiteral literal)
+{
+    if (literal.length() == 1)
+        return vm.smallStrings.singleCharacterStringRep(literal.characterAt(0));
+    return AtomStringImpl::add(literal);
 }
 
 inline bool operator==(const Identifier& a, const Identifier& b)

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -321,7 +321,7 @@ inline static bool isPokerBros()
 }
 #endif
 
-inline const char* inferBuiltinTag(JSGlobalObject* globalObject, JSObject* object)
+inline ASCIILiteral inferBuiltinTag(JSGlobalObject* globalObject, JSObject* object)
 {
     VM& vm = globalObject->vm();
 #if PLATFORM(IOS)
@@ -331,11 +331,11 @@ inline const char* inferBuiltinTag(JSGlobalObject* globalObject, JSObject* objec
 #endif
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool objectIsArray = isArray(globalObject, object);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    RETURN_IF_EXCEPTION(scope, { });
     if (objectIsArray)
-        return "Array";
+        return "Array"_s;
     if (object->isCallable())
-        return "Function";
+        return "Function"_s;
     JSType type = object->type();
     if (TypeInfo::isArgumentsType(type)
         || type == ErrorInstanceType
@@ -346,7 +346,7 @@ inline const char* inferBuiltinTag(JSGlobalObject* globalObject, JSObject* objec
         || type == JSDateType
         || type == RegExpObjectType)
         return object->className();
-    return "Object";
+    return "Object"_s;
 }
 
 JSString* objectPrototypeToString(JSGlobalObject* globalObject, JSValue thisValue)
@@ -366,7 +366,7 @@ JSString* objectPrototypeToString(JSGlobalObject* globalObject, JSValue thisValu
     if (result)
         return asString(result);
 
-    const char* tag = inferBuiltinTag(globalObject, thisObject);
+    ASCIILiteral tag = inferBuiltinTag(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
     JSString* jsTag = nullptr;
 
@@ -381,7 +381,7 @@ JSString* objectPrototypeToString(JSGlobalObject* globalObject, JSValue thisValu
     }
 
     if (!jsTag)
-        jsTag = jsString(vm, AtomStringImpl::add(tag).releaseNonNull());
+        jsTag = jsString(vm, AtomStringImpl::add(tag));
 
     JSString* jsResult = jsString(globalObject, vm.smallStrings.objectStringStart(), jsTag, vm.smallStrings.singleCharacterString(']'));
     RETURN_IF_EXCEPTION(scope, nullptr);

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -52,17 +52,17 @@ void SmallStrings::initializeCommonStrings(VM& vm)
         ASSERT(m_needsToBeVisited);
     }
 
-#define JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE(name) initialize(&vm, m_##name, #name);
+#define JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE(name) initialize(&vm, m_##name, #name ## _s);
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE
-    initialize(&vm, m_objectStringStart, "[object ");
-    initialize(&vm, m_nullObjectString, "[object Null]");
-    initialize(&vm, m_undefinedObjectString, "[object Undefined]");
-    initialize(&vm, m_boundPrefixString, "bound ");
-    initialize(&vm, m_notEqualString, "not-equal");
-    initialize(&vm, m_timedOutString, "timed-out");
-    initialize(&vm, m_okString, "ok");
-    initialize(&vm, m_sentinelString, "$");
+    initialize(&vm, m_objectStringStart, "[object "_s);
+    initialize(&vm, m_nullObjectString, "[object Null]"_s);
+    initialize(&vm, m_undefinedObjectString, "[object Undefined]"_s);
+    initialize(&vm, m_boundPrefixString, "bound "_s);
+    initialize(&vm, m_notEqualString, "not-equal"_s);
+    initialize(&vm, m_timedOutString, "timed-out"_s);
+    initialize(&vm, m_okString, "ok"_s);
+    initialize(&vm, m_sentinelString, "$"_s);
 
     setIsInitialized(true);
 }
@@ -102,9 +102,9 @@ Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char charact
     return AtomStringImpl::add(string, 1).releaseNonNull();
 }
 
-void SmallStrings::initialize(VM* vm, JSString*& string, const char* value)
+void SmallStrings::initialize(VM* vm, JSString*& string, ASCIILiteral value)
 {
-    string = JSString::create(*vm, AtomStringImpl::add(value).releaseNonNull());
+    string = JSString::create(*vm, AtomStringImpl::add(value));
     ASSERT(m_needsToBeVisited);
 }
 

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -131,7 +131,7 @@ public:
 private:
     static constexpr unsigned singleCharacterStringCount = maxSingleCharacterString + 1;
 
-    void initialize(VM*, JSString*&, const char* value);
+    void initialize(VM*, JSString*&, ASCIILiteral value);
 
     JSString* m_emptyString { nullptr };
 #define JSC_COMMON_STRINGS_ATTRIBUTE_DECLARATION(name) JSString* m_##name { nullptr };

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -136,9 +136,6 @@ void AtomString::show() const
 
 WTF_EXPORT_PRIVATE LazyNeverDestroyed<const AtomString> nullAtomData;
 WTF_EXPORT_PRIVATE LazyNeverDestroyed<const AtomString> emptyAtomData;
-WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> starAtomData;
-WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> xmlAtomData;
-WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> xmlnsAtomData;
 
 void AtomString::init()
 {
@@ -149,16 +146,6 @@ void AtomString::init()
 
         nullAtomData.construct();
         emptyAtomData.construct(AtomString::fromLatin1(""));
-
-        // When starting WebThread via StartWebThread function, we have special period between the prologue of StartWebThread and spawning WebThread actually.
-        // In this period, `isMainThread()` returns false even if this is called on the main thread since WebThread is now enabled and we are not taking a WebThread lock.
-        // This causes assertion hits in MainThreadLazyNeverDestroyed initialization only in WebThread platforms.
-        // We bypass this by using constructWithoutAccessCheck, which intentionally skips `isMainThread()` check for construction.
-        // In non WebThread environment, we do not lose the assertion coverage since we already have ASSERT(isUIThread()). And ASSERT(isUIThread()) ensures that this
-        // is called in system main thread in WebThread platforms.
-        starAtomData.constructWithoutAccessCheck("*"_s);
-        xmlAtomData.constructWithoutAccessCheck("xml"_s);
-        xmlnsAtomData.constructWithoutAccessCheck("xmlns"_s);
     });
 }
 

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -40,7 +40,6 @@ public:
     AtomString();
     AtomString(const LChar*, unsigned length);
     AtomString(const UChar*, unsigned length);
-    AtomString(const UChar*);
 
     ALWAYS_INLINE static AtomString fromLatin1(const char* characters) { return AtomString(characters); }
 
@@ -142,7 +141,7 @@ public:
         : AtomString(ucharFrom(characters), length) { }
 
     AtomString(const wchar_t* characters)
-        : AtomString(ucharFrom(characters)) { }
+        : AtomString(characters, wcslen(characters)) { }
 #endif
 
     // AtomString::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
@@ -203,7 +202,7 @@ inline AtomString::AtomString()
 }
 
 inline AtomString::AtomString(const char* string)
-    : m_string(AtomStringImpl::add(string))
+    : m_string(AtomStringImpl::addCString(string))
 {
 }
 
@@ -214,11 +213,6 @@ inline AtomString::AtomString(const LChar* string, unsigned length)
 
 inline AtomString::AtomString(const UChar* string, unsigned length)
     : m_string(AtomStringImpl::add(string, length))
-{
-}
-
-inline AtomString::AtomString(const UChar* string)
-    : m_string(AtomStringImpl::add(string))
 {
 }
 

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -283,17 +283,8 @@ inline AtomString::AtomString(NSString *string)
 extern WTF_EXPORT_PRIVATE LazyNeverDestroyed<const AtomString> nullAtomData;
 extern WTF_EXPORT_PRIVATE LazyNeverDestroyed<const AtomString> emptyAtomData;
 
-// Define external global variables for the commonly used atom strings.
-// These are only usable from the main thread.
-extern WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> starAtomData;
-extern WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> xmlAtomData;
-extern WTF_EXPORT_PRIVATE MainThreadLazyNeverDestroyed<const AtomString> xmlnsAtomData;
-
 inline const AtomString& nullAtom() { return nullAtomData.get(); }
 inline const AtomString& emptyAtom() { return emptyAtomData.get(); }
-inline const AtomString& starAtom() { return starAtomData.get(); }
-inline const AtomString& xmlAtom() { return xmlAtomData.get(); }
-inline const AtomString& xmlnsAtom() { return xmlnsAtomData.get(); }
 
 inline AtomString::AtomString(ASCIILiteral literal)
     : m_string(literal.length() ? AtomStringImpl::add(literal.characters(), literal.length()) : Ref { *emptyAtom().impl() })
@@ -377,8 +368,5 @@ template<> struct IntegerToStringConversionTrait<AtomString> {
 using WTF::AtomString;
 using WTF::nullAtom;
 using WTF::emptyAtom;
-using WTF::starAtom;
-using WTF::xmlAtom;
-using WTF::xmlnsAtom;
 
 #include <wtf/text/StringConcatenate.h>

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -88,36 +88,6 @@ static inline Ref<AtomStringImpl> addToStringTable(const T& value)
     return addToStringTable<T, HashTranslator>(locker, stringTable(), value);
 }
 
-struct CStringTranslator {
-    static unsigned hash(const LChar* characters)
-    {
-        return StringHasher::computeHashAndMaskTop8Bits(characters);
-    }
-
-    static inline bool equal(PackedPtr<StringImpl> str, const LChar* characters)
-    {
-        return WTF::equal(str.get(), characters);
-    }
-
-    static void translate(PackedPtr<StringImpl>& location, const LChar* const& characters, unsigned hash)
-    {
-        auto* pointer = &StringImpl::create(characters).leakRef();
-        pointer->setHash(hash);
-        pointer->setIsAtom(true);
-        location = pointer;
-    }
-};
-
-RefPtr<AtomStringImpl> AtomStringImpl::add(const LChar* characters)
-{
-    if (!characters)
-        return nullptr;
-    if (!*characters)
-        return static_cast<AtomStringImpl*>(StringImpl::empty());
-
-    return addToStringTable<const LChar*, CStringTranslator>(characters);
-}
-
 using UCharBuffer = HashTranslatorCharBuffer<UChar>;
 struct UCharBufferTranslator {
     static unsigned hash(const UCharBuffer& buf)
@@ -213,22 +183,6 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(const UChar* characters, unsigned len
 {
     if (!characters)
         return nullptr;
-
-    if (!length)
-        return static_cast<AtomStringImpl*>(StringImpl::empty());
-
-    UCharBuffer buffer { characters, length };
-    return addToStringTable<UCharBuffer, UCharBufferTranslator>(buffer);
-}
-
-RefPtr<AtomStringImpl> AtomStringImpl::add(const UChar* characters)
-{
-    if (!characters)
-        return nullptr;
-
-    unsigned length = 0;
-    while (characters[length] != UChar(0))
-        ++length;
 
     if (!length)
         return static_cast<AtomStringImpl*>(StringImpl::empty());

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -39,12 +39,9 @@ public:
 
     static void remove(AtomStringImpl*);
 
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const LChar*);
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(const char* s) { return add(reinterpret_cast<const LChar*>(s)); };
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const LChar*, unsigned length);
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const UChar*, unsigned length);
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(const char* s, unsigned length) { return add(reinterpret_cast<const LChar*>(s), length); };
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const UChar*);
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(const char* s, unsigned length) { return add(reinterpret_cast<const LChar*>(s), length); }
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(StringImpl*, unsigned offset, unsigned length);
     ALWAYS_INLINE static RefPtr<AtomStringImpl> add(StringImpl* string)
     {
@@ -59,7 +56,10 @@ public:
         return add(string.releaseNonNull());
     }
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const StaticStringImpl*);
-    WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(const char* characters, unsigned length);
+    ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.characters(), literal.length()); }
+
+    // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(s, strlen(s)) : nullptr; }
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
     static RefPtr<AtomStringImpl> addUTF8(const char* start, const char* end);
@@ -100,6 +100,8 @@ private:
         }
         return addSlowCase(WTFMove(string));
     }
+
+    WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(const char* characters, unsigned length);
 
     ALWAYS_INLINE static Ref<AtomStringImpl> add(AtomStringTable& stringTable, StringImpl& string)
     {

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -319,21 +319,6 @@ Ref<StringImpl> StringImpl::create8BitIfPossible(const UChar* characters, unsign
     return string;
 }
 
-Ref<StringImpl> StringImpl::create8BitIfPossible(const UChar* string)
-{
-    return StringImpl::create8BitIfPossible(string, lengthOfNullTerminatedString(string));
-}
-
-Ref<StringImpl> StringImpl::create(const LChar* string)
-{
-    if (!string)
-        return *empty();
-    size_t length = strlen(reinterpret_cast<const char*>(string));
-    if (length > MaxLength)
-        CRASH();
-    return create(string, length);
-}
-
 Ref<StringImpl> StringImpl::substring(unsigned start, unsigned length)
 {
     if (start >= m_length)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -237,13 +237,12 @@ public:
 
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(const UChar*, unsigned length);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(const LChar*, unsigned length);
+    ALWAYS_INLINE static Ref<StringImpl> create(const char* characters, unsigned length) { return create(reinterpret_cast<const LChar*>(characters), length); }
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(const UChar*, unsigned length);
     template<size_t inlineCapacity> static Ref<StringImpl> create8BitIfPossible(const Vector<UChar, inlineCapacity>&);
-    WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(const UChar*);
 
-    ALWAYS_INLINE static Ref<StringImpl> create(const char* characters, unsigned length) { return create(reinterpret_cast<const LChar*>(characters), length); }
-    WTF_EXPORT_PRIVATE static Ref<StringImpl> create(const LChar*);
-    ALWAYS_INLINE static Ref<StringImpl> create(const char* string) { return create(reinterpret_cast<const LChar*>(string)); }
+    // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
+    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(characters, strlen(characters)); }
 
     static Ref<StringImpl> createSubstringSharingImpl(StringImpl&, unsigned offset, unsigned length);
 
@@ -609,8 +608,6 @@ int codePointCompare(const StringImpl*, const StringImpl*);
 bool isSpaceOrNewline(UChar32);
 bool isNotSpaceOrNewline(UChar32);
 
-template<typename CharacterType> unsigned lengthOfNullTerminatedString(const CharacterType*);
-
 // StringHashd is the default hash for StringImpl* and RefPtr<StringImpl>
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<StringImpl*>;
@@ -773,17 +770,6 @@ inline bool isSpaceOrNewline(UChar32 character)
 inline bool isNotSpaceOrNewline(UChar32 character)
 {
     return !isSpaceOrNewline(character);
-}
-
-template<typename CharacterType> inline unsigned lengthOfNullTerminatedString(const CharacterType* string)
-{
-    ASSERT(string);
-    size_t length = 0;
-    while (string[length])
-        ++length;
-
-    RELEASE_ASSERT(length < StringImpl::MaxLength);
-    return static_cast<unsigned>(length);
 }
 
 inline StringImplShape::StringImplShape(unsigned refCount, unsigned length, const LChar* data8, unsigned hashAndFlags)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -46,13 +46,6 @@ String::String(const UChar* characters, unsigned length)
         m_impl = StringImpl::create(characters, length);
 }
 
-// Construct a string with UTF-16 data, from a null-terminated source.
-String::String(const UChar* nullTerminatedString)
-{
-    if (nullTerminatedString)
-        m_impl = StringImpl::create(nullTerminatedString, lengthOfNullTerminatedString(nullTerminatedString));
-}
-
 // Construct a string with latin1 data.
 String::String(const LChar* characters, unsigned length)
 {
@@ -70,7 +63,7 @@ String::String(const char* characters, unsigned length)
 String::String(const char* nullTerminatedString)
 {
     if (nullTerminatedString)
-        m_impl = StringImpl::create(reinterpret_cast<const LChar*>(nullTerminatedString));
+        m_impl = StringImpl::createFromCString(nullTerminatedString);
 }
 
 int codePointCompare(const String& a, const String& b)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -73,9 +73,6 @@ public:
     template<size_t inlineCapacity, typename OverflowHandler>
     explicit String(const Vector<UChar, inlineCapacity, OverflowHandler>&);
 
-    // Construct a string with UTF-16 data, from a null-terminated source.
-    WTF_EXPORT_PRIVATE String(const UChar*);
-
     // Construct a string with Latin-1 data.
     WTF_EXPORT_PRIVATE String(const LChar* characters, unsigned length);
     WTF_EXPORT_PRIVATE String(const char* characters, unsigned length);
@@ -275,7 +272,7 @@ public:
         : String(ucharFrom(characters), length) { }
 
     String(const wchar_t* characters)
-        : String(ucharFrom(characters)) { }
+        : String(characters, wcslen(characters)) { }
 
     WTF_EXPORT_PRIVATE Vector<wchar_t> wideCharacters() const;
 #endif

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -25,6 +25,7 @@
 #include "CSSParser.h"
 #include "CSSSelector.h"
 #include "CSSStyleSheet.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSMarkup.h"
 #include "CSSSelectorList.h"
+#include "CommonAtomStrings.h"
 #include "HTMLNames.h"
 #include "RuntimeEnabledFeatures.h"
 #include "SelectorPseudoTypeMap.h"

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -28,6 +28,7 @@
 #include "CSSSelectorList.h"
 
 #include "CSSParserSelector.h"
+#include "CommonAtomStrings.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "ElementInlines.h"
 #include "ElementRareData.h"

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -30,6 +30,7 @@
 #include "SelectorFilter.h"
 
 #include "CSSSelector.h"
+#include "CommonAtomStrings.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"
 #include "ShadowRoot.h"

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -26,6 +26,7 @@
 #include "CSSStyleSheet.h"
 #include "CachePolicy.h"
 #include "CachedCSSStyleSheet.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "Frame.h"
 #include "FrameLoader.h"

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSSelectorParser.h"
 
+#include "CommonAtomStrings.h"
 #include "RuntimeEnabledFeatures.h"
 #include <memory>
 #include <wtf/OptionSet.h>

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CommonAtomStrings.h"
 #include "DOMJITHelpers.h"
 #include "Element.h"
 #include "ElementData.h"

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -24,6 +24,7 @@
 #include "Attr.h"
 
 #include "AttributeChangeInvalidation.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "ElementInlines.h"
 #include "Event.h"

--- a/Source/WebCore/dom/Attribute.h
+++ b/Source/WebCore/dom/Attribute.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CommonAtomStrings.h"
 #include "QualifiedName.h"
 #include <wtf/Hasher.h>
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -28,6 +28,7 @@
 #include "ChildChangeInvalidation.h"
 #include "ChildListMutationScope.h"
 #include "ClassCollection.h"
+#include "CommonAtomStrings.h"
 #include "CommonVM.h"
 #include "ContainerNodeAlgorithms.h"
 #include "Editor.h"

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -28,6 +28,7 @@
 #include "AXObjectCache.h"
 #include "Attr.h"
 #include "ChildListMutationScope.h"
+#include "CommonAtomStrings.h"
 #include "CommonVM.h"
 #include "ComposedTreeAncestorIterator.h"
 #include "ContainerNodeAlgorithms.h"

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "ChildNodeList.h"
+#include "CommonAtomStrings.h"
 #include "HTMLCollection.h"
 #include "MutationObserverRegistration.h"
 #include "QualifiedName.h"

--- a/Source/WebCore/dom/QualifiedName.cpp
+++ b/Source/WebCore/dom/QualifiedName.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "QualifiedName.h"
 
+#include "CommonAtomStrings.h"
 #include "QualifiedNameCache.h"
 #include "ThreadGlobalData.h"
 #include <wtf/Assertions.h>

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -28,6 +28,7 @@
 #include "SelectorQuery.h"
 
 #include "CSSParser.h"
+#include "CommonAtomStrings.h"
 #include "ElementIterator.h"
 #include "HTMLNames.h"
 #include "SelectorChecker.h"

--- a/Source/WebCore/dom/TagCollection.h
+++ b/Source/WebCore/dom/TagCollection.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "CachedHTMLCollection.h"
+#include "CommonAtomStrings.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -29,6 +29,7 @@
 
 #include "CDATASection.h"
 #include "Comment.h"
+#include "CommonAtomStrings.h"
 #include "DocumentFragment.h"
 #include "DocumentType.h"
 #include "Editor.h"

--- a/Source/WebCore/html/LabelableElement.cpp
+++ b/Source/WebCore/html/LabelableElement.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "LabelableElement.h"
 
+#include "CommonAtomStrings.h"
 #include "LabelsNodeList.h"
 #include "NodeRareData.h"
 #include "RenderStyle.h"

--- a/Source/WebCore/html/LabelsNodeList.cpp
+++ b/Source/WebCore/html/LabelsNodeList.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "LabelsNodeList.h"
 
+#include "CommonAtomStrings.h"
 #include "HTMLLabelElement.h"
 #include "HTMLNames.h"
 #include "LabelableElement.h"

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "HTMLTreeBuilder.h"
 
+#include "CommonAtomStrings.h"
 #include "DocumentFragment.h"
 #include "HTMLDocument.h"
 #include "HTMLDocumentParser.h"

--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -47,13 +47,16 @@ namespace WebCore {
     macro(plaintextOnly, "plaintext-only") \
     macro(reset, "reset") \
     macro(search, "search") \
+    macro(star, "star") \
     macro(submit, "submit") \
     macro(subtitles, "subtitles") \
     macro(tel, "tel") \
     macro(text, "text") \
     macro(textPlainContentType, "text/plain") \
     macro(true, "true") \
-    macro(url, "url")
+    macro(url, "url") \
+    macro(xml, "xml") \
+    macro(xmlns, "xmlns")
 
 
 #define DECLARE_COMMON_ATOM(atomName, atomValue) \

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -83,10 +83,10 @@ static bool getWebLocData(IDataObject* dataObject, String& url, String* title)
     
     if (title) {
         PathRemoveExtension(filename);
-        *title = String((UChar*)filename);
+        *title = String(filename);
     }
     
-    url = String((UChar*)urlBuffer);
+    url = String(urlBuffer);
     succeeded = true;
 
 exit:
@@ -448,7 +448,7 @@ String getURL(IDataObject* dataObject, DragData::FilenameConversionPolicy filena
 
     if (SUCCEEDED(dataObject->GetData(urlWFormat(), &store))) {
         // URL using Unicode
-        UChar* data = static_cast<UChar*>(GlobalLock(store.hGlobal));
+        auto* data = static_cast<wchar_t*>(GlobalLock(store.hGlobal));
         url = extractURL(String(data), title);
         GlobalUnlock(store.hGlobal);
         ReleaseStgMedium(&store);
@@ -519,7 +519,7 @@ String getPlainText(IDataObject* dataObject)
     String text;
     if (SUCCEEDED(dataObject->GetData(plainTextWFormat(), &store))) {
         // Unicode text
-        UChar* data = static_cast<UChar*>(GlobalLock(store.hGlobal));
+        auto* data = static_cast<wchar_t*>(GlobalLock(store.hGlobal));
         text = String(data);
         GlobalUnlock(store.hGlobal);
         ReleaseStgMedium(&store);
@@ -554,7 +554,7 @@ String getTextHTML(IDataObject* data)
     STGMEDIUM store;
     String html;
     if (SUCCEEDED(data->GetData(texthtmlFormat(), &store))) {
-        UChar* data = static_cast<UChar*>(GlobalLock(store.hGlobal));
+        auto* data = static_cast<wchar_t*>(GlobalLock(store.hGlobal));
         html = String(data);
         GlobalUnlock(store.hGlobal);
         ReleaseStgMedium(&store);

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -630,11 +630,11 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
     }
 
     if (extension.isEmpty())
-        return String(fsPathBuffer);
+        return String(wcharFrom(fsPathBuffer));
 
     if (!isLink && usedURL) {
         PathRenameExtension(wcharFrom(fsPathBuffer), extension.wideCharacters().data());
-        return String(fsPathBuffer);
+        return String(wcharFrom(fsPathBuffer));
     }
 
     return makeString(const_cast<const UChar*>(fsPathBuffer), extension);
@@ -829,7 +829,7 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy, std:
 {
     if (::IsClipboardFormatAvailable(CF_UNICODETEXT) && ::OpenClipboard(m_owner)) {
         if (HANDLE cbData = ::GetClipboardData(CF_UNICODETEXT)) {
-            text.text = static_cast<UChar*>(GlobalLock(cbData));
+            text.text = static_cast<wchar_t*>(GlobalLock(cbData));
             GlobalUnlock(cbData);
             ::CloseClipboard();
             return;
@@ -872,7 +872,7 @@ RefPtr<DocumentFragment> Pasteboard::documentFragment(Frame& frame, const Simple
         if (::OpenClipboard(m_owner)) {
             HANDLE cbData = ::GetClipboardData(CF_UNICODETEXT);
             if (cbData) {
-                UChar* buffer = static_cast<UChar*>(GlobalLock(cbData));
+                auto* buffer = static_cast<wchar_t*>(GlobalLock(cbData));
                 String str(buffer);
                 GlobalUnlock(cbData);
                 ::CloseClipboard();

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -75,7 +75,7 @@ void RenderMathMLFenced::updateFromElement()
         m_separators = !characters.length() ? 0 : characters.toString().impl();
     } else {
         // The separator defaults to a single comma.
-        m_separators = StringImpl::create(",");
+        m_separators = StringImpl::createFromLiteral(","_s);
     }
 
     if (firstChild()) {

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "PageRuleCollector.h"
 
+#include "CommonAtomStrings.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include "UserAgentStyle.h"

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -33,6 +33,7 @@
 #include "CSSKeyframesRule.h"
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CommonAtomStrings.h"
 #include "HTMLNames.h"
 #include "MediaQueryEvaluator.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CSSSelector.h"
+#include "CommonAtomStrings.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -33,6 +33,7 @@
 #include "CSSKeyframesRule.h"
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CommonAtomStrings.h"
 #include "HTMLNames.h"
 #include "MediaQueryEvaluator.h"
 #include "RuleSetBuilder.h"

--- a/Source/WebCore/xml/NativeXPathNSResolver.cpp
+++ b/Source/WebCore/xml/NativeXPathNSResolver.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "NativeXPathNSResolver.h"
 
+#include "CommonAtomStrings.h"
 #include "Node.h"
 #include "XMLNames.h"
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/xml/XPathStep.cpp
+++ b/Source/WebCore/xml/XPathStep.cpp
@@ -29,6 +29,7 @@
 #include "XPathStep.h"
 
 #include "Attr.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "ElementInlines.h"
 #include "HTMLElement.h"

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -28,6 +28,7 @@
 
 #include "CDATASection.h"
 #include "Comment.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "DocumentFragment.h"
 #include "DocumentType.h"

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -31,6 +31,7 @@
 #include "CDATASection.h"
 #include "Comment.h"
 #include "CachedResourceLoader.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "DocumentFragment.h"
 #include "DocumentType.h"

--- a/Source/WebKitLegacy/win/DOMCoreClasses.cpp
+++ b/Source/WebKitLegacy/win/DOMCoreClasses.cpp
@@ -416,7 +416,7 @@ HRESULT DOMNode::setTextContent(_In_ BSTR /*text*/)
 HRESULT DOMNode::addEventListener(_In_ BSTR type, _In_opt_ IDOMEventListener* listener, BOOL useCapture)
 {
     auto webListener = WebEventListener::create(listener);
-    m_node->addEventListener(ucharFrom(type), WTFMove(webListener), useCapture);
+    m_node->addEventListener(String(type), WTFMove(webListener), useCapture);
 
     return S_OK;
 }
@@ -428,7 +428,7 @@ HRESULT DOMNode::removeEventListener(_In_ BSTR type, _In_opt_ IDOMEventListener*
     if (!m_node)
         return E_FAIL;
     auto webListener = WebEventListener::create(listener);
-    m_node->removeEventListener(ucharFrom(type), webListener, useCapture);
+    m_node->removeEventListener(String(type), webListener, useCapture);
     return S_OK;
 }
 
@@ -926,7 +926,7 @@ HRESULT DOMWindow::addEventListener(_In_ BSTR type, _In_opt_ IDOMEventListener* 
     if (!m_window)
         return E_FAIL;
     auto webListener = WebEventListener::create(listener);
-    m_window->addEventListener(ucharFrom(type), WTFMove(webListener), useCapture);
+    m_window->addEventListener(String(type), WTFMove(webListener), useCapture);
     return S_OK;
 }
 
@@ -937,7 +937,7 @@ HRESULT DOMWindow::removeEventListener(_In_ BSTR type, _In_opt_ IDOMEventListene
     if (!m_window)
         return E_FAIL;
     auto webListener = WebEventListener::create(listener);
-    m_window->removeEventListener(ucharFrom(type), webListener, useCapture);
+    m_window->removeEventListener(String(type), webListener, useCapture);
     return S_OK;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -119,7 +119,7 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)
     auto b = StringImpl::createFromLiteral("ABCDEFG"_s);
     auto c = StringImpl::createFromLiteral("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     auto shorter = StringImpl::createFromLiteral("abcdef"_s);
     auto different = StringImpl::createFromLiteral("abcrefg"_s);
 
@@ -162,8 +162,8 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseWithNull)
 
 TEST(WTF, StringImplEqualIgnoringASCIICaseWithEmpty)
 {
-    auto a = StringImpl::create(reinterpret_cast<const LChar*>(""));
-    auto b = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto a = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    auto b = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     ASSERT_TRUE(equalIgnoringASCIICase(a.ptr(), b.ptr()));
     ASSERT_TRUE(equalIgnoringASCIICase(b.ptr(), a.ptr()));
 }
@@ -341,7 +341,7 @@ TEST(WTF, StringImplFindIgnoringASCIICaseOnNull)
 TEST(WTF, StringImplFindIgnoringASCIICaseOnEmpty)
 {
     auto reference = stringFromUTF8("ABCÉEFG");
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr()));
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr(), 0));
     EXPECT_EQ(static_cast<size_t>(3), reference->findIgnoringASCIICase(empty.ptr(), 3));
@@ -417,14 +417,14 @@ TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::createFromLiteral("aBcDeFG"_s);
     ASSERT_FALSE(reference->startsWithIgnoringASCIICase(StringView { }));
 
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     ASSERT_FALSE(empty->startsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::createFromLiteral("aBcDeFG"_s);
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->startsWithIgnoringASCIICase(empty.ptr()));
@@ -506,14 +506,14 @@ TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::createFromLiteral("aBcDeFG"_s);
     ASSERT_FALSE(reference->endsWithIgnoringASCIICase(StringView { }));
 
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     ASSERT_FALSE(empty->endsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::createFromLiteral("aBcDeFG"_s);
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->endsWithIgnoringASCIICase(empty.ptr()));

--- a/Tools/TestWebKitAPI/Tests/WTF/StringOperators.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringOperators.cpp
@@ -258,7 +258,7 @@ TEST(WTF, ConcatenateCharacterArrayAndEmptyString)
     UChar ucharArray[] = { 't', 'e', 's', 't', '\0' };
     String concatenation16 = ucharArray + emptyString;
     ASSERT_EQ(static_cast<unsigned>(4), concatenation16.length());
-    ASSERT_TRUE(concatenation16 == String(ucharArray));
+    ASSERT_TRUE(concatenation16 == String(ucharArray, 4));
 
     LChar lcharArray[] = { 't', 'e', 's', 't' };
     String concatenation8 = String(lcharArray, 4) + emptyString;

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -339,7 +339,7 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
     RefPtr<StringImpl> b = StringImpl::createFromLiteral("ABCDEFG"_s);
     RefPtr<StringImpl> c = StringImpl::createFromLiteral("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    RefPtr<StringImpl> empty = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    RefPtr<StringImpl> empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     RefPtr<StringImpl> shorter = StringImpl::createFromLiteral("abcdef"_s);
     RefPtr<StringImpl> different = StringImpl::createFromLiteral("abcrefg"_s);
 
@@ -384,8 +384,8 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 {
-    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>(""));
-    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>(""));
+    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     ASSERT_TRUE(equalIgnoringASCIICase(stringViewA, stringViewB));
@@ -394,10 +394,10 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithLatin1Characters)
 {
-    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>("aBcéeFG"));
-    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>("ABCÉEFG"));
-    RefPtr<StringImpl> c = StringImpl::create(reinterpret_cast<const LChar*>("ABCéEFG"));
-    RefPtr<StringImpl> d = StringImpl::create(reinterpret_cast<const LChar*>("abcéefg"));
+    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>("aBcéeFG"), 7);
+    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>("ABCÉEFG"), 7);
+    RefPtr<StringImpl> c = StringImpl::create(reinterpret_cast<const LChar*>("ABCéEFG"), 7);
+    RefPtr<StringImpl> d = StringImpl::create(reinterpret_cast<const LChar*>("abcéefg"), 7);
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     StringView stringViewC(*c.get());
@@ -982,7 +982,7 @@ TEST(WTF, StringViewIsAllASCII)
     EXPECT_TRUE(StringView(String("Cocoa"_s)).isAllASCII());
     EXPECT_FALSE(StringView(String::fromLatin1("📱")).isAllASCII());
     EXPECT_FALSE(StringView(String::fromLatin1("\u0080")).isAllASCII());
-    EXPECT_TRUE(StringView(String(bitwise_cast<const UChar*>(u"Hello"))).isAllASCII());
+    EXPECT_TRUE(StringView(String(bitwise_cast<const UChar*>(u"Hello"), 0)).isAllASCII());
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -234,7 +234,7 @@ TEST(WTF_URLExtras, URLExtras_ParsingError)
     EXPECT_STREQ([[url2 absoluteString] UTF8String], "http://%E2%89%A7%E2%88%AE%EF%B9%A3%D9%A1%DB%B1");
 
     std::array<UChar, 3> utf16 { 0xC2, 0xB6, 0x00 };
-    WTF::URL url3 { String(utf16.data()) };
+    WTF::URL url3 { String(utf16.data(), utf16.size()) };
     EXPECT_FALSE(url3.string().is8Bit());
     EXPECT_FALSE(url3.isValid());
     EXPECT_STREQ([[url3 absoluteString] UTF8String], "%C3%82%C2%B6");


### PR DESCRIPTION
#### bfa84bca0e98f9110a4d14d6492c27ae55eb6498
<pre>
Move starAtom() / xmlAtom() / xmlnsAtom() from WTF to WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=239969">https://bugs.webkit.org/show_bug.cgi?id=239969</a>

Reviewed by NOBODY (OOPS!).

Move starAtom() / xmlAtom() / xmlnsAtom() from WTF to WebCore since
they are not useful outside WebCore.

* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::init):
* Source/WTF/wtf/text/AtomString.h:
(WTF::emptyAtom):
(WTF::starAtom): Deleted.
(WTF::xmlAtom): Deleted.
(WTF::xmlnsAtom): Deleted.
* Source/WebCore/css/CSSPageRule.cpp:
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/CSSSelectorList.cpp:
* Source/WebCore/css/SelectorChecker.cpp:
* Source/WebCore/css/SelectorFilter.cpp:
* Source/WebCore/css/StyleSheetContents.cpp:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
* Source/WebCore/dom/Attr.cpp:
* Source/WebCore/dom/Attribute.h:
* Source/WebCore/dom/ContainerNode.cpp:
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/dom/QualifiedName.cpp:
* Source/WebCore/dom/SelectorQuery.cpp:
* Source/WebCore/dom/TagCollection.h:
* Source/WebCore/editing/MarkupAccumulator.cpp:
* Source/WebCore/html/LabelableElement.cpp:
* Source/WebCore/html/LabelsNodeList.cpp:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
* Source/WebCore/platform/CommonAtomStrings.h:
* Source/WebCore/style/PageRuleCollector.cpp:
* Source/WebCore/style/RuleData.cpp:
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
* Source/WebCore/xml/NativeXPathNSResolver.cpp:
* Source/WebCore/xml/XPathStep.cpp:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
</pre>
----------------------------------------------------------------------
#### 47382f2866d7b7150ea941715fd5f188d8e44636
<pre>
Drop some unused StringImpl / AtomStringImpl / AtomString API
<a href="https://bugs.webkit.org/show_bug.cgi?id=239912">https://bugs.webkit.org/show_bug.cgi?id=239912</a>

Reviewed by Yusuke Suzuki.

Simplifies our API a bit and encourages people to write more efficient
code.

* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringOperators.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST):
* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::decode const):
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::addLiteral): Deleted.
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::Identifier):
(JSC::Identifier::add):
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::inferBuiltinTag):
(JSC::objectPrototypeToString):
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
(JSC::SmallStrings::initializeCommonStrings):
(JSC::SmallStrings::initialize):
* Source/JavaScriptCore/runtime/SmallStrings.h:
* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::AtomString):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::CStringTranslator::hash): Deleted.
(WTF::CStringTranslator::equal): Deleted.
(WTF::CStringTranslator::translate): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.h:
* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::create):
(WTF::StringImpl::createFromCString):
(WTF::lengthOfNullTerminatedString): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp:
(WebCore::RenderMathMLFenced::updateFromElement):
</pre>