### PR TITLE
[ iOS ] fast/text/international/system-language/navigator-language/navigator-language-fr.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3603,8 +3603,6 @@ webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-lo
 
 webkit.org/b/240081 webaudio/AudioBuffer/huge-buffer.html [ Pass Timeout ]
 
-webkit.org/b/240104 fast/text/international/system-language/navigator-language/navigator-language-fr.html [ Pass Failure ]
-
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 
 webkit.org/b/239568 imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-url-in-main-window-self-navigate-inherits.sub.html [ Pass Failure ]

--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -159,7 +159,7 @@
     }
 
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    JSC::JSArray* result = globalObject->moduleLoader()->dependencyKeysIfEvaluated(globalObject, JSC::jsString(vm, [[script sourceURL] absoluteString]));
+    JSC::JSArray* result = globalObject->moduleLoader()->dependencyKeysIfEvaluated(globalObject, JSC::jsString(vm, String([[script sourceURL] absoluteString])));
     if (scope.exception()) {
         JSValueRef exceptionValue = toRef(globalObject, scope.exception()->value());
         scope.clearException();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4460,7 +4460,7 @@ static void processClauseList(ClauseListNode* list, Vector<ExpressionNode*, 8>& 
                 typeForTable = SwitchNeither;
                 break;
             }
-            const String& value = static_cast<StringNode*>(clauseExpression)->value().string();
+            auto& value = static_cast<StringNode*>(clauseExpression)->value().string();
             if (singleCharacterSwitch &= value.length() == 1) {
                 int32_t intVal = value[0];
                 if (intVal < min_num)

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2580,7 +2580,7 @@ JSC_DEFINE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject* globa
     String lowercasedString = inputString.is8Bit() ? inputString.convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(failingIndex) : inputString.convertToLowercaseWithoutLocale();
     if (lowercasedString.impl() == inputString.impl())
         return string;
-    RELEASE_AND_RETURN(scope, jsString(vm, lowercasedString));
+    RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(lowercasedString)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationInt32ToString, char*, (JSGlobalObject* globalObject, int32_t value, int32_t radix))

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -266,7 +266,7 @@ JSValue JSInjectedScriptHost::functionDetails(JSGlobalObject* globalObject, Call
 
     String scriptID = String::number(sourceCode->provider()->asID());
     JSObject* location = constructEmptyObject(globalObject);
-    location->putDirect(vm, Identifier::fromString(vm, "scriptId"_s), jsString(vm, scriptID));
+    location->putDirect(vm, Identifier::fromString(vm, "scriptId"_s), jsString(vm, WTFMove(scriptID)));
     location->putDirect(vm, Identifier::fromString(vm, "lineNumber"_s), jsNumber(lineNumber));
     location->putDirect(vm, Identifier::fromString(vm, "columnNumber"_s), jsNumber(columnNumber));
 
@@ -275,11 +275,11 @@ JSValue JSInjectedScriptHost::functionDetails(JSGlobalObject* globalObject, Call
 
     String name = function->name(vm);
     if (!name.isEmpty())
-        result->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, name));
+        result->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, WTFMove(name)));
 
     String displayName = function->displayName(vm);
     if (!displayName.isEmpty())
