### PR TITLE
Optimize / simplify slow case in StringView::convertASCIILowercaseAtom()

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -253,16 +253,8 @@ template<typename CharacterType>
 static AtomString convertASCIILowercaseAtom(const CharacterType* input, unsigned length)
 {
     for (unsigned i = 0; i < length; ++i) {
-        if (UNLIKELY(isASCIIUpper(input[i]))) {
-            CharacterType* characters;
-            auto result = String::createUninitialized(length, characters);
-            StringImpl::copyCharacters(characters, input, i);
-            for (; i < length; ++i)
-                characters[i] = toASCIILower(input[i]);
-            // FIXME: This is inefficient. Ideally, we wouldn't have to allocate a String/StringImpl if the
-            // string is already in the AtomStringTable.
-            return AtomString(result);
-        }
+        if (UNLIKELY(isASCIIUpper(input[i])))
+            return makeAtomString(lowercase(StringView { input, length }));
     }
     // Fast path when the StringView is already all lowercase.
     return AtomString(input, length);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3014,6 +3014,7 @@ private:
     bool m_isShowingNavigationGestureSnapshot { false };
 
     bool m_mainFramePluginHandlesPageScaleGesture { false };
+    bool m_shouldReloadDueToCrashWhenVisible { false };
 
     unsigned m_pageCount { 0 };
 


### PR DESCRIPTION
#### 4c741ae212fadd4d6754704fe5a737569790efde
<pre>
Optimize / simplify slow case in StringView::convertASCIILowercaseAtom()
<a href="https://bugs.webkit.org/show_bug.cgi?id=240082">https://bugs.webkit.org/show_bug.cgi?id=240082</a>

Reviewed by NOBODY (OOPS!).

Optimize / simplify slow case in StringView::convertASCIILowercaseAtom() where the input string
is not already lowercase. We now call `makeAtomString(lowercase(input))` which simplifies the
code a lot and is actually more efficient because makeAtomString() has an optimization that
avoids a StringImpl allocation when the string is relatively small (&lt; 64 characters) and is
already part of the AtomStringTable already.

I validated the implementation by running it in a loop with the String &quot;BODY&quot; and got a
~35% speedup.

* Source/WTF/wtf/text/StringView.cpp:
(WTF::convertASCIILowercaseAtom):
</pre>
----------------------------------------------------------------------
#### 5eec25d248f578d73a1989411a210a30d2741be4
<pre>
WebKit should only reload WebViews automatically on crash if the view is visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=240079">https://bugs.webkit.org/show_bug.cgi?id=240079</a>
&lt;rdar://92442052 &gt;

Reviewed by NOBODY (OOPS!).

If the client app doesn&apos;t override WKNavigationDelegate.webViewWebContentProcessDidTerminate,
WebKit would previously reload the web view automatically. However, for some apps with a lot
of non-visible WebViews, this could cause a lot of churn when coming back to the foreground,
after many of these WebContent processes were jetsammed in the background.

To address this, WebKit now delays the automatic web view reload until the view becomes
visible (still reloads right away when the view is visible when the crash occurs).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::activityStateDidChange):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::dispatchProcessDidTerminate):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre>