### PR TITLE
Add find()/reverseFind()/contains() overloads takes an ASCIILiteral to our String types

### DIFF
--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -161,7 +161,7 @@ static String notAFunctionSourceAppender(const String& originalMessage, StringVi
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto notAFunctionIndex = originalMessage.reverseFind("is not a function");
+    auto notAFunctionIndex = originalMessage.reverseFind("is not a function"_s);
     RELEASE_ASSERT(notAFunctionIndex != notFound);
     StringView displayValue;
     if (originalMessage.is8Bit()) 
@@ -197,14 +197,14 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto inIndex = sourceText.reverseFind("in");
+    auto inIndex = sourceText.reverseFind("in"_s);
     if (inIndex == notFound) {
         // This should basically never happen, since JS code must use the literal
         // text "in" for the `in` operation. However, if we fail to find "in"
         // for any reason, just fail gracefully.
         return originalMessage;
     }
-    if (sourceText.find("in") != inIndex)
+    if (sourceText.find("in"_s) != inIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     static constexpr unsigned inLength = 2;
@@ -218,12 +218,12 @@ inline String invalidParameterInstanceofSourceAppender(const String& content, co
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto instanceofIndex = sourceText.reverseFind("instanceof");
+    auto instanceofIndex = sourceText.reverseFind("instanceof"_s);
     // This can happen when Symbol.hasInstance function is directly called.
     if (instanceofIndex == notFound)
         return originalMessage;
 
-    if (sourceText.find("instanceof") != instanceofIndex)
+    if (sourceText.find("instanceof"_s) != instanceofIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     static constexpr unsigned instanceofLength = 10;
@@ -246,8 +246,8 @@ static String invalidPrototypeSourceAppender(const String& originalMessage, Stri
     if (occurrence == ErrorInstance::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    auto extendsIndex = sourceText.reverseFind("extends");
-    if (extendsIndex == notFound || sourceText.find("extends") != extendsIndex)
+    auto extendsIndex = sourceText.reverseFind("extends"_s);
+    if (extendsIndex == notFound || sourceText.find("extends"_s) != extendsIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     return "The value of the superclass's prototype property is not an object or null."_s;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -320,7 +320,7 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
 {
     StringView locale(buffer.data(), buffer.size());
     ASSERT(locale.is8Bit());
-    size_t extensionIndex = locale.find("-u-");
+    size_t extensionIndex = locale.find("-u-"_s);
     if (extensionIndex == notFound)
         return WTFMove(buffer);
 
@@ -855,7 +855,7 @@ static MatcherResult lookupMatcher(JSGlobalObject* globalObject, const LocaleSet
     if (!availableLocale.isEmpty()) {
         result.locale = availableLocale;
         if (locale != noExtensionsLocale) {
-            size_t extensionIndex = locale.find("-u-");
+            size_t extensionIndex = locale.find("-u-"_s);
             RELEASE_ASSERT(extensionIndex != notFound);
 
             size_t extensionLength = locale.length() - extensionIndex;

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -130,7 +130,7 @@ static void initializeOverrideInfo(const SourceCode& origCode, const String& new
     FunctionOverridesAssertScope assertScope;
     String origProviderStr = origCode.provider()->source().toString();
     unsigned origStart = origCode.startOffset();
-    unsigned origFunctionStart = origProviderStr.reverseFind("function", origStart);
+    unsigned origFunctionStart = origProviderStr.reverseFind("function"_s, origStart);
     unsigned origBraceStart = origProviderStr.find('{', origStart);
     unsigned headerLength = origBraceStart - origFunctionStart;
     auto origHeaderView = StringView(origProviderStr).substring(origFunctionStart, headerLength);

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -97,12 +97,12 @@ public:
     // If we need more overloads of the number function, we can add all the others that String has, but these seem to do for now.
 
     bool contains(UChar character) const { return m_string.contains(character); }
-    bool contains(const LChar* string) const { return m_string.contains(string); }
+    bool contains(ASCIILiteral literal) const { return m_string.contains(literal); }
     bool contains(StringView) const;
     bool containsIgnoringASCIICase(StringView) const;
 
     size_t find(UChar character, unsigned start = 0) const { return m_string.find(character, start); }
-    size_t find(const LChar* string, unsigned start = 0) const { return m_string.find(string, start); }
+    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_string.find(literal, start); }
     size_t find(StringView, unsigned start = 0) const;
     size_t findIgnoringASCIICase(StringView) const;
     size_t findIgnoringASCIICase(StringView, unsigned start) const;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -432,7 +432,7 @@ public:
     size_t find(UChar character, unsigned start = 0);
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction, unsigned start = 0);
-    WTF_EXPORT_PRIVATE size_t find(const LChar*, unsigned start = 0);
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) { return find(literal.characters8(), literal.length(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView);
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start);
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
@@ -440,6 +440,7 @@ public:
 
     WTF_EXPORT_PRIVATE size_t reverseFind(UChar, unsigned start = MaxLength);
     WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = MaxLength);
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) { return reverseFind(literal.characters8(), literal.length(), start); }
 
     WTF_EXPORT_PRIVATE bool startsWith(StringView) const;
     WTF_EXPORT_PRIVATE bool startsWithIgnoringASCIICase(StringView) const;
@@ -494,6 +495,9 @@ private:
     template<typename> static size_t allocationSize(Checked<size_t> tailElementCount);
     template<typename> static size_t maxInternalLength();
     template<typename> static size_t tailOffset();
+
+    WTF_EXPORT_PRIVATE size_t find(const LChar*, unsigned length, unsigned start);
+    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar*, unsigned length, unsigned start);
 
     bool requiresCopy() const;
     template<typename T> const T* tailPointer() const;

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -109,6 +109,34 @@ size_t StringView::find(StringView matchString, unsigned start) const
     return findCommon(*this, matchString, start);
 }
 
+size_t StringView::find(const LChar* match, unsigned matchLength, unsigned start) const
+{
+    ASSERT(matchLength);
+    auto length = this->length();
+    if (start > length)
+        return notFound;
+
+    unsigned searchLength = length - start;
+    if (matchLength > searchLength)
+        return notFound;
+
+    if (is8Bit())
+        return findInner(characters8() + start, match, start, searchLength, matchLength);
+    return findInner(characters16() + start, match, start, searchLength, matchLength);
+}
+
+size_t StringView::reverseFind(const LChar* match, unsigned matchLength, unsigned start) const
+{
+    ASSERT(matchLength);
+    auto length = this->length();
+    if (matchLength > length)
+        return notFound;
+
+    if (is8Bit())
+        return reverseFindInner(characters8(), match, start, length, matchLength);
+    return reverseFindInner(characters16(), match, start, length, matchLength);
+}
+
 void StringView::SplitResult::Iterator::findNextSubstring()
 {
     for (size_t separatorPosition; (separatorPosition = m_result.m_string.find(m_result.m_separator, m_position)) != notFound; ++m_position) {

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -146,9 +146,11 @@ public:
     size_t find(UChar, unsigned start = 0) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.characters8(), literal.length(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start = 0) const;
 
     size_t reverseFind(UChar, unsigned index = std::numeric_limits<unsigned>::max()) const;
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.characters8(), literal.length(), start); }
     WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = std::numeric_limits<unsigned>::max()) const;
 
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
@@ -161,7 +163,8 @@ public:
     bool contains(UChar) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     bool contains(CodeUnitMatchFunction&&) const;
-    bool contains(StringView string) const { return find(string, 0) != notFound; }
+    bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
+    bool contains(StringView string) const { return find(string) != notFound; }
     WTF_EXPORT_PRIVATE bool contains(const char*) const;
 
     WTF_EXPORT_PRIVATE bool containsIgnoringASCIICase(StringView) const;
@@ -190,6 +193,9 @@ private:
 
     void initialize(const LChar*, unsigned length);
     void initialize(const UChar*, unsigned length);
+
+    WTF_EXPORT_PRIVATE size_t find(const LChar* match, unsigned matchLength, unsigned start) const;
+    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar* match, unsigned matchLength, unsigned start) const;
 
     template<typename CharacterType, typename MatchedCharacterPredicate>
     StringView stripLeadingAndTrailingMatchedCharacters(const CharacterType*, const MatchedCharacterPredicate&) const;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -162,10 +162,11 @@ public:
 
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
-    size_t find(const LChar* string, unsigned start = 0) const { return m_impl ? m_impl->find(string, start) : notFound; }
+    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
 
     // Find the last instance of a single character or string.
     size_t reverseFind(UChar character, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
+    size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
     size_t reverseFind(StringView, unsigned start = MaxLength) const;
 
     WTF_EXPORT_PRIVATE Vector<UChar> charactersWithNullTermination() const;
@@ -174,7 +175,7 @@ public:
     WTF_EXPORT_PRIVATE UChar32 characterStartingAt(unsigned) const;
 
     bool contains(UChar character) const { return find(character) != notFound; }
-    bool contains(const LChar* string) const { return find(string) != notFound; }
+    bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
     bool contains(StringView) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     bool contains(CodeUnitMatchFunction matchFunction) const { return find(matchFunction, 0) != notFound; }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -144,7 +144,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         size_t contentDispositionBegin = header.find(contentDispositionCharacters);
         if (contentDispositionBegin == notFound)
             return false;
-        size_t contentDispositionEnd = header.find("\r\n", contentDispositionBegin);
+        size_t contentDispositionEnd = header.find("\r\n"_s, contentDispositionBegin);
         size_t contentDispositionParametersBegin = header.find(';', contentDispositionBegin + strlen(contentDispositionCharacters));
         if (contentDispositionParametersBegin != notFound)
             contentDispositionParametersBegin++;
@@ -163,7 +163,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             size_t contentTypePrefixLength = strlen(contentTypeCharacters);
             size_t contentTypeBegin = header.find(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
-                size_t contentTypeEnd = header.find("\r\n", contentTypeBegin);
+                size_t contentTypeEnd = header.find("\r\n"_s, contentTypeBegin);
                 contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).stripLeadingAndTrailingMatchedCharacters(isHTTPSpace).toString();
             }
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -358,7 +358,7 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
     if (!m_shouldFilterICECandidates)
         return;
     sdp.split('\n', [](auto line) {
-        ASSERT(!line.startsWith("a=candidate") || line.contains(".local"));
+        ASSERT(!line.startsWith("a=candidate"_s) || line.contains(".local"_s));
     });
 #else
     UNUSED_PARAM(sdp);
@@ -381,7 +381,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
         ALWAYS_LOG(logSiteIdentifier, "Gathered ice candidate:", sdp);
         m_finishedGatheringCandidates = false;
 
-        ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local") || sdp.contains(" srflx "));
+        ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local"_s) || sdp.contains(" srflx "_s));
         auto candidate = RTCIceCandidate::create(WTFMove(sdp), WTFMove(mid), sdpMLineIndex);
         m_peerConnection.dispatchEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, WTFMove(candidate), WTFMove(serverURL)));
     });

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -307,7 +307,7 @@ AtomString YouTubePluginReplacement::youTubeURLFromAbsoluteURL(const URL& srcURL
     } else if (equalLettersIgnoringASCIICase(srcPath, "/watch"_s)) {
         // From the original URL, we need to get the part before /watch/#!v=VideoID
         // FIXME: Shouldn't this be ASCII case-insensitive?
-        locationOfPathBeforeVideoID = srcString.find("/watch");
+        locationOfPathBeforeVideoID = srcString.find("/watch"_s);
     } else
         return srcString;
 

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -39,7 +39,7 @@ namespace PAL {
 // See <http://en.wikipedia.org/wiki/Percent-encoding#Non-standard_implementations>.
 struct Unicode16BitEscapeSequence {
     enum { SequenceSize = 6 }; // e.g. %u26C4
-    static size_t findInString(StringView string, size_t startPosition) { return string.find("%u", startPosition); }
+    static size_t findInString(StringView string, size_t startPosition) { return string.find("%u"_s, startPosition); }
     static size_t findEndOfRun(StringView string, size_t startPosition, size_t endPosition)
     {
         size_t runEnd = startPosition;

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -318,7 +318,7 @@ Vector<String> DataTransfer::types(AddFilesType addFilesType) const
     
     if (!RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled()) {
         auto types = m_pasteboard->typesForLegacyUnsafeBindings();
-        ASSERT(!types.contains("Files"));
+        ASSERT(!types.contains("Files"_s));
         if (m_pasteboard->fileContentState() != Pasteboard::FileContentState::NoFileOrImageData && addFilesType == AddFilesType::Yes)
             types.append("Files"_s);
         return types;
@@ -340,14 +340,14 @@ Vector<String> DataTransfer::types(AddFilesType addFilesType) const
             return types;
         }
 
-        if (safeTypes.contains("text/uri-list"))
+        if (safeTypes.contains("text/uri-list"_s))
             types.append("text/uri-list"_s);
-        if (safeTypes.contains("text/html") && RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled())
+        if (safeTypes.contains("text/html"_s) && RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled())
             types.append("text/html"_s);
         return types;
     }
 
-    ASSERT(!safeTypes.contains("Files"));
+    ASSERT(!safeTypes.contains("Files"_s));
     return safeTypes;
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1085,7 +1085,7 @@ ExceptionOr<Ref<CDATASection>> Document::createCDATASection(String&& data)
     if (isHTMLDocument())
         return Exception { NotSupportedError };
 
-    if (data.contains("]]>"))
+    if (data.contains("]]>"_s))
         return Exception { InvalidCharacterError };
 
     return CDATASection::create(*this, WTFMove(data));
@@ -1096,7 +1096,7 @@ ExceptionOr<Ref<ProcessingInstruction>> Document::createProcessingInstruction(St
     if (!isValidName(target))
         return Exception { InvalidCharacterError };
 
-    if (data.contains("?>"))
+    if (data.contains("?>"_s))
         return Exception { InvalidCharacterError };
 
     return ProcessingInstruction::create(*this, WTFMove(target), WTFMove(data));

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1031,19 +1031,19 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
 
     String fontLigatures = _caches->propertyValueForNode(element, CSSPropertyFontVariantLigatures);
     if (fontLigatures.length()) {
-        if (fontLigatures.contains("normal"))
+        if (fontLigatures.contains("normal"_s))
             ;   // default: whatever the system decides to do
-        else if (fontLigatures.contains("common-ligatures"))
+        else if (fontLigatures.contains("common-ligatures"_s))
             [attrs setObject:@1 forKey:NSLigatureAttributeName];   // explicitly enabled
-        else if (fontLigatures.contains("no-common-ligatures"))
+        else if (fontLigatures.contains("no-common-ligatures"_s))
             [attrs setObject:@0 forKey:NSLigatureAttributeName];  // explicitly disabled
     }
 
     String textDecoration = _caches->propertyValueForNode(element, CSSPropertyTextDecorationLine);
     if (textDecoration.length()) {
-        if (textDecoration.contains("underline"))
+        if (textDecoration.contains("underline"_s))
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSUnderlineStyleAttributeName];
-        if (textDecoration.contains("line-through"))
+        if (textDecoration.contains("line-through"_s))
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
     }
 

--- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
+++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
@@ -45,7 +45,7 @@ static RefPtr<DocumentFragment> createFragmentFromPasteboardData(Pasteboard& pas
     if (types.isEmpty())
         return nullptr;
 
-    if (types.contains("text/html;charset=utf-8") && frame.document()) {
+    if (types.contains("text/html;charset=utf-8"_s) && frame.document()) {
         String markup = pasteboard.readString("text/html;charset=utf-8"_s);
         return createFragmentFromMarkup(*frame.document(), markup, emptyString(), DisallowScriptingAndPluginContent);
     }
@@ -53,7 +53,7 @@ static RefPtr<DocumentFragment> createFragmentFromPasteboardData(Pasteboard& pas
     if (!allowPlainText)
         return nullptr;
 
-    if (types.contains("text/plain;charset=utf-8")) {
+    if (types.contains("text/plain;charset=utf-8"_s)) {
         chosePlainText = true;
         return createFragmentFromText(range, pasteboard.readString("text/plain;charset=utf-8"_s));
     }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -519,7 +519,7 @@ bool StyledMarkupAccumulator::shouldPreserveMSOListStyleForElement(const Element
         return true;
     if (m_shouldPreserveMSOList) {
         auto style = element.getAttribute(styleAttr);
-        return style.startsWith("mso-list:") || style.contains(";mso-list:") || style.contains("\nmso-list:");
+        return style.startsWith("mso-list:"_s) || style.contains(";mso-list:"_s) || style.contains("\nmso-list:"_s);
     }
     return false;
 }
@@ -757,14 +757,14 @@ bool StyledMarkupAccumulator::appendNodeToPreserveMSOList(Node& node)
         auto& textChild = downcast<Text>(*firstChild);
         auto& styleContent = textChild.data();
 
-        const auto msoStyleDefinitionsStart = styleContent.find("/* Style Definitions */");
-        const auto msoListDefinitionsStart = styleContent.find("/* List Definitions */");
-        const auto lastListItem = styleContent.reverseFind("\n@list");
+        const auto msoStyleDefinitionsStart = styleContent.find("/* Style Definitions */"_s);
+        const auto msoListDefinitionsStart = styleContent.find("/* List Definitions */"_s);
+        const auto lastListItem = styleContent.reverseFind("\n@list"_s);
         if (msoListDefinitionsStart == notFound || lastListItem == notFound)
             return false;
         const auto start = msoStyleDefinitionsStart != notFound && msoStyleDefinitionsStart < msoListDefinitionsStart ? msoStyleDefinitionsStart : msoListDefinitionsStart;
 
-        const auto msoListDefinitionsEnd = styleContent.find(";}\n", lastListItem);
+        const auto msoListDefinitionsEnd = styleContent.find(";}\n"_s, lastListItem);
         if (msoListDefinitionsEnd == notFound || start >= msoListDefinitionsEnd)
             return false;
 
@@ -998,8 +998,8 @@ static bool shouldPreserveMSOLists(StringView markup)
     if (tagClose == notFound)
         return false;
     auto tag = markup.left(tagClose);
-    return tag.contains("xmlns:o=\"urn:schemas-microsoft-com:office:office\"")
-        && tag.contains("xmlns:w=\"urn:schemas-microsoft-com:office:word\"");
+    return tag.contains("xmlns:o=\"urn:schemas-microsoft-com:office:office\""_s)
+        && tag.contains("xmlns:w=\"urn:schemas-microsoft-com:office:word\""_s);
 }
 
 String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Document& document, MSOListQuirks msoListQuirks, const String& originalMarkup)

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -212,7 +212,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
     switch (setting) {
     case Id: {
         String stringValue = input.extractString(valueRun);
-        if (stringValue.find("-->") == notFound)
+        if (stringValue.find("-->"_s) == notFound)
             m_id = stringValue;
         break;
     }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -279,7 +279,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
             m_client.newRegionsParsed();
         if (!m_styleSheets.isEmpty())
             m_client.newStyleSheetsParsed();
-        if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"))
+        if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"_s))
             m_currentId = AtomString { m_previousLine };
         
         return state;
@@ -298,7 +298,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
 WebVTTParser::ParseState WebVTTParser::checkAndRecoverCue(const String& line)
 {
     // parse cue timings and settings
-    if (line.contains("-->")) {
+    if (line.contains("-->"_s)) {
         ParseState state = recoverCue(line);
         if (state != BadCue)
             return state;
@@ -318,7 +318,7 @@ WebVTTParser::ParseState WebVTTParser::collectStyleSheet(const String& line)
 
 bool WebVTTParser::checkAndCreateRegion(StringView line)
 {
-    if (m_previousLine.contains("-->"))
+    if (m_previousLine.contains("-->"_s))
         return false;
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
@@ -332,7 +332,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
 
 bool WebVTTParser::checkAndStoreRegion(StringView line)
 {
-    if (!line.isEmpty() && !line.contains("-->"))
+    if (!line.isEmpty() && !line.contains("-->"_s))
         return false;
 
     if (!m_currentRegion->id().isEmpty()) {
@@ -347,12 +347,12 @@ bool WebVTTParser::checkAndStoreRegion(StringView line)
 
 bool WebVTTParser::checkStyleSheet(StringView line)
 {
-    if (m_previousLine.contains("-->"))
+    if (m_previousLine.contains("-->"_s))
         return false;
     // line starts with the substring "STYLE" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these charecters it is invalid.
-    if (line.startsWith("STYLE") && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
+    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
         return true;
 
     return false;
@@ -360,7 +360,7 @@ bool WebVTTParser::checkStyleSheet(StringView line)
 
 bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
 {
-    if (!line.isEmpty() && !line.contains("-->"))
+    if (!line.isEmpty() && !line.contains("-->"_s))
         return false;
     
     auto styleSheetText = m_currentSourceStyleSheet.toString();
@@ -415,7 +415,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
 
 WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)
 {
-    if (line.contains("-->"))
+    if (line.contains("-->"_s))
         return collectTimingsAndSettings(line);
     m_currentId = AtomString { line };
     return TimingsAndSettings;
@@ -463,7 +463,7 @@ WebVTTParser::ParseState WebVTTParser::collectCueText(const String& line)
         return Id;
     }
     // Step 35.
-    if (line.contains("-->")) {
+    if (line.contains("-->"_s)) {
         // Step 39-40.
         createNewCue();
 
@@ -490,7 +490,7 @@ WebVTTParser::ParseState WebVTTParser::ignoreBadCue(const String& line)
 {
     if (line.isEmpty())
         return Id;
-    if (line.contains("-->"))
+    if (line.contains("-->"_s))
         return recoverCue(line);
     return BadCue;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -178,7 +178,7 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::Element
             auto* factory = reinterpret_cast<GstElementFactory*>(factories->data);
             auto metadata = String::fromLatin1(gst_element_factory_get_metadata(factory, GST_ELEMENT_METADATA_KLASS));
             auto components = metadata.split('/');
-            if (components.contains("Hardware")) {
+            if (components.contains("Hardware"_s)) {
                 isUsingHardware = true;
                 break;
             }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2763,7 +2763,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
         auto classifiers = elementClass.split('/');
 
         // Collect processing time metrics for video decoders and converters.
-        if ((classifiers.contains("Converter"_s) || classifiers.contains("Decoder"_s)) && classifiers.contains("Video"_s) && !classifiers.contains("Parser"))
+        if ((classifiers.contains("Converter"_s) || classifiers.contains("Decoder"_s)) && classifiers.contains("Video"_s) && !classifiers.contains("Parser"_s))
             webkitGstTraceProcessingTimeForElement(element);
 
         if (classifiers.contains("Decoder"_s) && classifiers.contains("Video"_s)) {

--- a/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGLCommon.cpp
+++ b/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGLCommon.cpp
@@ -78,13 +78,13 @@ ExtensionsGLOpenGLCommon::ExtensionsGLOpenGLCommon(GraphicsContextGLOpenGL* cont
     m_renderer = String::fromLatin1(reinterpret_cast<const char*>(::glGetString(GL_RENDERER)));
 
     Vector<String> vendorComponents = m_vendor.convertToASCIILowercase().split(' ');
-    if (vendorComponents.contains("nvidia"))
+    if (vendorComponents.contains("nvidia"_s))
         m_isNVIDIA = true;
-    if (vendorComponents.contains("ati") || vendorComponents.contains("amd"))
+    if (vendorComponents.contains("ati"_s) || vendorComponents.contains("amd"_s))
         m_isAMD = true;
-    if (vendorComponents.contains("intel"))
+    if (vendorComponents.contains("intel"_s))
         m_isIntel = true;
-    if (vendorComponents.contains("imagination"))
+    if (vendorComponents.contains("imagination"_s))
         m_isImagination = true;
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
@@ -55,8 +55,8 @@ const TextureMapperContextAttributes& TextureMapperContextAttributes::get()
         attributes.isGLES2Compliant = true;
 
         auto extensionsString = String::fromLatin1(reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)));
-        attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot");
-        attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage");
+        attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot"_s);
+        attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage"_s);
 #else
         attributes.isGLES2Compliant = false;
         attributes.supportsNPOTTextures = true;

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -72,7 +72,7 @@ static StringView deviceNameForUserAgent()
     static NeverDestroyed<String> name = [] {
         auto name = deviceName();
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
-        size_t location = name.find(" Simulator");
+        size_t location = name.find(" Simulator"_s);
         if (location != notFound)
             return name.left(location);
 #endif

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -162,12 +162,12 @@ static bool isValidCaptureDevice(const CoreAudioCaptureDevice& device, bool filt
         return false;
     }
 
-    if (device.label().startsWith("VPAUAggregateAudioDevice")) {
+    if (device.label().startsWith("VPAUAggregateAudioDevice"_s)) {
         RELEASE_LOG(WebRTC, "Ignoring output VPAUAggregateAudioDevice device");
         return false;
     }
 
-    if (device.label().contains("WebexMediaAudioDevice")) {
+    if (device.label().contains("WebexMediaAudioDevice"_s)) {
         RELEASE_LOG(WebRTC, "Ignoring webex audio device");
         return false;
     }

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -140,9 +140,9 @@ NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, 
         String areaName = name;
         bool startSide = isStartSide(side);
         if (!nameIsAreaName) {
-            size_t suffix = name.find("-start");
+            size_t suffix = name.find("-start"_s);
             if (suffix == notFound) {
-                suffix = name.find("-end");
+                suffix = name.find("-end"_s);
                 ASSERT(suffix != notFound);
                 startSide = false;
             } else

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -361,7 +361,7 @@ void Scope::collectActiveStyleSheets(Vector<RefPtr<StyleSheet>>& sheets)
                 if (linkElement.styleSheetIsLoading()) {
                     // it is loading but we should still decide which style sheet set to use
                     if (!enabledViaScript && !title.isEmpty() && m_preferredStylesheetSetName.isEmpty()) {
-                        if (!linkElement.attributeWithoutSynchronization(relAttr).contains("alternate"))
+                        if (!linkElement.attributeWithoutSynchronization(relAttr).contains("alternate"_s))
                             m_preferredStylesheetSetName = title;
                     }
                     continue;
@@ -389,14 +389,14 @@ void Scope::collectActiveStyleSheets(Vector<RefPtr<StyleSheet>>& sheets)
                     // we are NOT an alternate sheet, then establish
                     // us as the preferred set. Otherwise, just ignore
                     // this sheet.
-                    if (is<HTMLStyleElement>(element) || !rel.contains("alternate"))
+                    if (is<HTMLStyleElement>(element) || !rel.contains("alternate"_s))
                         m_preferredStylesheetSetName = title;
                 }
                 if (title != m_preferredStylesheetSetName)
                     sheet = nullptr;
             }
 
-            if (rel.contains("alternate") && title.isEmpty())
+            if (rel.contains("alternate"_s) && title.isEmpty())
                 sheet = nullptr;
 
             if (sheet)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1602,7 +1602,7 @@ bool Internals::isSupportingVP9VTB() const
 void Internals::isVP9VTBDeccoderUsed(RTCPeerConnection& connection, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
     connection.gatherDecoderImplementationName([promise = WTFMove(promise)](auto&& name) mutable {
-        promise.resolve(name.contains("VideoToolBox"));
+        promise.resolve(name.contains("VideoToolBox"_s));
     });
 }
 

--- a/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
+++ b/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
@@ -346,8 +346,8 @@ void MockLibWebRTCPeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::S
         sessionDescription->ToString(&sdp);
 
         m_isInitiator = false;
-        m_isReceivingAudio = sdp.find("m=audio") != std::string::npos;
-        m_isReceivingVideo = sdp.find("m=video") != std::string::npos;
+        m_isReceivingAudio = sdp.find("m=audio"_s) != std::string::npos;
+        m_isReceivingVideo = sdp.find("m=video"_s) != std::string::npos;
     }
 }
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
@@ -247,7 +247,7 @@ static const String ObservedDomainsTableSchemaV1Alternate()
 
 static bool needsNewCreateTableSchema(const String& schema)
 {
-    return schema.contains("REFERENCES TopLevelDomains");
+    return schema.contains("REFERENCES TopLevelDomains"_s);
 }
 
 const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& ResourceLoadStatisticsDatabaseStore::expectedTableAndIndexQueries()
@@ -789,7 +789,7 @@ void ResourceLoadStatisticsDatabaseStore::insertDomainRelationshipList(const Str
             return;
     }
     
-    if (statement.contains("REPLACE")) {
+    if (statement.contains("REPLACE"_s)) {
         if (insertRelationshipStatement->bindDouble(2, WallTime::now().secondsSinceEpoch().value()) != SQLITE_OK) {
             ITP_RELEASE_LOG_ERROR(m_sessionID, "%p - ResourceLoadStatisticsDatabaseStore::insertDomainRelationshipList failed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -852,7 +852,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
 
     if (isCrossOriginPrefetch()) {
         LOADER_RELEASE_LOG("didReceiveResponse: Using response for cross-origin prefetch");
-        if (response.httpHeaderField(HTTPHeaderName::Vary).contains("Cookie")) {
+        if (response.httpHeaderField(HTTPHeaderName::Vary).contains("Cookie"_s)) {
             LOADER_RELEASE_LOG("didReceiveResponse: Canceling cross-origin prefetch for Vary: Cookie");
             abort();
             return completionHandler(PolicyAction::Ignore);

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<PrefetchCache::Entry> PrefetchCache::take(const URL& url)
         return std::get<0>(tuple) == url;
     });
     auto entry = resources->take(url);
-    ASSERT(!entry || !entry->response.httpHeaderField(WebCore::HTTPHeaderName::Vary).contains("Cookie"));
+    ASSERT(!entry || !entry->response.httpHeaderField(WebCore::HTTPHeaderName::Vary).contains("Cookie"_s));
     return entry;
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5927,7 +5927,7 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
     }
 
     BOOL disableAutocorrectAndAutocapitalize = _focusedElementInformation.elementType == WebKit::InputType::Password || _focusedElementInformation.elementType == WebKit::InputType::Email
-        || _focusedElementInformation.elementType == WebKit::InputType::URL || _focusedElementInformation.formAction.contains("login");
+        || _focusedElementInformation.elementType == WebKit::InputType::URL || _focusedElementInformation.formAction.contains("login"_s);
     if ([traits respondsToSelector:@selector(setAutocapitalizationType:)])
         traits.autocapitalizationType = disableAutocorrectAndAutocapitalize ? UITextAutocapitalizationTypeNone : toUITextAutocapitalize(_focusedElementInformation.autocapitalizeType);
     if ([traits respondsToSelector:@selector(setAutocorrectionType:)])

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3536,7 +3536,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
             else {
                 information.elementType = InputType::Text;
                 if (!information.formAction.isEmpty()
-                    && (element.getNameAttribute().contains("search") || element.getIdAttribute().contains("search") || element.attributeWithoutSynchronization(HTMLNames::titleAttr).contains("search")))
+                    && (element.getNameAttribute().contains("search"_s) || element.getIdAttribute().contains("search"_s) || element.attributeWithoutSynchronization(HTMLNames::titleAttr).contains("search"_s)))
                     information.elementType = InputType::Search;
             }
         }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1997,9 +1997,9 @@ static inline void checkDocumentsCaptureStateConsistency(const Vector<String>& e
     });
 
     if (isCapturingAudio)
-        ASSERT(extensionIDs.findIf([](auto& id) { return id.contains("microphone"); }) == notFound);
+        ASSERT(!extensionIDs.containsIf([](auto& id) { return id.contains("microphone"_s); }));
     if (isCapturingVideo)
-        ASSERT(extensionIDs.findIf([](auto& id) { return id.contains("camera"); }) == notFound);
+        ASSERT(!extensionIDs.containsIf([](auto& id) { return id.contains("camera"_s); }));
 #endif // ASSERT_ENABLED
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9507,7 +9507,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
                 RefPtr<EditingStyle> typingStyle = coreFrame->selection().typingStyle();
                 if (typingStyle && typingStyle->style()) {
                     String value = typingStyle->style()->getPropertyValue(CSSPropertyWebkitTextDecorationsInEffect);
-                    [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline")];
+                    [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline"_s)];
                 } else
                     [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationsInEffect().contains(TextDecorationLine::Underline)];
 


### PR DESCRIPTION
#### 2a3e9ccdbf1935e000aa1993068ab993feb5dcb5
<pre>
Add find()/reverseFind()/contains() overloads takes an ASCIILiteral to our String types
<a href="https://bugs.webkit.org/show_bug.cgi?id=240247">https://bugs.webkit.org/show_bug.cgi?id=240247</a>

Reviewed by NOBODY (OOPS!).

Add find()/reverseFind()/contains() overloads takes an ASCIILiteral to our String types.
These versions are more efficient when the call sites have an ASCIILiteral as they have
less branching.

* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::notAFunctionSourceAppender):
(JSC::invalidParameterInSourceAppender):
(JSC::invalidParameterInstanceofSourceAppender):
(JSC::invalidPrototypeSourceAppender):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization):
(JSC::lookupMatcher):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::initializeOverrideInfo):
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::Unicode16BitEscapeSequence::findInString):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp:
(WebKit::needsNewCreateTableSchema):
(WebKit::ResourceLoadStatisticsDatabaseStore::insertDomainRelationshipList):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveResponse):
* Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp:
(WebKit::PrefetchCache::take):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraits:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::checkDocumentsCaptureStateConsistency):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView updateTextTouchBar]):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):
(WTF::StringView::reverseFind const):
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::validateSDP const):
(WebCore::PeerConnectionBackend::newICECandidate):
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::YouTubePluginReplacement::youTubeURLFromAbsoluteURL):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::types const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createCDATASection):
(WebCore::Document::createProcessingInstruction):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::computedAttributesForElement):
* Source/WebCore/editing/libwpe/EditorLibWPE.cpp:
(WebCore::createFragmentFromPasteboardData):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::shouldPreserveMSOListStyleForElement):
(WebCore::StyledMarkupAccumulator::appendNodeToPreserveMSOList):
(WebCore::shouldPreserveMSOLists):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::parseSettingValue):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectWebVTTBlock):
(WebCore::WebVTTParser::checkAndRecoverCue):
(WebCore::WebVTTParser::checkAndCreateRegion):
(WebCore::WebVTTParser::checkAndStoreRegion):
(WebCore::WebVTTParser::checkStyleSheet):
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
(WebCore::WebVTTParser::collectCueId):
(WebCore::WebVTTParser::collectCueText):
(WebCore::WebVTTParser::ignoreBadCue):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::ElementFactories::hasElementForMediaType const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGLCommon.cpp:
(WebCore::ExtensionsGLOpenGLCommon::ExtensionsGLOpenGLCommon):
* Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp:
(WebCore::TextureMapperContextAttributes::get):
* Source/WebCore/platform/ios/UserAgentIOS.mm:
(WebCore::deviceNameForUserAgent):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::isValidCaptureDevice):
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollectionBase::NamedLineCollectionBase):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::collectActiveStyleSheets):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isVP9VTBDeccoderUsed):
* Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp:
(WebCore::MockLibWebRTCPeerConnection::SetRemoteDescription):
</pre>