### PR TITLE
AX: Don't create isolated objects from ignored live objects

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -386,7 +386,7 @@ private:
     static HashMap<PageIdentifier, Ref<AXIsolatedTree>>& treePageCache() WTF_REQUIRES_LOCK(s_cacheLock);
 
     enum class AttachWrapper : bool { OnMainThread, OnAXThread };
-    NodeChange nodeChangeForObject(AXCoreObject&, AttachWrapper = AttachWrapper::OnMainThread);
+    std::optional<NodeChange> nodeChangeForObject(AXCoreObject&, AttachWrapper = AttachWrapper::OnMainThread);
     void collectNodeChangesForSubtree(AXCoreObject&);
     void queueChange(const NodeChange&) WTF_REQUIRES_LOCK(m_changeLogLock);
     void queueRemovals(const Vector<AXID>&);


### PR DESCRIPTION
#### ba75cdc3b84ff92eccfda7dce6d93af1ed8abb24
<pre>
AX: Don&apos;t create isolated objects from ignored live objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=240507">https://bugs.webkit.org/show_bug.cgi?id=240507</a>

Reviewed by NOBODY (OOPS!).

Sometimes, we can get into a state where a live object has dynamically
become ignored but not removed as a child from its parent (since
unignored objects are the only thing that should be in any
AccessibilityObject::m_children). This can cause us to create an
isolated object for this ignored live object.

With this change, we now return a std::nullopt NodeChange for an
ignored live object.

I split this change off from a different patch improving our handling of
modals. It is required to make accessibility/aria-modal-multiple-dialogs.html
pass in isolated tree mode.

* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::queueRemovalsAndUnresolvedChanges):
(WebCore::AXIsolatedTree::updateNode):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
</pre>