### PR TITLE
[Gardening]REGRESSION(r294317): [ iOS ] Thirteen layout tests are flaky or consistent timeouts

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3632,21 +3632,6 @@ webkit.org/b/240579 http/tests/push-api/subscribe-default-permissions-iframe-sam
 webkit.org/b/240579 http/tests/push-api/subscribe-default-permissions.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api/subscribe-deny-permissions-on-prompt.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api/subscribe-grant-permissions.html [ Skip ]
-<<<<<<< HEAD
-
-webkit.org/b/240616 editing/input/cocoa/autocorrect-off.html [ Slow ]
-webkit.org/b/240616 editing/input/cocoa/autocorrect-on.html [ Slow ]
-webkit.org/b/240616 fast/events/ios/keyup.html [ Slow ]
-webkit.org/b/240616 fast/shadow-dom/ios/accessory-bar-work-on-input-with-tabindex-in-shadow-tree.html [ Slow ]
-webkit.org/b/240616 fast/forms/ios/autocapitalize-words.html [ Slow ]
-webkit.org/b/240616 fast/forms/ios/form-control-refresh/select/select-multiple-picker.html [ Slow ]
-webkit.org/b/240616 fast/forms/ios/no-scrolling-when-moving-focus-between-adjacent-fields.html [ Slow ]
-webkit.org/b/240616 mathml/fractions-invalid.html [ Slow ]
-webkit.org/b/240616 editing/undo-manager/undo-manager-item-labels.html [ Pass Slow ]
-webkit.org/b/240616 fast/forms/ios/inputmode-none.html [ Pass Slow ]
-webkit.org/b/240616 fast/forms/validation-messages.html [ Pass Slow ]
-webkit.org/b/240616 fast/forms/ios/inputmode-removing-none.html [ Pass Slow ]
-webkit.org/b/240616 fast/forms/datalist/datalist.html [ Pass Slow Crash ]
 
 webkit.org/b/240654 fast/css/paint-order-shadow.html [ ImageOnlyFailure ]
 webkit.org/b/240654 fast/forms/ios/focus-ring-size.html [ ImageOnlyFailure ]
@@ -3661,5 +3646,3 @@ webkit.org/b/240654 fast/inline/hidpi-outline-auto-with-one-focusring-rect.html 
 webkit.org/b/240659 fast/text/isolate-ignore.html [ Crash ]
 
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
-=======
->>>>>>> parent of 4d4015d6dc57 (REGRESSION (r294317): [ iOS ] Thirteen layout tests are flaky or consistent timeouts)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -28,6 +28,7 @@ fast/forms/ios [ Pass ]
 fast/forms/ios/ipad [ Skip ]
 
 # These tests fail or are flaky in non-internal iOS 14 simulator
+fast/forms/ios/autocapitalize-words.html [ Pass Failure ]
 fast/forms/ios/inputmode-none-with-hardware-keyboard.html [ Pass Failure ]
 
 fast/forms/ios/dismiss-picker-using-keyboard.html [ Pass Timeout ]
@@ -3631,6 +3632,7 @@ webkit.org/b/240579 http/tests/push-api/subscribe-default-permissions-iframe-sam
 webkit.org/b/240579 http/tests/push-api/subscribe-default-permissions.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api/subscribe-deny-permissions-on-prompt.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api/subscribe-grant-permissions.html [ Skip ]
+<<<<<<< HEAD
 
 webkit.org/b/240616 editing/input/cocoa/autocorrect-off.html [ Slow ]
 webkit.org/b/240616 editing/input/cocoa/autocorrect-on.html [ Slow ]
@@ -3659,3 +3661,5 @@ webkit.org/b/240654 fast/inline/hidpi-outline-auto-with-one-focusring-rect.html 
 webkit.org/b/240659 fast/text/isolate-ignore.html [ Crash ]
 
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
+=======
+>>>>>>> parent of 4d4015d6dc57 (REGRESSION (r294317): [ iOS ] Thirteen layout tests are flaky or consistent timeouts)


### PR DESCRIPTION
#### b8e75b619c9b5daf81e40718c69c30fdc40e0b23
<pre>
[Gardening]REGRESSION(r294317): [ iOS ] Thirteen layout tests are flaky or consistent timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=240616">https://bugs.webkit.org/show_bug.cgi?id=240616</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
</pre>
----------------------------------------------------------------------
#### ddde2601611f78271a261fb0e7afc23d4e690898
<pre>
Revert &quot;REGRESSION (r294317): [ iOS ] Thirteen layout tests are flaky or consistent timeouts&quot;

This reverts commit 4d4015d6dc57a2543ddeff5bf6bc943094cbbad8.
Unreviewed revert
</pre>