### PR TITLE
Disabling the CSS Motion Path experimental feature does not prevent parsing of CSS Motion Path properties in Safari 15.3 and up

### DIFF
--- a/LayoutTests/ChangeLog
+++ b/LayoutTests/ChangeLog
@@ -1,5 +1,50 @@
 2022-05-16  Alan Coon  <alancoon@apple.com>
 
+        Cherry-pick r294012. rdar://problem/92425915
+
+    Fix inertness of pseudo-elements
+    https://bugs.webkit.org/show_bug.cgi?id=239831
+    
+    Reviewed by Antti Koivisto.
+    
+    When we adjust style for a pseudo-element, `m_element` and `document().activeModalDialog()` are both null. So we accidentally reset inertness to false in those cases.
+    
+    Fix this by making checking for m_element's existence too.
+    
+    LayoutTests/imported/w3c:
+    
+    * web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+    * web-platform-tests/inert/inert-pseudo-element-hittest.html: Added.
+    
+    Source/WebCore:
+    
+    Test: imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html
+    
+    * style/StyleAdjuster.cpp:
+    (WebCore::Style::Adjuster::adjust const):
+    
+    LayoutTests:
+    
+    * platform/ios-wk2/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+    
+    Canonical link: https://commits.webkit.org/250446@main
+    git-svn-id: https://svn.webkit.org/repository/webkit/trunk@294012 268f45cc-cd09-0410-ab3c-d52691b4dbfc
+
+    2022-05-10  Tim Nguyen  <ntim@apple.com>
+
+            Fix inertness of pseudo-elements
+            https://bugs.webkit.org/show_bug.cgi?id=239831
+
+            Reviewed by Antti Koivisto.
+
+            When we adjust style for a pseudo-element, `m_element` and `document().activeModalDialog()` are both null. So we accidentally reset inertness to false in those cases.
+
+            Fix this by making checking for m_element's existence too.
+
+            * platform/ios-wk2/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+
+2022-05-16  Alan Coon  <alancoon@apple.com>
+
         Cherry-pick r293987. rdar://problem/92775435
 
     Implement CSS :modal pseudo class

--- a/LayoutTests/imported/w3c/ChangeLog
+++ b/LayoutTests/imported/w3c/ChangeLog
@@ -1,5 +1,51 @@
 2022-05-16  Alan Coon  <alancoon@apple.com>
 
