### PR TITLE
Revert "Use _adoptEffectiveConfiguration instead of a separate NSURLSession without credentials"

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -280,7 +280,6 @@ typedef NS_ENUM(NSInteger, NSURLSessionCompanionProxyPreference) {
 @end
 
 @interface NSURLSessionTask ()
-- (void) _adoptEffectiveConfiguration:(NSURLSessionConfiguration*) newConfiguration;
 - (NSDictionary *)_timingData;
 @property (readwrite, copy) NSString *_pathToDownloadTaskFile;
 @property (copy) NSString *_storagePartitionIdentifier;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -356,20 +356,6 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 
     m_task = [m_sessionWrapper->session dataTaskWithRequest:nsRequest.get()];
 
-    switch (parameters.storedCredentialsPolicy) {
-    case WebCore::StoredCredentialsPolicy::Use:
-        ASSERT(m_sessionWrapper->session.get().configuration.URLCredentialStorage);
-        break;
-    case WebCore::StoredCredentialsPolicy::EphemeralStateless:
-        ASSERT(!m_sessionWrapper->session.get().configuration.URLCredentialStorage);
-        break;
-    case WebCore::StoredCredentialsPolicy::DoNotUse:
-        NSURLSessionConfiguration *effectiveConfiguration = m_sessionWrapper->session.get().configuration;
-        effectiveConfiguration.URLCredentialStorage = nil;
-        [m_task _adoptEffectiveConfiguration:effectiveConfiguration];
-        break;
-    };
-
     WTFBeginSignpost(m_task.get(), "DataTask", "%{public}s pri: %.2f preconnect: %d", url.string().ascii().data(), toNSURLSessionTaskPriority(request.priority()), parameters.shouldPreconnectOnly == PreconnectOnly::Yes);
 
     RELEASE_ASSERT(!m_sessionWrapper->dataTaskMap.contains([m_task taskIdentifier]));

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -68,6 +68,7 @@ struct IsolatedSession {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SessionWrapper sessionWithCredentialStorage;
+    SessionWrapper sessionWithoutCredentialStorage;
     WallTime lastUsed;
 };
 
@@ -86,6 +87,7 @@ public:
     std::unique_ptr<IsolatedSession> appBoundSession;
 
     SessionWrapper sessionWithCredentialStorage;
+    SessionWrapper sessionWithoutCredentialStorage;
     SessionWrapper ephemeralStatelessSession;
 
 private:

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1351,6 +1351,9 @@ void NetworkSessionCocoa::initializeNSURLSessionsInSet(SessionSet& sessionSet, N
     auto cookieAcceptPolicy = configuration.HTTPCookieStorage.cookieAcceptPolicy;
     LOG(NetworkSession, "Created NetworkSession with cookieAcceptPolicy %lu", cookieAcceptPolicy);
     RELEASE_LOG_IF(cookieAcceptPolicy == NSHTTPCookieAcceptPolicyNever, NetworkSession, "Creating network session with ID %" PRIu64 " that will not accept cookies.", m_sessionID.toUInt64());
+
+    configuration.URLCredentialStorage = nil;
+    sessionSet.sessionWithoutCredentialStorage.initialize(configuration, *this, WebCore::StoredCredentialsPolicy::DoNotUse, NavigatingToAppBoundDomain::No);
 }
 
 SessionSet& NetworkSessionCocoa::sessionSetForPage(WebPageProxyIdentifier webPageProxyID)
@@ -1376,7 +1379,7 @@ SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(Navigati
         return ephemeralStatelessSession;
 
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-    NSURLSessionConfiguration *existingConfiguration = sessionWithCredentialStorage.session.get().configuration;
+    NSURLSessionConfiguration *existingConfiguration = sessionWithoutCredentialStorage.session.get().configuration;
 
     configuration.HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
     configuration.URLCredentialStorage = nil;
@@ -1420,8 +1423,9 @@ SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(WebPageProxyIdentifie
 
     switch (storedCredentialsPolicy) {
     case WebCore::StoredCredentialsPolicy::Use:
-    case WebCore::StoredCredentialsPolicy::DoNotUse:
         return sessionSetForPage(webPageProxyID).sessionWithCredentialStorage;
+    case WebCore::StoredCredentialsPolicy::DoNotUse:
+        return sessionSetForPage(webPageProxyID).sessionWithoutCredentialStorage;
     case WebCore::StoredCredentialsPolicy::EphemeralStateless:
         return initializeEphemeralStatelessSessionIfNeeded(webPageProxyID, NavigatingToAppBoundDomain::No);
     }
@@ -1435,14 +1439,17 @@ SessionWrapper& NetworkSessionCocoa::appBoundSession(WebPageProxyIdentifier webP
     if (!sessionSet.appBoundSession) {
         sessionSet.appBoundSession = makeUnique<IsolatedSession>();
         sessionSet.appBoundSession->sessionWithCredentialStorage.initialize(sessionSet.sessionWithCredentialStorage.session.get().configuration, *this, WebCore::StoredCredentialsPolicy::Use, NavigatingToAppBoundDomain::Yes);
+        sessionSet.appBoundSession->sessionWithoutCredentialStorage.initialize(sessionSet.sessionWithoutCredentialStorage.session.get().configuration, *this, WebCore::StoredCredentialsPolicy::DoNotUse, NavigatingToAppBoundDomain::Yes);
     }
 
     auto& sessionWrapper = [&] (auto storedCredentialsPolicy) -> SessionWrapper& {
         switch (storedCredentialsPolicy) {
         case WebCore::StoredCredentialsPolicy::Use:
-        case WebCore::StoredCredentialsPolicy::DoNotUse:
-            LOG(NetworkSession, "Using app-bound NSURLSession.");
+            LOG(NetworkSession, "Using app-bound NSURLSession with credential storage.");
             return sessionSet.appBoundSession->sessionWithCredentialStorage;
+        case WebCore::StoredCredentialsPolicy::DoNotUse:
+            LOG(NetworkSession, "Using app-bound NSURLSession without credential storage.");
+            return sessionSet.appBoundSession->sessionWithoutCredentialStorage;
         case WebCore::StoredCredentialsPolicy::EphemeralStateless:
             return initializeEphemeralStatelessSessionIfNeeded(webPageProxyID, NavigatingToAppBoundDomain::Yes);
         }
@@ -1481,6 +1488,7 @@ SessionWrapper& SessionSet::isolatedSession(WebCore::StoredCredentialsPolicy sto
     auto& entry = isolatedSessions.ensure(firstPartyDomain, [this, &session, isNavigatingToAppBoundDomain] {
         auto newEntry = makeUnique<IsolatedSession>();
         newEntry->sessionWithCredentialStorage.initialize(sessionWithCredentialStorage.session.get().configuration, session, WebCore::StoredCredentialsPolicy::Use, isNavigatingToAppBoundDomain);
+        newEntry->sessionWithoutCredentialStorage.initialize(sessionWithoutCredentialStorage.session.get().configuration, session, WebCore::StoredCredentialsPolicy::DoNotUse, isNavigatingToAppBoundDomain);
         return newEntry;
     }).iterator->value;
 
@@ -1489,9 +1497,11 @@ SessionWrapper& SessionSet::isolatedSession(WebCore::StoredCredentialsPolicy sto
     auto& sessionWrapper = [&] (auto storedCredentialsPolicy) -> SessionWrapper& {
         switch (storedCredentialsPolicy) {
         case WebCore::StoredCredentialsPolicy::Use:
-        case WebCore::StoredCredentialsPolicy::DoNotUse:
-            LOG(NetworkSession, "Using isolated NSURLSession.");
+            LOG(NetworkSession, "Using isolated NSURLSession with credential storage.");
             return entry->sessionWithCredentialStorage;
+        case WebCore::StoredCredentialsPolicy::DoNotUse:
+            LOG(NetworkSession, "Using isolated NSURLSession without credential storage.");
+            return entry->sessionWithoutCredentialStorage;
         case WebCore::StoredCredentialsPolicy::EphemeralStateless:
             return initializeEphemeralStatelessSessionIfNeeded(isNavigatingToAppBoundDomain, session);
         }
@@ -1538,19 +1548,25 @@ void NetworkSessionCocoa::clearIsolatedSessions()
 void NetworkSessionCocoa::invalidateAndCancelSessionSet(SessionSet& sessionSet)
 {
     [sessionSet.sessionWithCredentialStorage.session invalidateAndCancel];
+    [sessionSet.sessionWithoutCredentialStorage.session invalidateAndCancel];
     [sessionSet.ephemeralStatelessSession.session invalidateAndCancel];
     [sessionSet.sessionWithCredentialStorage.delegate sessionInvalidated];
+    [sessionSet.sessionWithoutCredentialStorage.delegate sessionInvalidated];
     [sessionSet.ephemeralStatelessSession.delegate sessionInvalidated];
 
     for (auto& session : sessionSet.isolatedSessions.values()) {
         [session->sessionWithCredentialStorage.session invalidateAndCancel];
         [session->sessionWithCredentialStorage.delegate sessionInvalidated];
+        [session->sessionWithoutCredentialStorage.session invalidateAndCancel];
+        [session->sessionWithoutCredentialStorage.delegate sessionInvalidated];
     }
     sessionSet.isolatedSessions.clear();
 
     if (sessionSet.appBoundSession) {
         [sessionSet.appBoundSession->sessionWithCredentialStorage.session invalidateAndCancel];
         [sessionSet.appBoundSession->sessionWithCredentialStorage.delegate sessionInvalidated];
+        [sessionSet.appBoundSession->sessionWithoutCredentialStorage.session invalidateAndCancel];
+        [sessionSet.appBoundSession->sessionWithoutCredentialStorage.delegate sessionInvalidated];
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Preconnect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Preconnect.mm
@@ -87,16 +87,20 @@ TEST(Preconnect, ConnectionCount)
     });
     auto webView = adoptNS([WKWebView new]);
 
+    // The preconnect to the server will use the default setting of "use the credential store",
+    // and therefore use the credential-store-blessed NSURLSession.
     [webView _preconnectToServer:server.request().URL];
     Util::run(&anyConnections);
     Util::spinRunLoop(10);
     EXPECT_FALSE(requested);
 
+    // Then this request will *not* use the credential store, therefore using a different NSURLSession
+    // that doesn't know about the above preconnect, triggering a second connection to the server.
     webView.get()._canUseCredentialStorage = NO;
     [webView loadRequest:server.request()];
     Util::run(&requested);
 
-    EXPECT_EQ(connectionCount, 1u);
+    EXPECT_EQ(connectionCount, 2u);
 }
 
 TEST(Preconnect, HTTPS)

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -237,15 +237,7 @@ void HTTPServer::respondWithChallengeThenOK(Connection connection)
         "Content-Length: 0\r\n"
         "WWW-Authenticate: Basic realm=\"testrealm\"\r\n\r\n"_s;
         connection.send(challengeHeader, [connection] {
-            connection.receiveHTTPRequest([connection] (Vector<char>&&) {
-                connection.send(
-                    "HTTP/1.1 200 OK\r\n"
-                    "Content-Length: 34\r\n\r\n"
-                    "<script>alert('success!')</script>"_s, [connection] {
-                        respondWithChallengeThenOK(connection);
-                    }
-                );
-            });
+            respondWithOK(connection);
         });
     });
 }


### PR DESCRIPTION
#### 3b80954a6bf5d8eca95b2e78d0c23c6104c0ad4d
<pre>
Revert &quot;Use _adoptEffectiveConfiguration instead of a separate NSURLSession without credentials&quot;

This reverts commit 0b3dce5541de6015552e960821b78b7539ea2880.
</pre>