### PR TITLE
Introduce a SeekCompletion callback for MediaPlayer seek commands https://bugs.webkit.org/show_bug.cgi?id=238821

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -764,14 +764,14 @@ MediaTime MediaPlayer::getStartDate() const
     return m_private->getStartDate();
 }
 
-void MediaPlayer::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance)
+void MediaPlayer::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&& completion)
 {
-    m_private->seekWithTolerance(time, negativeTolerance, positiveTolerance);
+    m_private->seekWithTolerance(time, negativeTolerance, positiveTolerance, WTFMove(completion));
 }
 
-void MediaPlayer::seek(const MediaTime& time)
+void MediaPlayer::seek(const MediaTime& time, SeekCompletion&& completion)
 {
-    m_private->seek(time);
+    m_private->seek(time, WTFMove(completion));
 }
 
 void MediaPlayer::seekWhenPossible(const MediaTime& time)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -408,9 +408,12 @@ public:
     static double invalidTime() { return -1.0;}
     MediaTime duration() const;
     MediaTime currentTime() const;
-    void seek(const MediaTime&);
+
+    using SeekCompletion = CompletionHandler<void(MediaPlayerEnums::SeekResult)>;
+    void seek(const MediaTime&, SeekCompletion&& = [] (SeekResult) { });
     void seekWhenPossible(const MediaTime&);
-    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance);
+
+    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&& = [] (SeekResult) { });
 
     using CurrentTimeDidChangeCallback = std::function<void(const MediaTime&)>;
     bool setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&&);

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -111,6 +111,12 @@ public:
         BestForMusic,
         BestForSpeech,
     };
+
+    enum class SeekResult : uint8_t {
+        Unknown,
+        Cancelled,
+        Completed,
+    };
 };
 
 WEBCORE_EXPORT String convertEnumerationToString(MediaPlayerEnums::ReadyState);
@@ -251,6 +257,15 @@ using values = EnumValues<
     WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround,
     WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForMusic,
     WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForSpeech
+    >;
+};
+
+template<> struct EnumTraits<WebCore::MediaPlayerEnums::SeekResult> {
+using values = EnumValues<
+    WebCore::MediaPlayerEnums::SeekResult,
+    WebCore::MediaPlayerEnums::SeekResult::Unknown,
+    WebCore::MediaPlayerEnums::SeekResult::Cancelled,
+    WebCore::MediaPlayerEnums::SeekResult::Completed
     >;
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -121,10 +121,22 @@ public:
 
     virtual MediaTime getStartDate() const { return MediaTime::createWithDouble(std::numeric_limits<double>::quiet_NaN()); }
 
+    using SeekCompletion = CompletionHandler<void(MediaPlayerEnums::SeekResult)>;
+
     virtual void seek(float) { }
     virtual void seekDouble(double time) { seek(time); }
     virtual void seek(const MediaTime& time) { seekDouble(time.toDouble()); }
+    virtual void seek(const MediaTime& time, SeekCompletion&& completion)
+    {
+        seek(time);
+        completion(MediaPlayerEnums::SeekResult::Unknown);
+    }
     virtual void seekWithTolerance(const MediaTime& time, const MediaTime&, const MediaTime&) { seek(time); }
+    virtual void seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&& completion)
+    {
+        seekWithTolerance(time, negativeTolerance, positiveTolerance);
+        completion(MediaPlayerEnums::SeekResult::Unknown);
+    }
 
     virtual bool seeking() const = 0;
 

--- a/Source/WebCore/platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.h
@@ -90,7 +90,7 @@ private:
 
     void setRate(float) override;
     double rate() const override;
-    virtual void seekToTime(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance);
+    virtual void seekToTime(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&&);
     virtual unsigned long long totalBytes() const;
     virtual std::unique_ptr<PlatformTimeRanges> platformBufferedTimeRanges() const;
     virtual MediaTime platformMinTimeSeekable() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -211,7 +211,7 @@ private:
     double effectiveRate() const final;
     void setPreservesPitch(bool) final;
     void setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm) final;
-    void seekToTime(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance) final;
+    void seekToTime(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&&) final;
     unsigned long long totalBytes() const final;
     std::unique_ptr<PlatformTimeRanges> platformBufferedTimeRanges() const final;
     MediaTime platformMinTimeSeekable() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -87,6 +87,7 @@ public:
     void seekInternal();
     void waitForSeekCompleted();
     void seekCompleted();
+    void finishSeek();
     void setLoadingProgresssed(bool flag) { m_loadingProgressed = flag; }
     void setHasAvailableVideoFrame(bool);
     bool hasAvailableVideoFrame() const override;
@@ -202,7 +203,7 @@ private:
     MediaTime startTime() const override;
     MediaTime initialTime() const override;
 
-    void seekWithTolerance(const MediaTime&, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold) override;
+    void seekWithTolerance(const MediaTime&, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold, SeekCompletion&&) override;
     bool seeking() const override;
     void setRateDouble(double) override;
     double rate() const override;
@@ -288,15 +289,17 @@ private:
 
     struct PendingSeek {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
-        PendingSeek(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold)
+        PendingSeek(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold, SeekCompletion&& seekCompletion)
             : targetTime(targetTime)
             , negativeThreshold(negativeThreshold)
             , positiveThreshold(positiveThreshold)
+            , seekCompletion(WTFMove(seekCompletion))
         {
         }
         MediaTime targetTime;
         MediaTime negativeThreshold;
         MediaTime positiveThreshold;
+        SeekCompletion seekCompletion;
     };
     std::unique_ptr<PendingSeek> m_pendingSeek;
 
@@ -340,6 +343,7 @@ private:
     bool m_playing;
     bool m_seeking;
     SeekState m_seekCompleted { SeekCompleted };