+        Cherry-pick r294012. rdar://problem/92425915
+
+    Fix inertness of pseudo-elements
+    https://bugs.webkit.org/show_bug.cgi?id=239831
+    
+    Reviewed by Antti Koivisto.
+    
+    When we adjust style for a pseudo-element, `m_element` and `document().activeModalDialog()` are both null. So we accidentally reset inertness to false in those cases.
+    
+    Fix this by making checking for m_element's existence too.
+    
+    LayoutTests/imported/w3c:
+    
+    * web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+    * web-platform-tests/inert/inert-pseudo-element-hittest.html: Added.
+    
+    Source/WebCore:
+    
+    Test: imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html
+    
+    * style/StyleAdjuster.cpp:
+    (WebCore::Style::Adjuster::adjust const):
+    
+    LayoutTests:
+    
+    * platform/ios-wk2/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+    
+    Canonical link: https://commits.webkit.org/250446@main
+    git-svn-id: https://svn.webkit.org/repository/webkit/trunk@294012 268f45cc-cd09-0410-ab3c-d52691b4dbfc
+
+    2022-05-10  Tim Nguyen  <ntim@apple.com>
+
+            Fix inertness of pseudo-elements
+            https://bugs.webkit.org/show_bug.cgi?id=239831
+
+            Reviewed by Antti Koivisto.
+
+            When we adjust style for a pseudo-element, `m_element` and `document().activeModalDialog()` are both null. So we accidentally reset inertness to false in those cases.
+
+            Fix this by making checking for m_element's existence too.
+
+            * web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt: Added.
+            * web-platform-tests/inert/inert-pseudo-element-hittest.html: Added.
+
+2022-05-16  Alan Coon  <alancoon@apple.com>
+
         Cherry-pick r293987. rdar://problem/92775435
 
     Implement CSS :modal pseudo class

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt
@@ -1,0 +1,6 @@
+Manual test: hover the green square, pass if it does not turn red.
+
+
+PASS Hit-testing cannot reach pseudo elements of inert nodes
+PASS Hit-testing can reach pseudo elements of non-inert nodes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Hit-testing on pseudo elements of inert nodes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<style>
+#target::before {
+    content: "";
+    width: 50px;
+    height: 50px;
+    background-color: green;
+    display: inline-block;
+}
+
+#target:hover::before,
+#target:active::before {
+    background-color: red;
+}
+</style>
+<p>Manual test: hover the green square, pass if it does not turn red.</p>
+<div id="target" inert></div>
+<script>
+const events = [
+    "mousedown", "mouseenter", "mousemove", "mouseover",
+    "pointerdown", "pointerenter", "pointermove", "pointerover",
+];
+async function mouseDownAndGetEvents(test) {
+    const receivedEvents = [];
+    for (let event of events) {
+        target.addEventListener(event, () => {
+            receivedEvents.push(event);
+        }, { once: true, capture: true });
+    }
+
+    await new test_driver.Actions()
+        .pointerMove(0, 0, { origin: target })
+        .pointerDown()
+        .send();
+    test.add_cleanup(() => test_driver.click(document.body));
+
+    // Exact order of events is not interoperable.
+    receivedEvents.sort();
+    return receivedEvents;
+}
+promise_test(async function() {
+    const receivedEvents = await mouseDownAndGetEvents(this);
+    assert_array_equals(receivedEvents, [], "target got no event");
+    assert_false(target.matches(":active"), "target is not active");
+    assert_false(target.matches(":hover"), "target is not hovered");
+    assert_equals(getComputedStyle(target, "::before").backgroundColor, "rgb(0, 128, 0)", "#target::before has no hover style");
+}, "Hit-testing cannot reach pseudo elements of inert nodes");
+
+promise_test(async function() {
+    target.inert = false;
+    const receivedEvents = await mouseDownAndGetEvents(this);
+    assert_array_equals(receivedEvents, events, "target got all events");
+    assert_true(target.matches(":active"), "target is active");
+    assert_true(target.matches(":hover"), "target is hovered");
+    assert_equals(getComputedStyle(target, "::before").backgroundColor, "rgb(255, 0, 0)", "#target::before has hover style");
+}, "Hit-testing can reach pseudo elements of non-inert nodes");
+</script>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest-expected.txt
@@ -1,0 +1,6 @@
+Manual test: hover the green square, pass if it does not turn red.
+
+
+PASS Hit-testing cannot reach pseudo elements of inert nodes
+FAIL Hit-testing can reach pseudo elements of non-inert nodes assert_array_equals: target got all events lengths differ, expected array ["mousedown", "mouseenter", "mousemove", "mouseover", "pointerdown", "pointerenter", "pointermove", "pointerover"] length 8, got [] length 0
+

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -3329,14 +3329,24 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         case CSSPropertyOffsetPath:
             // The computed value of offset-path must only contain absolute draw commands.
             // https://github.com/w3c/fxtf-drafts/issues/225#issuecomment-334322738
+            if (!m_element->document().settings().cssMotionPathEnabled())
+                return nullptr;
             return valueForPathOperation(style, style.offsetPath(), SVGPathConversion::ForceAbsolute);
         case CSSPropertyOffsetDistance:
+            if (!m_element->document().settings().cssMotionPathEnabled())
+                return nullptr;
             return cssValuePool.createValue(style.offsetDistance(), style);
         case CSSPropertyOffsetPosition:
+            if (!m_element->document().settings().cssMotionPathEnabled())
+                return nullptr;
             return valueForPositionOrAuto(style, style.offsetPosition());
         case CSSPropertyOffsetAnchor:
+            if (!m_element->document().settings().cssMotionPathEnabled())
+                return nullptr;
             return valueForPositionOrAuto(style, style.offsetAnchor());
         case CSSPropertyOffsetRotate:
+            if (!m_element->document().settings().cssMotionPathEnabled())
+                return nullptr;
             return valueForOffsetRotate(style.offsetRotate());
         case CSSPropertyOpacity:
             return cssValuePool.createValue(style.opacity(), CSSUnitType::CSS_NUMBER);

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -112,6 +112,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , gradientPremultipliedAlphaInterpolationEnabled { document.settings().cssGradientPremultipliedAlphaInterpolationEnabled() }
     , gradientInterpolationColorSpacesEnabled { document.settings().cssGradientInterpolationColorSpacesEnabled() }
     , inputSecurityEnabled { document.settings().cssInputSecurityEnabled() }
+    , motionPathEnabled { document.settings().cssMotionPathEnabled() }
 #if ENABLE(ATTACHMENT_ELEMENT)
     , attachmentEnabled { RuntimeEnabledFeatures::sharedFeatures().attachmentElementEnabled() }
 #endif
