### PR TITLE
Add support for WebAssembly GC recursion groups

### DIFF
--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -1,0 +1,235 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testRecDeclaration() {
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (func (type 0))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (struct)) (type (func)))
+        (func (type 0))
+      )
+    `),
+    WebAssembly.CompileError,
+    "type signature was not a function signature"
+  );
+
+  instantiate(`
+    (module
+      (rec
+        (type (func (result (ref 1))))
+        (type (func (result (ref 0)))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec
+        (type (func))
+        (type (func (result (ref 0)))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (rec (type (func)) (type (struct)))
+      (elem declare funcref (ref.func 0))
+      (func (type 0))
+      (func (result (ref 2)) (ref.func 0))
+    )
+  `);
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (export "f") (type 0))
+      )
+    `);
+    instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (import "m" "f") (type 0))
+        (start 0)
+      )
+    `, { m: { f: m1.exports.f } });
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (func (export "f") (type 0))
+      )
+    `);
+    assert.throws(
+      () => instantiate(`
+        (module
+          (rec (type (struct)) (type (func)))
+          (func (import "m" "f") (type 1))
+          (start 0)
+        )
+      `, { m: { f: m1.exports.f } }),
+      WebAssembly.LinkError,
+      "imported function m:f signature doesn't match the provided WebAssembly function's signature"
+    );
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (elem declare funcref (ref.func 0))
+        (func)
+        (func (export "f") (result (ref 0)) (ref.func 0))
+      )
+    `);
+    assert.throws(
+      () => instantiate(`
+        (module
+          (rec (type (struct)) (type (func)))
+          (func (import "m" "f") (type 1))
+        )
+      `, { m: { f: m1.exports.f } }),
+      WebAssembly.LinkError,
+      "imported function m:f signature doesn't match the provided WebAssembly function's signature"
+    );
+  }
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (func)) (type (struct)))
+        (rec (type (struct)) (type (func)))
+        (global (ref 0) (ref.func 0))
+        (func (type 3))
+      )
+    `),
+    WebAssembly.CompileError,
+    "Global init_expr opcode of type Ref doesn't match global's type Ref"
+  );
+
+  instantiate(`
+    (module
+      (rec (type (func (result (ref 1))))
+           (type (func (result (ref 0)))))
+      (elem declare funcref (ref.func 0))
+      (elem declare funcref (ref.func 1))
+      (func (type 0) (ref.func 1))
+      (func (type 1) (ref.func 0))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (func (result (ref 1))))
+             (type (func (result (ref 0)))))
+        (elem declare funcref (ref.func 0))
+        (elem declare funcref (ref.func 1))
+        (func (type 0) (ref.func 1))
+        (func (type 1) (ref.func 1))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. Ref is not a Ref, in function at index 1"
+  );
+
+  instantiate(`
+    (module
+      (rec (type (func (param i32))) (type (struct)))
+      (elem declare funcref (ref.func 0))
+      (func (type 0))
+      (func (call_ref (i32.const 42) (ref.func 0)))
+      (start 1)
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (block (type 3)
+          (i32.const 42)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (loop (type 3)
+          (i32.const 42)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func (result i32))) (type (struct)))
+      (rec (type (struct)) (type (func (result i32))))
+      (func (type 0)
+        (i32.const 1)
+        (if (type 3) (then (i32.const 42)) (else (i32.const 43))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (struct)))
+      (table 5 funcref)
+      (elem (offset (i32.const 0)) funcref (ref.func 0))
+      (func (type 0))
+      (func (call_indirect (type 0) (i32.const 0)))
+      (start 1)
+    )
+  `);
+
+  // Ensure implicit rec groups are accounted for, and treated
+  // correctly with regards to equality.
+  instantiate(`
+    (module
+      (type $a (struct (field i32)))
+      (rec (type $b (struct (field i32))))
+      (type $c (struct (field i32)))
+
+      (func (result (ref null $a)) (ref.null $b))
+      (func (result (ref null $a)) (ref.null $c))
+      (func (result (ref null $b)) (ref.null $a))
+      (func (result (ref null $b)) (ref.null $c))
+      (func (result (ref null $c)) (ref.null $a))
+      (func (result (ref null $c)) (ref.null $b)))
+  `);
+
+  // This is the same test as above, but using a particular binary encoding.
+  // The encoding for this test specifically uses both shorthand and the full
+  // rec form to test the equivalence of the two.
+  new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x9e\x80\x80\x80\x00\x06\x5f\x01\x7f\x00\x4f\x01\x5f\x01\x7f\x00\x5f\x01\x7f\x00\x60\x00\x01\x6c\x00\x60\x00\x01\x6c\x01\x60\x00\x01\x6c\x02\x03\x87\x80\x80\x80\x00\x06\x03\x03\x04\x04\x05\x05\x0a\xb7\x80\x80\x80\x00\x06\x84\x80\x80\x80\x00\x00\xd0\x01\x0b\x84\x80\x80\x80\x00\x00\xd0\x02\x0b\x84\x80\x80\x80\x00\x00\xd0\x00\x0b\x84\x80\x80\x80\x00\x00\xd0\x02\x0b\x84\x80\x80\x80\x00\x00\xd0\x00\x0b\x84\x80\x80\x80\x00\x00\xd0\x01\x0b"));
+}
+
+testRecDeclaration();

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -18,6 +18,7 @@
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -948,7 +948,7 @@ void AirIRGenerator::restoreWasmContextInstance(BasicBlock* block, TypedTmp inst
     emitPatchpoint(block, patchpoint, Tmp(), instance);
 }
 
-AirIRGenerator::AirIRGenerator(const ModuleInformation& info, B3::Procedure& procedure, InternalFunction* compilation, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, unsigned functionIndex, std::optional<bool> hasExceptionHandlers, TierUpCount* tierUp, const TypeDefinition& signature, unsigned& osrEntryScratchBufferSize)
+AirIRGenerator::AirIRGenerator(const ModuleInformation& info, B3::Procedure& procedure, InternalFunction* compilation, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, unsigned functionIndex, std::optional<bool> hasExceptionHandlers, TierUpCount* tierUp, const TypeDefinition& originalSignature, unsigned& osrEntryScratchBufferSize)
     : m_info(info)
     , m_mode(mode)
     , m_functionIndex(functionIndex)
@@ -1056,6 +1056,7 @@ AirIRGenerator::AirIRGenerator(const ModuleInformation& info, B3::Procedure& pro
     m_mainEntrypointStart = m_code.addBlock();
     m_currentBlock = m_mainEntrypointStart;
 
+    const TypeDefinition& signature = originalSignature.expand();
     ASSERT(!m_locals.size());
     m_locals.grow(signature.as<FunctionSignature>()->argumentCount());
     for (unsigned i = 0; i < signature.as<FunctionSignature>()->argumentCount(); ++i) {
@@ -3780,9 +3781,10 @@ auto AirIRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signa
     return { };
 }
 
-auto AirIRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& signature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
+auto AirIRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& originalSignature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
 {
     ExpressionType calleeIndex = args.takeLast();
+    const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
     ASSERT(m_info.tableCount() > tableIndex);
     ASSERT(m_info.tables[tableIndex].type() == TableElementType::Funcref);
@@ -3849,7 +3851,7 @@ auto AirIRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& 
         });
 
         ExpressionType expectedSignatureIndex = g64();
-        append(Move, Arg::bigImm(TypeInformation::get(signature)), expectedSignatureIndex);
+        append(Move, Arg::bigImm(TypeInformation::get(originalSignature)), expectedSignatureIndex);
         emitCheck([&] {
             return Inst(Branch64, nullptr, Arg::relCond(MacroAssembler::NotEqual), calleeSignatureIndex, expectedSignatureIndex);
         }, [=, this] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -3066,9 +3066,10 @@ auto B3IRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signat
     return { };
 }
 
-auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& signature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
+auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& originalSignature, Vector<ExpressionType>& args, ResultList& results) -> PartialResult
 {
     Value* calleeIndex = get(args.takeLast());
+    const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
 
     m_makesCalls = true;
@@ -3127,7 +3128,7 @@ auto B3IRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& s
 
         // Check the signature matches the value we expect.
         {
-            Value* expectedSignatureIndex = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), TypeInformation::get(signature));
+            Value* expectedSignatureIndex = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), TypeInformation::get(originalSignature));
             CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
                 m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), calleeSignatureIndex, expectedSignatureIndex));
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -137,7 +137,7 @@ void BBQPlan::work(CompilationEffort effort)
 
     size_t functionIndexSpace = m_functionIndex + m_moduleInformation->importFunctionCount();
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
-    const TypeDefinition& signature = TypeInformation::get(typeIndex);
+    const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
     function->entrypoint.compilation = makeUnique<Compilation>(
         FINALIZE_WASM_CODE_FOR_MODE(CompilationMode::BBQMode, linkBuffer, JITCompilationPtrTag, "WebAssembly BBQ function[%i] %s name %s", m_functionIndex, signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data()),
         WTFMove(context.wasmEntrypointByproducts));
@@ -206,7 +206,7 @@ void BBQPlan::compileFunction(uint32_t functionIndex)
     if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->referencedFunctions().contains(functionIndex)) {
         Locker locker { m_lock };
         TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-        const TypeDefinition& signature = TypeInformation::get(typeIndex);
+        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
 
         m_compilationContexts[functionIndex].embedderEntrypointJIT = makeUnique<CCallHelpers>();
         auto embedderToWasmInternalFunction = createJSToWasmWrapper(*m_compilationContexts[functionIndex].embedderEntrypointJIT, signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), m_mode, functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -265,7 +265,7 @@ public:
 
     LLIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
 
-    const FunctionSignature& signature(unsigned index) const
+    const TypeDefinition& signature(unsigned index) const
     {
         return *m_signatures[index];
     }
@@ -304,7 +304,7 @@ private:
     std::unique_ptr<WasmInstructionStream> m_instructions;
     const void* m_instructionsRawPointer { nullptr };
     FixedVector<WasmInstructionStream::Offset> m_jumpTargets;
-    FixedVector<const FunctionSignature*> m_signatures;
+    FixedVector<const TypeDefinition*> m_signatures;
     OutOfLineJumpTargets m_outOfLineJumpTargets;
     LLIntTierUpCounter m_tierUpCounter;
     FixedVector<JumpTable> m_jumpTables;

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -74,6 +74,10 @@ inline bool isValueType(Type type)
     case TypeKind::Ref:
     case TypeKind::RefNull:
         return Options::useWebAssemblyTypedFunctionReferences();
+    // Rec type kinds are used internally to represent `rec.<i>` references
+    // within recursion groups. They are invalid in other contexts.
+    case TypeKind::Rec:
+        return Options::useWebAssemblyGC();
     default:
         break;
     }

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
@@ -51,7 +51,7 @@ WasmInstructionStream::Offset FunctionCodeBlockGenerator::outOfLineJumpOffset(Wa
     return m_outOfLineJumpTargets.get(bytecodeOffset);
 }
 
-unsigned FunctionCodeBlockGenerator::addSignature(const FunctionSignature& signature)
+unsigned FunctionCodeBlockGenerator::addSignature(const TypeDefinition& signature)
 {
     unsigned index = m_signatures.size();
     m_signatures.append(&signature);

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -48,7 +48,7 @@ class BytecodeGeneratorBase;
 namespace Wasm {
 
 class LLIntCallee;
-class FunctionSignature;
+class TypeDefinition;
 struct GeneratorTraits;
 
 struct JumpTableEntry {
@@ -116,7 +116,7 @@ public:
 
     HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData>& tierUpCounter() { return m_tierUpCounter; }
 
-    unsigned addSignature(const FunctionSignature&);
+    unsigned addSignature(const TypeDefinition&);
 
     JumpTable& addJumpTable(size_t numberOfEntries);
     unsigned numberOfJumpTables() const;
@@ -140,7 +140,7 @@ private:
     std::unique_ptr<WasmInstructionStream> m_instructions;
     const void* m_instructionsRawPointer { nullptr };
     Vector<WasmInstructionStream::Offset> m_jumpTargets;
-    Vector<const FunctionSignature*> m_signatures;
+    Vector<const TypeDefinition*> m_signatures;
     OutOfLineJumpTargets m_outOfLineJumpTargets;
     HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData> m_tierUpCounter;
     Vector<JumpTable> m_jumpTables;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -48,8 +48,9 @@ enum class CatchKind {
 };
 
 template<typename EnclosingStack, typename NewStack>
-void splitStack(BlockSignature signature, EnclosingStack& enclosingStack, NewStack& newStack)
+void splitStack(BlockSignature originalSignature, EnclosingStack& enclosingStack, NewStack& newStack)
 {
+    BlockSignature signature = &originalSignature->expand();
     newStack.reserveInitialCapacity(signature->as<FunctionSignature>()->argumentCount());
     ASSERT(enclosingStack.size() >= signature->as<FunctionSignature>()->argumentCount());
     unsigned offset = enclosingStack.size() - signature->as<FunctionSignature>()->argumentCount();
@@ -230,7 +231,7 @@ template<typename Context>
 FunctionParser<Context>::FunctionParser(Context& context, const uint8_t* functionStart, size_t functionLength, const TypeDefinition& signature, const ModuleInformation& info)
     : Parser(functionStart, functionLength)
     , m_context(context)
-    , m_signature(signature)
+    , m_signature(signature.expand())
     , m_info(info)
 {
     if (verbose)
@@ -243,6 +244,7 @@ auto FunctionParser<Context>::parse() -> Result
 {
     uint32_t localGroupsCount;
 
+    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature");
     const auto& signature = *m_signature.as<FunctionSignature>();
     WASM_PARSER_FAIL_IF(!m_context.addArguments(m_signature), "can't add ", signature.argumentCount(), " arguments to Function");
     WASM_PARSER_FAIL_IF(!parseVarUInt32(localGroupsCount), "can't get local groups count");
@@ -1258,7 +1260,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseFunctionIndex(functionIndex));
 
         TypeIndex calleeTypeIndex = m_info.typeIndexFromFunctionIndexSpace(functionIndex);
-        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex);
+        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex).expand();
         const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
         WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size(), "call function index ", functionIndex, " has ", calleeSignature.argumentCount(), " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
 
@@ -1297,7 +1299,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref");
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[signatureIndex].get();
-        const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
+        const auto& calleeSignature = *typeDefinition.expand().as<FunctionSignature>();
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_indirect expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
 
@@ -1329,7 +1331,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!isRefWithTypeIndex(m_expressionStack.last().type()), "non-funcref call_ref value ", m_expressionStack.last().type().kind);
 
         const TypeIndex calleeTypeIndex = m_expressionStack.last().type().index;
-        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex);
+        const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex).expand();
         const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's value.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_ref expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
@@ -1359,7 +1361,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get block's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for block. Block expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Block has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i) {
@@ -1370,7 +1373,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType block;
-        WASM_TRY_ADD_TO_CONTEXT(addBlock(inlineSignatureAsType, m_expressionStack, block, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addBlock(expandedSignature, m_expressionStack, block, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1383,7 +1386,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get loop's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for loop block. Loop expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Loop has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i) {
@@ -1394,7 +1398,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType loop;
-        WASM_TRY_ADD_TO_CONTEXT(addLoop(inlineSignatureAsType, m_expressionStack, loop, newStack, m_loopIndex++));
+        WASM_TRY_ADD_TO_CONTEXT(addLoop(expandedSignature, m_expressionStack, loop, newStack, m_loopIndex++));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1409,7 +1413,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get if's signature");
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type().kind);
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
@@ -1419,7 +1424,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, inlineSignatureAsType, m_expressionStack, control, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addIf(condition, expandedSignature, m_expressionStack, control, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1446,7 +1451,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         BlockSignature inlineSignatureAsType;
         WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignatureAsType), "can't get try's signature");
 
-        const FunctionSignature* inlineSignature = inlineSignatureAsType->as<FunctionSignature>();
+        BlockSignature expandedSignature = &inlineSignatureAsType->expand();
+        const FunctionSignature* inlineSignature = expandedSignature->as<FunctionSignature>();
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for try block. Trye expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Try block has signature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
         for (unsigned i = 0; i < inlineSignature->argumentCount(); ++i)
@@ -1455,7 +1461,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         int64_t oldSize = m_expressionStack.size();
         Stack newStack;
         ControlType control;
-        WASM_TRY_ADD_TO_CONTEXT(addTry(inlineSignatureAsType, m_expressionStack, control, newStack));
+        WASM_TRY_ADD_TO_CONTEXT(addTry(expandedSignature, m_expressionStack, control, newStack));
         ASSERT_UNUSED(oldSize, oldSize - m_expressionStack.size() == inlineSignature->argumentCount());
         ASSERT(newStack.size() == inlineSignature->argumentCount());
 
@@ -1472,7 +1478,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         uint32_t exceptionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
         TypeIndex typeIndex = m_info.typeIndexFromExceptionIndexSpace(exceptionIndex);
-        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex);
+        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex).expand();
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
@@ -1726,7 +1732,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         uint32_t exceptionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
         TypeIndex typeIndex = m_info.typeIndexFromExceptionIndexSpace(exceptionIndex);
-        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex);
+        const TypeDefinition& exceptionSignature = TypeInformation::get(typeIndex).expand();
 
         if (m_unreachableBlocks > 1)
             return { };

--- a/Source/JavaScriptCore/wasm/WasmInstance.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInstance.cpp
@@ -232,6 +232,7 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
         // https://bugs.webkit.org/show_bug.cgi?id=165510
         uint32_t functionIndex = segment.functionIndices[srcIndex];
         TypeIndex typeIndex = m_module->typeIndexFromFunctionIndexSpace(functionIndex);
+        const auto& signature = TypeInformation::getFunctionSignature(typeIndex);
         if (isImportFunction(functionIndex)) {
             JSObject* functionImport = importFunction<WriteBarrier<JSObject>>(functionIndex)->get();
             if (isWebAssemblyHostFunction(functionImport)) {
@@ -257,7 +258,6 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
 
         Callee& embedderEntrypointCallee = calleeGroup()->embedderEntrypointCalleeFromFunctionIndexSpace(functionIndex);
         WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
-        const auto& signature = TypeInformation::getFunctionSignature(typeIndex);
         // FIXME: Say we export local function "foo" at function index 0.
         // What if we also set it to the table an Element w/ index 0.
         // Does (new Instance(...)).exports.foo === table.get(0)?

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -152,7 +152,7 @@ void LLIntPlan::didCompleteCompilation()
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
         if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->referencedFunctions().contains(functionIndex)) {
             TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-            const TypeDefinition& signature = TypeInformation::get(typeIndex);
+            const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
             CCallHelpers jit;
             // The LLInt always bounds checks
             MemoryMode mode = MemoryMode::BoundsChecking;

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -45,6 +45,7 @@ constexpr size_t maxExceptions = 100000;
 constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxStructFieldCount = 10000;
+constexpr size_t maxRecursionGroupCount = 10000;
 
 constexpr size_t maxStringSize = 100000;
 constexpr size_t maxModuleSize = 1024 * 1024 * 1024;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -71,6 +71,7 @@ private:
 
     PartialResult WARN_UNUSED_RETURN parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
+    PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
 
     PartialResult WARN_UNUSED_RETURN validateElementTableIdx(uint32_t);
     PartialResult WARN_UNUSED_RETURN parseI32InitExprForElementSection(std::optional<I32InitExpr>&);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -500,7 +500,7 @@ inline SlowPathReturnType doWasmCallIndirect(CallFrame* callFrame, Wasm::Instanc
         WASM_THROW(Wasm::ExceptionType::NullTableEntry);
 
     const auto& callSignature = CALLEE()->signature(typeIndex);
-    if (callSignature != Wasm::TypeInformation::getFunctionSignature(function.typeIndex))
+    if (callSignature.index() != function.typeIndex)
         WASM_THROW(Wasm::ExceptionType::BadSignature);
 
     if (targetInstance != instance)
@@ -541,7 +541,7 @@ inline SlowPathReturnType doWasmCallRef(CallFrame* callFrame, Wasm::Instance* ca
     if (calleeInstance != callerInstance)
         calleeInstance->setCachedStackLimit(callerInstance->cachedStackLimit());
 
-    ASSERT(Wasm::TypeInformation::getFunctionSignature(function.typeIndex) == CALLEE()->signature(typeIndex));
+    ASSERT(function.typeIndex == CALLEE()->signature(typeIndex).index());
     UNUSED_PARAM(typeIndex);
     WASM_CALL_RETURN(calleeInstance, function.entrypointLoadLocation->executableAddress(), WasmEntryPtrTag);
 }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -45,8 +45,14 @@ void TypeDefinition::dump(PrintStream& out) const
     if (is<FunctionSignature>())
         return as<FunctionSignature>()->dump(out);
 
-    ASSERT(is<StructType>());
-    return as<StructType>()->dump(out);
+    if (is<StructType>())
+        return as<StructType>()->dump(out);
+
+    if (is<RecursionGroup>())
+        return as<RecursionGroup>()->dump(out);
+
+    ASSERT(is<Projection>());
+    return as<Projection>()->dump(out);
 }
 
 String FunctionSignature::toString() const
@@ -89,6 +95,36 @@ void StructType::dump(PrintStream& out) const
     out.print(")");
 }
 
+String RecursionGroup::toString() const
+{
+    return WTF::toString(*this);
+}
+
+void RecursionGroup::dump(PrintStream& out) const
+{
+    out.print("(");
+    CommaPrinter comma;
+    for (RecursionGroupCount typeIndex = 0; typeIndex < typeCount(); ++typeIndex) {
+        out.print(comma);
+        TypeInformation::get(type(typeIndex)).dump(out);
+    }
+    out.print(")");
+}
+
+String Projection::toString() const
+{
+    return WTF::toString(*this);
+}
+
+void Projection::dump(PrintStream& out) const
+{
+    out.print("(");
+    CommaPrinter comma;
+    TypeInformation::get(recursionGroup()).dump(out);
+    out.print(".", index());
+    out.print(")");
+}
+
 static unsigned computeSignatureHash(size_t returnCount, const Type* returnTypes, size_t argumentCount, const Type* argumentTypes)
 {
     unsigned accumulator = 0xa1bcedd8u;
@@ -117,6 +153,22 @@ static unsigned computeStructTypeHash(size_t fieldCount, const StructField* fiel
     return accumulator;
 }
 
+static unsigned computeRecursionGroupHash(size_t typeCount, const TypeIndex* types)
+{
+    unsigned accumulator = 0x9cfb89bb;
+    for (uint32_t i = 0; i < typeCount; ++i)
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(static_cast<TypeIndex>(types[i])));
+    return accumulator;
+}
+
+static unsigned computeProjectionHash(TypeIndex recursionGroup, ProjectionIndex index)
+{
+    unsigned accumulator = 0xbeae6d4e;
+    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(static_cast<TypeIndex>(recursionGroup)));
+    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint32_t>::hash(static_cast<uint32_t>(index)));
+    return accumulator;
+}
+
 unsigned TypeDefinition::hash() const
 {
     if (is<FunctionSignature>()) {
@@ -124,9 +176,19 @@ unsigned TypeDefinition::hash() const
         return computeSignatureHash(signature->returnCount(), signature->storage(0), signature->argumentCount(), signature->storage(signature->returnCount()));
     }
 
-    ASSERT(is<StructType>());
-    const StructType* structType = as<StructType>();
-    return computeStructTypeHash(structType->fieldCount(), structType->storage(0));
+    if (is<StructType>()) {
+        const StructType* structType = as<StructType>();
+        return computeStructTypeHash(structType->fieldCount(), structType->storage(0));
+    }
+
+    if (is<RecursionGroup>()) {
+        const RecursionGroup* recursionGroup = as<RecursionGroup>();
+        return computeRecursionGroupHash(recursionGroup->typeCount(), recursionGroup->storage(0));
+    }
+
+    ASSERT(is<Projection>());
+    const Projection* projection = as<Projection>();
+    return computeProjectionHash(projection->recursionGroup(), projection->index());
 }
 
 RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCount returnCount, FunctionArgCount argumentCount)
@@ -136,7 +198,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCou
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(returnCount, argumentCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::FunctionSignature, returnCount, argumentCount);
     return adoptRef(signature);
 }
 
@@ -147,8 +209,99 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fiel
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(fieldCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::StructType, fieldCount);
     return adoptRef(signature);
+}
+
+RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCount typeCount)
+{
+    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    auto result = tryFastMalloc(allocatedRecursionGroupSize(typeCount));
+    void* memory = nullptr;
+    if (!result.getValue(memory))
+        return nullptr;
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::RecursionGroup, typeCount);
+    return adoptRef(signature);
+}
+
+RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
+{
+    // We use WTF_MAKE_FAST_ALLOCATED for this class.
+    auto result = tryFastMalloc(allocatedProjectionSize());
+    void* memory = nullptr;
+    if (!result.getValue(memory))
+        return nullptr;
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::Projection);
+    return adoptRef(signature);
+}
+
+// Recursive types are stored "tied" in the sense that the spec refers to here:
+//
+//   https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#equivalence
+//
+// That is, the recursive "back edges" are stored as a special type index. These
+// need to be substituted back out to a Projection eventually so that the type
+// can be further expanded if necessary. The substitute and replacePlaceholders
+// functions below are used to implement this substitution.
+Type TypeDefinition::substitute(Type type, TypeIndex projectee)
+{
+    if (type.kind == TypeKind::Rec) {
+        RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(projectee, static_cast<ProjectionIndex>(type.index));
+        TypeKind kind = type.isNullable() ? TypeKind::RefNull : TypeKind::Ref;
+        return Type { kind, type.nullable, projection->index() };
+    }
+
+    return type;
+}
+
+// This operation is a helper for expand() that calls substitute() in order
+// to replace placeholder recursive references in structural types.
+const TypeDefinition& TypeDefinition::replacePlaceholders(TypeIndex projectee) const
+{
+    if (is<FunctionSignature>()) {
+        const FunctionSignature* func = as<FunctionSignature>();
+        Vector<Type> newArguments;
+        Vector<Type, 1> newReturns;
+        newArguments.tryReserveCapacity(func->argumentCount());
+        newReturns.tryReserveCapacity(func->returnCount());
+        for (unsigned i = 0; i < func->argumentCount(); ++i)
+            newArguments.uncheckedAppend(substitute(func->argumentType(i), projectee));
+        for (unsigned i = 0; i < func->returnCount(); ++i)
+            newReturns.uncheckedAppend(substitute(func->returnType(i), projectee));
+
+        RefPtr<TypeDefinition> def = TypeInformation::typeDefinitionForFunction(newReturns, newArguments);
+        return *def;
+    }
+
+    if (is<StructType>()) {
+        // FIXME: This case should be filled when struct operations are implemented.
+        ASSERT_NOT_REACHED();
+        return *this;
+    }
+
+    return *this;
+}
+
+// This function corresponds to the expand metafunction from the spec:
+//
+//  https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#auxiliary-definitions
+//
+// It expands a potentially recursive context type and returns the concrete structural
+// type definition that it corresponds to. It should be called whenever the concrete
+// type is needed during validation or other phases.
+//
+// Caching the result of this lookup may be useful if this becomes a bottleneck.
+const TypeDefinition& TypeDefinition::expand() const
+{
+    if (is<Projection>()) {
+        const Projection& projection = *as<Projection>();
+        const TypeDefinition& projectee = TypeInformation::get(projection.recursionGroup());
+        const RecursionGroup& recursionGroup = *projectee.as<RecursionGroup>();
+        const TypeDefinition& underlyingType = TypeInformation::get(recursionGroup.type(projection.index()));
+        return underlyingType.replacePlaceholders(projectee.index());
+    }
+
+    return *this;
 }
 
 TypeInformation::TypeInformation()
@@ -186,7 +339,7 @@ struct FunctionParameterTypes {
 
     static bool equal(const TypeHash& sig, const FunctionParameterTypes& params)
     {
-        if (sig.key->is<StructType>())
+        if (!sig.key->is<FunctionSignature>())
             return false;
 
         const FunctionSignature* signature = sig.key->as<FunctionSignature>();
@@ -207,6 +360,9 @@ struct FunctionParameterTypes {
         return true;
     }
 
+    // The translate method (here and in structs below) is used as a part of the
+    // HashTranslator interface in order to construct a hash set entry when the entry
+    // is not already in the set. See HashSet.h for details.
     static void translate(TypeHash& entry, const FunctionParameterTypes& params, unsigned)
     {
         RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateFunctionSignature(params.returnTypes.size(), params.argumentTypes.size());
@@ -232,7 +388,7 @@ struct StructParameterTypes {
 
     static bool equal(const TypeHash& sig, const StructParameterTypes& params)
     {
-        if (sig.key->is<FunctionSignature>())
+        if (!sig.key->is<StructType>())
             return false;
 
         const StructType* structType = sig.key->as<StructType>();
@@ -260,6 +416,78 @@ struct StructParameterTypes {
     }
 };
 
+struct RecursionGroupParameterTypes {
+    const Vector<TypeIndex>& types;
+
+    static unsigned hash(const RecursionGroupParameterTypes& params)
+    {
+        return computeRecursionGroupHash(params.types.size(), params.types.data());
+    }
+
+    static bool equal(const TypeHash& sig, const RecursionGroupParameterTypes& params)
+    {
+        if (!sig.key->is<RecursionGroup>())
+            return false;
+
+        const RecursionGroup* recursionGroup = sig.key->as<RecursionGroup>();
+        if (recursionGroup->typeCount() != params.types.size())
+            return false;
+
+        for (unsigned i = 0; i < recursionGroup->typeCount(); ++i) {
+            if (recursionGroup->type(i) != params.types[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    static void translate(TypeHash& entry, const RecursionGroupParameterTypes& params, unsigned)
+    {
+        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateRecursionGroup(params.types.size());
+        RELEASE_ASSERT(signature);
+
+        RecursionGroup* recursionGroup = signature->as<RecursionGroup>();
+        for (unsigned i = 0; i < params.types.size(); ++i)
+            recursionGroup->getType(i) = params.types[i];
+
+        entry.key = WTFMove(signature);
+    }
+};
+
+struct ProjectionParameterTypes {
+    const TypeIndex recursionGroup;
+    const ProjectionIndex index;
+
+    static unsigned hash(const ProjectionParameterTypes& params)
+    {
+        return computeProjectionHash(params.recursionGroup, params.index);
+    }
+
+    static bool equal(const TypeHash& sig, const ProjectionParameterTypes& params)
+    {
+        if (!sig.key->is<Projection>())
+            return false;
+
+        const Projection* projection = sig.key->as<Projection>();
+        if (projection->recursionGroup() != params.recursionGroup || projection->index() != params.index)
+            return false;
+
+        return true;
+    }
+
+    static void translate(TypeHash& entry, const ProjectionParameterTypes& params, unsigned)
+    {
+        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateProjection();
+        RELEASE_ASSERT(signature);
+
+        Projection* projection = signature->as<Projection>();
+        projection->getRecursionGroup() = params.recursionGroup;
+        projection->getIndex() = params.index;
+
+        entry.key = WTFMove(signature);
+    }
+};
+
 RefPtr<TypeDefinition> TypeInformation::typeDefinitionForFunction(const Vector<Type, 1>& results, const Vector<Type>& args)
 {
     if constexpr (ASSERT_ENABLED) {
@@ -279,6 +507,24 @@ RefPtr<TypeDefinition> TypeInformation::typeDefinitionForStruct(const Vector<Str
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<StructParameterTypes>(StructParameterTypes { fields });
+    return addResult.iterator->key;
+}
+
+RefPtr<TypeDefinition> TypeInformation::typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types)
+{
+    TypeInformation& info = singleton();
+    Locker locker { info.m_lock };
+
+    auto addResult = info.m_typeSet.template add<RecursionGroupParameterTypes>(RecursionGroupParameterTypes { types });
+    return addResult.iterator->key;
+}
+
+RefPtr<TypeDefinition> TypeInformation::typeDefinitionForProjection(TypeIndex recursionGroup, ProjectionIndex index)
+{
+    TypeInformation& info = singleton();
+    Locker locker { info.m_lock };
+
+    auto addResult = info.m_typeSet.template add<ProjectionParameterTypes>(ProjectionParameterTypes { recursionGroup, index });
     return addResult.iterator->key;
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -44,6 +44,8 @@ namespace Wasm {
 
 using FunctionArgCount = uint32_t;
 using StructFieldCount = uint32_t;
+using RecursionGroupCount = uint32_t;
+using ProjectionIndex = uint32_t;
 
 class FunctionSignature {
 public:
@@ -123,20 +125,93 @@ private:
     StructFieldCount m_fieldCount;
 };
 
+class RecursionGroup {
+public:
+    RecursionGroup(TypeIndex* payload, RecursionGroupCount typeCount)
+        : m_payload(payload)
+        , m_typeCount(typeCount)
+    {
+    }
+
+    RecursionGroupCount typeCount() const { return m_typeCount; }
+    TypeIndex type(RecursionGroupCount i) const { return const_cast<RecursionGroup*>(this)->getType(i); }
+
+    WTF::String toString() const;
+    void dump(WTF::PrintStream& out) const;
+
+    TypeIndex& getType(RecursionGroupCount i) { ASSERT(i < typeCount());; return *storage(i); }
+    TypeIndex* storage(RecursionGroupCount i) { return i + m_payload; }
+    const TypeIndex* storage(RecursionGroupCount i) const { return const_cast<RecursionGroup*>(this)->storage(i); }
+
+private:
+    TypeIndex* m_payload;
+    RecursionGroupCount m_typeCount;
+};
+
+// This class represents a projection into a recursion group. That is, if a recursion
+// group is defined as $r = (rec (type $s ...) (type $t ...)), then a projection accesses
+// the inner types. For example $r.$s or $r.$t, or $r.0 or $r.1 with numeric indices.
+//
+// See https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#type-contexts
+//
+// We store projections rather than the implied unfolding because the actual type being
+// represented may be recursive and infinite. Projections are unfolded into a concrete type
+// when operations on the type require a specific concrete type.
+class Projection {
+public:
+    Projection(TypeIndex* payload)
+        : m_payload(payload)
+    {
+    }
+
+    TypeIndex recursionGroup() const { return const_cast<Projection*>(this)->getRecursionGroup(); }
+    ProjectionIndex index() const { return const_cast<Projection*>(this)->getIndex(); }
+
+    WTF::String toString() const;
+    void dump(WTF::PrintStream& out) const;
+
+    TypeIndex& getRecursionGroup() { return *storage(0); }
+    ProjectionIndex& getIndex() { return *reinterpret_cast<ProjectionIndex*>(storage(1)); }
+    TypeIndex* storage(uint32_t i) { ASSERT(i <= 1); return i + m_payload; }
+    const TypeIndex* storage(uint32_t i) const { return const_cast<Projection*>(this)->storage(i); }
+
+private:
+    TypeIndex* m_payload;
+};
+static_assert(sizeof(ProjectionIndex) <= sizeof(TypeIndex));
+
+enum class TypeDefinitionKind : uint8_t {
+    FunctionSignature,
+    StructType,
+    RecursionGroup,
+    Projection
+};
+
 class TypeDefinition : public ThreadSafeRefCounted<TypeDefinition> {
     WTF_MAKE_FAST_ALLOCATED;
 
     TypeDefinition() = delete;
     TypeDefinition(const TypeDefinition&) = delete;
 
-    TypeDefinition(FunctionArgCount retCount, FunctionArgCount argCount)
+    TypeDefinition(TypeDefinitionKind kind, FunctionArgCount retCount, FunctionArgCount argCount)
         : m_typeHeader { FunctionSignature { static_cast<Type*>(payload()), argCount, retCount } }
     {
+        RELEASE_ASSERT(kind == TypeDefinitionKind::FunctionSignature);
     }
 
-    TypeDefinition(StructFieldCount fieldCount)
-        : m_typeHeader { StructType { static_cast<StructField*>(payload()), fieldCount } }
+    TypeDefinition(TypeDefinitionKind kind, uint32_t fieldCount)
+        : m_typeHeader { StructType { static_cast<StructField*>(payload()), static_cast<StructFieldCount>(fieldCount) } }
     {
+        if (kind == TypeDefinitionKind::RecursionGroup)
+            m_typeHeader = { RecursionGroup { static_cast<TypeIndex*>(payload()), static_cast<RecursionGroupCount>(fieldCount) } };
+        else
+            RELEASE_ASSERT(kind == TypeDefinitionKind::StructType);
+    }
+
+    TypeDefinition(TypeDefinitionKind kind)
+        : m_typeHeader { Projection { static_cast<TypeIndex*>(payload()) } }
+    {
+        RELEASE_ASSERT(kind == TypeDefinitionKind::Projection);
     }
 
     // Payload starts past end of this object.
@@ -144,6 +219,8 @@ class TypeDefinition : public ThreadSafeRefCounted<TypeDefinition> {
 
     static size_t allocatedFunctionSize(Checked<FunctionArgCount> retCount, Checked<FunctionArgCount> argCount) { return sizeof(TypeDefinition) + (retCount + argCount) * sizeof(Type); }
     static size_t allocatedStructSize(Checked<StructFieldCount> fieldCount) { return sizeof(TypeDefinition) + fieldCount * sizeof(StructField); }
+    static size_t allocatedRecursionGroupSize(Checked<RecursionGroupCount> typeCount) { return sizeof(TypeDefinition) + typeCount * sizeof(TypeIndex); }
+    static size_t allocatedProjectionSize() { return sizeof(TypeDefinition) + 2 * sizeof(TypeIndex); }
 
 public:
     template <typename T>
@@ -162,6 +239,9 @@ public:
     bool operator==(const TypeDefinition& rhs) const { return this == &rhs; }
     unsigned hash() const;
 
+    const TypeDefinition& replacePlaceholders(TypeIndex) const;
+    const TypeDefinition& expand() const;
+
     // Type definitions are uniqued and, for call_indirect, validated at runtime. Tables can create invalid TypeIndex values which cause call_indirect to fail. We use 0 as the invalidIndex so that the codegen can easily test for it and trap, and we add a token invalid entry in TypeInformation.
     static const constexpr TypeIndex invalidIndex = 0;
 
@@ -169,11 +249,17 @@ private:
     friend class TypeInformation;
     friend struct FunctionParameterTypes;
     friend struct StructParameterTypes;
+    friend struct RecursionGroupParameterTypes;
+    friend struct ProjectionParameterTypes;
 
     static RefPtr<TypeDefinition> tryCreateFunctionSignature(FunctionArgCount returnCount, FunctionArgCount argumentCount);
     static RefPtr<TypeDefinition> tryCreateStructType(StructFieldCount);
+    static RefPtr<TypeDefinition> tryCreateRecursionGroup(RecursionGroupCount);
+    static RefPtr<TypeDefinition> tryCreateProjection();
 
-    std::variant<FunctionSignature, StructType> m_typeHeader;
+    static Type substitute(Type, TypeIndex);
+
+    std::variant<FunctionSignature, StructType, RecursionGroup, Projection> m_typeHeader;
     // Payload is stored here.
 };
 
@@ -223,6 +309,8 @@ public:
 
     static RefPtr<TypeDefinition> typeDefinitionForFunction(const Vector<Type, 1>& returnTypes, const Vector<Type>& argumentTypes);
     static RefPtr<TypeDefinition> typeDefinitionForStruct(const Vector<StructField>& fields);
+    static RefPtr<TypeDefinition> typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types);
+    static RefPtr<TypeDefinition> typeDefinitionForProjection(TypeIndex, ProjectionIndex);
     ALWAYS_INLINE const TypeDefinition* thunkFor(Type type) const { return thunkTypes[linearizeType(type.kind)]; }
 
     static const TypeDefinition& get(TypeIndex);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -51,7 +51,14 @@ inline const TypeDefinition& TypeInformation::get(TypeIndex index)
 
 inline const FunctionSignature& TypeInformation::getFunctionSignature(TypeIndex index)
 {
-    return *get(index).as<FunctionSignature>();
+    const TypeDefinition& signature = get(index);
+    if (signature.is<Projection>()) {
+        const TypeDefinition& expanded = signature.expand();
+        ASSERT(expanded.is<FunctionSignature>());
+        return *expanded.as<FunctionSignature>();
+    }
+    ASSERT(signature.is<FunctionSignature>());
+    return *signature.as<FunctionSignature>();
 }
 
 inline TypeIndex TypeInformation::get(const TypeDefinition& type)

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -59,7 +59,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
     // It'd be super easy to do so: https://bugs.webkit.org/show_bug.cgi?id=169401
     const auto& wasmCC = wasmCallingConvention();
     const auto& jsCC = jsCallingConvention();
-    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex);
+    const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     const auto& signature = *typeDefinition.as<FunctionSignature>();
     unsigned argCount = signature.argumentCount();
     JIT jit;
@@ -117,6 +117,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Func:
             case TypeKind::Struct:
             case TypeKind::I31ref:
+            case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:
@@ -202,6 +203,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Func:
             case TypeKind::Struct:
             case TypeKind::I31ref:
+            case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -483,7 +483,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
 
     for (unsigned index = 0; index < moduleInformation.internalExceptionTypeIndices.size(); ++index) {
         Wasm::TypeIndex typeIndex = moduleInformation.internalExceptionTypeIndices[index];
-        m_instance->instance().setTag(moduleInformation.importExceptionCount() + index, Wasm::Tag::create(Wasm::TypeInformation::get(typeIndex)));
+        m_instance->instance().setTag(moduleInformation.importExceptionCount() + index, Wasm::Tag::create(Wasm::TypeInformation::get(typeIndex).expand()));
     }
 
     unsigned functionImportCount = calleeGroup->functionImportCount();

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -18,6 +18,7 @@
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },
     "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],


### PR DESCRIPTION
#### 5f3859595e5e1e337beac77a6b45ec05421e1842
<pre>
Add support for WebAssembly GC recursion groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=239666">https://bugs.webkit.org/show_bug.cgi?id=239666</a>

Reviewed by Justin Michaud.

Add support for the Wasm GC proposal&apos;s recursion groups. These are
a new kind of TypeDefinition that allows for recursive type
definitions. Recursive type index references are only allowed with
recursion group definitions.

Recursion groups can be stored hash-consed like other type
definitions, but to successfully compare them they must store several
definitions in the type store:

  - The recursion group itself (rec (type ...) ...)
  - Each type component in the group (type ...), where any potential
    recursive references are represented as a special value type.
  - Projections into the recursion group ((rec ...).&lt;i&gt;)

Projections can be expanded into the underlying function/struct/etc
type when the validator needs to examine the structure of the type.
This operation exposes the type component in the group, and replaces
recursive references with the appropriate projection (which can then
be expanded if required, and so on).

If expansion becomes a bottleneck, it is easy to memoize it with the
addition of a TypeIndex to TypeIndex mapping in the type store.

Generally, the expansion operation is needed when code relies on the
structure of the underlying type. For functions, these uses usually
look like `signature.as&lt;FunctionSignature&gt;()`. The signature *must* be
expanded before such a conversion is called.

When signatures need to be compared for equality, such as for
call_indirect or for matching function import/export, the comparison
should generally be done by the type index of the projection. That is,
*not* by equality of the underlying/expanded type.

Recursive references are not represented in the binary format and are
internal to the semantics and implementation. To avoid using extra
opcodes, they are internally represented as a type that uses the
opcode for recursion group (TypeKind::Rec), which cannot normally be
used for value types in the binary format, with a heap type that
encodes the index into the recursion group&apos;s type list.

* JSTests/wasm/gc/rec.js: Added.
(module):
(testRecDeclaration):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::AirIRGenerator):
(JSC::Wasm::AirIRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValueType):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp:
(JSC::Wasm::FunctionCodeBlockGenerator::addSignature):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::splitStack):
(JSC::Wasm::FunctionParser&lt;Context&gt;::FunctionParser):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::initElementSegment):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
(JSC::Wasm::LLIntGenerator::addCallIndirect):
(JSC::Wasm::LLIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::Parser):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseHeapType):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseRecursionGroup):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::doWasmCallIndirect):
(JSC::LLInt::doWasmCallRef):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::dump const):
(JSC::Wasm::RecursionGroup::toString const):
(JSC::Wasm::RecursionGroup::dump const):
(JSC::Wasm::Projection::toString const):
(JSC::Wasm::Projection::dump const):
(JSC::Wasm::computeRecursionGroupHash):
(JSC::Wasm::computeProjectionHash):
(JSC::Wasm::TypeDefinition::hash const):
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature):
(JSC::Wasm::TypeDefinition::tryCreateStructType):
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup):
(JSC::Wasm::TypeDefinition::tryCreateProjection):
(JSC::Wasm::TypeDefinition::substitute):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeDefinition::expand const):
(JSC::Wasm::FunctionParameterTypes::equal):
(JSC::Wasm::StructParameterTypes::equal):
(JSC::Wasm::RecursionGroupParameterTypes::hash):
(JSC::Wasm::RecursionGroupParameterTypes::equal):
(JSC::Wasm::RecursionGroupParameterTypes::translate):
(JSC::Wasm::ProjectionParameterTypes::hash):
(JSC::Wasm::ProjectionParameterTypes::equal):
(JSC::Wasm::ProjectionParameterTypes::translate):
(JSC::Wasm::TypeInformation::typeDefinitionForRecursionGroup):
(JSC::Wasm::TypeInformation::typeDefinitionForProjection):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::RecursionGroup::RecursionGroup):
(JSC::Wasm::RecursionGroup::typeCount const):
(JSC::Wasm::RecursionGroup::type const):
(JSC::Wasm::RecursionGroup::getType):
(JSC::Wasm::RecursionGroup::storage):
(JSC::Wasm::RecursionGroup::storage const):
(JSC::Wasm::Projection::Projection):
(JSC::Wasm::Projection::recursionGroup const):
(JSC::Wasm::Projection::index const):
(JSC::Wasm::Projection::getRecursionGroup):
(JSC::Wasm::Projection::getIndex):
(JSC::Wasm::Projection::storage):
(JSC::Wasm::Projection::storage const):
(JSC::Wasm::TypeDefinition::TypeDefinition):
(JSC::Wasm::TypeDefinition::allocatedRecursionGroupSize):
(JSC::Wasm::TypeDefinition::allocatedProjectionSize):
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeInformation::getFunctionSignature):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/253491@main">https://commits.webkit.org/253491@main</a>
</pre>
