### PR TITLE
Implement contain flag for ray() in offset path

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5077,9 +5077,6 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
 
 # CSS motion path needs to implement contain for ray: https://bugs.webkit.org/show_bug.cgi?id=240259.
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html [ ImageOnlyFailure ]
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002.html [ ImageOnlyFailure ]
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003.html [ ImageOnlyFailure ]
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -277,7 +277,7 @@ float toPositiveAngle(float angle)
 }
 
 // Compute acute angle from vertical axis
-static float toRelatedAcuteAngle(float angle)
+float toRelatedAcuteAngle(float angle)
 {
     angle = toPositiveAngle(angle);
     if (angle < 90)
@@ -287,14 +287,22 @@ static float toRelatedAcuteAngle(float angle)
     return std::abs(360 - angle);
 }
 
-RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect& boundingRect, const FloatPoint& position)
+RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect& box, const FloatPoint& position)
 {
     // Compute distance to each side of the containing box
     double top = std::abs(position.y());
-    double bottom = std::abs(position.y() - boundingRect.height());
+    double bottom = std::abs(position.y() - box.height());
     double left = std::abs(position.x());
-    double right = std::abs(position.x() - boundingRect.width());
+    double right = std::abs(position.x() - box.width());
     return RectEdges<double>(top, right, bottom, left);
+}
+
+Vector<FloatPoint> verticesForBox(const FloatRect& box, const FloatPoint position)
+{
+    return { FloatPoint(-position.x(), -position.y()),
+        FloatPoint(box.width() - position.x(), -position.y()),
+        FloatPoint(box.width() - position.x(), box.height() - position.y()),
+        FloatPoint(-position.x(), box.height() - position.y()) };
 }
 
 double lengthOfRayIntersectionWithBoundingBox(const FloatRect& boundingRect, const std::pair<const FloatPoint&, float> ray)

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -29,6 +29,8 @@
 #include "IntRect.h"
 #include <wtf/Forward.h>
 
+#include <wtf/Vector.h>
+
 namespace WebCore {
 
 class FloatQuad;
@@ -88,7 +90,13 @@ float angleOfPointToSideOfIntersection(const FloatRect& boundingRect, const std:
 
 // Given a box and an offset from the top left corner, calculate the distance of the point from each side
 RectEdges<double> distanceOfPointToSidesOfRect(const FloatRect&, const FloatPoint&);
+
+// Given a box and an offset from the top left corner, construct a coordinate system with this offset as the origin,
+// and return the vertices of the box in this coordinate system
+Vector<FloatPoint> verticesForBox(const FloatRect&, const FloatPoint);
+
 float toPositiveAngle(float angle);
+float toRelatedAcuteAngle(float angle);
 
 struct RotatedRect {
     FloatPoint center;

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -50,7 +50,7 @@ const SVGElement* ReferencePathOperation::element() const
     return m_element.get();
 }
 
-double RayPathOperation::lengthForPath() const
+float RayPathOperation::lengthForPath() const
 {
     auto boundingBox = m_containingBlockBoundingRect;
     auto distances = distanceOfPointToSidesOfRect(boundingBox, m_position);
@@ -70,13 +70,63 @@ double RayPathOperation::lengthForPath() const
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-const Path RayPathOperation::pathForReferenceRect() const
+double RayPathOperation::lengthForContainPath(const FloatRect& elementRect, double computedPathLength, const FloatPoint& anchor, const OffsetRotation rotation) const
+{
+    // Construct vertices of element for determining if they are within the path length
+    // Anchor point as origin
+    Vector<FloatPoint> vertices = verticesForBox(elementRect, anchor);
+    
+    // Rotate vertices depending on offset rotate or angle
+    if (!rotation.hasAuto()) {
+        auto deg = toRelatedAcuteAngle(toPositiveAngle(m_angle - rotation.angle()));
+        auto angle = deg2rad(deg);
+        std::for_each(vertices.begin(), vertices.end(), [angle] (FloatPoint& p) {
+            p.rotate(angle);
+        });
+    }
+    
+    Vector<std::pair<double, double>> bounds;
+    
+    for (const auto& p : vertices) {
+        // Use equation for circle (offset distance + x)^2 + y^2 <= r^2 to find offset distance that satisfies equation
+        // If no solution for above equation, must minimally increase it, otherwise clamp such that
+        // every point is within path
+        double discriminant = computedPathLength * computedPathLength - p.y() * p.y();
+        if (discriminant < 0) {
+            // Need to minimally increase path length
+            break;
+        }
+        bounds.append(std::make_pair(-p.x() - std::sqrt(discriminant), -p.x() + std::sqrt(discriminant)));
+    }
+    
+    if (vertices.size() == bounds.size()) {
+        auto lowerBound = std::max_element(bounds.begin(), bounds.end(),
+            [] (std::pair<double, double> const lhs, std::pair<double, double> const rhs) {
+            return lhs.first < rhs.first;
+        })->first;
+        
+        auto upperBound = std::min_element(bounds.begin(), bounds.end(),
+            [] (std::pair<double, double> const lhs, std::pair<double, double> const rhs) {
+            return lhs.second < rhs.second;
+        })->second;
+        
+        if (lowerBound <= upperBound)
+            return std::max(lowerBound, std::min(upperBound, computedPathLength));
+    }
+    
+    // TODO: Implement minimally increasing path length to allow all vertices to be within such a path length
+    return computedPathLength;
+}
+
+const Path RayPathOperation::pathForReferenceRect(const FloatRect& elementRect, const FloatPoint& anchor, const OffsetRotation rotation) const
 {
     Path path;
     if (m_containingBlockBoundingRect.isZero())
         return path;
-    auto length = lengthForPath();
-    auto radians = deg2rad(toPositiveAngle(m_angle) - 90);
+    double length = lengthForPath();
+    if (m_isContaining)
+        length = lengthForContainPath(elementRect, length, anchor, rotation);
+    auto radians = deg2rad(toPositiveAngle(m_angle) - 90.0);
     auto point = FloatPoint(std::cos(radians) * length, std::sin(radians) * length);
     path.addLineTo(point);
     return path;

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -196,8 +196,9 @@ public:
         return RayPathOperation::create(WebCore::blend(m_angle, to.m_angle, context), m_size, m_isContaining);
     }
 
-    const Path pathForReferenceRect() const;
-    double lengthForPath() const;
+    const Path pathForReferenceRect(const FloatRect& elementRect, const FloatPoint& anchor, const OffsetRotation rotation) const;
+    float lengthForPath() const;
+    double lengthForContainPath(const FloatRect& elementRect, double computedPathLength, const FloatPoint& anchor, const OffsetRotation rotation) const;
     
     void setContainingBlockReferenceRect(const FloatRect& boundingRect)
     {


### PR DESCRIPTION
#### 9e411c521e32c32bd408c643d7250e36850dfe83
<pre>
Implement contain flag for ray() in offset path
<a href="https://bugs.webkit.org/show_bug.cgi?id=240259">https://bugs.webkit.org/show_bug.cgi?id=240259</a>
&lt;rdar://93374029 &gt;

Reviewed by NOBODY (OOPS!).

No new tests (OOPS!).
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::toRelatedAcuteAngle):
(WebCore::distanceOfPointToSidesOfRect):
(WebCore::verticesForBox):
* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::RayPathOperation::lengthForPath const):
(WebCore::RayPathOperation::lengthForContainPath const):
(WebCore::RayPathOperation::pathForReferenceRect const):
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::getPathFromPathOperation):
(WebCore::RenderStyle::applyMotionPathTransform const):
* LayoutTests/TestExpectations:
</pre>