### PR TITLE
Remove WebSQLiteDatabaseTracker in web process

### DIFF
--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -582,6 +582,9 @@ void ApplicationCacheStorage::openDatabase(bool createIfDoesNotExist)
     if (m_database.isOpen())
         return;
 
+    if (!m_allowsOpeningDatabase)
+        return;
+
     // The cache directory should never be null, but if it for some weird reason is we bail out.
     if (m_cacheDirectory.isNull())
         return;
@@ -1517,5 +1520,16 @@ ApplicationCacheStorage::ApplicationCacheStorage(const String& cacheDirectory, c
     , m_flatFileSubdirectoryName(flatFileSubdirectoryName)
 {
 }
+
+void ApplicationCacheStorage::setAllowsOpeningDatabase(bool allow)
+{
+    if (m_allowsOpeningDatabase == allow)
+        return;
+
+    m_allowsOpeningDatabase = allow;
+    if (!allow)
+        m_database.close();
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -101,6 +101,8 @@ public:
     static int64_t unknownQuota() { return -1; }
     static int64_t noQuota() { return std::numeric_limits<int64_t>::max(); }
 
+    WEBCORE_EXPORT void setAllowsOpeningDatabase(bool);
+
 private:
     WEBCORE_EXPORT ApplicationCacheStorage(const String& cacheDirectory, const String& flatFileSubdirectoryName);
 
@@ -153,6 +155,7 @@ private:
     HashCountedSet<unsigned, AlreadyHashed> m_cacheHostSet;
     
     HashMap<String, ApplicationCacheGroup*> m_cachesInMemory; // Excludes obsolete cache groups.
+    bool m_allowsOpeningDatabase { true };
 
     friend class NeverDestroyed<ApplicationCacheStorage>;
 };

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -73,15 +73,6 @@ static void initializeSQLiteIfNecessary()
     });
 }
 
-static Lock isDatabaseOpeningForbiddenLock;
-static bool isDatabaseOpeningForbidden WTF_GUARDED_BY_LOCK(isDatabaseOpeningForbiddenLock) { false };
-
-void SQLiteDatabase::setIsDatabaseOpeningForbidden(bool isForbidden)
-{
-    Locker locker { isDatabaseOpeningForbiddenLock };
-    isDatabaseOpeningForbidden = isForbidden;
-}
-
 SQLiteDatabase::SQLiteDatabase() = default;
 
 SQLiteDatabase::~SQLiteDatabase()
@@ -105,12 +96,6 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode)
     });
 
     {
-        Locker locker { isDatabaseOpeningForbiddenLock };
-        if (isDatabaseOpeningForbidden) {
-            m_openErrorMessage = "opening database is forbidden";
-            return false;
-        }
-
         int flags = SQLITE_OPEN_AUTOPROXY;
         switch (openMode) {
         case OpenMode::ReadOnly:

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -158,8 +158,6 @@ public:
     void disableThreadingChecks() { }
 #endif
 
-    WEBCORE_EXPORT static void setIsDatabaseOpeningForbidden(bool);
-
     WEBCORE_EXPORT void releaseMemory();
 
     void incrementStatementCount();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -534,7 +534,6 @@ void WebProcessProxy::shutDown()
     }
 
     m_backgroundResponsivenessTimer.invalidate();
-    m_activityForHoldingLockedFiles = nullptr;
     m_audibleMediaActivity = std::nullopt;
 
     for (auto& frame : copyToVector(m_frameMap.values()))
@@ -1523,19 +1522,6 @@ void WebProcessProxy::updateAudibleMediaAssertions()
     } else {
         WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "updateAudibleMediaAssertions: Releasing MediaPlayback assertion for WebProcess");
         m_audibleMediaActivity = std::nullopt;
