### PR TITLE
Add support for Wasm ESM scripts for Worker.new

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: SyntaxError: Invalid character: '\0'
 
-FAIL Testing WebAssembly worker Script error.
+PASS Testing WebAssembly worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 const worker = new Worker("resources/worker.wasm", { type: "module" });
 worker.onmessage = (msg) => {
-  assert_equals(msg, 42);
+  assert_equals(msg.data, 42);
   done();
 }
 </script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -482,6 +482,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSWindowProxy.h
     bindings/js/ReadableStreamDefaultController.h
     bindings/js/RunJavaScriptParameters.h
+    bindings/js/ScriptBufferSourceProvider.h
     bindings/js/ScriptCachedFrameData.h
     bindings/js/ScriptController.h
     bindings/js/ScriptWrappable.h

--- a/Source/WebCore/bindings/js/AbstractScriptSourceCode.h
+++ b/Source/WebCore/bindings/js/AbstractScriptSourceCode.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResourceHandle.h"
+#include "CachedScript.h"
+#include "CachedScriptFetcher.h"
+#include "CachedScriptSourceProvider.h"
+#include "ScriptBufferSourceProvider.h"
+#include <JavaScriptCore/SourceCode.h>
+#include <JavaScriptCore/SourceProvider.h>
+#include <wtf/RefPtr.h>
+#include <wtf/URL.h>
+#include <wtf/text/TextPosition.h>
+
+namespace WebCore {
+
+class AbstractScriptSourceCode {
+public:
+    bool isEmpty() const { return !m_code.length(); }
+
+    const JSC::SourceCode& jsSourceCode() const { return m_code; }
+
+    JSC::SourceProvider& provider() { return m_provider.get(); }
+    StringView source() const { return m_provider->source(); }
+
+    int startLine() const { return m_code.firstLine().oneBasedInt(); }
+    int startColumn() const { return m_code.startColumn().oneBasedInt(); }
+
+    CachedScript* cachedScript() const { return m_cachedScript.get(); }
+
+    const URL& url() const { return m_provider->sourceOrigin().url(); }
+
+protected:
+    AbstractScriptSourceCode(Ref<JSC::SourceProvider>&& provider, int firstLine, int startColumn)
+        : m_provider(provider)
+        , m_code(m_provider.copyRef(), firstLine, startColumn)
+    {
+    }
+
+    AbstractScriptSourceCode(Ref<JSC::SourceProvider>&& provider, CachedResourceHandle<CachedScript> cachedScript)
+        : m_provider(provider)
+        , m_code(m_provider.copyRef())
+        , m_cachedScript(cachedScript)
+    {
+    }
+
+private:
+    Ref<JSC::SourceProvider> m_provider;
+    JSC::SourceCode m_code;
+    CachedResourceHandle<CachedScript> m_cachedScript;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/WebAssemblyScriptSourceCode.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptSourceCode.h
@@ -27,40 +27,23 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "CachedResourceHandle.h"
-#include "CachedScript.h"
-#include "CachedScriptFetcher.h"
-#include "SharedBuffer.h"
+#include "AbstractScriptSourceCode.h"
 #include "WebAssemblyCachedScriptSourceProvider.h"
 #include "WebAssemblyScriptBufferSourceProvider.h"
-#include <JavaScriptCore/SourceCode.h>
-#include <JavaScriptCore/SourceProvider.h>
-#include <wtf/RefPtr.h>
-#include <wtf/URL.h>
 
 namespace WebCore {
 
-class WebAssemblyScriptSourceCode {
+class WebAssemblyScriptSourceCode : public AbstractScriptSourceCode {
 public:
     WebAssemblyScriptSourceCode(CachedScript* cachedScript, Ref<CachedScriptFetcher>&& scriptFetcher)
-        : m_provider(WebAssemblyCachedScriptSourceProvider::create(cachedScript, WTFMove(scriptFetcher)))
-        , m_code(m_provider.copyRef())
-        , m_cachedScript(cachedScript)
+        : AbstractScriptSourceCode(WebAssemblyCachedScriptSourceProvider::create(cachedScript, WTFMove(scriptFetcher)), cachedScript)
     {
     }
 
     WebAssemblyScriptSourceCode(const ScriptBuffer& source, URL&& url, Ref<JSC::ScriptFetcher>&& scriptFetcher)
-        : m_provider(WebAssemblyScriptBufferSourceProvider::create(source, WTFMove(url), WTFMove(scriptFetcher)))
-        , m_code(m_provider.copyRef())
+        : AbstractScriptSourceCode(WebAssemblyScriptBufferSourceProvider::create(source, WTFMove(url), WTFMove(scriptFetcher)), nullptr)
     {
     }
-
-    const JSC::SourceCode& jsSourceCode() const { return m_code; }
-
-private:
-    Ref<JSC::SourceProvider> m_provider;
-    JSC::SourceCode m_code;
-    CachedResourceHandle<CachedScript> m_cachedScript;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -226,7 +226,7 @@ void Worker::notifyFinished()
         m_clientIdentifier,
         context->userAgent(m_scriptLoader->lastRequestURL())
     };
-    m_contextProxy.startWorkerGlobalScope(m_scriptLoader->lastRequestURL(), *sessionID, m_options.name, WTFMove(initializationData), m_scriptLoader->script(), contentSecurityPolicyResponseHeaders, m_shouldBypassMainWorldContentSecurityPolicy, m_scriptLoader->crossOriginEmbedderPolicy(), m_workerCreationTime, referrerPolicy, m_options.type, m_options.credentials, m_runtimeFlags);
+    m_contextProxy.startWorkerGlobalScope(m_scriptLoader->lastRequestURL(), *sessionID, m_options.name, WTFMove(initializationData), m_scriptLoader->script(), contentSecurityPolicyResponseHeaders, m_shouldBypassMainWorldContentSecurityPolicy, m_scriptLoader->crossOriginEmbedderPolicy(), m_workerCreationTime, referrerPolicy, m_options.type, m_options.credentials, m_runtimeFlags, m_scriptLoader->responseMIMEType());
     InspectorInstrumentation::scriptImported(*context, m_scriptLoader->identifier(), m_scriptLoader->script().toString());
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -623,7 +623,7 @@ void WorkerGlobalScope::releaseMemoryInWorkers(Synchronous synchronous)
     }
 }
 
-void WorkerGlobalScope::setMainScriptSourceProvider(ScriptBufferSourceProvider& provider)
+void WorkerGlobalScope::setMainScriptSourceProvider(AbstractScriptBufferHolder& provider)
 {
     ASSERT(!m_mainScriptSourceProvider);
     m_mainScriptSourceProvider = provider;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -30,6 +30,7 @@
 #include "CacheStorageConnection.h"
 #include "ClientOrigin.h"
 #include "ImageBitmap.h"
+#include "ScriptBufferSourceProvider.h"
 #include "ScriptExecutionContext.h"
 #include "Supplementable.h"
 #include "WindowOrWorkerGlobalScope.h"
@@ -156,7 +157,7 @@ public:
     void releaseMemory(Synchronous);
     static void releaseMemoryInWorkers(Synchronous);
 
-    void setMainScriptSourceProvider(ScriptBufferSourceProvider&);
+    void setMainScriptSourceProvider(AbstractScriptBufferHolder&);
     void addImportedScriptSourceProvider(const URL&, ScriptBufferSourceProvider&);
 
     ClientOrigin clientOrigin() const { return { topOrigin().data(), securityOrigin()->data() }; }
@@ -216,7 +217,7 @@ private:
     RefPtr<Performance> m_performance;
     mutable RefPtr<Crypto> m_crypto;
 
-    WeakPtr<ScriptBufferSourceProvider> m_mainScriptSourceProvider;
+    WeakPtr<AbstractScriptBufferHolder> m_mainScriptSourceProvider;
     MemoryCompactRobinHoodHashMap<URL, WeakHashSet<ScriptBufferSourceProvider>> m_importedScriptsSourceProviders;
 
     RefPtr<WorkerCacheStorageConnection> m_cacheStorageConnection;

--- a/Source/WebCore/workers/WorkerGlobalScopeProxy.h
+++ b/Source/WebCore/workers/WorkerGlobalScopeProxy.h
@@ -52,7 +52,7 @@ class WorkerGlobalScopeProxy {
 public:
     static WorkerGlobalScopeProxy& create(Worker&);
 
-    virtual void startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID, const String& name, WorkerInitializationData&&, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders&, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy&, MonotonicTime timeOrigin, ReferrerPolicy, WorkerType, FetchRequestCredentials, JSC::RuntimeFlags) = 0;
+    virtual void startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID, const String& name, WorkerInitializationData&&, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders&, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy&, MonotonicTime timeOrigin, ReferrerPolicy, WorkerType, FetchRequestCredentials, JSC::RuntimeFlags, const String&) = 0;
     virtual void terminateWorkerGlobalScope() = 0;
     virtual void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&) = 0;
     virtual void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&) = 0;

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -113,7 +113,7 @@ WorkerMessagingProxy::~WorkerMessagingProxy()
         || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread().thread() == &Thread::current()));
 }
 
