### PR TITLE
WKHTTPCookieStoreDeleteAllCookies should wait for response from network process before invoking callback

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -69,10 +69,11 @@ void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const
         storageSession->deleteCookiesForHostnames(hostnames);
 }
 
-void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID)
+void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* storageSession = m_process.storageSession(sessionID))
         storageSession->deleteAllCookies();
+    completionHandler();
 }
 
 void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -73,7 +73,7 @@ private:
 
     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
-    void deleteAllCookies(PAL::SessionID);
+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
 
     void setCookie(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -26,13 +26,13 @@
 messages -> WebCookieManager NotRefCounted {
     void GetHostnamesWithCookies(PAL::SessionID sessionID) -> (Vector<String> hostnames)
     void DeleteCookiesForHostnames(PAL::SessionID sessionID, Vector<String> hostnames)
-    void DeleteAllCookies(PAL::SessionID sessionID)
 
     void SetCookie(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookie) -> ()
     void SetCookies(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookies, URL url, URL mainDocumentURL) -> ()
     void GetAllCookies(PAL::SessionID sessionID) -> (Vector<WebCore::Cookie> cookies)
     void GetCookies(PAL::SessionID sessionID, URL url) -> (Vector<WebCore::Cookie> cookies)
     void DeleteCookie(PAL::SessionID sessionID, struct WebCore::Cookie cookie) -> ()
+    void DeleteAllCookies(PAL::SessionID sessionID) -> ()
     void DeleteAllCookiesModifiedSince(PAL::SessionID sessionID, WallTime time) -> ()
 
     void SetHTTPCookieAcceptPolicy(enum:uint8_t WebCore::HTTPCookieAcceptPolicy policy) -> ()

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -119,9 +119,7 @@ void HTTPCookieStore::deleteAllCookies(CompletionHandler<void()>&& completionHan
     if (!m_owningDataStore)
         return completionHandler();
     auto& cookieManager = m_owningDataStore->networkProcess().cookieManager();
-    cookieManager.deleteAllCookies(m_owningDataStore->sessionID());
-    // FIXME: The CompletionHandler should be passed to WebCookieManagerProxy::deleteAllCookies.
-    RunLoop::main().dispatch(WTFMove(completionHandler));
+    cookieManager.deleteAllCookies(m_owningDataStore->sessionID(), WTFMove(completionHandler));
 }
 
 void HTTPCookieStore::setHTTPCookieAcceptPolicy(WebCore::HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.cpp
@@ -66,10 +66,12 @@ void WebCookieManagerProxy::deleteCookiesForHostnames(PAL::SessionID sessionID, 
         m_networkProcess->send(Messages::WebCookieManager::DeleteCookiesForHostnames(sessionID, hostnames), 0);
 }
 
-void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID)
+void WebCookieManagerProxy::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& callbackFunction)
 {
     if (m_networkProcess)
-        m_networkProcess->send(Messages::WebCookieManager::DeleteAllCookies(sessionID), 0);
+        m_networkProcess->sendWithAsyncReply(Messages::WebCookieManager::DeleteAllCookies(sessionID), WTFMove(callbackFunction));
+    else
+        callbackFunction();
 }
 
 void WebCookieManagerProxy::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& callbackFunction)

--- a/Source/WebKit/UIProcess/WebCookieManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebCookieManagerProxy.h
@@ -61,7 +61,7 @@ public:
     void getHostnamesWithCookies(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
     void deleteCookie(PAL::SessionID, const WebCore::Cookie&, CompletionHandler<void()>&&);
     void deleteCookiesForHostnames(PAL::SessionID, const Vector<String>&);
-    void deleteAllCookies(PAL::SessionID);
+    void deleteAllCookies(PAL::SessionID, CompletionHandler<void()>&&);
     void deleteAllCookiesModifiedSince(PAL::SessionID, WallTime, CompletionHandler<void()>&&);
 
     void setCookies(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);


### PR DESCRIPTION
#### c5db694d5a4d3a59cffeded773312f48f879e444
<pre>
WKHTTPCookieStoreDeleteAllCookies should wait for response from network process before invoking callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=240743">https://bugs.webkit.org/show_bug.cgi?id=240743</a>

Reviewed by NOBODY (OOPS!).

Make API::HTTPCookieStore::deleteAllCookies actually wait for the
NetworkProcess to complete the operation before calling the
completion handler.

* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::deleteAllCookies):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::deleteAllCookies):
* Source/WebKit/UIProcess/WebCookieManagerProxy.cpp:
(WebKit::WebCookieManagerProxy::deleteAllCookies):
* Source/WebKit/UIProcess/WebCookieManagerProxy.h:
</pre>