### PR TITLE
Remove dead code in handling of GridTrackEntryAutoRepeat in canInterpolate

### DIFF
--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -161,7 +161,7 @@ static String notAFunctionSourceAppender(const String& originalMessage, StringVi
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto notAFunctionIndex = originalMessage.reverseFind("is not a function");
+    auto notAFunctionIndex = originalMessage.reverseFind("is not a function"_s);
     RELEASE_ASSERT(notAFunctionIndex != notFound);
     StringView displayValue;
     if (originalMessage.is8Bit()) 
@@ -197,14 +197,14 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto inIndex = sourceText.reverseFind("in");
+    auto inIndex = sourceText.reverseFind("in"_s);
     if (inIndex == notFound) {
         // This should basically never happen, since JS code must use the literal
         // text "in" for the `in` operation. However, if we fail to find "in"
         // for any reason, just fail gracefully.
         return originalMessage;
     }
-    if (sourceText.find("in") != inIndex)
+    if (sourceText.find("in"_s) != inIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     static constexpr unsigned inLength = 2;
@@ -218,12 +218,12 @@ inline String invalidParameterInstanceofSourceAppender(const String& content, co
         return defaultApproximateSourceError(originalMessage, sourceText);
 
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
-    auto instanceofIndex = sourceText.reverseFind("instanceof");
+    auto instanceofIndex = sourceText.reverseFind("instanceof"_s);
     // This can happen when Symbol.hasInstance function is directly called.
     if (instanceofIndex == notFound)
         return originalMessage;
 
-    if (sourceText.find("instanceof") != instanceofIndex)
+    if (sourceText.find("instanceof"_s) != instanceofIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     static constexpr unsigned instanceofLength = 10;
@@ -246,8 +246,8 @@ static String invalidPrototypeSourceAppender(const String& originalMessage, Stri
     if (occurrence == ErrorInstance::FoundApproximateSource)
         return defaultApproximateSourceError(originalMessage, sourceText);
 
-    auto extendsIndex = sourceText.reverseFind("extends");
-    if (extendsIndex == notFound || sourceText.find("extends") != extendsIndex)
+    auto extendsIndex = sourceText.reverseFind("extends"_s);
+    if (extendsIndex == notFound || sourceText.find("extends"_s) != extendsIndex)
         return makeString(originalMessage, " (evaluating '", sourceText, "')");
 
     return "The value of the superclass's prototype property is not an object or null."_s;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -320,7 +320,7 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
 {
     StringView locale(buffer.data(), buffer.size());
     ASSERT(locale.is8Bit());
-    size_t extensionIndex = locale.find("-u-");
+    size_t extensionIndex = locale.find("-u-"_s);
     if (extensionIndex == notFound)
         return WTFMove(buffer);
 
@@ -855,7 +855,7 @@ static MatcherResult lookupMatcher(JSGlobalObject* globalObject, const LocaleSet
     if (!availableLocale.isEmpty()) {
         result.locale = availableLocale;
         if (locale != noExtensionsLocale) {
-            size_t extensionIndex = locale.find("-u-");
+            size_t extensionIndex = locale.find("-u-"_s);
             RELEASE_ASSERT(extensionIndex != notFound);
 
             size_t extensionLength = locale.length() - extensionIndex;

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -130,7 +130,7 @@ static void initializeOverrideInfo(const SourceCode& origCode, const String& new
     FunctionOverridesAssertScope assertScope;
     String origProviderStr = origCode.provider()->source().toString();
     unsigned origStart = origCode.startOffset();
-    unsigned origFunctionStart = origProviderStr.reverseFind("function", origStart);
+    unsigned origFunctionStart = origProviderStr.reverseFind("function"_s, origStart);
     unsigned origBraceStart = origProviderStr.find('{', origStart);
     unsigned headerLength = origBraceStart - origFunctionStart;
     auto origHeaderView = StringView(origProviderStr).substring(origFunctionStart, headerLength);

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -97,14 +97,17 @@ public:
     // If we need more overloads of the number function, we can add all the others that String has, but these seem to do for now.
 
     bool contains(UChar character) const { return m_string.contains(character); }
-    bool contains(const LChar* string) const { return m_string.contains(string); }
+    bool contains(ASCIILiteral literal) const { return m_string.contains(literal); }
+    bool contains(const char*) const = delete;
     bool contains(StringView) const;
     bool containsIgnoringASCIICase(StringView) const;
 
     size_t find(UChar character, unsigned start = 0) const { return m_string.find(character, start); }
-    size_t find(const LChar* string, unsigned start = 0) const { return m_string.find(string, start); }
+    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_string.find(literal, start); }
+    size_t find(const char*, unsigned start = 0) const = delete;
     size_t find(StringView, unsigned start = 0) const;
     size_t findIgnoringASCIICase(StringView) const;
+    size_t findIgnoringASCIICase(const char*) const = delete;
     size_t findIgnoringASCIICase(StringView, unsigned start) const;
     size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_string.find(matchFunction, start); }
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -432,7 +432,8 @@ public:
     size_t find(UChar character, unsigned start = 0);
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction, unsigned start = 0);
-    WTF_EXPORT_PRIVATE size_t find(const LChar*, unsigned start = 0);
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) { return find(literal.characters8(), literal.length(), start); }
+    size_t find(const char*, unsigned start = 0) = delete;
     WTF_EXPORT_PRIVATE size_t find(StringView);
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start);
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
@@ -440,6 +441,8 @@ public:
 
     WTF_EXPORT_PRIVATE size_t reverseFind(UChar, unsigned start = MaxLength);
     WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = MaxLength);
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) { return reverseFind(literal.characters8(), literal.length(), start); }
+    size_t reverseFind(const char*, unsigned start = MaxLength) = delete;
 
     WTF_EXPORT_PRIVATE bool startsWith(StringView) const;
     WTF_EXPORT_PRIVATE bool startsWithIgnoringASCIICase(StringView) const;
@@ -494,6 +497,9 @@ private:
     template<typename> static size_t allocationSize(Checked<size_t> tailElementCount);
     template<typename> static size_t maxInternalLength();
     template<typename> static size_t tailOffset();
+
+    WTF_EXPORT_PRIVATE size_t find(const LChar*, unsigned length, unsigned start);
+    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar*, unsigned length, unsigned start);
 
     bool requiresCopy() const;
     template<typename T> const T* tailPointer() const;

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -109,6 +109,34 @@ size_t StringView::find(StringView matchString, unsigned start) const
     return findCommon(*this, matchString, start);
 }
 
+size_t StringView::find(const LChar* match, unsigned matchLength, unsigned start) const
+{
+    ASSERT(matchLength);
+    auto length = this->length();
+    if (start > length)
+        return notFound;
+
+    unsigned searchLength = length - start;
+    if (matchLength > searchLength)
+        return notFound;
+
+    if (is8Bit())
+        return findInner(characters8() + start, match, start, searchLength, matchLength);
+    return findInner(characters16() + start, match, start, searchLength, matchLength);
+}
+
+size_t StringView::reverseFind(const LChar* match, unsigned matchLength, unsigned start) const
+{
+    ASSERT(matchLength);
+    auto length = this->length();
+    if (matchLength > length)
+        return notFound;
+
+    if (is8Bit())
+        return reverseFindInner(characters8(), match, start, length, matchLength);
+    return reverseFindInner(characters16(), match, start, length, matchLength);
+}
+
 void StringView::SplitResult::Iterator::findNextSubstring()
 {
     for (size_t separatorPosition; (separatorPosition = m_result.m_string.find(m_result.m_separator, m_position)) != notFound; ++m_position) {
@@ -341,11 +369,6 @@ bool equalRespectingNullity(StringView a, StringView b)
         return a.isNull() == b.isNull();
 
     return equalCommon(a, b);
-}
-
-bool StringView::contains(const char* string) const
-{
-    return find(string) != notFound;
 }
 
 StringView StringView::stripWhiteSpace() const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -146,9 +146,13 @@ public:
     size_t find(UChar, unsigned start = 0) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.characters8(), literal.length(), start); }
+    size_t find(const char*, unsigned start = 0) const = delete;
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start = 0) const;
 
     size_t reverseFind(UChar, unsigned index = std::numeric_limits<unsigned>::max()) const;
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.characters8(), literal.length(), start); }
+    size_t reverseFind(const char*, unsigned start = std::numeric_limits<unsigned>::max()) const = delete;
     WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = std::numeric_limits<unsigned>::max()) const;
 
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
@@ -161,8 +165,9 @@ public:
     bool contains(UChar) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     bool contains(CodeUnitMatchFunction&&) const;
-    bool contains(StringView string) const { return find(string, 0) != notFound; }
-    WTF_EXPORT_PRIVATE bool contains(const char*) const;
+    bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
+    bool contains(const char*) const = delete;
+    bool contains(StringView string) const { return find(string) != notFound; }
 
     WTF_EXPORT_PRIVATE bool containsIgnoringASCIICase(StringView) const;
     WTF_EXPORT_PRIVATE bool containsIgnoringASCIICase(StringView, unsigned start) const;
@@ -190,6 +195,9 @@ private:
 
     void initialize(const LChar*, unsigned length);
     void initialize(const UChar*, unsigned length);