-void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID sessionID, const String& name, WorkerInitializationData&& initializationData, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, MonotonicTime timeOrigin, ReferrerPolicy referrerPolicy, WorkerType workerType, FetchRequestCredentials credentials, JSC::RuntimeFlags runtimeFlags)
+void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID sessionID, const String& name, WorkerInitializationData&& initializationData, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, MonotonicTime timeOrigin, ReferrerPolicy referrerPolicy, WorkerType workerType, FetchRequestCredentials credentials, JSC::RuntimeFlags runtimeFlags, const String& mimeType)
 {
     // FIXME: This need to be revisited when we support nested worker one day
     ASSERT(m_scriptExecutionContext);
@@ -129,7 +129,8 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 #if ENABLE(SERVICE_WORKER)
         WTFMove(initializationData.serviceWorkerData),
 #endif
-        initializationData.clientIdentifier.value_or(ScriptExecutionContextIdentifier { })
+        initializationData.clientIdentifier.value_or(ScriptExecutionContextIdentifier { }),
+        mimeType
     };
     auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, startMode, document.topOrigin(), proxy, socketProvider, runtimeFlags);
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -47,7 +47,7 @@ public:
 private:
     // Implementations of WorkerGlobalScopeProxy.
     // (Only use these functions in the worker object thread.)
