### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at com.apple.WebKit: WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions

### DIFF
--- a/LayoutTests/editing/text-iterator/sequential-collapsed-ranges-expected.txt
+++ b/LayoutTests/editing/text-iterator/sequential-collapsed-ranges-expected.txt
@@ -1,0 +1,53 @@
+a b
+
+Testing first letter with narrow width...
+  Default behavior
+    'a' (location 0 length 1)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a' (location 0 length 1)
+
+Testing first letter with wide width...
+  Default behavior
+    'a' (location 0 length 1)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a' (location 0 length 1)
+
+Testing everything except last letter with narrow width...
+  Default behavior
+    'a' (location 0 length 1)
+    ' ' (location 1 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a' (location 0 length 1)
+
+Testing everything except last letter with wide width...
+  Default behavior
+    'a ' (location 0 length 2)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a ' (location 0 length 2)
+
+Testing everything with narrow width...
+  Default behavior
+    'a' (location 0 length 1)
+    ' ' (location 1 length 0)
+    'b' (location 2 length 1)
+    '\n' (location 3 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a' (location 0 length 1)
+    ' ' (location 1 length 0)
+    'b' (location 1 length 1)
+    '\n' (location 3 length 0)
+
+Testing everything with wide width...
+  Default behavior
+    'a ' (location 0 length 2)
+    'b' (location 2 length 1)
+    '\n' (location 3 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'a ' (location 0 length 2)
+    'b' (location 2 length 1)
+    '\n' (location 3 length 0)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/text-iterator/sequential-collapsed-ranges.html
+++ b/LayoutTests/editing/text-iterator/sequential-collapsed-ranges.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="test">a    <span>    </span>    <span>    </span>    b</div>
+<div id="console"></div>
+<script>
+
+if (!window.internals)
+    testFailed("This test requires internals object");
+
+debug("");
+
+let container = document.getElementById("test");
+
+function test(description, rangeToSelect) {
+    let selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeToSelect);
+
+    debug(description);
+
+    [
+        [ ],
+        [ "IgnoresWhiteSpaceAtEndOfRun" ],
+    ].forEach((behaviors) => {
+        debug("  " + (behaviors.join("|") || "Default behavior"));
+        for (let {text, range} of internals.statesOfTextIterator(rangeToSelect, behaviors))
+            debug(`    '${text.replace("\n", "\\n")}' (location ${internals.locationFromRange(container, range, behaviors)} length ${internals.lengthFromRange(container, range, behaviors)})`);
+    });
+
+    debug("");
+}
+
+let rangeOfFirstLetter = document.createRange();
+rangeOfFirstLetter.setStart(container.firstChild, 0);
+rangeOfFirstLetter.setEnd(container.firstChild, 1);
+
+container.style.width = "1ch";
+test("Testing first letter with narrow width...", rangeOfFirstLetter);
+
+container.style.width = "";
+test("Testing first letter with wide width...", rangeOfFirstLetter);
+
+let rangeUntilLastLetter = document.createRange();
+rangeUntilLastLetter.setStart(container.firstChild, 0);
+rangeUntilLastLetter.setEnd(container.lastChild, 4);
+
+container.style.width = "1ch";
+test("Testing everything except last letter with narrow width...", rangeUntilLastLetter);
+
+container.style.width = "";
+test("Testing everything except last letter with wide width...", rangeUntilLastLetter);
+
+let rangeOfNode = document.createRange();
+rangeOfNode.selectNode(container);
+
+container.style.width = "1ch";
+test("Testing everything with narrow width...", rangeOfNode);
+
+container.style.width = "";
+test("Testing everything with wide width...", rangeOfNode);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace-expected.txt
+++ b/LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace-expected.txt
@@ -1,0 +1,33 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Testing first line...
+  Default behavior
+    'Lorem ipsum' (location 0 length 12)
+    ' ' (location 12 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'Lorem ipsum' (location 0 length 11)
+
+Testing second line...
+  Default behavior
+    'dolor sit amet,' (location 12 length 16)
+    ' ' (location 28 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'dolor sit amet,' (location 11 length 15)
+
+Testing third line...
+  Default behavior
+    'consectetur' (location 28 length 12)
+    ' ' (location 40 length 0)
+  IgnoresWhiteSpaceAtEndOfRun
+    'consectetur' (location 27 length 11)
+
+Testing fourth line...
+  Default behavior
+    'adipiscing elit.' (location 40 length 16)
+  IgnoresWhiteSpaceAtEndOfRun
+    'adipiscing elit.' (location 39 length 16)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace.html
+++ b/LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="test" style="width: 100px">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+<div id="console"></div>
+<script>
+
+if (!window.internals)
+    testFailed("This test requires internals object");
+
+debug("");
+
+let container = document.getElementById("test");
+
+function test(description, rangeToSelect) {
+    let selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(rangeToSelect);
+
+    debug(description);
+
+    [
+        [ ],
+        [ "IgnoresWhiteSpaceAtEndOfRun" ],
+    ].forEach((behaviors) => {
+        debug("  " + (behaviors.join("|") || "Default behavior"));
+        for (let {text, range} of internals.statesOfTextIterator(rangeToSelect, behaviors))
+            debug(`    '${text}' (location ${internals.locationFromRange(container, range, behaviors)} length ${internals.lengthFromRange(container, range, behaviors)})`);
+    });
+
+    debug("");
+}
+
+let rangeOfFirstLine = document.createRange();
+rangeOfFirstLine.setStart(container.firstChild, 0);
+rangeOfFirstLine.setEnd(container.firstChild, 12);
+test("Testing first line...", rangeOfFirstLine);
+
+let rangeOfSecondLine = document.createRange();
+rangeOfSecondLine.setStart(container.firstChild, 12);
+rangeOfSecondLine.setEnd(container.firstChild, 28);
+test("Testing second line...", rangeOfSecondLine);
+
+let rangeOfThirdLine = document.createRange();
+rangeOfThirdLine.setStart(container.firstChild, 28);
+rangeOfThirdLine.setEnd(container.firstChild, 40);
+test("Testing third line...", rangeOfThirdLine);
+
+let rangeOfFourthLine = document.createRange();
+rangeOfFourthLine.setStart(container.firstChild, 40);
+rangeOfFourthLine.setEnd(container.firstChild, 56);
+test("Testing fourth line...", rangeOfFourthLine);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -61,6 +61,8 @@ enum class TextIteratorBehavior : uint16_t {
     TraversesFlatTree = 1 << 9,
 
     EntersImageOverlays = 1 << 10,
+
+    IgnoresWhiteSpaceAtEndOfRun = 1 << 11,
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2184,19 +2184,29 @@ ExceptionOr<void> Internals::invalidateControlTints()
     return { };
 }
 
+static TextIteratorBehaviors toTextIteratorBehaviors(const Vector<String>& stringBehaviors)
+{
+    TextIteratorBehaviors behaviors;
+    for (const auto& stringBehavior : stringBehaviors) {
+        if (stringBehavior == "IgnoresWhiteSpaceAtEndOfRun"_s)
+            behaviors.add(TextIteratorBehavior::IgnoresWhiteSpaceAtEndOfRun);
+    }
+    return behaviors;
+}
+
 RefPtr<Range> Internals::rangeFromLocationAndLength(Element& scope, unsigned rangeLocation, unsigned rangeLength)
 {
     return createLiveRange(resolveCharacterRange(makeRangeSelectingNodeContents(scope), { rangeLocation, rangeLength }));
 }
 
-unsigned Internals::locationFromRange(Element& scope, const Range& range)
+unsigned Internals::locationFromRange(Element& scope, const Range& range, const Vector<String>& stringBehaviors)
 {
-    return clampTo<unsigned>(characterRange(makeBoundaryPointBeforeNodeContents(scope), makeSimpleRange(range)).location);
+    return clampTo<unsigned>(characterRange(makeBoundaryPointBeforeNodeContents(scope), makeSimpleRange(range), toTextIteratorBehaviors(stringBehaviors)).location);
 }
 
-unsigned Internals::lengthFromRange(Element& scope, const Range& range)
+unsigned Internals::lengthFromRange(Element& scope, const Range& range, const Vector<String>& stringBehaviors)
 {
-    return clampTo<unsigned>(characterRange(makeBoundaryPointBeforeNodeContents(scope), makeSimpleRange(range)).length);
+    return clampTo<unsigned>(characterRange(makeBoundaryPointBeforeNodeContents(scope), makeSimpleRange(range), toTextIteratorBehaviors(stringBehaviors)).length);
 }
 
 String Internals::rangeAsText(const Range& liveRange)
@@ -2238,6 +2248,17 @@ RefPtr<Range> Internals::rangeOfStringNearLocation(const Range& liveRange, const
     auto range = makeSimpleRange(liveRange);
     range.start.document().updateLayout();
     return createLiveRange(findClosestPlainText(range, text, { }, targetOffset));
+}
+
+Vector<Internals::TextIteratorState> Internals::statesOfTextIterator(const Range& liveRange, const Vector<String>& stringBehaviors)
+{
+    auto simpleRange = makeSimpleRange(liveRange);
+    simpleRange.start.document().updateLayout();
+
+    Vector<TextIteratorState> states;
+    for (TextIterator it(simpleRange, toTextIteratorBehaviors(stringBehaviors)); !it.atEnd(); it.advance())
+        states.append({ it.text().toString(), createLiveRange(it.range()) });
+    return states;
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -352,13 +352,19 @@ public:
     ExceptionOr<void> invalidateControlTints();
 
     RefPtr<Range> rangeFromLocationAndLength(Element& scope, unsigned rangeLocation, unsigned rangeLength);
-    unsigned locationFromRange(Element& scope, const Range&);
-    unsigned lengthFromRange(Element& scope, const Range&);
+    unsigned locationFromRange(Element& scope, const Range&, const Vector<String>& behaviors = { });
+    unsigned lengthFromRange(Element& scope, const Range&, const Vector<String>& behaviors = { });
     String rangeAsText(const Range&);
     String rangeAsTextUsingBackwardsTextIterator(const Range&);
     Ref<Range> subrange(Range&, unsigned rangeLocation, unsigned rangeLength);
     ExceptionOr<RefPtr<Range>> rangeForDictionaryLookupAtLocation(int x, int y);
     RefPtr<Range> rangeOfStringNearLocation(const Range&, const String&, unsigned);
+
+    struct TextIteratorState {
+        String text;
+        RefPtr<Range> range;
+    };
+    Vector<TextIteratorState> statesOfTextIterator(const Range&, const Vector<String>& behaviors = { });
 
     ExceptionOr<void> setDelegatesScrolling(bool enabled);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -291,6 +291,14 @@ enum HEVCParameterCodec {
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
+] dictionary TextIteratorState {
+    DOMString text;
+    Range range;
+};
+
+[
+    ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
+    JSGenerateToJSObject,
 ] dictionary ImageOverlayText {
     required DOMString text;
     required DOMPointReadOnly topLeft;
@@ -479,13 +487,14 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined scrollElementToRect(Element element, long x, long y, long w, long h);
 
     Range? rangeFromLocationAndLength(Element scope, unsigned long rangeLocation, unsigned long rangeLength);
-    unsigned long locationFromRange(Element scope, Range range);
-    unsigned long lengthFromRange(Element scope, Range range);
+    unsigned long locationFromRange(Element scope, Range range, optional sequence<DOMString> behaviors = []);
+    unsigned long lengthFromRange(Element scope, Range range, optional sequence<DOMString> behaviors = []);
     DOMString rangeAsText(Range range);
     DOMString rangeAsTextUsingBackwardsTextIterator(Range range);
     Range subrange(Range range, unsigned long rangeLocation, unsigned long rangeLength);
     Range? rangeForDictionaryLookupAtLocation(long x, long y);
     Range? rangeOfStringNearLocation(Range range, DOMString text, long targetOffset);
+    sequence<TextIteratorState> statesOfTextIterator(Range range, optional sequence<DOMString> behaviors = []);
 
     undefined setDelegatesScrolling(boolean enabled);
 


### PR DESCRIPTION
#### 0cc930aeaa7cde12d5517c7b0bb358a41c7a1984
<pre>
CrashTracer: com.apple.WebKit.WebContent at com.apple.WebKit: WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions
<a href="https://bugs.webkit.org/show_bug.cgi?id=239909">https://bugs.webkit.org/show_bug.cgi?id=239909</a>
&lt;rdar://problem/87885717 &gt;

Reviewed by Wenson Hsieh.

This exception happens when trying to add attributes for text that contains collapsed whitespace and
has also been wrapped due to the size of its parent container. The exception specifically is about
trying to add attributes beyond the current length of a `NSAttributedString`.

* Source/WebCore/editing/TextIteratorBehavior.h:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextRun):
In the case that `m_lastTextNodeEndedWithCollapsedSpace`, we only want to add the remaining text if
we&apos;re still within the desired portion of the `m_textRun`. Otherwise, we&apos;ll iterate over too much of
the text and result in a string that&apos;s longer than what would be the case if one manually calculated
it from the given `offset` and `offsetEnd`. Add a new `TextIteratorBehavior::IgnoresWhiteSpaceAtEndOfRun`
to not include the trailing whitespace.

* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
Use the new `WebCore::TextIteratorBehavior::IgnoresWhiteSpaceAtEndOfRun` to not include the trailing
whitespace.
Also add some defensive checks just in case.

* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::toTextIteratorBehaviors): Added.
(WebCore::Internals::locationFromRange):
(WebCore::Internals::lengthFromRange):
(WebCore::Internals::statesOfTextIterator): Added.
Add a way to provide `TextIteratorBehaviors` to methods that use `TextIterator`.
Add a method that gets the `text` and `range` of a `TextIterator` after every `advance`.

* LayoutTests/editing/text-iterator/sequential-collapsed-ranges.html: Added.
* LayoutTests/editing/text-iterator/sequential-collapsed-ranges-expected.txt: Added.
* LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace.html: Added.
* LayoutTests/editing/text-iterator/subrange-with-trailing-collapsed-whitespace-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/251061@main">https://commits.webkit.org/251061@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294955">https://svn.webkit.org/repository/webkit/trunk@294955</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
