### PR TITLE
Stop using ASCIILiteral::fromLiteralUnsafe() in FontCascade.cpp

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1130,6 +1130,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/FocusDirection.h
     page/Frame.h
     page/FrameDestructionObserver.h
+    page/FrameDestructionObserverInlines.h
     page/FrameFlattening.h
     page/FrameIdentifier.h
     page/FrameSnapshotting.h

--- a/Source/WebCore/Modules/applepay/PaymentSession.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentSession.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "FeaturePolicy.h"
+#include "FrameDestructionObserverInlines.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTTPParsers.h"
 #include "Navigator.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
@@ -27,6 +27,7 @@
 #include "IDBFactory.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "IDBBindingUtilities.h"
 #include "IDBConnectionProxy.h"
 #include "IDBDatabaseIdentifier.h"

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -38,6 +38,7 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSMediaDeviceInfo.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -40,6 +40,7 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSRTCPeerConnection.h"
 #include "JSRTCSessionDescriptionInit.h"

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -31,6 +31,7 @@
 #include "CachedResourceLoader.h"
 #include "DOMPromiseProxy.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "ElementChildIterator.h"
 #include "ElementInlines.h"
 #include "EventHandler.h"

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -38,6 +38,7 @@
 #include "DOMWindow.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "MessagePort.h"
 #include "NotificationClient.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -31,6 +31,7 @@
 #include "ApplePayPaymentHandler.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSPaymentDetailsUpdate.h"

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -28,6 +28,7 @@
 
 #include "ClientOrigin.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "EventNames.h"
 #include "PermissionController.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -29,6 +29,7 @@
 #include "ClientOrigin.h"
 #include "Document.h"
 #include "EventNames.h"
+#include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "SpeechRecognitionError.h"
 #include "SpeechRecognitionErrorEvent.h"

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "PlatformSpeechSynthesisVoice.h"
 #include "PlatformSpeechSynthesizer.h"

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -35,6 +35,7 @@
 #include "AuthenticatorResponseData.h"
 #include "Document.h"
 #include "FeaturePolicy.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSBasicCredential.h"
 #include "JSCredentialRequestOptions.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -41,6 +41,7 @@
 #include "EventListener.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
@@ -39,6 +39,7 @@
 #include "ExceptionCode.h"
 #include "FileReaderLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "InspectorInstrumentation.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -34,6 +34,7 @@
 #include "Blob.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "MixedContentChecker.h"
 #include "ScriptExecutionContext.h"
 #include "SocketProvider.h"

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -25,6 +25,7 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTTPParsers.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindowBase.h"

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -31,6 +31,7 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "FetchResponse.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSAbortAlgorithm.h"
 #include "JSAbortSignal.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -23,6 +23,7 @@
 
 #include "DOMWindowWebDatabase.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLDocument.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTTPParsers.h"

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -21,6 +21,7 @@
 #include "JSDocument.h"
 
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMWindowCustom.h"
 #include "JSHTMLDocument.h"
 #include "JSXMLDocument.h"

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "DocumentFragment.h"
 #include "DocumentType.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "JSAttr.h"

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "EventLoop.h"
 #include "FontFace.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "JSDOMBinding.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -36,6 +36,7 @@
 #include "Editor.h"
 #include "FileList.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLImageElement.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -32,6 +32,7 @@
 #import "Document.h"
 #import "DragImage.h"
 #import "Element.h"
+#import "FrameDestructionObserverInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -881,7 +881,7 @@ public:
     // In DOM Level 2, the Document's DOMWindow is called the defaultView.
     WEBCORE_EXPORT WindowProxy* windowProxy() const;
 
-    bool hasBrowsingContext() const { return !!frame(); }
+    inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
     Document& contextDocument() const;
     void setContextDocument(Document& document) { m_contextDocument = document; }

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "MediaProducer.h"
 #include "SecurityOrigin.h"
 #include "TextResourceDecoder.h"
@@ -86,5 +87,9 @@ inline ScriptExecutionContext* Node::scriptExecutionContext() const
     return &document().contextDocument();
 }
 
+inline bool Document::hasBrowsingContext() const
+{
+    return !!frame();
+}
 
 }

--- a/Source/WebCore/dom/DocumentTouch.cpp
+++ b/Source/WebCore/dom/DocumentTouch.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "Touch.h"
 #include "TouchList.h"
 #include "WindowProxy.h"

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -28,6 +28,7 @@
 #if ENABLE(FULLSCREEN_API)
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "LayoutRect.h"
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "IntSize.h"
 #include "ScriptableDocumentParser.h"
 #include "Settings.h"

--- a/Source/WebCore/editing/win/EditorWin.cpp
+++ b/Source/WebCore/editing/win/EditorWin.cpp
@@ -29,6 +29,7 @@
 #include "ClipboardUtilitiesWin.h"
 #include "DocumentFragment.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "Pasteboard.h"
 #include "Range.h"

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -49,6 +49,7 @@
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "ElementChildIterator.h"
 #include "EventLoop.h"

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -33,6 +33,7 @@
 #include "DocumentFragment.h"
 #include "DocumentType.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "HTMLElementFactory.h"

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -33,6 +33,7 @@
 #include "CachedResource.h"
 #include "CachedSVGDocument.h"
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InspectorPageAgent.h"
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InstrumentingAgents.h"
 #include "Page.h"
 #include "PageConsoleClient.h"

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -34,6 +34,7 @@
 #include "CachedResourceRequestInitiators.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTTPCookieAcceptPolicy.h"
 #include "NetworkStorageSession.h"

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -38,6 +38,7 @@
 #include "DiagnosticLoggingKeys.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "HTMLFrameOwnerElement.h"

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -38,7 +38,7 @@ public:
     WEBCORE_EXPORT virtual void frameDestroyed();
     WEBCORE_EXPORT virtual void willDetachPage();
 
-    WEBCORE_EXPORT Frame* frame() const;
+    inline Frame* frame() const; // Defined in FrameDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT virtual ~FrameDestructionObserver();

--- a/Source/WebCore/page/FrameDestructionObserverInlines.h
+++ b/Source/WebCore/page/FrameDestructionObserverInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,44 +23,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "FrameDestructionObserver.h"
+#pragma once
 
 #include "Frame.h"
+#include "FrameDestructionObserver.h"
 
 namespace WebCore {
 
-FrameDestructionObserver::FrameDestructionObserver(Frame* frame)
-    : m_frame(nullptr)
+inline Frame* FrameDestructionObserver::frame() const
 {
-    observeFrame(frame);
-}
-
-FrameDestructionObserver::~FrameDestructionObserver()
-{
-    observeFrame(nullptr);
-
-}
-
-void FrameDestructionObserver::observeFrame(Frame* frame)
-{
-    if (m_frame)
-        m_frame->removeDestructionObserver(*this);
-
-    m_frame = frame;
-
-    if (m_frame)
-        m_frame->addDestructionObserver(*this);
-}
-
-void FrameDestructionObserver::frameDestroyed()
-{
-    m_frame = nullptr;
-}
-
-void FrameDestructionObserver::willDetachPage()
-{
-    // Subclasses should override this function to handle this notification.
+    return m_frame.get();
 }
 
 }

