### PR TITLE
Fix boolean operation in WTF/BitMap test.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp
@@ -1169,7 +1169,7 @@ void testBitmapOperatorBitOrAssignmentImpl(size_t size, const Bitmap& bitmap1, c
 
     temp |= bitmap2;
     for (size_t i = 0; i < size; ++i)
-        EXPECT_EQ(temp.get(i), bitmap1.get(i) | bitmap2.get(i));
+        EXPECT_EQ(temp.get(i), bitmap1.get(i) || bitmap2.get(i));
 
     temp1 = temp;
     EXPECT_TRUE(temp1 == temp);
@@ -1237,7 +1237,7 @@ void testBitmapOperatorBitAndAssignmentImpl(size_t size, const Bitmap& bitmap1, 
 
     temp &= bitmap2;
     for (size_t i = 0; i < size; ++i)
-        EXPECT_EQ(temp.get(i), bitmap1.get(i) & bitmap2.get(i));
+        EXPECT_EQ(temp.get(i), bitmap1.get(i) && bitmap2.get(i));
 
     EXPECT_TRUE(!temp.isEmpty());
     temp1 = temp;


### PR DESCRIPTION
#### 5d22f11f91ceeb9d301d5cb5ef69d6cf82fd8aa3
<pre>
Fix boolean operation in WTF/BitMap test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=240668">https://bugs.webkit.org/show_bug.cgi?id=240668</a>

Reviewed by Adrian Perez de Castro.

Clang 14 starts complaining about using logical operators to boolean:
```
webkit/Tools/TestWebKitAPI/Tests/WTF/Bitmap.cpp:1172:32: warning: use of bitwise &apos;|&apos; with boolean operands [-Wbitwise-instead-of-logical]
        EXPECT_EQ(temp.get(i), bitmap1.get(i) | bitmap2.get(i));
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                              ||
```

Canonical link: <a href="https://commits.webkit.org/250773@main">https://commits.webkit.org/250773@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294517">https://svn.webkit.org/repository/webkit/trunk@294517</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
