### PR TITLE
Introduce WKHTTPCookieStore.deleteAllCookies

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -69,10 +69,11 @@ void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const
         storageSession->deleteCookiesForHostnames(hostnames);
 }
 
-void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID)
+void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* storageSession = m_process.storageSession(sessionID))
         storageSession->deleteAllCookies();
+    completionHandler();
 }
 
 void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -73,7 +73,7 @@ private:
 
     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
-    void deleteAllCookies(PAL::SessionID);
+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
 
     void setCookie(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -26,13 +26,13 @@
 messages -> WebCookieManager NotRefCounted {
     void GetHostnamesWithCookies(PAL::SessionID sessionID) -> (Vector<String> hostnames)
     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames)
-    void DeleteAllCookies(PAL::SessionID sessionID)
 
     void SetCookie(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookie) -> ()
     void SetCookies(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookies, URL url, URL mainDocumentURL) -> ()
     void GetAllCookies(PAL::SessionID sessionID) -> (Vector<WebCore::Cookie> cookies)
     void GetCookies(PAL::SessionID sessionID, URL url) -> (Vector<WebCore::Cookie> cookies)
     void DeleteCookie(PAL::SessionID sessionID, struct WebCore::Cookie cookie) -> ()
+    void DeleteAllCookies(PAL::SessionID sessionID) -> ()
     void DeleteAllCookiesModifiedSince(PAL::SessionID sessionID, WallTime time) -> ()
 
     void SetHTTPCookieAcceptPolicy(enum:uint8_t WebCore::HTTPCookieAcceptPolicy policy) -> ()

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -119,9 +119,7 @@ void HTTPCookieStore::deleteAllCookies(CompletionHandler<void()>&& completionHan
     if (!m_owningDataStore)
         return completionHandler();
     auto& cookieManager = m_owningDataStore->networkProcess().cookieManager();
-    cookieManager.deleteAllCookies(m_owningDataStore->sessionID());
-    // FIXME: The CompletionHandler should be passed to WebCookieManagerProxy::deleteAllCookies.
-    RunLoop::main().dispatch(WTFMove(completionHandler));
+    cookieManager.deleteAllCookies(m_owningDataStore->sessionID(), WTFMove(completionHandler));
 }
 
 void HTTPCookieStore::setHTTPCookieAcceptPolicy(WebCore::HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -61,6 +61,11 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
  */
 - (void)deleteCookie:(NSHTTPCookie *)cookie completionHandler:(nullable void (^)(void))completionHandler WK_SWIFT_ASYNC_NAME(deleteCookie(_:));
 
+/*! @abstract Deletes all stored cookies.
+ @param completionHandler A block to invoke once the cookies have been deleted.
+ */
+- (void)deleteAllCookies:(nullable void (^)(void))completionHandler;
+
 /*! @abstract Adds a WKHTTPCookieStoreObserver object with the cookie store.
  @param observer The observer object to add.
  @discussion The observer is not retained by the receiver. It is your responsibility

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -106,6 +106,15 @@ private:
     });
 }
 
+- (void)deleteAllCookies:(void (^)(void))completionHandler
+{
+    _cookieStore->deleteAllCookies([handler = adoptNS([completionHandler copy])]() {
+        auto rawHandler = (void (^)())handler.get();
+        if (rawHandler)
+            rawHandler();
+    });
+}
+
 - (void)addObserver:(id<WKHTTPCookieStoreObserver>)observer
 {
     auto result = _observers.add((__bridge CFTypeRef)observer, nullptr);

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
@@ -66,10 +66,12 @@ void WebCookieManagerProxy::deleteCookiesForHostnames(PAL::SessionID sessionID, 
         m_networkProcess->send(Messages::WebCookieManager::DeleteCookiesForHostnames(sessionID, hostnames), 0);
 }
 
-void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID)
+void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& callbackFunction)
 {
     if (m_networkProcess)
-        m_networkProcess->send(Messages::WebCookieManager::DeleteAllCookies(sessionID), 0);
+        m_networkProcess->sendWithAsyncReply(Messages::WebCookieManager::DeleteAllCookies(sessionID), WTFMove(callbackFunction));
+    else
+        callbackFunction();
 }
 
 void WebCookieManagerProxy::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& callbackFunction)

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
@@ -61,7 +61,7 @@ public:
     void getHostnamesWithCookies(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
-    void deleteAllCookies(PAL::SessionID);
+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
 
     void setCookies(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);


### PR DESCRIPTION
#### afc777fb499858ebeb497291e092c9c291090025
<pre>
Introduce WKHTTPCookieStore.deleteAllCookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=240671">https://bugs.webkit.org/show_bug.cgi?id=240671</a>

Reviewed by NOBODY (OOPS!).

Added deleteAllCookies to WKHTTPCookieStore. The method allows to remove
all cookies in one call. Also fixed the implementation to actually wait
for the NetworkProcess to complete the operation before calling the
completion handler.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(clearCookies): switched existing code to the new API method.

(TEST): Added WKHTTPCookieStore.DeleteAllCookies that populates cookie store,
navigates to a page that would get the cookies and in the navigation
handler clears the cookie store before doing navigation policy decision.
This way we try to ensure that deleteAllCookies callback is invoked only
after the network process actually cleared the cookie store.

(deleteCookies): Deleted.
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::deleteAllCookies):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in:
DeleteAllCookies now has asynchronouse reply.

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::deleteAllCookies): The method now actuall waits
for the confirmation from the network process before calling the
completion handler.

* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h:
Added new method deleteAllCookies.

* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(-[WKHTTPCookieStore deleteAllCookies:]):
* Source/WebKit/UIProcess/WebCookieManagerProxy.cpp:
(WebKit::WebCookieManagerProxy::deleteAllCookies):
* Source/WebKit/UIProcess/WebCookieManagerProxy.h:
</pre>