-        result->putDirect(vm, Identifier::fromString(vm, "displayName"_s), jsString(vm, displayName));
+        result->putDirect(vm, Identifier::fromString(vm, "displayName"_s), jsString(vm, WTFMove(displayName)));
 
     return result;
 }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2280,7 +2280,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentGetReport, (JSGlobalObject* globalOb
     if (!string)
         return JSValue::encode(jsNull());
     
-    return JSValue::encode(jsString(vm, string));
+    return JSValue::encode(jsString(vm, WTFMove(string)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionDollarAgentLeaving, (JSGlobalObject*, CallFrame*))
@@ -2305,7 +2305,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWaitForReport, (JSGlobalObject* globalObject, C
     if (!string)
         return JSValue::encode(jsNull());
     
-    return JSValue::encode(jsString(vm, string));
+    return JSValue::encode(jsString(vm, WTFMove(string)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionHeapCapacity, (JSGlobalObject* globalObject, CallFrame*))
@@ -2755,7 +2755,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshotForGCDebugging, (JSGlobalOb
         jsonString = snapshotBuilder.json();
     }
     scope.releaseAssertNoException();
-    return JSValue::encode(jsString(vm, jsonString));
+    return JSValue::encode(jsString(vm, WTFMove(jsonString)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionResetSuperSamplerState, (JSGlobalObject*, CallFrame*))

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -210,7 +210,7 @@ bool addErrorInfo(VM& vm, Vector<StackFrame>* stackTrace, JSObject* obj)
         obj->putDirect(vm, vm.propertyNames->line, jsNumber(line));
         obj->putDirect(vm, vm.propertyNames->column, jsNumber(column));
         if (!sourceURL.isEmpty())
-            obj->putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, sourceURL));
+            obj->putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTFMove(sourceURL)));
 
         obj->putDirect(vm, vm.propertyNames->stack, jsString(vm, Interpreter::stackTraceAsString(vm, *stackTrace)), static_cast<unsigned>(PropertyAttribute::DontEnum));
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -141,7 +141,7 @@ void ErrorInstance::finishCreation(VM& vm, JSGlobalObject* globalObject, const S
     }
 
     if (!messageWithSource.isNull())
-        putDirect(vm, vm.propertyNames->message, jsString(vm, messageWithSource), static_cast<unsigned>(PropertyAttribute::DontEnum));
+        putDirect(vm, vm.propertyNames->message, jsString(vm, WTFMove(messageWithSource)), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     if (!cause.isEmpty())
         putDirect(vm, vm.propertyNames->cause, cause, static_cast<unsigned>(PropertyAttribute::DontEnum));

--- a/Source/JavaScriptCore/runtime/ErrorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorPrototype.cpp
@@ -117,11 +117,11 @@ JSC_DEFINE_HOST_FUNCTION(errorProtoFuncToString, (JSGlobalObject* globalObject, 
 
     // 8. If name is the empty String, return msg.
     if (!nameString.length())
-        return JSValue::encode(message.isString() ? message : jsString(vm, messageString));
+        return JSValue::encode(message.isString() ? message : jsString(vm, WTFMove(messageString)));
 
     // 9. If msg is the empty String, return name.
     if (!messageString.length())
-        return JSValue::encode(name.isString() ? name : jsString(vm, nameString));
+        return JSValue::encode(name.isString() ? name : jsString(vm, WTFMove(nameString)));
 
     // 10. Return the result of concatenating name, ":", a single space character, and msg.
     RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, nameString, ": ", messageString)));

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -227,10 +227,10 @@ JSString* FunctionExecutable::toStringSlow(JSGlobalObject* globalObject)
         parametersStartOffset(),
         parametersStartOffset() + source().length());
 
-    String name = this->name().string();
+    auto name = this->name().string();
     if (name == vm.propertyNames->starDefaultPrivateName.string())