+
+    WTF_EXPORT_PRIVATE size_t find(const LChar* match, unsigned matchLength, unsigned start) const;
+    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar* match, unsigned matchLength, unsigned start) const;
 
     template<typename CharacterType, typename MatchedCharacterPredicate>
     StringView stripLeadingAndTrailingMatchedCharacters(const CharacterType*, const MatchedCharacterPredicate&) const;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -162,10 +162,11 @@ public:
 
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
-    size_t find(const LChar* string, unsigned start = 0) const { return m_impl ? m_impl->find(string, start) : notFound; }
+    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
 
     // Find the last instance of a single character or string.
     size_t reverseFind(UChar character, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
+    size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
     size_t reverseFind(StringView, unsigned start = MaxLength) const;
 
     WTF_EXPORT_PRIVATE Vector<UChar> charactersWithNullTermination() const;
@@ -174,7 +175,7 @@ public:
     WTF_EXPORT_PRIVATE UChar32 characterStartingAt(unsigned) const;
 
     bool contains(UChar character) const { return find(character) != notFound; }
-    bool contains(const LChar* string) const { return find(string) != notFound; }
+    bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
     bool contains(StringView) const;
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     bool contains(CodeUnitMatchFunction matchFunction) const { return find(matchFunction, 0) != notFound; }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -334,7 +334,6 @@ private:
 static_assert(sizeof(String) == sizeof(void*), "String should effectively be a pointer to a StringImpl, and efficient to pass by value");
 
 inline bool operator==(const String& a, const String& b) { return equal(a.impl(), b.impl()); }
-inline bool operator==(const String& a, const LChar* b) { return equal(a.impl(), b); }
 inline bool operator==(const String& a, const char* b) { return equal(a.impl(), reinterpret_cast<const LChar*>(b)); }
 inline bool operator==(const String& a, ASCIILiteral b) { return equal(a.impl(), b); }
 inline bool operator==(const LChar* a, const String& b) { return equal(a, b.impl()); }
@@ -344,7 +343,6 @@ template<size_t inlineCapacity> inline bool operator==(const Vector<char, inline
 template<size_t inlineCapacity> inline bool operator==(const String& a, const Vector<char, inlineCapacity>& b) { return b == a; }
 
 inline bool operator!=(const String& a, const String& b) { return !equal(a.impl(), b.impl()); }
-inline bool operator!=(const String& a, const LChar* b) { return !equal(a.impl(), b); }
 inline bool operator!=(const String& a, const char* b) { return !equal(a.impl(), reinterpret_cast<const LChar*>(b)); }
 inline bool operator!=(const String& a, ASCIILiteral b) { return !equal(a.impl(), b); }
 inline bool operator!=(const LChar* a, const String& b) { return !equal(a, b.impl()); }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -144,7 +144,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         size_t contentDispositionBegin = header.find(contentDispositionCharacters);
         if (contentDispositionBegin == notFound)
             return false;
-        size_t contentDispositionEnd = header.find("\r\n", contentDispositionBegin);
+        size_t contentDispositionEnd = header.find("\r\n"_s, contentDispositionBegin);
         size_t contentDispositionParametersBegin = header.find(';', contentDispositionBegin + strlen(contentDispositionCharacters));
         if (contentDispositionParametersBegin != notFound)
             contentDispositionParametersBegin++;
@@ -163,7 +163,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             size_t contentTypePrefixLength = strlen(contentTypeCharacters);
             size_t contentTypeBegin = header.find(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
-                size_t contentTypeEnd = header.find("\r\n", contentTypeBegin);
+                size_t contentTypeEnd = header.find("\r\n"_s, contentTypeBegin);
                 contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).stripLeadingAndTrailingMatchedCharacters(isHTTPSpace).toString();
             }
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -358,7 +358,7 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
     if (!m_shouldFilterICECandidates)
         return;
     sdp.split('\n', [](auto line) {
-        ASSERT(!line.startsWith("a=candidate") || line.contains(".local"));
+        ASSERT(!line.startsWith("a=candidate"_s) || line.contains(".local"_s));
     });
 #else
     UNUSED_PARAM(sdp);
@@ -381,7 +381,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
         ALWAYS_LOG(logSiteIdentifier, "Gathered ice candidate:", sdp);
         m_finishedGatheringCandidates = false;
 
-        ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local") || sdp.contains(" srflx "));
+        ASSERT(!m_shouldFilterICECandidates || sdp.contains(".local"_s) || sdp.contains(" srflx "_s));
         auto candidate = RTCIceCandidate::create(WTFMove(sdp), WTFMove(mid), sdpMLineIndex);
         m_peerConnection.dispatchEvent(RTCPeerConnectionIceEvent::create(Event::CanBubble::No, Event::IsCancelable::No, WTFMove(candidate), WTFMove(serverURL)));
     });

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -307,7 +307,7 @@ AtomString YouTubePluginReplacement::youTubeURLFromAbsoluteURL(const URL& srcURL
     } else if (equalLettersIgnoringASCIICase(srcPath, "/watch"_s)) {
         // From the original URL, we need to get the part before /watch/#!v=VideoID
         // FIXME: Shouldn't this be ASCII case-insensitive?
-        locationOfPathBeforeVideoID = srcString.find("/watch");
+        locationOfPathBeforeVideoID = srcString.find("/watch"_s);
     } else
         return srcString;
 

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -39,7 +39,7 @@ namespace PAL {
 // See <http://en.wikipedia.org/wiki/Percent-encoding#Non-standard_implementations>.
 struct Unicode16BitEscapeSequence {
     enum { SequenceSize = 6 }; // e.g. %u26C4
-    static size_t findInString(StringView string, size_t startPosition) { return string.find("%u", startPosition); }
+    static size_t findInString(StringView string, size_t startPosition) { return string.find("%u"_s, startPosition); }
     static size_t findEndOfRun(StringView string, size_t startPosition, size_t endPosition)
     {
         size_t runEnd = startPosition;

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -624,12 +624,8 @@ static inline bool canInterpolate(const GridTrackList& from, const GridTrackList
             return false;
         const auto& toEntry = std::get<GridTrackEntryRepeat>(to[i]);
         return repeat.repeats == toEntry.repeats && repeat.list.size() == toEntry.list.size();
-    }, [&](const GridTrackEntryAutoRepeat& repeat) {
+    }, [&](const GridTrackEntryAutoRepeat&) {
         return false;
-        if (!std::holds_alternative<GridTrackEntryAutoRepeat>(to[i]))
-            return false;
-        const auto& toEntry = std::get<GridTrackEntryAutoRepeat>(to[i]);
-        return repeat.type == toEntry.type && repeat.list.size() == toEntry.list.size();
     }, [&](const GridTrackEntrySubgrid&) {
         return false;
     });

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -29,6 +29,7 @@
 #include "DOMWrapperWorld.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindow.h"

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -319,7 +319,7 @@ Vector<String> DataTransfer::types(AddFilesType addFilesType) const
     
     if (!RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled()) {
         auto types = m_pasteboard->typesForLegacyUnsafeBindings();
-        ASSERT(!types.contains("Files"));
+        ASSERT(!types.contains("Files"_s));
         if (m_pasteboard->fileContentState() != Pasteboard::FileContentState::NoFileOrImageData && addFilesType == AddFilesType::Yes)
             types.append("Files"_s);
         return types;
@@ -341,14 +341,14 @@ Vector<String> DataTransfer::types(AddFilesType addFilesType) const
             return types;
         }
 
-        if (safeTypes.contains("text/uri-list"))
+        if (safeTypes.contains("text/uri-list"_s))
             types.append("text/uri-list"_s);
-        if (safeTypes.contains("text/html") && RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled())
+        if (safeTypes.contains("text/html"_s) && RuntimeEnabledFeatures::sharedFeatures().customPasteboardDataEnabled())
             types.append("text/html"_s);
         return types;
     }
 
-    ASSERT(!safeTypes.contains("Files"));
+    ASSERT(!safeTypes.contains("Files"_s));
     return safeTypes;
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1085,7 +1085,7 @@ ExceptionOr<Ref<CDATASection>> Document::createCDATASection(String&& data)
     if (isHTMLDocument())
         return Exception { NotSupportedError };
 
-    if (data.contains("]]>"))
+    if (data.contains("]]>"_s))
         return Exception { InvalidCharacterError };
 
     return CDATASection::create(*this, WTFMove(data));
@@ -1096,7 +1096,7 @@ ExceptionOr<Ref<ProcessingInstruction>> Document::createProcessingInstruction(St
     if (!isValidName(target))
         return Exception { InvalidCharacterError };
 
-    if (data.contains("?>"))
+    if (data.contains("?>"_s))
         return Exception { InvalidCharacterError };
 
     return ProcessingInstruction::create(*this, WTFMove(target), WTFMove(data));

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -34,6 +34,7 @@
 #include "CachedResourceRequest.h"
 #include "CachedResourceRequestInitiators.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -325,8 +325,8 @@ bool Element::isNonceable() const
 
     if (hasAttributes()
         && (is<HTMLScriptElement>(*this) || is<SVGScriptElement>(*this))) {
-        static const char scriptString[] = "<script";
-        static const char styleString[] = "<style";
+        static constexpr auto scriptString = "<script"_s;
+        static constexpr auto styleString = "<style"_s;
 
         for (const auto& attribute : attributesIterator()) {
             auto name = attribute.localName().convertToASCIILowercase();

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -27,6 +27,7 @@
 #include "IdleCallbackController.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "IdleDeadline.h"
 #include "WindowEventLoop.h"
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -38,6 +38,7 @@
 #include "Document.h"
 #include "ErrorEvent.h"
 #include "FontLoadRequest.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindow.h"
 #include "JSWorkerGlobalScope.h"

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -29,6 +29,7 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "ResourceLoadObserver.h"
 #include "SecurityOrigin.h"
 #include <wtf/MainThread.h>

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -31,6 +31,7 @@
 
 #include "ElementIterator.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLAnchorElementInlines.h"
 #include "Page.h"
 #include "SVGAElement.h"

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -29,6 +29,7 @@
 #include "Editing.h"
 #include "ElementAncestorIterator.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "HTMLElement.h"
 #include "HTMLOListElement.h"

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -985,7 +985,7 @@ void DeleteSelectionCommand::doApply()
     // If the deletion is occurring in a text field, and we're not deleting to replace the selection, then let the frame call across the bridge to notify the form delegate. 
     if (!m_replace) {
         if (RefPtr textControl = enclosingTextFormControl(m_selectionToDelete.start()); textControl && textControl->focused())
-            document().editor().textWillBeDeletedInTextField(textControl.get());
+            document().editor().textWillBeDeletedInTextField(*textControl);
     }
 
     // save this to later make the selection with

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "DocumentMarkerController.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "InsertParagraphSeparatorCommand.h"
 #include "InsertTextCommand.h"

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3462,26 +3462,26 @@ void Editor::computeAndSetTypingStyle(StyleProperties& properties, EditAction ed
     return computeAndSetTypingStyle(EditingStyle::create(&properties), editingAction);
 }
 
-void Editor::textFieldDidBeginEditing(Element* e)
+void Editor::textFieldDidBeginEditing(Element& e)
 {
     if (client())
         client()->textFieldDidBeginEditing(e);
 }
 
-void Editor::textFieldDidEndEditing(Element* e)
+void Editor::textFieldDidEndEditing(Element& e)
 {
     dismissCorrectionPanelAsIgnored();
     if (client())
         client()->textFieldDidEndEditing(e);
 }
 
-void Editor::textDidChangeInTextField(Element* e)
+void Editor::textDidChangeInTextField(Element& e)
 {
     if (client())
         client()->textDidChangeInTextField(e);
 }
 
-bool Editor::doTextFieldCommandFromEvent(Element* e, KeyboardEvent* ke)
+bool Editor::doTextFieldCommandFromEvent(Element& e, KeyboardEvent* ke)
 {
     if (client())
         return client()->doTextFieldCommandFromEvent(e, ke);
@@ -3489,13 +3489,13 @@ bool Editor::doTextFieldCommandFromEvent(Element* e, KeyboardEvent* ke)
     return false;
 }
 
-void Editor::textWillBeDeletedInTextField(Element* input)
+void Editor::textWillBeDeletedInTextField(Element& input)
 {
     if (client())
         client()->textWillBeDeletedInTextField(input);
 }
 
-void Editor::textDidChangeInTextArea(Element* e)
+void Editor::textDidChangeInTextArea(Element& e)
 {
     if (client())
         client()->textDidChangeInTextArea(e);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -485,12 +485,12 @@ public:
     bool markedTextMatchesAreHighlighted() const;
     WEBCORE_EXPORT void setMarkedTextMatchesAreHighlighted(bool);
 
-    void textFieldDidBeginEditing(Element*);
-    void textFieldDidEndEditing(Element*);
-    void textDidChangeInTextField(Element*);
-    bool doTextFieldCommandFromEvent(Element*, KeyboardEvent*);
-    void textWillBeDeletedInTextField(Element* input);
-    void textDidChangeInTextArea(Element*);
+    void textFieldDidBeginEditing(Element&);
+    void textFieldDidEndEditing(Element&);
+    void textDidChangeInTextField(Element&);
+    bool doTextFieldCommandFromEvent(Element&, KeyboardEvent*);
+    void textWillBeDeletedInTextField(Element& input);
+    void textDidChangeInTextArea(Element&);
     WEBCORE_EXPORT WritingDirection baseWritingDirectionForSelectionStart() const;
 
     enum class SelectReplacement : bool { No, Yes };

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1031,19 +1031,19 @@ NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)
 
     String fontLigatures = _caches->propertyValueForNode(element, CSSPropertyFontVariantLigatures);
     if (fontLigatures.length()) {
-        if (fontLigatures.contains("normal"))
+        if (fontLigatures.contains("normal"_s))
             ;   // default: whatever the system decides to do
-        else if (fontLigatures.contains("common-ligatures"))
+        else if (fontLigatures.contains("common-ligatures"_s))
             [attrs setObject:@1 forKey:NSLigatureAttributeName];   // explicitly enabled
-        else if (fontLigatures.contains("no-common-ligatures"))
+        else if (fontLigatures.contains("no-common-ligatures"_s))
             [attrs setObject:@0 forKey:NSLigatureAttributeName];  // explicitly disabled
     }
 
     String textDecoration = _caches->propertyValueForNode(element, CSSPropertyTextDecorationLine);
     if (textDecoration.length()) {
-        if (textDecoration.contains("underline"))
+        if (textDecoration.contains("underline"_s))
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSUnderlineStyleAttributeName];
-        if (textDecoration.contains("line-through"))
+        if (textDecoration.contains("line-through"_s))
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
     }
 

--- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
+++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
@@ -46,7 +46,7 @@ static RefPtr<DocumentFragment> createFragmentFromPasteboardData(Pasteboard& pas
     if (types.isEmpty())
         return nullptr;
 
-    if (types.contains("text/html;charset=utf-8") && frame.document()) {
+    if (types.contains("text/html;charset=utf-8"_s) && frame.document()) {
         String markup = pasteboard.readString("text/html;charset=utf-8"_s);
         return createFragmentFromMarkup(*frame.document(), markup, emptyString(), DisallowScriptingAndPluginContent);
     }
@@ -54,7 +54,7 @@ static RefPtr<DocumentFragment> createFragmentFromPasteboardData(Pasteboard& pas
     if (!allowPlainText)
         return nullptr;
 
-    if (types.contains("text/plain;charset=utf-8")) {
+    if (types.contains("text/plain;charset=utf-8"_s)) {
         chosePlainText = true;
         return createFragmentFromText(range, pasteboard.readString("text/plain;charset=utf-8"_s));
     }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -519,7 +519,7 @@ bool StyledMarkupAccumulator::shouldPreserveMSOListStyleForElement(const Element
         return true;
     if (m_shouldPreserveMSOList) {
         auto style = element.getAttribute(styleAttr);
-        return style.startsWith("mso-list:") || style.contains(";mso-list:") || style.contains("\nmso-list:");
+        return style.startsWith("mso-list:"_s) || style.contains(";mso-list:"_s) || style.contains("\nmso-list:"_s);
     }
     return false;
 }
@@ -757,14 +757,14 @@ bool StyledMarkupAccumulator::appendNodeToPreserveMSOList(Node& node)
         auto& textChild = downcast<Text>(*firstChild);
         auto& styleContent = textChild.data();
 
-        const auto msoStyleDefinitionsStart = styleContent.find("/* Style Definitions */");
-        const auto msoListDefinitionsStart = styleContent.find("/* List Definitions */");
-        const auto lastListItem = styleContent.reverseFind("\n@list");
+        const auto msoStyleDefinitionsStart = styleContent.find("/* Style Definitions */"_s);
+        const auto msoListDefinitionsStart = styleContent.find("/* List Definitions */"_s);
+        const auto lastListItem = styleContent.reverseFind("\n@list"_s);
         if (msoListDefinitionsStart == notFound || lastListItem == notFound)
             return false;
         const auto start = msoStyleDefinitionsStart != notFound && msoStyleDefinitionsStart < msoListDefinitionsStart ? msoStyleDefinitionsStart : msoListDefinitionsStart;
 
-        const auto msoListDefinitionsEnd = styleContent.find(";}\n", lastListItem);
+        const auto msoListDefinitionsEnd = styleContent.find(";}\n"_s, lastListItem);
         if (msoListDefinitionsEnd == notFound || start >= msoListDefinitionsEnd)
             return false;
 
@@ -998,8 +998,8 @@ static bool shouldPreserveMSOLists(StringView markup)
     if (tagClose == notFound)
         return false;
     auto tag = markup.left(tagClose);
-    return tag.contains("xmlns:o=\"urn:schemas-microsoft-com:office:office\"")
-        && tag.contains("xmlns:w=\"urn:schemas-microsoft-com:office:word\"");
+    return tag.contains("xmlns:o=\"urn:schemas-microsoft-com:office:office\""_s)
+        && tag.contains("xmlns:w=\"urn:schemas-microsoft-com:office:word\""_s);
 }
 
 String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Document& document, MSOListQuirks msoListQuirks, const String& originalMarkup)

--- a/Source/WebCore/html/HTMLHtmlElement.cpp
+++ b/Source/WebCore/html/HTMLHtmlElement.cpp
@@ -30,6 +30,7 @@
 #include "DocumentParser.h"
 #include "ElementInlines.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLNames.h"
 #include "Logging.h"

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -470,7 +470,7 @@ void HTMLInputElement::endEditing()
         return;
 
     if (RefPtr frame = document().frame())
-        frame->editor().textFieldDidEndEditing(this);
+        frame->editor().textFieldDidEndEditing(*this);
 }
 
 bool HTMLInputElement::shouldUseInputMethod()

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -297,8 +297,8 @@ void HTMLTextAreaElement::subtreeHasChanged()
 
     setChangedSinceLastFormControlChangeEvent(true);
 
-    if (RefPtr<Frame> frame = document().frame())
-        frame->editor().textDidChangeInTextArea(this);
+    if (RefPtr frame = document().frame())
+        frame->editor().textDidChangeInTextArea(*this);
     // When typing in a textarea, childrenChanged is not called, so we need to force the directionality check.
     calculateAndAdjustDirectionality();
 }

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -33,6 +33,7 @@
 #include "EventListener.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLAnchorElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLHeadElement.h"

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -23,6 +23,7 @@
 #include "RadioInputType.h"
 
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -201,8 +201,8 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
         event.setDefaultHandled();
     }
 #endif
-    RefPtr<Frame> frame = element()->document().frame();
-    if (frame && frame->editor().doTextFieldCommandFromEvent(element(), &event))
+    RefPtr frame = element()->document().frame();
+    if (frame && frame->editor().doTextFieldCommandFromEvent(*element(), &event))
         event.setDefaultHandled();
     return ShouldCallBaseEventHandler::Yes;
 }
@@ -275,8 +275,8 @@ void TextFieldInputType::handleFocusEvent(Node* oldFocusedNode, FocusDirection)
 {
     ASSERT(element());
     ASSERT_UNUSED(oldFocusedNode, oldFocusedNode != element());
-    if (RefPtr<Frame> frame = element()->document().frame()) {
-        frame->editor().textFieldDidBeginEditing(element());
+    if (RefPtr frame = element()->document().frame()) {
+        frame->editor().textFieldDidBeginEditing(*element());
 #if ENABLE(DATALIST_ELEMENT)
         if (shouldOnlyShowDataListDropdownButtonWhenFocusedOrEdited() && element()->list() && m_dataListDropdownIndicator)
             m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, suggestions().size() ? CSSValueBlock : CSSValueNone, true);
@@ -712,8 +712,8 @@ void TextFieldInputType::didSetValueByUserEdit()
     ASSERT(element());
     if (!element()->focused())
         return;
-    if (RefPtr<Frame> frame = element()->document().frame())
-        frame->editor().textDidChangeInTextField(element());
+    if (RefPtr frame = element()->document().frame())
+        frame->editor().textDidChangeInTextField(*element());
 #if ENABLE(DATALIST_ELEMENT)
     if (shouldOnlyShowDataListDropdownButtonWhenFocusedOrEdited() && element()->list() && m_dataListDropdownIndicator)
         m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, suggestions().size() ? CSSValueBlock : CSSValueNone, true);

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -32,6 +32,7 @@
 #include "DocumentLoader.h"
 #include "EventLoop.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLDocument.h"
 #include "HTMLParserScheduler.h"
 #include "HTMLPreloadScanner.h"

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "ScriptController.h"
 #include "Settings.h"

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -32,6 +32,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLInputStream.h"
 #include "HTMLNames.h"
 #include "HTMLScriptRunnerHost.h"

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -212,7 +212,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
     switch (setting) {
     case Id: {
         String stringValue = input.extractString(valueRun);
-        if (stringValue.find("-->") == notFound)
+        if (stringValue.find("-->"_s) == notFound)
             m_id = stringValue;
         break;
     }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -279,7 +279,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
             m_client.newRegionsParsed();
         if (!m_styleSheets.isEmpty())
             m_client.newStyleSheetsParsed();
-        if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"))
+        if (!m_previousLine.isEmpty() && !m_previousLine.contains("-->"_s))
             m_currentId = AtomString { m_previousLine };
         
         return state;
@@ -298,7 +298,7 @@ WebVTTParser::ParseState WebVTTParser::collectWebVTTBlock(const String& line)
 WebVTTParser::ParseState WebVTTParser::checkAndRecoverCue(const String& line)
 {
     // parse cue timings and settings
-    if (line.contains("-->")) {
+    if (line.contains("-->"_s)) {
         ParseState state = recoverCue(line);
         if (state != BadCue)
             return state;
@@ -318,7 +318,7 @@ WebVTTParser::ParseState WebVTTParser::collectStyleSheet(const String& line)
 
 bool WebVTTParser::checkAndCreateRegion(StringView line)
 {
-    if (m_previousLine.contains("-->"))
+    if (m_previousLine.contains("-->"_s))
         return false;
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
@@ -332,7 +332,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
 
 bool WebVTTParser::checkAndStoreRegion(StringView line)
 {
-    if (!line.isEmpty() && !line.contains("-->"))
+    if (!line.isEmpty() && !line.contains("-->"_s))
         return false;
 
     if (!m_currentRegion->id().isEmpty()) {
@@ -347,12 +347,12 @@ bool WebVTTParser::checkAndStoreRegion(StringView line)
 
 bool WebVTTParser::checkStyleSheet(StringView line)
 {
-    if (m_previousLine.contains("-->"))
+    if (m_previousLine.contains("-->"_s))
         return false;
     // line starts with the substring "STYLE" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these charecters it is invalid.
-    if (line.startsWith("STYLE") && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
+    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
         return true;
 
     return false;
@@ -360,7 +360,7 @@ bool WebVTTParser::checkStyleSheet(StringView line)
 
 bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
 {
-    if (!line.isEmpty() && !line.contains("-->"))
+    if (!line.isEmpty() && !line.contains("-->"_s))
         return false;
     
     auto styleSheetText = m_currentSourceStyleSheet.toString();
@@ -415,7 +415,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
 
 WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)
 {
-    if (line.contains("-->"))
+    if (line.contains("-->"_s))
         return collectTimingsAndSettings(line);
     m_currentId = AtomString { line };
     return TimingsAndSettings;
@@ -463,7 +463,7 @@ WebVTTParser::ParseState WebVTTParser::collectCueText(const String& line)
         return Id;
     }
     // Step 35.
-    if (line.contains("-->")) {
+    if (line.contains("-->"_s)) {
         // Step 39-40.
         createNewCue();
 
@@ -490,7 +490,7 @@ WebVTTParser::ParseState WebVTTParser::ignoreBadCue(const String& line)
 {
     if (line.isEmpty())
         return Id;
-    if (line.contains("-->"))
+    if (line.contains("-->"_s))
         return recoverCue(line);
     return BadCue;
 }

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -46,6 +46,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "ExtensionStyleSheets.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLHeadElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -38,6 +38,7 @@
 #include "Element.h"
 #include "EventLoop.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -38,6 +38,7 @@
 #include "CrossOriginAccessControl.h"
 #include "CrossOriginPreflightResultCache.h"
 #include "DocumentThreadableLoader.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "InspectorInstrumentation.h"
 #include "NetworkLoadMetrics.h"

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -42,6 +42,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorNetworkAgent.h"

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -305,12 +305,12 @@ private:
     void handleKeyboardEvent(KeyboardEvent&) final { }
     void handleInputMethodKeydown(KeyboardEvent&) final { }
 
-    void textFieldDidBeginEditing(Element*) final { }
-    void textFieldDidEndEditing(Element*) final { }
-    void textDidChangeInTextField(Element*) final { }
-    bool doTextFieldCommandFromEvent(Element*, KeyboardEvent*) final { return false; }
-    void textWillBeDeletedInTextField(Element*) final { }
-    void textDidChangeInTextArea(Element*) final { }
+    void textFieldDidBeginEditing(Element&) final { }
+    void textFieldDidEndEditing(Element&) final { }
+    void textDidChangeInTextField(Element&) final { }
+    bool doTextFieldCommandFromEvent(Element&, KeyboardEvent*) final { return false; }
+    void textWillBeDeletedInTextField(Element&) final { }
+    void textDidChangeInTextArea(Element&) final { }
     void overflowScrollPositionChanged() final { }
     void subFrameScrollPositionChanged() final { }
 

--- a/Source/WebCore/loader/FormState.cpp
+++ b/Source/WebCore/loader/FormState.cpp
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include "FormState.h"
+#include "FrameDestructionObserverInlines.h"
 
 #include "Document.h"
 #include "HTMLFormElement.h"

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -35,6 +35,7 @@
 #include "CrossOriginAccessControl.h"
 #include "Document.h"
 #include "Element.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoaderClient.h"
 #include "InspectorInstrumentation.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -33,6 +33,7 @@
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 
 namespace WebCore {

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -30,6 +30,7 @@
 #include "DOMWindow.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLFrameOwnerElement.h"
 #include "Performance.h"

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.cpp
@@ -34,6 +34,7 @@
 #include "DOMApplicationCache.h"
 #include "EventNames.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "Logging.h"

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -127,12 +127,12 @@ public:
     virtual void handleInputMethodKeydown(KeyboardEvent&) = 0;
     virtual void didDispatchInputMethodKeydown(KeyboardEvent&) { }
     
-    virtual void textFieldDidBeginEditing(Element*) = 0;
-    virtual void textFieldDidEndEditing(Element*) = 0;
-    virtual void textDidChangeInTextField(Element*) = 0;
-    virtual bool doTextFieldCommandFromEvent(Element*, KeyboardEvent*) = 0;
-    virtual void textWillBeDeletedInTextField(Element*) = 0;
-    virtual void textDidChangeInTextArea(Element*) = 0;
+    virtual void textFieldDidBeginEditing(Element&) = 0;
+    virtual void textFieldDidEndEditing(Element&) = 0;
+    virtual void textDidChangeInTextField(Element&) = 0;
+    virtual bool doTextFieldCommandFromEvent(Element&, KeyboardEvent*) = 0;
+    virtual void textWillBeDeletedInTextField(Element&) = 0;
+    virtual void textDidChangeInTextArea(Element&) = 0;
     virtual void overflowScrollPositionChanged() = 0;
     virtual void subFrameScrollPositionChanged() = 0;
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -107,23 +107,26 @@ static std::optional<InteractionRegion> regionForElement(Element& element)
         return rect;
     });
     
-    if (rectsInContentCoordinates.isEmpty())
-        return std::nullopt;
-
     if (is<RenderBox>(*renderer)) {
         RoundedRect::Radii borderRadii = downcast<RenderBox>(*renderer).borderRadii();
         region.borderRadius = borderRadii.minimumRadius();
     }
 
-    region.rectsInContentCoordinates = rectsInContentCoordinates.map([&](auto rect) {
+    region.rectsInContentCoordinates = compactMap(rectsInContentCoordinates, [&](auto rect) -> std::optional<FloatRect> {
         auto contentsRect = rect;
 
         if (&frameView != &mainFrameView)
             contentsRect.intersect(frameClipRect);
 
+        if (contentsRect.isEmpty())
+            return std::nullopt;
+
         return contentsRect;
     });
-        
+
+    if (region.rectsInContentCoordinates.isEmpty())
+        return std::nullopt;
+
     return region;
 }
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -32,6 +32,7 @@
 #include "CSSTokenizer.h"
 #include "DOMWindow.h"
 #include "Element.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"
 #include "IntersectionObserverCallback.h"
 #include "IntersectionObserverEntry.h"

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -295,7 +295,7 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
 
     if (equalLettersIgnoringASCIICase(host, "www.icloud.com"_s)) {
         auto path = url.path();
-        if (path.contains("notes") || url.fragmentIdentifier().contains("notes"))
+        if (path.contains("notes"_s) || url.fragmentIdentifier().contains("notes"_s))
             return true;
     }
 #endif

--- a/Source/WebCore/page/UndoManager.cpp
+++ b/Source/WebCore/page/UndoManager.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Editor.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "UndoItem.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "Page.h"
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -178,7 +178,7 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::Element
             auto* factory = reinterpret_cast<GstElementFactory*>(factories->data);
             auto metadata = String::fromLatin1(gst_element_factory_get_metadata(factory, GST_ELEMENT_METADATA_KLASS));
             auto components = metadata.split('/');
-            if (components.contains("Hardware")) {
+            if (components.contains("Hardware"_s)) {
                 isUsingHardware = true;
                 break;
             }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2763,7 +2763,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
         auto classifiers = elementClass.split('/');
 
         // Collect processing time metrics for video decoders and converters.
-        if ((classifiers.contains("Converter"_s) || classifiers.contains("Decoder"_s)) && classifiers.contains("Video"_s) && !classifiers.contains("Parser"))
+        if ((classifiers.contains("Converter"_s) || classifiers.contains("Decoder"_s)) && classifiers.contains("Video"_s) && !classifiers.contains("Parser"_s))
             webkitGstTraceProcessingTimeForElement(element);
 
         if (classifiers.contains("Decoder"_s) && classifiers.contains("Video"_s)) {

--- a/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGLCommon.cpp
+++ b/Source/WebCore/platform/graphics/opengl/ExtensionsGLOpenGLCommon.cpp
@@ -78,13 +78,13 @@ ExtensionsGLOpenGLCommon::ExtensionsGLOpenGLCommon(GraphicsContextGLOpenGL* cont
     m_renderer = String::fromLatin1(reinterpret_cast<const char*>(::glGetString(GL_RENDERER)));
 
     Vector<String> vendorComponents = m_vendor.convertToASCIILowercase().split(' ');
-    if (vendorComponents.contains("nvidia"))
+    if (vendorComponents.contains("nvidia"_s))
         m_isNVIDIA = true;
-    if (vendorComponents.contains("ati") || vendorComponents.contains("amd"))
+    if (vendorComponents.contains("ati"_s) || vendorComponents.contains("amd"_s))
         m_isAMD = true;
-    if (vendorComponents.contains("intel"))
+    if (vendorComponents.contains("intel"_s))
         m_isIntel = true;
-    if (vendorComponents.contains("imagination"))
+    if (vendorComponents.contains("imagination"_s))
         m_isImagination = true;
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
@@ -55,8 +55,8 @@ const TextureMapperContextAttributes& TextureMapperContextAttributes::get()
         attributes.isGLES2Compliant = true;
 
         auto extensionsString = String::fromLatin1(reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)));
-        attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot");
-        attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage");
+        attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot"_s);
+        attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage"_s);
 #else
         attributes.isGLES2Compliant = false;
         attributes.supportsNPOTTextures = true;

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -72,7 +72,7 @@ static StringView deviceNameForUserAgent()
     static NeverDestroyed<String> name = [] {
         auto name = deviceName();
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
-        size_t location = name.find(" Simulator");
+        size_t location = name.find(" Simulator"_s);
         if (location != notFound)
             return name.left(location);
 #endif

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -162,12 +162,12 @@ static bool isValidCaptureDevice(const CoreAudioCaptureDevice& device, bool filt
         return false;
     }
 
-    if (device.label().startsWith("VPAUAggregateAudioDevice")) {
+    if (device.label().startsWith("VPAUAggregateAudioDevice"_s)) {
         RELEASE_LOG(WebRTC, "Ignoring output VPAUAggregateAudioDevice device");
         return false;
     }
 
-    if (device.label().contains("WebexMediaAudioDevice")) {
+    if (device.label().contains("WebexMediaAudioDevice"_s)) {
         RELEASE_LOG(WebRTC, "Ignoring webex audio device");
         return false;
     }

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -140,9 +140,9 @@ NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, 
         String areaName = name;
         bool startSide = isStartSide(side);
         if (!nameIsAreaName) {
-            size_t suffix = name.find("-start");
+            size_t suffix = name.find("-start"_s);
             if (suffix == notFound) {
-                suffix = name.find("-end");
+                suffix = name.find("-end"_s);
                 ASSERT(suffix != notFound);
                 startSide = false;
             } else

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -32,6 +32,7 @@
 #include "CSSValueKeywords.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "RenderStyle.h"
 #include "Settings.h"
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -366,7 +366,7 @@ void Scope::collectActiveStyleSheets(Vector<RefPtr<StyleSheet>>& sheets)
                 if (linkElement.styleSheetIsLoading()) {
                     // it is loading but we should still decide which style sheet set to use
                     if (!enabledViaScript && !title.isEmpty() && m_preferredStylesheetSetName.isEmpty()) {
-                        if (!linkElement.attributeWithoutSynchronization(relAttr).contains("alternate"))
+                        if (!linkElement.attributeWithoutSynchronization(relAttr).contains("alternate"_s))
                             m_preferredStylesheetSetName = title;
                     }
                     continue;
@@ -394,14 +394,14 @@ void Scope::collectActiveStyleSheets(Vector<RefPtr<StyleSheet>>& sheets)
                     // we are NOT an alternate sheet, then establish
                     // us as the preferred set. Otherwise, just ignore
                     // this sheet.
-                    if (is<HTMLStyleElement>(element) || !rel.contains("alternate"))
+                    if (is<HTMLStyleElement>(element) || !rel.contains("alternate"_s))
                         m_preferredStylesheetSetName = title;
                 }
                 if (title != m_preferredStylesheetSetName)
                     sheet = nullptr;
             }
 
-            if (rel.contains("alternate") && title.isEmpty())
+            if (rel.contains("alternate"_s) && title.isEmpty())
                 sheet = nullptr;
 
             if (sheet)

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -26,6 +26,7 @@
 #include "Document.h"
 #include "EventListener.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "Page.h"
 #include "SMILTimeContainer.h"

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1602,7 +1602,7 @@ bool Internals::isSupportingVP9VTB() const
 void Internals::isVP9VTBDeccoderUsed(RTCPeerConnection& connection, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
     connection.gatherDecoderImplementationName([promise = WTFMove(promise)](auto&& name) mutable {
-        promise.resolve(name.contains("VideoToolBox"));
+        promise.resolve(name.contains("VideoToolBox"_s));
     });
 }
 

--- a/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
+++ b/Source/WebCore/testing/MockLibWebRTCPeerConnection.cpp
@@ -346,8 +346,8 @@ void MockLibWebRTCPeerConnection::SetRemoteDescription(std::unique_ptr<webrtc::S
         sessionDescription->ToString(&sdp);
 
         m_isInitiator = false;
-        m_isReceivingAudio = sdp.find("m=audio") != std::string::npos;
-        m_isReceivingVideo = sdp.find("m=video") != std::string::npos;
+        m_isReceivingAudio = sdp.find("m=audio"_s) != std::string::npos;
+        m_isReceivingVideo = sdp.find("m=video"_s) != std::string::npos;
     }
 }
 

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -26,6 +26,7 @@
 #include "CachedResourceLoader.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "Page.h"
 #include "PageConsoleClient.h"
 #include "TransformSource.h"

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -29,6 +29,7 @@
 #include "CachedResourceLoader.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "Page.h"
 #include "PageConsoleClient.h"

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
@@ -247,7 +247,7 @@ static const String ObservedDomainsTableSchemaV1Alternate()
 
 static bool needsNewCreateTableSchema(const String& schema)
 {
-    return schema.contains("REFERENCES TopLevelDomains");
+    return schema.contains("REFERENCES TopLevelDomains"_s);
 }
 
 const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& ResourceLoadStatisticsDatabaseStore::expectedTableAndIndexQueries()
@@ -789,7 +789,7 @@ void ResourceLoadStatisticsDatabaseStore::insertDomainRelationshipList(const Str
             return;
     }
     
-    if (statement.contains("REPLACE")) {
+    if (statement.contains("REPLACE"_s)) {
         if (insertRelationshipStatement->bindDouble(2, WallTime::now().secondsSinceEpoch().value()) != SQLITE_OK) {
             ITP_RELEASE_LOG_ERROR(m_sessionID, "%p - ResourceLoadStatisticsDatabaseStore::insertDomainRelationshipList failed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -852,7 +852,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
 
     if (isCrossOriginPrefetch()) {
         LOADER_RELEASE_LOG("didReceiveResponse: Using response for cross-origin prefetch");
-        if (response.httpHeaderField(HTTPHeaderName::Vary).contains("Cookie")) {
+        if (response.httpHeaderField(HTTPHeaderName::Vary).contains("Cookie"_s)) {
             LOADER_RELEASE_LOG("didReceiveResponse: Canceling cross-origin prefetch for Vary: Cookie");
             abort();
             return completionHandler(PolicyAction::Ignore);

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<PrefetchCache::Entry> PrefetchCache::take(const URL& url)
         return std::get<0>(tuple) == url;
     });
     auto entry = resources->take(url);
-    ASSERT(!entry || !entry->response.httpHeaderField(WebCore::HTTPHeaderName::Vary).contains("Cookie"));
+    ASSERT(!entry || !entry->response.httpHeaderField(WebCore::HTTPHeaderName::Vary).contains("Cookie"_s));
     return entry;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -263,24 +263,6 @@ void WebProcessPool::platformInitialize()
 #endif
 }
 
-#if PLATFORM(IOS_FAMILY)
-String WebProcessPool::cacheDirectoryInContainerOrHomeDirectory(const String& subpath)
-{
-    String path = pathForProcessContainer();
-    if (path.isEmpty())
-        path = NSHomeDirectory();
-
-    path = path + subpath;
-    path = stringByResolvingSymlinksInPath(path);
-    return path;
-}
-
-String WebProcessPool::cookieStorageDirectory()
-{
-    return cacheDirectoryInContainerOrHomeDirectory("/Library/Cookies"_s);
-}
-#endif
-
 void WebProcessPool::platformResolvePathsForSandboxExtensions()
 {
     m_resolvedPaths.uiProcessBundleResourcePath = resolvePathForSandboxExtension(String { [[NSBundle mainBundle] resourcePath] });
@@ -480,47 +462,6 @@ void WebProcessPool::platformInvalidateContext()
 {
     unregisterNotificationObservers();
 }
-
-#if PLATFORM(IOS_FAMILY)
-String WebProcessPool::parentBundleDirectory()
-{
-    return [[[NSBundle mainBundle] bundlePath] stringByStandardizingPath];
-}
-
-String WebProcessPool::networkingCachesDirectory()
-{
-    String path = cacheDirectoryInContainerOrHomeDirectory("/Library/Caches/com.apple.WebKit.Networking/"_s);
-
-    NSError *error = nil;
-    NSString* nsPath = path;
-    if (![[NSFileManager defaultManager] createDirectoryAtPath:nsPath withIntermediateDirectories:YES attributes:nil error:&error]) {
-        NSLog(@"could not create networking caches directory \"%@\", error %@", nsPath, error);
-        return String();
-    }
-
-    return path;
-}
-
-String WebProcessPool::webContentCachesDirectory()
-{
-    String path = cacheDirectoryInContainerOrHomeDirectory("/Library/Caches/com.apple.WebKit.WebContent/"_s);
-
-    NSError *error = nil;
-    NSString* nsPath = path;
-    if (![[NSFileManager defaultManager] createDirectoryAtPath:nsPath withIntermediateDirectories:YES attributes:nil error:&error]) {
-        NSLog(@"could not create web content caches directory \"%@\", error %@", nsPath, error);
-        return String();
-    }
-
-    return path;
-}
-
-String WebProcessPool::containerTemporaryDirectory()
-{
-    String path = NSTemporaryDirectory();
-    return stringByResolvingSymlinksInPath(path);
-}
-#endif
 
 #if PLATFORM(IOS_FAMILY)
 void WebProcessPool::setJavaScriptConfigurationFileEnabledFromDefaults()

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -106,7 +106,7 @@ GPUProcessProxy* GPUProcessProxy::singletonIfCreated()
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
 static String gpuProcessCachesDirectory()
 {
-    String path = WebProcessPool::cacheDirectoryInContainerOrHomeDirectory("/Library/Caches/com.apple.WebKit.GPU/"_s);
+    String path = WebsiteDataStore::cacheDirectoryInContainerOrHomeDirectory("/Library/Caches/com.apple.WebKit.GPU/"_s);
 
     FileSystem::makeAllDirectories(path);
     
@@ -142,7 +142,7 @@ GPUProcessProxy::GPUProcessProxy()
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
     auto containerCachesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(gpuProcessCachesDirectory());
-    auto containerTemporaryDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebProcessPool::containerTemporaryDirectory());
+    auto containerTemporaryDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebsiteDataStore::containerTemporaryDirectory());
 
     if (!containerCachesDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(containerCachesDirectory, SandboxExtension::Type::ReadWrite))

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -87,8 +87,12 @@ void updateLayersForInteractionRegions(CALayer *layer, const RemoteLayerTreeTran
 
     HashMap<IntRect, CALayer *> interactionRegionLayers;
     for (CALayer *sublayer in layer.sublayers) {
-        if (isInteractionRegionLayer(sublayer))
-            interactionRegionLayers.set(enclosingIntRect(sublayer.frame), sublayer);
+        if (!isInteractionRegionLayer(sublayer))
+            continue;
+        auto enclosingFrame = enclosingIntRect(sublayer.frame);
+        if (enclosingFrame.isEmpty())
+            continue;
+        interactionRegionLayers.set(enclosingFrame, sublayer);
     }
 
     bool applyBackgroundColorForDebugging = [[NSUserDefaults standardUserDefaults] boolForKey:@"WKInteractionRegionDebugFill"];

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -761,14 +761,14 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
-    if (auto& directory = websiteDataStore.cookieStorageDirectory(); !directory.isEmpty())
-        cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
+    if (auto directory = websiteDataStore.cookieStorageDirectory(); !directory.isEmpty())
+        cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
-    if (auto& directory = websiteDataStore.containerCachesDirectory(); !directory.isEmpty())
-        containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
+    if (auto directory = websiteDataStore.containerCachesDirectory(); !directory.isEmpty())
+        containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
     std::optional<SandboxExtension::Handle> containerTemporaryDirectoryExtensionHandle;
-    if (auto& directory = websiteDataStore.containerTemporaryDirectory(); !directory.isEmpty())
-        containerTemporaryDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
+    if (auto directory = WebsiteDataStore::containerTemporaryDirectory(); !directory.isEmpty())
+        containerTemporaryDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
 #endif
 
     return WebProcessDataStoreParameters {

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -512,15 +512,6 @@ public:
     static void platformInitializeNetworkProcess(NetworkProcessCreationParameters&);
     static Vector<String> urlSchemesWithCustomProtocolHandlers();
 
-#if PLATFORM(IOS_FAMILY)
-    static String cacheDirectoryInContainerOrHomeDirectory(const String& subpath);
-    static String cookieStorageDirectory();
-    static String parentBundleDirectory();
-    static String networkingCachesDirectory();
-    static String webContentCachesDirectory();
-    static String containerTemporaryDirectory();
-#endif
-
     Ref<WebProcessProxy> createNewWebProcess(WebsiteDataStore*, WebProcessProxy::CaptivePortalMode, WebProcessProxy::IsPrewarmed = WebProcessProxy::IsPrewarmed::No, WebCore::CrossOriginMode = WebCore::CrossOriginMode::Shared);
 
     bool hasAudibleMediaActivity() const { return !!m_audibleMediaActivity; }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -299,13 +299,6 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
     if (!m_configuration->modelElementCacheDirectory().isEmpty())
         m_resolvedConfiguration->setModelElementCacheDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->modelElementCacheDirectory()));
 #endif
-#if PLATFORM(IOS_FAMILY)
-    if (isPersistent()) {
-        m_cookieStorageDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebProcessPool::cookieStorageDirectory());
-        m_containerCachesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebProcessPool::webContentCachesDirectory());
-        m_containerTemporaryDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebProcessPool::containerTemporaryDirectory());
-    }
-#endif
 
     // Resolve directories for file paths.
     if (!m_configuration->cookieStorageFile().isEmpty()) {
@@ -1928,12 +1921,12 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 
 #if PLATFORM(IOS_FAMILY)
     if (isPersistent()) {
-        if (String cookieStorageDirectory = WebProcessPool::cookieStorageDirectory(); !cookieStorageDirectory.isEmpty())
-            parameters.cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(cookieStorageDirectory);
-        if (String containerCachesDirectory = WebProcessPool::networkingCachesDirectory(); !containerCachesDirectory.isEmpty())
-            parameters.containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(containerCachesDirectory);
-        if (String parentBundleDirectory = WebProcessPool::parentBundleDirectory(); !parentBundleDirectory.isEmpty())
-            parameters.parentBundleDirectoryExtensionHandle = SandboxExtension::createHandle(parentBundleDirectory, SandboxExtension::Type::ReadOnly);
+        if (auto directory = cookieStorageDirectory(); !directory.isEmpty())
+            parameters.cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
+        if (auto directory = networkingCachesDirectory(); !directory.isEmpty())
+            parameters.containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
+        if (auto directory = parentBundleDirectory(); !directory.isEmpty())
+            parameters.parentBundleDirectoryExtensionHandle = SandboxExtension::createHandle(directory, SandboxExtension::Type::ReadOnly);
         if (auto handleAndFilePath = SandboxExtension::createHandleForTemporaryFile(emptyString(), SandboxExtension::Type::ReadWrite))
             parameters.tempDirectoryExtensionHandle = WTFMove(handleAndFilePath->first);
     }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -161,9 +161,10 @@ public:
     const String& cacheStorageDirectory() const { return m_resolvedConfiguration->cacheStorageDirectory(); }
 
 #if PLATFORM(IOS_FAMILY)
-    const String& cookieStorageDirectory() const { return m_cookieStorageDirectory; }
-    const String& containerCachesDirectory() const { return m_containerCachesDirectory; }
-    const String& containerTemporaryDirectory() const { return m_containerTemporaryDirectory; }
+    String cookieStorageDirectory();
+    String containerCachesDirectory();
+    static String containerTemporaryDirectory();
+    static String cacheDirectoryInContainerOrHomeDirectory(const String& subpath);
 #endif
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
@@ -427,17 +428,17 @@ private:
     void setAppBoundDomainsForITP(const HashSet<WebCore::RegistrableDomain>&, CompletionHandler<void()>&&);
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    String networkingCachesDirectory();
+    String parentBundleDirectory();
+#endif
+
     const PAL::SessionID m_sessionID;
 
     Ref<WebsiteDataStoreConfiguration> m_resolvedConfiguration;
     Ref<const WebsiteDataStoreConfiguration> m_configuration;
     bool m_hasResolvedDirectories { false };
     const Ref<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
-#if PLATFORM(IOS_FAMILY)
-    String m_cookieStorageDirectory;
-    String m_containerCachesDirectory;
-    String m_containerTemporaryDirectory;
-#endif
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
     bool m_resourceLoadStatisticsDebugMode { false };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5927,7 +5927,7 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
     }
 
     BOOL disableAutocorrectAndAutocapitalize = _focusedElementInformation.elementType == WebKit::InputType::Password || _focusedElementInformation.elementType == WebKit::InputType::Email
-        || _focusedElementInformation.elementType == WebKit::InputType::URL || _focusedElementInformation.formAction.contains("login");
+        || _focusedElementInformation.elementType == WebKit::InputType::URL || _focusedElementInformation.formAction.contains("login"_s);
     if ([traits respondsToSelector:@selector(setAutocapitalizationType:)])
         traits.autocapitalizationType = disableAutocorrectAndAutocapitalize ? UITextAutocapitalizationTypeNone : toUITextAutocapitalize(_focusedElementInformation.autocapitalizeType);
     if ([traits respondsToSelector:@selector(setAutocorrectionType:)])

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -465,11 +465,11 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
         {
         }
 
-        void didFocusTextField(WebKit::WebPage*, WebCore::HTMLInputElement* inputElement, WebKit::WebFrame* frame) final
+        void didFocusTextField(WebKit::WebPage*, WebCore::HTMLInputElement& inputElement, WebKit::WebFrame* frame) final
         {
             auto formDelegate = m_controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:didFocusTextField:inFrame:)])
-                [formDelegate _webProcessPlugInBrowserContextController:m_controller didFocusTextField:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement).get()) inFrame:wrapper(*frame)];
+                [formDelegate _webProcessPlugInBrowserContextController:m_controller didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)) inFrame:wrapper(*frame)];
         }
 
         void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement* formElement, WebKit::WebFrame* targetFrame, WebKit::WebFrame* sourceFrame, const Vector<std::pair<String, String>>& values) final
@@ -510,11 +510,11 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
             }
         }
 
-        void textDidChangeInTextField(WebKit::WebPage*, WebCore::HTMLInputElement* inputElement, WebKit::WebFrame* frame, bool initiatedByUserTyping) final
+        void textDidChangeInTextField(WebKit::WebPage*, WebCore::HTMLInputElement& inputElement, WebKit::WebFrame* frame, bool initiatedByUserTyping) final
         {
             auto formDelegate = m_controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:textDidChangeInTextField:inFrame:initiatedByUserTyping:)])
-                [formDelegate _webProcessPlugInBrowserContextController:m_controller textDidChangeInTextField:wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)) inFrame:wrapper(*frame) initiatedByUserTyping:initiatedByUserTyping];
+                [formDelegate _webProcessPlugInBrowserContextController:m_controller textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)) inFrame:wrapper(*frame) initiatedByUserTyping:initiatedByUserTyping];
         }
 
         void willBeginInputSession(WebKit::WebPage*, WebCore::Element* element, WebKit::WebFrame* frame, bool userIsInteracting, RefPtr<API::Object>& userData) final

