### PR TITLE
[JSC] Add fast path to TypedArray.from

### DIFF
--- a/JSTests/microbenchmarks/typed-array-from-array.js
+++ b/JSTests/microbenchmarks/typed-array-from-array.js
@@ -1,0 +1,4 @@
+var a1 = new Array(1024 * 1024 * 1);
+a1.fill(99);
+for (var i = 0; i < 1e2; ++i)
+    var a2 = Uint8Array.from(a1);

--- a/JSTests/microbenchmarks/typed-array-from.js
+++ b/JSTests/microbenchmarks/typed-array-from.js
@@ -1,0 +1,4 @@
+var a1 = new Uint8Array(1024 * 1024 * 1);
+a1.fill(99);
+for (var i = 0; i < 1e2; ++i)
+    var a2 = Uint8Array.from(a1);

--- a/JSTests/stress/bigint64-array-from-array-throw.js
+++ b/JSTests/stress/bigint64-array-from-array-throw.js
@@ -1,0 +1,29 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    var a = new Int32Array([0, 1, 2, 3]);
+    BigInt64Array.from(a);
+}, `TypeError: Content types of source and destination typed arrays are different`);
+
+shouldThrow(() => {
+    var a = [0, 1, 2, 3];
+    BigInt64Array.from(a);
+}, `TypeError: Invalid argument type in ToBigInt operation`);
+
+shouldThrow(() => {
+    var a = [0.0, 0.1, 0.2, 0.3];
+    BigInt64Array.from(a);
+}, `TypeError: Invalid argument type in ToBigInt operation`);

--- a/JSTests/stress/typed-array-from-array-iterator-protocol.js
+++ b/JSTests/stress/typed-array-from-array-iterator-protocol.js
@@ -1,0 +1,38 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+{
+    let length = 5;
+    let index = 0;
+    [].values().__proto__.next = function () {
+        if (index < length) {
+            ++index;
+            return {
+                value: index,
+                done: false
+            };
+        }
+        return {
+            value: null,
+            done: true
+        };
+    };
+
+    let a0 = new Uint32Array([0xffffffff, 0xfffffffe, 0xfffffff0, 0xfffff0f0]);
+    let a1 = Uint8Array.from(a0);
+    shouldBeArray(a1, [1, 2, 3, 4, 5]);
+}

--- a/JSTests/stress/typed-array-from-custom-length-parent.js
+++ b/JSTests/stress/typed-array-from-custom-length-parent.js
@@ -1,0 +1,11 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(128);
+Reflect.defineProperty(Uint8Array.prototype, 'length', {
+    value: 42
+});
+var result = Uint8Array.from(array);
+shouldBe(result.length, 42);

--- a/JSTests/stress/typed-array-from-custom-length.js
+++ b/JSTests/stress/typed-array-from-custom-length.js
@@ -1,0 +1,11 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(128);
+Reflect.defineProperty(array, 'length', {
+    value: 42
+});
+var result = Uint8Array.from(array);
+shouldBe(result.length, 42);

--- a/JSTests/stress/typed-array-from-different-type.js
+++ b/JSTests/stress/typed-array-from-different-type.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let a = new Int32Array([0, 1, 2]);
+    let b = Float64Array.from(a);
+    shouldBe(b.length, 3);
+    shouldBe(b[0], 0);
+    shouldBe(b[1], 1);
+    shouldBe(b[2], 2);
+}
+{
+    let a = new Float32Array([0, 1, 2]);
+    let b = Int32Array.from(a);
+    shouldBe(b.length, 3);
+    shouldBe(b[0], 0);
+    shouldBe(b[1], 1);
+    shouldBe(b[2], 2);
+}