-        name = emptyString();
-    return cacheIfNoException(jsMakeNontrivialString(globalObject, functionHeader, name, src));
+        name = emptyAtom();
+    return cacheIfNoException(jsMakeNontrivialString(globalObject, functionHeader, WTFMove(name), src));
 }
 
 void FunctionExecutable::overrideInfo(const FunctionOverrideInfo& overrideInfo)

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -86,13 +86,11 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(StringImpl& impl)
 class Identifier {
     friend class Structure;
 public:
-    Identifier() { }
+    Identifier() = default;
     enum EmptyIdentifierFlag { EmptyIdentifier };
     Identifier(EmptyIdentifierFlag) : m_string(StringImpl::empty()) { ASSERT(m_string.impl()->isAtom()); }
 
-    // FIXME: Consider renaming atomString() to string() and always return an AtomString.
-    const AtomString& atomString() const { return m_string; }
-    const String& string() const { return m_string.string(); }
+    const AtomString& string() const { return m_string; }
 
     UniquedStringImpl* impl() const { return static_cast<UniquedStringImpl*>(m_string.impl()); }
 

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -129,14 +129,14 @@ inline JSValue identifierToJSValue(VM& vm, const Identifier& identifier)
 {
     if (identifier.isSymbol())
         return Symbol::create(vm, static_cast<SymbolImpl&>(*identifier.impl()));
-    return jsString(vm, String { identifier.impl() });
+    return jsString(vm, identifier.string());
 }
 
 inline JSValue identifierToSafePublicJSValue(VM& vm, const Identifier& identifier) 
 {
     if (identifier.isSymbol() && !identifier.isPrivateName())
         return Symbol::create(vm, static_cast<SymbolImpl&>(*identifier.impl()));
-    return jsString(vm, String { identifier.impl() });
+    return jsString(vm, identifier.string());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1290,7 +1290,7 @@ JSValue IntlDateTimeFormat::format(JSGlobalObject* globalObject, double value) c
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format date value"_s);
 
-    return jsString(vm, String(result));
+    return jsString(vm, String(WTFMove(result)));
 }
 
 static ASCIILiteral partTypeString(UDateFormatField field)
@@ -1613,7 +1613,7 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
         return { };
     }
 
-    return jsString(vm, String(buffer));
+    return jsString(vm, String(WTFMove(buffer)));
 #endif
 }
 

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -338,8 +338,8 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
 
         buffer = vm.intlCache().getFieldDisplayName(m_localeCString.data(), field.value(), style, status);
         if (U_FAILURE(status))
-            return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, code);
-        return jsString(vm, String(buffer));
+            return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, WTFMove(code));
+        return jsString(vm, String(WTFMove(buffer)));
     }
     }
     if (U_FAILURE(status)) {
@@ -349,7 +349,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
             return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, String(canonicalCode.data(), canonicalCode.length()));
         return throwTypeError(globalObject, scope, "Failed to query a display name."_s);
     }
-    return jsString(vm, String(buffer));
+    return jsString(vm, String(WTFMove(buffer)));
 }
 
 // https://tc39.es/proposal-intl-displaynames/#sec-Intl.DisplayNames.prototype.resolvedOptions

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -226,7 +226,7 @@ JSValue IntlListFormat::format(JSGlobalObject* globalObject, JSValue list) const
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
 
-    return jsString(vm, String(result));
+    return jsString(vm, String(WTFMove(result)));
 #else
     UNUSED_PARAM(list);
     return throwTypeError(globalObject, scope, "failed to format list of strings"_s);

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -270,7 +270,7 @@ JSValue IntlRelativeTimeFormat::format(JSGlobalObject* globalObject, double valu
     String result = formatInternal(globalObject, value, unit);
     RETURN_IF_EXCEPTION(scope, { });
 
-    return jsString(vm, result);
+    return jsString(vm, WTFMove(result));
 }
 
 // https://tc39.es/ecma402/#sec-FormatRelativeTimeToParts

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -629,7 +629,7 @@ void JSFunction::reifyName(VM& vm, JSGlobalObject* globalObject, String name)
         name = makeString("set ", name);
 
     rareData->setHasReifiedName();