--- a/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
@@ -51,11 +51,11 @@ class FormClient {
 public:
     virtual ~FormClient() { }
 
-    virtual void didFocusTextField(WebKit::WebPage*, WebCore::HTMLInputElement*, WebKit::WebFrame*) { }
-    virtual void textFieldDidBeginEditing(WebKit::WebPage*, WebCore::HTMLInputElement*, WebKit::WebFrame*) { }
-    virtual void textFieldDidEndEditing(WebKit::WebPage*, WebCore::HTMLInputElement*, WebKit::WebFrame*) { }
-    virtual void textDidChangeInTextField(WebKit::WebPage*, WebCore::HTMLInputElement*, WebKit::WebFrame*, bool) { }
-    virtual void textDidChangeInTextArea(WebKit::WebPage*, WebCore::HTMLTextAreaElement*, WebKit::WebFrame*) { }
+    virtual void didFocusTextField(WebKit::WebPage*, WebCore::HTMLInputElement&, WebKit::WebFrame*) { }
+    virtual void textFieldDidBeginEditing(WebKit::WebPage*, WebCore::HTMLInputElement&, WebKit::WebFrame*) { }
+    virtual void textFieldDidEndEditing(WebKit::WebPage*, WebCore::HTMLInputElement&, WebKit::WebFrame*) { }
+    virtual void textDidChangeInTextField(WebKit::WebPage*, WebCore::HTMLInputElement&, WebKit::WebFrame*, bool) { }
+    virtual void textDidChangeInTextArea(WebKit::WebPage*, WebCore::HTMLTextAreaElement&, WebKit::WebFrame*) { }
 
     enum class InputFieldAction {
         MoveUp,
@@ -67,7 +67,7 @@ public:
         InsertDelete,
     };
 
-    virtual bool shouldPerformActionInTextField(WebKit::WebPage*, WebCore::HTMLInputElement*, InputFieldAction, WebKit::WebFrame*) { return false; }
+    virtual bool shouldPerformActionInTextField(WebKit::WebPage*, WebCore::HTMLInputElement&, InputFieldAction, WebKit::WebFrame*) { return false; }
     virtual void willSubmitForm(WebKit::WebPage*, WebCore::HTMLFormElement*, WebKit::WebFrame*, WebKit::WebFrame*, const Vector<std::pair<WTF::String, WTF::String>>&, RefPtr<API::Object>& userData) { UNUSED_PARAM(userData); }
     virtual void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement*, WebKit::WebFrame*, WebKit::WebFrame*, const Vector<std::pair<WTF::String, WTF::String>>&) { }
     virtual void didAssociateFormControls(WebKit::WebPage*, const Vector<RefPtr<WebCore::Element>>&, WebKit::WebFrame*) { }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
