### PR TITLE
[GLib] Fix build without ContentExtensions

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
@@ -336,14 +336,16 @@ API::UserScript& webkitUserScriptGetUserScript(WebKitUserScript* userScript)
 
 struct _WebKitUserContentFilter {
     _WebKitUserContentFilter(RefPtr<API::ContentRuleList>&& contentRuleList)
-        : identifier(contentRuleList->name().utf8())
-        , contentRuleList(WTFMove(contentRuleList))
+        : contentRuleList(WTFMove(contentRuleList))
+#if ENABLE(CONTENT_EXTENSIONS)
+        , identifier(this->contentRuleList->name().utf8())
+#endif
         , referenceCount(1)
     {
     }
 
-    CString identifier;
     RefPtr<API::ContentRuleList> contentRuleList;
+    CString identifier;
     int referenceCount;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -386,7 +386,9 @@ void webkit_user_content_manager_add_filter(WebKitUserContentManager* manager, W
 {
     g_return_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager));
     g_return_if_fail(filter);
+#if ENABLE(CONTENT_EXTENSIONS)
     manager->priv->userContentController->addContentRuleList(webkitUserContentFilterGetContentRuleList(filter));
+#endif
 }
 
 /**
@@ -402,7 +404,9 @@ void webkit_user_content_manager_remove_filter(WebKitUserContentManager* manager
 {
     g_return_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager));
     g_return_if_fail(filter);
+#if ENABLE(CONTENT_EXTENSIONS)
     manager->priv->userContentController->removeContentRuleList(webkitUserContentFilterGetContentRuleList(filter).name());
+#endif
 }
 
 /**
@@ -420,7 +424,9 @@ void webkit_user_content_manager_remove_filter_by_id(WebKitUserContentManager* m
 {
     g_return_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager));
     g_return_if_fail(filterId);
+#if ENABLE(CONTENT_EXTENSIONS)
     manager->priv->userContentController->removeContentRuleList(String::fromUTF8(filterId));
+#endif
 }
 
 /**
@@ -434,7 +440,9 @@ void webkit_user_content_manager_remove_filter_by_id(WebKitUserContentManager* m
 void webkit_user_content_manager_remove_all_filters(WebKitUserContentManager* manager)
 {
     g_return_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager));
+#if ENABLE(CONTENT_EXTENSIONS)
     manager->priv->userContentController->removeAllContentRuleLists();
+#endif
 }
 
 WebUserContentControllerProxy* webkitUserContentManagerGetUserContentControllerProxy(WebKitUserContentManager* manager)


### PR DESCRIPTION
#### 8484c9ba1afef49e25b0ce5c57694004be423c2b
<pre>
[GLib] Fix build without ContentExtensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=240719">https://bugs.webkit.org/show_bug.cgi?id=240719</a>

Reviewed by Adrian Perez de Castro.

Build without ContentExtensions is broken since r241790 because of
API::ContentRuleList usage in WebKitUserContent* API files.

* Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp:
(_WebKitUserContentFilter::_WebKitUserContentFilter): Make identifier
conditional and reorder fields to make build checks easier to read
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp:
(webkitUserContentFilterStoreConstructed):
(webkit_user_content_filter_store_save):
(webkit_user_content_filter_store_save_from_file):
(webkit_user_content_filter_store_remove):
(webkit_user_content_filter_store_load):
(webkit_user_content_filter_store_fetch_identifiers):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
(webkit_user_content_manager_add_filter):
(webkit_user_content_manager_remove_filter):
(webkit_user_content_manager_remove_filter_by_id):
(webkit_user_content_manager_remove_all_filters):

Canonical link: <a href="https://commits.webkit.org/251866@main">https://commits.webkit.org/251866@main</a>
</pre>
