### PR TITLE
[ iOS ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html is a flaky timeout

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,3 +1,12 @@
+2022-05-16  Karl Rackler  <rackler@apple.com>
+
+        [ iOS ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html is a flaky timeout
+        https://bugs.webkit.org/show_bug.cgi?id=240489
+
+        Unreviewed test gardening. 
+
+        * platform/ios/TestExpectations:
+
 2022-05-16  Ziran Sun  <zsun@igalia.com>
 
         [css-ui] alias appearance <compat-auto> keywords to 'auto' for textfield

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3615,3 +3615,5 @@ webkit.org/b/240167 [ Release ] fast/css-custom-paint/animate-repaint.html [ Pas
 webkit.org/b/240348 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html [ Failure ]
 
 webkit.org/b/240463 imported/w3c/web-platform-tests/webrtc/RTCRtpSender-replaceTrack.https.html [ Failure ]
+
+webkit.org/b/240489 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html [ Slow ]


### PR DESCRIPTION
#### fc9a534b922d5b3c8d8cd541fdce26c7103a7831
<pre>
[ iOS ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=240489">https://bugs.webkit.org/show_bug.cgi?id=240489</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/250622@main">https://commits.webkit.org/250622@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294278">https://svn.webkit.org/repository/webkit/trunk@294278</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