@@ -165,6 +166,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
 #if ENABLE(ATTACHMENT_ELEMENT)
         && a.attachmentEnabled == b.attachmentEnabled
 #endif
+        && a.motionPathEnabled == b.motionPathEnabled
     ;
 }
 
@@ -209,7 +211,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #endif
         | context.accentColorEnabled                        << 29
         | context.inputSecurityEnabled                      << 30
-        | context.mode                                      << 31; // This is multiple bits, so keep it last.
+        | context.motionPathEnabled                         << 31
+        | (uint64_t)context.mode                            << 32; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, bits);
 }
 
@@ -254,6 +257,12 @@ bool CSSParserContext::isPropertyRuntimeDisabled(CSSPropertyID property) const
     case CSSPropertyWebkitOverflowScrolling:
         return !legacyOverflowScrollingTouchEnabled;
 #endif
+    case CSSPropertyOffsetPath:
+    case CSSPropertyOffsetDistance:
+    case CSSPropertyOffsetPosition:
+    case CSSPropertyOffsetAnchor:
+    case CSSPropertyOffsetRotate:
+        return !motionPathEnabled;
     default:
         return false;
     }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -89,6 +89,7 @@ struct CSSParserContext {
     bool gradientPremultipliedAlphaInterpolationEnabled { false };
     bool gradientInterpolationColorSpacesEnabled { false };
     bool inputSecurityEnabled { false };
+    bool motionPathEnabled { false };
 
     // RuntimeEnabledFeatures.
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -4475,13 +4475,21 @@ RefPtr<CSSValue> CSSPropertyParser::parseSingleValue(CSSPropertyID property, CSS
             return parsedValue;
         return consumePercent(m_range, ValueRange::All);
     case CSSPropertyOffsetPath:
+        if (!m_context.motionPathEnabled)
+            return nullptr;
         return consumePathOperation(m_range, m_context, ConsumeRay::Include);
     case CSSPropertyOffsetDistance:
+        if (!m_context.motionPathEnabled)
+            return nullptr;
         return consumeLengthOrPercent(m_range, m_context.mode, ValueRange::All, UnitlessQuirk::Forbid);
     case CSSPropertyOffsetPosition:
     case CSSPropertyOffsetAnchor:
+        if (!m_context.motionPathEnabled)
+            return nullptr;
         return consumePositionOrAuto(m_range, m_context.mode, UnitlessQuirk::Forbid, PositionSyntax::Position);
     case CSSPropertyOffsetRotate:
+        if (!m_context.motionPathEnabled)
+            return nullptr;
         return consumeOffsetRotate(m_range, m_context.mode);
     case CSSPropertyWebkitBoxFlex:
         return consumeNumber(m_range, ValueRange::All);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -540,19 +540,18 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     if (isInertSubtreeRoot(m_element))
         style.setEffectiveInert(true);
 
-    // Make sure the active dialog is interactable when the whole document is blocked by the modal dialog
-    if (m_element == m_document.activeModalDialog() && !hasInertAttribute(m_element))
-        style.setEffectiveInert(false);
+    if (m_element) {
+        // Make sure the active dialog is interactable when the whole document is blocked by the modal dialog
+        if (m_element == m_document.activeModalDialog() && !hasInertAttribute(m_element))
+            style.setEffectiveInert(false);
 
-    if (m_element)
         style.setEventListenerRegionTypes(computeEventListenerRegionTypes(*m_element, m_parentStyle.eventListenerRegionTypes()));
 
 #if ENABLE(TEXT_AUTOSIZING)
-    if (m_element && m_document.settings().textAutosizingUsesIdempotentMode())
-        adjustForTextAutosizing(style, *m_element);
+        if (m_document.settings().textAutosizingUsesIdempotentMode())
+            adjustForTextAutosizing(style, *m_element);
 #endif
 
-    if (m_element) {
         if (auto observer = m_element->document().modalContainerObserverIfExists()) {
             if (observer->shouldHide(*m_element))
                 style.setDisplay(DisplayType::None);


### PR DESCRIPTION
bedda8e8b477
<pre>
Disabling the CSS Motion Path experimental feature does not prevent parsing of CSS Motion Path properties in Safari 15.3 and up
<a href="https://bugs.webkit.org/show_bug.cgi?id=240599">https://bugs.webkit.org/show_bug.cgi?id=240599</a>
&lt;rdar://93518191>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==):
(WebCore::add):
(WebCore::CSSParserContext::isPropertyRuntimeDisabled const):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseSingleValue):
</pre>
