### PR TITLE
[ iOS ][ macOS ] css3/calc/transitions-dependent.html is a flaky failure

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,12 @@
+2022-05-03  Karl Rackler  <rackler@apple.com>
+
+        REGRESSION (r293427): [ iOS ] http/tests/quicklook/same-origin-xmlhttprequest-allowed.html is a constant failure and crash
+        https://bugs.webkit.org/show_bug.cgi?id=240024
+
+        Unreviewed test gardening. 
+
+        * platform/ios/TestExpectations:
+
 2022-05-03  Sihui Liu  <sihui_liu@apple.com>
 
         StorageMap::removeItem may fail to remove item from map

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3589,3 +3589,5 @@ webkit.org/b/239567 tables/mozilla/bugs/bug26178.html [ Pass Failure ]
 
 # iOS has a WebGPU implementation.
 http/tests/webgpu [ Pass ]
+
+webkit.org/b/240024 http/tests/quicklook/same-origin-xmlhttprequest-allowed.html [ Pass Failure Crash ]


### PR DESCRIPTION
#### 1c985ce6d18dc194864a18ce49af0fd80b68ab2b
<pre>
[ iOS ][ macOS ] css3/calc/transitions-dependent.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=239990">https://bugs.webkit.org/show_bug.cgi?id=239990</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
</pre>