-    void startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID, const String& name, WorkerInitializationData&&, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders&, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy&, MonotonicTime timeOrigin, ReferrerPolicy, WorkerType, FetchRequestCredentials, JSC::RuntimeFlags) final;
+    void startWorkerGlobalScope(const URL& scriptURL, PAL::SessionID, const String& name, WorkerInitializationData&&, const ScriptBuffer& sourceCode, const ContentSecurityPolicyResponseHeaders&, bool shouldBypassMainWorldContentSecurityPolicy, const CrossOriginEmbedderPolicy&, MonotonicTime timeOrigin, ReferrerPolicy, WorkerType, FetchRequestCredentials, JSC::RuntimeFlags, const String&) final;
     void terminateWorkerGlobalScope() final;
     void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&) final;
     void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&) final;

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "WorkerOrWorkletScriptController.h"
 
+#include "AbstractScriptSourceCode.h"
 #include "CommonVM.h"
 #include "DedicatedWorkerGlobalScope.h"
 #include "EventLoop.h"
@@ -40,7 +41,6 @@
 #include "JSSharedWorkerGlobalScope.h"
 #include "ModuleFetchFailureKind.h"
 #include "ModuleFetchParameters.h"
-#include "ScriptSourceCode.h"
 #include "WebCoreJSClientData.h"
 #include "WorkerConsoleClient.h"
 #include "WorkerModuleScriptLoader.h"
@@ -202,7 +202,7 @@ void WorkerOrWorkletScriptController::disableWebAssembly(const String& errorMess
     m_globalScopeWrapper->setWebAssemblyEnabled(false, errorMessage);
 }
 
-void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCode, String* returnedExceptionMessage)
+void WorkerOrWorkletScriptController::evaluate(const AbstractScriptSourceCode& sourceCode, String* returnedExceptionMessage)
 {
     if (isExecutionForbidden())
         return;
@@ -220,7 +220,7 @@ void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCod
     }
 }
 
-void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCode, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage)
+void WorkerOrWorkletScriptController::evaluate(const AbstractScriptSourceCode& sourceCode, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage)
 {
     if (isExecutionForbidden())
         return;
@@ -270,7 +270,7 @@ JSC::JSValue WorkerOrWorkletScriptController::evaluateModule(JSC::AbstractModule
     return moduleRecord.evaluate(&globalObject, awaitedValue, resumeMode);
 }
 
-bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetcher& scriptFetcher, const ScriptSourceCode& sourceCode)
+bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetcher& scriptFetcher, const AbstractScriptSourceCode& sourceCode)
 {
     if (isExecutionForbidden())
         return false;
@@ -378,7 +378,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
     return success;
 }
 