@@ -45,16 +45,16 @@ InjectedBundlePageFormClient::InjectedBundlePageFormClient(const WKBundlePageFor
     initialize(client);
 }
 
-void InjectedBundlePageFormClient::didFocusTextField(WebPage* page, HTMLInputElement* inputElement, WebFrame* frame)
+void InjectedBundlePageFormClient::didFocusTextField(WebPage* page, HTMLInputElement& inputElement, WebFrame* frame)
 {
     if (!m_client.didFocusTextField)
         return;
 
-    RefPtr<InjectedBundleNodeHandle> nodeHandle = InjectedBundleNodeHandle::getOrCreate(inputElement);
+    auto nodeHandle = InjectedBundleNodeHandle::getOrCreate(inputElement);
     m_client.didFocusTextField(toAPI(page), toAPI(nodeHandle.get()), toAPI(frame), m_client.base.clientInfo);
 }
 
-void InjectedBundlePageFormClient::textFieldDidBeginEditing(WebPage* page, HTMLInputElement* inputElement, WebFrame* frame)
+void InjectedBundlePageFormClient::textFieldDidBeginEditing(WebPage* page, HTMLInputElement& inputElement, WebFrame* frame)
 {
     if (!m_client.textFieldDidBeginEditing)
         return;
@@ -63,7 +63,7 @@ void InjectedBundlePageFormClient::textFieldDidBeginEditing(WebPage* page, HTMLI
     m_client.textFieldDidBeginEditing(toAPI(page), toAPI(nodeHandle.get()), toAPI(frame), m_client.base.clientInfo);
 }
 
-void InjectedBundlePageFormClient::textFieldDidEndEditing(WebPage* page, HTMLInputElement* inputElement, WebFrame* frame)
+void InjectedBundlePageFormClient::textFieldDidEndEditing(WebPage* page, HTMLInputElement& inputElement, WebFrame* frame)
 {
     if (!m_client.textFieldDidEndEditing)
         return;
@@ -72,7 +72,7 @@ void InjectedBundlePageFormClient::textFieldDidEndEditing(WebPage* page, HTMLInp
     m_client.textFieldDidEndEditing(toAPI(page), toAPI(nodeHandle.get()), toAPI(frame), m_client.base.clientInfo);
 }
 
-void InjectedBundlePageFormClient::textDidChangeInTextField(WebPage* page, HTMLInputElement* inputElement, WebFrame* frame, bool initiatedByUserTyping)
+void InjectedBundlePageFormClient::textDidChangeInTextField(WebPage* page, HTMLInputElement& inputElement, WebFrame* frame, bool initiatedByUserTyping)
 {
     if (!m_client.textDidChangeInTextField)
         return;
@@ -84,7 +84,7 @@ void InjectedBundlePageFormClient::textDidChangeInTextField(WebPage* page, HTMLI
     m_client.textDidChangeInTextField(toAPI(page), toAPI(nodeHandle.get()), toAPI(frame), m_client.base.clientInfo);
 }
 
-void InjectedBundlePageFormClient::textDidChangeInTextArea(WebPage* page, HTMLTextAreaElement* textAreaElement, WebFrame* frame)
+void InjectedBundlePageFormClient::textDidChangeInTextArea(WebPage* page, HTMLTextAreaElement& textAreaElement, WebFrame* frame)
 {
     if (!m_client.textDidChangeInTextArea)
         return;
@@ -116,7 +116,7 @@ static WKInputFieldActionType toWKInputFieldActionType(API::InjectedBundle::Form
     return WKInputFieldActionTypeCancel;
 }
 
-bool InjectedBundlePageFormClient::shouldPerformActionInTextField(WebPage* page, HTMLInputElement* inputElement, API::InjectedBundle::FormClient::InputFieldAction actionType, WebFrame* frame)
+bool InjectedBundlePageFormClient::shouldPerformActionInTextField(WebPage* page, HTMLInputElement& inputElement, API::InjectedBundle::FormClient::InputFieldAction actionType, WebFrame* frame)
 {
     if (!m_client.shouldPerformActionInTextField)
         return false;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.h
@@ -43,12 +43,12 @@ class InjectedBundlePageFormClient : public API::Client<WKBundlePageFormClientBa
 public:
     explicit InjectedBundlePageFormClient(const WKBundlePageFormClientBase*);
 
-    void didFocusTextField(WebPage*, WebCore::HTMLInputElement*, WebFrame*) override;
-    void textFieldDidBeginEditing(WebPage*, WebCore::HTMLInputElement*, WebFrame*) override;
-    void textFieldDidEndEditing(WebPage*, WebCore::HTMLInputElement*, WebFrame*) override;
-    void textDidChangeInTextField(WebPage*, WebCore::HTMLInputElement*, WebFrame*, bool initiatedByUserTyping) override;
-    void textDidChangeInTextArea(WebPage*, WebCore::HTMLTextAreaElement*, WebFrame*) override;
-    bool shouldPerformActionInTextField(WebPage*, WebCore::HTMLInputElement*, InputFieldAction, WebFrame*) override;    
+    void didFocusTextField(WebPage*, WebCore::HTMLInputElement&, WebFrame*) override;
+    void textFieldDidBeginEditing(WebPage*, WebCore::HTMLInputElement&, WebFrame*) override;
+    void textFieldDidEndEditing(WebPage*, WebCore::HTMLInputElement&, WebFrame*) override;
+    void textDidChangeInTextField(WebPage*, WebCore::HTMLInputElement&, WebFrame*, bool initiatedByUserTyping) override;
+    void textDidChangeInTextArea(WebPage*, WebCore::HTMLTextAreaElement&, WebFrame*) override;
+    bool shouldPerformActionInTextField(WebPage*, WebCore::HTMLInputElement&, InputFieldAction, WebFrame*) override;
     void willSubmitForm(WebPage*, WebCore::HTMLFormElement*, WebFrame*, WebFrame* sourceFrame, const Vector<std::pair<String, String>>&, RefPtr<API::Object>& userData) override;
     void willSendSubmitEvent(WebPage*, WebCore::HTMLFormElement*, WebFrame*, WebFrame* sourceFrame, const Vector<std::pair<String, String>>&) override;
     void didAssociateFormControls(WebPage*, const Vector<RefPtr<WebCore::Element>>&, WebFrame*) override;

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FocusController.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SerializedScriptValue.h>

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -39,6 +39,7 @@
 #include "WebUserContentControllerProxyMessages.h"
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <WebCore/UserStyleSheet.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -260,16 +260,13 @@ void WebChromeClient::takeFocus(FocusDirection direction)
 
 void WebChromeClient::focusedElementChanged(Element* element)
 {
-    if (!is<HTMLInputElement>(element))
-        return;
-
-    HTMLInputElement& inputElement = downcast<HTMLInputElement>(*element);
-    if (!inputElement.isText())
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement || !inputElement->isText())
         return;
 
     WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
     ASSERT(webFrame);
-    m_page.injectedBundleFormClient().didFocusTextField(&m_page, &inputElement, webFrame);
+    m_page.injectedBundleFormClient().didFocusTextField(&m_page, *inputElement, webFrame);
 }
 
 void WebChromeClient::focusedFrameChanged(Frame* frame)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -352,50 +352,54 @@ void WebEditorClient::handleInputMethodKeydown(KeyboardEvent&)
 
 #endif // !PLATFORM(COCOA) && !USE(GLIB)
 
-void WebEditorClient::textFieldDidBeginEditing(Element* element)
+void WebEditorClient::textFieldDidBeginEditing(Element& element)
 {
-    if (!is<HTMLInputElement>(*element))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement)
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page, downcast<HTMLInputElement>(element), webFrame);
+    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page, *inputElement, webFrame);
 }
 
-void WebEditorClient::textFieldDidEndEditing(Element* element)
+void WebEditorClient::textFieldDidEndEditing(Element& element)
 {
-    if (!is<HTMLInputElement>(*element))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement)
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page, downcast<HTMLInputElement>(element), webFrame);
+    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page, *inputElement, webFrame);
 }
 