-    putDirect(vm, propID, jsString(vm, name), initialAttributes);
+    putDirect(vm, propID, jsString(vm, WTFMove(name)), initialAttributes);
 }
 
 JSFunction::PropertyStatus JSFunction::reifyLazyPropertyIfNeeded(VM& vm, JSGlobalObject* globalObject, PropertyName propertyName)

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -232,7 +232,7 @@ JSInternalPromise* JSModuleLoader::requestImportModule(JSGlobalObject* globalObj
     ASSERT(callData.type != CallData::Type::None);
 
     MarkedArgumentBuffer arguments;
-    arguments.append(jsString(vm, String { moduleKey.impl() }));
+    arguments.append(jsString(vm, moduleKey.string()));
     arguments.append(parameters);
     arguments.append(scriptFetcher);
     ASSERT(!arguments.hasOverflowed());

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -50,7 +50,13 @@ class LLIntOffsetsExtractor;
 JSString* jsEmptyString(VM&);
 JSString* jsString(VM&, const String&); // returns empty string if passed null string
 JSString* jsString(VM&, String&&); // returns empty string if passed null string
+JSString* jsString(VM&, const AtomString&); // returns empty string if passed null string
+JSString* jsString(VM&, AtomString&&); // returns empty string if passed null string
 JSString* jsString(VM&, StringView); // returns empty string if passed null string
+
+JSString* jsString(VM&, RefPtr<AtomStringImpl>&&);
+JSString* jsString(VM&, Ref<AtomStringImpl>&&);
+JSString* jsString(VM&, Ref<StringImpl>&&);
 
 JSString* jsSingleCharacterString(VM&, UChar);
 JSString* jsSubstring(VM&, const String&, unsigned offset, unsigned length);
@@ -894,6 +900,16 @@ inline JSString* jsString(VM& vm, String&& s)
     return JSString::create(vm, s.releaseImpl().releaseNonNull());
 }
 
+ALWAYS_INLINE JSString* jsString(VM& vm, const AtomString& s)
+{
+    return jsString(vm, s.string());
+}
+
+ALWAYS_INLINE JSString* jsString(VM& vm, AtomString&& s)
+{
+    return jsString(vm, s.releaseString());
+}
+
 inline JSString* jsString(VM& vm, StringView s)
 {
     int size = s.length();
@@ -906,6 +922,21 @@ inline JSString* jsString(VM& vm, StringView s)
     }
     auto impl = s.is8Bit() ? StringImpl::create(s.characters8(), s.length()) : StringImpl::create(s.characters16(), s.length());
     return JSString::create(vm, WTFMove(impl));
+}
+
+ALWAYS_INLINE JSString* jsString(VM& vm, RefPtr<AtomStringImpl>&& s)
+{
+    return jsString(vm, String { WTFMove(s) });
+}
+
+ALWAYS_INLINE JSString* jsString(VM& vm, Ref<AtomStringImpl>&& s)
+{
+    return jsString(vm, String { WTFMove(s) });
+}
+
+ALWAYS_INLINE JSString* jsString(VM& vm, Ref<StringImpl>&& s)
+{
+    return jsString(vm, String { WTFMove(s) });
 }
 
 inline JSString* jsSubstring(VM& vm, JSGlobalObject* globalObject, JSString* base, unsigned offset, unsigned length)

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -77,7 +77,7 @@ inline JSString* repeatCharacter(JSGlobalObject* globalObject, CharacterType cha
 
     std::fill_n(buffer, repeatCount, character);
 
-    RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(impl)));
+    RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -332,7 +332,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
             }
         }
 
-        RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(impl)));
+        RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
     }
 
     UChar* buffer;
@@ -352,7 +352,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
         }
     }
 
-    RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(impl)));
+    RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
 static ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalObject, JSString* sourceVal, const String& source, const StringRange* substringRanges, int rangeCount, const String* separators, int separatorCount)
@@ -420,7 +420,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* 
             }
         }        
 
-        RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(impl)));
+        RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
     }
 
     UChar* buffer;
@@ -453,7 +453,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* 
         }
     }
 
-    RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(impl)));
+    RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
 #define OUT_OF_MEMORY(exec__, scope__) \