-    }
-}
-
-void WebProcessProxy::setIsHoldingLockedFiles(bool isHoldingLockedFiles)
-{
-    if (!isHoldingLockedFiles) {
-        WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "setIsHoldingLockedFiles: UIProcess is releasing a background assertion because the WebContent process is no longer holding locked files");
-        m_activityForHoldingLockedFiles = nullptr;
-        return;
-    }
-    if (!m_activityForHoldingLockedFiles) {
-        WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "setIsHoldingLockedFiles: UIProcess is taking a background assertion because the WebContent process is holding locked files");
-        m_activityForHoldingLockedFiles = m_throttler.backgroundActivity("Holding locked files"_s).moveToUniquePtr();
     }
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -271,8 +271,6 @@ public:
 
     void windowServerConnectionStateChanged();
 
-    void setIsHoldingLockedFiles(bool);
-
     ProcessThrottler& throttler() final { return m_throttler; }
 
     void isResponsive(CompletionHandler<void(bool isWebProcessResponsive)>&&);
@@ -593,7 +591,6 @@ private:
 
     int m_numberOfTimesSuddenTerminationWasDisabled;
     ProcessThrottler m_throttler;
-    std::unique_ptr<ProcessThrottler::BackgroundActivity> m_activityForHoldingLockedFiles;
     ForegroundWebProcessToken m_foregroundToken;
     BackgroundWebProcessToken m_backgroundToken;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -37,8 +37,6 @@ messages -> WebProcessProxy LegacyReceiver {
     CreateGPUProcessConnection(IPC::Attachment connectionIdentifier, struct WebKit::GPUProcessConnectionParameters parameters)
 #endif
 
-    SetIsHoldingLockedFiles(bool isHoldingLockedFiles)
-
     DidExceedActiveMemoryLimit()
     DidExceedInactiveMemoryLimit()
     DidExceedCPULimit()

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -667,8 +667,6 @@ private:
     bool m_hasRichContentServices { false };
 #endif
 
-    bool m_processIsSuspended { false };
-
     HashSet<WebCore::PageIdentifier> m_pagesInWindows;
     WebCore::Timer m_nonVisibleProcessGraphicsCleanupTimer;
 
@@ -677,10 +675,6 @@ private:
 #endif
 
     RefPtr<WebCore::ApplicationCacheStorage> m_applicationCacheStorage;
-
-#if PLATFORM(IOS_FAMILY)
-    WebSQLiteDatabaseTracker m_webSQLiteDatabaseTracker;
-#endif
 
     bool m_suppressMemoryPressureHandler { false };
     bool m_loggedProcessLimitWarningMemoryStatistics { false };


### PR DESCRIPTION
#### 4596c1459a9de783b6d52662c529912683c4828d
<pre>
Remove WebSQLiteDatabaseTracker in web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=240598">https://bugs.webkit.org/show_bug.cgi?id=240598</a>

Reviewed by NOBODY (OOPS!).

Currently when web process starts performing SQLite database operations, it sends a message to UI process to ask UI
process to hold an assertion for it. This is unreliable because UI process might drop assertion and make web process
suspended before it receives the messasge. To avoid this, we apply the solution we made for network process to web
process. That is, aborting and suspending database operations when process receives PrepareToSuspend, and resuming
database operations after process receives ProcessDidResume. This patch also simplifies process suspesion logic since
UI process does not need to take assertion for web process for holding locked files.

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::setIsHoldingLockedFiles): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::m_nonVisibleProcessMemoryCleanupTimer):
(WebKit::WebProcess::prepareToSuspend):
(WebKit::WebProcess::processDidResume):
(WebKit::m_webSQLiteDatabaseTracker): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
No new tests (OOPS!).
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::openDatabase):
(WebCore::ApplicationCacheStorage::setAllowsOpeningDatabase):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
(WebCore::WTF_GUARDED_BY_LOCK): Deleted.
(WebCore::SQLiteDatabase::setIsDatabaseOpeningForbidden): Deleted.
* Source/WebCore/platform/sql/SQLiteDatabase.h:
</pre>