+    std::unique_ptr<SeekCompletion> m_seekCompletion;
     mutable bool m_loadingProgressed;
     bool m_hasBeenAskedToPaintGL { false };
     bool m_hasAvailableVideoFrame { false };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -205,14 +205,14 @@ void RemoteMediaPlayerProxy::pause()
     sendCachedState();
 }
 
-void RemoteMediaPlayerProxy::seek(const MediaTime& time)
+void RemoteMediaPlayerProxy::seek(const MediaTime& time, SeekCompletion&& seekCompletion)
 {
-    m_player->seek(time);
+    m_player->seek(time, WTFMove(seekCompletion));
 }
 
-void RemoteMediaPlayerProxy::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance)
+void RemoteMediaPlayerProxy::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&& seekCompletion)
 {
-    m_player->seekWithTolerance(time, negativeTolerance, positiveTolerance);
+    m_player->seekWithTolerance(time, negativeTolerance, positiveTolerance, WTFMove(seekCompletion));
 }
 
 void RemoteMediaPlayerProxy::setVolume(double volume)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -145,8 +145,9 @@ public:
     void play();
     void pause();
 
-    void seek(const MediaTime&);
-    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance);
+    using SeekCompletion = WebCore::MediaPlayer::SeekCompletion;
+    void seek(const MediaTime&, SeekCompletion&&);
+    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&&);
 
     void setVolume(double);
     void setMuted(bool);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -40,8 +40,8 @@ messages -> RemoteMediaPlayerProxy NotRefCounted {
     SetVolume(double volume)
     SetMuted(bool muted)
 
-    Seek(MediaTime time)
-    SeekWithTolerance(MediaTime time, MediaTime negativeTolerance, MediaTime positiveTolerance)
+    Seek(MediaTime time) -> (WebCore::MediaPlayerEnums::SeekResult result)
+    SeekWithTolerance(MediaTime time, MediaTime negativeTolerance, MediaTime positiveTolerance) -> (WebCore::MediaPlayerEnums::SeekResult result)
 
     SetPreload(enum:uint8_t WebCore::MediaPlayerEnums::Preload preload)
     SetPrivateBrowsingMode(bool privateMode)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -291,18 +291,18 @@ MediaTime MediaPlayerPrivateRemote::currentMediaTime() const
     return std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), durationMediaTime());
 }
 
-void MediaPlayerPrivateRemote::seek(const MediaTime& time)
+void MediaPlayerPrivateRemote::seek(const MediaTime& time, SeekCompletion&& seekCompletion)
 {
     m_seeking = true;
     m_cachedMediaTime = time;
-    connection().send(Messages::RemoteMediaPlayerProxy::Seek(time), m_id);
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Seek(time), WTFMove(seekCompletion), m_id);
 }
 
-void MediaPlayerPrivateRemote::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance)
+void MediaPlayerPrivateRemote::seekWithTolerance(const MediaTime& time, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&& seekCompletion)
 {
     m_seeking = true;
     m_cachedMediaTime = time;
-    connection().send(Messages::RemoteMediaPlayerProxy::SeekWithTolerance(time, negativeTolerance, positiveTolerance), m_id);
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::SeekWithTolerance(time, negativeTolerance, positiveTolerance), WTFMove(seekCompletion), m_id);
 }
 
 bool MediaPlayerPrivateRemote::didLoadingProgress() const

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -258,8 +258,8 @@ private:
 
     MediaTime getStartDate() const final;
 
-    void seek(const MediaTime&) final;
-    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance) final;
+    void seek(const MediaTime&, SeekCompletion&&) final;
+    void seekWithTolerance(const MediaTime&, const MediaTime& negativeTolerance, const MediaTime& positiveTolerance, SeekCompletion&&) final;
 
     bool seeking() const final { return m_seeking; }
 


### PR DESCRIPTION
#### eaaeab5f02541539baf7aab2f4cb6ea07f083aa5
<pre>
Introduce a SeekCompletion callback for MediaPlayer seek commands <a href="https://bugs.webkit.org/show_bug.cgi?id=238821">https://bugs.webkit.org/show_bug.cgi?id=238821</a>

Reviewed by NOBODY (OOPS!).

Currently, when issuing a seek command, HTMLMediaElement will wait for a subsequent timeUpdate
notification to indicate that seeking is complete. Rather than relying on potentially complicated
state management to determine whether a seek has finished, MediaPlayer can now support passing
in a CompletionHandler, and using the resulting callback to determine that a seek has completed,
failed, cancelled, etc.

In this patch, the Cocoa port will adopt this new SeekCompletion callback, leaving the existing
behavior in place for other ports.

* html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged):
* platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::seekWithTolerance):
(WebCore::MediaPlayer::seek):
* platform/graphics/MediaPlayer.h:
* platform/graphics/MediaPlayerEnums.h:
* platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::seek):
(WebCore::MediaPlayerPrivateInterface::seekWithTolerance):
* platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::seek):
(WebCore::MediaPlayerPrivateAVFoundation::seekWithTolerance):
(WebCore::MediaPlayerPrivateAVFoundation::dispatchNotification):
(WebCore::MediaPlayerPrivateAVFoundation::seekCompleted): Deleted.
* platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::PendingSeek::PendingSeek):
* platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.cpp:
(WebCore::MediaPlayerPrivateAVFoundationCF::seekToTime):
(WebCore::AVFWrapper::~AVFWrapper):
(WebCore::AVFWrapper::seekCompletedCallback):
(WebCore::AVFWrapper::seekToTime):
* platform/graphics/avfoundation/cf/MediaPlayerPrivateAVFoundationCF.h:
* platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::seekToTime):
* platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::PendingSeek::PendingSeek):
* platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekWithTolerance):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekCompleted):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::finishSeek):
</pre>