### PR TITLE
[Catalina GPU] fast/canvas/webgl/lose-context-on-timeout.html is a flaky timeout

### DIFF
--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost
+CONSOLE MESSAGE: WebGL: context lost.
 Checks that a GPU process timeout on a result producing WebGL call will lose the context.
 NOTE: This only passes in the test harness because it requires Internals.
 

--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html
@@ -27,6 +27,14 @@ async function webGLContextLost(canvas) {
 }
 var val;
 async function runTest() {
+    // keep the WP-GPUP connection open by ensure there will be atleast one
+    // active GL context at all times.
+    let keepalive_canvas = document.createElement("canvas");
+    keepalive_canvas.width = 200;
+    keepalive_canvas.height = 200;
+    let keepalive_gl = wtu.create3DContext(keepalive_canvas);
+    wtu.setupColorQuad(keepalive_gl);
+
     let canvas = document.createElement("canvas");
     canvas.width = 200;
     canvas.height = 200;

--- a/LayoutTests/gpu-process/TestExpectations
+++ b/LayoutTests/gpu-process/TestExpectations
@@ -1,0 +1,2 @@
+# GPUP-only WebGL tests
+webkit.org/b/229523 [ Debug ] fast/canvas/webgl/lose-context-on-timeout.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1533,8 +1533,6 @@ webkit.org/b/229472 [ BigSur Debug ] webgl/1.0.3/conformance/glsl/constructors/g
 
 webkit.org/b/229502 [ BigSur Debug ] http/tests/inspector/paymentrequest/payment-request-internal-properties.https.html [ Pass Failure ]
 
-webkit.org/b/229523 [ Debug ] fast/canvas/webgl/lose-context-on-timeout.html [ Pass Timeout ]
-
 webkit.org/b/229561 http/tests/navigation/page-cache-video.html [ Pass Failure ]
 
 webkit.org/b/229579 [ BigSur Debug ] http/tests/loading/preload-img-test.html [ Pass Failure ]

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -814,8 +814,9 @@ bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC
 #endif
 #if ENABLE(WEBGL)
     if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName()) {
-        // Skip messages for already removed receivers.
-        return true;
+        // Invalidate out-of-stream messages for already removed receivers.
+        decoder.markInvalid();
+        return false;
     }
 #endif
 
@@ -900,9 +901,11 @@ bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection,
     }
 #endif
 #if ENABLE(WEBGL)
-    if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName())
-        // Skip messages for already removed receivers.
-        return true;
+    if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName()) {
+        // Invalidate out-of-stream messages for already removed receivers.
+        decoder.markInvalid();
+        return false;
+    }
 #endif
 #if ENABLE(IPC_TESTING_API)
     if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -129,7 +129,7 @@ protected:
 #if ENABLE(VIDEO)
     void copyTextureFromVideoFrame(RemoteVideoFrameReadReference, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
 #endif
-    void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting);
+    void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting, CompletionHandler<void()>&&);
     void readnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t>&& data, CompletionHandler<void(IPC::ArrayReference<uint8_t>)>&&);
     void readnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset);
     void multiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t>&& firstsAndCounts);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -50,7 +50,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
 #if ENABLE(MEDIA_STREAM)
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
-    void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
+    void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event) -> () Synchronous
     void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t> data) -> (IPC::ArrayReference<uint8_t> data) Synchronous
     void ReadnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4347,6 +4347,12 @@
 		37FC19461850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextLoadDelegatePrivate.h; sourceTree = "<group>"; };
 		37FC194818510D6A008CFA47 /* WKNSURLAuthenticationChallenge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKNSURLAuthenticationChallenge.mm; sourceTree = "<group>"; };
 		37FC194918510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNSURLAuthenticationChallenge.h; sourceTree = "<group>"; };
+		3ADAB87D282CAA8C006107A4 /* RemoteGraphicsContextGLMessagesReplies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLMessagesReplies.h; sourceTree = "<group>"; };
+		3ADAB87E282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		3ADAB87F282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxyMessages.h; sourceTree = "<group>"; };
+		3ADAB880282CAA8C006107A4 /* RemoteGraphicsContextGLMessages.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = RemoteGraphicsContextGLMessages.h; sourceTree = "<group>"; };
+		3ADAB881282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessagesReplies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxyMessagesReplies.h; sourceTree = "<group>"; };
+		3ADAB882282CAA8C006107A4 /* RemoteGraphicsContextGLMessageReceiver.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; path = RemoteGraphicsContextGLMessageReceiver.cpp; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource113.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource113.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VideoFullscreenManagerMessageReceiver.cpp; path = DerivedSources/WebKit/VideoFullscreenManagerMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F418EF61887BD97002795FD /* VideoFullscreenManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VideoFullscreenManagerMessages.h; path = DerivedSources/WebKit/VideoFullscreenManagerMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -12839,6 +12845,12 @@
 				1CDDFC7D2755866D00C93C62 /* RemoteGPUProxyMessageReceiver.cpp */,
 				1CDDFC7E2755866D00C93C62 /* RemoteGPUProxyMessages.h */,
 				1CDDFC7C2755866D00C93C62 /* RemoteGPUProxyMessagesReplies.h */,