--- a/JSTests/stress/typed-array-from-hole.js
+++ b/JSTests/stress/typed-array-from-hole.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let a = Int32Array.from([0, , , 6]);
+    shouldBe(a.length, 4);
+    shouldBe(a[0], 0);
+    shouldBe(a[1], 0);
+    shouldBe(a[2], 0);
+    shouldBe(a[3], 6);
+}
+{
+    let a = Int32Array.from([0.2, , , 6.1]);
+    shouldBe(a.length, 4);
+    shouldBe(a[0], 0);
+    shouldBe(a[1], 0);
+    shouldBe(a[2], 0);
+    shouldBe(a[3], 6);
+}
+{
+    let a = Float64Array.from([0, , , 6]);
+    shouldBe(a.length, 4);
+    shouldBe(a[0], 0);
+    shouldBe(Number.isNaN(a[1]), true);
+    shouldBe(Number.isNaN(a[2]), true);
+    shouldBe(a[3], 6);
+}
+{
+    let a = Float64Array.from([0.2, , , 6.1]);
+    shouldBe(a.length, 4);
+    shouldBe(a[0], 0.2);
+    shouldBe(Number.isNaN(a[1]), true);
+    shouldBe(Number.isNaN(a[2]), true);
+    shouldBe(a[3], 6.1);
+}

