### PR TITLE
Template TextBoxPainter on line layout path

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -94,6 +94,13 @@ LineBoxIterator Box::lineBox() const
     );
 }
 
+FloatRect Box::visualRect() const
+{
+    auto rect = visualRectIgnoringBlockDirection();
+    containingBlock().flipForWritingMode(rect);
+    return rect;
+}
+
 RenderObject::HighlightState Box::selectionState() const
 {
     if (isText()) {

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -76,6 +76,11 @@ public:
         return m_inlineBox->renderer();
     }
 
+    const RenderBlockFlow& containingBlock() const
+    {
+        return m_inlineBox->root().blockFlow();
+    }
+
     const RenderStyle& style() const
     {
         return m_inlineBox->lineStyle();
@@ -112,6 +117,9 @@ public:
     {
         return { inlineFlowBox()->lastLeafDescendant() };
     }
+
+    TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
+    bool isFirstLine() const { return !rootInlineBox().prevRootBox(); }
 
     bool operator==(const BoxLegacyPath& other) const { return m_inlineBox == other.m_inlineBox; }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h
@@ -103,6 +103,11 @@ public:
         return m_inlineContent->rendererForLayoutBox(box().layoutBox());
     }
 
+    const RenderBlockFlow& containingBlock() const
+    {
+        return m_inlineContent->containingBlock();
+    }
+
     const RenderStyle& style() const
     {
         return box().style();
@@ -207,6 +212,9 @@ public:
         return last;
     }
 
+    TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
+    bool isFirstLine() const { return !box().lineIndex(); }
+
     bool operator==(const BoxModernPath& other) const { return m_inlineContent == other.m_inlineContent && m_boxIndex == other.m_boxIndex; }
 
     bool atEnd() const { return !m_inlineContent || m_boxIndex == boxes().size(); }
@@ -272,7 +280,6 @@ private:
     const LayoutIntegration::Line& line() const { return m_inlineContent->lineForBox(box()); }
 
     const RenderText& renderText() const { return downcast<RenderText>(renderer()); }
-    TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
 
     WeakPtr<const LayoutIntegration::InlineContent> m_inlineContent;
     size_t m_boxIndex { 0 };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -800,7 +800,7 @@ void LineLayout::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
             if (!box.text()->length() || !hasDamage(box))
                 continue;
 
-            TextBoxPainter painter(*m_inlineContent, box, paintInfo, paintOffset);
+            ModernTextBoxPainter painter(*m_inlineContent, box, paintInfo, paintOffset);
             painter.paint();
             continue;
         }

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -35,6 +35,12 @@
 
 namespace WebCore {
 
+class LegacyInlineTextBox;
+
+namespace InlineDisplay {
+struct Box;
+}
+
 template<typename LayoutRun>
 class GlyphDisplayListCache {
 public:
@@ -42,6 +48,7 @@ public:
 
     static GlyphDisplayListCache& singleton()
     {
+        static_assert(std::is_same_v<LayoutRun, LegacyInlineTextBox> || std::is_same_v<LayoutRun, InlineDisplay::Box>);
         static NeverDestroyed<GlyphDisplayListCache> cache;
         return cache;
     }

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -141,7 +141,7 @@ void InlineBoxPainter::paintMask()
         return;
 
     // Move x/y to our coordinates.
-    auto localRect = LayoutRect { m_inlineBox.visualRect(m_inlineBox.lineBox()->containingBlock().logicalHeight()) };
+    auto localRect = LayoutRect { m_inlineBox.visualRect() };
     LayoutPoint adjustedPaintOffset = m_paintOffset + localRect.location();
 
     const NinePieceImage& maskNinePieceImage = renderer().style().maskBoxImage();
@@ -217,7 +217,7 @@ void InlineBoxPainter::paintDecorations()
         return;
 
     // Move x/y to our coordinates.
-    auto localRect = LayoutRect { m_inlineBox.visualRect(m_inlineBox.lineBox()->containingBlock().logicalHeight()) };
+    auto localRect = LayoutRect { m_inlineBox.visualRect() };
     LayoutPoint adjustedPaintoffset = m_paintOffset + localRect.location();
     GraphicsContext& context = m_paintInfo.context();
     LayoutRect paintRect = LayoutRect(adjustedPaintoffset, localRect.size());

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -926,7 +926,7 @@ inline void LegacyInlineFlowBox::addTextBoxVisualOverflow(LegacyInlineTextBox& t
     
     logicalVisualOverflow = LayoutRect(logicalLeftVisualOverflow, logicalTopVisualOverflow, logicalRightVisualOverflow - logicalLeftVisualOverflow, logicalBottomVisualOverflow - logicalTopVisualOverflow);
 
-    auto documentMarkerBounds = TextBoxPainter::calculateUnionOfAllDocumentMarkerBounds(textBox);
+    auto documentMarkerBounds = LegacyTextBoxPainter::calculateUnionOfAllDocumentMarkerBounds(textBox);
     documentMarkerBounds.move(textBox.logicalLeft(), textBox.logicalTop());
     logicalVisualOverflow = unionRect(logicalVisualOverflow, LayoutRect(documentMarkerBounds));
 

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -397,7 +397,7 @@ void LegacyInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (logicalStart >= paintEnd || logicalStart + logicalExtent <= paintStart)
         return;
 
-    TextBoxPainter textBoxPainter(*this, paintInfo, paintOffset);
+    LegacyTextBoxPainter textBoxPainter(*this, paintInfo, paintOffset);
     textBoxPainter.paint();
 }
 

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -150,7 +150,6 @@ public:
 
 private:
     friend class InlineIterator::BoxLegacyPath;
-    friend class TextBoxPainter;
 
     const RenderCombineText* combinedText() const;
     const FontCascade& lineFont() const;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -727,7 +727,12 @@ void RenderBoxModelObject::paintMaskForTextFillBox(ImageBuffer* maskImage, const
         for (auto box = inlineBox->firstLeafBox(), end = inlineBox->endLeafBox(); box != end; box.traverseNextOnLine()) {
             if (!box->isText())
                 continue;
-            TextBoxPainter textBoxPainter(downcast<InlineIterator::TextBoxIterator>(box), maskInfo, paintOffset);
+            if (auto* legacyTextBox = downcast<LegacyInlineTextBox>(box->legacyInlineBox())) {
+                LegacyTextBoxPainter textBoxPainter(*legacyTextBox, maskInfo, paintOffset);
+                textBoxPainter.paint();
+                continue;
+            }
+            ModernTextBoxPainter textBoxPainter(box->modernPath().inlineContent(), box->modernPath().box(), maskInfo, paintOffset);
             textBoxPainter.paint();
         }
         return;

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -45,22 +45,17 @@ struct MarkedText;
 struct PaintInfo;
 struct StyledMarkedText;
 
+template<typename TextBoxPath>
 class TextBoxPainter {
 public:
-    TextBoxPainter(const LegacyInlineTextBox&, PaintInfo&, const LayoutPoint& paintOffset);
-#if ENABLE(LAYOUT_FORMATTING_CONTEXT)
-    TextBoxPainter(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&, PaintInfo&, const LayoutPoint& paintOffset);
-#endif
-    TextBoxPainter(const InlineIterator::TextBoxIterator&, PaintInfo&, const LayoutPoint& paintOffset);
-
+    TextBoxPainter(TextBoxPath&&, PaintInfo&, const LayoutPoint& paintOffset);
     ~TextBoxPainter();
 
     void paint();
 
-    static FloatRect calculateUnionOfAllDocumentMarkerBounds(const LegacyInlineTextBox&);
-
-private:
-    auto& textBox() const { return *m_textBox; }
+protected:
+    auto& textBox() const { return m_textBox; }
+    InlineIterator::TextBoxIterator makeIterator() const;
 
     void paintBackground();
     void paintForegroundAndDecorations();
@@ -78,8 +73,7 @@ private:
     void paintCompositionUnderline(const CompositionUnderline&);
     void paintPlatformDocumentMarker(const MarkedText&);
 
-    static FloatRect calculateDocumentMarkerBounds(const InlineIterator::TextBoxIterator&, const MarkedText&);
-
+    float textPosition();
     FloatRect computePaintRect(const LayoutPoint& paintOffset);
     bool computeHaveSelection() const;
     MarkedText createMarkedTextFromSelectionInBox();
@@ -88,20 +82,36 @@ private:
 
     const ShadowData* debugTextShadow() const;
 
-    const InlineIterator::TextBoxIterator m_textBox;
+    const TextBoxPath m_textBox;
     const RenderText& m_renderer;
     const Document& m_document;
     const RenderStyle& m_style;
+    const FloatRect m_logicalRect;
     const TextRun m_paintTextRun;
     PaintInfo& m_paintInfo;
     const TextBoxSelectableRange m_selectableRange;
     const FloatRect m_paintRect;
     const bool m_isFirstLine;
+    const bool m_isCombinedText;
     const bool m_isPrinting;
     const bool m_haveSelection;
     const bool m_containsComposition;
     const bool m_useCustomUnderlines;
     std::optional<bool> m_emphasisMarkExistsAndIsAbove { };
 };
+
+class LegacyTextBoxPainter : public TextBoxPainter<InlineIterator::BoxLegacyPath> {
+public:
+    LegacyTextBoxPainter(const LegacyInlineTextBox&, PaintInfo&, const LayoutPoint& paintOffset);
+
+    static FloatRect calculateUnionOfAllDocumentMarkerBounds(const LegacyInlineTextBox&);
+};
+
+#if ENABLE(LAYOUT_FORMATTING_CONTEXT)
+class ModernTextBoxPainter : public TextBoxPainter<InlineIterator::BoxModernPath> {
+public:
+    ModernTextBoxPainter(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&, PaintInfo&, const LayoutPoint& paintOffset);
+};
+#endif
 
 }


### PR DESCRIPTION
#### ce6f5ff93a06d4523e7a9602a957a7a8fd9974f1
<pre>
Template TextBoxPainter on line layout path
<a href="https://bugs.webkit.org/show_bug.cgi?id=240416">https://bugs.webkit.org/show_bug.cgi?id=240416</a>

Reviewed by Alan Bujtas.

Painting currently goes via a line layout path agnostic iterator.
This is inefficient since we always know what sort of layout we are painting.

* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp:
(WebCore::InlineIterator::Box::visualRect const):
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::Box::containingBlock const):
(WebCore::InlineIterator::Box::visualRect const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h:
(WebCore::InlineIterator::BoxLegacyPath::containingBlock const):
(WebCore::InlineIterator::BoxLegacyPath::direction const):
(WebCore::InlineIterator::BoxLegacyPath::isFirstLine const):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPath.h:
(WebCore::InlineIterator::BoxModernPath::containingBlock const):
(WebCore::InlineIterator::BoxModernPath::direction const):
(WebCore::InlineIterator::BoxModernPath::isFirstLine const):
(WebCore::InlineIterator::BoxModernPath::renderText const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::paint):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCache::singleton):
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paintMask):
(WebCore::InlineBoxPainter::paintDecorations):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addTextBoxVisualOverflow):
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::paint):
* Source/WebCore/rendering/LegacyInlineTextBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::paintMaskForTextFillBox):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::LegacyTextBoxPainter::LegacyTextBoxPainter):
(WebCore::ModernTextBoxPainter::ModernTextBoxPainter):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::TextBoxPainter):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::~TextBoxPainter):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::makeIterator const):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paint):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::createMarkedTextFromSelectionInBox):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintBackground):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintForegroundAndDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintCompositionBackground):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::createDecorationPainter):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintBackgroundDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintForegroundDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintCompositionUnderlines):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::textPosition):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintCompositionUnderline):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintPlatformDocumentMarkers):
(WebCore::LegacyTextBoxPainter::calculateUnionOfAllDocumentMarkerBounds):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::paintPlatformDocumentMarker):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::computePaintRect):
(WebCore::calculateDocumentMarkerBounds):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::computeHaveSelection const):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::fontCascade const):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::textOriginFromPaintRect const):
(WebCore::TextBoxPainter&lt;TextBoxPath &gt;::debugTextShadow const):
(WebCore::TextBoxPainter::TextBoxPainter): Deleted.
(WebCore::TextBoxPainter::~TextBoxPainter): Deleted.
(WebCore::TextBoxPainter::paint): Deleted.
(WebCore::TextBoxPainter::createMarkedTextFromSelectionInBox): Deleted.
(WebCore::TextBoxPainter::paintBackground): Deleted.
(WebCore::TextBoxPainter::paintForegroundAndDecorations): Deleted.
(WebCore::TextBoxPainter::paintCompositionBackground): Deleted.
(WebCore::TextBoxPainter::paintForeground): Deleted.
(WebCore::TextBoxPainter::createDecorationPainter): Deleted.
(WebCore::TextBoxPainter::paintBackgroundDecorations): Deleted.
(WebCore::TextBoxPainter::paintForegroundDecorations): Deleted.
(WebCore::TextBoxPainter::paintCompositionUnderlines): Deleted.
(WebCore::textPosition): Deleted.
(WebCore::TextBoxPainter::paintCompositionUnderline): Deleted.
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers): Deleted.
(WebCore::TextBoxPainter::calculateUnionOfAllDocumentMarkerBounds): Deleted.
(WebCore::TextBoxPainter::paintPlatformDocumentMarker): Deleted.
(WebCore::TextBoxPainter::computePaintRect): Deleted.
(WebCore::TextBoxPainter::calculateDocumentMarkerBounds): Deleted.
(WebCore::TextBoxPainter::computeHaveSelection const): Deleted.
(WebCore::TextBoxPainter::fontCascade const): Deleted.
(WebCore::TextBoxPainter::textOriginFromPaintRect const): Deleted.
(WebCore::TextBoxPainter::debugTextShadow const): Deleted.
* Source/WebCore/rendering/TextBoxPainter.h:
(WebCore::TextBoxPainter::textBox const):
</pre>