@@ -1624,7 +1624,7 @@ static EncodedJSValue toLocaleCase(JSGlobalObject* globalObject, CallFrame* call
         return throwVMTypeError(globalObject, scope, String::fromLatin1(u_errorName(status)));
 
     // 18. Return L.
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, String { buffer })));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, String { WTFMove(buffer) })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLocaleLowerCase, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1923,7 +1923,7 @@ static JSValue normalize(JSGlobalObject* globalObject, JSString* string, Normali
     unorm2_normalize(normalizer, characters, view.length(), buffer, normalizedStringLength, &status);
     ASSERT(U_SUCCESS(status));
 
-    RELEASE_AND_RETURN(scope, jsString(vm, WTFMove(result)));
+    RELEASE_AND_RETURN(scope, jsString(vm, result.releaseNonNull()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncNormalize, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
@@ -97,8 +97,8 @@ JSC_DEFINE_CUSTOM_GETTER(symbolProtoGetterDescription, (JSGlobalObject* globalOb
         return throwVMTypeError(globalObject, scope, SymbolDescriptionTypeError);
     scope.release();
     Integrity::auditStructureID(symbol->structureID());
-    const auto description = symbol->description();
-    return JSValue::encode(description.isNull() ? jsUndefined() : jsString(vm, description));
+    auto description = symbol->description();
+    return JSValue::encode(description.isNull() ? jsUndefined() : jsString(vm, WTFMove(description)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(symbolProtoFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -113,16 +113,6 @@ Vector<String> userPreferredLanguagesOverride()
     return preferredLanguagesOverride();
 }
 
-void overrideUserPreferredLanguages(const Vector<String>& override)
-{
-    LOG_WITH_STREAM(Language, stream << "Languages are being overridden to: " << override);
-    {
-        Locker locker { preferredLanguagesOverrideLock };
-        preferredLanguagesOverride() = override;
-    }
-    languageDidChange();
-}
-
 Vector<String> userPreferredLanguages(ShouldMinimizeLanguages shouldMinimizeLanguages)
 {
     {
@@ -145,6 +135,16 @@ Vector<String> userPreferredLanguages(ShouldMinimizeLanguages shouldMinimizeLang
 }
 
 #if !PLATFORM(COCOA)
+
+void overrideUserPreferredLanguages(const Vector<String>& override)
+{
+    LOG_WITH_STREAM(Language, stream << "Languages are being overridden to: " << override);
+    {
+        Locker locker { preferredLanguagesOverrideLock };
+        preferredLanguagesOverride() = override;
+    }
+    languageDidChange();
+}
 
 static String canonicalLanguageIdentifier(const String& languageCode)
 {

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/PrintStream.h>
 
+#include <wtf/text/AtomString.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -102,6 +103,11 @@ void printInternal(PrintStream& out, const CString& string)
 void printInternal(PrintStream& out, const String& string)
 {
     printExpectedCStringHelper(out, "String", string.tryGetUtf8());
+}
+
+void printInternal(PrintStream& out, const AtomString& string)
+{
+    printExpectedCStringHelper(out, "String", string.string().tryGetUtf8());
 }
 
 void printInternal(PrintStream& out, const StringImpl* string)

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -98,6 +98,7 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const char*);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, StringView);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const CString&);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const String&);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const AtomString&);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const StringImpl*);
 inline void printInternal(PrintStream& out, const AtomStringImpl* value) { printInternal(out, bitwise_cast<const StringImpl*>(value)); }
 inline void printInternal(PrintStream& out, const UniquedStringImpl* value) { printInternal(out, bitwise_cast<const StringImpl*>(value)); }

--- a/Source/WTF/wtf/cf/LanguageCF.cpp
+++ b/Source/WTF/wtf/cf/LanguageCF.cpp
@@ -113,4 +113,14 @@ Vector<String> platformUserPreferredLanguages(ShouldMinimizeLanguages shouldMini
     return languages;
 }
 
+void overrideUserPreferredLanguages(const Vector<String>& override)
+{
+    LOG_WITH_STREAM(Language, stream << "Languages are being overridden to: " << override);
+    auto languages = adoptCF(CFArrayCreateMutable(nullptr, override.size(), nullptr));
+    for (auto& language : override)
+        CFArrayAppendValue(languages.get(), language.createCFString().get());
+    CFPreferencesSetValue(CFSTR("AppleLanguages"), languages.get(), kCFPreferencesCurrentApplication, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+    languageDidChange();
+}
+
 } // namespace WTF

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -230,7 +230,7 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
     //    properties, or which are in input properties and conform to the <custom-property-name> production.
     Vector<JSC::Identifier> animationProperties;
     for (auto& inputProperty : inputProperties) {
-        auto cssProperty = IDLAttributeNameToAnimationPropertyName(inputProperty.atomString());
+        auto cssProperty = IDLAttributeNameToAnimationPropertyName(inputProperty.string());
         auto resolvedCSSProperty = CSSProperty::resolveDirectionAwareProperty(cssProperty, RenderStyle::initialDirection(), RenderStyle::initialWritingMode());
         if (CSSPropertyAnimation::isPropertyAnimatable(resolvedCSSProperty))
             animationProperties.append(inputProperty);
@@ -238,7 +238,7 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
 
     // 5. Sort animation properties in ascending order by the Unicode codepoints that define each property name.
     std::sort(animationProperties.begin(), animationProperties.end(), [](auto& lhs, auto& rhs) {
-        return lhs.string().utf8() < rhs.string().utf8();
+        return lhs.string().string().utf8() < rhs.string().string().utf8();
     });
 
     // 6. For each property name in animation properties,
@@ -271,7 +271,7 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
         RETURN_IF_EXCEPTION(scope, Exception { TypeError });
 
         // 4. Calculate the normalized property name as the result of applying the IDL attribute name to animation property name algorithm to property name.
-        auto cssPropertyID = IDLAttributeNameToAnimationPropertyName(animationProperties[i].atomString());
+        auto cssPropertyID = IDLAttributeNameToAnimationPropertyName(animationProperties[i].string());
 
         // 5. Add a property to to keyframe output with normalized property name as the property name, and property values as the property value.
         keyframeOuput.propertiesAndValues.append({ cssPropertyID, propertyValues });

--- a/Source/WebCore/inspector/WebInjectedScriptHost.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptHost.cpp
@@ -219,7 +219,7 @@ JSValue WebInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
 
         String name = worker->name();
         if (!name.isEmpty())
-            array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "name"_s, jsString(vm, name)));
+            array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "name"_s, jsString(vm, WTFMove(name))));
 
         array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "terminated"_s, jsBoolean(worker->wasTerminated())));
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -551,7 +551,6 @@ void Internals::resetToConsistentState(Page& page)
     }
 
     WTF::clearDefaultPortForProtocolMapForTesting();