-void WebEditorClient::textDidChangeInTextField(Element* element)
+void WebEditorClient::textDidChangeInTextField(Element& element)
 {
-    if (!is<HTMLInputElement>(*element))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement)
         return;
 
-    bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == element;
+    bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == inputElement;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page, downcast<HTMLInputElement>(element), webFrame, initiatedByUserTyping);
+    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page, *inputElement, webFrame, initiatedByUserTyping);
 }
 
-void WebEditorClient::textDidChangeInTextArea(Element* element)
+void WebEditorClient::textDidChangeInTextArea(Element& element)
 {
-    if (!is<HTMLTextAreaElement>(*element))
+    auto* textAreaElement = dynamicDowncast<HTMLTextAreaElement>(element);
+    if (!textAreaElement)
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page, downcast<HTMLTextAreaElement>(element), webFrame);
+    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page, *textAreaElement, webFrame);
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -455,30 +459,32 @@ static API::InjectedBundle::FormClient::InputFieldAction toInputFieldAction(WKIn
     return API::InjectedBundle::FormClient::InputFieldAction::Cancel;
 }
 
-bool WebEditorClient::doTextFieldCommandFromEvent(Element* element, KeyboardEvent* event)
+bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEvent* event)
 {
-    if (!is<HTMLInputElement>(*element))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement)
         return false;
 
     WKInputFieldActionType actionType = static_cast<WKInputFieldActionType>(0);
     if (!getActionTypeForKeyEvent(event, actionType))
         return false;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, downcast<HTMLInputElement>(element), toInputFieldAction(actionType), webFrame);