--- a/JSTests/stress/typed-array-from.js
+++ b/JSTests/stress/typed-array-from.js
@@ -1,0 +1,81 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        try {
+            shouldBe(actual[i], expected[i]);
+        } catch(e) {
+            print(JSON.stringify(actual));
+            throw e;
+        }
+    }
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+{
+    let a0 = new Uint32Array([0xffffffff, 0xfffffffe, 0xfffffff0, 0xfffff0f0]);
+    let a1 = Uint8Array.from(a0);
+    shouldBeArray(a1, [0xff, 0xfe, 0xf0, 0xf0]);
+
+    let a2 = Uint32Array.from(a0);
+    shouldBeArray(a2, a0);
+}
+{
+    class TestArray extends Uint8Array {
+        constructor(size) {
+            super(size);
+        }
+    }
+
+    let a0 = new Uint32Array([0xffffffff, 0xfffffffe, 0xfffffff0, 0xfffff0f0]);
+    let a1 = TestArray.from(a0);
+    shouldBeArray(a1, [0xff, 0xfe, 0xf0, 0xf0]);
+
+    let a2 = Uint32Array.from(a0);
+    shouldBeArray(a2, a0);
+}
+{
+    let a0 = new Uint32Array([0xffffffff, 0xfffffffe, 0xfffffff0, 0xfffff0f0]);
+    class TestArray extends Uint8Array {
+        constructor(size) {
+            super(size);
+            transferArrayBuffer(a0.buffer);
+        }
+    }
+
+    let a1 = TestArray.from(a0);
+    shouldBeArray(a1, [0xff, 0xfe, 0xf0, 0xf0]); // This should pass. When TestArray is created, we should have already collected the data from a0.
+
+    shouldThrow(() => {
+        Uint32Array.from(a0);
+    }, `TypeError: Underlying ArrayBuffer has been detached from the view`);
+}
+
+Uint8Array.prototype.__proto__[Symbol.iterator] = function *() {
+    for (var i = 0; i < this.length; ++i)
+        yield 42;
+};
+
+{
+    let a0 = new Uint32Array([0xffffffff, 0xfffffffe, 0xfffffff0, 0xfffff0f0]);
+    let a1 = Uint8Array.from(a0);
+    shouldBeArray(a1, [42, 42, 42, 42]);
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -130,6 +130,7 @@ namespace JSC {
     macro(isSharedTypedArrayView) \
     macro(isDetached) \
     macro(typedArrayDefaultComparator) \
+    macro(typedArrayFromFast) \
     macro(isBoundFunction) \
     macro(hasInstanceBoundFunction) \
     macro(instanceOf) \

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Jarred Sumner. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +59,12 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
     }
 
     var arrayLike = @toObject(items, "TypedArray.from requires an array-like object - not null or undefined");
+
+    if (!mapFn) {
+        var fastResult = @typedArrayFromFast(this, arrayLike);
+        if (fastResult)
+            return fastResult;
+    }
 
     var iteratorMethod = items.@@iterator;
     if (!@isUndefinedOrNull(iteratorMethod)) {

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -56,6 +56,7 @@ class JSGlobalObject;
     v(typedArraySort, nullptr) \
     v(isTypedArrayView, nullptr) \
     v(isSharedTypedArrayView, nullptr) \
+    v(typedArrayFromFast, nullptr) \
     v(isDetached, nullptr) \
     v(typedArrayDefaultComparator, nullptr) \
     v(isBoundFunction, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -207,6 +207,8 @@ public:
     static RefPtr<ArrayBufferView> toWrapped(VM&, JSValue);
     static RefPtr<ArrayBufferView> toWrappedAllowShared(VM&, JSValue);
 
+    bool isIteratorProtocolFastAndNonObservable();
+
 private:
     enum Requester { Mutator, ConcurrentThread };
     template<Requester, typename ResultType> ResultType byteOffsetImpl();

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -81,6 +81,7 @@ JS_EXPORT_PRIVATE const ClassInfo* getBigUint64ArrayClassInfo();
 //     static int8_t toNativeFromInt32(int32_t);
 //     static int8_t toNativeFromUint32(uint32_t);
 //     static int8_t toNativeFromDouble(double);
+//     static int8_t toNativeFromUndefined();
 //     static JSValue toJSValue(int8_t);
 //     template<T> static T::Type convertTo(uint8_t);
 // };

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -273,10 +273,6 @@ bool JSGenericTypedArrayView<Adaptor>::set(
     if (typedArrayType == Adaptor::typeValue)
         return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
 
-    auto isSomeUint8 = [] (TypedArrayType type) {
-        return type == TypedArrayType::TypeUint8 || type == TypedArrayType::TypeUint8Clamped;
-    };
-
     if (isSomeUint8(typedArrayType) && isSomeUint8(Adaptor::typeValue))
         return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -37,14 +37,14 @@ JSGenericTypedArrayViewPrototype<ViewClass>::JSGenericTypedArrayViewPrototype(VM
 
 template<typename ViewClass>
 void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
-    VM& vm, JSGlobalObject*)
+    VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     
     ASSERT(inherits(info()));
 
-    putDirect(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
-
+    putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
+    globalObject->installTypedArrayIteratorProtocolWatchpoint(this, ViewClass::TypedArrayStorageType);
 }
 
 template<typename ViewClass>

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -531,8 +531,10 @@ public:
     InlineWatchpointSet m_arrayBufferSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_sharedArrayBufferSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_typedArrayConstructorSpeciesWatchpointSet { IsWatched };
+    InlineWatchpointSet m_typedArrayPrototypeIteratorProtocolWatchpointSet { IsWatched };
 #define DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET(name) \
-    InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint };
+    InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint }; \
+    InlineWatchpointSet m_typedArray ## name ## IteratorProtocolWatchpointSet { ClearWatchpoint };
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET)
 #undef DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET
 
@@ -553,8 +555,12 @@ public:
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayBufferConstructorSpeciesWatchpoints[2];
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayBufferPrototypeConstructorWatchpoints[2];
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayConstructorSpeciesWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayPrototypeSymbolIteratorWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayPrototypeLengthWatchpoint;
 #define DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT(name) \
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## ConstructorSpeciesAbsenceWatchpoint; \
+    std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## PrototypeLengthAbsenceWatchpoint; \
+    std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## PrototypeSymbolIteratorAbsenceWatchpoint; \
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArray ## name ## PrototypeConstructorWatchpoint;
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
 #undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
@@ -571,6 +577,34 @@ public:
         }
         RELEASE_ASSERT_NOT_REACHED();
         return m_typedArrayInt8ConstructorSpeciesAbsenceWatchpoint;
