### PR TITLE
[Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,5 +1,14 @@
 2022-05-11  Karl Rackler  <rackler@apple.com>
 
+        [Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure
+        https://bugs.webkit.org/show_bug.cgi?id=239818
+
+        Unreviewed test gardening. 
+
+        * platform/mac-wk2/TestExpectations:
+
+2022-05-11  Karl Rackler  <rackler@apple.com>
+
         [Gardening][ macOS Debug wk2 ] fast/css/variables/test-suite/168.html is a flaky image failure
         https://bugs.webkit.org/show_bug.cgi?id=239822
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1715,11 +1715,5 @@ webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gestu
 
 webkit.org/b/239634 [ arm64 ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Failure ]
 
-<<<<<<< HEAD
-webkit.org/b/239818 [ Debug ] fast/css/identical-logical-height-decl.html [ Pass ImageOnlyFailure ]
-=======
-webkit.org/b/239818 [ Debug ] fast/css/variables/test-suite/168.html [ Pass ImageOnlyFailure ]
->>>>>>> 6d3bdd661e49 ([Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure)
-
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1715,7 +1715,11 @@ webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gestu
 
 webkit.org/b/239634 [ arm64 ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Failure ]
 
+<<<<<<< HEAD
 webkit.org/b/239818 [ Debug ] fast/css/identical-logical-height-decl.html [ Pass ImageOnlyFailure ]
+=======
+webkit.org/b/239818 [ Debug ] fast/css/variables/test-suite/168.html [ Pass ImageOnlyFailure ]
+>>>>>>> 6d3bdd661e49 ([Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure)
 
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 


### PR DESCRIPTION
#### fb93a53367f0e17bd0137cb017603d739032a9a6
<pre>
[Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=239818">https://bugs.webkit.org/show_bug.cgi?id=239818</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:
</pre>
----------------------------------------------------------------------
#### 1c0e1fb0a7285779b4aad2cc998e9c7b1e24bc85
<pre>
[Gardening][ macOS Debug wk2 ] fast/css/identical-logical-height-decl.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=239818">https://bugs.webkit.org/show_bug.cgi?id=239818</a>

Unreviewed test gardening.
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre>