### PR TITLE
Add myself (Asumu Takikawa) to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -947,6 +947,17 @@
    },
    {
       "emails" : [
+         "asumu@igalia.com",
+         "atakikawa@igalia.com"
+      ],
+      "github" : "takikawa",
+      "name" : "Asumu Takikawa",
+      "nicks" : [
+         "asumu"
+      ]
+   },
+   {
+      "emails" : [
          "ayumi_kojima@apple.com"
       ],
       "name" : "Ayumi Kojima",


### PR DESCRIPTION
#### 556b2c380d2eaf1a97da02787db583a14a73a097
<pre>
Add myself (Asumu Takikawa) to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=240546">https://bugs.webkit.org/show_bug.cgi?id=240546</a>

Patch by Asumu Takikawa &lt;asumu@igalia.com &gt; on 2022-05-17
Reviewed by Yusuke Suzuki.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/250677@main">https://commits.webkit.org/250677@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294380">https://svn.webkit.org/repository/webkit/trunk@294380</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