+    }
+
+    std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeLengthAbsenceWatchpoint(TypedArrayType type)
+    {
+        switch (type) {
+        case NotTypedArray:
+            RELEASE_ASSERT_NOT_REACHED();
+            return m_typedArrayInt8PrototypeLengthAbsenceWatchpoint;
+#define TYPED_ARRAY_TYPE_CASE(name) case Type ## name: return m_typedArray ## name ## PrototypeLengthAbsenceWatchpoint;
+            FOR_EACH_TYPED_ARRAY_TYPE(TYPED_ARRAY_TYPE_CASE)
+#undef TYPED_ARRAY_TYPE_CASE
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+        return m_typedArrayInt8PrototypeLengthAbsenceWatchpoint;
+    }
+
+    std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType type)
+    {
+        switch (type) {
+        case NotTypedArray:
+            RELEASE_ASSERT_NOT_REACHED();
+            return m_typedArrayInt8PrototypeSymbolIteratorAbsenceWatchpoint;
+#define TYPED_ARRAY_TYPE_CASE(name) case Type ## name: return m_typedArray ## name ## PrototypeSymbolIteratorAbsenceWatchpoint;
+            FOR_EACH_TYPED_ARRAY_TYPE(TYPED_ARRAY_TYPE_CASE)
+#undef TYPED_ARRAY_TYPE_CASE
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+        return m_typedArrayInt8PrototypeSymbolIteratorAbsenceWatchpoint;
     }
 
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>& typedArrayPrototypeConstructorWatchpoint(TypedArrayType type)
@@ -629,9 +663,24 @@ public:
         RELEASE_ASSERT_NOT_REACHED();
         return m_typedArrayInt8SpeciesWatchpointSet;
     }
+    InlineWatchpointSet& typedArrayIteratorProtocolWatchpointSet(TypedArrayType type)
+    {
+        switch (type) {
+        case NotTypedArray:
+            RELEASE_ASSERT_NOT_REACHED();
+            return m_typedArrayInt8IteratorProtocolWatchpointSet;
+#define TYPED_ARRAY_TYPE_CASE(name) case Type ## name: return m_typedArray ## name ## IteratorProtocolWatchpointSet;
+            FOR_EACH_TYPED_ARRAY_TYPE(TYPED_ARRAY_TYPE_CASE)
+#undef TYPED_ARRAY_TYPE_CASE
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+        return m_typedArrayInt8IteratorProtocolWatchpointSet;
+    }
     InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() { return m_typedArrayConstructorSpeciesWatchpointSet; }
+    InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
 
     bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
+    bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
     bool isMapPrototypeIteratorProtocolFastAndNonObservable();
     bool isSetPrototypeIteratorProtocolFastAndNonObservable();
     bool isStringPrototypeIteratorProtocolFastAndNonObservable();
@@ -1256,7 +1305,9 @@ public:
     void installSetPrototypeWatchpoint(SetPrototype*);
     void tryInstallArrayBufferSpeciesWatchpoint(ArrayBufferSharingMode);
     void tryInstallTypedArraySpeciesWatchpoint(TypedArrayType);
+    void installTypedArrayIteratorProtocolWatchpoint(JSObject* prototype, TypedArrayType);
     void installTypedArrayConstructorSpeciesWatchpoint(JSTypedArrayViewConstructor*);
+    void installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype*, GetterSetter*);
 
 protected:
     enum class HasSpeciesProperty : bool { Yes, No };

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
@@ -53,6 +53,7 @@ private:
 
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsTypedArrayView);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsSharedTypedArrayView);
+JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncTypedArrayFromFast);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncDefaultComparator);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncSort);
@@ -60,5 +61,5 @@ JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncLength);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncClone);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncContentType);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncGetOriginalConstructor);
-    
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
@@ -73,6 +73,11 @@ struct IntegralTypedArrayAdaptor {
             result = toInt32(value);
         return static_cast<Type>(result);
     }
+
+    static constexpr Type toNativeFromUndefined()
+    {
+        return 0;
+    }
     
     template<typename OtherAdaptor>
     static typename OtherAdaptor::Type convertTo(Type value)
@@ -146,6 +151,11 @@ struct FloatTypedArrayAdaptor {
         return static_cast<Type>(value);
     }
 
