### PR TITLE
[css-scroll-snap] Improve snapping behavior with incremental directional scrolls

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Snaps to bottom-left after pressing ArrowDown
 PASS Snaps to top-left after pressing ArrowUp
 PASS Snaps to top-right after pressing ArrowRight
 PASS Snaps to top-left after pressing ArrowLeft
 PASS If the original intended offset is valid as making a snap area cover thesnapport, and there's no other snap offset in between, use the originalintended offset
-TIMEOUT If the original intended offset is valid as making a snap area cover the snapport, but there's a defined snap offset in between, use the defined snap offset. Test timed out
-NOTRUN If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is mandatory, stay at the current offset.
-NOTRUN If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is proximity, go to the original intended offset
+PASS If the original intended offset is valid as making a snap area cover the snapport, but there's a defined snap offset in between, use the defined snap offset.
+PASS If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is mandatory, stay at the current offset.
+PASS If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is proximity, go to the original intended offset
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
 FAIL Snaps to bottom-left after pressing ArrowDown assert_greater_than: expected a number greater than 2 but got 0
 FAIL Snaps to top-left after pressing ArrowUp assert_greater_than: expected a number greater than 2 but got 0
 FAIL Snaps to top-right after pressing ArrowRight assert_greater_than: expected a number greater than 2 but got 0
 FAIL Snaps to top-left after pressing ArrowLeft assert_greater_than: expected a number greater than 2 but got 0
 PASS If the original intended offset is valid as making a snap area cover thesnapport, and there's no other snap offset in between, use the originalintended offset
-TIMEOUT If the original intended offset is valid as making a snap area cover the snapport, but there's a defined snap offset in between, use the defined snap offset. Test timed out
-NOTRUN If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is mandatory, stay at the current offset.
-NOTRUN If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is proximity, go to the original intended offset
+PASS If the original intended offset is valid as making a snap area cover the snapport, but there's a defined snap offset in between, use the defined snap offset.
+PASS If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is mandatory, stay at the current offset.
+PASS If there is no valid snap offset on the arrow key's direction other than the current offset, and the scroll-snap-type is proximity, go to the original intended offset
 


### PR DESCRIPTION
#### 9b8aa254c93dbe07e6f5ced571c0cfe69407fbe8
<pre>
[css-scroll-snap] Improve snapping behavior with incremental directional scrolls
<a href="https://bugs.webkit.org/show_bug.cgi?id=237360">https://bugs.webkit.org/show_bug.cgi?id=237360</a>
&lt;rdar://problem/90024215&gt;

Reviewed by NOBODY (OOPS!).

No new tests. This is covered by an existing WPT test.

* page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::closestSnapOffsetWithInfoAndAxis): Improve incremental direction scrolls (such as scrolling
with the keyboard arrow key) in a couple ways. First, don&apos;t skip past intermediate snap points that
happen to be in the middle of long scroll snap areas. Second, allow escaping into areas without valid
snap points when using proximity snapping with directional scrolls.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8aa254c93dbe07e6f5ced571c0cfe69407fbe8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104020 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164294 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3578 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31737 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100020 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100023 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2567 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-on-large-element-not-covering-snapport.tentative.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80748 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29612 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-on-large-element-not-covering-snapport.tentative.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72503 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38132 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17924 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-on-large-element-not-covering-snapport.tentative.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36009 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19196 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-on-large-element-not-covering-snapport.tentative.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39896 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41807 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-on-large-element-not-covering-snapport.tentative.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38425 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->