+    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, *inputElement, toInputFieldAction(actionType), webFrame);
 }
 
-void WebEditorClient::textWillBeDeletedInTextField(Element* element)
+void WebEditorClient::textWillBeDeletedInTextField(Element& element)
 {
-    if (!is<HTMLInputElement>(*element))
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    if (!inputElement)
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, downcast<HTMLInputElement>(element), toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame);
+    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame);
 }
 
 bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -107,12 +107,12 @@ private:
     void handleKeyboardEvent(WebCore::KeyboardEvent&) final;
     void handleInputMethodKeydown(WebCore::KeyboardEvent&) final;
     
-    void textFieldDidBeginEditing(WebCore::Element*) final;
-    void textFieldDidEndEditing(WebCore::Element*) final;
-    void textDidChangeInTextField(WebCore::Element*) final;
-    bool doTextFieldCommandFromEvent(WebCore::Element*, WebCore::KeyboardEvent*) final;
-    void textWillBeDeletedInTextField(WebCore::Element*) final;
-    void textDidChangeInTextArea(WebCore::Element*) final;
+    void textFieldDidBeginEditing(WebCore::Element&) final;
+    void textFieldDidEndEditing(WebCore::Element&) final;
+    void textDidChangeInTextField(WebCore::Element&) final;
+    bool doTextFieldCommandFromEvent(WebCore::Element&, WebCore::KeyboardEvent*) final;
+    void textWillBeDeletedInTextField(WebCore::Element&) final;
+    void textDidChangeInTextArea(WebCore::Element&) final;
     void overflowScrollPositionChanged() final;
     void subFrameScrollPositionChanged() final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
