### PR TITLE
[Gardening]: REGRESSION (r264117): [ Mac iOS ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,5 +1,14 @@
 2022-05-16  Karl Rackler  <rackler@apple.com>
 
+        [Gardening]: REGRESSION (r264117): [ Mac iOS ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html
+        https://bugs.webkit.org/show_bug.cgi?id=214155
+
+        Unreviewed test gardening. 
+
+        * platform/ios/TestExpectations:
+
+2022-05-16  Karl Rackler  <rackler@apple.com>
+
         [ iOS ] imported/w3c/web-platform-tests/webrtc/RTCRtpSender-replaceTrack.https.html is a consistent failure
         https://bugs.webkit.org/show_bug.cgi?id=240463
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3171,7 +3171,7 @@ imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-repeat-max-wid
 
 fast/text/text-styles/-apple-system [ Pass ]
 
-webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Failure ]
+webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Timeout Failure ]
 
 webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/normal-flow-overconstrained-vlr-005.xht [ ImageOnlyFailure ]
 

--- a/Source/WebCore/ChangeLog
+++ b/Source/WebCore/ChangeLog
@@ -1,3 +1,17 @@
+2022-05-16  Loïc Le Page  <llepage@igalia.com>
+
+        REGRESSION(r294104): [GStreamer][VideoCapture] Webcam raw streams may hang up the video capture pipeline
+        https://bugs.webkit.org/show_bug.cgi?id=240456
+
+        Reviewed by Philippe Normand.
+
+        When capturing a raw stream from a webcam, the pipeline may hang up because the decodebin3 cannot fix the upstream caps.
+        The webcam capsfilter should not only specify the captured mime-type (video/x-raw) but also the capture image dimensions.
+
+        Manually tested.
+
+        * platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
+
 2022-05-16  Alan Bujtas  <zalan@apple.com>
 
         [LFC][FFC] Add support for logical ordering

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -317,6 +317,9 @@ void GStreamerVideoCapturer::reconfigure()
 
             if (*width >= selector->stopCondition.width && *height >= selector->stopCondition.height
                 && *frameRate >= selector->stopCondition.frameRate) {
+                selector->maxWidth = *width;
+                selector->maxHeight = *height;
+                selector->maxFrameRate = *frameRate;
                 selector->mimeType = gst_structure_get_name(structure);
                 selector->format = gst_structure_get_string(structure, "format");
                 return FALSE;
@@ -333,7 +336,8 @@ void GStreamerVideoCapturer::reconfigure()
             return TRUE;
         }), &selector);
 
-    auto caps = adoptGRef(gst_caps_new_empty_simple(selector.mimeType));
+    auto caps = adoptGRef(gst_caps_new_simple(selector.mimeType, "width", G_TYPE_INT, selector.maxWidth,
+        "height", G_TYPE_INT, selector.maxHeight, nullptr));
 
     // Workaround for https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1793.
     if (selector.format)


### PR DESCRIPTION
#### e680ecfbe59fb6002f294b3dff1b61858f5a90c8
<pre>
[Gardening]: REGRESSION (r264117): [ Mac iOS ] imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=214155">https://bugs.webkit.org/show_bug.cgi?id=214155</a>

Unreviewed test gardening.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/250602@main">https://commits.webkit.org/250602@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294244">https://svn.webkit.org/repository/webkit/trunk@294244</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