--- a/Source/WebCore/page/UserMessageHandlersNamespace.cpp
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMWrapperWorld.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "UserContentController.h"
 #include "UserMessageHandler.h"

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -53,16 +53,16 @@ static bool useBackslashAsYenSignForFamily(const AtomString& family)
         return false;
     static NeverDestroyed set = [] {
         MemoryCompactLookupOnlyRobinHoodHashSet<AtomString> set;
-        auto add = [&set] (const char* name, std::initializer_list<UChar> unicodeName) {
-            set.add(AtomString { ASCIILiteral::fromLiteralUnsafe(name) });
+        auto add = [&set] (ASCIILiteral name, std::initializer_list<UChar> unicodeName) {
+            set.add(AtomString { name });
             unsigned unicodeNameLength = unicodeName.size();
             set.add(AtomString { unicodeName.begin(), unicodeNameLength });
         };
-        add("MS PGothic", { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
-        add("MS PMincho", { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x660E, 0x671D });
-        add("MS Gothic", { 0xFF2D, 0xFF33, 0x0020, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
-        add("MS Mincho", { 0xFF2D, 0xFF33, 0x0020, 0x660E, 0x671D });
-        add("Meiryo", { 0x30E1, 0x30A4, 0x30EA, 0x30AA });
+        add("MS PGothic"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
+        add("MS PMincho"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x660E, 0x671D });
+        add("MS Gothic"_s, { 0xFF2D, 0xFF33, 0x0020, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
+        add("MS Mincho"_s, { 0xFF2D, 0xFF33, 0x0020, 0x660E, 0x671D });
+        add("Meiryo"_s, { 0x30E1, 0x30A4, 0x30EA, 0x30AA });
         return set;
     }();
     return set.get().contains(family);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -29,6 +29,7 @@
 #include "Element.h"
 #include "FloatQuad.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLNames.h"
 #include "LayoutRect.h"
 #include "Page.h"

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -50,6 +50,7 @@
 #include "FontPalette.h"
 #include "FontSelectionValueInlines.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "GridPositionsResolver.h"
 #include "Length.h"
 #include "Pair.h"

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -29,6 +29,7 @@
 
 #include "DeprecatedGlobalSettings.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InternalSettings.h"
 #include "Internals.h"
 #include "JSDocument.h"

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "SWClientConnection.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/CrossThreadCopier.h>

--- a/Source/WebCore/xml/XMLTreeViewer.cpp
+++ b/Source/WebCore/xml/XMLTreeViewer.cpp
@@ -35,6 +35,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "ScriptController.h"
 #include "ScriptSourceCode.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -36,6 +36,7 @@
 #include "DocumentFragment.h"
 #include "DocumentType.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLEntityParser.h"
 #include "HTMLHtmlElement.h"

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -29,6 +29,7 @@
 #include "ArgumentCoders.h"
 #include "WebProcess.h"
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/Page.h>
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -35,6 +35,7 @@
 #include "WebPageProxyMessages.h"
 #include <WebCore/Document.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/CaptureDevice.h>
 #include <WebCore/Document.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/MediaConstraints.h>
 #include <WebCore/SecurityOrigin.h>

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -57,6 +57,7 @@
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/InspectorInstrumentationWebKit.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -36,6 +36,7 @@
 #include "WebProcess.h"
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <WebCore/HTMLFrameOwnerElement.h>

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/Document.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <WebCore/Settings.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -28,6 +28,7 @@
 #import "DOMNodeInternal.h"
 #import <WebCore/Document.h>
 #import <WebCore/Frame.h>
+#import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/JSNode.h>
 #import <WebCore/ScriptController.h>
 #import <WebCore/WebScriptObjectPrivate.h>

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -30,6 +30,7 @@
 
 #import "WebKitVersionChecks.h"
 #import "WebView.h"
+#import <WebCore/FrameDestructionObserverInlines.h>
 
 using namespace WebCore;
 

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
@@ -34,6 +34,7 @@
 #include <comutil.h>
 #include <WebCore/BString.h>
 #include <WebCore/Document.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/HTMLElement.h>
 #include <WebCore/HTMLInputElement.h>
 #include <WebCore/HTMLNames.h>


### PR DESCRIPTION
#### e74925d4a6f49d0c9c7af660a7acad3b78f42477
<pre>
Stop using ASCIILiteral::fromLiteralUnsafe() in FontCascade.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=240548">https://bugs.webkit.org/show_bug.cgi?id=240548</a>

Reviewed by NOBODY (OOPS!).

Stop using ASCIILiteral::fromLiteralUnsafe() in FontCascade.cpp and use ASCIILiteral
directly.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::useBackslashAsYenSignForFamily):
</pre>
----------------------------------------------------------------------
#### 1f6f461c2a33e43de1bb81a29a28ee9d80b9a8e6
<pre>
Inline FrameDestructionObserver::frame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=240506">https://bugs.webkit.org/show_bug.cgi?id=240506</a>

Reviewed by NOBODY (OOPS!).

Inline FrameDestructionObserver::frame() and it is a trivial getter and it shows on Speedometer
profiles.

* Source/WebKit/Shared/WebsitePoliciesData.cpp:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
* Source/WebKitLegacy/mac/DOM/DOMInternal.mm:
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm:
* Source/WebCore/Modules/applepay/PaymentSession.cpp:
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebCore/Modules/notifications/Notification.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
* Source/WebCore/Modules/websockets/WebSocketChannel.cpp:
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/FontFaceSet.cpp:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/DataTransferMac.mm:
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasBrowsingContext const): Deleted.
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::hasBrowsingContext const):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/ViewportArguments.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
* Source/WebCore/loader/ResourceLoader.cpp:
* Source/WebCore/page/FrameDestructionObserver.cpp:
(WebCore::FrameDestructionObserver::frame const): Deleted.
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameDestructionObserverInlines.h: Copied from Source/WebCore/page/FrameDestructionObserver.h.
(WebCore::FrameDestructionObserver::frame const):
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
* Source/WebCore/workers/service/ServiceWorkerClientData.cpp:
* Source/WebCore/xml/XMLTreeViewer.cpp:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
</pre>