@@ -24,6 +24,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/Editor.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/KeyboardEvent.h>
 #include <WebCore/PlatformKeyboardEvent.h>
 #include <WebPage.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/Editor.h>
 #include <WebCore/EventNames.h>
 #include <WebCore/Frame.h>
+#include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/KeyboardEvent.h>
 #include <WebCore/Node.h>
 #include <WebCore/PlatformKeyboardEvent.h>

--- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
@@ -28,6 +28,8 @@
 
 #include "WebFrame.h"
 
+#include <WebCore/FrameDestructionObserverInlines.h>
+
 namespace WebKit {
 using namespace WebCore;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3536,7 +3536,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
             else {
                 information.elementType = InputType::Text;
                 if (!information.formAction.isEmpty()
-                    && (element.getNameAttribute().contains("search") || element.getIdAttribute().contains("search") || element.attributeWithoutSynchronization(HTMLNames::titleAttr).contains("search")))
+                    && (element.getNameAttribute().contains("search"_s) || element.getIdAttribute().contains("search"_s) || element.attributeWithoutSynchronization(HTMLNames::titleAttr).contains("search"_s)))
                     information.elementType = InputType::Search;
             }
         }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1940,9 +1940,9 @@ static inline void checkDocumentsCaptureStateConsistency(const Vector<String>& e
     });
 
     if (isCapturingAudio)