-    overrideUserPreferredLanguages(Vector<String>());
     WebCore::DeprecatedGlobalSettings::setUsesOverlayScrollbars(false);
     if (!page.mainFrame().editor().isContinuousSpellCheckingEnabled())
         page.mainFrame().editor().toggleContinuousSpellChecking();

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -33,6 +33,7 @@
 #import <pal/spi/cf/CFUtilitiesSPI.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <sys/sysctl.h>
+#import <wtf/Language.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
@@ -47,18 +48,15 @@ static void setAppleLanguagesPreference()
 
     if (xpc_object_t languages = xpc_dictionary_get_value(bootstrap.get(), "OverrideLanguages")) {
         @autoreleasepool {
-            NSDictionary *existingArguments = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain];
-            auto newArguments = adoptNS([existingArguments mutableCopy]);
-            RetainPtr<NSMutableArray> newLanguages = adoptNS([[NSMutableArray alloc] init]);
+            Vector<String> newLanguages;
+            auto* newLanguagesPtr = &newLanguages;
             xpc_array_apply(languages, ^(size_t index, xpc_object_t value) {
-                [newLanguages addObject:[NSString stringWithCString:xpc_string_get_string_ptr(value) encoding:NSUTF8StringEncoding]];
+                newLanguagesPtr->append(String::fromUTF8(xpc_string_get_string_ptr(value)));
                 return true;
             });
 
-            LOG_WITH_STREAM(Language, stream << "Bootstrap message contains OverrideLanguages: " << newLanguages.get());
-
-            [newArguments setValue:newLanguages.get() forKey:@"AppleLanguages"];
-            [[NSUserDefaults standardUserDefaults] setVolatileDomain:newArguments.get() forName:NSArgumentDomain];
+            LOG_WITH_STREAM(Language, stream << "Bootstrap message contains OverrideLanguages: " << newLanguages);
+            overrideUserPreferredLanguages(newLanguages);
         }
     } else
         LOG(Language, "Bootstrap message does not contain OverrideLanguages");