+    static Type toNativeFromUndefined()
+    {
+        return PNaN;
+    }
+
     template<typename OtherAdaptor>
     static typename OtherAdaptor::Type convertTo(Type value)
     {
@@ -209,6 +219,12 @@ struct BigIntTypedArrayAdaptor {
     static Type toNativeFromDouble(double value)
     {
         return static_cast<Type>(value);
+    }
+
+    static Type toNativeFromUndefined()
+    {
+        // This function is a stub since undefined->BigInt conversion throws an error.
+        return 0;
     }
 
     template<typename OtherAdaptor>
@@ -277,6 +293,11 @@ struct Uint8ClampedAdaptor {
         if (value > 255)
             return 255;
         return static_cast<uint8_t>(lrint(value));
+    }
+
+    static constexpr Type toNativeFromUndefined()
+    {
+        return 0;
     }
 
     template<typename OtherAdaptor>

--- a/Source/JavaScriptCore/runtime/TypedArrayType.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayType.h
@@ -297,6 +297,28 @@ inline constexpr TypedArrayContentType contentType(TypedArrayType type)
     return TypedArrayContentType::None;
 }
 
+inline constexpr bool isSomeUint8(TypedArrayType type)
+{
+    switch (type) {
+    case TypeUint8:
+    case TypeUint8Clamped:
+        return true;
+    case TypeInt8:
+    case TypeInt16:
+    case TypeInt32:
+    case TypeUint16:
+    case TypeUint32:
+    case TypeFloat32:
+    case TypeFloat64:
+    case TypeBigInt64:
+    case TypeBigUint64:
+    case NotTypedArray:
+    case TypeDataView:
+        return false;
+    }
+    return false;
+}
+
 } // namespace JSC
 
 namespace WTF {


### PR DESCRIPTION
#### 1b440efcb4ae8dbc2a031e14ad222cc411e6e61b
<pre>
[JSC] Add fast path to TypedArray.from
<a href="https://bugs.webkit.org/show_bug.cgi?id=239936">https://bugs.webkit.org/show_bug.cgi?id=239936</a>

Reviewed by Mark Lam, Ross Kirsling and Keith Miller.

This patch adds a fast path to TypedArray.from. Similar to what we do with Array, we integrate TypedArray&apos;s iterator-protocol WatchpointSet.
And now TypedArray has isIteratorProtocolFastAndNonObservable() function which answers whether we can do fast-iteration without
user observable behavior withhout using normal generic for-of iterator protocol.

The most complicated part of this WatchpointSet is that &quot;length&quot; property of TypedArray. Unlike Array, TypedArray does not have
its own &quot;length&quot; property. Instead it has &quot;length&quot; getter in TypedArray.prototype. Thus, we need to ensure the following.

1. Uint8Array instance does not have its own &quot;length&quot; property
2. Uint8Array instance&apos;s [[Prototype]] is Uint8Array.prototype
3. Uint8Array.prototype does not have &quot;length&quot; property
4. Uint8Array.prototype&apos;s [[Prototype]] is TypedArray.prototype
5. TypedArray.prototype has default &quot;length&quot; getter

We set &quot;length&quot; absence ObjectPropertyCondition (OPC) on Uint8Array.prototype. And we also set &quot;length&quot; equivalence OPC on TypedArray.prototype.length.
As the same with Array&apos;s iterator protocol, we also ensure @@iterator function&apos;s absence status on Uint8Array.prototype and TypedArray.prototype too.
By installing these watchpoints, we can quickly answer whether this TypedArray instance can get fast iteration.

And in TypedArray.from, we use this condition to bypass normal for-of iteration protocol. Also we extend this function to accept normal Array: using
Array&apos;s iterator protocol WatchpointSet to make it fast for Int32 and Double Arrays.

TypedArray.from from TypedArray gets 396.0x faster. And TypedArray.from from Array gets 6.8x faster.

                                   ToT                     Patched

typed-array-from-array      913.8926+-1.7045     ^    133.6719+-0.1703        ^ definitely 6.8368x faster
typed-array-from           1183.6522+-2.1020     ^      2.9890+-0.3176        ^ definitely 396.0042x faster

* microbenchmarks/typed-array-from.js: Added.
* stress/typed-array-from-array-iterator-protocol.js: Added.
(shouldBe):
(shouldBeArray):
(values.__proto__.next):
* stress/typed-array-from.js: Added.
(shouldBe):
(shouldBeArray):
(shouldThrow):
(shouldBeArray.TestArray):
(Uint8Array.prototype.__proto__.Symbol.iterator):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::isTypedArrayViewConstructor):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSTypedArrayViewPrototype::finishCreation):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h:

Canonical link: <a href="https://commits.webkit.org/252976@main">https://commits.webkit.org/252976@main</a>
</pre>