-        ASSERT(extensionIDs.findIf([](auto& id) { return id.contains("microphone"); }) == notFound);
+        ASSERT(!extensionIDs.containsIf([](auto& id) { return id.contains("microphone"_s); }));
     if (isCapturingVideo)
-        ASSERT(extensionIDs.findIf([](auto& id) { return id.contains("camera"); }) == notFound);
+        ASSERT(!extensionIDs.containsIf([](auto& id) { return id.contains("camera"_s); }));
 #endif // ASSERT_ENABLED
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -132,12 +132,12 @@ private:
     void handleKeyboardEvent(WebCore::KeyboardEvent&) final;
     void handleInputMethodKeydown(WebCore::KeyboardEvent&) final;
 
-    void textFieldDidBeginEditing(WebCore::Element*) final;
-    void textFieldDidEndEditing(WebCore::Element*) final;
-    void textDidChangeInTextField(WebCore::Element*) final;
-    bool doTextFieldCommandFromEvent(WebCore::Element*, WebCore::KeyboardEvent*) final;
-    void textWillBeDeletedInTextField(WebCore::Element*) final;
-    void textDidChangeInTextArea(WebCore::Element*) final;
+    void textFieldDidBeginEditing(WebCore::Element&) final;
+    void textFieldDidEndEditing(WebCore::Element&) final;
+    void textDidChangeInTextField(WebCore::Element&) final;
+    bool doTextFieldCommandFromEvent(WebCore::Element&, WebCore::KeyboardEvent*) final;
+    void textWillBeDeletedInTextField(WebCore::Element&) final;
+    void textDidChangeInTextArea(WebCore::Element&) final;
     void overflowScrollPositionChanged() final { };
     void subFrameScrollPositionChanged() final { };
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9507,7 +9507,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
                 RefPtr<EditingStyle> typingStyle = coreFrame->selection().typingStyle();
                 if (typingStyle && typingStyle->style()) {
                     String value = typingStyle->style()->getPropertyValue(CSSPropertyWebkitTextDecorationsInEffect);
-                    [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline")];
+                    [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline"_s)];
                 } else
                     [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationsInEffect().contains(TextDecorationLine::Underline)];
 

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
@@ -392,15 +392,15 @@ bool WebEditorClient::isSelectTrailingWhitespaceEnabled(void) const
     return page->settings().selectTrailingWhitespaceEnabled();
 }
 
-void WebEditorClient::textFieldDidBeginEditing(Element* e)
+void WebEditorClient::textFieldDidBeginEditing(Element& e)
 {
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLInputElement* domInputElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLInputElement, (void**)&domInputElement))) {
-                formDelegate->textFieldDidBeginEditing(domInputElement, kit(e->document().frame()));
+                formDelegate->textFieldDidBeginEditing(domInputElement, kit(e.document().frame()));
                 domInputElement->Release();
             }
             domElement->Release();
@@ -409,15 +409,15 @@ void WebEditorClient::textFieldDidBeginEditing(Element* e)
     }
 }
 
-void WebEditorClient::textFieldDidEndEditing(Element* e)
+void WebEditorClient::textFieldDidEndEditing(Element& e)
 {
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLInputElement* domInputElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLInputElement, (void**)&domInputElement))) {
-                formDelegate->textFieldDidEndEditing(domInputElement, kit(e->document().frame()));
+                formDelegate->textFieldDidEndEditing(domInputElement, kit(e.document().frame()));
                 domInputElement->Release();
             }
             domElement->Release();
@@ -426,18 +426,18 @@ void WebEditorClient::textFieldDidEndEditing(Element* e)
     }
 }
 
-void WebEditorClient::textDidChangeInTextField(Element* e)
+void WebEditorClient::textDidChangeInTextField(Element& e)
 {
-    if (!UserTypingGestureIndicator::processingUserTypingGesture() || UserTypingGestureIndicator::focusedElementAtGestureStart() != e)
+    if (!UserTypingGestureIndicator::processingUserTypingGesture() || UserTypingGestureIndicator::focusedElementAtGestureStart() != &e)
         return;
 
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLInputElement* domInputElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLInputElement, (void**)&domInputElement))) {
-                formDelegate->textDidChangeInTextField(domInputElement, kit(e->document().frame()));
+                formDelegate->textDidChangeInTextField(domInputElement, kit(e.document().frame()));
                 domInputElement->Release();
             }
             domElement->Release();
@@ -446,19 +446,19 @@ void WebEditorClient::textDidChangeInTextField(Element* e)
     }
 }
 
-bool WebEditorClient::doTextFieldCommandFromEvent(Element* e, KeyboardEvent* ke)
+bool WebEditorClient::doTextFieldCommandFromEvent(Element& e, KeyboardEvent* ke)
 {
     BOOL result = FALSE;
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLInputElement* domInputElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLInputElement, (void**)&domInputElement))) {
                 auto command = String::fromLatin1(m_webView->interpretKeyEvent(ke));
                 // We allow empty commands here because the app code actually depends on this being called for all key presses.
                 // We may want to revisit this later because it doesn't really make sense to send an empty command.
-                formDelegate->doPlatformCommand(domInputElement, BString(command), kit(e->document().frame()), &result);
+                formDelegate->doPlatformCommand(domInputElement, BString(command), kit(e.document().frame()), &result);
                 domInputElement->Release();
             }
             domElement->Release();
@@ -468,17 +468,17 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element* e, KeyboardEvent* ke)
     return !!result;
 }
 
-void WebEditorClient::textWillBeDeletedInTextField(Element* e)
+void WebEditorClient::textWillBeDeletedInTextField(Element& e)
 {
     // We're using the deleteBackward command for all deletion operations since the autofill code treats all deletions the same way.
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLInputElement* domInputElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLInputElement, (void**)&domInputElement))) {
                 BOOL result;
-                formDelegate->doPlatformCommand(domInputElement, BString(L"DeleteBackward"), kit(e->document().frame()), &result);
+                formDelegate->doPlatformCommand(domInputElement, BString(L"DeleteBackward"), kit(e.document().frame()), &result);
                 domInputElement->Release();
             }
             domElement->Release();
@@ -487,15 +487,15 @@ void WebEditorClient::textWillBeDeletedInTextField(Element* e)
     }
 }
 
-void WebEditorClient::textDidChangeInTextArea(Element* e)
+void WebEditorClient::textDidChangeInTextArea(Element& e)
 {
     IWebFormDelegate* formDelegate;
     if (SUCCEEDED(m_webView->formDelegate(&formDelegate)) && formDelegate) {
-        IDOMElement* domElement = DOMElement::createInstance(e);
+        IDOMElement* domElement = DOMElement::createInstance(&e);
         if (domElement) {
             IDOMHTMLTextAreaElement* domTextAreaElement;
             if (SUCCEEDED(domElement->QueryInterface(IID_IDOMHTMLTextAreaElement, (void**)&domTextAreaElement))) {
-                formDelegate->textDidChangeInTextArea(domTextAreaElement, kit(e->document().frame()));
+                formDelegate->textDidChangeInTextArea(domTextAreaElement, kit(e.document().frame()));
                 domTextAreaElement->Release();
             }
             domElement->Release();

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.h
@@ -88,12 +88,12 @@ private:
     void redo() final;
     
     bool shouldChangeSelectedRange(const std::optional<WebCore::SimpleRange>& fromRange, const std::optional<WebCore::SimpleRange>& toRange, WebCore::Affinity, bool stillSelecting) final;
-    void textFieldDidBeginEditing(WebCore::Element*) final;
-    void textFieldDidEndEditing(WebCore::Element*) final;
-    void textDidChangeInTextField(WebCore::Element*) final;
-    bool doTextFieldCommandFromEvent(WebCore::Element*, WebCore::KeyboardEvent*) final;
-    void textWillBeDeletedInTextField(WebCore::Element* input) final;
-    void textDidChangeInTextArea(WebCore::Element*) final;
+    void textFieldDidBeginEditing(WebCore::Element&) final;
+    void textFieldDidEndEditing(WebCore::Element&) final;
+    void textDidChangeInTextField(WebCore::Element&) final;
+    bool doTextFieldCommandFromEvent(WebCore::Element&, WebCore::KeyboardEvent*) final;
+    void textWillBeDeletedInTextField(WebCore::Element& input) final;
+    void textDidChangeInTextArea(WebCore::Element&) final;
     void overflowScrollPositionChanged() final { }
     void subFrameScrollPositionChanged() final { }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -1315,7 +1315,7 @@ static WTF::String addLeadingSpaceStripTrailingSpacesAddNewline(const WTF::Strin
 
 static StringView lastFileURLPathComponent(StringView path)
 {
-    auto pos = path.find("file://");
+    auto pos = path.find("file://"_s);
     ASSERT(WTF::notFound != pos);
 
     auto tmpPath = path.substring(pos + 7);


### PR DESCRIPTION
#### 7ef0c28845c9d5a7e637fdaeabe25d184cf38bb1
<pre>
Remove dead code in handling of GridTrackEntryAutoRepeat in canInterpolate
<a href="https://bugs.webkit.org/show_bug.cgi?id=240620">https://bugs.webkit.org/show_bug.cgi?id=240620</a>

Patch by Kiet Ho &lt;tho22@apple.com &gt; on 2022-05-19
Reviewed by Tim Nguyen.

No new tests, no changes in behavior.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::canInterpolate):

Canonical link: <a href="https://commits.webkit.org/250733@main">https://commits.webkit.org/250733@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294471">https://svn.webkit.org/repository/webkit/trunk@294471</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
