### PR TITLE
[Cocoa] ProcessLauncher instance was not released well on the error case

### DIFF
--- a/Source/WebKit/ChangeLog
+++ b/Source/WebKit/ChangeLog
@@ -1,3 +1,21 @@
+2022-05-11  Basuke Suzuki  <basuke@mac.com>
+
+        [Cocoa] ProcessLauncher instance was not released well on the error case.
+        https://bugs.webkit.org/show_bug.cgi?id=240321
+
+        Reviewed by NOBODY (OOPS!).
+
+        It's very rare case but when xpc is failing to establish the connection to the sub process, the error handler is
+        called after executing xpc_connection_send_message_with_reply() and ProcessLauncher is failing its responsibility.
+        At the end the owner of ProcessLauncher is terminated and releases the ownership of ProcessLauncher at the destructor
+        of AuxiliaryProcessProxy.
+
+        But just before calling xpc_connection_send_message_with_reply(), the process is ref()ed. There's no chance to deref()
+        the instance because the callback of  xpc_connection_send_message_with_reply() won't be called if error happens.
+
+        * UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
+        (WebKit::ProcessLauncher::launchProcess):
+
 2022-05-11  Per Arne Vollan  <pvollan@apple.com>
 
         [WP] Remove obsolete message filters

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -272,6 +272,7 @@ void ProcessLauncher::launchProcess()
         processLauncher->m_xpcConnection = nullptr;
 
         processLauncher->didFinishLaunchingProcess(0, IPC::Connection::Identifier());
+        processLauncher->deref();
     };
 
     auto eventHandler = [errorHandlerImpl = WTFMove(errorHandlerImpl), eventHandler = m_client->xpcEventHandler()] (xpc_object_t event) mutable {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=240321

Reviewed by NOBODY (OOPS!).

It's very rare case but when xpc is failing to establish the connection to the sub process, the error handler is
called after executing xpc_connection_send_message_with_reply() and ProcessLauncher is failing its responsibility.
At the end the owner of ProcessLauncher is terminated and releases the ownership of ProcessLauncher at the destructor
of AuxiliaryProcessProxy.

But just before calling xpc_connection_send_message_with_reply(), the process is ref()ed. There's no chance to deref()
the instance because the callback of  xpc_connection_send_message_with_reply() won't be called if error happens.

* UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
