### PR TITLE
innerText from element with "white-space: pre-line" incorrectly removes line breaks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -32,8 +32,8 @@ PASS \t preserved ("<span style='white-space:pre'>abc\tdef")
 PASS Leading whitespace removed ("<div style='white-space:pre-line'> abc")
 PASS Trailing whitespace removed ("<div style='white-space:pre-line'>abc ")
 PASS Internal whitespace collapsed ("<div style='white-space:pre-line'>abc  def")
-FAIL \n preserved ("<div style='white-space:pre-line'>abc\ndef") assert_equals: innerText expected "abc\ndef" but got "abc def"
-FAIL \r converted to newline ("<div style='white-space:pre-line'>abc\rdef") assert_equals: innerText expected "abc\ndef" but got "abc def"
+PASS \n preserved ("<div style='white-space:pre-line'>abc\ndef")
+PASS \r converted to newline ("<div style='white-space:pre-line'>abc\rdef")
 PASS \t converted to space ("<div style='white-space:pre-line'>abc\tdef")
 PASS Whitespace collapses across element boundaries ("<div><span>abc </span> def")
 PASS Whitespace collapses across element boundaries ("<div><span>abc </span><span></span> def")


### PR DESCRIPTION
#### 22c4c7e9e13deee81aac4b88bf5e96ff41d53d6f
<pre>
innerText from element with &quot;white-space: pre-line&quot; incorrectly removes line breaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=240566">https://bugs.webkit.org/show_bug.cgi?id=240566</a>

Reviewed by NOBODY (OOPS!).

Element.innerText() now preserves new lines when &quot;white-space: pre-line&quot; is used, to match
the behavior of Blink &amp; Gecko.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextRun):
</pre>