+				3ADAB882282CAA8C006107A4 /* RemoteGraphicsContextGLMessageReceiver.cpp */,
+				3ADAB880282CAA8C006107A4 /* RemoteGraphicsContextGLMessages.h */,
+				3ADAB87D282CAA8C006107A4 /* RemoteGraphicsContextGLMessagesReplies.h */,
+				3ADAB87E282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */,
+				3ADAB87F282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessages.h */,
+				3ADAB881282CAA8C006107A4 /* RemoteGraphicsContextGLProxyMessagesReplies.h */,
 				1D47659B25CE74AD007AF312 /* RemoteImageDecoderAVFManagerMessageReceiver.cpp */,
 				1D47659925CE74AC007AF312 /* RemoteImageDecoderAVFManagerMessages.h */,
 				1D47659A25CE74AC007AF312 /* RemoteImageDecoderAVFManagerMessagesReplies.h */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -253,7 +253,7 @@ GCGLenum RemoteGraphicsContextGLProxy::getError()
 void RemoteGraphicsContextGLProxy::simulateEventForTesting(SimulatedEventForTesting event)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SimulateEventForTesting(event));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::SimulateEventForTesting(event), Messages::RemoteGraphicsContextGL::SimulateEventForTesting::Reply());
         if (!sendResult)
             markContextLost();
     }

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -96,7 +96,10 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
 #if USE(GRAPHICS_LAYER_WC)
     void PrepareForDisplay() -> (std::optional<WebKit::WCContentBufferIdentifier> contentBuffer) Synchronous
 #endif
-#if !PLATFORM(COCOA) && !USE(GRAPHICS_LAYER_WC)
+#if USE(LIBGBM)
+    void PrepareForDisplay() -> (WebCore::DMABufObject dmabufObject) Synchronous NotStreamEncodableReply
+#endif
+#if !PLATFORM(COCOA) && !USE(GRAPHICS_LAYER_WC) && !USE(LIBGBM)
     void PrepareForDisplay() -> () Synchronous
 #endif
     void EnsureExtensionEnabled(String extension)
@@ -111,7 +114,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
 #if ENABLE(MEDIA_STREAM)
     void PaintCompositedResultsToVideoFrame() -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
 #endif
-    void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
+    void SimulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event) -> () Synchronous
     void ReadnPixels0(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, IPC::ArrayReference<uint8_t> data) -> (IPC::ArrayReference<uint8_t> data) Synchronous
     void ReadnPixels1(int32_t x, int32_t y, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)


### PR DESCRIPTION
#### 4a252fa8dc083a715095358068c85d32bc99b33a
<pre>
[Catalina GPU] fast/canvas/webgl/lose-context-on-timeout.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=229523">https://bugs.webkit.org/show_bug.cgi?id=229523</a>
&lt;rdar://problem/82360416 &gt;

Fix the race conditions in simulating GPUP GraphicsContextGL timeout by
switching from async to sync calls.  This ensures that the processing of
subsequent messages will fail, triggering webglcontextlost event which the test
relies on to complete successfully.

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/generate-gpup-webgl
- Add missing LIBGBM PrepareForDisplay()
- Make SimulateEventForTesting(...) synchronous so subsequent
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::dispatchMessage):
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
GraphicsContextGL messages received out-of-stream are invalid and + should be
treated as a failure.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
Don&apos;t unconditionally access m_context. In the testing case of
lose-context-on-timeout, m_context is NULL on shutdown.
(WebKit::RemoteGraphicsContextGL::simulateEventForTesting):
Make SimulatedEventForTesting::Timeout case synchronous. Making the IPC message
SimulateEventForTesting synchronous and using callOnMainRunLoopAndWait fixes the
flaky behavior of lose-context-on-timeout.html
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
Source changes due to generate-gpup-webgl
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Add generated files for RemoteGraphicsContextGL and RemoteGraphicsContextGLProxy.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::simulateEventForTesting):
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt:
Correct output from test.
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html:
Add a second WebGL context to keep the WP-GPUP connection alive. This stops the
WP-GPUP connection from being closed when no more GraphicsContextGL remain,
causing the test to pass.
* LayoutTests/gpu-process/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
GPUP is required for correct execution of lose-context-on-timeout.html.
</pre>