### PR TITLE
[WebGPU] Work around https://bugs.webkit.org/show_bug.cgi?id=240219

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -38,16 +38,16 @@ void GPUBuffer::setLabel(String&& label)
     m_backing->setLabel(WTFMove(label));
 }
 
-void GPUBuffer::mapAsync(GPUMapModeFlags mode, GPUSize64 offset, std::optional<GPUSize64> size, MapAsyncPromise&& promise)
+void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, std::optional<GPUSize64> size, MapAsyncPromise&& promise)
 {
-    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset, size, [promise = WTFMove(promise)] () mutable {
+    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset.value_or(0), size, [promise = WTFMove(promise)] () mutable {
         promise.resolve(nullptr);
     });
 }
 
-Ref<JSC::ArrayBuffer> GPUBuffer::getMappedRange(GPUSize64 offset, std::optional<GPUSize64> size)
+Ref<JSC::ArrayBuffer> GPUBuffer::getMappedRange(std::optional<GPUSize64> offset, std::optional<GPUSize64> size)
 {
-    auto mappedRange = m_backing->getMappedRange(offset, size);
+    auto mappedRange = m_backing->getMappedRange(offset.value_or(0), size);
     return ArrayBuffer::create(mappedRange.source, mappedRange.byteLength);
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -49,8 +49,8 @@ public:
     void setLabel(String&&);
 
     using MapAsyncPromise = DOMPromiseDeferred<IDLNull>;
-    void mapAsync(GPUMapModeFlags, GPUSize64 offset, std::optional<GPUSize64> sizeForMap, MapAsyncPromise&&);
-    Ref<JSC::ArrayBuffer> getMappedRange(GPUSize64 offset, std::optional<GPUSize64> rangeSize);
+    void mapAsync(GPUMapModeFlags, std::optional<GPUSize64> offset, std::optional<GPUSize64> sizeForMap, MapAsyncPromise&&);
+    Ref<JSC::ArrayBuffer> getMappedRange(std::optional<GPUSize64> offset, std::optional<GPUSize64> rangeSize);
     void unmap();
 
     void destroy();

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
@@ -35,8 +35,9 @@ typedef [EnforceRange] unsigned long long GPUSize64;
     SecureContext
 ]
 interface GPUBuffer {
-    Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
-    ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219 The next two lines should be able to say "optional thingy = 0" instead of just "optional thingy".
+    Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset, optional GPUSize64 size);
+    ArrayBuffer getMappedRange(optional GPUSize64 offset, optional GPUSize64 size);
     undefined unmap();
 
     undefined destroy();


### PR DESCRIPTION
#### c111a1e4641116920aeae9d57610c8fd37839833
<pre>
[WebGPU] Work around <a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=240441">https://bugs.webkit.org/show_bug.cgi?id=240441</a>

<a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a> is about a bug where we can&apos;t
say &quot;optional thingy = 0&quot; in an IDL file. This patch works around that in WebGPU
by replacing it with &quot;optional thingy&quot; and then &quot;thingy.value_or(0)&quot; in the C++
code. This is temporary, until <a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a> is
fixed.

No new tests because there is no behavior change.

* Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::mapAsync):
(WebCore::GPUBuffer::getMappedRange):
* Modules/WebGPU/GPUBuffer.h:
* Modules/WebGPU/GPUBuffer.idl:
</pre>