-void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher& scriptFetcher, const ScriptSourceCode& sourceCode, String* returnedExceptionMessage)
+void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher& scriptFetcher, const AbstractScriptSourceCode& sourceCode, String* returnedExceptionMessage)
 {
     if (isExecutionForbidden())
         return;

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -45,9 +45,9 @@ class VM;
 
 namespace WebCore {
 
+class AbstractScriptSourceCode;
 class Exception;
 class JSDOMGlobalObject;
-class ScriptSourceCode;
 class WorkerConsoleClient;
 class WorkerOrWorkletGlobalScope;
 class WorkerScriptFetcher;
@@ -94,13 +94,13 @@ public:
     void disableEval(const String& errorMessage);
     void disableWebAssembly(const String& errorMessage);
 
-    void evaluate(const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
-    void evaluate(const ScriptSourceCode&, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage = nullptr);
+    void evaluate(const AbstractScriptSourceCode&, String* returnedExceptionMessage = nullptr);
+    void evaluate(const AbstractScriptSourceCode&, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage = nullptr);
 
     JSC::JSValue evaluateModule(JSC::AbstractModuleRecord&, JSC::JSValue awaitedValue, JSC::JSValue resumeMode);
 
-    void linkAndEvaluateModule(WorkerScriptFetcher&, const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
-    bool loadModuleSynchronously(WorkerScriptFetcher&, const ScriptSourceCode&);
+    void linkAndEvaluateModule(WorkerScriptFetcher&, const AbstractScriptSourceCode&, String* returnedExceptionMessage = nullptr);
+    bool loadModuleSynchronously(WorkerScriptFetcher&, const AbstractScriptSourceCode&);
 
     void loadAndEvaluateModule(const URL& moduleURL, FetchOptions::Credentials, CompletionHandler<void(std::optional<Exception>&&)>&&);
 

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -82,6 +82,7 @@ public:
     std::optional<ServiceWorkerData> serviceWorkerData;
 #endif
     ScriptExecutionContextIdentifier clientIdentifier;
+    String mimeType;
 
     WorkerParameters isolatedCopy() const;
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -98,7 +98,8 @@ static WorkerParameters generateWorkerParameters(const ServiceWorkerContextData&
         workerThreadMode,
         sessionID,
         { },
-        { }
+        { },
+        emptyString()
     };
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -78,7 +78,8 @@ static WorkerParameters generateWorkerParameters(const WorkerFetchResult& worker
 #if ENABLE(SERVICE_WORKER)
         WTFMove(initializationData.serviceWorkerData),
 #endif
-        *initializationData.clientIdentifier
+        *initializationData.clientIdentifier,
+        emptyString()
     };
 }
 


### PR DESCRIPTION
#### ed5b30b183148c2460360b3faa28a2cae2465ba0
<pre>
Add support for Wasm ESM scripts for Worker.new
<a href="https://bugs.webkit.org/show_bug.cgi?id=238292">https://bugs.webkit.org/show_bug.cgi?id=238292</a>

Reviewed by NOBODY (OOPS!).

Added AbstractScriptSourceCode to abstract over ScriptSourceCode (for
JS) and WebAssemblyScriptSourceCode when initializing Workers. Depending
on the MIME type of the script (and whether Wasm/ESM integration is
enabled), Workers will either load the script as JS or Wasm.

* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/AbstractScriptSourceCode.h: Copied from Source/WebCore/bindings/js/ScriptSourceCode.h.
(WebCore::AbstractScriptSourceCode::isEmpty const):
(WebCore::AbstractScriptSourceCode::jsSourceCode const):
(WebCore::AbstractScriptSourceCode::provider):
(WebCore::AbstractScriptSourceCode::source const):
(WebCore::AbstractScriptSourceCode::startLine const):
(WebCore::AbstractScriptSourceCode::startColumn const):
(WebCore::AbstractScriptSourceCode::cachedScript const):
(WebCore::AbstractScriptSourceCode::url const):
(WebCore::AbstractScriptSourceCode::AbstractScriptSourceCode):
* Source/WebCore/bindings/js/ScriptSourceCode.h:
(WebCore::ScriptSourceCode::ScriptSourceCode):
(WebCore::ScriptSourceCode::m_code): Deleted.
(WebCore::ScriptSourceCode::isEmpty const): Deleted.
(WebCore::ScriptSourceCode::jsSourceCode const): Deleted.
(WebCore::ScriptSourceCode::provider): Deleted.
(WebCore::ScriptSourceCode::source const): Deleted.
(WebCore::ScriptSourceCode::startLine const): Deleted.
(WebCore::ScriptSourceCode::startColumn const): Deleted.
(WebCore::ScriptSourceCode::cachedScript const): Deleted.
(WebCore::ScriptSourceCode::url const): Deleted.
* Source/WebCore/bindings/js/WebAssemblyScriptSourceCode.h:
(WebCore::WebAssemblyScriptSourceCode::WebAssemblyScriptSourceCode):
(WebCore::WebAssemblyScriptSourceCode::jsSourceCode const): Deleted.
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::notifyFinished):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::setMainScriptSourceProvider):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerGlobalScopeProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::evaluate):
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
(WebCore::WorkerOrWorkletScriptController::linkAndEvaluateModule):
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerParameters::isolatedCopy const):
(WebCore::WorkerThread::evaluateScriptIfNecessary):
* Source/WebCore/workers/WorkerThread.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::generateWorkerParameters):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::generateWorkerParameters):
</pre>