### PR DESCRIPTION
#### 067130fe2a7db19352ee5029692b99c8e239b792
<pre>
[ iOS ] fast/text/international/system-language/navigator-language/navigator-language-fr.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=240104">https://bugs.webkit.org/show_bug.cgi?id=240104</a>

Reviewed by NOBODY (OOPS!).

The test was flaky and navigator.language would sometimes return &quot;fr&quot; and sometimes &quot;fr-FR&quot;.
The reason for this is that Cocoa ports used 2 separate mechanisms to override the system
language:
1. The override languages were used to set the AppleLanguages NSUserDefaults, causing APIs
   such as CFLocaleCopyPreferredLanguages() to return the overriden languages.
2. During process initialization we would also call WTF::overrideUserPreferredLanguages()
   which would add the override languages to an override Vector in WTF.

The test was setting the override language to &quot;fr&quot;. When method 2 would succeed,
navigator.language would return &quot;fr&quot;, from preferredLanguagesOverride().

However, Internals::resetToConsistentState() would reset WTF::preferredLanguagesOverride()
shortly after the test starts running. As a result, the override Vector in WTF would often
end up being empty and we would end up calling CFLocaleCopyPreferredLanguages().
However, CFLocaleCopyPreferredLanguages() return &quot;fr-FR&quot;, which is equivalent but not
exactly the same.

To address the issue, I made 2 changes:
a. Use a single method for overriding languages for Cocoa ports. We are now using the
   AppleLanguages user default exclusively and not the WTF::preferredLanguagesOverride()
   Vector.
b. We stop resetting the override languages in Internals::resetToConsistentState(), since
   this runs after the test options have been processed and which may set the override
   languages. Once making fix a., we would end up with no override language for the test
   since resetting would reliably work. We don&apos;t need to reset languages manually anyway
   to avoid flakiness. The reason is that the override languages get set on the process
   pool configuration and we switch to a new process pool / WKWebView between tests when
   the previous &amp; next tests have different test options (override languages being one of
   the options).

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::setAppleLanguagesPreference):
* Source/WTF/wtf/Language.cpp:
(WTF::overrideUserPreferredLanguages):
* Source/WTF/wtf/cf/LanguageCF.cpp:
(WTF::overrideUserPreferredLanguages):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* LayoutTests/platform/ios/TestExpectations:
</pre>
----------------------------------------------------------------------
#### 73cafd8fef8153abc397ccc26f873009beec592b
<pre>
Identifier::string() should return an AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=240122">https://bugs.webkit.org/show_bug.cgi?id=240122</a>

Reviewed by NOBODY (OOPS!).

Identifier::string() should return an AtomString instead of a String, since
it holds an AtomString internally.

Also add some overloads to jsString() to resolve ambiguity for some callers.

* Source/JavaScriptCore/API/JSContext.mm:
(-[JSContext dependencyIdentifiersForModuleJSScript:]):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::processClauseList):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::functionDetails):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::addErrorInfo):
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::finishCreation):
* Source/JavaScriptCore/runtime/ErrorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::toStringSlow):
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::string const):
(JSC::Identifier::atomString const): Deleted.
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::identifierToJSValue):
(JSC::identifierToSafePublicJSValue):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::format const):
(JSC::IntlDateTimeFormat::formatRange):
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/IntlListFormat.cpp:
(JSC::IntlListFormat::format const):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::format const):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::reifyName):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::requestImportModule):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::jsString):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::repeatCharacter):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::jsSpliceSubstrings):
(JSC::jsSpliceSubstringsWithSeparators):
(JSC::toLocaleCase):
(JSC::normalize):
* Source/JavaScriptCore/runtime/SymbolPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printInternal):
* Source/WTF/wtf/PrintStream.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::processKeyframeLikeObject):
* Source/WebCore/inspector/WebInjectedScriptHost.cpp:
(WebCore::WebInjectedScriptHost::getInternalProperties):
</pre>