### PR TITLE
[git-webkit] Make --overwrite the default

### DIFF
--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -1,7 +1,7 @@
 [pull]
         rebase = true
 [webkitscmpy]
-        pull-request = append
+        pull-request = overwrite
         history = disabled
         update-fork = true
         auto-check = true


### PR DESCRIPTION
#### c34b82f5904e55328550b321c78ded5fbccfe2fd
<pre>
[git-webkit] Make --overwrite the default
<a href="https://bugs.webkit.org/show_bug.cgi?id=240607">https://bugs.webkit.org/show_bug.cgi?id=240607</a>
&lt;rdar://problem/93531574&gt;

Reviewed by NOBODY (OOPS!).

* metadata/git_config_extension: Make overwrite the default for the WebKit project.
</pre>