### PR TITLE
Make the StringView(const char*) constructor explicit

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -825,7 +825,7 @@ static URL currentWorkingDirectory()
     DWORD lengthNotIncludingNull = ::GetCurrentDirectoryW(bufferLength, buffer.data());
     String directoryString(buffer.data(), lengthNotIncludingNull);
     // We don't support network path like \\host\share\<path name>.
-    if (directoryString.startsWith("\\\\"))
+    if (directoryString.startsWith("\\\\"_s))
         return { };
 
 #else

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -548,7 +548,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
     }
 #endif
 
-    for (auto logLevelComponent : StringView(logLevel).split(',')) {
+    for (auto logLevelComponent : StringView::fromLatin1(logLevel).split(',')) {
         auto componentInfo = logLevelComponent.split('=');
         auto it = componentInfo.begin();
         if (it == componentInfo.end())

--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -70,7 +70,7 @@ static size_t computeMemoryFootprint()
             }
             if (scannedCount == 7) {
                 StringView pathString(path);
-                isAnonymous = pathString == "[heap]" || pathString.startsWith("[stack");
+                isAnonymous = pathString == "[heap]"_s || pathString.startsWith("[stack"_s);
                 return;
             }
         }

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -234,7 +234,7 @@ inline void StringBuilder::appendSubstring(const String& string, unsigned offset
 
 inline void StringBuilder::append(const char* characters)
 {
-    append(StringView { characters });
+    append(StringView::fromLatin1(characters));
 }
 
 inline void StringBuilder::appendCharacter(UChar32 c)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -70,7 +70,7 @@ public:
     StringView(ASCIILiteral);
 
     // FIXME: Make private once all call sites have been ported to fromLatin1.
-    StringView(const char*);
+    explicit StringView(const char*);
 
     ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -215,7 +215,7 @@ bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& config
     for (auto& server : configuration.iceServers) {
         bool stunSet = false;
         for (auto& url : server.urls) {
-            if (url.protocol().startsWith("turn")) {
+            if (url.protocol().startsWith("turn"_s)) {
                 auto valid = makeStringByReplacingAll(url.string().isolatedCopy(), "turn:"_s, "turn://"_s);
                 valid = makeStringByReplacingAll(valid, "turns:"_s, "turns://"_s);
                 URL validURL(URL(), valid);
@@ -229,7 +229,7 @@ bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& config
                 if (!result)
                     GST_WARNING("Unable to use TURN server: %s", validURL.string().utf8().data());
             }
-            if (!stunSet && url.protocol().startsWith("stun")) {
+            if (!stunSet && url.protocol().startsWith("stun"_s)) {
                 auto valid = makeStringByReplacingAll(url.string().isolatedCopy(), "stun:"_s, "stun://"_s);
                 URL validURL(URL(), valid);
                 // FIXME: libnice currently doesn't seem to handle IPv6 addresses very well.
@@ -923,7 +923,7 @@ void GStreamerMediaEndpoint::addIceCandidate(GStreamerIceCandidate& candidate, P
 {
     GST_DEBUG_OBJECT(m_pipeline.get(), "Adding ICE candidate %s", candidate.candidate.utf8().data());
 
-    if (!candidate.candidate.startsWith("candidate:")) {
+    if (!candidate.candidate.startsWith("candidate:"_s)) {
         callOnMainThread([task = createSharedTask<PeerConnectionBackend::AddIceCandidateCallbackFunction>(WTFMove(callback))]() mutable {
             task->run(Exception { OperationError, "Expect line: candidate:<candidate-str>"_s });
         });

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -96,7 +96,7 @@ bool GStreamerRtpTransceiverBackend::stopped() const
 
 static inline WARN_UNUSED_RETURN ExceptionOr<GstCaps*> toRtpCodecCapability(const RTCRtpCodecCapability& codec)
 {
-    if (!codec.mimeType.startsWith("video/") && !codec.mimeType.startsWith("audio/"))
+    if (!codec.mimeType.startsWith("video/"_s) && !codec.mimeType.startsWith("audio/"_s))
         return Exception { InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };
 
     auto components = codec.mimeType.split('/');

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -203,7 +203,7 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
 {
     ensureDebugCategoryInitialized();
     GST_DEBUG("Parsing ICE Candidate: %s", sdp.utf8().data());
-    if (!sdp.startsWith("candidate:"))
+    if (!sdp.startsWith("candidate:"_s))
         return { };
 
     String foundation;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -84,9 +84,9 @@ bool LibWebRTCRtpTransceiverBackend::stopped() const
 static inline ExceptionOr<webrtc::RtpCodecCapability> toRtpCodecCapability(const RTCRtpCodecCapability& codec)
 {
     webrtc::RtpCodecCapability rtcCodec;
-    if (codec.mimeType.startsWith("video/"))
+    if (codec.mimeType.startsWith("video/"_s))
         rtcCodec.kind = cricket::MEDIA_TYPE_VIDEO;
-    else if (codec.mimeType.startsWith("audio/"))
+    else if (codec.mimeType.startsWith("audio/"_s))
         rtcCodec.kind = cricket::MEDIA_TYPE_AUDIO;
     else
         return Exception { InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -57,14 +57,14 @@ namespace WebCore::ContentExtensions {
 #else
 static void makeSecureIfNecessary(ContentRuleListResults& results, const URL& url, const URL& redirectFrom = { })
 {
-    if (redirectFrom.host() == url.host() && redirectFrom.protocolIs("https"))
+    if (redirectFrom.host() == url.host() && redirectFrom.protocolIs("https"_s))
         return;
 
-    if (!url.protocolIs("http"))
+    if (!url.protocolIs("http"_s))
         return;
-    if (url.host() == "www.opengl.org"
-        || url.host() == "webkit.org"
-        || url.host() == "download")
+    if (url.host() == "www.opengl.org"_s
+        || url.host() == "webkit.org"_s
+        || url.host() == "download"_s)
         results.summary.madeHTTPS = true;
 }
 #endif

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -129,13 +129,13 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {
         const auto& nameA = a.key;
         const auto& nameB = b.key;
-        if (nameA.startsWith("--"))
-            return nameB.startsWith("--") && codePointCompareLessThan(nameA, nameB);
+        if (nameA.startsWith("--"_s))
+            return nameB.startsWith("--"_s) && codePointCompareLessThan(nameA, nameB);
 
-        if (nameA.startsWith("-"))
-            return nameB.startsWith("--") || (nameB.startsWith("-") && codePointCompareLessThan(nameA, nameB));
+        if (nameA.startsWith('-'))
+            return nameB.startsWith("--"_s) || (nameB.startsWith('-') && codePointCompareLessThan(nameA, nameB));
 
-        return nameB.startsWith("-") || codePointCompareLessThan(nameA, nameB);
+        return nameB.startsWith('-') || codePointCompareLessThan(nameA, nameB);
     });
 
     return values;

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(DatasetDOMStringMap);
 
 static bool isValidAttributeName(const String& name)
 {
-    if (!name.startsWith("data-"))
+    if (!name.startsWith("data-"_s))
         return false;
 
     unsigned length = name.length();
@@ -73,7 +73,7 @@ static String convertAttributeNameToPropertyName(const String& name)
 
 static bool propertyNameMatchesAttributeName(const String& propertyName, const String& attributeName)
 {
-    if (!attributeName.startsWith("data-"))
+    if (!attributeName.startsWith("data-"_s))
         return false;
 
     unsigned propertyLength = propertyName.length();

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -428,10 +428,10 @@ static String viewportErrorMessage(ViewportErrorCode errorCode, StringView repla
 {
     String message = viewportErrorMessageTemplate(errorCode);
     if (!replacement1.isNull())
-        message = makeStringByReplacingAll(message, "%replacement1", replacement1);
+        message = makeStringByReplacingAll(message, "%replacement1"_s, replacement1);
     // FIXME: This will do the wrong thing if replacement1 contains the substring "%replacement2".
     if (!replacement2.isNull())
-        message = makeStringByReplacingAll(message, "%replacement2", replacement2);
+        message = makeStringByReplacingAll(message, "%replacement2"_s, replacement2);
 
     if ((errorCode == UnrecognizedViewportArgumentValueError || errorCode == TruncatedViewportArgumentValueError) && replacement1.contains(';'))
         message = makeString(message, " Note that ';' is not a separator in viewport values. The list should be comma-separated."_s);

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -833,7 +833,7 @@ bool HTMLConverterCaches::elementHasOwnBackgroundColor(Element& element)
         return false;
     // In the text system, text blocks (table elements) and documents (body elements)
     // have their own background colors, which should not be inherited.
-    return element.hasTagName(htmlTag) || element.hasTagName(bodyTag) || propertyValueForNode(element, CSSPropertyDisplay).startsWith("table");
+    return element.hasTagName(htmlTag) || element.hasTagName(bodyTag) || propertyValueForNode(element, CSSPropertyDisplay).startsWith("table"_s);
 }
 
 Element* HTMLConverter::_blockLevelElementForNode(Node* node)

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -135,7 +135,7 @@ static bool canCacheFrame(Frame& frame, DiagnosticLoggingClient& diagnosticLoggi
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isErrorPageKey());
         isCacheable = false;
     }
-    if (frame.isMainFrame() && frame.document() && frame.document()->url().protocolIs("https") && documentLoader->response().cacheControlContainsNoStore()) {
+    if (frame.isMainFrame() && frame.document() && frame.document()->url().protocolIs("https"_s) && documentLoader->response().cacheControlContainsNoStore()) {
         PCLOG("   -Frame is HTTPS, and cache control prohibits storing");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::httpsNoStoreKey());
         isCacheable = false;

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -197,7 +197,7 @@ static std::optional<std::optional<uint16_t>> parsePort(StringView string, Strin
 void URLDecomposition::setPort(StringView value)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIs("file") || !fullURL.canSetHostOrPort())
+    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIs("file"_s) || !fullURL.canSetHostOrPort())
         return;
     auto port = parsePort(value, fullURL.protocol());
     if (!port)

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -323,7 +323,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these charecters it is invalid.
-    if (line.startsWith("REGION") && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASpace>()) {
+    if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASpace>()) {
         m_currentRegion = VTTRegion::create(m_document);
         return true;
     }
@@ -396,7 +396,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         auto selector = selectorList.selectorAt(0);
         auto selectorText = selector->selectorText();
         
-        bool isCue = selectorText == "::cue" || selectorText.startsWith("::cue(");
+        bool isCue = selectorText == "::cue"_s || selectorText.startsWith("::cue("_s);
         if (!isCue)
             return true;
 

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -42,7 +42,7 @@ static constexpr auto privateClickMeasurementTriggerAttributionPath = "/.well-kn
 static const char privateClickMeasurementTokenSignaturePath[] = "/.well-known/private-click-measurement/sign-unlinkable-token/";
 static const char privateClickMeasurementTokenPublicKeyPath[] = "/.well-known/private-click-measurement/get-token-public-key/";
 static const char privateClickMeasurementReportAttributionPath[] = "/.well-known/private-click-measurement/report-attribution/";
-static const char privateClickMeasurementToSKAdNetworkURLPrefix[] = "https://apps.apple.com/app/apple-store/id";
+static constexpr auto privateClickMeasurementToSKAdNetworkURLPrefix = "https://apps.apple.com/app/apple-store/id"_s;
 const size_t privateClickMeasurementAttributionTriggerDataPathSegmentSize = 2;
 const size_t privateClickMeasurementPriorityPathSegmentSize = 2;
 const uint8_t privateClickMeasurementVersion = 3;
@@ -181,7 +181,7 @@ Expected<PrivateClickMeasurement::AttributionTriggerData, String> PrivateClickMe
     if (path.isEmpty() || !path.startsWith(privateClickMeasurementTriggerAttributionPath))
         return makeUnexpected(nullString());
 
-    if (!redirectURL.protocolIs("https") || redirectURL.hasCredentials() || redirectURL.hasFragmentIdentifier())
+    if (!redirectURL.protocolIs("https"_s) || redirectURL.hasCredentials() || redirectURL.hasFragmentIdentifier())
         return makeUnexpected("[Private Click Measurement] Triggering event was not accepted because the URL's protocol is not HTTPS or the URL contains one or more of username, password, and fragment."_s);
 
     auto result = parseAttributionRequestQuery(redirectURL);
@@ -422,7 +422,7 @@ std::optional<uint64_t> PrivateClickMeasurement::appStoreURLAdamID(const URL& ur
     StringView stringView { url.string() };
     if (!stringView.startsWith(privateClickMeasurementToSKAdNetworkURLPrefix))
         return std::nullopt;
-    return parseInteger<uint64_t>(stringView.substring(strlen(privateClickMeasurementToSKAdNetworkURLPrefix)));
+    return parseInteger<uint64_t>(stringView.substring(privateClickMeasurementToSKAdNetworkURLPrefix.length()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -63,8 +63,8 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
     // Do not correct filenames that are reported with a mime type of tar, and 
     // have a filename which has .tar in it or ends in .tgz
     if ((mimeType == "application/tar" || mimeType == "application/x-tar")
-        && (String(filename).containsIgnoringASCIICase(".tar")
-        || String(filename).endsWithIgnoringASCIICase(".tgz"))) {
+        && (String(filename).containsIgnoringASCIICase(".tar"_s)
+        || String(filename).endsWithIgnoringASCIICase(".tgz"_s))) {
         return filename;
     }
 

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -597,7 +597,7 @@ void Chrome::didReceiveDocType(Frame& frame)
         return;
 
     auto* doctype = frame.document()->doctype();
-    m_client.didReceiveMobileDocType(doctype && doctype->publicId().containsIgnoringASCIICase("xhtml mobile"));
+    m_client.didReceiveMobileDocType(doctype && doctype->publicId().containsIgnoringASCIICase("xhtml mobile"_s));
 #endif
 }
 

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -75,7 +75,7 @@ UniqueRef<ParentalControlsContentFilter> ParentalControlsContentFilter::create()
 static inline bool canHandleResponse(const ResourceResponse& response)
 {
 #if HAVE(SYSTEM_HTTP_CONTENT_FILTERING)
-    return response.url().protocolIs("https");
+    return response.url().protocolIs("https"_s);
 #else
     return response.url().protocolIsInHTTPFamily();
 #endif

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1901,8 +1901,8 @@ String GraphicsContextGLANGLE::getUnmangledInfoLog(PlatformGLObject shaders[2], 
     // causes a warning in some compilers. There is no point showing
     // this warning to the user since they didn't write the code that
     // is causing it.
-    static constexpr char angleWarning[] = "WARNING: 0:1: extension 'GL_ARB_gpu_shader5' is not supported\n";
-    int startFrom = log.startsWith(angleWarning) ? strlen(angleWarning) : 0;
+    static constexpr auto angleWarning = "WARNING: 0:1: extension 'GL_ARB_gpu_shader5' is not supported\n"_s;
+    int startFrom = log.startsWith(angleWarning) ? angleWarning.length() : 0;
     processedLog.append(StringView(log).substring(startFrom, log.length() - startFrom));
 
     LOG(WebGL, "Unmangled ShaderInfoLog:\n%s", processedLog.toString().utf8().data());

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
@@ -46,7 +46,7 @@ namespace WebCore {
 
 auto CDMPrivateMediaSourceAVFObjC::parseKeySystem(const String& keySystem) -> std::optional<KeySystemParameters>
 {
-    static NeverDestroyed<RegularExpression> keySystemRE("^com\\.apple\\.fps\\.[23]_\\d+(?:,\\d+)*$", JSC::Yarr::TextCaseInsensitive);
+    static NeverDestroyed<RegularExpression> keySystemRE("^com\\.apple\\.fps\\.[23]_\\d+(?:,\\d+)*$"_s, JSC::Yarr::TextCaseInsensitive);
 
     if (keySystemRE.get().match(keySystem) < 0)
         return std::nullopt;

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -338,7 +338,7 @@ static String getFamilyNameStringFromFamily(const String& family)
 {
     // If we're creating a fallback font (e.g. "-webkit-monospace"), convert the name into
     // the fallback name (like "monospace") that fontconfig understands.
-    if (family.length() && !family.startsWith("-webkit-"))
+    if (family.length() && !family.startsWith("-webkit-"_s))
         return family;
 
     if (family == familyNamesData->at(FamilyNamesIndex::StandardFamily) || family == familyNamesData->at(FamilyNamesIndex::SerifFamily))

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -250,7 +250,7 @@ Vector<String> extractGStreamerOptionsFromCommandLine()
     Vector<String> options;
     auto optionsString = String::fromUTF8(contents.get(), length);
     optionsString.split('\0', [&options](StringView item) {
-        if (item.startsWith("--gst"))
+        if (item.startsWith("--gst"_s))
             options.append(item.toString());
     });
     return options;
@@ -500,9 +500,9 @@ bool isGStreamerPluginAvailable(const char* name)
     return plugin;
 }
 
-bool gstElementFactoryEquals(GstElement* element, const char* name)
+bool gstElementFactoryEquals(GstElement* element, ASCIILiteral name)
 {
-    return equal(GST_OBJECT_NAME(gst_element_get_factory(element)), name);
+    return name == GST_OBJECT_NAME(gst_element_get_factory(element));
 }
 
 GstElement* createAutoAudioSink(const String& role)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -309,7 +309,7 @@ void disconnectSimpleBusMessageCallback(GstElement*);
 enum class GstVideoDecoderPlatform { ImxVPU, Video4Linux, OpenMAX };
 
 bool isGStreamerPluginAvailable(const char* name);
-bool gstElementFactoryEquals(GstElement*, const char* name);
+bool gstElementFactoryEquals(GstElement*, ASCIILiteral name);
 
 GstElement* createAutoAudioSink(const String& role);
 GstElement* createPlatformAudioSink(const String& role);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -512,7 +512,7 @@ bool GStreamerRegistryScanner::isCodecSupported(Configuration configuration, con
     String codecName = slashIndex != notFound ? codec.substring(slashIndex + 1) : codec;
 
     bool supported = false;
-    if (codecName.startsWith("avc1"))
+    if (codecName.startsWith("avc1"_s))
         supported = isAVC1CodecSupported(configuration, codecName, shouldCheckForHardwareUse);
     else {
         auto& codecMap = configuration == Configuration::Decoding ? m_decoderCodecMap : m_encoderCodecMap;

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -104,7 +104,7 @@ bool ImageDecoderGStreamer::supportsContainerType(const String& type)
     if (!isInWebProcess())
         return false;
 
-    if (!type.startsWith("video/"))
+    if (!type.startsWith("video/"_s))
         return false;
 
     return GStreamerRegistryScanner::singleton().isContainerTypeSupported(GStreamerRegistryScanner::Configuration::Decoding, type);
@@ -115,7 +115,7 @@ bool ImageDecoderGStreamer::canDecodeType(const String& mimeType)
     if (mimeType.isEmpty())
         return false;
 
-    if (!mimeType.startsWith("video/"))
+    if (!mimeType.startsWith("video/"_s))
         return false;
 
     // Ideally this decoder should operate only from the WebProcess (or from the GPUProcess) which

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -75,6 +75,7 @@
 #include "AudioSourceProviderGStreamer.h"
 #endif
 
+#include <cstring>
 #include <glib.h>
 #include <gst/audio/streamvolume.h>
 #include <gst/gst.h>
@@ -2177,7 +2178,7 @@ void MediaPlayerPrivateGStreamer::configureDownloadBuffer(GstElement* element)
     g_object_set(element, "temp-template", newDownloadTemplate.get(), nullptr);
     GST_DEBUG_OBJECT(pipeline(), "Reconfigured file download template from '%s' to '%s'", oldDownloadTemplate.get(), newDownloadTemplate.get());
 
-    auto newDownloadPrefixPath = makeStringByReplacingAll(String::fromLatin1(newDownloadTemplate.get()), "XXXXXX", "");
+    auto newDownloadPrefixPath = makeStringByReplacingAll(String::fromLatin1(newDownloadTemplate.get()), "XXXXXX"_s, ""_s);
     purgeOldDownloadFiles(newDownloadPrefixPath);
 }
 
@@ -2593,7 +2594,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
         return result;
 
     // This player doesn't support pictures rendering.
-    if (parameters.type.raw().startsWith("image"))
+    if (parameters.type.raw().startsWith("image"_s))
         return result;
 
     auto& gstRegistryScanner = GStreamerRegistryScanner::singleton();
@@ -2705,7 +2706,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     // MSE and Mediastream require playbin3. Regular playback can use playbin3 on-demand with the
     // WEBKIT_GST_USE_PLAYBIN3 environment variable.
     const char* usePlaybin3 = g_getenv("WEBKIT_GST_USE_PLAYBIN3");
-    if ((isMediaSource() || url.protocolIs("mediastream") || (usePlaybin3 && equal(usePlaybin3, "1"))))
+    if (isMediaSource() || url.protocolIs("mediastream"_s) || (usePlaybin3 && !strcmp(usePlaybin3, "1")))
         playbinName = "playbin3";
 
     ASSERT(!m_pipeline);
@@ -2714,7 +2715,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     if (elementId.isEmpty())
         elementId = "media-player"_s;
 
-    const char* type = isMediaSource() ? "MSE-" : url.protocolIs("mediastream") ? "mediastream-" : "";
+    const char* type = isMediaSource() ? "MSE-" : url.protocolIs("mediastream"_s) ? "mediastream-" : "";
 
     m_isLegacyPlaybin = !g_strcmp0(playbinName, "playbin");
 
@@ -3725,7 +3726,7 @@ GstElement* MediaPlayerPrivateGStreamer::createVideoSinkDMABuf()
 GstElement* MediaPlayerPrivateGStreamer::createVideoSinkGL()
 {
     const char* disableGLSink = g_getenv("WEBKIT_GST_DISABLE_GL_SINK");
-    if (disableGLSink && equal(disableGLSink, "1")) {
+    if (disableGLSink && !strcmp(disableGLSink, "1")) {
         GST_INFO("Disabling hardware-accelerated rendering per user request.");
         return nullptr;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -183,7 +183,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
 #endif
 
     const char* value = g_getenv("WEBKIT_GST_ENABLE_AUDIO_MIXER");
-    if (value && equal(value, "1")) {
+    if (value && !strcmp(value, "1")) {
         if (!GStreamerAudioMixer::isAvailable()) {
             GST_WARNING("Internal audio mixing request cannot be fulfilled.");
             return false;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -142,13 +142,13 @@ AppendPipeline::AppendPipeline(SourceBufferPrivateGStreamer& sourceBufferPrivate
     const String& type = m_sourceBufferPrivate.type().containerType();
     GST_DEBUG("SourceBuffer containerType: %s", type.utf8().data());
     bool hasDemuxer = true;
-    if (type.endsWith("mp4") || type.endsWith("aac")) {
+    if (type.endsWith("mp4"_s) || type.endsWith("aac"_s)) {
         m_demux = makeGStreamerElement("qtdemux", nullptr);
         m_typefind = makeGStreamerElement("identity", nullptr);
-    } else if (type.endsWith("webm")) {
+    } else if (type.endsWith("webm"_s)) {
         m_demux = makeGStreamerElement("matroskademux", nullptr);
         m_typefind = makeGStreamerElement("identity", nullptr);
-    } else if (type == "audio/mpeg") {
+    } else if (type == "audio/mpeg"_s) {
         m_demux = makeGStreamerElement("identity", nullptr);
         m_typefind = makeGStreamerElement("typefind", nullptr);
         hasDemuxer = false;
@@ -690,7 +690,7 @@ std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipel
     GST_DEBUG_OBJECT(pipeline(), "Creating Track object for pad %" GST_PTR_FORMAT, demuxerSrcPad);
 
     const String& type = m_sourceBufferPrivate.type().containerType();
-    if (type.endsWith("webm"))
+    if (type.endsWith("webm"_s))
         gst_pad_add_probe(demuxerSrcPad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, matroskademuxForceSegmentStartToEqualZero, nullptr, nullptr);
 
     auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(demuxerSrcPad)).get());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -78,7 +78,7 @@ AtomString GStreamerMediaDescription::extractCodecName()
 
     // Report "H.264 (Main Profile)" and "H.264 (High Profile)" just as "H.264" to allow changes between both variants
     // go unnoticed to the SourceBuffer layer.
-    if (codecName.startsWith("H.264")) {
+    if (codecName.startsWith("H.264"_s)) {
         size_t braceStart = codecName.find(" ("_s);
         size_t braceEnd = codecName.find(')', braceStart + 1);
         if (braceStart != notFound && braceEnd != notFound) {

--- a/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
+++ b/Source/WebCore/platform/graphics/opengl/GraphicsContextGLOpenGL.cpp
@@ -1942,7 +1942,7 @@ void GraphicsContextGLOpenGL::getNonBuiltInActiveSymbolCount(PlatformGLObject pr
     for (GCGLint i = 0; i < attributeCount; ++i) {
         ActiveInfo info;
         getActiveAttribImpl(program, i, info);
-        if (info.name.startsWith("gl_"))
+        if (info.name.startsWith("gl_"_s))
             continue;
 
         symbolCounts.filteredToActualAttributeIndexMap.append(i);
@@ -1954,7 +1954,7 @@ void GraphicsContextGLOpenGL::getNonBuiltInActiveSymbolCount(PlatformGLObject pr
     for (GCGLint i = 0; i < uniformCount; ++i) {
         ActiveInfo info;
         getActiveUniformImpl(program, i, info);
-        if (info.name.startsWith("gl_"))
+        if (info.name.startsWith("gl_"_s))
             continue;
         
         symbolCounts.filteredToActualUniformIndexMap.append(i);
@@ -1967,7 +1967,7 @@ String GraphicsContextGLOpenGL::getUnmangledInfoLog(PlatformGLObject shaders[2],
 {
     LOG(WebGL, "Original ShaderInfoLog:\n%s", log.utf8().data());
 
-    JSC::Yarr::RegularExpression regExp("webgl_[0123456789abcdefABCDEF]+");
+    JSC::Yarr::RegularExpression regExp("webgl_[0123456789abcdefABCDEF]+"_s);
 
     StringBuilder processedLog;
     
@@ -1975,8 +1975,8 @@ String GraphicsContextGLOpenGL::getUnmangledInfoLog(PlatformGLObject shaders[2],
     // causes a warning in some compilers. There is no point showing
     // this warning to the user since they didn't write the code that
     // is causing it.
-    static constexpr char angleWarning[] = "WARNING: 0:1: extension 'GL_ARB_gpu_shader5' is not supported\n";
-    int startFrom = log.startsWith(angleWarning) ? strlen(angleWarning) : 0;
+    static constexpr auto angleWarning = "WARNING: 0:1: extension 'GL_ARB_gpu_shader5' is not supported\n"_s;
+    int startFrom = log.startsWith(angleWarning) ? angleWarning.length() : 0;
     int matchedLength = 0;
 
     do {

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -65,8 +65,8 @@ static StringView deviceNameForUserAgent()
 {
     if (isClassic()) {
         if (isClassicPad())
-            return "iPad";
-        return "iPhone";
+            return "iPad"_s;
+        return "iPhone"_s;
     }
 
     static NeverDestroyed<String> name = [] {

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -173,7 +173,7 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateGStreamer::containerPro
 
     const char* containerCapsDescription = "";
     auto containerType = contentType.containerType();
-    if (containerType.endsWith("mp4"))
+    if (containerType.endsWith("mp4"_s))
         containerCapsDescription = "video/quicktime, variant=iso";
     else
         containerCapsDescription = containerType.utf8().data();
@@ -181,7 +181,7 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateGStreamer::containerPro
     auto containerCaps = adoptGRef(gst_caps_from_string(containerCapsDescription));
     auto profile = adoptGRef(gst_encoding_container_profile_new(nullptr, nullptr, containerCaps.get(), nullptr));
 
-    if (containerType.endsWith("mp4"))
+    if (containerType.endsWith("mp4"_s))
         gst_encoding_profile_set_element_properties(GST_ENCODING_PROFILE(profile.get()), gst_structure_from_string("element-properties-map, map={[mp4mux,fragment-duration=1000,fragment-mode=0,streamable=0,force-create-timecode-trak=1]}", nullptr));
 
     auto codecs = contentType.codecs();
@@ -194,11 +194,11 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateGStreamer::containerPro
             videoCapsName = "video/x-vp9"_s;
         else if (codecs.contains("av1"_s))
             videoCapsName = "video/x-av1"_s;
-        else if (codecs.findIf([](auto& codec) { return codec.startsWith("avc1"); }) != notFound)
+        else if (codecs.findIf([](auto& codec) { return codec.startsWith("avc1"_s); }) != notFound)
             videoCapsName = "video/x-h264"_s;
-        else if (containerType.endsWith("webm"))
+        else if (containerType.endsWith("webm"_s))
             videoCapsName = "video/x-vp8"_s;
-        else if (containerType.endsWith("mp4"))
+        else if (containerType.endsWith("mp4"_s))
             videoCapsName = "video/x-h264"_s;
         else {
             GST_WARNING("Video codec for %s not supported", contentType.raw().utf8().data());
@@ -218,11 +218,11 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateGStreamer::containerPro
             audioCapsName = "audio/x-vorbis"_s;
         else if (codecs.contains("opus"_s))
             audioCapsName = "audio/x-opus"_s;
-        else if (codecs.findIf([](auto& codec) { return codec.startsWith("mp4a"); }) != notFound)
+        else if (codecs.findIf([](auto& codec) { return codec.startsWith("mp4a"_s); }) != notFound)
             audioCapsName = "audio/mpeg, mpegversion=4"_s;
-        else if (containerType.endsWith("webm"))
+        else if (containerType.endsWith("webm"_s))
             audioCapsName = "audio/x-vorbis"_s;
-        else if (containerType.endsWith("mp4"))
+        else if (containerType.endsWith("mp4"_s))
             audioCapsName = "audio/mpeg, mpegversion=4"_s;
         else {
             GST_WARNING("Audio codec for %s not supported", contentType.raw().utf8().data());

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -104,9 +104,9 @@ void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
     CaptureDevice::DeviceType type = deviceType();
     GUniquePtr<char> deviceClassChar(gst_device_get_device_class(device.get()));
     auto deviceClass = String::fromLatin1(deviceClassChar.get());
-    if (type == CaptureDevice::DeviceType::Microphone && !deviceClass.startsWith("Audio"))
+    if (type == CaptureDevice::DeviceType::Microphone && !deviceClass.startsWith("Audio"_s))
         return;
-    if (type == CaptureDevice::DeviceType::Camera && !deviceClass.startsWith("Video"))
+    if (type == CaptureDevice::DeviceType::Camera && !deviceClass.startsWith("Video"_s))
         return;
 
     // This isn't really a UID but should be good enough (libwebrtc

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -54,7 +54,7 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
     GST_DEBUG_OBJECT(m_bin.get(), "Outgoing audio source payload caps: %" GST_PTR_FORMAT, caps.get());
     auto* structure = gst_caps_get_structure(caps.get(), 0);
     if (const char* encodingName = gst_structure_get_string(structure, "encoding-name")) {
-        if (equal(encodingName, "OPUS")) {
+        if (!strcmp(encodingName, "OPUS")) {
             m_encoder = makeGStreamerElement("opusenc", nullptr);
             m_payloader = makeGStreamerElement("rtpopuspay", nullptr);
             if (!m_encoder || !m_payloader)
@@ -67,11 +67,11 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
                 if (!strcmp(useInbandFec, "1"))
                     g_object_set(m_encoder.get(), "inband-fec", true, nullptr);
             }
-        } else if (equal(encodingName, "G722")) {
+        } else if (!strcmp(encodingName, "G722")) {
             m_payloader = makeGStreamerElement("rtpg722pay", nullptr);
             if (!m_payloader)
                 return false;
-        } else if (equal(encodingName, "PCMA") || equal(encodingName, "PCMU")) {
+        } else if (!strcmp(encodingName, "PCMA") || !strcmp(encodingName, "PCMU")) {
             auto payloaderName = makeString("rtp", encodingName, "pay");
             m_payloader = makeGStreamerElement(payloaderName.convertToASCIILowercase().ascii().data(), nullptr);
             m_encoder = makeGStreamerElement("alawenc", nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -45,11 +45,11 @@ RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer(Ref<M
         auto* source = reinterpret_cast<RealtimeOutgoingVideoSourceGStreamer*>(userData);
         const char* name = gst_structure_get_name(structure);
         const char* encodingName = nullptr;
-        if (equal(name, "video/x-vp8"))
+        if (!strcmp(name, "video/x-vp8"))
             encodingName = "VP8";
-        else if (equal(name, "video/x-vp9"))
+        else if (!strcmp(name, "video/x-vp9"))
             encodingName = "VP9";
-        else if (equal(name, "video/x-h264"))
+        else if (!strcmp(name, "video/x-h264"))
             encodingName = "H264";
         if (encodingName)
             gst_caps_append_structure(source->m_allowedCaps.get(), gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, "video", "encoding-name", G_TYPE_STRING, encodingName, "clock-rate", G_TYPE_INT, 90000, nullptr));
@@ -65,13 +65,13 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
     auto* structure = gst_caps_get_structure(caps.get(), 0);
     GRefPtr<GstCaps> encoderCaps;
     if (const char* encodingName = gst_structure_get_string(structure, "encoding-name")) {
-        if (equal(encodingName, "VP8")) {
+        if (!strcmp(encodingName, "VP8")) {
             encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp8"));
             m_payloader = makeGStreamerElement("rtpvp8pay", nullptr);
-        } else if (equal(encodingName, "VP9")) {
+        } else if (!strcmp(encodingName, "VP9")) {
             encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
             m_payloader = makeGStreamerElement("rtpvp9pay", nullptr);
-        } else if (equal(encodingName, "H264")) {
+        } else if (!strcmp(encodingName, "H264")) {
             encoderCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
             m_payloader = makeGStreamerElement("rtph264pay", nullptr);
             // FIXME: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/issues/893

--- a/Source/WebCore/platform/network/cf/NetworkStorageSessionCFNetWin.cpp
+++ b/Source/WebCore/platform/network/cf/NetworkStorageSessionCFNetWin.cpp
@@ -322,7 +322,7 @@ bool NetworkStorageSession::getRawCookies(const URL& firstParty, const SameSiteI
     UNUSED_PARAM(pageID);
     rawCookies.clear();
     
-    auto includeSecureCookies = url.protocolIs("https") ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
+    auto includeSecureCookies = url.protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
     
     RetainPtr<CFArrayRef> cookiesCF = copyCookiesForURLWithFirstPartyURL(*this, firstParty, url, includeSecureCookies);
     
@@ -353,7 +353,7 @@ void NetworkStorageSession::deleteCookie(const URL& url, const String& name) con
     
     RetainPtr<CFURLRef> urlCF = url.createCFURL();
     
-    bool sendSecureCookies = url.protocolIs("https");
+    bool sendSecureCookies = url.protocolIs("https"_s);
     RetainPtr<CFArrayRef> cookiesCF = adoptCF(CFHTTPCookieStorageCopyCookiesForURL(cookieStorage.get(), urlCF.get(), sendSecureCookies));
     
     CFIndex count = CFArrayGetCount(cookiesCF.get());

--- a/Source/WebCore/platform/network/curl/AuthenticationChallengeCurl.cpp
+++ b/Source/WebCore/platform/network/curl/AuthenticationChallengeCurl.cpp
@@ -48,11 +48,11 @@ AuthenticationChallenge::AuthenticationChallenge(const URL& url, const Certifica
 
 ProtectionSpace::ServerType AuthenticationChallenge::protectionSpaceServerTypeFromURI(const URL& url, bool isForProxy)
 {
-    if (url.protocolIs("https"))
+    if (url.protocolIs("https"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyHTTPS : ProtectionSpace::ServerType::HTTPS;
-    if (url.protocolIs("http"))
+    if (url.protocolIs("http"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyHTTP : ProtectionSpace::ServerType::HTTP;
-    if (url.protocolIs("ftp"))
+    if (url.protocolIs("ftp"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyFTP : ProtectionSpace::ServerType::FTP;
     return isForProxy ? ProtectionSpace::ServerType::ProxyHTTP : ProtectionSpace::ServerType::HTTP;
 }

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -490,11 +490,11 @@ bool CookieJarDB::hasHttpOnlyCookie(const String& name, const String& domain, co
 
 static bool checkSecureCookie(const Cookie& cookie)
 {
-    if (cookie.name.startsWith("__Secure-") && !cookie.secure)
+    if (cookie.name.startsWith("__Secure-"_s) && !cookie.secure)
         return false;
 
     // Cookies for __Host must have the Secure attribute, path explicitly set to "/", and no domain attribute
-    if (cookie.name.startsWith("__Host-") && (!cookie.secure || cookie.path != "/"_s || !cookie.domain.isEmpty()))
+    if (cookie.name.startsWith("__Host-"_s) && (!cookie.secure || cookie.path != "/"_s || !cookie.domain.isEmpty()))
         return false;
 
     return true;

--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -416,7 +416,7 @@ void CurlHandle::setUrl(const URL& url)
     // url is in ASCII so latin1() will only convert it to char* without character translation.
     curl_easy_setopt(m_handle, CURLOPT_URL, curlUrl.string().latin1().data());
 
-    if (url.protocolIs("https"))
+    if (url.protocolIs("https"_s))
         enableSSLForHost(m_url.host().toString());
 }
 
@@ -470,7 +470,7 @@ void CurlHandle::enableRequestHeaders()
 
 void CurlHandle::enableHttp()
 {
-    if (m_url.protocolIs("https") && CurlContext::singleton().isHttp2Enabled()) {
+    if (m_url.protocolIs("https"_s) && CurlContext::singleton().isHttp2Enabled()) {
         curl_easy_setopt(m_handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
         curl_easy_setopt(m_handle, CURLOPT_PIPEWAIT, 1L);
         curl_easy_setopt(m_handle, CURLOPT_SSL_ENABLE_ALPN, 1L);

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -79,7 +79,7 @@ std::optional<String> CurlMultipartHandle::extractBoundaryFromContentType(const 
 {
     static const size_t length = strlen("boundary=");
 
-    auto boundaryStart = contentType.findIgnoringASCIICase("boundary=");
+    auto boundaryStart = contentType.findIgnoringASCIICase("boundary="_s);
     if (boundaryStart == notFound)
         return std::nullopt;
 

--- a/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
+++ b/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
@@ -47,7 +47,7 @@ CurlProxySettings::CurlProxySettings(URL&& proxyUrl, String&& ignoreHosts)
     , m_ignoreHosts(WTFMove(ignoreHosts))
 {
     if (m_url.protocol().isEmpty())
-        m_url.setProtocol("http");
+        m_url.setProtocol("http"_s);
 
     rebuildUrl();
 }
@@ -86,7 +86,7 @@ void CurlProxySettings::setAuthMethod(long authMethod)
 
 bool protocolIsInSocksFamily(const URL& url)
 {
-    return url.protocolIs("socks4") || url.protocolIs("socks4a") || url.protocolIs("socks5") || url.protocolIs("socks5h");
+    return url.protocolIs("socks4"_s) || url.protocolIs("socks4a"_s) || url.protocolIs("socks5"_s) || url.protocolIs("socks5h"_s);
 }
 
 static std::optional<uint16_t> getProxyPort(const URL& url)

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -531,7 +531,7 @@ int CurlRequest::didReceiveDebugInfo(curl_infotype type, char* data, size_t size
 
     if (type == CURLINFO_HEADER_OUT) {
         String requestHeader(data, size);
-        auto headerFields = requestHeader.split("\r\n");
+        auto headerFields = requestHeader.split("\r\n"_s);
         // Remove the request line
         if (headerFields.size())
             headerFields.remove(0);

--- a/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
+++ b/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
@@ -87,11 +87,11 @@ void CurlResourceHandleDelegate::curlDidSendData(CurlRequest&, unsigned long lon
 
 static void handleCookieHeaders(ResourceHandleInternal* d, const ResourceRequest& request, const CurlResponse& response)
 {
-    static const auto setCookieHeader = "set-cookie: ";
+    static constexpr auto setCookieHeader = "set-cookie: "_s;
 
     for (const auto& header : response.headers) {
         if (header.startsWithIgnoringASCIICase(setCookieHeader)) {
-            const auto contents = header.right(header.length() - strlen(setCookieHeader));
+            const auto contents = header.right(header.length() - setCookieHeader.length());
             d->m_context->storageSession()->setCookiesFromHTTPResponse(request.firstPartyForCookies(), response.url, contents);
         }
     }

--- a/Source/WebCore/platform/network/curl/CurlStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
@@ -42,7 +42,7 @@ CurlStream::CurlStream(CurlStreamScheduler& scheduler, CurlStreamID streamID, UR
 
     m_curlHandle = makeUnique<CurlHandle>();
 
-    url.setProtocol(url.protocolIs("wss") ? "https" : "http");
+    url.setProtocol(url.protocolIs("wss"_s) ? "https"_s : "http"_s);
     m_curlHandle->setUrl(WTFMove(url));
 
     m_curlHandle->enableConnectionOnly();

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 static String defaultCookieJarPath()
 {
-    static const char* defaultFileName = "cookie.jar.db";
+    static constexpr auto defaultFileName = "cookie.jar.db"_s;
     char* cookieJarPath = getenv("CURL_COOKIE_JAR_PATH");
     if (cookieJarPath)
         return String::fromUTF8(cookieJarPath);
@@ -49,7 +49,7 @@ static String defaultCookieJarPath()
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), defaultFileName);
 #else
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=192417
-    return String::fromLatin1(defaultFileName);
+    return defaultFileName;
 #endif
 }
 
@@ -58,7 +58,7 @@ static String cookiesForSession(const NetworkStorageSession& session, const URL&
     StringBuilder cookies;
 
     auto searchHTTPOnly = forHTTPHeader ? std::nullopt : std::optional<bool> { false };
-    auto secure = url.protocolIs("https") ? std::nullopt : std::optional<bool> { false };
+    auto secure = url.protocolIs("https"_s) ? std::nullopt : std::optional<bool> { false };
 
     if (auto result = session.cookieDatabase().searchCookies(firstParty, url, searchHTTPOnly, secure, std::nullopt)) {
         for (const auto& cookie : *result) {

--- a/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
@@ -143,7 +143,7 @@ Ref<CurlRequest> ResourceHandle::createCurlRequest(ResourceRequest&& request, Re
     if (status == RequestStatus::NewRequest) {
         addCacheValidationHeaders(request);
 
-        auto includeSecureCookies = request.url().protocolIs("https") ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
+        auto includeSecureCookies = request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
         String cookieHeaderField = d->m_context->storageSession()->cookieRequestHeaderFieldValue(request.firstPartyForCookies(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ShouldAskITP::Yes, ShouldRelaxThirdPartyCookieBlocking::No).first;
         if (!cookieHeaderField.isEmpty())
             request.addHTTPHeaderField(HTTPHeaderName::Cookie, cookieHeaderField);
@@ -530,7 +530,7 @@ void ResourceHandle::handleDataURL()
     String data = url.substring(index + 1);
     auto originalSize = data.length();
 
-    bool base64 = mediaType.endsWithIgnoringASCIICase(";base64");
+    bool base64 = mediaType.endsWithIgnoringASCIICase(";base64"_s);
     if (base64)
         mediaType = mediaType.left(mediaType.length() - 7);
 

--- a/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
+++ b/Source/WebCore/platform/network/curl/SocketStreamHandleImplCurl.cpp
@@ -50,7 +50,7 @@ SocketStreamHandleImpl::SocketStreamHandleImpl(const URL& url, SocketStreamHandl
     , m_scheduler(CurlContext::singleton().streamScheduler())
 {
     // FIXME: Using DeprecatedGlobalSettings from here is a layering violation.
-    if (m_url.protocolIs("wss") && DeprecatedGlobalSettings::allowsAnySSLCertificate())
+    if (m_url.protocolIs("wss"_s) && DeprecatedGlobalSettings::allowsAnySSLCertificate())
         CurlContext::singleton().sslHandle().setIgnoreSSLErrors(true);
 
     m_streamID = m_scheduler.createStream(m_url, *this);

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -225,10 +225,10 @@ static void append(Vector<char>& vector, const CString& string)
 // Find the markup between "<!--StartFragment -->" and "<!--EndFragment -->", accounting for browser quirks.
 static String extractMarkupFromCFHTML(const String& cfhtml)
 {
-    unsigned markupStart = cfhtml.findIgnoringASCIICase("<html");
-    unsigned tagStart = cfhtml.findIgnoringASCIICase("startfragment", markupStart);
+    unsigned markupStart = cfhtml.findIgnoringASCIICase("<html"_s);
+    unsigned tagStart = cfhtml.findIgnoringASCIICase("startfragment"_s, markupStart);
     unsigned fragmentStart = cfhtml.find('>', tagStart) + 1;
-    unsigned tagEnd = cfhtml.findIgnoringASCIICase("endfragment", fragmentStart);
+    unsigned tagEnd = cfhtml.findIgnoringASCIICase("endfragment"_s, fragmentStart);
     unsigned fragmentEnd = cfhtml.reverseFind('<', tagEnd);
     return cfhtml.substring(fragmentStart, fragmentEnd - fragmentStart).stripWhiteSpace();
 }

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -276,12 +276,12 @@ bool SessionHost::buildSessionCapabilities(GVariantBuilder* builder) const
             switch (m_capabilities.proxy->socksVersion.value()) {
             case 4:
                 if (URL::hostIsIPAddress(socksURL.host()))
-                    socksURL.setProtocol("socks4");
+                    socksURL.setProtocol("socks4"_s);
                 else
-                    socksURL.setProtocol("socks4a");
+                    socksURL.setProtocol("socks4a"_s);
                 break;
             case 5:
-                socksURL.setProtocol("socks5");
+                socksURL.setProtocol("socks5"_s);
                 break;
             default:
                 break;

--- a/Source/WebDriver/socket/HTTPParser.cpp
+++ b/Source/WebDriver/socket/HTTPParser.cpp
@@ -143,8 +143,8 @@ size_t HTTPParser::expectedBodyLength() const
     if (m_message.method == "HEAD")
         return 0;
 
-    const char* name = "content-length:";
-    const size_t nameLength = std::strlen(name);
+    constexpr auto name = "content-length:"_s;
+    const size_t nameLength = name.length();
 
     for (const auto& header : m_message.requestHeaders) {
         if (header.startsWithIgnoringASCIICase(name))

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
@@ -470,8 +470,8 @@ void ResourceLoadStatisticsDatabaseStore::migrateDataToPCMDatabaseIfNecessary()
     }
 
     auto transactionScope = beginTransactionIfNecessary();
-    deleteTable("UnattributedPrivateClickMeasurement");
-    deleteTable("AttributedPrivateClickMeasurement");
+    deleteTable("UnattributedPrivateClickMeasurement"_s);
+    deleteTable("AttributedPrivateClickMeasurement"_s);
 }
 
 void ResourceLoadStatisticsDatabaseStore::addMissingTablesIfNecessary()
@@ -958,11 +958,11 @@ Vector<WebResourceLoadStatisticsStore::ThirdPartyData> ResourceLoadStatisticsDat
     ASSERT(!RunLoop::isMain());
 
     Vector<WebResourceLoadStatisticsStore::ThirdPartyData> thirdPartyDataList;
-    const auto prevalentDomainsBindParameter = thirdPartyCookieBlockingMode() == ThirdPartyCookieBlockingMode::All ? "%" : "1";
+    const auto prevalentDomainsBindParameter = thirdPartyCookieBlockingMode() == ThirdPartyCookieBlockingMode::All ? "%"_s : "1"_s;
     auto sortedStatistics = m_database.prepareStatement(joinSubStatisticsForSorting());
     if (!sortedStatistics
         || sortedStatistics->bindText(1, prevalentDomainsBindParameter)
-        || sortedStatistics->bindText(2, "%") != SQLITE_OK) {
+        || sortedStatistics->bindText(2, "%"_s) != SQLITE_OK) {
         RELEASE_LOG_ERROR(Network, "ResourceLoadStatisticsDatabaseStore::aggregatedThirdPartyData, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return thirdPartyDataList;

--- a/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp
@@ -35,7 +35,7 @@ void NetworkSchemeRegistry::registerURLSchemeAsCORSEnabled(String&& scheme)
 
 bool NetworkSchemeRegistry::shouldTreatURLSchemeAsCORSEnabled(StringView scheme)
 {
-    if (scheme.startsWith("http"))
+    if (scheme.startsWith("http"_s))
         return scheme.length() == 4 || (scheme.length() == 5 && scheme[4] == 's');
     return m_corsEnabledSchemes.contains<StringViewHashTranslator>(scheme);
 }

--- a/Source/WebKit/NetworkProcess/WebStorage/LocalStorageDatabaseTracker.cpp
+++ b/Source/WebKit/NetworkProcess/WebStorage/LocalStorageDatabaseTracker.cpp
@@ -50,7 +50,7 @@ LocalStorageDatabaseTracker::LocalStorageDatabaseTracker(String&& localStorageDi
 {
     ASSERT(!RunLoop::isMain());
 
-    SQLiteFileSystem::deleteDatabaseFile(databasePath("StorageTracker.db"));
+    SQLiteFileSystem::deleteDatabaseFile(databasePath("StorageTracker.db"_s));
 }
 
 String LocalStorageDatabaseTracker::localStorageDirectory() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -79,7 +79,7 @@ void BlobStorage::synchronize()
 String BlobStorage::blobPathForHash(const SHA1::Digest& hash) const
 {
     auto hashAsString = SHA1::hexDigest(hash);
-    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), hashAsString.data());
+    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(hashAsString.data()));
 }
 
 BlobStorage::Blob BlobStorage::add(const String& path, const Data& data)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -49,11 +49,11 @@
 namespace WebKit {
 namespace NetworkCache {
 
-static const char saltFileName[] = "salt";
-static const char versionDirectoryPrefix[] = "Version ";
-static const char recordsDirectoryName[] = "Records";
-static const char blobsDirectoryName[] = "Blobs";
-static const char blobSuffix[] = "-blob";
+static constexpr auto saltFileName = "salt"_s;
+static constexpr auto versionDirectoryPrefix = "Version "_s;
+static constexpr auto recordsDirectoryName = "Records"_s;
+static constexpr auto blobsDirectoryName = "Blobs"_s;
+static constexpr auto blobSuffix = "-blob"_s;
 
 static inline size_t maximumInlineBodySize()
 {

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -516,7 +516,7 @@ void NetworkDataTaskCurl::restartWithCredential(const ProtectionSpace& protectio
 
 void NetworkDataTaskCurl::appendCookieHeader(WebCore::ResourceRequest& request)
 {
-    auto includeSecureCookies = request.url().protocolIs("https") ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
+    auto includeSecureCookies = request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
     auto cookieHeaderField = m_session->networkStorageSession()->cookieRequestHeaderFieldValue(request.firstPartyForCookies(), WebCore::SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ShouldAskITP::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
     if (!cookieHeaderField.isEmpty())
         request.addHTTPHeaderField(HTTPHeaderName::Cookie, cookieHeaderField);
@@ -524,11 +524,11 @@ void NetworkDataTaskCurl::appendCookieHeader(WebCore::ResourceRequest& request)
 
 void NetworkDataTaskCurl::handleCookieHeaders(const WebCore::ResourceRequest& request, const CurlResponse& response)
 {
-    static const auto setCookieHeader = "set-cookie: ";
+    static constexpr auto setCookieHeader = "set-cookie: "_s;
 
     for (auto header : response.headers) {
         if (header.startsWithIgnoringASCIICase(setCookieHeader)) {
-            String setCookieString = header.right(header.length() - strlen(setCookieHeader));
+            String setCookieString = header.right(header.length() - setCookieHeader.length());
             m_session->networkStorageSession()->setCookiesFromHTTPResponse(request.firstPartyForCookies(), response.url, setCookieString);
         }
     }

--- a/Source/WebKit/Platform/unix/EnvironmentUtilities.cpp
+++ b/Source/WebKit/Platform/unix/EnvironmentUtilities.cpp
@@ -60,7 +60,7 @@ void removeValuesEndingWith(const char* environmentVariable, const char* searchV
     if (!before)
         return;
 
-    auto after = stripEntriesEndingWith(before, searchValue);
+    auto after = stripEntriesEndingWith(StringView::fromLatin1(before), StringView::fromLatin1(searchValue));
     if (after.isEmpty()) {
         unsetenv(environmentVariable);
         return;

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -55,7 +55,7 @@ XPCEndpoint::XPCEndpoint()
 #if PLATFORM(MAC)
                 auto [signingIdentifier, isPlatformBinary] = codeSigningIdentifierAndPlatformBinaryStatus(connection.get());
 
-                if (!isPlatformBinary || !signingIdentifier.startsWith("com.apple.WebKit.WebContent")) {
+                if (!isPlatformBinary || !signingIdentifier.startsWith("com.apple.WebKit.WebContent"_s)) {
                     WTFLogAlways("XPC endpoint denied to connect with unknown client");
                     return;
                 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -96,7 +96,7 @@ bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehav
 
 bool XPCServiceInitializerDelegate::getProcessIdentifier(WebCore::ProcessIdentifier& identifier)
 {
-    auto parsedIdentifier = parseInteger<uint64_t>(xpc_dictionary_get_string(m_initializerMessage, "process-identifier"));
+    auto parsedIdentifier = parseInteger<uint64_t>(StringView::fromLatin1(xpc_dictionary_get_string(m_initializerMessage, "process-identifier")));
     if (!parsedIdentifier)
         return false;
 

--- a/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
+++ b/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
@@ -36,9 +36,9 @@ bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
 {
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "-clientIdentifier") && i + 1 < argc)
-            m_parameters.connectionIdentifier = reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(argv[++i]).value_or(0));
+            m_parameters.connectionIdentifier = reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0));
         else if (!strcmp(argv[i], "-processIdentifier") && i + 1 < argc)
-            m_parameters.processIdentifier = makeObjectIdentifier<WebCore::ProcessIdentifierType>(parseIntegerAllowingTrailingJunk<uint64_t>(argv[++i]).value_or(0));
+            m_parameters.processIdentifier = makeObjectIdentifier<WebCore::ProcessIdentifierType>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0));
         else if (!strcmp(argv[i], "-configure-jsc-for-testing"))
             JSC::Config::configureForTesting();
         else if (!strcmp(argv[i], "-disable-jit"))

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -82,13 +82,11 @@ ContentRuleListStore::ContentRuleListStore(const WTF::String& storePath)
 ContentRuleListStore::~ContentRuleListStore() = default;
 
 // FIXME: Remove legacyFilename in 2022 or 2023 after users have had a chance to run the updating logic.
-static const char* constructedPathPrefix(bool legacyFilename)
+static ASCIILiteral constructedPathPrefix(bool legacyFilename)
 {
-    static auto* prefix("ContentRuleList-");
-    static auto* legacyPrefix("ContentExtension-");
     if (legacyFilename)
-        return legacyPrefix;
-    return prefix;
+        return "ContentExtension-"_s;
+    return "ContentRuleList-"_s;
 }
 
 static WTF::String constructedPath(const WTF::String& base, const WTF::String& identifier, bool legacyFilename)

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -84,8 +84,8 @@ public:
     const Vector<WTF::String>& alwaysRevalidatedURLSchemes() { return m_alwaysRevalidatedURLSchemes; }
     void setAlwaysRevalidatedURLSchemes(Vector<WTF::String>&& alwaysRevalidatedURLSchemes) { m_alwaysRevalidatedURLSchemes = WTFMove(alwaysRevalidatedURLSchemes); }
 
-    const Vector<WTF::CString>& additionalReadAccessAllowedPaths() { return m_additionalReadAccessAllowedPaths; }
-    void setAdditionalReadAccessAllowedPaths(Vector<WTF::CString>&& additionalReadAccessAllowedPaths) { m_additionalReadAccessAllowedPaths = additionalReadAccessAllowedPaths; }
+    const Vector<WTF::String>& additionalReadAccessAllowedPaths() { return m_additionalReadAccessAllowedPaths; }
+    void setAdditionalReadAccessAllowedPaths(Vector<WTF::String>&& additionalReadAccessAllowedPaths) { m_additionalReadAccessAllowedPaths = additionalReadAccessAllowedPaths; }
 
     bool fullySynchronousModeIsAllowedForTesting() const { return m_fullySynchronousModeIsAllowedForTesting; }
     void setFullySynchronousModeIsAllowedForTesting(bool allowed) { m_fullySynchronousModeIsAllowedForTesting = allowed; }
@@ -172,7 +172,7 @@ private:
     Vector<WTF::String> m_customClassesForParameterCoder;
     Vector<WTF::String> m_cachePartitionedURLSchemes;
     Vector<WTF::String> m_alwaysRevalidatedURLSchemes;
-    Vector<WTF::CString> m_additionalReadAccessAllowedPaths;
+    Vector<WTF::String> m_additionalReadAccessAllowedPaths;
     bool m_fullySynchronousModeIsAllowedForTesting { false };
     bool m_ignoreSynchronousMessagingTimeoutsForTesting { false };
     bool m_attrStyleEnabled { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -158,19 +158,19 @@
         return @[ ];
 
     return createNSArray(paths, [] (auto& path) {
-        return [NSURL fileURLWithFileSystemRepresentation:path.data() isDirectory:NO relativeToURL:nil];
+        return [NSURL fileURLWithFileSystemRepresentation:path.utf8().data() isDirectory:NO relativeToURL:nil];
     }).autorelease();
 }
 
 - (void)setAdditionalReadAccessAllowedURLs:(NSArray<NSURL *> *)additionalReadAccessAllowedURLs
 {
-    Vector<CString> paths;
+    Vector<String> paths;
     paths.reserveInitialCapacity(additionalReadAccessAllowedURLs.count);
     for (NSURL *url in additionalReadAccessAllowedURLs) {
         if (!url.isFileURL)
             [NSException raise:NSInvalidArgumentException format:@"%@ is not a file URL", url];
 
-        paths.uncheckedAppend(url.fileSystemRepresentation);
+        paths.uncheckedAppend(String::fromUTF8(url.fileSystemRepresentation));
     }
 
     _processPoolConfiguration->setAdditionalReadAccessAllowedPaths(WTFMove(paths));

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -225,9 +225,9 @@ void WebPageProxy::createSandboxExtensionsIfNeeded(const Vector<String>& files, 
         if ([[NSFileManager defaultManager] fileExistsAtPath:files[0] isDirectory:&isDirectory] && !isDirectory) {
             ASSERT(process().connection() && process().connection()->getAuditToken());
             if (process().connection() && process().connection()->getAuditToken()) {
-                if (auto handle = SandboxExtension::createHandleForReadByAuditToken("/", *(process().connection()->getAuditToken())))
+                if (auto handle = SandboxExtension::createHandleForReadByAuditToken("/"_s, *(process().connection()->getAuditToken())))
                     fileReadHandle = WTFMove(*handle);
-            } else if (auto handle = SandboxExtension::createHandle("/", SandboxExtension::Type::ReadOnly))
+            } else if (auto handle = SandboxExtension::createHandle("/"_s, SandboxExtension::Type::ReadOnly))
                 fileReadHandle = WTFMove(*handle);
             willAcquireUniversalFileReadSandboxExtension(m_process);
         }
@@ -875,7 +875,7 @@ NSDictionary *WebPageProxy::contentsOfUserInterfaceItem(NSString *userInterfaceI
 #if PLATFORM(MAC)
 bool WebPageProxy::isQuarantinedAndNotUserApproved(const String& fileURLString)
 {
-    if (!fileURLString.endsWithIgnoringASCIICase(".webarchive"))
+    if (!fileURLString.endsWithIgnoringASCIICase(".webarchive"_s))
         return false;
 
     NSURL *fileURL = [NSURL URLWithString:fileURLString];

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -316,7 +316,7 @@ bool WebProcessProxy::messageSourceIsValidWebContentProcess()
     // Confirm that the connection is from a WebContent process:
     auto [signingIdentifier, isPlatformBinary] = codeSigningIdentifierAndPlatformBinaryStatus(connection()->xpcConnection());
 
-    if (!isPlatformBinary || !signingIdentifier.startsWith("com.apple.WebKit.WebContent")) {
+    if (!isPlatformBinary || !signingIdentifier.startsWith("com.apple.WebKit.WebContent"_s)) {
         RELEASE_LOG_ERROR(Process, "Process is not an entitled WebContent process.");
         return false;
     }

--- a/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp
+++ b/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp
@@ -258,10 +258,10 @@ void DeviceIdHashSaltStorage::getDeviceIdHashSaltOrigins(CompletionHandler<void(
 
 void DeviceIdHashSaltStorage::deleteHashSaltFromDisk(const HashSaltForOrigin& hashSaltForOrigin)
 {
-    m_queue->dispatch([this, protectedThis = Ref { *this }, deviceIdHashSalt = hashSaltForOrigin.deviceIdHashSalt.utf8()]() mutable {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, deviceIdHashSalt = hashSaltForOrigin.deviceIdHashSalt.isolatedCopy()]() mutable {
         ASSERT(!RunLoop::isMain());
 
-        String fileFullPath = FileSystem::pathByAppendingComponent(m_deviceIdHashSaltStorageDirectory, deviceIdHashSalt.data());
+        String fileFullPath = FileSystem::pathByAppendingComponent(m_deviceIdHashSaltStorageDirectory, deviceIdHashSalt);
         FileSystem::deleteFile(fileFullPath);
     });
 }

--- a/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
@@ -44,7 +44,7 @@ void InspectorResourceURLSchemeHandler::platformStartTask(WebPageProxy&, WebURLS
 #if USE(CF) && USE(CURL)
     auto requestURL = task.request().url();
     auto requestPath = requestURL.fileSystemPath();
-    if (requestPath.startsWith("\\"))
+    if (requestPath.startsWith("\\"_s))
         requestPath = requestPath.substring(1);
     auto path = URL(adoptCF(CFBundleCopyBundleURL(WebCore::webKitBundle())).get()).fileSystemPath();
     path = FileSystem::pathByAppendingComponent(path, "WebInspectorUI"_s);

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -302,7 +302,7 @@ void ViewGestureController::SnapshotRemovalTracker::log(StringView log) const
 void ViewGestureController::SnapshotRemovalTracker::resume()
 {
     if (isPaused() && m_outstandingEvents)
-        log("resume");
+        log("resume"_s);
     m_paused = false;
 }
 
@@ -312,7 +312,7 @@ void ViewGestureController::SnapshotRemovalTracker::start(Events desiredEvents, 
     m_removalCallback = WTFMove(removalCallback);
     m_startTime = MonotonicTime::now();
 
-    log("start");
+    log("start"_s);
 
     startWatchdog(swipeSnapshotRemovalWatchdogDuration);
 
@@ -381,7 +381,7 @@ void ViewGestureController::SnapshotRemovalTracker::fireRemovalCallbackImmediate
 
     auto removalCallback = WTFMove(m_removalCallback);
     if (removalCallback) {
-        log("removing snapshot");
+        log("removing snapshot"_s);
         reset();
         removalCallback();
     }
@@ -389,7 +389,7 @@ void ViewGestureController::SnapshotRemovalTracker::fireRemovalCallbackImmediate
 
 void ViewGestureController::SnapshotRemovalTracker::watchdogTimerFired()
 {
-    log("watchdog timer fired");
+    log("watchdog timer fired"_s);
     fireRemovalCallbackImmediately();
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1331,14 +1331,14 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
 #if HAVE(AUDIT_TOKEN)
     ASSERT(process.connection() && process.connection()->getAuditToken());
     if (process.connection() && process.connection()->getAuditToken()) {
-        if (auto handle = SandboxExtension::createHandleForReadByAuditToken("/", *(process.connection()->getAuditToken()))) {
+        if (auto handle = SandboxExtension::createHandleForReadByAuditToken("/"_s, *(process.connection()->getAuditToken()))) {
             createdExtension = true;
             sandboxExtensionHandle = WTFMove(*handle);
         }
     } else
 #endif
     {
-        if (auto handle = SandboxExtension::createHandle("/", SandboxExtension::Type::ReadOnly)) {
+        if (auto handle = SandboxExtension::createHandle("/"_s, SandboxExtension::Type::ReadOnly)) {
             createdExtension = true;
             sandboxExtensionHandle = WTFMove(*handle);
         }
@@ -9209,7 +9209,7 @@ void WebPageProxy::saveDataToFileInDownloadsFolder(String&& suggestedFilename, S
 void WebPageProxy::savePDFToFileInDownloadsFolder(String&& suggestedFilename, URL&& originatingURL, const IPC::DataReference& dataReference)
 {
     String sanitizedFilename = ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename);
-    if (!sanitizedFilename.endsWithIgnoringASCIICase(".pdf"))
+    if (!sanitizedFilename.endsWithIgnoringASCIICase(".pdf"_s))
         return;
 
     saveDataToFileInDownloadsFolder(WTFMove(sanitizedFilename), "application/pdf"_s, WTFMove(originatingURL),

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -630,7 +630,7 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
 
     m_resolvedPaths.additionalWebProcessSandboxExtensionPaths.reserveCapacity(m_configuration->additionalReadAccessAllowedPaths().size());
     for (const auto& path : m_configuration->additionalReadAccessAllowedPaths())
-        m_resolvedPaths.additionalWebProcessSandboxExtensionPaths.uncheckedAppend(resolvePathForSandboxExtension(path.data()));
+        m_resolvedPaths.additionalWebProcessSandboxExtensionPaths.uncheckedAppend(resolvePathForSandboxExtension(path));
 
     platformResolvePathsForSandboxExtensions();
 }

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -509,7 +509,7 @@ void WebsiteDataStore::initializeAppBoundDomains(ForceReinitialization forceRein
 
                 URL url { data };
                 if (url.protocol().isEmpty())
-                    url.setProtocol("https");
+                    url.setProtocol("https"_s);
                 if (!url.isValid())
                     continue;
                 WebCore::RegistrableDomain appBoundDomain { url };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11919,7 +11919,7 @@ static UIMenu *menuFromLegacyPreviewOrDefaultActions(UIViewController *previewVi
         if (_positionInformation.isImage) {
             if ([uiDelegate respondsToSelector:@selector(_webView:commitPreviewedImageWithURL:)]) {
                 const auto& imageURL = _positionInformation.imageURL;
-                if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data")))
+                if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                     return;
                 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                 [uiDelegate _webView:self.webView commitPreviewedImageWithURL:(NSURL *)imageURL];
@@ -12176,7 +12176,7 @@ static UIMenu *menuFromLegacyPreviewOrDefaultActions(UIViewController *previewVi
 
     NSURL *targetURL = controller.previewData[UIPreviewDataLink];
     URL coreTargetURL = targetURL;
-    bool isValidURLForImagePreview = !coreTargetURL.isEmpty() && (coreTargetURL.protocolIsInHTTPFamily() || coreTargetURL.protocolIs("data"));
+    bool isValidURLForImagePreview = !coreTargetURL.isEmpty() && (coreTargetURL.protocolIsInHTTPFamily() || coreTargetURL.protocolIs("data"_s));
 
     if ([_previewItemController type] == UIPreviewItemTypeLink) {
         _longPressCanClick = NO;
@@ -12268,7 +12268,7 @@ static UIMenu *menuFromLegacyPreviewOrDefaultActions(UIViewController *previewVi
     if ([_previewItemController type] == UIPreviewItemTypeImage) {
         if ([uiDelegate respondsToSelector:@selector(_webView:commitPreviewedImageWithURL:)]) {
             const URL& imageURL = _positionInformation.imageURL;
-            if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data")))
+            if (imageURL.isEmpty() || !(imageURL.protocolIsInHTTPFamily() || imageURL.protocolIs("data"_s)))
                 return;
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [uiDelegate _webView:self.webView commitPreviewedImageWithURL:(NSURL *)imageURL];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1315,73 +1315,73 @@ static RecommendDesktopClassBrowsingForRequest desktopClassBrowsingRecommendedFo
     // disabled by default in WKWebView, so we would need a new preference for controlling site-specific quirks that are on-by-default
     // in all apps, but may be turned off via SPI (or via Web Inspector). See also: <rdar://problem/50035167>.
     auto host = request.url().host();
-    if (equalLettersIgnoringASCIICase(host, "tv.kakao.com"_s) || host.endsWithIgnoringASCIICase(".tv.kakao.com"))
+    if (equalLettersIgnoringASCIICase(host, "tv.kakao.com"_s) || host.endsWithIgnoringASCIICase(".tv.kakao.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "tving.com"_s) || host.endsWithIgnoringASCIICase(".tving.com"))
+    if (equalLettersIgnoringASCIICase(host, "tving.com"_s) || host.endsWithIgnoringASCIICase(".tving.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "live.iqiyi.com"_s) || host.endsWithIgnoringASCIICase(".live.iqiyi.com"))
+    if (equalLettersIgnoringASCIICase(host, "live.iqiyi.com"_s) || host.endsWithIgnoringASCIICase(".live.iqiyi.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "jsfiddle.net"_s) || host.endsWithIgnoringASCIICase(".jsfiddle.net"))
+    if (equalLettersIgnoringASCIICase(host, "jsfiddle.net"_s) || host.endsWithIgnoringASCIICase(".jsfiddle.net"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "video.sina.com.cn"_s) || host.endsWithIgnoringASCIICase(".video.sina.com.cn"))
+    if (equalLettersIgnoringASCIICase(host, "video.sina.com.cn"_s) || host.endsWithIgnoringASCIICase(".video.sina.com.cn"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "huya.com"_s) || host.endsWithIgnoringASCIICase(".huya.com"))
+    if (equalLettersIgnoringASCIICase(host, "huya.com"_s) || host.endsWithIgnoringASCIICase(".huya.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "video.tudou.com"_s) || host.endsWithIgnoringASCIICase(".video.tudou.com"))
+    if (equalLettersIgnoringASCIICase(host, "video.tudou.com"_s) || host.endsWithIgnoringASCIICase(".video.tudou.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "cctv.com"_s) || host.endsWithIgnoringASCIICase(".cctv.com"))
+    if (equalLettersIgnoringASCIICase(host, "cctv.com"_s) || host.endsWithIgnoringASCIICase(".cctv.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
     if (equalLettersIgnoringASCIICase(host, "v.china.com.cn"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "trello.com"_s) || host.endsWithIgnoringASCIICase(".trello.com"))
+    if (equalLettersIgnoringASCIICase(host, "trello.com"_s) || host.endsWithIgnoringASCIICase(".trello.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (equalLettersIgnoringASCIICase(host, "ted.com"_s) || host.endsWithIgnoringASCIICase(".ted.com"))
+    if (equalLettersIgnoringASCIICase(host, "ted.com"_s) || host.endsWithIgnoringASCIICase(".ted.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
-    if (host.containsIgnoringASCIICase("hsbc.")) {
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.au"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.au"))
+    if (host.containsIgnoringASCIICase("hsbc."_s)) {
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.au"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.au"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.eg"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.eg"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.eg"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.eg"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.lk"_s) || host.endsWithIgnoringASCIICase(".hsbc.lk"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.lk"_s) || host.endsWithIgnoringASCIICase(".hsbc.lk"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.co.uk"_s) || host.endsWithIgnoringASCIICase(".hsbc.co.uk"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.co.uk"_s) || host.endsWithIgnoringASCIICase(".hsbc.co.uk"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.hk"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.hk"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.hk"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.hk"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.mx"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.mx"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.mx"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.mx"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.ca"_s) || host.endsWithIgnoringASCIICase(".hsbc.ca"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.ca"_s) || host.endsWithIgnoringASCIICase(".hsbc.ca"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ar"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ar"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ar"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ar"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ph"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ph"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ph"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ph"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com"_s) || host.endsWithIgnoringASCIICase(".hsbc.com"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com"_s) || host.endsWithIgnoringASCIICase(".hsbc.com"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.cn"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.cn"))
+        if (equalLettersIgnoringASCIICase(host, "hsbc.com.cn"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.cn"_s))
             return RecommendDesktopClassBrowsingForRequest::No;
     }
 
-    if (equalLettersIgnoringASCIICase(host, "nhl.com"_s) || host.endsWithIgnoringASCIICase(".nhl.com"))
+    if (equalLettersIgnoringASCIICase(host, "nhl.com"_s) || host.endsWithIgnoringASCIICase(".nhl.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
     // FIXME: Remove this quirk when <rdar://problem/59480381> is complete.
-    if (equalLettersIgnoringASCIICase(host, "fidelity.com"_s) || host.endsWithIgnoringASCIICase(".fidelity.com"))
+    if (equalLettersIgnoringASCIICase(host, "fidelity.com"_s) || host.endsWithIgnoringASCIICase(".fidelity.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
     // FIXME: Remove this quirk when <rdar://problem/61733101> is complete.
-    if (equalLettersIgnoringASCIICase(host, "roblox.com"_s) || host.endsWithIgnoringASCIICase(".roblox.com"))
+    if (equalLettersIgnoringASCIICase(host, "roblox.com"_s) || host.endsWithIgnoringASCIICase(".roblox.com"_s))
         return RecommendDesktopClassBrowsingForRequest::No;
 
     return RecommendDesktopClassBrowsingForRequest::Auto;

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -435,7 +435,7 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
     }
 
     auto sanitizedFilename = ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename);
-    if (!sanitizedFilename.endsWithIgnoringASCIICase(".pdf")) {
+    if (!sanitizedFilename.endsWithIgnoringASCIICase(".pdf"_s)) {
         WTFLogAlways("Cannot save file without .pdf extension to the temporary directory.");
         return;
     }

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -56,7 +56,7 @@ bool WebProcessProxy::shouldAllowNonValidInjectedCode() const
         return false;
 
     const String& path = m_processPool->configuration().injectedBundlePath();
-    return !path.isEmpty() && !path.startsWith("/System/");
+    return !path.isEmpty() && !path.startsWith("/System/"_s);
 }
 
 void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)

--- a/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
@@ -75,7 +75,7 @@ void WebProcessPool::platformInitialize()
 {
 #if ENABLE(REMOTE_INSPECTOR)
     if (const char* address = getenv("WEBKIT_INSPECTOR_SERVER"))
-        initializeRemoteInspectorServer(address);
+        initializeRemoteInspectorServer(StringView::fromLatin1(address));
 #endif
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -154,7 +154,7 @@ void WKBundleClearAllDatabases(WKBundleRef)
 void WKBundleSetDatabaseQuota(WKBundleRef bundleRef, uint64_t quota)
 {
     // Historically, we've used the following (somewhat nonsensical) string for the databaseIdentifier of local files.
-    WebCore::DatabaseTracker::singleton().setQuota(*WebCore::SecurityOriginData::fromDatabaseIdentifier("file__0"), quota);
+    WebCore::DatabaseTracker::singleton().setQuota(*WebCore::SecurityOriginData::fromDatabaseIdentifier("file__0"_s), quota);
 }
 
 void WKBundleReleaseMemory(WKBundleRef)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -278,7 +278,7 @@ bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resource
 #if ENABLE(PDFJS)
 bool WebLoaderStrategy::tryLoadingUsingPDFJSHandler(ResourceLoader& resourceLoader, const WebResourceLoader::TrackingParameters& trackingParameters)
 {
-    if (!resourceLoader.request().url().protocolIs("webkit-pdfjs-viewer"))
+    if (!resourceLoader.request().url().protocolIs("webkit-pdfjs-viewer"_s))
         return false;
 
     LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be handled as a PDFJS resource.", resourceLoader.url().string().utf8().data());

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1670,7 +1670,7 @@ void PDFPlugin::streamDidReceiveResponse(const WebCore::ResourceResponse& respon
     m_suggestedFilename = response.suggestedFilename();
     if (m_suggestedFilename.isEmpty())
         m_suggestedFilename = suggestedFilenameWithMIMEType(nil, "application/pdf"_s);
-    if (!m_suggestedFilename.endsWithIgnoringASCIICase(".pdf"))
+    if (!m_suggestedFilename.endsWithIgnoringASCIICase(".pdf"_s))
         m_suggestedFilename = makeString(m_suggestedFilename, ".pdf"_s);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2138,7 +2138,7 @@ static void dumpHistoryItem(HistoryItem& item, size_t indent, bool isCurrentItem
     }
 
     auto url = item.url();
-    if (url.protocolIs("file")) {
+    if (url.protocolIs("file"_s)) {
         size_t start = url.string().find(directoryName);
         if (start == WTF::notFound)
             start = 0;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -216,7 +216,7 @@ bool WebPage::shouldUsePDFPlugin(const String& contentType, StringView path) con
         && getPDFLayerControllerClass()
         && (MIMETypeRegistry::isPDFOrPostScriptMIMEType(contentType)
             || (contentType.isEmpty()
-                && (path.endsWithIgnoringASCIICase(".pdf") || path.endsWithIgnoringASCIICase(".ps"))));
+                && (path.endsWithIgnoringASCIICase(".pdf"_s) || path.endsWithIgnoringASCIICase(".ps"_s))));
 }
 
 static String commandNameForSelectorName(const String& selectorName)
@@ -528,7 +528,7 @@ bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)
         return true;
 
     // FIXME: Return true if this scheme is any one WebKit2 knows how to handle.
-    return request.url().protocolIs("applewebdata");
+    return request.url().protocolIs("applewebdata"_s);
 }
 
 void WebPage::shouldDelayWindowOrderingEvent(const WebKit::WebMouseEvent& event, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/webpushd/AppBundleRequest.mm
+++ b/Source/WebKit/webpushd/AppBundleRequest.mm
@@ -58,7 +58,7 @@ void AppBundleRequest::start()
 #if ENABLE(INSTALL_COORDINATION_BUNDLES)
         m_appBundle = ICAppBundle::create(*m_connection, m_originString, *this);
 #else
-        m_connection->broadcastDebugMessage("Client is trying to initiate app bundle request without having configured mock app bundles for testing. About to crash...");
+        m_connection->broadcastDebugMessage("Client is trying to initiate app bundle request without having configured mock app bundles for testing. About to crash..."_s);
         RELEASE_ASSERT_NOT_REACHED();
 #endif
     }

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -186,7 +186,7 @@ void ClientConnection::didCompleteAppBundleRequest(AppBundleRequest& request)
 
 void ClientConnection::connectionClosed()
 {
-    broadcastDebugMessage("Connection closed");
+    broadcastDebugMessage("Connection closed"_s);
 
     RELEASE_ASSERT(m_xpcConnection);
     m_xpcConnection = nullptr;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -340,7 +340,7 @@ void Daemon::broadcastDebugMessage(StringView message)
 
 void Daemon::broadcastAllConnectionIdentities()
 {
-    broadcastDebugMessage("===\nCurrent connections:");
+    broadcastDebugMessage("===\nCurrent connections:"_s);
 
     auto connections = copyToVector(m_connectionMap.values());
     std::sort(connections.begin(), connections.end(), [] (const Ref<ClientConnection>& a, const Ref<ClientConnection>& b) {
@@ -348,8 +348,8 @@ void Daemon::broadcastAllConnectionIdentities()
     });
 
     for (auto& iterator : connections)
-        iterator->broadcastDebugMessage("");
-    broadcastDebugMessage("===");
+        iterator->broadcastDebugMessage(""_s);
+    broadcastDebugMessage("==="_s);
 }
 
 void Daemon::connectionEventHandler(xpc_object_t request)
@@ -539,13 +539,13 @@ void Daemon::updateConnectionConfiguration(ClientConnection* clientConnection, c
 void Daemon::injectPushMessageForTesting(ClientConnection* connection, const PushMessageForTesting& message, CompletionHandler<void(bool)>&& replySender)
 {
     if (!connection->hostAppHasPushInjectEntitlement()) {
-        connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process");
+        connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process"_s);
         replySender(false);
         return;
     }
 
     if (message.targetAppCodeSigningIdentifier.isEmpty() || !message.registrationURL.isValid()) {
-        connection->broadcastDebugMessage("Attempting to inject an invalid push message");
+        connection->broadcastDebugMessage("Attempting to inject an invalid push message"_s);
         replySender(false);
         return;
     }
@@ -566,7 +566,7 @@ void Daemon::injectPushMessageForTesting(ClientConnection* connection, const Pus
 void Daemon::injectEncryptedPushMessageForTesting(ClientConnection* connection, const String& message, CompletionHandler<void(bool)>&& replySender)
 {
     if (!connection->hostAppHasPushInjectEntitlement()) {
-        connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process");
+        connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process"_s);
         replySender(false);
         return;
     }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -358,7 +358,7 @@ static RegularExpression* regExpForLabels(NSArray *labels)
     static const unsigned int regExpCacheSize = 4;
     static NeverDestroyed<RetainPtr<NSMutableArray>> regExpLabels = adoptNS([[NSMutableArray alloc] initWithCapacity:regExpCacheSize]);
     static NeverDestroyed<Vector<RegularExpression*>> regExps;
-    static NeverDestroyed<RegularExpression> wordRegExp("\\w");
+    static NeverDestroyed<RegularExpression> wordRegExp("\\w"_s);
 
     RegularExpression* result;
     CFIndex cacheHit = [regExpLabels.get() indexOfObject:labels];
@@ -484,7 +484,7 @@ static NSString *matchLabelsAgainstString(NSArray *labels, const String& stringT
     String mutableStringToMatch = stringToMatch;
     
     // Make numbers and _'s in field names behave like word boundaries, e.g., "address2"
-    replace(mutableStringToMatch, RegularExpression("\\d"), " ");
+    replace(mutableStringToMatch, RegularExpression("\\d"_s), " "_s);
     mutableStringToMatch = makeStringByReplacingAll(mutableStringToMatch, '_', ' ');
     
     RegularExpression* regExp = regExpForLabels(labels);

--- a/Source/WebKitLegacy/win/DefaultPolicyDelegate.cpp
+++ b/Source/WebKitLegacy/win/DefaultPolicyDelegate.cpp
@@ -119,7 +119,7 @@ HRESULT DefaultPolicyDelegate::decidePolicyForNavigationAction(_In_opt_ IWebView
             BString url;
             // A file URL shouldn't fall through to here, but if it did,
             // it would be a security risk to open it.
-            if (SUCCEEDED(request->URL(&url)) && !String(url, SysStringLen(url)).startsWith("file:")) {
+            if (SUCCEEDED(request->URL(&url)) && !String(url, SysStringLen(url)).startsWith("file:"_s)) {
                 // FIXME: Open the URL not by means of a webframe, but by handing it over to the system and letting it determine how to open that particular URL scheme.  See documentation for [NSWorkspace openURL]
                 ;
             }
@@ -149,7 +149,7 @@ HRESULT DefaultPolicyDelegate::decidePolicyForMIMEType(_In_opt_ IWebView* webVie
     BString url;
     request->URL(&url);
 
-    if (String(url, SysStringLen(url)).startsWith("file:")) {
+    if (String(url, SysStringLen(url)).startsWith("file:"_s)) {
         BOOL isDirectory = FALSE;
         WIN32_FILE_ATTRIBUTE_DATA attrs;
         if (GetFileAttributesEx(url, GetFileExInfoStandard, &attrs))

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -1324,7 +1324,7 @@ bool WebView::canHandleRequest(const WebCore::ResourceRequest& request)
 {
 #if USE(CFURLCONNECTION)
     // On the Mac there's an about URL protocol implementation but Windows CFNetwork doesn't have that.
-    if (request.url().protocolIs("about"))
+    if (request.url().protocolIs("about"_s))
         return true;
 
     return CFURLProtocolCanHandleRequest(request.cfURLRequest(UpdateHTTPBody));

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1502,9 +1502,9 @@ static void changeWindowScaleIfNeeded(const char* testPathOrURL)
     auto localPathOrURL = String::fromUTF8(testPathOrURL);
     float currentScaleFactor = [[[mainFrame webView] window] backingScaleFactor];
     float requiredScaleFactor = 1;
-    if (localPathOrURL.containsIgnoringASCIICase("/hidpi-3x-"))
+    if (localPathOrURL.containsIgnoringASCIICase("/hidpi-3x-"_s))
         requiredScaleFactor = 3;
-    else if (localPathOrURL.containsIgnoringASCIICase("/hidpi-"))
+    else if (localPathOrURL.containsIgnoringASCIICase("/hidpi-"_s))
         requiredScaleFactor = 2;
     if (currentScaleFactor == requiredScaleFactor)
         return;

--- a/Tools/DumpRenderTree/win/DefaultPolicyDelegate.cpp
+++ b/Tools/DumpRenderTree/win/DefaultPolicyDelegate.cpp
@@ -119,7 +119,7 @@ HRESULT DefaultPolicyDelegate::decidePolicyForNavigationAction(_In_opt_ IWebView
             BString url;
             // A file URL shouldn't fall through to here, but if it did,
             // it would be a security risk to open it.
-            if (SUCCEEDED(request->URL(&url)) && !String(url, SysStringLen(url)).startsWith("file:")) {
+            if (SUCCEEDED(request->URL(&url)) && !String(url, SysStringLen(url)).startsWith("file:"_s)) {
                 // FIXME: Open the URL not by means of a webframe, but by handing it over to the system and letting it determine how to open that particular URL scheme.  See documentation for [NSWorkspace openURL]
                 ;
             }
@@ -149,7 +149,7 @@ HRESULT DefaultPolicyDelegate::decidePolicyForMIMEType(_In_opt_ IWebView* webVie
     BString url;
     request->URL(&url);
 
-    if (String(url, SysStringLen(url)).startsWith("file:")) {
+    if (String(url, SysStringLen(url)).startsWith("file:"_s)) {
         BOOL isDirectory = FALSE;
         WIN32_FILE_ATTRIBUTE_DATA attrs;
         if (GetFileAttributesEx(url, GetFileExInfoStandard, &attrs))

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -496,13 +496,13 @@ TEST_F(FileSystemTest, volumeFreeSpace)
     ASSERT_TRUE(freeSpace);
     EXPECT_GT(*freeSpace, 0U);
 
-    String fileThatDoesNotExist = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist");
+    String fileThatDoesNotExist = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "does-not-exist"_s);
     EXPECT_FALSE(FileSystem::volumeFreeSpace(fileThatDoesNotExist));
 }
 
 TEST_F(FileSystemTest, createSymbolicLink)
 {
-    auto symlinkPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "tempFile-symlink");
+    auto symlinkPath = FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "tempFile-symlink"_s);
     EXPECT_FALSE(FileSystem::fileExists(symlinkPath));
     EXPECT_TRUE(FileSystem::createSymbolicLink(tempFilePath(), symlinkPath));
     EXPECT_TRUE(FileSystem::fileExists(symlinkPath));
@@ -749,7 +749,7 @@ TEST_F(FileSystemTest, pathByAppendingComponents)
     EXPECT_STREQ(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "file.txt"_s).utf8().data(), FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "file.txt"_s }).utf8().data());
 #if OS(UNIX)
     EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/"_s, { "var"_s, "tmp"_s, "file.txt"_s }).utf8().data());
-    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var"_s, { "tmp"_s, "file.txt" }).utf8().data());
+    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var"_s, { "tmp"_s, "file.txt"_s }).utf8().data());
     EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/"_s, { "tmp"_s, "file.txt"_s }).utf8().data());
     EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/tmp"_s, { "file.txt"_s }).utf8().data());
 #endif

--- a/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
@@ -70,29 +70,29 @@ TEST(WTF, SortedArraySet)
     };
     static constexpr SortedArraySet scriptTypesSet { scriptTypesArray };
 
-    EXPECT_FALSE(caseFoldingSet.contains(""));
-    EXPECT_TRUE(caseFoldingSet.contains("_"));
-    EXPECT_TRUE(caseFoldingSet.contains("c"));
-    EXPECT_TRUE(caseFoldingSet.contains("delightful"));
-    EXPECT_FALSE(caseFoldingSet.contains("d"));
-    EXPECT_TRUE(caseFoldingSet.contains("q_"));
-    EXPECT_FALSE(caseFoldingSet.contains("q__"));
+    EXPECT_FALSE(caseFoldingSet.contains(""_s));
+    EXPECT_TRUE(caseFoldingSet.contains("_"_s));
+    EXPECT_TRUE(caseFoldingSet.contains("c"_s));
+    EXPECT_TRUE(caseFoldingSet.contains("delightful"_s));
+    EXPECT_FALSE(caseFoldingSet.contains("d"_s));
+    EXPECT_TRUE(caseFoldingSet.contains("q_"_s));
+    EXPECT_FALSE(caseFoldingSet.contains("q__"_s));
 
-    EXPECT_FALSE(lettersSet.contains(""));
-    EXPECT_FALSE(lettersSet.contains("_"));
-    EXPECT_TRUE(lettersSet.contains("c"));
-    EXPECT_TRUE(lettersSet.contains("delightful"));
-    EXPECT_FALSE(lettersSet.contains("d"));
-    EXPECT_FALSE(lettersSet.contains("q_"));
-    EXPECT_FALSE(lettersSet.contains("q__"));
+    EXPECT_FALSE(lettersSet.contains(""_s));
+    EXPECT_FALSE(lettersSet.contains("_"_s));
+    EXPECT_TRUE(lettersSet.contains("c"_s));
+    EXPECT_TRUE(lettersSet.contains("delightful"_s));
+    EXPECT_FALSE(lettersSet.contains("d"_s));
+    EXPECT_FALSE(lettersSet.contains("q_"_s));
+    EXPECT_FALSE(lettersSet.contains("q__"_s));
 
-    ASSERT_TRUE(scriptTypesSet.contains("text/javascript"));
-    ASSERT_TRUE(scriptTypesSet.contains("TEXT/JAVASCRIPT"));
-    ASSERT_TRUE(scriptTypesSet.contains("application/javascript"));
-    ASSERT_TRUE(scriptTypesSet.contains("application/ecmascript"));
-    ASSERT_TRUE(scriptTypesSet.contains("application/x-javascript"));
-    ASSERT_TRUE(scriptTypesSet.contains("application/x-ecmascript"));
-    ASSERT_FALSE(scriptTypesSet.contains("text/plain"));
-    ASSERT_FALSE(scriptTypesSet.contains("application/json"));
-    ASSERT_FALSE(scriptTypesSet.contains("foo/javascript"));
+    ASSERT_TRUE(scriptTypesSet.contains("text/javascript"_s));
+    ASSERT_TRUE(scriptTypesSet.contains("TEXT/JAVASCRIPT"_s));
+    ASSERT_TRUE(scriptTypesSet.contains("application/javascript"_s));
+    ASSERT_TRUE(scriptTypesSet.contains("application/ecmascript"_s));
+    ASSERT_TRUE(scriptTypesSet.contains("application/x-javascript"_s));
+    ASSERT_TRUE(scriptTypesSet.contains("application/x-ecmascript"_s));
+    ASSERT_FALSE(scriptTypesSet.contains("text/plain"_s));
+    ASSERT_FALSE(scriptTypesSet.contains("application/json"_s));
+    ASSERT_FALSE(scriptTypesSet.contains("foo/javascript"_s));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -38,14 +38,14 @@ TEST(WTF, StringImplCreationFromLiteral)
     // Constructor taking an ASCIILiteral.
     auto stringWithTemplate = StringImpl::create("Template Literal"_s);
     ASSERT_EQ(strlen("Template Literal"), stringWithTemplate->length());
-    ASSERT_TRUE(equal(stringWithTemplate.get(), "Template Literal"));
+    ASSERT_TRUE(equal(stringWithTemplate.get(), "Template Literal"_s));
     ASSERT_TRUE(stringWithTemplate->is8Bit());
 
     // Constructor taking the size explicitly.
     const char* programmaticStringData = "Explicit Size Literal";
     auto programmaticString = StringImpl::createWithoutCopying(programmaticStringData, strlen(programmaticStringData));
     ASSERT_EQ(strlen(programmaticStringData), programmaticString->length());
-    ASSERT_TRUE(equal(programmaticString.get(), programmaticStringData));
+    ASSERT_TRUE(equal(programmaticString.get(), StringView::fromLatin1(programmaticStringData)));
     ASSERT_EQ(programmaticStringData, reinterpret_cast<const char*>(programmaticString->characters8()));
     ASSERT_TRUE(programmaticString->is8Bit());
 
@@ -64,42 +64,42 @@ TEST(WTF, StringImplReplaceWithLiteral)
     ASSERT_TRUE(testStringImpl->is8Bit());
 
     // Cases for 8Bit source.
-    testStringImpl = testStringImpl->replace('2', "", 0);
-    ASSERT_TRUE(equal(testStringImpl.get(), "14"));
+    testStringImpl = testStringImpl->replace('2', ""_s, 0);
+    ASSERT_TRUE(equal(testStringImpl.get(), "14"_s));
 
     testStringImpl = StringImpl::create("1224"_s);
     ASSERT_TRUE(testStringImpl->is8Bit());
 
-    testStringImpl = testStringImpl->replace('3', "NotFound", 8);
-    ASSERT_TRUE(equal(testStringImpl.get(), "1224"));
+    testStringImpl = testStringImpl->replace('3', "NotFound"_s, 8);
+    ASSERT_TRUE(equal(testStringImpl.get(), "1224"_s));
 
-    testStringImpl = testStringImpl->replace('2', "3", 1);
-    ASSERT_TRUE(equal(testStringImpl.get(), "1334"));
+    testStringImpl = testStringImpl->replace('2', "3"_s, 1);
+    ASSERT_TRUE(equal(testStringImpl.get(), "1334"_s));
 
     testStringImpl = StringImpl::create("1224"_s);
     ASSERT_TRUE(testStringImpl->is8Bit());
-    testStringImpl = testStringImpl->replace('2', "555", 3);
-    ASSERT_TRUE(equal(testStringImpl.get(), "15555554"));
+    testStringImpl = testStringImpl->replace('2', "555"_s, 3);
+    ASSERT_TRUE(equal(testStringImpl.get(), "15555554"_s));
 
     // Cases for 16Bit source.
     String testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
 
-    testStringImpl = testString.impl()->replace('2', "NotFound", 8);
+    testStringImpl = testString.impl()->replace('2', "NotFound"_s, 8);
     ASSERT_TRUE(equal(testStringImpl.get(), String::fromUTF8("résumé").impl()));
 
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "e", 1);
-    ASSERT_TRUE(equal(testStringImpl.get(), "resume"));
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "e"_s, 1);
+    ASSERT_TRUE(equal(testStringImpl.get(), "resume"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "", 0);
-    ASSERT_TRUE(equal(testStringImpl.get(), "rsum"));
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), ""_s, 0);
+    ASSERT_TRUE(equal(testStringImpl.get(), "rsum"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "555", 3);
-    ASSERT_TRUE(equal(testStringImpl.get(), "r555sum555"));
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "555"_s, 3);
+    ASSERT_TRUE(equal(testStringImpl.get(), "r555sum555"_s));
 }
 
 TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)
@@ -682,10 +682,10 @@ static void doStaticStringImplTests(StaticStringImplTestSet testSet, String& hel
     ASSERT_EQ(strlen("longer"), longer.length());
     ASSERT_EQ(strlen("hello"), hello2.length());
 
-    ASSERT_TRUE(equal(hello, "hello"));
-    ASSERT_TRUE(equal(world, "world"));
-    ASSERT_TRUE(equal(longer, "longer"));
-    ASSERT_TRUE(equal(hello2, "hello"));
+    ASSERT_TRUE(equal(hello, "hello"_s));
+    ASSERT_TRUE(equal(world, "world"_s));
+    ASSERT_TRUE(equal(longer, "longer"_s));
+    ASSERT_TRUE(equal(hello2, "hello"_s));
 
     // Each StaticStringImpl* returned by MAKE_STATIC_STRING_IMPL should be unique.
     ASSERT_NE(hello.impl(), hello2.impl());
@@ -694,11 +694,11 @@ static void doStaticStringImplTests(StaticStringImplTestSet testSet, String& hel
         // Test that MAKE_STATIC_STRING_IMPL isn't allocating a StaticStringImpl on the stack.
         const String& str1 = getNeverDestroyedStringAtStackDepth(10);
         ASSERT_EQ(strlen("NeverDestroyedString"), str1.length());
-        ASSERT_TRUE(equal(str1, "NeverDestroyedString"));
+        ASSERT_TRUE(equal(str1, "NeverDestroyedString"_s));
 
         const String& str2 = getNeverDestroyedStringAtStackDepth(20);
         ASSERT_EQ(strlen("NeverDestroyedString"), str2.length());
-        ASSERT_TRUE(equal(str2, "NeverDestroyedString"));
+        ASSERT_TRUE(equal(str2, "NeverDestroyedString"_s));
 
         ASSERT_TRUE(equal(str1, str2));
         ASSERT_EQ(&str1, &str2);

--- a/Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp
@@ -30,56 +30,56 @@ namespace TestWebKitAPI {
 
 TEST(WTF, ParseInteger)
 {
-    EXPECT_EQ(std::nullopt, parseInteger<int>(static_cast<const char*>(nullptr)));
-    EXPECT_EQ(std::nullopt, parseInteger<int>(""));
-    EXPECT_EQ(0, parseInteger<int>("0"));
-    EXPECT_EQ(1, parseInteger<int>("1"));
-    EXPECT_EQ(3, parseInteger<int>("3"));
-    EXPECT_EQ(-3, parseInteger<int>("-3"));
-    EXPECT_EQ(12345, parseInteger<int>("12345"));
-    EXPECT_EQ(-12345, parseInteger<int>("-12345"));
-    EXPECT_EQ(2147483647, parseInteger<int>("2147483647"));
-    EXPECT_EQ(std::nullopt, parseInteger<int>("2147483648"));
-    EXPECT_EQ(-2147483647 - 1, parseInteger<int>("-2147483648"));
-    EXPECT_EQ(std::nullopt, parseInteger<int>("-2147483649"));
-    EXPECT_EQ(std::nullopt, parseInteger<int>("x1"));
-    EXPECT_EQ(1, parseInteger<int>(" 1"));
-    EXPECT_EQ(std::nullopt, parseInteger<int>("1x"));
+    EXPECT_EQ(std::nullopt, parseInteger<int>({ }));
+    EXPECT_EQ(std::nullopt, parseInteger<int>(""_s));
+    EXPECT_EQ(0, parseInteger<int>("0"_s));
+    EXPECT_EQ(1, parseInteger<int>("1"_s));
+    EXPECT_EQ(3, parseInteger<int>("3"_s));
+    EXPECT_EQ(-3, parseInteger<int>("-3"_s));
+    EXPECT_EQ(12345, parseInteger<int>("12345"_s));
+    EXPECT_EQ(-12345, parseInteger<int>("-12345"_s));
+    EXPECT_EQ(2147483647, parseInteger<int>("2147483647"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<int>("2147483648"_s));
+    EXPECT_EQ(-2147483647 - 1, parseInteger<int>("-2147483648"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<int>("-2147483649"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<int>("x1"_s));
+    EXPECT_EQ(1, parseInteger<int>(" 1"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<int>("1x"_s));
 
-    EXPECT_EQ(0U, 0U + *parseInteger<uint16_t>("0"));
-    EXPECT_EQ(3U, 0U + *parseInteger<uint16_t>("3"));
-    EXPECT_EQ(12345U, 0U + *parseInteger<uint16_t>("12345"));
-    EXPECT_EQ(65535U, 0U + *parseInteger<uint16_t>("65535"));
-    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("-1"));
-    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("-3"));
-    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("65536"));
+    EXPECT_EQ(0U, 0U + *parseInteger<uint16_t>("0"_s));
+    EXPECT_EQ(3U, 0U + *parseInteger<uint16_t>("3"_s));
+    EXPECT_EQ(12345U, 0U + *parseInteger<uint16_t>("12345"_s));
+    EXPECT_EQ(65535U, 0U + *parseInteger<uint16_t>("65535"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("-1"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("-3"_s));
+    EXPECT_EQ(std::nullopt, parseInteger<uint16_t>("65536"_s));
 }
 
 TEST(WTF, ParseIntegerAllowingTrailingJunk)
 {
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>(static_cast<const char*>(nullptr)));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>(""));
-    EXPECT_EQ(0, parseIntegerAllowingTrailingJunk<int>("0"));
-    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>("1"));
-    EXPECT_EQ(3, parseIntegerAllowingTrailingJunk<int>("3"));
-    EXPECT_EQ(-3, parseIntegerAllowingTrailingJunk<int>("-3"));
-    EXPECT_EQ(12345, parseIntegerAllowingTrailingJunk<int>("12345"));
-    EXPECT_EQ(-12345, parseIntegerAllowingTrailingJunk<int>("-12345"));
-    EXPECT_EQ(2147483647, parseIntegerAllowingTrailingJunk<int>("2147483647"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("2147483648"));
-    EXPECT_EQ(-2147483647 - 1, parseIntegerAllowingTrailingJunk<int>("-2147483648"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("-2147483649"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("x1"));
-    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>(" 1"));
-    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>("1x"));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>({ }));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>(""_s));
+    EXPECT_EQ(0, parseIntegerAllowingTrailingJunk<int>("0"_s));
+    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>("1"_s));
+    EXPECT_EQ(3, parseIntegerAllowingTrailingJunk<int>("3"_s));
+    EXPECT_EQ(-3, parseIntegerAllowingTrailingJunk<int>("-3"_s));
+    EXPECT_EQ(12345, parseIntegerAllowingTrailingJunk<int>("12345"_s));
+    EXPECT_EQ(-12345, parseIntegerAllowingTrailingJunk<int>("-12345"_s));
+    EXPECT_EQ(2147483647, parseIntegerAllowingTrailingJunk<int>("2147483647"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("2147483648"_s));
+    EXPECT_EQ(-2147483647 - 1, parseIntegerAllowingTrailingJunk<int>("-2147483648"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("-2147483649"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<int>("x1"_s));
+    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>(" 1"_s));
+    EXPECT_EQ(1, parseIntegerAllowingTrailingJunk<int>("1x"_s));
 
-    EXPECT_EQ(0U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("0"));
-    EXPECT_EQ(3U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("3"));
-    EXPECT_EQ(12345U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("12345"));
-    EXPECT_EQ(65535U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("65535"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("-1"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("-3"));
-    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("65536"));
+    EXPECT_EQ(0U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("0"_s));
+    EXPECT_EQ(3U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("3"_s));
+    EXPECT_EQ(12345U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("12345"_s));
+    EXPECT_EQ(65535U, 0U + *parseIntegerAllowingTrailingJunk<uint16_t>("65535"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("-1"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("-3"_s));
+    EXPECT_EQ(std::nullopt, parseIntegerAllowingTrailingJunk<uint16_t>("65536"_s));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -328,7 +328,7 @@ TEST(WTF, StringViewEqualBasic)
     EXPECT_FALSE(a == "Hell\0");
     EXPECT_FALSE(a == "Hell");
 
-    StringView test3 = "Hello";
+    StringView test3 = "Hello"_s;
     EXPECT_TRUE(test3 == "Hello\0");
     EXPECT_TRUE(test3 == "Hello");
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -136,10 +136,10 @@ TEST_F(WTF_URL, URLSetQuery)
     URL url3 = createURL("http://www.webkit.org/?test"_s);
     URL url4 = createURL("http://www.webkit.org/?test1"_s);
 
-    url1.setQuery("test");
-    url2.setQuery("test");
-    url3.setQuery("test");
-    url4.setQuery("test");
+    url1.setQuery("test"_s);
+    url2.setQuery("test"_s);
+    url3.setQuery("test"_s);
+    url4.setQuery("test"_s);
 
     EXPECT_EQ(url.string(), url1.string());
     EXPECT_EQ(url.string(), url2.string());
@@ -151,9 +151,9 @@ TEST_F(WTF_URL, URLSetQuery)
     URL urlWithFragmentIdentifier2 = createURL("http://www.webkit.org/?#newFragment"_s);
     URL urlWithFragmentIdentifier3 = createURL("http://www.webkit.org/?test1#newFragment"_s);
 
-    urlWithFragmentIdentifier1.setQuery("test\xc3\xa5");
-    urlWithFragmentIdentifier2.setQuery("test\xc3\xa5");
-    urlWithFragmentIdentifier3.setQuery("test\xc3\xa5");
+    urlWithFragmentIdentifier1.setQuery("test\xc3\xa5"_s);
+    urlWithFragmentIdentifier2.setQuery("test\xc3\xa5"_s);
+    urlWithFragmentIdentifier3.setQuery("test\xc3\xa5"_s);
 
     EXPECT_EQ(urlWithFragmentIdentifier.string(), urlWithFragmentIdentifier1.string());
     EXPECT_EQ(urlWithFragmentIdentifier.string(), urlWithFragmentIdentifier2.string());
@@ -167,9 +167,9 @@ TEST_F(WTF_URL, URLSetFragmentIdentifier)
     URL url2 = createURL("http://www.webkit.org/#test2"_s);
     URL url3 = createURL("http://www.webkit.org/#"_s);
 
-    url1.setFragmentIdentifier("newFragment\xc3\xa5");
-    url2.setFragmentIdentifier("newFragment\xc3\xa5");
-    url3.setFragmentIdentifier("newFragment\xc3\xa5");
+    url1.setFragmentIdentifier("newFragment\xc3\xa5"_s);
+    url2.setFragmentIdentifier("newFragment\xc3\xa5"_s);
+    url3.setFragmentIdentifier("newFragment\xc3\xa5"_s);
 
     EXPECT_EQ(url.string(), url1.string());
     EXPECT_EQ(url.string(), url2.string());
@@ -180,9 +180,9 @@ TEST_F(WTF_URL, URLSetFragmentIdentifier)
     URL urlWithQuery2 = createURL("http://www.webkit.org/?test1#"_s);
     URL urlWithQuery3 = createURL("http://www.webkit.org/?test1#test2"_s);
 
-    urlWithQuery1.setFragmentIdentifier("newFragment");
-    urlWithQuery2.setFragmentIdentifier("newFragment");
-    urlWithQuery3.setFragmentIdentifier("newFragment");
+    urlWithQuery1.setFragmentIdentifier("newFragment"_s);
+    urlWithQuery2.setFragmentIdentifier("newFragment"_s);
+    urlWithQuery3.setFragmentIdentifier("newFragment"_s);
 
     EXPECT_EQ(urlWithQuery.string(), urlWithQuery1.string());
     EXPECT_EQ(urlWithQuery.string(), urlWithQuery2.string());
@@ -267,59 +267,59 @@ TEST_F(WTF_URL, EqualIgnoringFragmentIdentifier)
 TEST_F(WTF_URL, ProtocolIsInHTTPFamily)
 {
     EXPECT_FALSE(WTF::protocolIsInHTTPFamily({ }));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily(""));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("a"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("ab"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abc"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcd"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcde"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcdef"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcdefg"));
-    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("http:"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("http"));
-    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("https:"));
-    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("https"));
-    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("https://!@#$%^&*()"));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily(""_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("a"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("ab"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abc"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcd"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcde"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcdef"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("abcdefg"_s));
+    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("http:"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("http"_s));
+    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("https:"_s));
+    EXPECT_FALSE(WTF::protocolIsInHTTPFamily("https"_s));
+    EXPECT_TRUE(WTF::protocolIsInHTTPFamily("https://!@#$%^&*()"_s));
 }
 
 TEST_F(WTF_URL, HostIsIPAddress)
 {
     EXPECT_FALSE(URL::hostIsIPAddress({ }));
-    EXPECT_FALSE(URL::hostIsIPAddress(""));
-    EXPECT_FALSE(URL::hostIsIPAddress("localhost"));
-    EXPECT_FALSE(URL::hostIsIPAddress("127.localhost"));
-    EXPECT_FALSE(URL::hostIsIPAddress("localhost.127"));
-    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0"));
-    EXPECT_FALSE(URL::hostIsIPAddress("127.0 .0.1"));
-    EXPECT_FALSE(URL::hostIsIPAddress(" 127.0.0.1"));
-    EXPECT_FALSE(URL::hostIsIPAddress("127..0.0.1"));
-    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0."));
-    EXPECT_FALSE(URL::hostIsIPAddress("256.0.0.1"));
-    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98"));
-    EXPECT_FALSE(URL::hostIsIPAddress("012x:4567:89AB:cdef:3210:7654:ba98:FeDc"));
+    EXPECT_FALSE(URL::hostIsIPAddress(""_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("localhost"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("127.localhost"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("localhost.127"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("127.0 .0.1"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress(" 127.0.0.1"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("127..0.0.1"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0."_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("256.0.0.1"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("012x:4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
 #if !PLATFORM(COCOA)
     // FIXME: This fails in Mac.
-    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0.01"));
-    EXPECT_FALSE(URL::hostIsIPAddress("00123:4567:89AB:cdef:3210:7654:ba98:FeDc"));
+    EXPECT_FALSE(URL::hostIsIPAddress("127.0.0.01"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("00123:4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
 #endif
-    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:123.45.67.89"));
-    EXPECT_FALSE(URL::hostIsIPAddress(":::"));
-    EXPECT_FALSE(URL::hostIsIPAddress("0123::89AB:cdef:3210:7654::FeDc"));
-    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:"));
-    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:FeDc:"));
-    EXPECT_FALSE(URL::hostIsIPAddress(":4567:89AB:cdef:3210:7654:ba98:FeDc"));
-    EXPECT_FALSE(URL::hostIsIPAddress(":0123:4567:89AB:cdef:3210:7654:ba98:FeDc"));
+    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:123.45.67.89"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress(":::"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("0123::89AB:cdef:3210:7654::FeDc"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:FeDc:"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress(":4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
+    EXPECT_FALSE(URL::hostIsIPAddress(":0123:4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
 
-    EXPECT_TRUE(URL::hostIsIPAddress("127.0.0.1"));
-    EXPECT_TRUE(URL::hostIsIPAddress("255.1.10.100"));
-    EXPECT_TRUE(URL::hostIsIPAddress("0.0.0.0"));
-    EXPECT_TRUE(URL::hostIsIPAddress("::1"));
-    EXPECT_TRUE(URL::hostIsIPAddress("::"));
-    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:FeDc"));
-    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98::"));
-    EXPECT_TRUE(URL::hostIsIPAddress("::4567:89AB:cdef:3210:7654:ba98:FeDc"));
-    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:123.45.67.89"));
-    EXPECT_TRUE(URL::hostIsIPAddress("::123.45.67.89"));
+    EXPECT_TRUE(URL::hostIsIPAddress("127.0.0.1"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("255.1.10.100"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("0.0.0.0"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("::1"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("::"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:ba98::"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("::4567:89AB:cdef:3210:7654:ba98:FeDc"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("0123:4567:89AB:cdef:3210:7654:123.45.67.89"_s));
+    EXPECT_TRUE(URL::hostIsIPAddress("::123.45.67.89"_s));
 }
 
 TEST_F(WTF_URL, HostIsMatchingDomain)
@@ -328,22 +328,22 @@ TEST_F(WTF_URL, HostIsMatchingDomain)
 
     EXPECT_TRUE(url.isMatchingDomain(String { }));
     EXPECT_TRUE(url.isMatchingDomain(emptyString()));
-    EXPECT_TRUE(url.isMatchingDomain("org"));
-    EXPECT_TRUE(url.isMatchingDomain("webkit.org"));
-    EXPECT_TRUE(url.isMatchingDomain("www.webkit.org"));
+    EXPECT_TRUE(url.isMatchingDomain("org"_s));
+    EXPECT_TRUE(url.isMatchingDomain("webkit.org"_s));
+    EXPECT_TRUE(url.isMatchingDomain("www.webkit.org"_s));
 
-    EXPECT_FALSE(url.isMatchingDomain("rg"));
-    EXPECT_FALSE(url.isMatchingDomain(".org"));
-    EXPECT_FALSE(url.isMatchingDomain("ww.webkit.org"));
-    EXPECT_FALSE(url.isMatchingDomain("http://www.webkit.org"));
+    EXPECT_FALSE(url.isMatchingDomain("rg"_s));
+    EXPECT_FALSE(url.isMatchingDomain(".org"_s));
+    EXPECT_FALSE(url.isMatchingDomain("ww.webkit.org"_s));
+    EXPECT_FALSE(url.isMatchingDomain("http://www.webkit.org"_s));
 
     url = createURL("file:///www.webkit.org"_s);
 
     EXPECT_TRUE(url.isMatchingDomain(String { }));
     EXPECT_TRUE(url.isMatchingDomain(emptyString()));
-    EXPECT_FALSE(url.isMatchingDomain("org"));
-    EXPECT_FALSE(url.isMatchingDomain("webkit.org"));
-    EXPECT_FALSE(url.isMatchingDomain("www.webkit.org"));
+    EXPECT_FALSE(url.isMatchingDomain("org"_s));
+    EXPECT_FALSE(url.isMatchingDomain("webkit.org"_s));
+    EXPECT_FALSE(url.isMatchingDomain("www.webkit.org"_s));
 
     URL emptyURL;
     EXPECT_FALSE(emptyURL.isMatchingDomain(String { }));

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -63,8 +63,7 @@ struct ExpectedParts {
     }
 };
 
-template<typename T, typename U>
-bool eq(T&& s1, U&& s2)
+bool eq(StringView s1, StringView s2)
 {
     EXPECT_STREQ(s1.utf8().data(), s2.utf8().data());
     return s1.utf8() == s2.utf8();
@@ -78,7 +77,7 @@ static String insertTabAtLocation(StringView string, size_t location)
 
 static ExpectedParts invalidParts(StringView urlStringWithTab)
 {
-    return {"", "", "", "", 0, "" , "", "", urlStringWithTab};
+    return { ""_s, ""_s, ""_s, ""_s, 0, ""_s , ""_s, ""_s, urlStringWithTab };
 }
 
 enum class TestTabs { No, Yes };
@@ -202,304 +201,304 @@ static void checkRelativeURLDifferences(StringView urlString, StringView baseURL
 
 static void shouldFail(StringView urlString)
 {
-    checkURL(urlString, {"", "", "", "", 0, "", "", "", urlString});
+    checkURL(urlString, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, urlString });
 }
 
 static void shouldFail(StringView urlString, StringView baseString)
 {
-    checkRelativeURL(urlString, baseString, {"", "", "", "", 0, "", "", "", urlString});
+    checkRelativeURL(urlString, baseString, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, urlString });
 }
 
 TEST_F(WTF_URLParser, Idempotence)
 {
-    checkURL("a://", {"a", "", "", "", 0, "", "", "", "a://"});
-    checkURL("b:///", {"b", "", "", "", 0, "/", "", "", "b:///"});
-    checkURL("c:/.//", {"c", "", "", "", 0, "//", "", "", "c:/.//"});
-    checkURL("d:/..//", {"d", "", "", "", 0, "//", "", "", "d:/.//"});
-    checkURL("e:/../..//", {"e", "", "", "", 0, "//", "", "", "e:/.//"});
-    checkURL("f:/../../", {"f", "", "", "", 0, "/", "", "", "f:/"});
-    checkURL("g:/././", {"g", "", "", "", 0, "/", "", "", "g:/"});
-    checkURL("h:/./../", {"h", "", "", "", 0, "/", "", "", "h:/"});
-    checkURL("i:/.././", {"i", "", "", "", 0, "/", "", "", "i:/"});
-    checkURL("j:/./..//", {"j", "", "", "", 0, "//", "", "", "j:/.//"});
-    checkURL("k:/.././/", {"k", "", "", "", 0, "//", "", "", "k:/.//"});
-    checkURL("l:/.?", {"l", "", "", "", 0, "/", "", "", "l:/?"});
-    checkURL("m:/./?", {"m", "", "", "", 0, "/", "", "", "m:/?"});
-    checkURL("n:/.//?", {"n", "", "", "", 0, "//", "", "", "n:/.//?"});
-    checkURL("o:/.#", {"o", "", "", "", 0, "/", "", "", "o:/#"});
-    checkURL("p:/%2e//", {"p", "", "", "", 0, "//", "", "", "p:/.//"});
-    checkURL("q:/%2e%2e//", {"q", "", "", "", 0, "//", "", "", "q:/.//"});
-    checkURL("r:/%2e%2e/", {"r", "", "", "", 0, "/", "", "", "r:/"});
-    checkURL("s:/%2e/", {"s", "", "", "", 0, "/", "", "", "s:/"});
-    checkURL("t:/.//p/../../../..//x", {"t", "", "", "", 0, "//x", "", "", "t:/.//x"});
-    checkRelativeURL("../path", "u:/.//p", {"u", "", "", "", 0, "/path", "", "", "u:/path"});
-    checkURL("v:/.//..", {"v", "", "", "", 0, "/", "", "", "v:/"});
-    checkURL("w:/.//..//", {"w", "", "", "", 0, "//", "", "", "w:/.//"});
-    checkURL("x:/.//../a", {"x", "", "", "", 0, "/a", "", "", "x:/a"});
-    checkURL("http://host/./", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host/../", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host/.../", {"http", "", "", "host", 0, "/.../", "", "", "http://host/.../"});
-    checkURL("http://host/..", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host/.", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
+    checkURL("a://"_s, { "a"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "a://"_s });
+    checkURL("b:///"_s, { "b"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "b:///"_s });
+    checkURL("c:/.//"_s, { "c"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "c:/.//"_s });
+    checkURL("d:/..//"_s, { "d"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "d:/.//"_s });
+    checkURL("e:/../..//"_s, { "e"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "e:/.//"_s });
+    checkURL("f:/../../"_s, { "f"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "f:/"_s });
+    checkURL("g:/././"_s, { "g"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "g:/"_s });
+    checkURL("h:/./../"_s, { "h"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "h:/"_s });
+    checkURL("i:/.././"_s, { "i"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "i:/"_s });
+    checkURL("j:/./..//"_s, { "j"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "j:/.//"_s });
+    checkURL("k:/.././/"_s, { "k"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "k:/.//"_s });
+    checkURL("l:/.?"_s, { "l"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "l:/?"_s });
+    checkURL("m:/./?"_s, { "m"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "m:/?"_s });
+    checkURL("n:/.//?"_s, { "n"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "n:/.//?"_s });
+    checkURL("o:/.#"_s, { "o"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "o:/#"_s });
+    checkURL("p:/%2e//"_s, { "p"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "p:/.//"_s });
+    checkURL("q:/%2e%2e//"_s, { "q"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "q:/.//"_s });
+    checkURL("r:/%2e%2e/"_s, { "r"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "r:/"_s });
+    checkURL("s:/%2e/"_s, { "s"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "s:/"_s });
+    checkURL("t:/.//p/../../../..//x"_s, { "t"_s, ""_s, ""_s, ""_s, 0, "//x"_s, ""_s, ""_s, "t:/.//x"_s });
+    checkRelativeURL("../path"_s, "u:/.//p"_s, { "u"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "u:/path"_s });
+    checkURL("v:/.//.."_s, { "v"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "v:/"_s });
+    checkURL("w:/.//..//"_s, { "w"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "w:/.//"_s });
+    checkURL("x:/.//../a"_s, { "x"_s, ""_s, ""_s, ""_s, 0, "/a"_s, ""_s, ""_s, "x:/a"_s });
+    checkURL("http://host/./"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host/../"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host/.../"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/.../"_s, ""_s, ""_s, "http://host/.../"_s });
+    checkURL("http://host/.."_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host/."_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
 }
 
 TEST_F(WTF_URLParser, Basic)
 {
-    checkURL("http://user:pass@webkit.org:123/path?query#fragment", {"http", "user", "pass", "webkit.org", 123, "/path", "query", "fragment", "http://user:pass@webkit.org:123/path?query#fragment"});
-    checkURL("http://user:pass@webkit.org:123/path?query", {"http", "user", "pass", "webkit.org", 123, "/path", "query", "", "http://user:pass@webkit.org:123/path?query"});
-    checkURL("http://user:pass@webkit.org:123/path", {"http", "user", "pass", "webkit.org", 123, "/path", "", "", "http://user:pass@webkit.org:123/path"});
-    checkURL("http://user:pass@webkit.org:123/", {"http", "user", "pass", "webkit.org", 123, "/", "", "", "http://user:pass@webkit.org:123/"});
-    checkURL("http://user:pass@webkit.org:123", {"http", "user", "pass", "webkit.org", 123, "/", "", "", "http://user:pass@webkit.org:123/"});
-    checkURL("http://user:pass@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://user:\t\t\tpass@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://us\ter:pass@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://user:pa\tss@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://user:pass\t@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://\tuser:pass@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://user\t:pass@webkit.org", {"http", "user", "pass", "webkit.org", 0, "/", "", "", "http://user:pass@webkit.org/"});
-    checkURL("http://webkit.org", {"http", "", "", "webkit.org", 0, "/", "", "", "http://webkit.org/"});
-    checkURL("http://127.0.0.1", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    checkURL("http://webkit.org/", {"http", "", "", "webkit.org", 0, "/", "", "", "http://webkit.org/"});
-    checkURL("http://webkit.org/path1/path2/index.html", {"http", "", "", "webkit.org", 0, "/path1/path2/index.html", "", "", "http://webkit.org/path1/path2/index.html"});
-    checkURL("about:blank", {"about", "", "", "", 0, "blank", "", "", "about:blank"});
-    checkURL("about:blank?query", {"about", "", "", "", 0, "blank", "query", "", "about:blank?query"});
-    checkURL("about:blank#fragment", {"about", "", "", "", 0, "blank", "", "fragment", "about:blank#fragment"});
-    checkURL("http://[0::0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[0::]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[::]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[::0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[::0:0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[f::0:0]/", {"http", "", "", "[f::]", 0, "/", "", "", "http://[f::]/"});
-    checkURL("http://[f:0::f]/", {"http", "", "", "[f::f]", 0, "/", "", "", "http://[f::f]/"});
-    checkURL("http://[::0:ff]/", {"http", "", "", "[::ff]", 0, "/", "", "", "http://[::ff]/"});
-    checkURL("http://[::00:0:0:0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[::0:00:0:0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[::0:0.0.0.0]/", {"http", "", "", "[::]", 0, "/", "", "", "http://[::]/"});
-    checkURL("http://[0:f::f:f:0:0]", {"http", "", "", "[0:f::f:f:0:0]", 0, "/", "", "", "http://[0:f::f:f:0:0]/"});
-    checkURL("http://[0:f:0:0:f::]", {"http", "", "", "[0:f:0:0:f::]", 0, "/", "", "", "http://[0:f:0:0:f::]/"});
-    checkURL("http://[::f:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[0:f:0:0:f::]:", {"http", "", "", "[0:f:0:0:f::]", 0, "/", "", "", "http://[0:f:0:0:f::]/"});
-    checkURL("http://[0:f:0:0:f::]:\t", {"http", "", "", "[0:f:0:0:f::]", 0, "/", "", "", "http://[0:f:0:0:f::]/"});
-    checkURL("http://[0:f:0:0:f::]\t:", {"http", "", "", "[0:f:0:0:f::]", 0, "/", "", "", "http://[0:f:0:0:f::]/"});
-    checkURL("http://\t[::f:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[\t::f:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[:\t:f:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[::\tf:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[::f\t:0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://[::f:\t0:0:f:0:0]", {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"});
-    checkURL("http://example.com/path1/path2/.", {"http", "", "", "example.com", 0, "/path1/path2/", "", "", "http://example.com/path1/path2/"});
-    checkURL("http://example.com/path1/path2/..", {"http", "", "", "example.com", 0, "/path1/", "", "", "http://example.com/path1/"});
-    checkURL("http://example.com/path1/path2/./path3", {"http", "", "", "example.com", 0, "/path1/path2/path3", "", "", "http://example.com/path1/path2/path3"});
-    checkURL("http://example.com/path1/path2/.\\path3", {"http", "", "", "example.com", 0, "/path1/path2/path3", "", "", "http://example.com/path1/path2/path3"});
-    checkURL("http://example.com/path1/path2/../path3", {"http", "", "", "example.com", 0, "/path1/path3", "", "", "http://example.com/path1/path3"});
-    checkURL("http://example.com/path1/path2/..\\path3", {"http", "", "", "example.com", 0, "/path1/path3", "", "", "http://example.com/path1/path3"});
-    checkURL("http://example.com/.", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com/..", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com/./path1", {"http", "", "", "example.com", 0, "/path1", "", "", "http://example.com/path1"});
-    checkURL("http://example.com/../path1", {"http", "", "", "example.com", 0, "/path1", "", "", "http://example.com/path1"});
-    checkURL("http://example.com/../path1/../../path2/path3/../path4", {"http", "", "", "example.com", 0, "/path2/path4", "", "", "http://example.com/path2/path4"});
-    checkURL("http://example.com/path1/.%2", {"http", "", "", "example.com", 0, "/path1/.%2", "", "", "http://example.com/path1/.%2"});
-    checkURL("http://example.com/path1/%2", {"http", "", "", "example.com", 0, "/path1/%2", "", "", "http://example.com/path1/%2"});
-    checkURL("http://example.com/path1/%", {"http", "", "", "example.com", 0, "/path1/%", "", "", "http://example.com/path1/%"});
-    checkURL("http://example.com/path1/.%", {"http", "", "", "example.com", 0, "/path1/.%", "", "", "http://example.com/path1/.%"});
-    checkURL("http://example.com//.", {"http", "", "", "example.com", 0, "//", "", "", "http://example.com//"});
-    checkURL("http://example.com//./", {"http", "", "", "example.com", 0, "//", "", "", "http://example.com//"});
-    checkURL("http://example.com//.//", {"http", "", "", "example.com", 0, "///", "", "", "http://example.com///"});
-    checkURL("http://example.com//..", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com//../", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com//..//", {"http", "", "", "example.com", 0, "//", "", "", "http://example.com//"});
-    checkURL("http://example.com//..", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com/.//", {"http", "", "", "example.com", 0, "//", "", "", "http://example.com//"});
-    checkURL("http://example.com/..//", {"http", "", "", "example.com", 0, "//", "", "", "http://example.com//"});
-    checkURL("http://example.com/./", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com/../", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkURL("http://example.com/path1/.../path3", {"http", "", "", "example.com", 0, "/path1/.../path3", "", "", "http://example.com/path1/.../path3"});
-    checkURL("http://example.com/path1/...", {"http", "", "", "example.com", 0, "/path1/...", "", "", "http://example.com/path1/..."});
-    checkURL("http://example.com/path1/.../", {"http", "", "", "example.com", 0, "/path1/.../", "", "", "http://example.com/path1/.../"});
-    checkURL("http://example.com/.path1/", {"http", "", "", "example.com", 0, "/.path1/", "", "", "http://example.com/.path1/"});
-    checkURL("http://example.com/..path1/", {"http", "", "", "example.com", 0, "/..path1/", "", "", "http://example.com/..path1/"});
-    checkURL("http://example.com/path1/.path2", {"http", "", "", "example.com", 0, "/path1/.path2", "", "", "http://example.com/path1/.path2"});
-    checkURL("http://example.com/path1/..path2", {"http", "", "", "example.com", 0, "/path1/..path2", "", "", "http://example.com/path1/..path2"});
-    checkURL("http://example.com/path1/path2/.?query", {"http", "", "", "example.com", 0, "/path1/path2/", "query", "", "http://example.com/path1/path2/?query"});
-    checkURL("http://example.com/path1/path2/..?query", {"http", "", "", "example.com", 0, "/path1/", "query", "", "http://example.com/path1/?query"});
-    checkURL("http://example.com/path1/path2/.#fragment", {"http", "", "", "example.com", 0, "/path1/path2/", "", "fragment", "http://example.com/path1/path2/#fragment"});
-    checkURL("http://example.com/path1/path2/..#fragment", {"http", "", "", "example.com", 0, "/path1/", "", "fragment", "http://example.com/path1/#fragment"});
+    checkURL("http://user:pass@webkit.org:123/path?query#fragment"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 123, "/path"_s, "query"_s, "fragment"_s, "http://user:pass@webkit.org:123/path?query#fragment"_s });
+    checkURL("http://user:pass@webkit.org:123/path?query"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 123, "/path"_s, "query"_s, ""_s, "http://user:pass@webkit.org:123/path?query"_s });
+    checkURL("http://user:pass@webkit.org:123/path"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 123, "/path"_s, ""_s, ""_s, "http://user:pass@webkit.org:123/path"_s });
+    checkURL("http://user:pass@webkit.org:123/"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 123, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org:123/"_s });
+    checkURL("http://user:pass@webkit.org:123"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 123, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org:123/"_s });
+    checkURL("http://user:pass@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://user:\t\t\tpass@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://us\ter:pass@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://user:pa\tss@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://user:pass\t@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://\tuser:pass@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://user\t:pass@webkit.org"_s, { "http"_s, "user"_s, "pass"_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://user:pass@webkit.org/"_s });
+    checkURL("http://webkit.org"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://webkit.org/"_s });
+    checkURL("http://127.0.0.1"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    checkURL("http://webkit.org/"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://webkit.org/"_s });
+    checkURL("http://webkit.org/path1/path2/index.html"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/path1/path2/index.html"_s, ""_s, ""_s, "http://webkit.org/path1/path2/index.html"_s });
+    checkURL("about:blank"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "blank"_s, ""_s, ""_s, "about:blank"_s });
+    checkURL("about:blank?query"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "blank"_s, "query"_s, ""_s, "about:blank?query"_s });
+    checkURL("about:blank#fragment"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "blank"_s, ""_s, "fragment"_s, "about:blank#fragment"_s });
+    checkURL("http://[0::0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[0::]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[::]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[::0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[::0:0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[f::0:0]/"_s, { "http"_s, ""_s, ""_s, "[f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[f::]/"_s });
+    checkURL("http://[f:0::f]/"_s, { "http"_s, ""_s, ""_s, "[f::f]"_s, 0, "/"_s, ""_s, ""_s, "http://[f::f]/"_s });
+    checkURL("http://[::0:ff]/"_s, { "http"_s, ""_s, ""_s, "[::ff]"_s, 0, "/"_s, ""_s, ""_s, "http://[::ff]/"_s });
+    checkURL("http://[::00:0:0:0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[::0:00:0:0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[::0:0.0.0.0]/"_s, { "http"_s, ""_s, ""_s, "[::]"_s, 0, "/"_s, ""_s, ""_s, "http://[::]/"_s });
+    checkURL("http://[0:f::f:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]/"_s });
+    checkURL("http://[0:f:0:0:f::]"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]/"_s });
+    checkURL("http://[::f:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[0:f:0:0:f::]:"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]/"_s });
+    checkURL("http://[0:f:0:0:f::]:\t"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]/"_s });
+    checkURL("http://[0:f:0:0:f::]\t:"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]/"_s });
+    checkURL("http://\t[::f:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[\t::f:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[:\t:f:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[::\tf:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[::f\t:0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://[::f:\t0:0:f:0:0]"_s, { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s });
+    checkURL("http://example.com/path1/path2/."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/"_s, ""_s, ""_s, "http://example.com/path1/path2/"_s });
+    checkURL("http://example.com/path1/path2/.."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, ""_s, "http://example.com/path1/"_s });
+    checkURL("http://example.com/path1/path2/./path3"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/path3"_s, ""_s, ""_s, "http://example.com/path1/path2/path3"_s });
+    checkURL("http://example.com/path1/path2/.\\path3"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/path3"_s, ""_s, ""_s, "http://example.com/path1/path2/path3"_s });
+    checkURL("http://example.com/path1/path2/../path3"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path3"_s, ""_s, ""_s, "http://example.com/path1/path3"_s });
+    checkURL("http://example.com/path1/path2/..\\path3"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path3"_s, ""_s, ""_s, "http://example.com/path1/path3"_s });
+    checkURL("http://example.com/."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com/.."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com/./path1"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1"_s, ""_s, ""_s, "http://example.com/path1"_s });
+    checkURL("http://example.com/../path1"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1"_s, ""_s, ""_s, "http://example.com/path1"_s });
+    checkURL("http://example.com/../path1/../../path2/path3/../path4"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path2/path4"_s, ""_s, ""_s, "http://example.com/path2/path4"_s });
+    checkURL("http://example.com/path1/.%2"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.%2"_s, ""_s, ""_s, "http://example.com/path1/.%2"_s });
+    checkURL("http://example.com/path1/%2"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2"_s, ""_s, ""_s, "http://example.com/path1/%2"_s });
+    checkURL("http://example.com/path1/%"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%"_s, ""_s, ""_s, "http://example.com/path1/%"_s });
+    checkURL("http://example.com/path1/.%"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.%"_s, ""_s, ""_s, "http://example.com/path1/.%"_s });
+    checkURL("http://example.com//."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "//"_s, ""_s, ""_s, "http://example.com//"_s });
+    checkURL("http://example.com//./"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "//"_s, ""_s, ""_s, "http://example.com//"_s });
+    checkURL("http://example.com//.//"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "///"_s, ""_s, ""_s, "http://example.com///"_s });
+    checkURL("http://example.com//.."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com//../"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com//..//"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "//"_s, ""_s, ""_s, "http://example.com//"_s });
+    checkURL("http://example.com//.."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com/.//"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "//"_s, ""_s, ""_s, "http://example.com//"_s });
+    checkURL("http://example.com/..//"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "//"_s, ""_s, ""_s, "http://example.com//"_s });
+    checkURL("http://example.com/./"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com/../"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkURL("http://example.com/path1/.../path3"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.../path3"_s, ""_s, ""_s, "http://example.com/path1/.../path3"_s });
+    checkURL("http://example.com/path1/..."_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/..."_s, ""_s, ""_s, "http://example.com/path1/..."_s });
+    checkURL("http://example.com/path1/.../"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.../"_s, ""_s, ""_s, "http://example.com/path1/.../"_s });
+    checkURL("http://example.com/.path1/"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/.path1/"_s, ""_s, ""_s, "http://example.com/.path1/"_s });
+    checkURL("http://example.com/..path1/"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/..path1/"_s, ""_s, ""_s, "http://example.com/..path1/"_s });
+    checkURL("http://example.com/path1/.path2"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.path2"_s, ""_s, ""_s, "http://example.com/path1/.path2"_s });
+    checkURL("http://example.com/path1/..path2"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/..path2"_s, ""_s, ""_s, "http://example.com/path1/..path2"_s });
+    checkURL("http://example.com/path1/path2/.?query"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/"_s, "query"_s, ""_s, "http://example.com/path1/path2/?query"_s });
+    checkURL("http://example.com/path1/path2/..?query"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, "query"_s, ""_s, "http://example.com/path1/?query"_s });
+    checkURL("http://example.com/path1/path2/.#fragment"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/"_s, ""_s, "fragment"_s, "http://example.com/path1/path2/#fragment"_s });
+    checkURL("http://example.com/path1/path2/..#fragment"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, "fragment"_s, "http://example.com/path1/#fragment"_s });
 
-    checkURL("file:", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file:/", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file://", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file:///", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file:////", {"file", "", "", "", 0, "//", "", "", "file:////"}); // This matches Firefox and URL::parse which I believe are correct, but not Chrome.
-    checkURL("file:/path", {"file", "", "", "", 0, "/path", "", "", "file:///path"});
-    checkURL("file://host/path", {"file", "", "", "host", 0, "/path", "", "", "file://host/path"});
-    checkURL("file://host", {"file", "", "", "host", 0, "/", "", "", "file://host/"});
-    checkURL("file://host/", {"file", "", "", "host", 0, "/", "", "", "file://host/"});
-    checkURL("file:///path", {"file", "", "", "", 0, "/path", "", "", "file:///path"});
-    checkURL("file:////path", {"file", "", "", "", 0, "//path", "", "", "file:////path"});
-    checkURL("file://localhost/path", {"file", "", "", "", 0, "/path", "", "", "file:///path"});
-    checkURL("file://localhost/", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file://localhost", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file://lOcAlHoSt", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file://lOcAlHoSt/", {"file", "", "", "", 0, "/", "", "", "file:///"});
-    checkURL("file:/pAtH/", {"file", "", "", "", 0, "/pAtH/", "", "", "file:///pAtH/"});
-    checkURL("file:/pAtH", {"file", "", "", "", 0, "/pAtH", "", "", "file:///pAtH"});
-    checkURL("file:?query", {"file", "", "", "", 0, "/", "query", "", "file:///?query"});
-    checkURL("file:#fragment", {"file", "", "", "", 0, "/", "", "fragment", "file:///#fragment"});
-    checkURL("file:?query#fragment", {"file", "", "", "", 0, "/", "query", "fragment", "file:///?query#fragment"});
-    checkURL("file:#fragment?notquery", {"file", "", "", "", 0, "/", "", "fragment?notquery", "file:///#fragment?notquery"});
-    checkURL("file:/?query", {"file", "", "", "", 0, "/", "query", "", "file:///?query"});
-    checkURL("file:/#fragment", {"file", "", "", "", 0, "/", "", "fragment", "file:///#fragment"});
-    checkURL("file://?query", {"file", "", "", "", 0, "/", "query", "", "file:///?query"});
-    checkURL("file://#fragment", {"file", "", "", "", 0, "/", "", "fragment", "file:///#fragment"});
-    checkURL("file:///?query", {"file", "", "", "", 0, "/", "query", "", "file:///?query"});
-    checkURL("file:///#fragment", {"file", "", "", "", 0, "/", "", "fragment", "file:///#fragment"});
-    checkURL("file:////?query", {"file", "", "", "", 0, "//", "query", "", "file:////?query"});
-    checkURL("file:////#fragment", {"file", "", "", "", 0, "//", "", "fragment", "file:////#fragment"});
-    checkURL("file://?Q", {"file", "", "", "", 0, "/", "Q", "", "file:///?Q"});
-    checkURL("file://#F", {"file", "", "", "", 0, "/", "", "F", "file:///#F"});
-    checkURL("file://host?Q", {"file", "", "", "host", 0, "/", "Q", "", "file://host/?Q"});
-    checkURL("file://host#F", {"file", "", "", "host", 0, "/", "", "F", "file://host/#F"});
-    checkURL("file://host\\P", {"file", "", "", "host", 0, "/P", "", "", "file://host/P"});
-    checkURL("file://host\\?Q", {"file", "", "", "host", 0, "/", "Q", "", "file://host/?Q"});
-    checkURL("file://host\\../P", {"file", "", "", "host", 0, "/P", "", "", "file://host/P"});
-    checkURL("file://host\\/../P", {"file", "", "", "host", 0, "/P", "", "", "file://host/P"});
-    checkURL("file://host\\/P", {"file", "", "", "host", 0, "//P", "", "", "file://host//P"});
-    checkURL("http://host/A b", {"http", "", "", "host", 0, "/A%20b", "", "", "http://host/A%20b"});
-    checkURL("http://host/a%20B", {"http", "", "", "host", 0, "/a%20B", "", "", "http://host/a%20B"});
-    checkURL("http://host?q=@ <>!#fragment", {"http", "", "", "host", 0, "/", "q=@%20%3C%3E!", "fragment", "http://host/?q=@%20%3C%3E!#fragment"});
-    checkURL("http://user:@host", {"http", "user", "", "host", 0, "/", "", "", "http://user@host/"});
-    checkURL("http://user:@\thost", {"http", "user", "", "host", 0, "/", "", "", "http://user@host/"});
-    checkURL("http://user:\t@host", {"http", "user", "", "host", 0, "/", "", "", "http://user@host/"});
-    checkURL("http://user\t:@host", {"http", "user", "", "host", 0, "/", "", "", "http://user@host/"});
-    checkURL("http://use\tr:@host", {"http", "user", "", "host", 0, "/", "", "", "http://user@host/"});
-    checkURL("http://127.0.0.1:10100/path", {"http", "", "", "127.0.0.1", 10100, "/path", "", "", "http://127.0.0.1:10100/path"});
-    checkURL("http://127.0.0.1:/path", {"http", "", "", "127.0.0.1", 0, "/path", "", "", "http://127.0.0.1/path"});
-    checkURL("http://127.0.0.1\t:/path", {"http", "", "", "127.0.0.1", 0, "/path", "", "", "http://127.0.0.1/path"});
-    checkURL("http://127.0.0.1:\t/path", {"http", "", "", "127.0.0.1", 0, "/path", "", "", "http://127.0.0.1/path"});
-    checkURL("http://127.0.0.1:/\tpath", {"http", "", "", "127.0.0.1", 0, "/path", "", "", "http://127.0.0.1/path"});
-    checkURL("http://127.0.0.1:123", {"http", "", "", "127.0.0.1", 123, "/", "", "", "http://127.0.0.1:123/"});
-    checkURL("http://127.0.0.1:", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    shouldFail("ws://08./");
-    checkURL("http://[0:f::f:f:0:0]:123/path", {"http", "", "", "[0:f::f:f:0:0]", 123, "/path", "", "", "http://[0:f::f:f:0:0]:123/path"});
-    checkURL("http://[0:f::f:f:0:0]:123", {"http", "", "", "[0:f::f:f:0:0]", 123, "/", "", "", "http://[0:f::f:f:0:0]:123/"});
-    checkURL("http://[0:f:0:0:f:\t:]:123", {"http", "", "", "[0:f:0:0:f::]", 123, "/", "", "", "http://[0:f:0:0:f::]:123/"});
-    checkURL("http://[0:f:0:0:f::\t]:123", {"http", "", "", "[0:f:0:0:f::]", 123, "/", "", "", "http://[0:f:0:0:f::]:123/"});
-    checkURL("http://[0:f:0:0:f::]\t:123", {"http", "", "", "[0:f:0:0:f::]", 123, "/", "", "", "http://[0:f:0:0:f::]:123/"});
-    checkURL("http://[0:f:0:0:f::]:\t123", {"http", "", "", "[0:f:0:0:f::]", 123, "/", "", "", "http://[0:f:0:0:f::]:123/"});
-    checkURL("http://[0:f:0:0:f::]:1\t23", {"http", "", "", "[0:f:0:0:f::]", 123, "/", "", "", "http://[0:f:0:0:f::]:123/"});
-    checkURL("http://[0:f::f:f:0:0]:/path", {"http", "", "", "[0:f::f:f:0:0]", 0, "/path", "", "", "http://[0:f::f:f:0:0]/path"});
-    checkURL("a://[::2:]", {"a", "", "", "[::2]", 0, "", "", "", "a://[::2]"});
-    checkURL("http://[0:f::f:f:0:0]:", {"http", "", "", "[0:f::f:f:0:0]", 0, "/", "", "", "http://[0:f::f:f:0:0]/"});
-    checkURL("http://host:10100/path", {"http", "", "", "host", 10100, "/path", "", "", "http://host:10100/path"});
-    checkURL("http://host:/path", {"http", "", "", "host", 0, "/path", "", "", "http://host/path"});
-    checkURL("http://host:123", {"http", "", "", "host", 123, "/", "", "", "http://host:123/"});
-    checkURL("http://host:", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://hos\tt\n:\t1\n2\t3\t/\npath", {"http", "", "", "host", 123, "/path", "", "", "http://host:123/path"});
-    checkURL("http://user@example.org/path3", {"http", "user", "", "example.org", 0, "/path3", "", "", "http://user@example.org/path3"});
-    checkURL("sc:/pa/pa", {"sc", "", "", "", 0, "/pa/pa", "", "", "sc:/pa/pa"});
-    checkURL("sc:/pa", {"sc", "", "", "", 0, "/pa", "", "", "sc:/pa"});
-    checkURL("sc:/pa/", {"sc", "", "", "", 0, "/pa/", "", "", "sc:/pa/"});
-    checkURL("notspecial:/notuser:notpassword@nothost", {"notspecial", "", "", "", 0, "/notuser:notpassword@nothost", "", "", "notspecial:/notuser:notpassword@nothost"});
-    checkURL("sc://pa/", {"sc", "", "", "pa", 0, "/", "", "", "sc://pa/"});
-    checkURL("sc://\tpa/", {"sc", "", "", "pa", 0, "/", "", "", "sc://pa/"});
-    checkURL("sc:/\t/pa/", {"sc", "", "", "pa", 0, "/", "", "", "sc://pa/"});
-    checkURL("sc:\t//pa/", {"sc", "", "", "pa", 0, "/", "", "", "sc://pa/"});
-    checkURL("http://host   \a   ", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("notspecial:/a", {"notspecial", "", "", "", 0, "/a", "", "", "notspecial:/a"});
-    checkURL("notspecial:", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
-    checkURL("http:/a", {"http", "", "", "a", 0, "/", "", "", "http://a/"});
-    checkURL("http://256../", {"http", "", "", "256..", 0, "/", "", "", "http://256../"});
-    checkURL("http://256..", {"http", "", "", "256..", 0, "/", "", "", "http://256../"});
-    shouldFail("http://127..1/");
-    shouldFail("http://127.a.0.1/");
-    checkURL("http://127.0.0.1/", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    checkURL("http://12\t7.0.0.1/", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    checkURL("http://127.\t0.0.1/", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    checkURL("http://./", {"http", "", "", ".", 0, "/", "", "", "http://./"});
-    checkURL("http://.", {"http", "", "", ".", 0, "/", "", "", "http://./"});
-    checkURL("notspecial:/a", {"notspecial", "", "", "", 0, "/a", "", "", "notspecial:/a"});
-    checkURL("notspecial:", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
-    checkURL("notspecial:/", {"notspecial", "", "", "", 0, "/", "", "", "notspecial:/"});
-    checkURL("data:image/png;base64,encoded-data-follows-here", {"data", "", "", "", 0, "image/png;base64,encoded-data-follows-here", "", "", "data:image/png;base64,encoded-data-follows-here"});
-    checkURL("data:image/png;base64,encoded/data-with-slash", {"data", "", "", "", 0, "image/png;base64,encoded/data-with-slash", "", "", "data:image/png;base64,encoded/data-with-slash"});
-    checkURL("about:~", {"about", "", "", "", 0, "~", "", "", "about:~"});
-    checkURL("https://@test@test@example:800\\path@end", {"", "", "", "", 0, "", "", "", "https://@test@test@example:800\\path@end"});
-    checkURL("http://www.example.com/#a\nb\rc\td", {"http", "", "", "www.example.com", 0, "/", "", "abcd", "http://www.example.com/#abcd"});
-    checkURL("http://[A:b:c:DE:fF:0:1:aC]/", {"http", "", "", "[a:b:c:de:ff:0:1:ac]", 0, "/", "", "", "http://[a:b:c:de:ff:0:1:ac]/"});
-    checkURL("http:////////user:@webkit.org:99?foo", {"http", "user", "", "webkit.org", 99, "/", "foo", "", "http://user@webkit.org:99/?foo"});
-    checkURL("http:////////user:@webkit.org:99#foo", {"http", "user", "", "webkit.org", 99, "/", "", "foo", "http://user@webkit.org:99/#foo"});
-    checkURL("http:////\t////user:@webkit.org:99?foo", {"http", "user", "", "webkit.org", 99, "/", "foo", "", "http://user@webkit.org:99/?foo"});
-    checkURL("http://\t//\\///user:@webkit.org:99?foo", {"http", "user", "", "webkit.org", 99, "/", "foo", "", "http://user@webkit.org:99/?foo"});
-    checkURL("http:/\\user:@webkit.org:99?foo", {"http", "user", "", "webkit.org", 99, "/", "foo", "", "http://user@webkit.org:99/?foo"});
-    checkURL("http://127.0.0.1", {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"});
-    checkURLDifferences("http://127.0.0.1.",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.0.0.1.", 0, "/", "", "", "http://127.0.0.1./"});
-    checkURLDifferences("http://127.0.0.1./",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.0.0.1.", 0, "/", "", "", "http://127.0.0.1./"});
-    checkURL("http://127.0.0.1../", {"http", "", "", "127.0.0.1..", 0, "/", "", "", "http://127.0.0.1../"});
-    checkURLDifferences("http://0x100.0/",
-        {"", "", "", "", 0, "", "", "", "http://0x100.0/"},
-        {"http", "", "", "0x100.0", 0, "/", "", "", "http://0x100.0/"});
-    checkURLDifferences("http://0.0.0x100.0/",
-        {"", "", "", "", 0, "", "", "", "http://0.0.0x100.0/"},
-        {"http", "", "", "0.0.0x100.0", 0, "/", "", "", "http://0.0.0x100.0/"});
-    checkURLDifferences("http://0.0.0.0x100/",
-        {"", "", "", "", 0, "", "", "", "http://0.0.0.0x100/"},
-        {"http", "", "", "0.0.0.0x100", 0, "/", "", "", "http://0.0.0.0x100/"});
-    checkURL("http://host:123?", {"http", "", "", "host", 123, "/", "", "", "http://host:123/?"});
-    checkURL("http://host:123?query", {"http", "", "", "host", 123, "/", "query", "", "http://host:123/?query"});
-    checkURL("http://host:123#", {"http", "", "", "host", 123, "/", "", "", "http://host:123/#"});
-    checkURL("http://host:123#fragment", {"http", "", "", "host", 123, "/", "", "fragment", "http://host:123/#fragment"});
-    checkURLDifferences("foo:////",
-        {"foo", "", "", "", 0, "//", "", "", "foo:////"},
-        {"foo", "", "", "", 0, "////", "", "", "foo:////"});
-    checkURLDifferences("foo:///?",
-        {"foo", "", "", "", 0, "/", "", "", "foo:///?"},
-        {"foo", "", "", "", 0, "///", "", "", "foo:///?"});
-    checkURLDifferences("foo:///#",
-        {"foo", "", "", "", 0, "/", "", "", "foo:///#"},
-        {"foo", "", "", "", 0, "///", "", "", "foo:///#"});
-    checkURLDifferences("foo:///",
-        {"foo", "", "", "", 0, "/", "", "", "foo:///"},
-        {"foo", "", "", "", 0, "///", "", "", "foo:///"});
-    checkURLDifferences("foo://?",
-        {"foo", "", "", "", 0, "", "", "", "foo://?"},
-        {"foo", "", "", "", 0, "//", "", "", "foo://?"});
-    checkURLDifferences("foo://#",
-        {"foo", "", "", "", 0, "", "", "", "foo://#"},
-        {"foo", "", "", "", 0, "//", "", "", "foo://#"});
-    checkURLDifferences("foo://",
-        {"foo", "", "", "", 0, "", "", "", "foo://"},
-        {"foo", "", "", "", 0, "//", "", "", "foo://"});
-    checkURL("foo:/?", {"foo", "", "", "", 0, "/", "", "", "foo:/?"});
-    checkURL("foo:/#", {"foo", "", "", "", 0, "/", "", "", "foo:/#"});
-    checkURL("foo:/", {"foo", "", "", "", 0, "/", "", "", "foo:/"});
-    checkURL("foo:?", {"foo", "", "", "", 0, "", "", "", "foo:?"});
-    checkURL("foo:#", {"foo", "", "", "", 0, "", "", "", "foo:#"});
-    checkURLDifferences("A://",
-        {"a", "", "", "", 0, "", "", "", "a://"},
-        {"a", "", "", "", 0, "//", "", "", "a://"});
-    checkURLDifferences("aA://",
-        {"aa", "", "", "", 0, "", "", "", "aa://"},
-        {"aa", "", "", "", 0, "//", "", "", "aa://"});
-    checkURL(utf16String(u"foo://host/#ПП\u0007 a</"), {"foo", "", "", "host", 0, "/", "", "%D0%9F%D0%9F%07%20a%3C/", "foo://host/#%D0%9F%D0%9F%07%20a%3C/"});
-    checkURL(utf16String(u"foo://host/#\u0007 a</"), {"foo", "", "", "host", 0, "/", "", "%07%20a%3C/", "foo://host/#%07%20a%3C/"});
-    checkURL(utf16String(u"http://host?ß😍#ß😍"), {"http", "", "", "host", 0, "/", "%C3%9F%F0%9F%98%8D", "%C3%9F%F0%9F%98%8D", "http://host/?%C3%9F%F0%9F%98%8D#%C3%9F%F0%9F%98%8D"}, testTabsValueForSurrogatePairs);
-    checkURL(utf16String(u"http://host/path#💩\t💩"), {"http", "", "", "host", 0, "/path", "", "%F0%9F%92%A9%F0%9F%92%A9", "http://host/path#%F0%9F%92%A9%F0%9F%92%A9"}, testTabsValueForSurrogatePairs);
-    checkURL(utf16String(u"http://host/#ПП\u0007 a</"), {"http", "", "", "host", 0, "/", "", "%D0%9F%D0%9F%07%20a%3C/", "http://host/#%D0%9F%D0%9F%07%20a%3C/"});
-    checkURL(utf16String(u"http://host/#\u0007 a</"), {"http", "", "", "host", 0, "/", "", "%07%20a%3C/", "http://host/#%07%20a%3C/"});
+    checkURL("file:"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file:/"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file://"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file:///"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file:////"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "file:////"_s }); // This matches Firefox and URL::parse which I believe are correct, but not Chrome.
+    checkURL("file:/path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path"_s });
+    checkURL("file://host/path"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, ""_s, ""_s, "file://host/path"_s });
+    checkURL("file://host"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "file://host/"_s });
+    checkURL("file://host/"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "file://host/"_s });
+    checkURL("file:///path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path"_s });
+    checkURL("file:////path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "//path"_s, ""_s, ""_s, "file:////path"_s });
+    checkURL("file://localhost/path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path"_s });
+    checkURL("file://localhost/"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file://localhost"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file://lOcAlHoSt"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file://lOcAlHoSt/"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "file:///"_s });
+    checkURL("file:/pAtH/"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/pAtH/"_s, ""_s, ""_s, "file:///pAtH/"_s });
+    checkURL("file:/pAtH"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/pAtH"_s, ""_s, ""_s, "file:///pAtH"_s });
+    checkURL("file:?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "query"_s, ""_s, "file:///?query"_s });
+    checkURL("file:#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "fragment"_s, "file:///#fragment"_s });
+    checkURL("file:?query#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "query"_s, "fragment"_s, "file:///?query#fragment"_s });
+    checkURL("file:#fragment?notquery"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "fragment?notquery"_s, "file:///#fragment?notquery"_s });
+    checkURL("file:/?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "query"_s, ""_s, "file:///?query"_s });
+    checkURL("file:/#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "fragment"_s, "file:///#fragment"_s });
+    checkURL("file://?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "query"_s, ""_s, "file:///?query"_s });
+    checkURL("file://#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "fragment"_s, "file:///#fragment"_s });
+    checkURL("file:///?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "query"_s, ""_s, "file:///?query"_s });
+    checkURL("file:///#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "fragment"_s, "file:///#fragment"_s });
+    checkURL("file:////?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "//"_s, "query"_s, ""_s, "file:////?query"_s });
+    checkURL("file:////#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, "fragment"_s, "file:////#fragment"_s });
+    checkURL("file://?Q"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, "Q"_s, ""_s, "file:///?Q"_s });
+    checkURL("file://#F"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "F"_s, "file:///#F"_s });
+    checkURL("file://host?Q"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, "Q"_s, ""_s, "file://host/?Q"_s });
+    checkURL("file://host#F"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, "F"_s, "file://host/#F"_s });
+    checkURL("file://host\\P"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/P"_s, ""_s, ""_s, "file://host/P"_s });
+    checkURL("file://host\\?Q"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, "Q"_s, ""_s, "file://host/?Q"_s });
+    checkURL("file://host\\../P"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/P"_s, ""_s, ""_s, "file://host/P"_s });
+    checkURL("file://host\\/../P"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/P"_s, ""_s, ""_s, "file://host/P"_s });
+    checkURL("file://host\\/P"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "//P"_s, ""_s, ""_s, "file://host//P"_s });
+    checkURL("http://host/A b"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/A%20b"_s, ""_s, ""_s, "http://host/A%20b"_s });
+    checkURL("http://host/a%20B"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/a%20B"_s, ""_s, ""_s, "http://host/a%20B"_s });
+    checkURL("http://host?q=@ <>!#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, "q=@%20%3C%3E!"_s, "fragment"_s, "http://host/?q=@%20%3C%3E!#fragment"_s });
+    checkURL("http://user:@host"_s, { "http"_s, "user"_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://user@host/"_s });
+    checkURL("http://user:@\thost"_s, { "http"_s, "user"_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://user@host/"_s });
+    checkURL("http://user:\t@host"_s, { "http"_s, "user"_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://user@host/"_s });
+    checkURL("http://user\t:@host"_s, { "http"_s, "user"_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://user@host/"_s });
+    checkURL("http://use\tr:@host"_s, { "http"_s, "user"_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://user@host/"_s });
+    checkURL("http://127.0.0.1:10100/path"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 10100, "/path"_s, ""_s, ""_s, "http://127.0.0.1:10100/path"_s });
+    checkURL("http://127.0.0.1:/path"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/path"_s, ""_s, ""_s, "http://127.0.0.1/path"_s });
+    checkURL("http://127.0.0.1\t:/path"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/path"_s, ""_s, ""_s, "http://127.0.0.1/path"_s });
+    checkURL("http://127.0.0.1:\t/path"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/path"_s, ""_s, ""_s, "http://127.0.0.1/path"_s });
+    checkURL("http://127.0.0.1:/\tpath"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/path"_s, ""_s, ""_s, "http://127.0.0.1/path"_s });
+    checkURL("http://127.0.0.1:123"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 123, "/"_s, ""_s, ""_s, "http://127.0.0.1:123/"_s });
+    checkURL("http://127.0.0.1:"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    shouldFail("ws://08./"_s);
+    checkURL("http://[0:f::f:f:0:0]:123/path"_s, { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 123, "/path"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]:123/path"_s });
+    checkURL("http://[0:f::f:f:0:0]:123"_s, { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]:123/"_s });
+    checkURL("http://[0:f:0:0:f:\t:]:123"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]:123/"_s });
+    checkURL("http://[0:f:0:0:f::\t]:123"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]:123/"_s });
+    checkURL("http://[0:f:0:0:f::]\t:123"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]:123/"_s });
+    checkURL("http://[0:f:0:0:f::]:\t123"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]:123/"_s });
+    checkURL("http://[0:f:0:0:f::]:1\t23"_s, { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 123, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]:123/"_s });
+    checkURL("http://[0:f::f:f:0:0]:/path"_s, { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 0, "/path"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]/path"_s });
+    checkURL("a://[::2:]"_s, { "a"_s, ""_s, ""_s, "[::2]"_s, 0, ""_s, ""_s, ""_s, "a://[::2]"_s });
+    checkURL("http://[0:f::f:f:0:0]:"_s, { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]/"_s });
+    checkURL("http://host:10100/path"_s, { "http"_s, ""_s, ""_s, "host"_s, 10100, "/path"_s, ""_s, ""_s, "http://host:10100/path"_s });
+    checkURL("http://host:/path"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, ""_s, ""_s, "http://host/path"_s });
+    checkURL("http://host:123"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/"_s, ""_s, ""_s, "http://host:123/"_s });
+    checkURL("http://host:"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://hos\tt\n:\t1\n2\t3\t/\npath"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/path"_s, ""_s, ""_s, "http://host:123/path"_s });
+    checkURL("http://user@example.org/path3"_s, { "http"_s, "user"_s, ""_s, "example.org"_s, 0, "/path3"_s, ""_s, ""_s, "http://user@example.org/path3"_s });
+    checkURL("sc:/pa/pa"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa/pa"_s, ""_s, ""_s, "sc:/pa/pa"_s });
+    checkURL("sc:/pa"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa"_s, ""_s, ""_s, "sc:/pa"_s });
+    checkURL("sc:/pa/"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa/"_s, ""_s, ""_s, "sc:/pa/"_s });
+    checkURL("notspecial:/notuser:notpassword@nothost"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/notuser:notpassword@nothost"_s, ""_s, ""_s, "notspecial:/notuser:notpassword@nothost"_s });
+    checkURL("sc://pa/"_s, { "sc"_s, ""_s, ""_s, "pa"_s, 0, "/"_s, ""_s, ""_s, "sc://pa/"_s });
+    checkURL("sc://\tpa/"_s, { "sc"_s, ""_s, ""_s, "pa"_s, 0, "/"_s, ""_s, ""_s, "sc://pa/"_s });
+    checkURL("sc:/\t/pa/"_s, { "sc"_s, ""_s, ""_s, "pa"_s, 0, "/"_s, ""_s, ""_s, "sc://pa/"_s });
+    checkURL("sc:\t//pa/"_s, { "sc"_s, ""_s, ""_s, "pa"_s, 0, "/"_s, ""_s, ""_s, "sc://pa/"_s });
+    checkURL("http://host   \a   "_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("notspecial:/a"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/a"_s, ""_s, ""_s, "notspecial:/a"_s });
+    checkURL("notspecial:"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
+    checkURL("http:/a"_s, { "http"_s, ""_s, ""_s, "a"_s, 0, "/"_s, ""_s, ""_s, "http://a/"_s });
+    checkURL("http://256../"_s, { "http"_s, ""_s, ""_s, "256.."_s, 0, "/"_s, ""_s, ""_s, "http://256../"_s });
+    checkURL("http://256.."_s, { "http"_s, ""_s, ""_s, "256.."_s, 0, "/"_s, ""_s, ""_s, "http://256../"_s });
+    shouldFail("http://127..1/"_s);
+    shouldFail("http://127.a.0.1/"_s);
+    checkURL("http://127.0.0.1/"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    checkURL("http://12\t7.0.0.1/"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    checkURL("http://127.\t0.0.1/"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    checkURL("http://./"_s, { "http"_s, ""_s, ""_s, "."_s, 0, "/"_s, ""_s, ""_s, "http://./"_s });
+    checkURL("http://."_s, { "http"_s, ""_s, ""_s, "."_s, 0, "/"_s, ""_s, ""_s, "http://./"_s });
+    checkURL("notspecial:/a"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/a"_s, ""_s, ""_s, "notspecial:/a"_s });
+    checkURL("notspecial:"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
+    checkURL("notspecial:/"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "notspecial:/"_s });
+    checkURL("data:image/png;base64,encoded-data-follows-here"_s, { "data"_s, ""_s, ""_s, ""_s, 0, "image/png;base64,encoded-data-follows-here"_s, ""_s, ""_s, "data:image/png;base64,encoded-data-follows-here"_s });
+    checkURL("data:image/png;base64,encoded/data-with-slash"_s, { "data"_s, ""_s, ""_s, ""_s, 0, "image/png;base64,encoded/data-with-slash"_s, ""_s, ""_s, "data:image/png;base64,encoded/data-with-slash"_s });
+    checkURL("about:~"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "~"_s, ""_s, ""_s, "about:~"_s });
+    checkURL("https://@test@test@example:800\\path@end"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "https://@test@test@example:800\\path@end"_s });
+    checkURL("http://www.example.com/#a\nb\rc\td"_s, { "http"_s, ""_s, ""_s, "www.example.com"_s, 0, "/"_s, ""_s, "abcd"_s, "http://www.example.com/#abcd"_s });
+    checkURL("http://[A:b:c:DE:fF:0:1:aC]/"_s, { "http"_s, ""_s, ""_s, "[a:b:c:de:ff:0:1:ac]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:de:ff:0:1:ac]/"_s });
+    checkURL("http:////////user:@webkit.org:99?foo"_s, { "http"_s, "user"_s, ""_s, "webkit.org"_s, 99, "/"_s, "foo"_s, ""_s, "http://user@webkit.org:99/?foo"_s });
+    checkURL("http:////////user:@webkit.org:99#foo"_s, { "http"_s, "user"_s, ""_s, "webkit.org"_s, 99, "/"_s, ""_s, "foo"_s, "http://user@webkit.org:99/#foo"_s });
+    checkURL("http:////\t////user:@webkit.org:99?foo"_s, { "http"_s, "user"_s, ""_s, "webkit.org"_s, 99, "/"_s, "foo"_s, ""_s, "http://user@webkit.org:99/?foo"_s });
+    checkURL("http://\t//\\///user:@webkit.org:99?foo"_s, { "http"_s, "user"_s, ""_s, "webkit.org"_s, 99, "/"_s, "foo"_s, ""_s, "http://user@webkit.org:99/?foo"_s });
+    checkURL("http:/\\user:@webkit.org:99?foo"_s, { "http"_s, "user"_s, ""_s, "webkit.org"_s, 99, "/"_s, "foo"_s, ""_s, "http://user@webkit.org:99/?foo"_s });
+    checkURL("http://127.0.0.1"_s, { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s });
+    checkURLDifferences("http://127.0.0.1."_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.0.0.1."_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1./"_s });
+    checkURLDifferences("http://127.0.0.1./"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.0.0.1."_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1./"_s });
+    checkURL("http://127.0.0.1../"_s, { "http"_s, ""_s, ""_s, "127.0.0.1.."_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1../"_s });
+    checkURLDifferences("http://0x100.0/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://0x100.0/"_s },
+        { "http"_s, ""_s, ""_s, "0x100.0"_s, 0, "/"_s, ""_s, ""_s, "http://0x100.0/"_s });
+    checkURLDifferences("http://0.0.0x100.0/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://0.0.0x100.0/"_s },
+        { "http"_s, ""_s, ""_s, "0.0.0x100.0"_s, 0, "/"_s, ""_s, ""_s, "http://0.0.0x100.0/"_s });
+    checkURLDifferences("http://0.0.0.0x100/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://0.0.0.0x100/"_s },
+        { "http"_s, ""_s, ""_s, "0.0.0.0x100"_s, 0, "/"_s, ""_s, ""_s, "http://0.0.0.0x100/"_s });
+    checkURL("http://host:123?"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/"_s, ""_s, ""_s, "http://host:123/?"_s });
+    checkURL("http://host:123?query"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/"_s, "query"_s, ""_s, "http://host:123/?query"_s });
+    checkURL("http://host:123#"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/"_s, ""_s, ""_s, "http://host:123/#"_s });
+    checkURL("http://host:123#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 123, "/"_s, ""_s, "fragment"_s, "http://host:123/#fragment"_s });
+    checkURLDifferences("foo:////"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "foo:////"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "////"_s, ""_s, ""_s, "foo:////"_s });
+    checkURLDifferences("foo:///?"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:///?"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "///"_s, ""_s, ""_s, "foo:///?"_s });
+    checkURLDifferences("foo:///#"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:///#"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "///"_s, ""_s, ""_s, "foo:///#"_s });
+    checkURLDifferences("foo:///"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:///"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "///"_s, ""_s, ""_s, "foo:///"_s });
+    checkURLDifferences("foo://?"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo://?"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "foo://?"_s });
+    checkURLDifferences("foo://#"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo://#"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "foo://#"_s });
+    checkURLDifferences("foo://"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo://"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "foo://"_s });
+    checkURL("foo:/?"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:/?"_s });
+    checkURL("foo:/#"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:/#"_s });
+    checkURL("foo:/"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:/"_s });
+    checkURL("foo:?"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo:?"_s });
+    checkURL("foo:#"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo:#"_s });
+    checkURLDifferences("A://"_s,
+        { "a"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "a://"_s },
+        { "a"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "a://"_s });
+    checkURLDifferences("aA://"_s,
+        { "aa"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "aa://"_s },
+        { "aa"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "aa://"_s });
+    checkURL(utf16String(u"foo://host/#ПП\u0007 a</"), { "foo"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, "%D0%9F%D0%9F%07%20a%3C/"_s, "foo://host/#%D0%9F%D0%9F%07%20a%3C/"_s });
+    checkURL(utf16String(u"foo://host/#\u0007 a</"), { "foo"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, "%07%20a%3C/"_s, "foo://host/#%07%20a%3C/"_s });
+    checkURL(utf16String(u"http://host?ß😍#ß😍"), { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, "%C3%9F%F0%9F%98%8D"_s, "%C3%9F%F0%9F%98%8D"_s, "http://host/?%C3%9F%F0%9F%98%8D#%C3%9F%F0%9F%98%8D"_s }, testTabsValueForSurrogatePairs);
+    checkURL(utf16String(u"http://host/path#💩\t💩"), { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, ""_s, "%F0%9F%92%A9%F0%9F%92%A9"_s, "http://host/path#%F0%9F%92%A9%F0%9F%92%A9"_s }, testTabsValueForSurrogatePairs);
+    checkURL(utf16String(u"http://host/#ПП\u0007 a</"), { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, "%D0%9F%D0%9F%07%20a%3C/"_s, "http://host/#%D0%9F%D0%9F%07%20a%3C/"_s });
+    checkURL(utf16String(u"http://host/#\u0007 a</"), { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, "%07%20a%3C/"_s, "http://host/#%07%20a%3C/"_s });
 
     // This disagrees with the web platform test for http://:@www.example.com but agrees with Chrome and URL::parse,
     // and Firefox fails the web platform test differently. Maybe the web platform test ought to be changed.
-    checkURL("http://:@host", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
+    checkURL("http://:@host"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
 }
 
 static void testUserPassword(StringView value, StringView decoded, StringView encoded)
 {
-    URL userURL { makeString("http://", value, "@example.com/") };
-    URL passURL { makeString("http://user:", value, "@example.com/") };
+    URL userURL { makeString("http://"_s, value, "@example.com/"_s) };
+    URL passURL { makeString("http://user:"_s, value, "@example.com/"_s) };
     EXPECT_EQ(encoded, userURL.encodedUser());
     EXPECT_EQ(encoded, passURL.encodedPassword());
     EXPECT_EQ(decoded, userURL.user());
@@ -517,791 +516,791 @@ TEST_F(WTF_URLParser, Credentials)
     auto invalidSurrogate = utf16String<3>({0xD800, 'A', '\0'});
     auto replacementA = utf16String<3>({0xFFFD, 'A', '\0'});
 
-    testUserPassword("a", "a");
-    testUserPassword("%", "%");
-    testUserPassword("%25", "%", "%25");
-    testUserPassword("%2525", "%25", "%2525");
-    testUserPassword("%FX", "%FX");
-    testUserPassword("%00", String::fromUTF8("\0", 1), "%00");
-    testUserPassword("%F%25", "%F%", "%F%25");
-    testUserPassword("%X%25", "%X%", "%X%25");
-    testUserPassword("%%25", "%%", "%%25");
-    testUserPassword("💩", "%C3%B0%C2%9F%C2%92%C2%A9");
-    testUserPassword("%💩", "%%C3%B0%C2%9F%C2%92%C2%A9");
-    testUserPassword(validSurrogate, "%F0%90%85%95");
-    testUserPassword(replacementA, "%EF%BF%BDA");
-    testUserPassword(invalidSurrogate, replacementA, "%EF%BF%BDA");
+    testUserPassword("a"_s, "a"_s);
+    testUserPassword("%"_s, "%"_s);
+    testUserPassword("%25"_s, "%"_s, "%25"_s);
+    testUserPassword("%2525"_s, "%25"_s, "%2525"_s);
+    testUserPassword("%FX"_s, "%FX"_s);
+    testUserPassword("%00"_s, String::fromUTF8("\0"_s, 1), "%00"_s);
+    testUserPassword("%F%25"_s, "%F%"_s, "%F%25"_s);
+    testUserPassword("%X%25"_s, "%X%"_s, "%X%25"_s);
+    testUserPassword("%%25"_s, "%%"_s, "%%25"_s);
+    testUserPassword("💩"_s, "%C3%B0%C2%9F%C2%92%C2%A9"_s);
+    testUserPassword("%💩"_s, "%%C3%B0%C2%9F%C2%92%C2%A9"_s);
+    testUserPassword(validSurrogate, "%F0%90%85%95"_s);
+    testUserPassword(replacementA, "%EF%BF%BDA"_s);
+    testUserPassword(invalidSurrogate, replacementA, "%EF%BF%BDA"_s);
 }
 
 TEST_F(WTF_URLParser, ParseRelative)
 {
-    checkRelativeURL("/index.html", "http://webkit.org/path1/path2/", {"http", "", "", "webkit.org", 0, "/index.html", "", "", "http://webkit.org/index.html"});
-    checkRelativeURL("http://whatwg.org/index.html", "http://webkit.org/path1/path2/", {"http", "", "", "whatwg.org", 0, "/index.html", "", "", "http://whatwg.org/index.html"});
-    checkRelativeURL("index.html", "http://webkit.org/path1/path2/page.html?query#fragment", {"http", "", "", "webkit.org", 0, "/path1/path2/index.html", "", "", "http://webkit.org/path1/path2/index.html"});
-    checkRelativeURL("//whatwg.org/index.html", "https://www.webkit.org/path", {"https", "", "", "whatwg.org", 0, "/index.html", "", "", "https://whatwg.org/index.html"});
-    checkRelativeURL("http://example\t.\norg", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/", "", "", "http://example.org/"});
-    checkRelativeURL("test", "file:///path1/path2", {"file", "", "", "", 0, "/path1/test", "", "", "file:///path1/test"});
-    checkRelativeURL(utf16String(u"http://www.foo。bar.com"), "http://other.com/", {"http", "", "", "www.foo.bar.com", 0, "/", "", "", "http://www.foo.bar.com/"});
-    checkRelativeURLDifferences(utf16String(u"sc://ñ.test/"), "about:blank",
-        {"sc", "", "", "%C3%B1.test", 0, "/", "", "", "sc://%C3%B1.test/"},
-        {"sc", "", "", "xn--ida.test", 0, "/", "", "", "sc://xn--ida.test/"});
-    checkRelativeURL("#fragment", "http://host/path", {"http", "", "", "host", 0, "/path", "", "fragment", "http://host/path#fragment"});
-    checkRelativeURL("#fragment", "file:///path", {"file", "", "", "", 0, "/path", "", "fragment", "file:///path#fragment"});
-    checkRelativeURL("#fragment", "file:///path#old", {"file", "", "", "", 0, "/path", "", "fragment", "file:///path#fragment"});
-    checkRelativeURL("#", "file:///path#old", {"file", "", "", "", 0, "/path", "", "", "file:///path#"});
-    checkRelativeURL("  ", "file:///path#old", {"file", "", "", "", 0, "/path", "", "", "file:///path"});
-    checkRelativeURL("#", "file:///path", {"file", "", "", "", 0, "/path", "", "", "file:///path#"});
-    checkRelativeURL("#", "file:///path?query", {"file", "", "", "", 0, "/path", "query", "", "file:///path?query#"});
-    checkRelativeURL("#", "file:///path?query#old", {"file", "", "", "", 0, "/path", "query", "", "file:///path?query#"});
-    checkRelativeURL("?query", "http://host/path", {"http", "", "", "host", 0, "/path", "query", "", "http://host/path?query"});
-    checkRelativeURL("?query#fragment", "http://host/path", {"http", "", "", "host", 0, "/path", "query", "fragment", "http://host/path?query#fragment"});
-    checkRelativeURL("?new", "file:///path?old#fragment", {"file", "", "", "", 0, "/path", "new", "", "file:///path?new"});
-    checkRelativeURL("?", "file:///path?old#fragment", {"file", "", "", "", 0, "/path", "", "", "file:///path?"});
-    checkRelativeURL("?", "file:///path", {"file", "", "", "", 0, "/path", "", "", "file:///path?"});
-    checkRelativeURL("?query", "file:///path", {"file", "", "", "", 0, "/path", "query", "", "file:///path?query"});
-    checkRelativeURL(utf16String(u"?β"), "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "%CE%B2", "", "http://example.org/foo/bar?%CE%B2"});
-    checkRelativeURL("?", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar?"});
-    checkRelativeURL("#", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar#"});
-    checkRelativeURL("?#", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar?#"});
-    checkRelativeURL("#?", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "?", "http://example.org/foo/bar#?"});
-    checkRelativeURL("/", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/", "", "", "http://example.org/"});
-    checkRelativeURL("http://@host", "about:blank", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("http://:@host", "about:blank", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("http://foo.com/\\@", "http://example.org/foo/bar", {"http", "", "", "foo.com", 0, "//@", "", "", "http://foo.com//@"});
-    checkRelativeURL("\\@", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/@", "", "", "http://example.org/@"});
-    checkRelativeURL("/path3", "http://user@example.org/path1/path2", {"http", "user", "", "example.org", 0, "/path3", "", "", "http://user@example.org/path3"});
-    checkRelativeURL("", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar"});
-    checkRelativeURL("\t", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar"});
-    checkRelativeURL(" ", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar"});
-    checkRelativeURL("  \a  \t\n", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar"});
-    checkRelativeURL(":foo.com\\", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/:foo.com/", "", "", "http://example.org/foo/:foo.com/"});
-    checkRelativeURL("http:/example.com/", "about:blank", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkRelativeURL("http:example.com/", "about:blank", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkRelativeURL("http:\\\\foo.com\\", "http://example.org/foo/bar", {"http", "", "", "foo.com", 0, "/", "", "", "http://foo.com/"});
-    checkRelativeURL("http:\\\\foo.com/", "http://example.org/foo/bar", {"http", "", "", "foo.com", 0, "/", "", "", "http://foo.com/"});
-    checkRelativeURL("http:\\\\foo.com", "http://example.org/foo/bar", {"http", "", "", "foo.com", 0, "/", "", "", "http://foo.com/"});
-    checkRelativeURL("http://ExAmPlE.CoM", "http://other.com", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
-    checkRelativeURL("http:", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "", "http://example.org/foo/bar"});
-    checkRelativeURL("#x", "data:,", {"data", "", "", "", 0, ",", "", "x", "data:,#x"});
-    checkRelativeURL("#x", "about:blank", {"about", "", "", "", 0, "blank", "", "x", "about:blank#x"});
-    checkRelativeURL("  foo.com  ", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/foo.com", "", "", "http://example.org/foo/foo.com"});
-    checkRelativeURL(" \a baz", "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/baz", "", "", "http://example.org/foo/baz"});
-    checkRelativeURL("~", "http://example.org", {"http", "", "", "example.org", 0, "/~", "", "", "http://example.org/~"});
-    checkRelativeURL("notspecial:", "about:blank", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
-    checkRelativeURL("notspecial:", "http://host", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
-    checkRelativeURL("http:", "http://host", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("i", "sc:/pa/po", {"sc", "", "", "", 0, "/pa/i", "", "", "sc:/pa/i"});
-    checkRelativeURL("i    ", "sc:/pa/po", {"sc", "", "", "", 0, "/pa/i", "", "", "sc:/pa/i"});
-    checkRelativeURL("i\t\n  ", "sc:/pa/po", {"sc", "", "", "", 0, "/pa/i", "", "", "sc:/pa/i"});
-    checkRelativeURL("i", "sc://ho/pa", {"sc", "", "", "ho", 0, "/i", "", "", "sc://ho/i"});
-    checkRelativeURL("!", "sc://ho/pa", {"sc", "", "", "ho", 0, "/!", "", "", "sc://ho/!"});
-    checkRelativeURL("!", "sc:/ho/pa", {"sc", "", "", "", 0, "/ho/!", "", "", "sc:/ho/!"});
-    checkRelativeURL("notspecial:/", "about:blank", {"notspecial", "", "", "", 0, "/", "", "", "notspecial:/"});
-    checkRelativeURL("notspecial:/", "http://host", {"notspecial", "", "", "", 0, "/", "", "", "notspecial:/"});
-    checkRelativeURL("foo:/", "http://example.org/foo/bar", {"foo", "", "", "", 0, "/", "", "", "foo:/"});
-    checkRelativeURL("://:0/", "http://webkit.org/", {"http", "", "", "webkit.org", 0, "/://:0/", "", "", "http://webkit.org/://:0/"});
-    checkRelativeURL(String(), "http://webkit.org/", {"http", "", "", "webkit.org", 0, "/", "", "", "http://webkit.org/"});
-    checkRelativeURL("https://@test@test@example:800\\path@end", "http://doesnotmatter/", {"", "", "", "", 0, "", "", "", "https://@test@test@example:800\\path@end"});
-    checkRelativeURL("http://f:0/c", "http://example.org/foo/bar", {"http", "", "", "f", 0, "/c", "", "", "http://f:0/c"});
-    checkRelativeURL(String(), "http://host/#fragment", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("", "http://host/#fragment", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("  ", "http://host/#fragment", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURL("  ", "http://host/path?query#fra#gment", {"http", "", "", "host", 0, "/path", "query", "", "http://host/path?query"});
-    checkRelativeURL(" \a ", "http://host/#fragment", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkRelativeURLDifferences("foo://", "http://example.org/foo/bar",
-        {"foo", "", "", "", 0, "", "", "", "foo://"},
-        {"foo", "", "", "", 0, "//", "", "", "foo://"});
-    checkRelativeURL(utf16String(u"#β"), "http://example.org/foo/bar", {"http", "", "", "example.org", 0, "/foo/bar", "", "%CE%B2", "http://example.org/foo/bar#%CE%B2"});
-    checkRelativeURL("index.html", "applewebdata://Host/", {"applewebdata", "", "", "Host", 0, "/index.html", "", "", "applewebdata://Host/index.html"});
-    checkRelativeURL("index.html", "applewebdata://Host", {"applewebdata", "", "", "Host", 0, "/index.html", "", "", "applewebdata://Host/index.html"});
-    checkRelativeURL("", "applewebdata://Host", {"applewebdata", "", "", "Host", 0, "", "", "", "applewebdata://Host"});
-    checkRelativeURL("?query", "applewebdata://Host", {"applewebdata", "", "", "Host", 0, "", "query", "", "applewebdata://Host?query"});
-    checkRelativeURL("#fragment", "applewebdata://Host", {"applewebdata", "", "", "Host", 0, "", "", "fragment", "applewebdata://Host#fragment"});
-    checkRelativeURL("notspecial://something?", "file:////var//containers//stuff/", {"notspecial", "", "", "something", 0, "", "", "", "notspecial://something?"}, TestTabs::No);
-    checkRelativeURL("notspecial://something#", "file:////var//containers//stuff/", {"notspecial", "", "", "something", 0, "", "", "", "notspecial://something#"}, TestTabs::No);
-    checkRelativeURL("http://something?", "file:////var//containers//stuff/", {"http", "", "", "something", 0, "/", "", "", "http://something/?"}, TestTabs::No);
-    checkRelativeURL("http://something#", "file:////var//containers//stuff/", {"http", "", "", "something", 0, "/", "", "", "http://something/#"}, TestTabs::No);
-    checkRelativeURL("file:", "file:///path?query#fragment", {"file", "", "", "", 0, "/path", "query", "", "file:///path?query"});
-    checkRelativeURL("/", "file:///C:/a/b", {"file", "", "", "", 0, "/C:/", "", "", "file:///C:/"});
-    checkRelativeURL("/abc", "file:///C:/a/b", {"file", "", "", "", 0, "/C:/abc", "", "", "file:///C:/abc"});
-    checkRelativeURL("/abc", "file:///C:", {"file", "", "", "", 0, "/C:/abc", "", "", "file:///C:/abc"});
-    checkRelativeURL("/abc", "file:///", {"file", "", "", "", 0, "/abc", "", "", "file:///abc"});
-    checkRelativeURL("//d:", "file:///C:/a/b", {"file", "", "", "", 0, "/d:", "", "", "file:///d:"}, TestTabs::No);
-    checkRelativeURL("//d|", "file:///C:/a/b", {"file", "", "", "", 0, "/d:", "", "", "file:///d:"}, TestTabs::No);
-    checkRelativeURL("//A|", "file:///C:/a/b", {"file", "", "", "", 0, "/A:", "", "", "file:///A:"}, TestTabs::No);
+    checkRelativeURL("/index.html"_s, "http://webkit.org/path1/path2/"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/index.html"_s, ""_s, ""_s, "http://webkit.org/index.html"_s });
+    checkRelativeURL("http://whatwg.org/index.html"_s, "http://webkit.org/path1/path2/"_s, { "http"_s, ""_s, ""_s, "whatwg.org"_s, 0, "/index.html"_s, ""_s, ""_s, "http://whatwg.org/index.html"_s });
+    checkRelativeURL("index.html"_s, "http://webkit.org/path1/path2/page.html?query#fragment"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/path1/path2/index.html"_s, ""_s, ""_s, "http://webkit.org/path1/path2/index.html"_s });
+    checkRelativeURL("//whatwg.org/index.html"_s, "https://www.webkit.org/path"_s, { "https"_s, ""_s, ""_s, "whatwg.org"_s, 0, "/index.html"_s, ""_s, ""_s, "https://whatwg.org/index.html"_s });
+    checkRelativeURL("http://example\t.\norg"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/"_s, ""_s, ""_s, "http://example.org/"_s });
+    checkRelativeURL("test"_s, "file:///path1/path2"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path1/test"_s, ""_s, ""_s, "file:///path1/test"_s });
+    checkRelativeURL(utf16String(u"http://www.foo。bar.com"), "http://other.com/"_s, { "http"_s, ""_s, ""_s, "www.foo.bar.com"_s, 0, "/"_s, ""_s, ""_s, "http://www.foo.bar.com/"_s });
+    checkRelativeURLDifferences(utf16String(u"sc://ñ.test/"), "about:blank"_s,
+        { "sc"_s, ""_s, ""_s, "%C3%B1.test"_s, 0, "/"_s, ""_s, ""_s, "sc://%C3%B1.test/"_s },
+        { "sc"_s, ""_s, ""_s, "xn--ida.test"_s, 0, "/"_s, ""_s, ""_s, "sc://xn--ida.test/"_s });
+    checkRelativeURL("#fragment"_s, "http://host/path"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, ""_s, "fragment"_s, "http://host/path#fragment"_s });
+    checkRelativeURL("#fragment"_s, "file:///path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, "fragment"_s, "file:///path#fragment"_s });
+    checkRelativeURL("#fragment"_s, "file:///path#old"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, "fragment"_s, "file:///path#fragment"_s });
+    checkRelativeURL("#"_s, "file:///path#old"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path#"_s });
+    checkRelativeURL("  "_s, "file:///path#old"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path"_s });
+    checkRelativeURL("#"_s, "file:///path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path#"_s });
+    checkRelativeURL("#"_s, "file:///path?query"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, "query"_s, ""_s, "file:///path?query#"_s });
+    checkRelativeURL("#"_s, "file:///path?query#old"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, "query"_s, ""_s, "file:///path?query#"_s });
+    checkRelativeURL("?query"_s, "http://host/path"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, "query"_s, ""_s, "http://host/path?query"_s });
+    checkRelativeURL("?query#fragment"_s, "http://host/path"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, "query"_s, "fragment"_s, "http://host/path?query#fragment"_s });
+    checkRelativeURL("?new"_s, "file:///path?old#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, "new"_s, ""_s, "file:///path?new"_s });
+    checkRelativeURL("?"_s, "file:///path?old#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path?"_s });
+    checkRelativeURL("?"_s, "file:///path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path?"_s });
+    checkRelativeURL("?query"_s, "file:///path"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, "query"_s, ""_s, "file:///path?query"_s });
+    checkRelativeURL(utf16String(u"?β"), "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, "%CE%B2"_s, ""_s, "http://example.org/foo/bar?%CE%B2"_s });
+    checkRelativeURL("?"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar?"_s });
+    checkRelativeURL("#"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar#"_s });
+    checkRelativeURL("?#"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar?#"_s });
+    checkRelativeURL("#?"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, "?"_s, "http://example.org/foo/bar#?"_s });
+    checkRelativeURL("/"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/"_s, ""_s, ""_s, "http://example.org/"_s });
+    checkRelativeURL("http://@host"_s, "about:blank"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL("http://:@host"_s, "about:blank"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL("http://foo.com/\\@"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "foo.com"_s, 0, "//@"_s, ""_s, ""_s, "http://foo.com//@"_s });
+    checkRelativeURL("\\@"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/@"_s, ""_s, ""_s, "http://example.org/@"_s });
+    checkRelativeURL("/path3"_s, "http://user@example.org/path1/path2"_s, { "http"_s, "user"_s, ""_s, "example.org"_s, 0, "/path3"_s, ""_s, ""_s, "http://user@example.org/path3"_s });
+    checkRelativeURL(""_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar"_s });
+    checkRelativeURL("\t"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar"_s });
+    checkRelativeURL(" "_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar"_s });
+    checkRelativeURL("  \a  \t\n"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar"_s });
+    checkRelativeURL(":foo.com\\"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/:foo.com/"_s, ""_s, ""_s, "http://example.org/foo/:foo.com/"_s });
+    checkRelativeURL("http:/example.com/"_s, "about:blank"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkRelativeURL("http:example.com/"_s, "about:blank"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkRelativeURL("http:\\\\foo.com\\"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "foo.com"_s, 0, "/"_s, ""_s, ""_s, "http://foo.com/"_s });
+    checkRelativeURL("http:\\\\foo.com/"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "foo.com"_s, 0, "/"_s, ""_s, ""_s, "http://foo.com/"_s });
+    checkRelativeURL("http:\\\\foo.com"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "foo.com"_s, 0, "/"_s, ""_s, ""_s, "http://foo.com/"_s });
+    checkRelativeURL("http://ExAmPlE.CoM"_s, "http://other.com"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
+    checkRelativeURL("http:"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, ""_s, "http://example.org/foo/bar"_s });
+    checkRelativeURL("#x"_s, "data:,"_s, { "data"_s, ""_s, ""_s, ""_s, 0, ","_s, ""_s, "x"_s, "data:,#x"_s });
+    checkRelativeURL("#x"_s, "about:blank"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "blank"_s, ""_s, "x"_s, "about:blank#x"_s });
+    checkRelativeURL("  foo.com  "_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/foo.com"_s, ""_s, ""_s, "http://example.org/foo/foo.com"_s });
+    checkRelativeURL(" \a baz"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/baz"_s, ""_s, ""_s, "http://example.org/foo/baz"_s });
+    checkRelativeURL("~"_s, "http://example.org"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/~"_s, ""_s, ""_s, "http://example.org/~"_s });
+    checkRelativeURL("notspecial:"_s, "about:blank"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
+    checkRelativeURL("notspecial:"_s, "http://host"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
+    checkRelativeURL("http:"_s, "http://host"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL("i"_s, "sc:/pa/po"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa/i"_s, ""_s, ""_s, "sc:/pa/i"_s });
+    checkRelativeURL("i    "_s, "sc:/pa/po"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa/i"_s, ""_s, ""_s, "sc:/pa/i"_s });
+    checkRelativeURL("i\t\n  "_s, "sc:/pa/po"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/pa/i"_s, ""_s, ""_s, "sc:/pa/i"_s });
+    checkRelativeURL("i"_s, "sc://ho/pa"_s, { "sc"_s, ""_s, ""_s, "ho"_s, 0, "/i"_s, ""_s, ""_s, "sc://ho/i"_s });
+    checkRelativeURL("!"_s, "sc://ho/pa"_s, { "sc"_s, ""_s, ""_s, "ho"_s, 0, "/!"_s, ""_s, ""_s, "sc://ho/!"_s });
+    checkRelativeURL("!"_s, "sc:/ho/pa"_s, { "sc"_s, ""_s, ""_s, ""_s, 0, "/ho/!"_s, ""_s, ""_s, "sc:/ho/!"_s });
+    checkRelativeURL("notspecial:/"_s, "about:blank"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "notspecial:/"_s });
+    checkRelativeURL("notspecial:/"_s, "http://host"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "notspecial:/"_s });
+    checkRelativeURL("foo:/"_s, "http://example.org/foo/bar"_s, { "foo"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "foo:/"_s });
+    checkRelativeURL("://:0/"_s, "http://webkit.org/"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/://:0/"_s, ""_s, ""_s, "http://webkit.org/://:0/"_s });
+    checkRelativeURL(String(), "http://webkit.org/"_s, { "http"_s, ""_s, ""_s, "webkit.org"_s, 0, "/"_s, ""_s, ""_s, "http://webkit.org/"_s });
+    checkRelativeURL("https://@test@test@example:800\\path@end"_s, "http://doesnotmatter/"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "https://@test@test@example:800\\path@end"_s });
+    checkRelativeURL("http://f:0/c"_s, "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "f"_s, 0, "/c"_s, ""_s, ""_s, "http://f:0/c"_s });
+    checkRelativeURL(String(), "http://host/#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL(""_s, "http://host/#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL("  "_s, "http://host/#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURL("  "_s, "http://host/path?query#fra#gment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path"_s, "query"_s, ""_s, "http://host/path?query"_s });
+    checkRelativeURL(" \a "_s, "http://host/#fragment"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkRelativeURLDifferences("foo://"_s, "http://example.org/foo/bar"_s,
+        { "foo"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "foo://"_s },
+        { "foo"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "foo://"_s });
+    checkRelativeURL(utf16String(u"#β"), "http://example.org/foo/bar"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, ""_s, "%CE%B2"_s, "http://example.org/foo/bar#%CE%B2"_s });
+    checkRelativeURL("index.html"_s, "applewebdata://Host/"_s, { "applewebdata"_s, ""_s, ""_s, "Host"_s, 0, "/index.html"_s, ""_s, ""_s, "applewebdata://Host/index.html"_s });
+    checkRelativeURL("index.html"_s, "applewebdata://Host"_s, { "applewebdata"_s, ""_s, ""_s, "Host"_s, 0, "/index.html"_s, ""_s, ""_s, "applewebdata://Host/index.html"_s });
+    checkRelativeURL(""_s, "applewebdata://Host"_s, { "applewebdata"_s, ""_s, ""_s, "Host"_s, 0, ""_s, ""_s, ""_s, "applewebdata://Host"_s });
+    checkRelativeURL("?query"_s, "applewebdata://Host"_s, { "applewebdata"_s, ""_s, ""_s, "Host"_s, 0, ""_s, "query"_s, ""_s, "applewebdata://Host?query"_s });
+    checkRelativeURL("#fragment"_s, "applewebdata://Host"_s, { "applewebdata"_s, ""_s, ""_s, "Host"_s, 0, ""_s, ""_s, "fragment"_s, "applewebdata://Host#fragment"_s });
+    checkRelativeURL("notspecial://something?"_s, "file:////var//containers//stuff/"_s, { "notspecial"_s, ""_s, ""_s, "something"_s, 0, ""_s, ""_s, ""_s, "notspecial://something?"_s }, TestTabs::No);
+    checkRelativeURL("notspecial://something#"_s, "file:////var//containers//stuff/"_s, { "notspecial"_s, ""_s, ""_s, "something"_s, 0, ""_s, ""_s, ""_s, "notspecial://something#"_s }, TestTabs::No);
+    checkRelativeURL("http://something?"_s, "file:////var//containers//stuff/"_s, { "http"_s, ""_s, ""_s, "something"_s, 0, "/"_s, ""_s, ""_s, "http://something/?"_s }, TestTabs::No);
+    checkRelativeURL("http://something#"_s, "file:////var//containers//stuff/"_s, { "http"_s, ""_s, ""_s, "something"_s, 0, "/"_s, ""_s, ""_s, "http://something/#"_s }, TestTabs::No);
+    checkRelativeURL("file:"_s, "file:///path?query#fragment"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, "query"_s, ""_s, "file:///path?query"_s });
+    checkRelativeURL("/"_s, "file:///C:/a/b"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/"_s, ""_s, ""_s, "file:///C:/"_s });
+    checkRelativeURL("/abc"_s, "file:///C:/a/b"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/abc"_s, ""_s, ""_s, "file:///C:/abc"_s });
+    checkRelativeURL("/abc"_s, "file:///C:"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/abc"_s, ""_s, ""_s, "file:///C:/abc"_s });
+    checkRelativeURL("/abc"_s, "file:///"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/abc"_s, ""_s, ""_s, "file:///abc"_s });
+    checkRelativeURL("//d:"_s, "file:///C:/a/b"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/d:"_s, ""_s, ""_s, "file:///d:"_s }, TestTabs::No);
+    checkRelativeURL("//d|"_s, "file:///C:/a/b"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/d:"_s, ""_s, ""_s, "file:///d:"_s }, TestTabs::No);
+    checkRelativeURL("//A|"_s, "file:///C:/a/b"_s, { "file"_s, ""_s, ""_s, ""_s, 0, "/A:"_s, ""_s, ""_s, "file:///A:"_s }, TestTabs::No);
 
     // The checking of slashes in SpecialAuthoritySlashes needed to get this to pass contradicts what is in the spec,
     // but it is included in the web platform tests.
-    checkRelativeURL("http:\\\\host\\foo", "about:blank", {"http", "", "", "host", 0, "/foo", "", "", "http://host/foo"});
+    checkRelativeURL("http:\\\\host\\foo"_s, "about:blank"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/foo"_s, ""_s, ""_s, "http://host/foo"_s });
 }
 
 // These are differences between the new URLParser and the old URL::parse which make URLParser more standards compliant.
 TEST_F(WTF_URLParser, ParserDifferences)
 {
-    checkURLDifferences("http://127.0.1",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.0.1", 0, "/", "", "", "http://127.0.1/"});
-    checkURLDifferences("http://011.11.0X11.0x011",
-        {"http", "", "", "9.11.17.17", 0, "/", "", "", "http://9.11.17.17/"},
-        {"http", "", "", "011.11.0x11.0x011", 0, "/", "", "", "http://011.11.0x11.0x011/"});
-    checkURLDifferences("http://[1234:0078:90AB:CdEf:0123:0007:89AB:0000]",
-        {"http", "", "", "[1234:78:90ab:cdef:123:7:89ab:0]", 0, "/", "", "", "http://[1234:78:90ab:cdef:123:7:89ab:0]/"},
-        {"http", "", "", "[1234:0078:90ab:cdef:0123:0007:89ab:0000]", 0, "/", "", "", "http://[1234:0078:90ab:cdef:0123:0007:89ab:0000]/"});
-    checkURLDifferences("http://[0:f:0:0:f:f:0:0]",
-        {"http", "", "", "[0:f::f:f:0:0]", 0, "/", "", "", "http://[0:f::f:f:0:0]/"},
-        {"http", "", "", "[0:f:0:0:f:f:0:0]", 0, "/", "", "", "http://[0:f:0:0:f:f:0:0]/"});
-    checkURLDifferences("http://[0:f:0:0:f:0:0:0]",
-        {"http", "", "", "[0:f:0:0:f::]", 0, "/", "", "", "http://[0:f:0:0:f::]/"},
-        {"http", "", "", "[0:f:0:0:f:0:0:0]", 0, "/", "", "", "http://[0:f:0:0:f:0:0:0]/"});
-    checkURLDifferences("http://[0:0:f:0:0:f:0:0]",
-        {"http", "", "", "[::f:0:0:f:0:0]", 0, "/", "", "", "http://[::f:0:0:f:0:0]/"},
-        {"http", "", "", "[0:0:f:0:0:f:0:0]", 0, "/", "", "", "http://[0:0:f:0:0:f:0:0]/"});
-    checkURLDifferences("http://[a:0:0:0:b:c::d]",
-        {"http", "", "", "[a::b:c:0:d]", 0, "/", "", "", "http://[a::b:c:0:d]/"},
-        {"http", "", "", "[a:0:0:0:b:c::d]", 0, "/", "", "", "http://[a:0:0:0:b:c::d]/"});
-    checkURLDifferences("http://[::7f00:0001]/",
-        {"http", "", "", "[::7f00:1]", 0, "/", "", "", "http://[::7f00:1]/"},
-        {"http", "", "", "[::7f00:0001]", 0, "/", "", "", "http://[::7f00:0001]/"});
-    checkURLDifferences("http://[::7f00:00]/",
-        {"http", "", "", "[::7f00:0]", 0, "/", "", "", "http://[::7f00:0]/"},
-        {"http", "", "", "[::7f00:00]", 0, "/", "", "", "http://[::7f00:00]/"});
-    checkURLDifferences("http://[::0:7f00:0001]/",
-        {"http", "", "", "[::7f00:1]", 0, "/", "", "", "http://[::7f00:1]/"},
-        {"http", "", "", "[::0:7f00:0001]", 0, "/", "", "", "http://[::0:7f00:0001]/"});
-    checkURLDifferences("http://127.00.0.1/",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.00.0.1", 0, "/", "", "", "http://127.00.0.1/"});
-    checkURLDifferences("http://127.0.0.01/",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.0.0.01", 0, "/", "", "", "http://127.0.0.01/"});
-    checkURLDifferences("http://example.com/path1/.%2e",
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"},
-        {"http", "", "", "example.com", 0, "/path1/.%2e", "", "", "http://example.com/path1/.%2e"});
-    checkURLDifferences("http://example.com/path1/.%2E",
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"},
-        {"http", "", "", "example.com", 0, "/path1/.%2E", "", "", "http://example.com/path1/.%2E"});
-    checkURLDifferences("http://example.com/path1/.%2E/",
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"},
-        {"http", "", "", "example.com", 0, "/path1/.%2E/", "", "", "http://example.com/path1/.%2E/"});
-    checkURLDifferences("http://example.com/path1/%2e.",
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"},
-        {"http", "", "", "example.com", 0, "/path1/%2e.", "", "", "http://example.com/path1/%2e."});
-    checkURLDifferences("http://example.com/path1/%2E%2e",
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"},
-        {"http", "", "", "example.com", 0, "/path1/%2E%2e", "", "", "http://example.com/path1/%2E%2e"});
-    checkURLDifferences("http://example.com/path1/%2e",
-        {"http", "", "", "example.com", 0, "/path1/", "", "", "http://example.com/path1/"},
-        {"http", "", "", "example.com", 0, "/path1/%2e", "", "", "http://example.com/path1/%2e"});
-    checkURLDifferences("http://example.com/path1/%2E",
-        {"http", "", "", "example.com", 0, "/path1/", "", "", "http://example.com/path1/"},
-        {"http", "", "", "example.com", 0, "/path1/%2E", "", "", "http://example.com/path1/%2E"});
-    checkURLDifferences("http://example.com/path1/%2E/",
-        {"http", "", "", "example.com", 0, "/path1/", "", "", "http://example.com/path1/"},
-        {"http", "", "", "example.com", 0, "/path1/%2E/", "", "", "http://example.com/path1/%2E/"});
-    checkURLDifferences("http://example.com/path1/path2/%2e?query",
-        {"http", "", "", "example.com", 0, "/path1/path2/", "query", "", "http://example.com/path1/path2/?query"},
-        {"http", "", "", "example.com", 0, "/path1/path2/%2e", "query", "", "http://example.com/path1/path2/%2e?query"});
-    checkURLDifferences("http://example.com/path1/path2/%2e%2e?query",
-        {"http", "", "", "example.com", 0, "/path1/", "query", "", "http://example.com/path1/?query"},
-        {"http", "", "", "example.com", 0, "/path1/path2/%2e%2e", "query", "", "http://example.com/path1/path2/%2e%2e?query"});
-    checkURLDifferences("http://example.com/path1/path2/%2e#fragment",
-        {"http", "", "", "example.com", 0, "/path1/path2/", "", "fragment", "http://example.com/path1/path2/#fragment"},
-        {"http", "", "", "example.com", 0, "/path1/path2/%2e", "", "fragment", "http://example.com/path1/path2/%2e#fragment"});
-    checkURLDifferences("http://example.com/path1/path2/%2e%2e#fragment",
-        {"http", "", "", "example.com", 0, "/path1/", "", "fragment", "http://example.com/path1/#fragment"},
-        {"http", "", "", "example.com", 0, "/path1/path2/%2e%2e", "", "fragment", "http://example.com/path1/path2/%2e%2e#fragment"});
-    checkURL("http://example.com/path1/path2/A%2e%2e#fragment", {"http", "", "", "example.com", 0, "/path1/path2/A%2e%2e", "", "fragment", "http://example.com/path1/path2/A%2e%2e#fragment"});
-    checkURLDifferences("file://[0:a:0:0:b:c:0:0]/path",
-        {"file", "", "", "[0:a::b:c:0:0]", 0, "/path", "", "", "file://[0:a::b:c:0:0]/path"},
-        {"file", "", "", "[0:a:0:0:b:c:0:0]", 0, "/path", "", "", "file://[0:a:0:0:b:c:0:0]/path"});
-    checkURLDifferences("http://",
-        {"", "", "", "", 0, "", "", "", "http://"},
-        {"http", "", "", "", 0, "/", "", "", "http:/"});
-    checkRelativeURLDifferences("//", "https://www.webkit.org/path",
-        {"", "", "", "", 0, "", "", "", "//"},
-        {"https", "", "", "", 0, "/", "", "", "https:/"});
-    checkURLDifferences("http://127.0.0.1:65536/path",
-        {"", "", "", "", 0, "", "", "", "http://127.0.0.1:65536/path"},
-        {"http", "", "", "127.0.0.1", 0, "/path", "", "", "http://127.0.0.1:65536/path"});
-    checkURLDifferences("http://host:65536",
-        {"", "", "", "", 0, "", "", "", "http://host:65536"},
-        {"http", "", "", "host", 0, "/", "", "", "http://host:65536/"});
-    checkURLDifferences("http://127.0.0.1:65536",
-        {"", "", "", "", 0, "", "", "", "http://127.0.0.1:65536"},
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1:65536/"});
-    checkURLDifferences("http://[0:f::f:f:0:0]:65536",
-        {"", "", "", "", 0, "", "", "", "http://[0:f::f:f:0:0]:65536"},
-        {"http", "", "", "[0:f::f:f:0:0]", 0, "/", "", "", "http://[0:f::f:f:0:0]:65536/"});
-    checkRelativeURLDifferences(":foo.com\\", "notspecial://example.org/foo/bar",
-        {"notspecial", "", "", "example.org", 0, "/foo/:foo.com\\", "", "", "notspecial://example.org/foo/:foo.com\\"},
-        {"notspecial", "", "", "example.org", 0, "/foo/:foo.com/", "", "", "notspecial://example.org/foo/:foo.com/"});
-    checkURL("sc://pa", {"sc", "", "", "pa", 0, "", "", "", "sc://pa"});
-    checkRelativeURLDifferences("notspecial:\\\\foo.com\\", "http://example.org/foo/bar",
-        {"notspecial", "", "", "", 0, "\\\\foo.com\\", "", "", "notspecial:\\\\foo.com\\"},
-        {"notspecial", "", "", "foo.com", 0, "/", "", "", "notspecial://foo.com/"});
-    checkRelativeURLDifferences("notspecial:\\\\foo.com/", "http://example.org/foo/bar",
-        {"notspecial", "", "", "", 0, "\\\\foo.com/", "", "", "notspecial:\\\\foo.com/"},
-        {"notspecial", "", "", "foo.com", 0, "/", "", "", "notspecial://foo.com/"});
-    checkRelativeURLDifferences("notspecial:\\\\foo.com", "http://example.org/foo/bar",
-        {"notspecial", "", "", "", 0, "\\\\foo.com", "", "", "notspecial:\\\\foo.com"},
-        {"notspecial", "", "", "foo.com", 0, "", "", "", "notspecial://foo.com"});
-    checkURLDifferences("file://notuser:notpassword@test",
-        {"", "", "", "", 0, "", "", "", "file://notuser:notpassword@test"},
-        {"file", "notuser", "notpassword", "test", 0, "/", "", "", "file://notuser:notpassword@test/"});
-    checkURLDifferences("file://notuser:notpassword@test/",
-        {"", "", "", "", 0, "", "", "", "file://notuser:notpassword@test/"},
-        {"file", "notuser", "notpassword", "test", 0, "/", "", "", "file://notuser:notpassword@test/"});
-    checkRelativeURLDifferences("http:/", "about:blank",
-        {"", "", "", "", 0, "", "", "", "http:/"},
-        {"http", "", "", "", 0, "/", "", "", "http:/"});
-    checkRelativeURL("http:", "about:blank", {"", "", "", "", 0, "", "", "", "http:"});
-    checkRelativeURLDifferences("http:/", "http://host",
-        {"", "", "", "", 0, "", "", "", "http:/"},
-        {"http", "", "", "", 0, "/", "", "", "http:/"});
-    checkURLDifferences("http:/",
-        {"", "", "", "", 0, "", "", "", "http:/"},
-        {"http", "", "", "", 0, "/", "", "", "http:/"});
-    checkURL("http:", {"", "", "", "", 0, "", "", "", "http:"});
-    checkRelativeURLDifferences("http:/example.com/", "http://example.org/foo/bar",
-        {"http", "", "", "example.org", 0, "/example.com/", "", "", "http://example.org/example.com/"},
-        {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
+    checkURLDifferences("http://127.0.1"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.1/"_s });
+    checkURLDifferences("http://011.11.0X11.0x011"_s,
+        { "http"_s, ""_s, ""_s, "9.11.17.17"_s, 0, "/"_s, ""_s, ""_s, "http://9.11.17.17/"_s },
+        { "http"_s, ""_s, ""_s, "011.11.0x11.0x011"_s, 0, "/"_s, ""_s, ""_s, "http://011.11.0x11.0x011/"_s });
+    checkURLDifferences("http://[1234:0078:90AB:CdEf:0123:0007:89AB:0000]"_s,
+        { "http"_s, ""_s, ""_s, "[1234:78:90ab:cdef:123:7:89ab:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[1234:78:90ab:cdef:123:7:89ab:0]/"_s },
+        { "http"_s, ""_s, ""_s, "[1234:0078:90ab:cdef:0123:0007:89ab:0000]"_s, 0, "/"_s, ""_s, ""_s, "http://[1234:0078:90ab:cdef:0123:0007:89ab:0000]/"_s });
+    checkURLDifferences("http://[0:f:0:0:f:f:0:0]"_s,
+        { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]/"_s },
+        { "http"_s, ""_s, ""_s, "[0:f:0:0:f:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f:f:0:0]/"_s });
+    checkURLDifferences("http://[0:f:0:0:f:0:0:0]"_s,
+        { "http"_s, ""_s, ""_s, "[0:f:0:0:f::]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f::]/"_s },
+        { "http"_s, ""_s, ""_s, "[0:f:0:0:f:0:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f:0:0:f:0:0:0]/"_s });
+    checkURLDifferences("http://[0:0:f:0:0:f:0:0]"_s,
+        { "http"_s, ""_s, ""_s, "[::f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::f:0:0:f:0:0]/"_s },
+        { "http"_s, ""_s, ""_s, "[0:0:f:0:0:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:0:f:0:0:f:0:0]/"_s });
+    checkURLDifferences("http://[a:0:0:0:b:c::d]"_s,
+        { "http"_s, ""_s, ""_s, "[a::b:c:0:d]"_s, 0, "/"_s, ""_s, ""_s, "http://[a::b:c:0:d]/"_s },
+        { "http"_s, ""_s, ""_s, "[a:0:0:0:b:c::d]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:0:0:0:b:c::d]/"_s });
+    checkURLDifferences("http://[::7f00:0001]/"_s,
+        { "http"_s, ""_s, ""_s, "[::7f00:1]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7f00:1]/"_s },
+        { "http"_s, ""_s, ""_s, "[::7f00:0001]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7f00:0001]/"_s });
+    checkURLDifferences("http://[::7f00:00]/"_s,
+        { "http"_s, ""_s, ""_s, "[::7f00:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7f00:0]/"_s },
+        { "http"_s, ""_s, ""_s, "[::7f00:00]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7f00:00]/"_s });
+    checkURLDifferences("http://[::0:7f00:0001]/"_s,
+        { "http"_s, ""_s, ""_s, "[::7f00:1]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7f00:1]/"_s },
+        { "http"_s, ""_s, ""_s, "[::0:7f00:0001]"_s, 0, "/"_s, ""_s, ""_s, "http://[::0:7f00:0001]/"_s });
+    checkURLDifferences("http://127.00.0.1/"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.00.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.00.0.1/"_s });
+    checkURLDifferences("http://127.0.0.01/"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.0.0.01"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.01/"_s });
+    checkURLDifferences("http://example.com/path1/.%2e"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.%2e"_s, ""_s, ""_s, "http://example.com/path1/.%2e"_s });
+    checkURLDifferences("http://example.com/path1/.%2E"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.%2E"_s, ""_s, ""_s, "http://example.com/path1/.%2E"_s });
+    checkURLDifferences("http://example.com/path1/.%2E/"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/.%2E/"_s, ""_s, ""_s, "http://example.com/path1/.%2E/"_s });
+    checkURLDifferences("http://example.com/path1/%2e."_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2e."_s, ""_s, ""_s, "http://example.com/path1/%2e."_s });
+    checkURLDifferences("http://example.com/path1/%2E%2e"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2E%2e"_s, ""_s, ""_s, "http://example.com/path1/%2E%2e"_s });
+    checkURLDifferences("http://example.com/path1/%2e"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, ""_s, "http://example.com/path1/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2e"_s, ""_s, ""_s, "http://example.com/path1/%2e"_s });
+    checkURLDifferences("http://example.com/path1/%2E"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, ""_s, "http://example.com/path1/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2E"_s, ""_s, ""_s, "http://example.com/path1/%2E"_s });
+    checkURLDifferences("http://example.com/path1/%2E/"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, ""_s, "http://example.com/path1/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/%2E/"_s, ""_s, ""_s, "http://example.com/path1/%2E/"_s });
+    checkURLDifferences("http://example.com/path1/path2/%2e?query"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/"_s, "query"_s, ""_s, "http://example.com/path1/path2/?query"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/%2e"_s, "query"_s, ""_s, "http://example.com/path1/path2/%2e?query"_s });
+    checkURLDifferences("http://example.com/path1/path2/%2e%2e?query"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, "query"_s, ""_s, "http://example.com/path1/?query"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/%2e%2e"_s, "query"_s, ""_s, "http://example.com/path1/path2/%2e%2e?query"_s });
+    checkURLDifferences("http://example.com/path1/path2/%2e#fragment"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/"_s, ""_s, "fragment"_s, "http://example.com/path1/path2/#fragment"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/%2e"_s, ""_s, "fragment"_s, "http://example.com/path1/path2/%2e#fragment"_s });
+    checkURLDifferences("http://example.com/path1/path2/%2e%2e#fragment"_s,
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/"_s, ""_s, "fragment"_s, "http://example.com/path1/#fragment"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/%2e%2e"_s, ""_s, "fragment"_s, "http://example.com/path1/path2/%2e%2e#fragment"_s });
+    checkURL("http://example.com/path1/path2/A%2e%2e#fragment"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/path1/path2/A%2e%2e"_s, ""_s, "fragment"_s, "http://example.com/path1/path2/A%2e%2e#fragment"_s });
+    checkURLDifferences("file://[0:a:0:0:b:c:0:0]/path"_s,
+        { "file"_s, ""_s, ""_s, "[0:a::b:c:0:0]"_s, 0, "/path"_s, ""_s, ""_s, "file://[0:a::b:c:0:0]/path"_s },
+        { "file"_s, ""_s, ""_s, "[0:a:0:0:b:c:0:0]"_s, 0, "/path"_s, ""_s, ""_s, "file://[0:a:0:0:b:c:0:0]/path"_s });
+    checkURLDifferences("http://"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http:/"_s });
+    checkRelativeURLDifferences("//"_s, "https://www.webkit.org/path"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "//"_s },
+        { "https"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "https:/"_s });
+    checkURLDifferences("http://127.0.0.1:65536/path"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.0.1:65536/path"_s },
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/path"_s, ""_s, ""_s, "http://127.0.0.1:65536/path"_s });
+    checkURLDifferences("http://host:65536"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://host:65536"_s },
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host:65536/"_s });
+    checkURLDifferences("http://127.0.0.1:65536"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.0.1:65536"_s },
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1:65536/"_s });
+    checkURLDifferences("http://[0:f::f:f:0:0]:65536"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[0:f::f:f:0:0]:65536"_s },
+        { "http"_s, ""_s, ""_s, "[0:f::f:f:0:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f::f:f:0:0]:65536/"_s });
+    checkRelativeURLDifferences(":foo.com\\"_s, "notspecial://example.org/foo/bar"_s,
+        { "notspecial"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/:foo.com\\"_s, ""_s, ""_s, "notspecial://example.org/foo/:foo.com\\"_s },
+        { "notspecial"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/:foo.com/"_s, ""_s, ""_s, "notspecial://example.org/foo/:foo.com/"_s });
+    checkURL("sc://pa"_s, { "sc"_s, ""_s, ""_s, "pa"_s, 0, ""_s, ""_s, ""_s, "sc://pa"_s });
+    checkRelativeURLDifferences("notspecial:\\\\foo.com\\"_s, "http://example.org/foo/bar"_s,
+        { "notspecial"_s, ""_s, ""_s, ""_s, 0, "\\\\foo.com\\"_s, ""_s, ""_s, "notspecial:\\\\foo.com\\"_s },
+        { "notspecial"_s, ""_s, ""_s, "foo.com"_s, 0, "/"_s, ""_s, ""_s, "notspecial://foo.com/"_s });
+    checkRelativeURLDifferences("notspecial:\\\\foo.com/"_s, "http://example.org/foo/bar"_s,
+        { "notspecial"_s, ""_s, ""_s, ""_s, 0, "\\\\foo.com/"_s, ""_s, ""_s, "notspecial:\\\\foo.com/"_s },
+        { "notspecial"_s, ""_s, ""_s, "foo.com"_s, 0, "/"_s, ""_s, ""_s, "notspecial://foo.com/"_s });
+    checkRelativeURLDifferences("notspecial:\\\\foo.com"_s, "http://example.org/foo/bar"_s,
+        { "notspecial"_s, ""_s, ""_s, ""_s, 0, "\\\\foo.com"_s, ""_s, ""_s, "notspecial:\\\\foo.com"_s },
+        { "notspecial"_s, ""_s, ""_s, "foo.com"_s, 0, ""_s, ""_s, ""_s, "notspecial://foo.com"_s });
+    checkURLDifferences("file://notuser:notpassword@test"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://notuser:notpassword@test"_s },
+        { "file"_s, "notuser"_s, "notpassword"_s, "test"_s, 0, "/"_s, ""_s, ""_s, "file://notuser:notpassword@test/"_s });
+    checkURLDifferences("file://notuser:notpassword@test/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://notuser:notpassword@test/"_s },
+        { "file"_s, "notuser"_s, "notpassword"_s, "test"_s, 0, "/"_s, ""_s, ""_s, "file://notuser:notpassword@test/"_s });
+    checkRelativeURLDifferences("http:/"_s, "about:blank"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http:/"_s });
+    checkRelativeURL("http:"_s, "about:blank"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:"_s });
+    checkRelativeURLDifferences("http:/"_s, "http://host"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http:/"_s });
+    checkURLDifferences("http:/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http:/"_s });
+    checkURL("http:"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:"_s });
+    checkRelativeURLDifferences("http:/example.com/"_s, "http://example.org/foo/bar"_s,
+        { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/example.com/"_s, ""_s, ""_s, "http://example.org/example.com/"_s },
+        { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
 
     // This behavior matches Chrome and Firefox, but not WebKit using URL::parse.
     // The behavior of URL::parse is clearly wrong because reparsing file://path would make path the host.
     // The spec is unclear.
-    checkURLDifferences("file:path",
-        {"file", "", "", "", 0, "/path", "", "", "file:///path"},
-        {"file", "", "", "", 0, "path", "", "", "file://path"});
-    checkURLDifferences("file:pAtH",
-        {"file", "", "", "", 0, "/pAtH", "", "", "file:///pAtH"},
-        {"file", "", "", "", 0, "pAtH", "", "", "file://pAtH"});
-    checkURLDifferences("file:pAtH/",
-        {"file", "", "", "", 0, "/pAtH/", "", "", "file:///pAtH/"},
-        {"file", "", "", "", 0, "pAtH/", "", "", "file://pAtH/"});
-    checkURLDifferences("http://example.com%A0",
-        {"", "", "", "", 0, "", "", "", "http://example.com%A0"},
-        {"http", "", "", "example.com%a0", 0, "/", "", "", "http://example.com%a0/"});
-    checkURLDifferences("http://%E2%98%83",
-        {"http", "", "", "xn--n3h", 0, "/", "", "", "http://xn--n3h/"},
-        {"http", "", "", "%e2%98%83", 0, "/", "", "", "http://%e2%98%83/"});
-    checkURLDifferences("http://host%73",
-        {"http", "", "", "hosts", 0, "/", "", "", "http://hosts/"},
-        {"http", "", "", "host%73", 0, "/", "", "", "http://host%73/"});
-    checkURLDifferences("http://host%53",
-        {"http", "", "", "hosts", 0, "/", "", "", "http://hosts/"},
-        {"http", "", "", "host%53", 0, "/", "", "", "http://host%53/"});
-    checkURLDifferences("http://%",
-        {"", "", "", "", 0, "", "", "", "http://%"},
-        {"http", "", "", "%", 0, "/", "", "", "http://%/"});
-    checkURLDifferences("http://%7",
-        {"", "", "", "", 0, "", "", "", "http://%7"},
-        {"http", "", "", "%7", 0, "/", "", "", "http://%7/"});
-    checkURLDifferences("http://%7s",
-        {"", "", "", "", 0, "", "", "", "http://%7s"},
-        {"http", "", "", "%7s", 0, "/", "", "", "http://%7s/"});
-    checkURLDifferences("http://%73",
-        {"http", "", "", "s", 0, "/", "", "", "http://s/"},
-        {"http", "", "", "%73", 0, "/", "", "", "http://%73/"});
-    checkURLDifferences("http://abcdefg%",
-        {"", "", "", "", 0, "", "", "", "http://abcdefg%"},
-        {"http", "", "", "abcdefg%", 0, "/", "", "", "http://abcdefg%/"});
-    checkURLDifferences("http://abcd%7Xefg",
-        {"", "", "", "", 0, "", "", "", "http://abcd%7Xefg"},
-        {"http", "", "", "abcd%7xefg", 0, "/", "", "", "http://abcd%7xefg/"});
-    checkURL("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {"ws", "", "", "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a", 0, "/", "", "", "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a/"}, TestTabs::No);
-    checkURL("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {"ws", "", "", "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a", 0, "/", "", "", "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a/"}, TestTabs::No);
-    checkURL("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {"ws", "", "", "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a", 0, "/", "", "", "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a/"}, TestTabs::No);
-    checkURL("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", {"ws", "", "", "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a", 0, "/", "", "", "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a/"}, TestTabs::No);
+    checkURLDifferences("file:path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/path"_s, ""_s, ""_s, "file:///path"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "path"_s, ""_s, ""_s, "file://path"_s });
+    checkURLDifferences("file:pAtH"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/pAtH"_s, ""_s, ""_s, "file:///pAtH"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "pAtH"_s, ""_s, ""_s, "file://pAtH"_s });
+    checkURLDifferences("file:pAtH/"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/pAtH/"_s, ""_s, ""_s, "file:///pAtH/"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "pAtH/"_s, ""_s, ""_s, "file://pAtH/"_s });
+    checkURLDifferences("http://example.com%A0"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://example.com%A0"_s },
+        { "http"_s, ""_s, ""_s, "example.com%a0"_s, 0, "/"_s, ""_s, ""_s, "http://example.com%a0/"_s });
+    checkURLDifferences("http://%E2%98%83"_s,
+        { "http"_s, ""_s, ""_s, "xn--n3h"_s, 0, "/"_s, ""_s, ""_s, "http://xn--n3h/"_s },
+        { "http"_s, ""_s, ""_s, "%e2%98%83"_s, 0, "/"_s, ""_s, ""_s, "http://%e2%98%83/"_s });
+    checkURLDifferences("http://host%73"_s,
+        { "http"_s, ""_s, ""_s, "hosts"_s, 0, "/"_s, ""_s, ""_s, "http://hosts/"_s },
+        { "http"_s, ""_s, ""_s, "host%73"_s, 0, "/"_s, ""_s, ""_s, "http://host%73/"_s });
+    checkURLDifferences("http://host%53"_s,
+        { "http"_s, ""_s, ""_s, "hosts"_s, 0, "/"_s, ""_s, ""_s, "http://hosts/"_s },
+        { "http"_s, ""_s, ""_s, "host%53"_s, 0, "/"_s, ""_s, ""_s, "http://host%53/"_s });
+    checkURLDifferences("http://%"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://%"_s },
+        { "http"_s, ""_s, ""_s, "%"_s, 0, "/"_s, ""_s, ""_s, "http://%/"_s });
+    checkURLDifferences("http://%7"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://%7"_s },
+        { "http"_s, ""_s, ""_s, "%7"_s, 0, "/"_s, ""_s, ""_s, "http://%7/"_s });
+    checkURLDifferences("http://%7s"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://%7s"_s },
+        { "http"_s, ""_s, ""_s, "%7s"_s, 0, "/"_s, ""_s, ""_s, "http://%7s/"_s });
+    checkURLDifferences("http://%73"_s,
+        { "http"_s, ""_s, ""_s, "s"_s, 0, "/"_s, ""_s, ""_s, "http://s/"_s },
+        { "http"_s, ""_s, ""_s, "%73"_s, 0, "/"_s, ""_s, ""_s, "http://%73/"_s });
+    checkURLDifferences("http://abcdefg%"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://abcdefg%"_s },
+        { "http"_s, ""_s, ""_s, "abcdefg%"_s, 0, "/"_s, ""_s, ""_s, "http://abcdefg%/"_s });
+    checkURLDifferences("http://abcd%7Xefg"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://abcd%7Xefg"_s },
+        { "http"_s, ""_s, ""_s, "abcd%7xefg"_s, 0, "/"_s, ""_s, ""_s, "http://abcd%7xefg/"_s });
+    checkURL("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s, { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a/"_s }, TestTabs::No);
+    checkURL("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s, { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a/"_s }, TestTabs::No);
+    checkURL("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s, { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a/"_s }, TestTabs::No);
+    checkURL("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s, { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a/"_s }, TestTabs::No);
 
     // URLParser matches Chrome and the spec, but not URL::parse or Firefox.
     checkURLDifferences(utf16String(u"http://０Ｘｃ０．０２５０．０１"),
-        {"http", "", "", "192.168.0.1", 0, "/", "", "", "http://192.168.0.1/"},
-        {"http", "", "", "0xc0.0250.01", 0, "/", "", "", "http://0xc0.0250.01/"});
+        { "http"_s, ""_s, ""_s, "192.168.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://192.168.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "0xc0.0250.01"_s, 0, "/"_s, ""_s, ""_s, "http://0xc0.0250.01/"_s });
 
-    checkURL("http://host/path%2e.%2E", {"http", "", "", "host", 0, "/path%2e.%2E", "", "", "http://host/path%2e.%2E"});
+    checkURL("http://host/path%2e.%2E"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/path%2e.%2E"_s, ""_s, ""_s, "http://host/path%2e.%2E"_s });
 
-    checkRelativeURLDifferences(utf16String(u"http://foo:💩@example.com/bar"), "http://other.com/",
-        {"http", "foo", utf16String(u"💩"), "example.com", 0, "/bar", "", "", "http://foo:%F0%9F%92%A9@example.com/bar"},
-        {"", "", "", "", 0, "", "", "", utf16String(u"http://foo:💩@example.com/bar")}, testTabsValueForSurrogatePairs);
-    checkRelativeURLDifferences("http://&a:foo(b]c@d:2/", "http://example.org/foo/bar",
-        {"http", "&a", "foo(b]c", "d", 2, "/", "", "", "http://&a:foo(b%5Dc@d:2/"},
-        {"", "", "", "", 0, "", "", "", "http://&a:foo(b]c@d:2/"});
-    checkRelativeURLDifferences("http://`{}:`{}@h/`{}?`{}", "http://doesnotmatter/",
-        {"http", "`{}", "`{}", "h", 0, "/%60%7B%7D", "`{}", "", "http://%60%7B%7D:%60%7B%7D@h/%60%7B%7D?`{}"},
-        {"", "", "", "", 0, "", "", "", "http://`{}:`{}@h/`{}?`{}"});
-    checkURLDifferences("http://[0:f::f::f]",
-        {"", "", "", "", 0, "" , "", "", "http://[0:f::f::f]"},
-        {"http", "", "", "[0:f::f::f]", 0, "/" , "", "", "http://[0:f::f::f]/"});
-    checkURLDifferences("http://123",
-        {"http", "", "", "0.0.0.123", 0, "/", "", "", "http://0.0.0.123/"},
-        {"http", "", "", "123", 0, "/", "", "", "http://123/"});
-    checkURLDifferences("http://123.234/",
-        {"http", "", "", "123.0.0.234", 0, "/", "", "", "http://123.0.0.234/"},
-        {"http", "", "", "123.234", 0, "/", "", "", "http://123.234/"});
-    checkURLDifferences("http://123.234.012",
-        {"http", "", "", "123.234.0.10", 0, "/", "", "", "http://123.234.0.10/"},
-        {"http", "", "", "123.234.012", 0, "/", "", "", "http://123.234.012/"});
-    checkURLDifferences("http://123.234.12",
-        {"http", "", "", "123.234.0.12", 0, "/", "", "", "http://123.234.0.12/"},
-        {"http", "", "", "123.234.12", 0, "/", "", "", "http://123.234.12/"});
-    checkRelativeURLDifferences("file:c:\\foo\\bar.html", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/c:/foo/bar.html", "", "", "file:///c:/foo/bar.html"},
-        {"file", "", "", "", 0, "/tmp/mock/c:/foo/bar.html", "", "", "file:///tmp/mock/c:/foo/bar.html"});
-    checkRelativeURLDifferences("  File:c|////foo\\bar.html", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/c:////foo/bar.html", "", "", "file:///c:////foo/bar.html"},
-        {"file", "", "", "", 0, "/tmp/mock/c|////foo/bar.html", "", "", "file:///tmp/mock/c|////foo/bar.html"});
-    checkRelativeURLDifferences("  Fil\t\n\te\n\t\n:\t\n\tc\t\n\t|\n\t\n/\t\n\t/\n\t\n//foo\\bar.html", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/c:////foo/bar.html", "", "", "file:///c:////foo/bar.html"},
-        {"file", "", "", "", 0, "/tmp/mock/c|////foo/bar.html", "", "", "file:///tmp/mock/c|////foo/bar.html"});
-    checkRelativeURLDifferences("C|/foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/foo/bar", "", "", "file:///C:/foo/bar"},
-        {"file", "", "", "", 0, "/tmp/mock/C|/foo/bar", "", "", "file:///tmp/mock/C|/foo/bar"});
-    checkRelativeURLDifferences("/C|/foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/foo/bar", "", "", "file:///C:/foo/bar"},
-        {"file", "", "", "", 0, "/C|/foo/bar", "", "", "file:///C|/foo/bar"});
-    checkRelativeURLDifferences("https://@test@test@example:800/", "http://doesnotmatter/",
-        {"https", "@test@test", "", "example", 800, "/", "", "", "https://%40test%40test@example:800/"},
-        {"", "", "", "", 0, "", "", "", "https://@test@test@example:800/"});
-    checkRelativeURLDifferences("https://@test@test@example:800/path@end", "http://doesnotmatter/",
-        {"https", "@test@test", "", "example", 800, "/path@end", "", "", "https://%40test%40test@example:800/path@end"},
-        {"", "", "", "", 0, "", "", "", "https://@test@test@example:800/path@end"});
-    checkURLDifferences("notspecial://@test@test@example:800/path@end",
-        {"notspecial", "@test@test", "", "example", 800, "/path@end", "", "", "notspecial://%40test%40test@example:800/path@end"},
-        {"", "", "", "", 0, "", "", "", "notspecial://@test@test@example:800/path@end"});
-    checkURLDifferences("notspecial://@test@test@example:800\\path@end",
-        {"notspecial", "@test@test@example", "800\\path", "end", 0, "", "", "", "notspecial://%40test%40test%40example:800%5Cpath@end"},
-        {"", "", "", "", 0, "", "", "", "notspecial://@test@test@example:800\\path@end"});
-    checkURLDifferences("http://%48OsT",
-        {"http", "", "", "host", 0, "/", "", "", "http://host/"},
-        {"http", "", "", "%48ost", 0, "/", "", "", "http://%48ost/"});
-    checkURLDifferences("http://h%4FsT",
-        {"http", "", "", "host", 0, "/", "", "", "http://host/"},
-        {"http", "", "", "h%4fst", 0, "/", "", "", "http://h%4fst/"});
-    checkURLDifferences("http://h%4fsT",
-        {"http", "", "", "host", 0, "/", "", "", "http://host/"},
-        {"http", "", "", "h%4fst", 0, "/", "", "", "http://h%4fst/"});
-    checkURLDifferences("http://h%6fsT",
-        {"http", "", "", "host", 0, "/", "", "", "http://host/"},
-        {"http", "", "", "h%6fst", 0, "/", "", "", "http://h%6fst/"});
-    checkURLDifferences("http://host/`",
-        {"http", "", "", "host", 0, "/%60", "", "", "http://host/%60"},
-        {"http", "", "", "host", 0, "/`", "", "", "http://host/`"});
-    checkURLDifferences("http://://",
-        {"", "", "", "", 0, "", "", "", "http://://"},
-        {"http", "", "", "", 0, "//", "", "", "http://://"});
-    checkURLDifferences("http://:123?",
-        {"", "", "", "", 0, "", "", "", "http://:123?"},
-        {"http", "", "", "", 123, "/", "", "", "http://:123/?"});
-    checkURLDifferences("http:/:",
-        {"", "", "", "", 0, "", "", "", "http:/:"},
-        {"http", "", "", "", 0, "/", "", "", "http://:/"});
-    checkURLDifferences("asdf://:",
-        {"", "", "", "", 0, "", "", "", "asdf://:"},
-        {"asdf", "", "", "", 0, "", "", "", "asdf://:"});
-    checkURLDifferences("http://:",
-        {"", "", "", "", 0, "", "", "", "http://:"},
-        {"http", "", "", "", 0, "/", "", "", "http://:/"});
-    checkURLDifferences("http:##foo",
-        {"", "", "", "", 0, "", "", "", "http:##foo"},
-        {"http", "", "", "", 0, "/", "", "#foo", "http:/##foo"});
-    checkURLDifferences("http:??bar",
-        {"", "", "", "", 0, "", "", "", "http:??bar"},
-        {"http", "", "", "", 0, "/", "?bar", "", "http:/??bar"});
-    checkURL("asdf:##foo", {"asdf", "", "", "", 0, "", "", "#foo", "asdf:##foo"});
-    checkURL("asdf:??bar", {"asdf", "", "", "", 0, "", "?bar", "", "asdf:??bar"});
-    checkRelativeURLDifferences("//C|/foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/foo/bar", "", "", "file:///C:/foo/bar"},
-        {"", "", "", "", 0, "", "", "", "//C|/foo/bar"});
-    checkRelativeURLDifferences("//C:/foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/foo/bar", "", "", "file:///C:/foo/bar"},
-        {"file", "", "", "c", 0, "/foo/bar", "", "", "file://c/foo/bar"});
-    checkRelativeURLDifferences("//C|?foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/", "foo/bar", "", "file:///C:/?foo/bar"},
-        {"", "", "", "", 0, "", "", "", "//C|?foo/bar"});
-    checkRelativeURLDifferences("//C|#foo/bar", "file:///tmp/mock/path",
-        {"file", "", "", "", 0, "/C:/", "", "foo/bar", "file:///C:/#foo/bar"},
-        {"", "", "", "", 0, "", "", "", "//C|#foo/bar"});
-    checkURLDifferences("http://0xFFFFFfFF/",
-        {"http", "", "", "255.255.255.255", 0, "/", "", "", "http://255.255.255.255/"},
-        {"http", "", "", "0xffffffff", 0, "/", "", "", "http://0xffffffff/"});
-    checkURLDifferences("http://0000000000000000037777777777/",
-        {"http", "", "", "255.255.255.255", 0, "/", "", "", "http://255.255.255.255/"},
-        {"http", "", "", "0000000000000000037777777777", 0, "/", "", "", "http://0000000000000000037777777777/"});
-    checkURLDifferences("http://4294967295/",
-        {"http", "", "", "255.255.255.255", 0, "/", "", "", "http://255.255.255.255/"},
-        {"http", "", "", "4294967295", 0, "/", "", "", "http://4294967295/"});
-    checkURLDifferences("http://256/",
-        {"http", "", "", "0.0.1.0", 0, "/", "", "", "http://0.0.1.0/"},
-        {"http", "", "", "256", 0, "/", "", "", "http://256/"});
-    checkURLDifferences("http://256./",
-        {"http", "", "", "0.0.1.0", 0, "/", "", "", "http://0.0.1.0/"},
-        {"http", "", "", "256.", 0, "/", "", "", "http://256./"});
-    checkURLDifferences("http://123.256/",
-        {"http", "", "", "123.0.1.0", 0, "/", "", "", "http://123.0.1.0/"},
-        {"http", "", "", "123.256", 0, "/", "", "", "http://123.256/"});
-    checkURLDifferences("http://127.%.0.1/",
-        {"", "", "", "", 0, "", "", "", "http://127.%.0.1/"},
-        {"http", "", "", "127.%.0.1", 0, "/", "", "", "http://127.%.0.1/"});
-    checkURLDifferences("http://[1:2:3:4:5:6:7:8:]/",
-        {"", "", "", "", 0, "", "", "", "http://[1:2:3:4:5:6:7:8:]/"},
-        {"http", "", "", "[1:2:3:4:5:6:7:8:]", 0, "/", "", "", "http://[1:2:3:4:5:6:7:8:]/"});
-    checkURLDifferences("http://[:2:3:4:5:6:7:8:]/",
-        {"", "", "", "", 0, "", "", "", "http://[:2:3:4:5:6:7:8:]/"},
-        {"http", "", "", "[:2:3:4:5:6:7:8:]", 0, "/", "", "", "http://[:2:3:4:5:6:7:8:]/"});
-    checkURLDifferences("http://[1:2:3:4:5:6:7::]/",
-        {"http", "", "", "[1:2:3:4:5:6:7:0]", 0, "/", "", "", "http://[1:2:3:4:5:6:7:0]/"},
-        {"http", "", "", "[1:2:3:4:5:6:7::]", 0, "/", "", "", "http://[1:2:3:4:5:6:7::]/"});
-    checkURLDifferences("http://[1:2:3:4:5:6:7:::]/",
-        {"", "", "", "", 0, "", "", "", "http://[1:2:3:4:5:6:7:::]/"},
-        {"http", "", "", "[1:2:3:4:5:6:7:::]", 0, "/", "", "", "http://[1:2:3:4:5:6:7:::]/"});
-    checkURLDifferences("http://127.0.0.1~/",
-        {"http", "", "", "127.0.0.1~", 0, "/", "", "", "http://127.0.0.1~/"},
-        {"", "", "", "", 0, "", "", "", "http://127.0.0.1~/"});
-    checkURLDifferences("http://127.0.1~/",
-        {"http", "", "", "127.0.1~", 0, "/", "", "", "http://127.0.1~/"},
-        {"", "", "", "", 0, "", "", "", "http://127.0.1~/"});
-    checkURLDifferences("http://127.0.1./",
-        {"http", "", "", "127.0.0.1", 0, "/", "", "", "http://127.0.0.1/"},
-        {"http", "", "", "127.0.1.", 0, "/", "", "", "http://127.0.1./"});
-    checkURLDifferences("http://127.0.1.~/",
-        {"http", "", "", "127.0.1.~", 0, "/", "", "", "http://127.0.1.~/"},
-        {"", "", "", "", 0, "", "", "", "http://127.0.1.~/"});
-    checkURLDifferences("http://127.0.1.~",
-        {"http", "", "", "127.0.1.~", 0, "/", "", "", "http://127.0.1.~/"},
-        {"", "", "", "", 0, "", "", "", "http://127.0.1.~"});
-    checkRelativeURLDifferences("http://f:000/c", "http://example.org/foo/bar",
-        {"http", "", "", "f", 0, "/c", "", "", "http://f:0/c"},
-        {"http", "", "", "f", 0, "/c", "", "", "http://f:000/c"});
-    checkRelativeURLDifferences("http://f:010/c", "http://example.org/foo/bar",
-        {"http", "", "", "f", 10, "/c", "", "", "http://f:10/c"},
-        {"http", "", "", "f", 10, "/c", "", "", "http://f:010/c"});
-    checkURL("notspecial://HoSt", {"notspecial", "", "", "HoSt", 0, "", "", "", "notspecial://HoSt"});
-    checkURL("notspecial://H%6FSt", {"notspecial", "", "", "H%6FSt", 0, "", "", "", "notspecial://H%6FSt"});
-    checkURL("notspecial://H%4fSt", {"notspecial", "", "", "H%4fSt", 0, "", "", "", "notspecial://H%4fSt"});
+    checkRelativeURLDifferences(utf16String(u"http://foo:💩@example.com/bar"), "http://other.com/"_s,
+        { "http"_s, "foo"_s, utf16String(u"💩"), "example.com"_s, 0, "/bar"_s, ""_s, ""_s, "http://foo:%F0%9F%92%A9@example.com/bar"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://foo:💩@example.com/bar") }, testTabsValueForSurrogatePairs);
+    checkRelativeURLDifferences("http://&a:foo(b]c@d:2/"_s, "http://example.org/foo/bar"_s,
+        { "http"_s, "&a"_s, "foo(b]c"_s, "d"_s, 2, "/"_s, ""_s, ""_s, "http://&a:foo(b%5Dc@d:2/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://&a:foo(b]c@d:2/"_s });
+    checkRelativeURLDifferences("http://`{}:`{}@h/`{}?`{}"_s, "http://doesnotmatter/"_s,
+        { "http"_s, "`{}"_s, "`{}"_s, "h"_s, 0, "/%60%7B%7D"_s, "`{}"_s, ""_s, "http://%60%7B%7D:%60%7B%7D@h/%60%7B%7D?`{}"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://`{}:`{}@h/`{}?`{}"_s });
+    checkURLDifferences("http://[0:f::f::f]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[0:f::f::f]"_s },
+        { "http"_s, ""_s, ""_s, "[0:f::f::f]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:f::f::f]/"_s });
+    checkURLDifferences("http://123"_s,
+        { "http"_s, ""_s, ""_s, "0.0.0.123"_s, 0, "/"_s, ""_s, ""_s, "http://0.0.0.123/"_s },
+        { "http"_s, ""_s, ""_s, "123"_s, 0, "/"_s, ""_s, ""_s, "http://123/"_s });
+    checkURLDifferences("http://123.234/"_s,
+        { "http"_s, ""_s, ""_s, "123.0.0.234"_s, 0, "/"_s, ""_s, ""_s, "http://123.0.0.234/"_s },
+        { "http"_s, ""_s, ""_s, "123.234"_s, 0, "/"_s, ""_s, ""_s, "http://123.234/"_s });
+    checkURLDifferences("http://123.234.012"_s,
+        { "http"_s, ""_s, ""_s, "123.234.0.10"_s, 0, "/"_s, ""_s, ""_s, "http://123.234.0.10/"_s },
+        { "http"_s, ""_s, ""_s, "123.234.012"_s, 0, "/"_s, ""_s, ""_s, "http://123.234.012/"_s });
+    checkURLDifferences("http://123.234.12"_s,
+        { "http"_s, ""_s, ""_s, "123.234.0.12"_s, 0, "/"_s, ""_s, ""_s, "http://123.234.0.12/"_s },
+        { "http"_s, ""_s, ""_s, "123.234.12"_s, 0, "/"_s, ""_s, ""_s, "http://123.234.12/"_s });
+    checkRelativeURLDifferences("file:c:\\foo\\bar.html"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/c:/foo/bar.html"_s, ""_s, ""_s, "file:///c:/foo/bar.html"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/tmp/mock/c:/foo/bar.html"_s, ""_s, ""_s, "file:///tmp/mock/c:/foo/bar.html"_s });
+    checkRelativeURLDifferences("  File:c|////foo\\bar.html"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/c:////foo/bar.html"_s, ""_s, ""_s, "file:///c:////foo/bar.html"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/tmp/mock/c|////foo/bar.html"_s, ""_s, ""_s, "file:///tmp/mock/c|////foo/bar.html"_s });
+    checkRelativeURLDifferences("  Fil\t\n\te\n\t\n:\t\n\tc\t\n\t|\n\t\n/\t\n\t/\n\t\n//foo\\bar.html"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/c:////foo/bar.html"_s, ""_s, ""_s, "file:///c:////foo/bar.html"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/tmp/mock/c|////foo/bar.html"_s, ""_s, ""_s, "file:///tmp/mock/c|////foo/bar.html"_s });
+    checkRelativeURLDifferences("C|/foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/foo/bar"_s, ""_s, ""_s, "file:///C:/foo/bar"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/tmp/mock/C|/foo/bar"_s, ""_s, ""_s, "file:///tmp/mock/C|/foo/bar"_s });
+    checkRelativeURLDifferences("/C|/foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/foo/bar"_s, ""_s, ""_s, "file:///C:/foo/bar"_s },
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C|/foo/bar"_s, ""_s, ""_s, "file:///C|/foo/bar"_s });
+    checkRelativeURLDifferences("https://@test@test@example:800/"_s, "http://doesnotmatter/"_s,
+        { "https"_s, "@test@test"_s, ""_s, "example"_s, 800, "/"_s, ""_s, ""_s, "https://%40test%40test@example:800/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "https://@test@test@example:800/"_s });
+    checkRelativeURLDifferences("https://@test@test@example:800/path@end"_s, "http://doesnotmatter/"_s,
+        { "https"_s, "@test@test"_s, ""_s, "example"_s, 800, "/path@end"_s, ""_s, ""_s, "https://%40test%40test@example:800/path@end"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "https://@test@test@example:800/path@end"_s });
+    checkURLDifferences("notspecial://@test@test@example:800/path@end"_s,
+        { "notspecial"_s, "@test@test"_s, ""_s, "example"_s, 800, "/path@end"_s, ""_s, ""_s, "notspecial://%40test%40test@example:800/path@end"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial://@test@test@example:800/path@end"_s });
+    checkURLDifferences("notspecial://@test@test@example:800\\path@end"_s,
+        { "notspecial"_s, "@test@test@example"_s, "800\\path"_s, "end"_s, 0, ""_s, ""_s, ""_s, "notspecial://%40test%40test%40example:800%5Cpath@end"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial://@test@test@example:800\\path@end"_s });
+    checkURLDifferences("http://%48OsT"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s },
+        { "http"_s, ""_s, ""_s, "%48ost"_s, 0, "/"_s, ""_s, ""_s, "http://%48ost/"_s });
+    checkURLDifferences("http://h%4FsT"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s },
+        { "http"_s, ""_s, ""_s, "h%4fst"_s, 0, "/"_s, ""_s, ""_s, "http://h%4fst/"_s });
+    checkURLDifferences("http://h%4fsT"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s },
+        { "http"_s, ""_s, ""_s, "h%4fst"_s, 0, "/"_s, ""_s, ""_s, "http://h%4fst/"_s });
+    checkURLDifferences("http://h%6fsT"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s },
+        { "http"_s, ""_s, ""_s, "h%6fst"_s, 0, "/"_s, ""_s, ""_s, "http://h%6fst/"_s });
+    checkURLDifferences("http://host/`"_s,
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/%60"_s, ""_s, ""_s, "http://host/%60"_s },
+        { "http"_s, ""_s, ""_s, "host"_s, 0, "/`"_s, ""_s, ""_s, "http://host/`"_s });
+    checkURLDifferences("http://://"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://://"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "//"_s, ""_s, ""_s, "http://://"_s });
+    checkURLDifferences("http://:123?"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://:123?"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 123, "/"_s, ""_s, ""_s, "http://:123/?"_s });
+    checkURLDifferences("http:/:"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:/:"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http://:/"_s });
+    checkURLDifferences("asdf://:"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "asdf://:"_s },
+        { "asdf"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "asdf://:"_s });
+    checkURLDifferences("http://:"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://:"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, ""_s, "http://:/"_s });
+    checkURLDifferences("http:##foo"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:##foo"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, ""_s, "#foo"_s, "http:/##foo"_s });
+    checkURLDifferences("http:??bar"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http:??bar"_s },
+        { "http"_s, ""_s, ""_s, ""_s, 0, "/"_s, "?bar"_s, ""_s, "http:/??bar"_s });
+    checkURL("asdf:##foo"_s, { "asdf"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, "#foo"_s, "asdf:##foo"_s });
+    checkURL("asdf:??bar"_s, { "asdf"_s, ""_s, ""_s, ""_s, 0, ""_s, "?bar"_s, ""_s, "asdf:??bar"_s });
+    checkRelativeURLDifferences("//C|/foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/foo/bar"_s, ""_s, ""_s, "file:///C:/foo/bar"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "//C|/foo/bar"_s });
+    checkRelativeURLDifferences("//C:/foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/foo/bar"_s, ""_s, ""_s, "file:///C:/foo/bar"_s },
+        { "file"_s, ""_s, ""_s, "c"_s, 0, "/foo/bar"_s, ""_s, ""_s, "file://c/foo/bar"_s });
+    checkRelativeURLDifferences("//C|?foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/"_s, "foo/bar"_s, ""_s, "file:///C:/?foo/bar"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "//C|?foo/bar"_s });
+    checkRelativeURLDifferences("//C|#foo/bar"_s, "file:///tmp/mock/path"_s,
+        { "file"_s, ""_s, ""_s, ""_s, 0, "/C:/"_s, ""_s, "foo/bar"_s, "file:///C:/#foo/bar"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "//C|#foo/bar"_s });
+    checkURLDifferences("http://0xFFFFFfFF/"_s,
+        { "http"_s, ""_s, ""_s, "255.255.255.255"_s, 0, "/"_s, ""_s, ""_s, "http://255.255.255.255/"_s },
+        { "http"_s, ""_s, ""_s, "0xffffffff"_s, 0, "/"_s, ""_s, ""_s, "http://0xffffffff/"_s });
+    checkURLDifferences("http://0000000000000000037777777777/"_s,
+        { "http"_s, ""_s, ""_s, "255.255.255.255"_s, 0, "/"_s, ""_s, ""_s, "http://255.255.255.255/"_s },
+        { "http"_s, ""_s, ""_s, "0000000000000000037777777777"_s, 0, "/"_s, ""_s, ""_s, "http://0000000000000000037777777777/"_s });
+    checkURLDifferences("http://4294967295/"_s,
+        { "http"_s, ""_s, ""_s, "255.255.255.255"_s, 0, "/"_s, ""_s, ""_s, "http://255.255.255.255/"_s },
+        { "http"_s, ""_s, ""_s, "4294967295"_s, 0, "/"_s, ""_s, ""_s, "http://4294967295/"_s });
+    checkURLDifferences("http://256/"_s,
+        { "http"_s, ""_s, ""_s, "0.0.1.0"_s, 0, "/"_s, ""_s, ""_s, "http://0.0.1.0/"_s },
+        { "http"_s, ""_s, ""_s, "256"_s, 0, "/"_s, ""_s, ""_s, "http://256/"_s });
+    checkURLDifferences("http://256./"_s,
+        { "http"_s, ""_s, ""_s, "0.0.1.0"_s, 0, "/"_s, ""_s, ""_s, "http://0.0.1.0/"_s },
+        { "http"_s, ""_s, ""_s, "256."_s, 0, "/"_s, ""_s, ""_s, "http://256./"_s });
+    checkURLDifferences("http://123.256/"_s,
+        { "http"_s, ""_s, ""_s, "123.0.1.0"_s, 0, "/"_s, ""_s, ""_s, "http://123.0.1.0/"_s },
+        { "http"_s, ""_s, ""_s, "123.256"_s, 0, "/"_s, ""_s, ""_s, "http://123.256/"_s });
+    checkURLDifferences("http://127.%.0.1/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.%.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.%.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.%.0.1/"_s });
+    checkURLDifferences("http://[1:2:3:4:5:6:7:8:]/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7:8:]/"_s },
+        { "http"_s, ""_s, ""_s, "[1:2:3:4:5:6:7:8:]"_s, 0, "/"_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7:8:]/"_s });
+    checkURLDifferences("http://[:2:3:4:5:6:7:8:]/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[:2:3:4:5:6:7:8:]/"_s },
+        { "http"_s, ""_s, ""_s, "[:2:3:4:5:6:7:8:]"_s, 0, "/"_s, ""_s, ""_s, "http://[:2:3:4:5:6:7:8:]/"_s });
+    checkURLDifferences("http://[1:2:3:4:5:6:7::]/"_s,
+        { "http"_s, ""_s, ""_s, "[1:2:3:4:5:6:7:0]"_s, 0, "/"_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7:0]/"_s },
+        { "http"_s, ""_s, ""_s, "[1:2:3:4:5:6:7::]"_s, 0, "/"_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7::]/"_s });
+    checkURLDifferences("http://[1:2:3:4:5:6:7:::]/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7:::]/"_s },
+        { "http"_s, ""_s, ""_s, "[1:2:3:4:5:6:7:::]"_s, 0, "/"_s, ""_s, ""_s, "http://[1:2:3:4:5:6:7:::]/"_s });
+    checkURLDifferences("http://127.0.0.1~/"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1~"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1~/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.0.1~/"_s });
+    checkURLDifferences("http://127.0.1~/"_s,
+        { "http"_s, ""_s, ""_s, "127.0.1~"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.1~/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.1~/"_s });
+    checkURLDifferences("http://127.0.1./"_s,
+        { "http"_s, ""_s, ""_s, "127.0.0.1"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.0.1/"_s },
+        { "http"_s, ""_s, ""_s, "127.0.1."_s, 0, "/"_s, ""_s, ""_s, "http://127.0.1./"_s });
+    checkURLDifferences("http://127.0.1.~/"_s,
+        { "http"_s, ""_s, ""_s, "127.0.1.~"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.1.~/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.1.~/"_s });
+    checkURLDifferences("http://127.0.1.~"_s,
+        { "http"_s, ""_s, ""_s, "127.0.1.~"_s, 0, "/"_s, ""_s, ""_s, "http://127.0.1.~/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://127.0.1.~"_s });
+    checkRelativeURLDifferences("http://f:000/c"_s, "http://example.org/foo/bar"_s,
+        { "http"_s, ""_s, ""_s, "f"_s, 0, "/c"_s, ""_s, ""_s, "http://f:0/c"_s },
+        { "http"_s, ""_s, ""_s, "f"_s, 0, "/c"_s, ""_s, ""_s, "http://f:000/c"_s });
+    checkRelativeURLDifferences("http://f:010/c"_s, "http://example.org/foo/bar"_s,
+        { "http"_s, ""_s, ""_s, "f"_s, 10, "/c"_s, ""_s, ""_s, "http://f:10/c"_s },
+        { "http"_s, ""_s, ""_s, "f"_s, 10, "/c"_s, ""_s, ""_s, "http://f:010/c"_s });
+    checkURL("notspecial://HoSt"_s, { "notspecial"_s, ""_s, ""_s, "HoSt"_s, 0, ""_s, ""_s, ""_s, "notspecial://HoSt"_s });
+    checkURL("notspecial://H%6FSt"_s, { "notspecial"_s, ""_s, ""_s, "H%6FSt"_s, 0, ""_s, ""_s, ""_s, "notspecial://H%6FSt"_s });
+    checkURL("notspecial://H%4fSt"_s, { "notspecial"_s, ""_s, ""_s, "H%4fSt"_s, 0, ""_s, ""_s, ""_s, "notspecial://H%4fSt"_s });
     checkURLDifferences(utf16String(u"notspecial://H😍ßt"),
-        {"notspecial", "", "", "H%F0%9F%98%8D%C3%9Ft", 0, "", "", "", "notspecial://H%F0%9F%98%8D%C3%9Ft"},
-        {"notspecial", "", "", "xn--hsst-qc83c", 0, "", "", "", "notspecial://xn--hsst-qc83c"}, testTabsValueForSurrogatePairs);
-    checkURLDifferences("http://[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]/",
-        {"http", "", "", "[ffff:aaaa:cccc:eeee:bbbb:dddd:ffff:ffff]", 0, "/", "", "", "http://[ffff:aaaa:cccc:eeee:bbbb:dddd:ffff:ffff]/"},
-        {"http", "", "", "[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]", 0, "/", "", "", "http://[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]/"}, TestTabs::No);
-    checkURLDifferences("http://[::123.234.12.210]/",
-        {"http", "", "", "[::7bea:cd2]", 0, "/", "", "", "http://[::7bea:cd2]/"},
-        {"http", "", "", "[::123.234.12.210]", 0, "/", "", "", "http://[::123.234.12.210]/"});
-    checkURLDifferences("http://[::a:255.255.255.255]/",
-        {"http", "", "", "[::a:ffff:ffff]", 0, "/", "", "", "http://[::a:ffff:ffff]/"},
-        {"http", "", "", "[::a:255.255.255.255]", 0, "/", "", "", "http://[::a:255.255.255.255]/"});
-    checkURLDifferences("http://[::0.00.255.255]/",
-        {"", "", "", "", 0, "", "", "", "http://[::0.00.255.255]/"},
-        {"http", "", "", "[::0.00.255.255]", 0, "/", "", "", "http://[::0.00.255.255]/"});
-    checkURLDifferences("http://[::0.0.255.255]/",
-        {"http", "", "", "[::ffff]", 0, "/", "", "", "http://[::ffff]/"},
-        {"http", "", "", "[::0.0.255.255]", 0, "/", "", "", "http://[::0.0.255.255]/"});
-    checkURLDifferences("http://[::0:1.0.255.255]/",
-        {"http", "", "", "[::100:ffff]", 0, "/", "", "", "http://[::100:ffff]/"},
-        {"http", "", "", "[::0:1.0.255.255]", 0, "/", "", "", "http://[::0:1.0.255.255]/"});
-    checkURLDifferences("http://[::A:1.0.255.255]/",
-        {"http", "", "", "[::a:100:ffff]", 0, "/", "", "", "http://[::a:100:ffff]/"},
-        {"http", "", "", "[::a:1.0.255.255]", 0, "/", "", "", "http://[::a:1.0.255.255]/"});
-    checkURLDifferences("http://[:127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[:127.0.0.1]"},
-        {"http", "", "", "[:127.0.0.1]", 0, "/", "", "", "http://[:127.0.0.1]/"});
-    checkURLDifferences("http://[127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[127.0.0.1]"},
-        {"http", "", "", "[127.0.0.1]", 0, "/", "", "", "http://[127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.1]",
-        {"http", "", "", "[a:b:c:d:e:f:7f00:1]", 0, "/", "", "", "http://[a:b:c:d:e:f:7f00:1]/"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.0.1]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.101]",
-        {"http", "", "", "[a:b:c:d:e:f:7f00:65]", 0, "/", "", "", "http://[a:b:c:d:e:f:7f00:65]/"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.0.101]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.0.101]/"});
-    checkURLDifferences("http://[::a:b:c:d:e:f:127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[::a:b:c:d:e:f:127.0.0.1]"},
-        {"http", "", "", "[::a:b:c:d:e:f:127.0.0.1]", 0, "/", "", "", "http://[::a:b:c:d:e:f:127.0.0.1]/"});
-    checkURLDifferences("http://[a:b::c:d:e:f:127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b::c:d:e:f:127.0.0.1]"},
-        {"http", "", "", "[a:b::c:d:e:f:127.0.0.1]", 0, "/", "", "", "http://[a:b::c:d:e:f:127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:127.0.0.1]"},
-        {"http", "", "", "[a:b:c:d:e:127.0.0.1]", 0, "/", "", "", "http://[a:b:c:d:e:127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0.0.0.1]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.0.0.1]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0.1]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.1]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.011]", // Chrome treats this as octal, Firefox and the spec fail
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0.0.011]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.0.011]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.0.011]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.00.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0.00.1]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.00.1]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.00.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.1.]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0.0.1.]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0.0.1.]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0.0.1.]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f:127.0..0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f:127.0..0.1]"},
-        {"http", "", "", "[a:b:c:d:e:f:127.0..0.1]", 0, "/", "", "", "http://[a:b:c:d:e:f:127.0..0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.1]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f::127.0.0.1]"},
-        {"http", "", "", "[a:b:c:d:e:f::127.0.0.1]", 0, "/", "", "", "http://[a:b:c:d:e:f::127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e::127.0.0.1]",
-        {"http", "", "", "[a:b:c:d:e:0:7f00:1]", 0, "/", "", "", "http://[a:b:c:d:e:0:7f00:1]/"},
-        {"http", "", "", "[a:b:c:d:e::127.0.0.1]", 0, "/", "", "", "http://[a:b:c:d:e::127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d::e:127.0.0.1]",
-        {"http", "", "", "[a:b:c:d:0:e:7f00:1]", 0, "/", "", "", "http://[a:b:c:d:0:e:7f00:1]/"},
-        {"http", "", "", "[a:b:c:d::e:127.0.0.1]", 0, "/", "", "", "http://[a:b:c:d::e:127.0.0.1]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f::127.0.0.]"},
-        {"http", "", "", "[a:b:c:d:e:f::127.0.0.]", 0, "/", "", "", "http://[a:b:c:d:e:f::127.0.0.]/"});
-    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.256]",
-        {"", "", "", "", 0, "", "", "", "http://[a:b:c:d:e:f::127.0.0.256]"},
-        {"http", "", "", "[a:b:c:d:e:f::127.0.0.256]", 0, "/", "", "", "http://[a:b:c:d:e:f::127.0.0.256]/"});
-    checkURLDifferences("http://123456", {"http", "", "", "0.1.226.64", 0, "/", "", "", "http://0.1.226.64/"}, {"http", "", "", "123456", 0, "/", "", "", "http://123456/"});
-    checkURL("asdf://123456", {"asdf", "", "", "123456", 0, "", "", "", "asdf://123456"});
-    checkURLDifferences("http://[0:0:0:0:a:b:c:d]",
-        {"http", "", "", "[::a:b:c:d]", 0, "/", "", "", "http://[::a:b:c:d]/"},
-        {"http", "", "", "[0:0:0:0:a:b:c:d]", 0, "/", "", "", "http://[0:0:0:0:a:b:c:d]/"});
-    checkURLDifferences("asdf://[0:0:0:0:a:b:c:d]",
-        {"asdf", "", "", "[::a:b:c:d]", 0, "", "", "", "asdf://[::a:b:c:d]"},
-        {"asdf", "", "", "[0:0:0:0:a:b:c:d]", 0, "", "", "", "asdf://[0:0:0:0:a:b:c:d]"}, TestTabs::No);
-    shouldFail("a://%:a");
-    checkURL("a://%:/", {"a", "", "", "%", 0, "/", "", "", "a://%/"});
-    checkURL("a://%:", {"a", "", "", "%", 0, "", "", "", "a://%"});
-    checkURL("a://%:1/", {"a", "", "", "%", 1, "/", "", "", "a://%:1/"});
-    checkURLDifferences("http://%:",
-        {"", "", "", "", 0, "", "", "", "http://%:"},
-        {"http", "", "", "%", 0, "/", "", "", "http://%/"});
-    checkURL("a://123456", {"a", "", "", "123456", 0, "", "", "", "a://123456"});
-    checkURL("a://123456:7", {"a", "", "", "123456", 7, "", "", "", "a://123456:7"});
-    checkURL("a://123456:7/", {"a", "", "", "123456", 7, "/", "", "", "a://123456:7/"});
-    checkURL("a://A", {"a", "", "", "A", 0, "", "", "", "a://A"});
-    checkURL("a://A:2", {"a", "", "", "A", 2, "", "", "", "a://A:2"});
-    checkURL("a://A:2/", {"a", "", "", "A", 2, "/", "", "", "a://A:2/"});
-    checkURLDifferences(reinterpret_cast<const char*>(u8"asd://ß"),
-        {"asd", "", "", "%C3%83%C2%9F", 0, "", "", "", "asd://%C3%83%C2%9F"},
-        {"", "", "", "", 0, "", "", "", "about:blank"}, TestTabs::No);
-    checkURLDifferences(reinterpret_cast<const char*>(u8"asd://ß:4"),
-        {"asd", "", "", "%C3%83%C2%9F", 4, "", "", "", "asd://%C3%83%C2%9F:4"},
-        {"", "", "", "", 0, "", "", "", "about:blank"}, TestTabs::No);
-    checkURLDifferences(reinterpret_cast<const char*>(u8"asd://ß:4/"),
-        {"asd", "", "", "%C3%83%C2%9F", 4, "/", "", "", "asd://%C3%83%C2%9F:4/"},
-        {"", "", "", "", 0, "", "", "", "about:blank"}, TestTabs::No);
-    checkURLDifferences("a://[A::b]:4",
-        {"a", "", "", "[a::b]", 4, "", "", "", "a://[a::b]:4"},
-        {"a", "", "", "[A::b]", 4, "", "", "", "a://[A::b]:4"});
-    shouldFail("http://[~]");
-    shouldFail("a://[~]");
-    checkRelativeURLDifferences("a://b", "//[aBc]",
-        {"a", "", "", "b", 0, "", "", "", "a://b"},
-        {"", "", "", "", 0, "", "", "", "a://b"});
-    checkURL(utf16String(u"http://öbb.at"), {"http", "", "", "xn--bb-eka.at", 0, "/", "", "", "http://xn--bb-eka.at/"});
-    checkURL(utf16String(u"http://ÖBB.at"), {"http", "", "", "xn--bb-eka.at", 0, "/", "", "", "http://xn--bb-eka.at/"});
-    checkURL(utf16String(u"http://√.com"), {"http", "", "", "xn--19g.com", 0, "/", "", "", "http://xn--19g.com/"});
+        { "notspecial"_s, ""_s, ""_s, "H%F0%9F%98%8D%C3%9Ft"_s, 0, ""_s, ""_s, ""_s, "notspecial://H%F0%9F%98%8D%C3%9Ft"_s },
+        { "notspecial"_s, ""_s, ""_s, "xn--hsst-qc83c"_s, 0, ""_s, ""_s, ""_s, "notspecial://xn--hsst-qc83c"_s }, testTabsValueForSurrogatePairs);
+    checkURLDifferences("http://[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]/"_s,
+        { "http"_s, ""_s, ""_s, "[ffff:aaaa:cccc:eeee:bbbb:dddd:ffff:ffff]"_s, 0, "/"_s, ""_s, ""_s, "http://[ffff:aaaa:cccc:eeee:bbbb:dddd:ffff:ffff]/"_s },
+        { "http"_s, ""_s, ""_s, "[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[ffff:aaaa:cccc:eeee:bbbb:dddd:255.255.255.255]/"_s }, TestTabs::No);
+    checkURLDifferences("http://[::123.234.12.210]/"_s,
+        { "http"_s, ""_s, ""_s, "[::7bea:cd2]"_s, 0, "/"_s, ""_s, ""_s, "http://[::7bea:cd2]/"_s },
+        { "http"_s, ""_s, ""_s, "[::123.234.12.210]"_s, 0, "/"_s, ""_s, ""_s, "http://[::123.234.12.210]/"_s });
+    checkURLDifferences("http://[::a:255.255.255.255]/"_s,
+        { "http"_s, ""_s, ""_s, "[::a:ffff:ffff]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:ffff:ffff]/"_s },
+        { "http"_s, ""_s, ""_s, "[::a:255.255.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:255.255.255.255]/"_s });
+    checkURLDifferences("http://[::0.00.255.255]/"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[::0.00.255.255]/"_s },
+        { "http"_s, ""_s, ""_s, "[::0.00.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[::0.00.255.255]/"_s });
+    checkURLDifferences("http://[::0.0.255.255]/"_s,
+        { "http"_s, ""_s, ""_s, "[::ffff]"_s, 0, "/"_s, ""_s, ""_s, "http://[::ffff]/"_s },
+        { "http"_s, ""_s, ""_s, "[::0.0.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[::0.0.255.255]/"_s });
+    checkURLDifferences("http://[::0:1.0.255.255]/"_s,
+        { "http"_s, ""_s, ""_s, "[::100:ffff]"_s, 0, "/"_s, ""_s, ""_s, "http://[::100:ffff]/"_s },
+        { "http"_s, ""_s, ""_s, "[::0:1.0.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[::0:1.0.255.255]/"_s });
+    checkURLDifferences("http://[::A:1.0.255.255]/"_s,
+        { "http"_s, ""_s, ""_s, "[::a:100:ffff]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:100:ffff]/"_s },
+        { "http"_s, ""_s, ""_s, "[::a:1.0.255.255]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:1.0.255.255]/"_s });
+    checkURLDifferences("http://[:127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[:127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[:127.0.0.1]/"_s });
+    checkURLDifferences("http://[127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.1]"_s,
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:7f00:1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:7f00:1]/"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.101]"_s,
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:7f00:65]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:7f00:65]/"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.0.101]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.101]/"_s });
+    checkURLDifferences("http://[::a:b:c:d:e:f:127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[::a:b:c:d:e:f:127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[::a:b:c:d:e:f:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:b:c:d:e:f:127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b::c:d:e:f:127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b::c:d:e:f:127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b::c:d:e:f:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b::c:d:e:f:127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.011]"_s, // Chrome treats this as octal, Firefox and the spec fail
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.011]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.0.011]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.011]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.00.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.00.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.00.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.00.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0.0.1.]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.1.]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0.0.1.]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0.0.1.]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f:127.0..0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0..0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f:127.0..0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f:127.0..0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.1]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.1]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f::127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e::127.0.0.1]"_s,
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:0:7f00:1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:0:7f00:1]/"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e::127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e::127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d::e:127.0.0.1]"_s,
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:0:e:7f00:1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:0:e:7f00:1]/"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d::e:127.0.0.1]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d::e:127.0.0.1]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f::127.0.0.]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.]/"_s });
+    checkURLDifferences("http://[a:b:c:d:e:f::127.0.0.256]"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.256]"_s },
+        { "http"_s, ""_s, ""_s, "[a:b:c:d:e:f::127.0.0.256]"_s, 0, "/"_s, ""_s, ""_s, "http://[a:b:c:d:e:f::127.0.0.256]/"_s });
+    checkURLDifferences("http://123456"_s, { "http"_s, ""_s, ""_s, "0.1.226.64"_s, 0, "/"_s, ""_s, ""_s, "http://0.1.226.64/"_s }, { "http"_s, ""_s, ""_s, "123456"_s, 0, "/"_s, ""_s, ""_s, "http://123456/"_s });
+    checkURL("asdf://123456"_s, { "asdf"_s, ""_s, ""_s, "123456"_s, 0, ""_s, ""_s, ""_s, "asdf://123456"_s });
+    checkURLDifferences("http://[0:0:0:0:a:b:c:d]"_s,
+        { "http"_s, ""_s, ""_s, "[::a:b:c:d]"_s, 0, "/"_s, ""_s, ""_s, "http://[::a:b:c:d]/"_s },
+        { "http"_s, ""_s, ""_s, "[0:0:0:0:a:b:c:d]"_s, 0, "/"_s, ""_s, ""_s, "http://[0:0:0:0:a:b:c:d]/"_s });
+    checkURLDifferences("asdf://[0:0:0:0:a:b:c:d]"_s,
+        { "asdf"_s, ""_s, ""_s, "[::a:b:c:d]"_s, 0, ""_s, ""_s, ""_s, "asdf://[::a:b:c:d]"_s },
+        { "asdf"_s, ""_s, ""_s, "[0:0:0:0:a:b:c:d]"_s, 0, ""_s, ""_s, ""_s, "asdf://[0:0:0:0:a:b:c:d]"_s }, TestTabs::No);
+    shouldFail("a://%:a"_s);
+    checkURL("a://%:/"_s, { "a"_s, ""_s, ""_s, "%"_s, 0, "/"_s, ""_s, ""_s, "a://%/"_s });
+    checkURL("a://%:"_s, { "a"_s, ""_s, ""_s, "%"_s, 0, ""_s, ""_s, ""_s, "a://%"_s });
+    checkURL("a://%:1/"_s, { "a"_s, ""_s, ""_s, "%"_s, 1, "/"_s, ""_s, ""_s, "a://%:1/"_s });
+    checkURLDifferences("http://%:"_s,
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://%:"_s },
+        { "http"_s, ""_s, ""_s, "%"_s, 0, "/"_s, ""_s, ""_s, "http://%/"_s });
+    checkURL("a://123456"_s, { "a"_s, ""_s, ""_s, "123456"_s, 0, ""_s, ""_s, ""_s, "a://123456"_s });
+    checkURL("a://123456:7"_s, { "a"_s, ""_s, ""_s, "123456"_s, 7, ""_s, ""_s, ""_s, "a://123456:7"_s });
+    checkURL("a://123456:7/"_s, { "a"_s, ""_s, ""_s, "123456"_s, 7, "/"_s, ""_s, ""_s, "a://123456:7/"_s });
+    checkURL("a://A"_s, { "a"_s, ""_s, ""_s, "A"_s, 0, ""_s, ""_s, ""_s, "a://A"_s });
+    checkURL("a://A:2"_s, { "a"_s, ""_s, ""_s, "A"_s, 2, ""_s, ""_s, ""_s, "a://A:2"_s });
+    checkURL("a://A:2/"_s, { "a"_s, ""_s, ""_s, "A"_s, 2, "/"_s, ""_s, ""_s, "a://A:2/"_s });
+    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß")),
+        { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 0, ""_s, ""_s, ""_s, "asd://%C3%83%C2%9F"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "about:blank"_s }, TestTabs::No);
+    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß:4")),
+        { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 4, ""_s, ""_s, ""_s, "asd://%C3%83%C2%9F:4"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "about:blank"_s }, TestTabs::No);
+    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß:4/")),
+        { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 4, "/"_s, ""_s, ""_s, "asd://%C3%83%C2%9F:4/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "about:blank"_s }, TestTabs::No);
+    checkURLDifferences("a://[A::b]:4"_s,
+        { "a"_s, ""_s, ""_s, "[a::b]"_s, 4, ""_s, ""_s, ""_s, "a://[a::b]:4"_s },
+        { "a"_s, ""_s, ""_s, "[A::b]"_s, 4, ""_s, ""_s, ""_s, "a://[A::b]:4"_s });
+    shouldFail("http://[~]"_s);
+    shouldFail("a://[~]"_s);
+    checkRelativeURLDifferences("a://b"_s, "//[aBc]"_s,
+        { "a"_s, ""_s, ""_s, "b"_s, 0, ""_s, ""_s, ""_s, "a://b"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "a://b"_s });
+    checkURL(utf16String(u"http://öbb.at"), { "http"_s, ""_s, ""_s, "xn--bb-eka.at"_s, 0, "/"_s, ""_s, ""_s, "http://xn--bb-eka.at/"_s });
+    checkURL(utf16String(u"http://ÖBB.at"), { "http"_s, ""_s, ""_s, "xn--bb-eka.at"_s, 0, "/"_s, ""_s, ""_s, "http://xn--bb-eka.at/"_s });
+    checkURL(utf16String(u"http://√.com"), { "http"_s, ""_s, ""_s, "xn--19g.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--19g.com/"_s });
     checkURLDifferences(utf16String(u"http://faß.de"),
-        {"http", "", "", "xn--fa-hia.de", 0, "/", "", "", "http://xn--fa-hia.de/"},
-        {"http", "", "", "fass.de", 0, "/", "", "", "http://fass.de/"});
-    checkURL(utf16String(u"http://ԛәлп.com"), {"http", "", "", "xn--k1ai47bhi.com", 0, "/", "", "", "http://xn--k1ai47bhi.com/"});
+        { "http"_s, ""_s, ""_s, "xn--fa-hia.de"_s, 0, "/"_s, ""_s, ""_s, "http://xn--fa-hia.de/"_s },
+        { "http"_s, ""_s, ""_s, "fass.de"_s, 0, "/"_s, ""_s, ""_s, "http://fass.de/"_s });
+    checkURL(utf16String(u"http://ԛәлп.com"), { "http"_s, ""_s, ""_s, "xn--k1ai47bhi.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--k1ai47bhi.com/"_s });
     checkURLDifferences(utf16String(u"http://Ⱥbby.com"),
-        {"http", "", "", "xn--bby-iy0b.com", 0, "/", "", "", "http://xn--bby-iy0b.com/"},
-        {"http", "", "", "xn--bby-spb.com", 0, "/", "", "", "http://xn--bby-spb.com/"});
+        { "http"_s, ""_s, ""_s, "xn--bby-iy0b.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--bby-iy0b.com/"_s },
+        { "http"_s, ""_s, ""_s, "xn--bby-spb.com"_s, 0, "/"_s, ""_s, ""_s, "http://xn--bby-spb.com/"_s });
     checkURLDifferences(utf16String(u"http://\u2132"),
-        {"", "", "", "", 0, "", "", "", utf16String(u"http://Ⅎ")},
-        {"http", "", "", "xn--f3g", 0, "/", "", "", "http://xn--f3g/"});
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://Ⅎ") },
+        { "http"_s, ""_s, ""_s, "xn--f3g"_s, 0, "/"_s, ""_s, ""_s, "http://xn--f3g/"_s });
     checkURLDifferences(utf16String(u"http://\u05D9\u05B4\u05D5\u05D0\u05B8/"),
-        {"http", "", "", "xn--cdbi5etas", 0, "/", "", "", "http://xn--cdbi5etas/"},
-        {"", "", "", "", 0, "", "", "", "about:blank"}, TestTabs::No);
+        { "http"_s, ""_s, ""_s, "xn--cdbi5etas"_s, 0, "/"_s, ""_s, ""_s, "http://xn--cdbi5etas/"_s },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "about:blank"_s }, TestTabs::No);
     checkURLDifferences(utf16String(u"http://bidirectional\u0786\u07AE\u0782\u07B0\u0795\u07A9\u0793\u07A6\u0783\u07AA/"),
-        {"", "", "", "", 0, "", "", "", utf16String(u"http://bidirectionalކޮންޕީޓަރު/")},
-        {"", "", "", "", 0, "", "", "", "about:blank"}, TestTabs::No);
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://bidirectionalކޮންޕީޓަރު/") },
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "about:blank"_s }, TestTabs::No);
     checkURLDifferences(utf16String(u"http://contextj\u200D"),
-        {"", "", "", "", 0, "", "", "", utf16String(u"http://contextj\u200D")},
-        {"http", "", "", "contextj", 0, "/", "", "", "http://contextj/"});
-    checkURL(utf16String(u"http://contexto\u30FB"), {"http", "", "", "xn--contexto-wg5g", 0, "/", "", "", "http://xn--contexto-wg5g/"});
+        { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, utf16String(u"http://contextj\u200D") },
+        { "http"_s, ""_s, ""_s, "contextj"_s, 0, "/"_s, ""_s, ""_s, "http://contextj/"_s });
+    checkURL(utf16String(u"http://contexto\u30FB"), { "http"_s, ""_s, ""_s, "xn--contexto-wg5g"_s, 0, "/"_s, ""_s, ""_s, "http://xn--contexto-wg5g/"_s });
     checkURLDifferences(utf16String(u"http://\u321D\u321E/"),
-        {"http", "", "", "xn--()()-bs0sc174agx4b", 0, "/", "", "", "http://xn--()()-bs0sc174agx4b/"},
-        {"http", "", "", "xn--5mkc", 0, "/", "", "", "http://xn--5mkc/"});
+        { "http"_s, ""_s, ""_s, "xn--()()-bs0sc174agx4b"_s, 0, "/"_s, ""_s, ""_s, "http://xn--()()-bs0sc174agx4b/"_s },
+        { "http"_s, ""_s, ""_s, "xn--5mkc"_s, 0, "/"_s, ""_s, ""_s, "http://xn--5mkc/"_s });
 }
 
 TEST_F(WTF_URLParser, DefaultPort)
 {
-    checkURL("FtP://host:21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host:21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("f\ttp://host:21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("f\ttp://host\t:21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("f\ttp://host:\t21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("f\ttp://host:2\t1/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("f\ttp://host:21\t/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host\t:21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host:\t21/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host:2\t1/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host:21\t/", {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"});
-    checkURL("ftp://host:22/", {"ftp", "", "", "host", 22, "/", "", "", "ftp://host:22/"});
-    checkURLDifferences("ftp://host:21",
-        {"ftp", "", "", "host", 0, "/", "", "", "ftp://host/"},
-        {"ftp", "", "", "host", 0, "", "", "", "ftp://host"});
-    checkURLDifferences("ftp://host:22",
-        {"ftp", "", "", "host", 22, "/", "", "", "ftp://host:22/"},
-        {"ftp", "", "", "host", 22, "", "", "", "ftp://host:22"});
+    checkURL("FtP://host:21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host:21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("f\ttp://host:21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("f\ttp://host\t:21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("f\ttp://host:\t21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("f\ttp://host:2\t1/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("f\ttp://host:21\t/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host\t:21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host:\t21/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host:2\t1/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host:21\t/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s });
+    checkURL("ftp://host:22/"_s, { "ftp"_s, ""_s, ""_s, "host"_s, 22, "/"_s, ""_s, ""_s, "ftp://host:22/"_s });
+    checkURLDifferences("ftp://host:21"_s,
+        { "ftp"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ftp://host/"_s },
+        { "ftp"_s, ""_s, ""_s, "host"_s, 0, ""_s, ""_s, ""_s, "ftp://host"_s });
+    checkURLDifferences("ftp://host:22"_s,
+        { "ftp"_s, ""_s, ""_s, "host"_s, 22, "/"_s, ""_s, ""_s, "ftp://host:22/"_s },
+        { "ftp"_s, ""_s, ""_s, "host"_s, 22, ""_s, ""_s, ""_s, "ftp://host:22"_s });
     
-    checkURL("gOpHeR://host:70/", {"gopher", "", "", "host", 70, "/", "", "", "gopher://host:70/"});
-    checkURL("gopher://host:70/", {"gopher", "", "", "host", 70, "/", "", "", "gopher://host:70/"});
-    checkURL("gopher://host:71/", {"gopher", "", "", "host", 71, "/", "", "", "gopher://host:71/"});
+    checkURL("gOpHeR://host:70/"_s, { "gopher"_s, ""_s, ""_s, "host"_s, 70, "/"_s, ""_s, ""_s, "gopher://host:70/"_s });
+    checkURL("gopher://host:70/"_s, { "gopher"_s, ""_s, ""_s, "host"_s, 70, "/"_s, ""_s, ""_s, "gopher://host:70/"_s });
+    checkURL("gopher://host:71/"_s, { "gopher"_s, ""_s, ""_s, "host"_s, 71, "/"_s, ""_s, ""_s, "gopher://host:71/"_s });
     
-    checkURL("hTtP://host:80", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host:80", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host:80/", {"http", "", "", "host", 0, "/", "", "", "http://host/"});
-    checkURL("http://host:81", {"http", "", "", "host", 81, "/", "", "", "http://host:81/"});
-    checkURL("http://host:81/", {"http", "", "", "host", 81, "/", "", "", "http://host:81/"});
+    checkURL("hTtP://host:80"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host:80"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host:80/"_s, { "http"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "http://host/"_s });
+    checkURL("http://host:81"_s, { "http"_s, ""_s, ""_s, "host"_s, 81, "/"_s, ""_s, ""_s, "http://host:81/"_s });
+    checkURL("http://host:81/"_s, { "http"_s, ""_s, ""_s, "host"_s, 81, "/"_s, ""_s, ""_s, "http://host:81/"_s });
     
-    checkURL("hTtPs://host:443", {"https", "", "", "host", 0, "/", "", "", "https://host/"});
-    checkURL("https://host:443", {"https", "", "", "host", 0, "/", "", "", "https://host/"});
-    checkURL("https://host:443/", {"https", "", "", "host", 0, "/", "", "", "https://host/"});
-    checkURL("https://host:444", {"https", "", "", "host", 444, "/", "", "", "https://host:444/"});
-    checkURL("https://host:444/", {"https", "", "", "host", 444, "/", "", "", "https://host:444/"});
+    checkURL("hTtPs://host:443"_s, { "https"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "https://host/"_s });
+    checkURL("https://host:443"_s, { "https"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "https://host/"_s });
+    checkURL("https://host:443/"_s, { "https"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "https://host/"_s });
+    checkURL("https://host:444"_s, { "https"_s, ""_s, ""_s, "host"_s, 444, "/"_s, ""_s, ""_s, "https://host:444/"_s });
+    checkURL("https://host:444/"_s, { "https"_s, ""_s, ""_s, "host"_s, 444, "/"_s, ""_s, ""_s, "https://host:444/"_s });
     
-    checkURL("wS://host:80/", {"ws", "", "", "host", 0, "/", "", "", "ws://host/"});
-    checkURL("ws://host:80/", {"ws", "", "", "host", 0, "/", "", "", "ws://host/"});
-    checkURL("ws://host:81/", {"ws", "", "", "host", 81, "/", "", "", "ws://host:81/"});
+    checkURL("wS://host:80/"_s, { "ws"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ws://host/"_s });
+    checkURL("ws://host:80/"_s, { "ws"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ws://host/"_s });
+    checkURL("ws://host:81/"_s, { "ws"_s, ""_s, ""_s, "host"_s, 81, "/"_s, ""_s, ""_s, "ws://host:81/"_s });
     // URLParser matches Chrome and Firefox, but not URL::parse
-    checkURLDifferences("ws://host:80",
-        {"ws", "", "", "host", 0, "/", "", "", "ws://host/"},
-        {"ws", "", "", "host", 0, "", "", "", "ws://host"});
-    checkURLDifferences("ws://host:81",
-        {"ws", "", "", "host", 81, "/", "", "", "ws://host:81/"},
-        {"ws", "", "", "host", 81, "", "", "", "ws://host:81"});
+    checkURLDifferences("ws://host:80"_s,
+        { "ws"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "ws://host/"_s },
+        { "ws"_s, ""_s, ""_s, "host"_s, 0, ""_s, ""_s, ""_s, "ws://host"_s });
+    checkURLDifferences("ws://host:81"_s,
+        { "ws"_s, ""_s, ""_s, "host"_s, 81, "/"_s, ""_s, ""_s, "ws://host:81/"_s },
+        { "ws"_s, ""_s, ""_s, "host"_s, 81, ""_s, ""_s, ""_s, "ws://host:81"_s });
     
-    checkURL("WsS://host:443/", {"wss", "", "", "host", 0, "/", "", "", "wss://host/"});
-    checkURL("wss://host:443/", {"wss", "", "", "host", 0, "/", "", "", "wss://host/"});
-    checkURL("wss://host:444/", {"wss", "", "", "host", 444, "/", "", "", "wss://host:444/"});
+    checkURL("WsS://host:443/"_s, { "wss"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "wss://host/"_s });
+    checkURL("wss://host:443/"_s, { "wss"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "wss://host/"_s });
+    checkURL("wss://host:444/"_s, { "wss"_s, ""_s, ""_s, "host"_s, 444, "/"_s, ""_s, ""_s, "wss://host:444/"_s });
     // URLParser matches Chrome and Firefox, but not URL::parse
-    checkURLDifferences("wss://host:443",
-        {"wss", "", "", "host", 0, "/", "", "", "wss://host/"},
-        {"wss", "", "", "host", 0, "", "", "", "wss://host"});
-    checkURLDifferences("wss://host:444",
-        {"wss", "", "", "host", 444, "/", "", "", "wss://host:444/"},
-        {"wss", "", "", "host", 444, "", "", "", "wss://host:444"});
+    checkURLDifferences("wss://host:443"_s,
+        { "wss"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "wss://host/"_s },
+        { "wss"_s, ""_s, ""_s, "host"_s, 0, ""_s, ""_s, ""_s, "wss://host"_s });
+    checkURLDifferences("wss://host:444"_s,
+        { "wss"_s, ""_s, ""_s, "host"_s, 444, "/"_s, ""_s, ""_s, "wss://host:444/"_s },
+        { "wss"_s, ""_s, ""_s, "host"_s, 444, ""_s, ""_s, ""_s, "wss://host:444"_s });
 
-    checkURL("fTpS://host:990/", {"ftps", "", "", "host", 990, "/", "", "", "ftps://host:990/"});
-    checkURL("ftps://host:990/", {"ftps", "", "", "host", 990, "/", "", "", "ftps://host:990/"});
-    checkURL("ftps://host:991/", {"ftps", "", "", "host", 991, "/", "", "", "ftps://host:991/"});
-    checkURL("ftps://host:990", {"ftps", "", "", "host", 990, "", "", "", "ftps://host:990"});
-    checkURL("ftps://host:991", {"ftps", "", "", "host", 991, "", "", "", "ftps://host:991"});
+    checkURL("fTpS://host:990/"_s, { "ftps"_s, ""_s, ""_s, "host"_s, 990, "/"_s, ""_s, ""_s, "ftps://host:990/"_s });
+    checkURL("ftps://host:990/"_s, { "ftps"_s, ""_s, ""_s, "host"_s, 990, "/"_s, ""_s, ""_s, "ftps://host:990/"_s });
+    checkURL("ftps://host:991/"_s, { "ftps"_s, ""_s, ""_s, "host"_s, 991, "/"_s, ""_s, ""_s, "ftps://host:991/"_s });
+    checkURL("ftps://host:990"_s, { "ftps"_s, ""_s, ""_s, "host"_s, 990, ""_s, ""_s, ""_s, "ftps://host:990"_s });
+    checkURL("ftps://host:991"_s, { "ftps"_s, ""_s, ""_s, "host"_s, 991, ""_s, ""_s, ""_s, "ftps://host:991"_s });
 
-    checkURL("uNkNoWn://host:80/", {"unknown", "", "", "host", 80, "/", "", "", "unknown://host:80/"});
-    checkURL("unknown://host:80/", {"unknown", "", "", "host", 80, "/", "", "", "unknown://host:80/"});
-    checkURL("unknown://host:81/", {"unknown", "", "", "host", 81, "/", "", "", "unknown://host:81/"});
-    checkURL("unknown://host:80", {"unknown", "", "", "host", 80, "", "", "", "unknown://host:80"});
-    checkURL("unknown://host:81", {"unknown", "", "", "host", 81, "", "", "", "unknown://host:81"});
+    checkURL("uNkNoWn://host:80/"_s, { "unknown"_s, ""_s, ""_s, "host"_s, 80, "/"_s, ""_s, ""_s, "unknown://host:80/"_s });
+    checkURL("unknown://host:80/"_s, { "unknown"_s, ""_s, ""_s, "host"_s, 80, "/"_s, ""_s, ""_s, "unknown://host:80/"_s });
+    checkURL("unknown://host:81/"_s, { "unknown"_s, ""_s, ""_s, "host"_s, 81, "/"_s, ""_s, ""_s, "unknown://host:81/"_s });
+    checkURL("unknown://host:80"_s, { "unknown"_s, ""_s, ""_s, "host"_s, 80, ""_s, ""_s, ""_s, "unknown://host:80"_s });
+    checkURL("unknown://host:81"_s, { "unknown"_s, ""_s, ""_s, "host"_s, 81, ""_s, ""_s, ""_s, "unknown://host:81"_s });
 
-    checkURL("file://host/", {"file", "", "", "host", 0, "/", "", "", "file://host/"});
-    checkURL("file://host:", {"", "", "", "", 0, "", "", "", "file://host:"});
-    checkURL("file://host:0", {"", "", "", "", 0, "", "", "", "file://host:0"});
-    checkURL("file://host:80", {"", "", "", "", 0, "", "", "", "file://host:80"});
-    checkURL("file://host:80/path", {"", "", "", "", 0, "", "", "", "file://host:80/path"});
-    checkURL("file://:80/path", {"", "", "", "", 0, "", "", "", "file://:80/path"});
-    checkURL("file://:0/path", {"", "", "", "", 0, "", "", "", "file://:0/path"});
+    checkURL("file://host/"_s, { "file"_s, ""_s, ""_s, "host"_s, 0, "/"_s, ""_s, ""_s, "file://host/"_s });
+    checkURL("file://host:"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://host:"_s });
+    checkURL("file://host:0"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://host:0"_s });
+    checkURL("file://host:80"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://host:80"_s });
+    checkURL("file://host:80/path"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://host:80/path"_s });
+    checkURL("file://:80/path"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://:80/path"_s });
+    checkURL("file://:0/path"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "file://:0/path"_s });
     
-    checkURL("http://example.com:0000000000000077", {"http", "", "", "example.com", 77, "/", "", "", "http://example.com:77/"});
-    checkURL("http://example.com:0000000000000080", {"http", "", "", "example.com", 0, "/", "", "", "http://example.com/"});
+    checkURL("http://example.com:0000000000000077"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 77, "/"_s, ""_s, ""_s, "http://example.com:77/"_s });
+    checkURL("http://example.com:0000000000000080"_s, { "http"_s, ""_s, ""_s, "example.com"_s, 0, "/"_s, ""_s, ""_s, "http://example.com/"_s });
 }
 
 TEST_F(WTF_URLParser, ParserFailures)
 {
-    shouldFail("    ");
-    shouldFail("  \a  ");
-    shouldFail("");
+    shouldFail("    "_s);
+    shouldFail("  \a  "_s);
+    shouldFail(""_s);
     shouldFail(String());
-    shouldFail("", "about:blank");
-    shouldFail(String(), "about:blank");
-    shouldFail("http://127.0.0.1:abc");
-    shouldFail("http://host:abc");
-    shouldFail("http://:abc");
-    shouldFail("http://a:@", "about:blank");
-    shouldFail("http://:b@", "about:blank");
-    shouldFail("http://:@", "about:blank");
-    shouldFail("http://a:@");
-    shouldFail("http://:b@");
-    shouldFail("http://@");
-    shouldFail("http://[0:f::f:f:0:0]:abc");
-    shouldFail("../i", "sc:sd");
-    shouldFail("../i", "sc:sd/sd");
-    shouldFail("/i", "sc:sd");
-    shouldFail("/i", "sc:sd/sd");
-    shouldFail("?i", "sc:sd");
-    shouldFail("?i", "sc:sd/sd");
-    shouldFail("http://example example.com", "http://other.com/");
-    shouldFail("http://[www.example.com]/", "about:blank");
-    shouldFail("http://192.168.0.1 hello", "http://other.com/");
-    shouldFail("http://[example.com]", "http://other.com/");
-    shouldFail("i", "sc:sd");
-    shouldFail("i", "sc:sd/sd");
-    shouldFail("i");
-    shouldFail("asdf");
-    shouldFail("~");
-    shouldFail("%");
-    shouldFail("//%");
-    shouldFail("~", "about:blank");
-    shouldFail("~~~");
-    shouldFail("://:0/");
-    shouldFail("://:0/", "");
-    shouldFail("://:0/", "about:blank");
-    shouldFail("about~");
-    shouldFail("//C:asdf/foo/bar", "file:///tmp/mock/path");
-    shouldFail("wss://[c::]abc/");
-    shouldFail("abc://[c::]:abc/");
-    shouldFail("abc://[c::]01");
-    shouldFail("http://[1234::ab#]");
-    shouldFail("http://[1234::ab/]");
-    shouldFail("http://[1234::ab?]");
-    shouldFail("http://[1234::ab@]");
-    shouldFail("http://[1234::ab~]");
-    shouldFail("http://[2001::1");
-    shouldFail("http://4:b\xE1");
-    shouldFail("http://[1:2:3:4:5:6:7:8~]/");
-    shouldFail("http://[a:b:c:d:e:f:g:127.0.0.1]");
-    shouldFail("http://[a:b:c:d:e:f:g:h:127.0.0.1]");
-    shouldFail("http://[a:b:c:d:e:f:127.0.0.0x11]"); // Chrome treats this as hex, Firefox and the spec fail
-    shouldFail("http://[a:b:c:d:e:f:127.0.-0.1]");
-    shouldFail("asdf://space In\aHost");
-    shouldFail("asdf://[0:0:0:0:a:b:c:d");
-    shouldFail("http://[::0:0.0.00000.0]/");
+    shouldFail(""_s, "about:blank"_s);
+    shouldFail(String(), "about:blank"_s);
+    shouldFail("http://127.0.0.1:abc"_s);
+    shouldFail("http://host:abc"_s);
+    shouldFail("http://:abc"_s);
+    shouldFail("http://a:@"_s, "about:blank"_s);
+    shouldFail("http://:b@"_s, "about:blank"_s);
+    shouldFail("http://:@"_s, "about:blank"_s);
+    shouldFail("http://a:@"_s);
+    shouldFail("http://:b@"_s);
+    shouldFail("http://@"_s);
+    shouldFail("http://[0:f::f:f:0:0]:abc"_s);
+    shouldFail("../i"_s, "sc:sd"_s);
+    shouldFail("../i"_s, "sc:sd/sd"_s);
+    shouldFail("/i"_s, "sc:sd"_s);
+    shouldFail("/i"_s, "sc:sd/sd"_s);
+    shouldFail("?i"_s, "sc:sd"_s);
+    shouldFail("?i"_s, "sc:sd/sd"_s);
+    shouldFail("http://example example.com"_s, "http://other.com/"_s);
+    shouldFail("http://[www.example.com]/"_s, "about:blank"_s);
+    shouldFail("http://192.168.0.1 hello"_s, "http://other.com/"_s);
+    shouldFail("http://[example.com]"_s, "http://other.com/"_s);
+    shouldFail("i"_s, "sc:sd"_s);
+    shouldFail("i"_s, "sc:sd/sd"_s);
+    shouldFail("i"_s);
+    shouldFail("asdf"_s);
+    shouldFail("~"_s);
+    shouldFail("%"_s);
+    shouldFail("//%"_s);
+    shouldFail("~"_s, "about:blank"_s);
+    shouldFail("~~~"_s);
+    shouldFail("://:0/"_s);
+    shouldFail("://:0/"_s, ""_s);
+    shouldFail("://:0/"_s, "about:blank"_s);
+    shouldFail("about~"_s);
+    shouldFail("//C:asdf/foo/bar"_s, "file:///tmp/mock/path"_s);
+    shouldFail("wss://[c::]abc/"_s);
+    shouldFail("abc://[c::]:abc/"_s);
+    shouldFail("abc://[c::]01"_s);
+    shouldFail("http://[1234::ab#]"_s);
+    shouldFail("http://[1234::ab/]"_s);
+    shouldFail("http://[1234::ab?]"_s);
+    shouldFail("http://[1234::ab@]"_s);
+    shouldFail("http://[1234::ab~]"_s);
+    shouldFail("http://[2001::1"_s);
+    shouldFail("http://4:b\xE1"_s);
+    shouldFail("http://[1:2:3:4:5:6:7:8~]/"_s);
+    shouldFail("http://[a:b:c:d:e:f:g:127.0.0.1]"_s);
+    shouldFail("http://[a:b:c:d:e:f:g:h:127.0.0.1]"_s);
+    shouldFail("http://[a:b:c:d:e:f:127.0.0.0x11]"_s); // Chrome treats this as hex, Firefox and the spec fail
+    shouldFail("http://[a:b:c:d:e:f:127.0.-0.1]"_s);
+    shouldFail("asdf://space In\aHost"_s);
+    shouldFail("asdf://[0:0:0:0:a:b:c:d"_s);
+    shouldFail("http://[::0:0.0.00000.0]/"_s);
 }
 
 // These are in the spec but not in the web platform tests.
 TEST_F(WTF_URLParser, AdditionalTests)
 {
-    checkURL("about:\a\aabc", {"about", "", "", "", 0, "%07%07abc", "", "", "about:%07%07abc"});
-    checkURL("notspecial:\t\t\n\t", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
-    checkURL("notspecial\t\t\n\t:\t\t\n\t/\t\t\n\t/\t\t\n\thost", {"notspecial", "", "", "host", 0, "", "", "", "notspecial://host"});
-    checkRelativeURL("http:", "http://example.org/foo/bar?query#fragment", {"http", "", "", "example.org", 0, "/foo/bar", "query", "", "http://example.org/foo/bar?query"});
-    checkRelativeURL("ws:", "http://example.org/foo/bar", {"", "", "", "", 0, "", "", "", "ws:"});
-    checkRelativeURL("notspecial:", "http://example.org/foo/bar", {"notspecial", "", "", "", 0, "", "", "", "notspecial:"});
+    checkURL("about:\a\aabc"_s, { "about"_s, ""_s, ""_s, ""_s, 0, "%07%07abc"_s, ""_s, ""_s, "about:%07%07abc"_s });
+    checkURL("notspecial:\t\t\n\t"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
+    checkURL("notspecial\t\t\n\t:\t\t\n\t/\t\t\n\t/\t\t\n\thost"_s, { "notspecial"_s, ""_s, ""_s, "host"_s, 0, ""_s, ""_s, ""_s, "notspecial://host"_s });
+    checkRelativeURL("http:"_s, "http://example.org/foo/bar?query#fragment"_s, { "http"_s, ""_s, ""_s, "example.org"_s, 0, "/foo/bar"_s, "query"_s, ""_s, "http://example.org/foo/bar?query"_s });
+    checkRelativeURL("ws:"_s, "http://example.org/foo/bar"_s, { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "ws:"_s });
+    checkRelativeURL("notspecial:"_s, "http://example.org/foo/bar"_s, { "notspecial"_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "notspecial:"_s });
 
     const wchar_t surrogateBegin = 0xD800;
     const wchar_t validSurrogateEnd = 0xDD55;
     const wchar_t invalidSurrogateEnd = 'A';
     const wchar_t replacementCharacter = 0xFFFD;
     checkURL(utf16String<12>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', surrogateBegin, validSurrogateEnd, '\0'}),
-        {"http", "", "", "w", 0, "/%F0%90%85%95", "", "", "http://w/%F0%90%85%95"}, testTabsValueForSurrogatePairs);
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/%F0%90%85%95"_s, ""_s, ""_s, "http://w/%F0%90%85%95"_s }, testTabsValueForSurrogatePairs);
     shouldFail(utf16String<10>({'h', 't', 't', 'p', ':', '/', surrogateBegin, invalidSurrogateEnd, '/', '\0'}));
     shouldFail(utf16String<9>({'h', 't', 't', 'p', ':', '/', replacementCharacter, '/', '\0'}));
     
     // URLParser matches Chrome and Firefox but not URL::parse.
     checkURLDifferences(utf16String<12>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', surrogateBegin, invalidSurrogateEnd}),
-        {"http", "", "", "w", 0, "/%EF%BF%BDA", "", "", "http://w/%EF%BF%BDA"},
-        {"http", "", "", "w", 0, "/%ED%A0%80A", "", "", "http://w/%ED%A0%80A"});
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/%EF%BF%BDA"_s, ""_s, ""_s, "http://w/%EF%BF%BDA"_s },
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/%ED%A0%80A"_s, ""_s, ""_s, "http://w/%ED%A0%80A"_s });
     checkURLDifferences(utf16String<13>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', '?', surrogateBegin, invalidSurrogateEnd, '\0'}),
-        {"http", "", "", "w", 0, "/", "%EF%BF%BDA", "", "http://w/?%EF%BF%BDA"},
-        {"http", "", "", "w", 0, "/", "%ED%A0%80A", "", "http://w/?%ED%A0%80A"});
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%EF%BF%BDA"_s, ""_s, "http://w/?%EF%BF%BDA"_s },
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%ED%A0%80A"_s, ""_s, "http://w/?%ED%A0%80A"_s });
     checkURLDifferences(utf16String<11>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', surrogateBegin, '\0'}),
-        {"http", "", "", "w", 0, "/%EF%BF%BD", "", "", "http://w/%EF%BF%BD"},
-        {"http", "", "", "w", 0, "/%ED%A0%80", "", "", "http://w/%ED%A0%80"});
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/%EF%BF%BD"_s, ""_s, ""_s, "http://w/%EF%BF%BD"_s },
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/%ED%A0%80"_s, ""_s, ""_s, "http://w/%ED%A0%80"_s });
     checkURLDifferences(utf16String<12>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', '?', surrogateBegin, '\0'}),
-        {"http", "", "", "w", 0, "/", "%EF%BF%BD", "", "http://w/?%EF%BF%BD"},
-        {"http", "", "", "w", 0, "/", "%ED%A0%80", "", "http://w/?%ED%A0%80"});
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%EF%BF%BD"_s, ""_s, "http://w/?%EF%BF%BD"_s },
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%ED%A0%80"_s, ""_s, "http://w/?%ED%A0%80"_s });
     checkURLDifferences(utf16String<13>({'h', 't', 't', 'p', ':', '/', '/', 'w', '/', '?', surrogateBegin, ' ', '\0'}),
-        {"http", "", "", "w", 0, "/", "%EF%BF%BD", "", "http://w/?%EF%BF%BD"},
-        {"http", "", "", "w", 0, "/", "%ED%A0%80", "", "http://w/?%ED%A0%80"});
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%EF%BF%BD"_s, ""_s, "http://w/?%EF%BF%BD"_s },
+        { "http"_s, ""_s, ""_s, "w"_s, 0, "/"_s, "%ED%A0%80"_s, ""_s, "http://w/?%ED%A0%80"_s });
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
@@ -44,21 +44,21 @@ TEST(WTF, TestUUIDVersion4Parsing)
 {
     // xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
 
-    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-5de0-89AB-0123456789ab"));
-    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4dea-79AB-0123456789ab"));
-    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4de0-7fff-0123456789ab"));
-    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4de0-c0000-0123456789ab"));
+    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-5de0-89AB-0123456789ab"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4dea-79AB-0123456789ab"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4de0-7fff-0123456789ab"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("12345678-9abc-4de0-c0000-0123456789ab"_s));
 
-    EXPECT_FALSE(!!UUID::parseVersion4("+ef944c1-5cb8-48aa-Ad12-C5f823f005c3"));
-    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-+cb8-48aa-Ad12-C5f823f005c3"));
-    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-+8aa-Ad12-C5f823f005c3"));
-    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-48aa-+d12-C5f823f005c3"));
-    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-48aa-Ad12-+5f823f005c3"));
+    EXPECT_FALSE(!!UUID::parseVersion4("+ef944c1-5cb8-48aa-Ad12-C5f823f005c3"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-+cb8-48aa-Ad12-C5f823f005c3"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-+8aa-Ad12-C5f823f005c3"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-48aa-+d12-C5f823f005c3"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("6ef944c1-5cb8-48aa-Ad12-+5f823f005c3"_s));
 
-    EXPECT_FALSE(!!UUID::parseVersion4("00000000-0000-0000-0000-000000000000"));
-    EXPECT_FALSE(!!UUID::parseVersion4("00000000-0000-0000-0000-000000000001"));
-    EXPECT_TRUE(!!UUID::parseVersion4("00000000-0000-4000-8000-000000000000"));
-    EXPECT_TRUE(!!UUID::parseVersion4("00000000-0000-4000-8000-000000000001"));
+    EXPECT_FALSE(!!UUID::parseVersion4("00000000-0000-0000-0000-000000000000"_s));
+    EXPECT_FALSE(!!UUID::parseVersion4("00000000-0000-0000-0000-000000000001"_s));
+    EXPECT_TRUE(!!UUID::parseVersion4("00000000-0000-4000-8000-000000000000"_s));
+    EXPECT_TRUE(!!UUID::parseVersion4("00000000-0000-4000-8000-000000000001"_s));
 
     for (size_t cptr = 0; cptr < 10; ++cptr) {
         auto createdUUID = UUID::createVersion4();

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -566,8 +566,8 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithIdenticalActionAreMerged)
 {
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("foo\\.org", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("ba\\.org", false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("foo\\.org"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("ba\\.org"_s, false, 0));
 
     Vector<ContentExtensions::NFA> nfas = createNFAs(combinedURLFilters);
     EXPECT_EQ(1ul, nfas.size());
@@ -591,8 +591,8 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithDistinguishableActionAreNotMerged
 {
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("foo\\.org", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("ba\\.org", false, 1));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("foo\\.org"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("ba\\.org"_s, false, 1));
 
     Vector<ContentExtensions::NFA> nfas = createNFAs(combinedURLFilters);
 
@@ -1107,13 +1107,13 @@ TEST_F(ContentExtensionTest, UselessTermsMatchingEverythingAreEliminated)
 {
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern(".*web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.*)web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.)*web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.+)*web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.?)*web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.+)?web", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.?)+web", false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern(".*web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.*)web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.)*web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.+)*web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.?)*web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.+)?web"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(.?)+web"_s, false, 0));
 
     Vector<ContentExtensions::NFA> nfas = createNFAs(combinedURLFilters);
     EXPECT_EQ(1ul, nfas.size());
@@ -1358,13 +1358,13 @@ TEST_F(ContentExtensionTest, DeepNFA)
     StringBuilder lotsOfAs;
     for (unsigned i = 0; i < size; ++i)
         lotsOfAs.append('A');
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern(lotsOfAs.toString().utf8().data(), false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern(lotsOfAs.toString(), false, 0));
     
     // FIXME: Yarr ought to be able to handle 2MB regular expressions.
     StringBuilder tooManyAs;
     for (unsigned i = 0; i < size * 20; ++i)
         tooManyAs.append('A');
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::YarrError, parser.addPattern(tooManyAs.toString().utf8().data(), false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::YarrError, parser.addPattern(tooManyAs.toString(), false, 0));
     
     StringBuilder nestedGroups;
     for (unsigned i = 0; i < size; ++i)
@@ -1618,11 +1618,11 @@ TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines1Partitioning)
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
 
     // Those two share a prefix.
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^.*foo", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("bar$", false, 1));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^.*foo"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("bar$"_s, false, 1));
 
     // Not this one.
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^[ab]+bang", false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^[ab]+bang"_s, false, 0));
 
     EXPECT_EQ(2ul, createNFAs(combinedURLFilters).size());
 }
@@ -1651,10 +1651,10 @@ TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines2Partitioning)
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
 
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^foo", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^.*[a-c]+bar", false, 1));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^webkit:", false, 2));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("[a-c]+b+oom", false, 3));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^foo"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^.*[a-c]+bar"_s, false, 1));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("^webkit:"_s, false, 2));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("[a-c]+b+oom"_s, false, 3));
 
     // "^foo" and "^webkit:" can be grouped, the other two have a variable prefix.
     EXPECT_EQ(3ul, createNFAs(combinedURLFilters).size());
@@ -1683,9 +1683,9 @@ TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines3Partitioning)
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
     
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*D", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*BA+", false, 1));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*BC", false, 2));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*D"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*BA+"_s, false, 1));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A*BC"_s, false, 2));
     
     // "A*A" and "A*BC" can be grouped, "A*BA+" should not.
     EXPECT_EQ(2ul, createNFAs(combinedURLFilters).size());
@@ -1699,9 +1699,9 @@ TEST_F(ContentExtensionTest, SplittingLargeNFAs)
         ContentExtensions::CombinedURLFilters combinedURLFilters;
         ContentExtensions::URLFilterParser parser(combinedURLFilters);
         
-        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+BBB", false, 1));
-        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+CCC", false, 2));
-        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+DDD", false, 2));
+        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+BBB"_s, false, 1));
+        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+CCC"_s, false, 2));
+        EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("A+DDD"_s, false, 2));
         
         Vector<ContentExtensions::NFA> nfas;
         combinedURLFilters.processNFAs(i, [&](ContentExtensions::NFA&& nfa) {
@@ -1739,11 +1739,11 @@ TEST_F(ContentExtensionTest, QuantifierInGroup)
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
     
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A+)B)C)", false, 0));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B+)C)", false, 1));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B+)C)D", false, 2));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B)C+)", false, 3));
-    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B)C)", false, 4));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A+)B)C)"_s, false, 0));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B+)C)"_s, false, 1));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B+)C)D"_s, false, 2));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B)C+)"_s, false, 3));
+    EXPECT_EQ(ContentExtensions::URLFilterParser::ParseStatus::Ok, parser.addPattern("(((A)B)C)"_s, false, 4));
     
     // (((A)B+)C) and (((A)B+)C)D should be in the same NFA.
     EXPECT_EQ(4ul, createNFAs(combinedURLFilters).size());

--- a/Tools/TestWebKitAPI/Tests/WebCore/DFACombiner.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DFACombiner.cpp
@@ -59,11 +59,11 @@ Vector<DFA> combine(Vector<DFA> dfas, unsigned minimumSize)
 
 TEST_F(DFACombinerTest, Basic)
 {
-    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"}), buildDFAFromPatterns({ "bar"}) };
+    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"_s }), buildDFAFromPatterns({ "bar"_s }) };
     Vector<DFA> combinedDFAs = combine(dfas, 10000);
     EXPECT_EQ(static_cast<size_t>(1), combinedDFAs.size());
 
-    DFA reference = buildDFAFromPatterns({ "foo", "bar"});
+    DFA reference = buildDFAFromPatterns({ "foo"_s, "bar"_s });
     reference.minimize();
     EXPECT_EQ(countLiveNodes(reference), countLiveNodes(combinedDFAs.first()));
 }
@@ -71,12 +71,12 @@ TEST_F(DFACombinerTest, Basic)
 
 TEST_F(DFACombinerTest, IdenticalDFAs)
 {
-    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"}), buildDFAFromPatterns({ "foo"}) };
+    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"_s }), buildDFAFromPatterns({ "foo"_s }) };
     Vector<DFA> combinedDFAs = combine(dfas, 10000);
     EXPECT_EQ(static_cast<size_t>(1), combinedDFAs.size());
 
     // The result should have the exact same size as the minimized input.
-    DFA reference = buildDFAFromPatterns({ "foo"});
+    DFA reference = buildDFAFromPatterns({ "foo"_s });
     reference.minimize();
     EXPECT_EQ(countLiveNodes(reference), countLiveNodes(combinedDFAs.first()));
 }
@@ -93,18 +93,18 @@ TEST_F(DFACombinerTest, NoInput)
 
 TEST_F(DFACombinerTest, SingleInput)
 {
-    Vector<DFA> dfas = { buildDFAFromPatterns({ "WebKit"}) };
+    Vector<DFA> dfas = { buildDFAFromPatterns({ "WebKit"_s }) };
     Vector<DFA> combinedDFAs = combine(dfas, 10000);
     EXPECT_EQ(static_cast<size_t>(1), combinedDFAs.size());
 
-    DFA reference = buildDFAFromPatterns({ "WebKit"});
+    DFA reference = buildDFAFromPatterns({ "WebKit"_s });
     reference.minimize();
     EXPECT_EQ(countLiveNodes(reference), countLiveNodes(combinedDFAs.first()));
 }
 
 TEST_F(DFACombinerTest, InputTooLargeForMinimumSize)
 {
-    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"}), buildDFAFromPatterns({ "bar"}) };
+    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"_s }), buildDFAFromPatterns({ "bar"_s }) };
     Vector<DFA> combinedDFAs = combine(dfas, 2);
     EXPECT_EQ(static_cast<size_t>(2), combinedDFAs.size());
     EXPECT_EQ(static_cast<size_t>(4), countLiveNodes(combinedDFAs[0]));
@@ -113,7 +113,7 @@ TEST_F(DFACombinerTest, InputTooLargeForMinimumSize)
 
 TEST_F(DFACombinerTest, CombinedInputReachesMinimumSize)
 {
-    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"}), buildDFAFromPatterns({ "bar"}), buildDFAFromPatterns({ "WebKit"}) };
+    Vector<DFA> dfas = { buildDFAFromPatterns({ "foo"_s }), buildDFAFromPatterns({ "bar"_s }), buildDFAFromPatterns({ "WebKit"_s }) };
     Vector<DFA> combinedDFAs = combine(dfas, 5);
     EXPECT_EQ(static_cast<size_t>(2), combinedDFAs.size());
     EXPECT_EQ(static_cast<size_t>(7), countLiveNodes(combinedDFAs[0]));

--- a/Tools/TestWebKitAPI/Tests/WebCore/DFAHelpers.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DFAHelpers.h
@@ -56,12 +56,12 @@ static Vector<ContentExtensions::NFA> createNFAs(ContentExtensions::CombinedURLF
     return nfas;
 }
 
-static ContentExtensions::DFA buildDFAFromPatterns(Vector<const char*> patterns)
+static ContentExtensions::DFA buildDFAFromPatterns(const Vector<ASCIILiteral>& patterns)
 {
     ContentExtensions::CombinedURLFilters combinedURLFilters;
     ContentExtensions::URLFilterParser parser(combinedURLFilters);
 
-    for (const char* pattern : patterns)
+    for (auto pattern : patterns)
         parser.addPattern(pattern, false, 0);
     Vector<ContentExtensions::NFA> nfas = createNFAs(combinedURLFilters);
     EXPECT_EQ(1ul, nfas.size());

--- a/Tools/TestWebKitAPI/Tests/WebCore/DFAMinimizer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DFAMinimizer.cpp
@@ -42,7 +42,7 @@ public:
 
 TEST_F(DFAMinimizerTest, BasicSearch)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*foo", ".*bar", ".*bang"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*foo"_s, ".*bar"_s, ".*bang"_s });
     EXPECT_EQ(static_cast<size_t>(8), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(7), countLiveNodes(dfa));
@@ -50,7 +50,7 @@ TEST_F(DFAMinimizerTest, BasicSearch)
 
 TEST_F(DFAMinimizerTest, MergeSuffixes)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*aaa", ".*aab", ".*aba", ".*abb", ".*baa", ".*bab", ".*bba", ".*bbb"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*aaa"_s, ".*aab"_s, ".*aba"_s, ".*abb"_s, ".*baa"_s, ".*bab"_s, ".*bba"_s, ".*bbb"_s });
     EXPECT_EQ(static_cast<size_t>(12), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(4), countLiveNodes(dfa));
@@ -58,7 +58,7 @@ TEST_F(DFAMinimizerTest, MergeSuffixes)
 
 TEST_F(DFAMinimizerTest, MergeInfixes)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*aaakit", ".*aabkit", ".*abakit", ".*abbkit", ".*baakit", ".*babkit", ".*bbakit", ".*bbbkit"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ ".*aaakit"_s, ".*aabkit"_s, ".*abakit"_s, ".*abbkit"_s, ".*baakit"_s, ".*babkit"_s, ".*bbakit"_s, ".*bbbkit"_s });
     EXPECT_EQ(static_cast<size_t>(15), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(7), countLiveNodes(dfa));
@@ -66,7 +66,7 @@ TEST_F(DFAMinimizerTest, MergeInfixes)
 
 TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge1)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.a", "^b.a", "^bac", "^bbc", "^BCC"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.a"_s, "^b.a"_s, "^bac"_s, "^bbc"_s, "^BCC"_s });
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
@@ -74,7 +74,7 @@ TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge1)
 
 TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge2)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^bbc", "^BCC", "^a.a", "^b.a"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^bbc"_s, "^BCC"_s, "^a.a"_s, "^b.a"_s });
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
@@ -82,7 +82,7 @@ TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge2)
 
 TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge3)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.c", "^b.c", "^baa", "^bba", "^BCA"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.c"_s, "^b.c"_s, "^baa"_s, "^bba"_s, "^BCA"_s });
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
@@ -90,7 +90,7 @@ TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge3)
 
 TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge4)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^baa", "^bba", "^BCA", "^a.c", "^b.c"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^baa"_s, "^bba"_s, "^BCA"_s, "^a.c"_s, "^b.c"_s });
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(6), countLiveNodes(dfa));
@@ -98,7 +98,7 @@ TEST_F(DFAMinimizerTest, FallbackTransitionsWithDifferentiatorDoNotMerge4)
 
 TEST_F(DFAMinimizerTest, FallbackTransitionsToOtherNodeInSameGroupDoesNotDifferentiateGroup)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^aac", "^a.c", "^b.c"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^aac"_s, "^a.c"_s, "^b.c"_s });
     EXPECT_EQ(static_cast<size_t>(5), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(4), countLiveNodes(dfa));
@@ -106,7 +106,7 @@ TEST_F(DFAMinimizerTest, FallbackTransitionsToOtherNodeInSameGroupDoesNotDiffere
 
 TEST_F(DFAMinimizerTest, SimpleFallBackTransitionDifferentiator1)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.bc.de", "^a.bd.ef"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^a.bc.de"_s, "^a.bd.ef"_s });
     EXPECT_EQ(static_cast<size_t>(11), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(11), countLiveNodes(dfa));
@@ -114,7 +114,7 @@ TEST_F(DFAMinimizerTest, SimpleFallBackTransitionDifferentiator1)
 
 TEST_F(DFAMinimizerTest, SimpleFallBackTransitionDifferentiator2)
 {
-    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^cb.", "^db.b"});
+    ContentExtensions::DFA dfa = buildDFAFromPatterns({ "^cb."_s, "^db.b"_s });
     EXPECT_EQ(static_cast<size_t>(7), countLiveNodes(dfa));
     dfa.minimize();
     EXPECT_EQ(static_cast<size_t>(7), countLiveNodes(dfa));

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -111,7 +111,7 @@ static String readContentsOfFile(const String& path)
         return emptyString();
 
     String result(static_cast<const LChar*>(buffer->data()), buffer->size());
-    if (result.endsWith("\n"))
+    if (result.endsWith('\n'))
         return result.left(result.length() - 1);
 
     return result;

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -47,54 +47,54 @@ static bool parseHTMLIntegerFails(StringView input)
 
 TEST(WebCoreHTMLParserIdioms, parseHTMLInteger)
 {
-    EXPECT_EQ(0, testParseHTMLInteger("0"));
-    EXPECT_EQ(0, testParseHTMLInteger("-0"));
-    EXPECT_EQ(0, testParseHTMLInteger("+0"));
-    EXPECT_EQ(123, testParseHTMLInteger("123"));
-    EXPECT_EQ(123, testParseHTMLInteger("+123"));
-    EXPECT_EQ(-123, testParseHTMLInteger("-123"));
-    EXPECT_EQ(123, testParseHTMLInteger("  123"));
-    EXPECT_EQ(123, testParseHTMLInteger("123   "));
-    EXPECT_EQ(123, testParseHTMLInteger("   123   "));
-    EXPECT_EQ(123, testParseHTMLInteger("123abc"));
-    EXPECT_EQ(-123, testParseHTMLInteger("-123abc"));
-    EXPECT_EQ(123, testParseHTMLInteger("  +123"));
-    EXPECT_EQ(-123, testParseHTMLInteger("  -123"));
-    EXPECT_EQ(12, testParseHTMLInteger("   12 3"));
-    EXPECT_EQ(1, testParseHTMLInteger("1.0"));
-    EXPECT_EQ(1, testParseHTMLInteger("1."));
-    EXPECT_EQ(1, testParseHTMLInteger("1e1"));
+    EXPECT_EQ(0, testParseHTMLInteger("0"_s));
+    EXPECT_EQ(0, testParseHTMLInteger("-0"_s));
+    EXPECT_EQ(0, testParseHTMLInteger("+0"_s));
+    EXPECT_EQ(123, testParseHTMLInteger("123"_s));
+    EXPECT_EQ(123, testParseHTMLInteger("+123"_s));
+    EXPECT_EQ(-123, testParseHTMLInteger("-123"_s));
+    EXPECT_EQ(123, testParseHTMLInteger("  123"_s));
+    EXPECT_EQ(123, testParseHTMLInteger("123   "_s));
+    EXPECT_EQ(123, testParseHTMLInteger("   123   "_s));
+    EXPECT_EQ(123, testParseHTMLInteger("123abc"_s));
+    EXPECT_EQ(-123, testParseHTMLInteger("-123abc"_s));
+    EXPECT_EQ(123, testParseHTMLInteger("  +123"_s));
+    EXPECT_EQ(-123, testParseHTMLInteger("  -123"_s));
+    EXPECT_EQ(12, testParseHTMLInteger("   12 3"_s));
+    EXPECT_EQ(1, testParseHTMLInteger("1.0"_s));
+    EXPECT_EQ(1, testParseHTMLInteger("1."_s));
+    EXPECT_EQ(1, testParseHTMLInteger("1e1"_s));
 
     // All HTML whitespaces.
-    EXPECT_EQ(123, testParseHTMLInteger(" \t\r\n\f123"));
+    EXPECT_EQ(123, testParseHTMLInteger(" \t\r\n\f123"_s));
 
     // Boundaries.
-    EXPECT_EQ(-2147483648, testParseHTMLInteger("-2147483648"));
-    EXPECT_EQ(2147483647, testParseHTMLInteger("2147483647"));
+    EXPECT_EQ(-2147483648, testParseHTMLInteger("-2147483648"_s));
+    EXPECT_EQ(2147483647, testParseHTMLInteger("2147483647"_s));
 
     // Failure cases.
-    EXPECT_TRUE(parseHTMLIntegerFails("-2147483649"));
-    EXPECT_TRUE(parseHTMLIntegerFails("2147483648"));
-    EXPECT_TRUE(parseHTMLIntegerFails("111111111111111111"));
-    EXPECT_TRUE(parseHTMLIntegerFails(""));
-    EXPECT_TRUE(parseHTMLIntegerFails(" "));
-    EXPECT_TRUE(parseHTMLIntegerFails("   "));
-    EXPECT_TRUE(parseHTMLIntegerFails("+"));
-    EXPECT_TRUE(parseHTMLIntegerFails("+ 123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("-"));
-    EXPECT_TRUE(parseHTMLIntegerFails("- 123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("a"));
-    EXPECT_TRUE(parseHTMLIntegerFails("-a"));
-    EXPECT_TRUE(parseHTMLIntegerFails("+-123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("-+123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("++123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("--123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("\v123")); // '\v' is an ASCII space but not an HTML whitespace.
-    EXPECT_TRUE(parseHTMLIntegerFails("a123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("+a123"));
-    EXPECT_TRUE(parseHTMLIntegerFails("-a123"));
-    EXPECT_TRUE(parseHTMLIntegerFails(".1"));
-    EXPECT_TRUE(parseHTMLIntegerFails("infinity"));
+    EXPECT_TRUE(parseHTMLIntegerFails("-2147483649"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("2147483648"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("111111111111111111"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails(""_s));
+    EXPECT_TRUE(parseHTMLIntegerFails(" "_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("   "_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("+"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("+ 123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("-"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("- 123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("a"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("-a"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("+-123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("-+123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("++123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("--123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("\v123"_s)); // '\v' is an ASCII space but not an HTML whitespace.
+    EXPECT_TRUE(parseHTMLIntegerFails("a123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("+a123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("-a123"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails(".1"_s));
+    EXPECT_TRUE(parseHTMLIntegerFails("infinity"_s));
 }
 
 static unsigned testParseHTMLNonNegativeInteger(StringView input)
@@ -111,54 +111,54 @@ static bool parseHTMLNonNegativeIntegerFails(StringView input)
 
 TEST(WebCoreHTMLParserIdioms, parseHTMLNonNegativeInteger)
 {
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123"));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("+123"));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("  123"));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123   "));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("   123   "));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123abc"));
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("  +123"));
-    EXPECT_EQ(12u, testParseHTMLNonNegativeInteger("   12 3"));
-    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1.0"));
-    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1."));
-    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1e1"));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123"_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("+123"_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("  123"_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123   "_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("   123   "_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("123abc"_s));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger("  +123"_s));
+    EXPECT_EQ(12u, testParseHTMLNonNegativeInteger("   12 3"_s));
+    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1.0"_s));
+    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1."_s));
+    EXPECT_EQ(1u, testParseHTMLNonNegativeInteger("1e1"_s));
 
     // All HTML whitespaces.
-    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger(" \t\r\n\f123"));
+    EXPECT_EQ(123u, testParseHTMLNonNegativeInteger(" \t\r\n\f123"_s));
 
     // Boundaries.
-    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("+0"));
-    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("0"));
-    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("-0"));
-    EXPECT_EQ(2147483647u, testParseHTMLNonNegativeInteger("2147483647"));
+    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("+0"_s));
+    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("0"_s));
+    EXPECT_EQ(0u, testParseHTMLNonNegativeInteger("-0"_s));
+    EXPECT_EQ(2147483647u, testParseHTMLNonNegativeInteger("2147483647"_s));
 
     // Failure cases.
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-1"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("2147483648"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("2147483649"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("111111111111111111"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("  -123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-123abc"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(""));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(" "));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("   "));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+ 123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("- 123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("a"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-a"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+-123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-+123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("++123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("--123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("\v123")); // '\v' is an ASCII space but not an HTML whitespace.
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("a123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+a123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-a123"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(".1"));
-    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("infinity"));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-1"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("2147483648"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("2147483649"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("111111111111111111"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("  -123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-123abc"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(""_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(" "_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("   "_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+ 123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("- 123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("a"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-a"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+-123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-+123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("++123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("--123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("\v123"_s)); // '\v' is an ASCII space but not an HTML whitespace.
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("a123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("+a123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("-a123"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails(".1"_s));
+    EXPECT_TRUE(parseHTMLNonNegativeIntegerFails("infinity"_s));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
@@ -34,26 +34,26 @@ namespace TestWebKitAPI {
 
 TEST(HTTPParsers, ParseCrossOriginResourcePolicyHeader)
 {
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("") == CrossOriginResourcePolicy::None);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" ") == CrossOriginResourcePolicy::None);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(""_s) == CrossOriginResourcePolicy::None);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" "_s) == CrossOriginResourcePolicy::None);
 
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same-origin") == CrossOriginResourcePolicy::SameOrigin);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("Same-Origin") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAME-ORIGIN") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" same-orIGIN ") == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same-origin"_s) == CrossOriginResourcePolicy::SameOrigin);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("Same-Origin"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAME-ORIGIN"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" same-orIGIN "_s) == CrossOriginResourcePolicy::Invalid);
 
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same-site") == CrossOriginResourcePolicy::SameSite);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("Same-Site") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAME-SITE") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" same-site ") == CrossOriginResourcePolicy::SameSite);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same-site"_s) == CrossOriginResourcePolicy::SameSite);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("Same-Site"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAME-SITE"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(" same-site "_s) == CrossOriginResourcePolicy::SameSite);
 
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SameOrigin") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("zameorigin") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("samesite") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same site") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same–site") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAMESITE") == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("") == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SameOrigin"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("zameorigin"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("samesite"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same site"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same–site"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAMESITE"_s) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(StringView::fromLatin1("")) == CrossOriginResourcePolicy::Invalid);
 }
 
 #if USE(GLIB)

--- a/Tools/TestWebKitAPI/Tests/WebKit/EnvironmentUtilitiesTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EnvironmentUtilitiesTest.cpp
@@ -33,53 +33,53 @@
 namespace TestWebKitAPI {
 
 #define PROCESS_DYLIB "Process.dylib"
-const char* const stripValue = "/" PROCESS_DYLIB;
+constexpr auto stripValue = "/" PROCESS_DYLIB ""_s;
 
-static void testStrip(const char* input, const char* expected)
+static void testStrip(ASCIILiteral input, ASCIILiteral expected)
 {
     auto actual = WebKit::EnvironmentUtilities::stripEntriesEndingWith(input, stripValue);
-    EXPECT_STREQ(actual.utf8().data(), expected);
+    EXPECT_STREQ(actual.utf8().data(), expected.characters());
 }
 
 TEST(WebKit, StripEntriesEndingWith)
 {
-    testStrip("", "");
-    testStrip(":", ":");
-    testStrip("::", "::");
-    testStrip(":::", ":::");
-    testStrip("::::", "::::");
-    testStrip(":::::", ":::::");
+    testStrip(""_s, ""_s);
+    testStrip(":"_s, ":"_s);
+    testStrip("::"_s, "::"_s);
+    testStrip(":::"_s, ":::"_s);
+    testStrip("::::"_s, "::::"_s);
+    testStrip(":::::"_s, ":::::"_s);
 
-    testStrip(PROCESS_DYLIB, PROCESS_DYLIB);
-    testStrip(":" PROCESS_DYLIB, ":" PROCESS_DYLIB);
-    testStrip(PROCESS_DYLIB ":", PROCESS_DYLIB ":");
-    testStrip(":" PROCESS_DYLIB ":", ":" PROCESS_DYLIB ":");
+    testStrip(PROCESS_DYLIB ""_s, PROCESS_DYLIB ""_s);
+    testStrip(":" PROCESS_DYLIB ""_s, ":" PROCESS_DYLIB ""_s);
+    testStrip(PROCESS_DYLIB ":"_s, PROCESS_DYLIB ":"_s);
+    testStrip(":" PROCESS_DYLIB ":"_s, ":" PROCESS_DYLIB ":"_s);
 
-    testStrip("/" PROCESS_DYLIB, "");
-    testStrip(":/" PROCESS_DYLIB, "");
-    testStrip("/" PROCESS_DYLIB ":", "");
-    testStrip(":/" PROCESS_DYLIB ":", ":");
+    testStrip("/" PROCESS_DYLIB ""_s, ""_s);
+    testStrip(":/" PROCESS_DYLIB ""_s, ""_s);
+    testStrip("/" PROCESS_DYLIB ":"_s, ""_s);
+    testStrip(":/" PROCESS_DYLIB ":"_s, ":"_s);
 
-    testStrip(PROCESS_DYLIB "/", PROCESS_DYLIB "/");
-    testStrip(":" PROCESS_DYLIB "/", ":" PROCESS_DYLIB "/");
-    testStrip(PROCESS_DYLIB "/:", PROCESS_DYLIB "/:");
-    testStrip(":" PROCESS_DYLIB "/:", ":" PROCESS_DYLIB "/:");
+    testStrip(PROCESS_DYLIB "/"_s, PROCESS_DYLIB "/"_s);
+    testStrip(":" PROCESS_DYLIB "/"_s, ":" PROCESS_DYLIB "/"_s);
+    testStrip(PROCESS_DYLIB "/:"_s, PROCESS_DYLIB "/:"_s);
+    testStrip(":" PROCESS_DYLIB "/:"_s, ":" PROCESS_DYLIB "/:"_s);
 
-    testStrip("/" PROCESS_DYLIB "/", "/" PROCESS_DYLIB "/");
-    testStrip(":/" PROCESS_DYLIB "/", ":/" PROCESS_DYLIB "/");
-    testStrip("/" PROCESS_DYLIB "/:", "/" PROCESS_DYLIB "/:");
-    testStrip(":/" PROCESS_DYLIB "/:", ":/" PROCESS_DYLIB "/:");
+    testStrip("/" PROCESS_DYLIB "/"_s, "/" PROCESS_DYLIB "/"_s);
+    testStrip(":/" PROCESS_DYLIB "/"_s, ":/" PROCESS_DYLIB "/"_s);
+    testStrip("/" PROCESS_DYLIB "/:"_s, "/" PROCESS_DYLIB "/:"_s);
+    testStrip(":/" PROCESS_DYLIB "/:"_s, ":/" PROCESS_DYLIB "/:"_s);
 
-    testStrip("/Before.dylib:/" PROCESS_DYLIB, "/Before.dylib");
-    testStrip("/" PROCESS_DYLIB ":/After.dylib", "/After.dylib");
-    testStrip("/Before.dylib:/" PROCESS_DYLIB ":/After.dylib", "/Before.dylib:/After.dylib");
-    testStrip("/Before.dylib:/" PROCESS_DYLIB ":/Middle.dylib:/" PROCESS_DYLIB ":/After.dylib", "/Before.dylib:/Middle.dylib:/After.dylib");
+    testStrip("/Before.dylib:/" PROCESS_DYLIB ""_s, "/Before.dylib"_s);
+    testStrip("/" PROCESS_DYLIB ":/After.dylib"_s, "/After.dylib"_s);
+    testStrip("/Before.dylib:/" PROCESS_DYLIB ":/After.dylib"_s, "/Before.dylib:/After.dylib"_s);
+    testStrip("/Before.dylib:/" PROCESS_DYLIB ":/Middle.dylib:/" PROCESS_DYLIB ":/After.dylib"_s, "/Before.dylib:/Middle.dylib:/After.dylib"_s);
 
-    testStrip("/" PROCESS_DYLIB ":/" PROCESS_DYLIB, "");
-    testStrip("/" PROCESS_DYLIB ":/" PROCESS_DYLIB ":/" PROCESS_DYLIB, "");
+    testStrip("/" PROCESS_DYLIB ":/" PROCESS_DYLIB ""_s, ""_s);
+    testStrip("/" PROCESS_DYLIB ":/" PROCESS_DYLIB ":/" PROCESS_DYLIB ""_s, ""_s);
 
-    testStrip("/usr/lib/" PROCESS_DYLIB, "");
-    testStrip("/" PROCESS_DYLIB "/" PROCESS_DYLIB, "");
+    testStrip("/usr/lib/" PROCESS_DYLIB ""_s, ""_s);
+    testStrip("/" PROCESS_DYLIB "/" PROCESS_DYLIB ""_s, ""_s);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm
@@ -434,7 +434,7 @@ TEST(ContentRuleList, CSPReport)
         TestWebKitAPI::Util::spinRunLoop();
 
     URL expectedURL = server.request().URL;
-    expectedURL.setPath("/resources/save-report.py");
+    expectedURL.setPath("/resources/save-report.py"_s);
     EXPECT_STREQ(expectedURL.string().utf8().data(), notificationList.first().url.utf8().data());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -91,10 +91,10 @@ TEST(CopyHTML, Sanitizes)
     EXPECT_WK_STREQ("<meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b><!-- secret-->, world<script>dangerousCode()</script>",
         [webView stringByEvaluatingJavaScript:@"pastedHTML"]);
     String htmlInNativePasteboard = readHTMLStringFromPasteboard();
-    EXPECT_TRUE(htmlInNativePasteboard.contains("hello"));
-    EXPECT_TRUE(htmlInNativePasteboard.contains(", world"));
-    EXPECT_FALSE(htmlInNativePasteboard.contains("secret"));
-    EXPECT_FALSE(htmlInNativePasteboard.contains("dangerousCode"));
+    EXPECT_TRUE(htmlInNativePasteboard.contains("hello"_s));
+    EXPECT_TRUE(htmlInNativePasteboard.contains(", world"_s));
+    EXPECT_FALSE(htmlInNativePasteboard.contains("secret"_s));
+    EXPECT_FALSE(htmlInNativePasteboard.contains("dangerousCode"_s));
 }
 
 TEST(CopyHTML, SanitizationPreservesCharacterSetInSelectedText)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm
@@ -87,7 +87,7 @@ TEST(WKWebView, FTPMainResourceRedirect)
     
     consoleMessages = [NSMutableArray arrayWithCapacity:2];
 
-    [webView loadRequest:httpServer.request("/ftp_redirect")];
+    [webView loadRequest:httpServer.request("/ftp_redirect"_s)];
     [webView _test_waitForDidFailProvisionalNavigation];
 
     EXPECT_EQ([consoleMessages count], 1u);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
@@ -100,7 +100,7 @@ TEST(IndexedDB, CheckpointsWALAutomatically)
     }];
     TestWebKitAPI::Util::run(&done);
     NSURL *indexedDBDirectory = [NSURL fileURLWithPath:indexedDBDirectoryString isDirectory:YES];
-    NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("test-wal-checkpoint");
+    NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("test-wal-checkpoint"_s);
     NSURL *indexedDBDatabaseDirectory = [indexedDBDirectory URLByAppendingPathComponent:databaseHash];
     NSURL *indexedDBDatabaseFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
     NSURL *indexedDBDatabaseWAL = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -63,7 +63,7 @@ TEST(IndexedDB, IndexUpgradeToV2)
     NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IndexUpgrade" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
     NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"IndexUpgrade" withExtension:@"blob" subdirectory:@"TestWebKitAPI.resources"];
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
     NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash] stringByExpandingTildeInPath];
     NSURL *targetURL = [NSURL fileURLWithPath:databaseDirectory];
@@ -91,7 +91,7 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     NSURL *url = [[NSBundle mainBundle] URLForResource:databaseName withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
     NSURL *originURL = [NSURL URLWithString:@"file://"];
     __block NSString *originDirectoryString = nil;
     [configuration.get().websiteDataStore _originDirectoryForTesting:originURL topOrigin:originURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm
@@ -61,7 +61,7 @@ TEST(IndexedDB, IDBObjectStoreInfoUpgradeToV2)
     // Copy database files with old ObjectStoreInfo schema to the database directory.
     NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"IDBObjectStoreInfoUpgrade" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("objectstoreinfo-upgrade-test");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("objectstoreinfo-upgrade-test"_s);
     NSString *originDirectory = @"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/v1/file__0/";
     NSString *databaseDirectory = [[originDirectory stringByAppendingString:hash] stringByExpandingTildeInPath];
     NSURL *targetURL = [NSURL fileURLWithPath:databaseDirectory];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/InAppBrowserPrivacy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/InAppBrowserPrivacy.mm
@@ -966,7 +966,7 @@ TEST(InAppBrowserPrivacy, AppBoundDomainAllowsServiceWorkers)
 
     // Expect the service worker load to complete successfully.
     expectedMessage = "Message from worker: ServiceWorker received: Hello from an app-bound domain"_s;
-    [webView loadRequest:server.requestWithLocalhost("/main.html")];
+    [webView loadRequest:server.requestWithLocalhost("/main.html"_s)];
     TestWebKitAPI::Util::run(&isDone);
     isDone = false;
 
@@ -993,7 +993,7 @@ TEST(InAppBrowserPrivacy, UnregisterServiceWorker)
     });
 
     expectedMessage = "Unregistration success"_s;
-    [webView loadRequest:server.requestWithLocalhost("/main.html")];
+    [webView loadRequest:server.requestWithLocalhost("/main.html"_s)];
     TestWebKitAPI::Util::run(&isDone);
 
     isDone = false;
@@ -1021,7 +1021,7 @@ TEST(InAppBrowserPrivacy, UnregisterServiceWorkerMaxRegistrationCount)
     });
 
     expectedMessage = "Unregistration success"_s;
-    [webView loadRequest:server.requestWithLocalhost("/main.html")];
+    [webView loadRequest:server.requestWithLocalhost("/main.html"_s)];
     TestWebKitAPI::Util::run(&isDone);
 
     isDone = false;
@@ -1050,7 +1050,7 @@ TEST(InAppBrowserPrivacy, ReregisterServiceWorkerMaxRegistrationCount)
     });
 
     expectedMessage = "Reregistration success"_s;
-    [webView loadRequest:server.requestWithLocalhost("/main.html")];
+    [webView loadRequest:server.requestWithLocalhost("/main.html"_s)];
     TestWebKitAPI::Util::run(&isDone);
 
     isDone = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -160,25 +160,25 @@ static void createDirectories(StringView testName)
 
 TEST(IndexedDB, IndexedDBFileName)
 {
-    createDirectories("none");
+    createDirectories("none"_s);
     runTest();
 }
 
 TEST(IndexedDB, IndexedDBFileNameV0)
 {
-    createDirectories("v0");
+    createDirectories("v0"_s);
     runTest();
 }
 
 TEST(IndexedDB, IndexedDBFileNameV1)
 {
-    createDirectories("v1");
+    createDirectories("v1"_s);
     runTest();
 }
 
 TEST(IndexedDB, IndexedDBFileNameAPI)
 {
-    createDirectories("API");
+    createDirectories("API"_s);
     
     auto types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -212,7 +212,7 @@ TEST(IndexedDB, IndexedDBFileNameAPI)
 
 TEST(IndexedDB, IndexedDBFileHashCollision)
 {
-    createDirectories("collision");
+    createDirectories("collision"_s);
     
     auto handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -327,7 +327,7 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
 TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess");
+    NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
     NSURL *webkitURL = [NSURL URLWithString:@"http://webkit.org"];
     NSURL *iframeURL = [NSURL URLWithString:@"iframe://"];
     __block NSString *directoryString = nil;
@@ -383,7 +383,7 @@ TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
     NSURL *wrongWebkitIframeDatabaseDirectory = [webkitOriginDirectory URLByAppendingPathComponent:@"IndexedDB/iframe__0"];
     NSURL *webkitIframeOriginDirectory = [generalStorageDirectory URLByAppendingPathComponent:@"EAO66s8JvCWNn4D3YQut5pXfiGF_UXNZGvMGN6aKILg/vudvbMlKXj1m6RibnVvc8PdAdcXZsNE6ON_Al7yqOsg"];
     NSURL *webkitIframeOriginFile = [webkitIframeOriginDirectory URLByAppendingPathComponent:@"origin"];
-    NSString *hashedDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess");
+    NSString *hashedDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
     NSURL *webkitIframeDatabaseFile= [NSURL fileURLWithPath:[NSString pathWithComponents:@[webkitIframeOriginDirectory.path, @"IndexedDB", hashedDatabaseName, @"IndexedDB.sqlite3"]]];
     NSURL *idbDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *oldWebkitIframeDatabaseDirectory = [NSURL fileURLWithPath:[NSString pathWithComponents:@[idbDirectory.path, @"v1/http_webkit.org_0/iframe__0", hashedDatabaseName]]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
@@ -68,7 +68,7 @@ TEST(IndexedDB, IndexedDBTempFileSize)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
     NSURL *databaseRootDirectory = [NSURL fileURLWithPath:databaseRootDirectoryString isDirectory:YES];
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBTempFileSize");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBTempFileSize"_s);
     NSURL *databaseDirectory = [databaseRootDirectory URLByAppendingPathComponent:hash];
     NSURL *walFilePath = [databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
@@ -37,8 +37,8 @@ namespace TestWebKitAPI {
 
 static String parseUserAgent(const Vector<char>& request)
 {
-    auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n");
-    auto index = headers.findIf([] (auto& header) { return header.startsWith("User-Agent:"); });
+    auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+    auto index = headers.findIf([] (auto& header) { return header.startsWith("User-Agent:"_s); });
     if (index != notFound)
         return headers[index];
     return emptyString();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
@@ -283,28 +283,28 @@ TEST_F(MediaSessionTest, DISABLED_OnlyOneHandler)
 #endif
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPlay));
-    waitForSessionHandlerToBeCalled("play");
-    ASSERT_TRUE(sessionHandlerWasCalled("play"));
-    ASSERT_FALSE(eventListenerWasCalled("play"));
+    waitForSessionHandlerToBeCalled("play"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("play"_s));
+    ASSERT_FALSE(eventListenerWasCalled("play"_s));
 
     // The media session only registered for Play, but no other commands should reach HTMLMediaElement.
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipForward, 1));
-    ASSERT_FALSE(sessionHandlerWasCalled("seekforward"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    ASSERT_FALSE(sessionHandlerWasCalled("seekforward"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipBackward, 10));
-    ASSERT_FALSE(sessionHandlerWasCalled("seekbackward"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    ASSERT_FALSE(sessionHandlerWasCalled("seekbackward"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSeekToPlaybackPosition, 6));
-    ASSERT_FALSE(sessionHandlerWasCalled("seekto"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    ASSERT_FALSE(sessionHandlerWasCalled("seekto"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandNextTrack));
-    ASSERT_FALSE(sessionHandlerWasCalled("nexttrack"));
+    ASSERT_FALSE(sessionHandlerWasCalled("nexttrack"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPreviousTrack));
-    ASSERT_FALSE(sessionHandlerWasCalled("previoustrack"));
+    ASSERT_FALSE(sessionHandlerWasCalled("previoustrack"_s));
 }
 
 TEST_F(MediaSessionTest, DISABLED_RemoteCommands)
@@ -328,63 +328,63 @@ TEST_F(MediaSessionTest, DISABLED_RemoteCommands)
 #endif
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPlay));
-    waitForSessionHandlerToBeCalled("play");
-    ASSERT_TRUE(sessionHandlerWasCalled("play"));
-    ASSERT_FALSE(eventListenerWasCalled("play"));
+    waitForSessionHandlerToBeCalled("play"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("play"_s));
+    ASSERT_FALSE(eventListenerWasCalled("play"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPause));
-    waitForSessionHandlerToBeCalled("pause");
-    ASSERT_TRUE(sessionHandlerWasCalled("pause"));
-    ASSERT_FALSE(eventListenerWasCalled("pause"));
+    waitForSessionHandlerToBeCalled("pause"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("pause"_s));
+    ASSERT_FALSE(eventListenerWasCalled("pause"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipForward, 1));
-    waitForSessionHandlerToBeCalled("seekforward");
-    ASSERT_TRUE(sessionHandlerWasCalled("seekforward"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    waitForSessionHandlerToBeCalled("seekforward"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("seekforward"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipBackward, 10));
-    waitForSessionHandlerToBeCalled("seekbackward");
-    ASSERT_TRUE(sessionHandlerWasCalled("seekbackward"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    waitForSessionHandlerToBeCalled("seekbackward"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("seekbackward"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSeekToPlaybackPosition, 6));
-    waitForSessionHandlerToBeCalled("seekto");
-    ASSERT_TRUE(sessionHandlerWasCalled("seekto"));
-    ASSERT_FALSE(eventListenerWasCalled("seeked"));
+    waitForSessionHandlerToBeCalled("seekto"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("seekto"_s));
+    ASSERT_FALSE(eventListenerWasCalled("seeked"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandNextTrack));
-    waitForSessionHandlerToBeCalled("nexttrack");
-    ASSERT_TRUE(sessionHandlerWasCalled("nexttrack"));
+    waitForSessionHandlerToBeCalled("nexttrack"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("nexttrack"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPreviousTrack));
-    waitForSessionHandlerToBeCalled("previoustrack");
-    ASSERT_TRUE(sessionHandlerWasCalled("previoustrack"));
+    waitForSessionHandlerToBeCalled("previoustrack"_s);
+    ASSERT_TRUE(sessionHandlerWasCalled("previoustrack"_s));
 
     // Unregister action handlers, supported commands should go to HTMLMediaElement.
     [webView() objectByEvaluatingJavaScript:@"clearActionHandlers()"];
     clearEventListenerState();
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPlay));
-    waitForEventListenerToBeCalled("play");
-    ASSERT_TRUE(eventListenerWasCalled("play"));
+    waitForEventListenerToBeCalled("play"_s);
+    ASSERT_TRUE(eventListenerWasCalled("play"_s));
 
     ASSERT_TRUE(sendMediaRemoteCommand(MRMediaRemoteCommandPause));
-    waitForEventListenerToBeCalled("pause");
-    ASSERT_TRUE(eventListenerWasCalled("pause"));
+    waitForEventListenerToBeCalled("pause"_s);
+    ASSERT_TRUE(eventListenerWasCalled("pause"_s));
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipForward, 1));
-    waitForEventListenerToBeCalled("seeked");
-    ASSERT_TRUE(eventListenerWasCalled("seeked"));
+    waitForEventListenerToBeCalled("seeked"_s);
+    ASSERT_TRUE(eventListenerWasCalled("seeked"_s));
     clearEventListenerState();
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSkipBackward, 10));
-    waitForEventListenerToBeCalled("seeked");
-    ASSERT_TRUE(eventListenerWasCalled("seeked"));
+    waitForEventListenerToBeCalled("seeked"_s);
+    ASSERT_TRUE(eventListenerWasCalled("seeked"_s));
     clearEventListenerState();
 
     ASSERT_TRUE(sendMediaRemoteSeekCommand(MRMediaRemoteCommandSeekToPlaybackPosition, 6));
-    waitForEventListenerToBeCalled("seeked");
-    ASSERT_TRUE(eventListenerWasCalled("seeked"));
+    waitForEventListenerToBeCalled("seeked"_s);
+    ASSERT_TRUE(eventListenerWasCalled("seeked"_s));
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
@@ -120,7 +120,7 @@ static void addAttributedPCMv2(WebCore::SQLiteDatabase& database)
 
     constexpr auto insertAttributedPrivateClickMeasurementQueryV2 = "INSERT OR REPLACE INTO AttributedPrivateClickMeasurement (sourceSiteDomainID, attributeOnSiteDomainID, "
         "sourceID, attributionTriggerData, priority, timeOfAdClick, earliestTimeToSend, token, signature, keyID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
-    addValuesToTable<10>(database, insertAttributedPrivateClickMeasurementQueryV2, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token", "test signature", "test key id" });
+    addValuesToTable<10>(database, insertAttributedPrivateClickMeasurementQueryV2, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token"_s, "test signature"_s, "test key id"_s });
 }
 
 static void addUnattributedPCMv2(WebCore::SQLiteDatabase& database)
@@ -134,7 +134,7 @@ static void addUnattributedPCMv2(WebCore::SQLiteDatabase& database)
 
     constexpr auto insertUnattributedPrivateClickMeasurementQueryV2 = "INSERT OR REPLACE INTO UnattributedPrivateClickMeasurement (sourceSiteDomainID, attributeOnSiteDomainID, "
         "sourceID, timeOfAdClick, token, signature, keyID) VALUES (?, ?, ?, ?, ?, ?, ?)"_s;
-    addValuesToTable<7>(database, insertUnattributedPrivateClickMeasurementQueryV2, { 2, 3, 43, 1.0, "test token", "test signature", "test key id" });
+    addValuesToTable<7>(database, insertUnattributedPrivateClickMeasurementQueryV2, { 2, 3, 43, 1.0, "test token"_s, "test signature"_s, "test key id"_s });
 }
 
 static void addAttributedPCMv3(WebCore::SQLiteDatabase& database)
@@ -149,7 +149,7 @@ static void addAttributedPCMv3(WebCore::SQLiteDatabase& database)
 
     constexpr auto insertAttributedPrivateClickMeasurementQueryV3 = "INSERT OR REPLACE INTO AttributedPrivateClickMeasurement (sourceSiteDomainID, destinationSiteDomainID, "
         "sourceID, attributionTriggerData, priority, timeOfAdClick, earliestTimeToSendToSource, token, signature, keyID, earliestTimeToSendToDestination) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
-    addValuesToTable<11>(database, insertAttributedPrivateClickMeasurementQueryV3, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token", "test signature", "test key id", earliestTimeToSend() });
+    addValuesToTable<11>(database, insertAttributedPrivateClickMeasurementQueryV3, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token"_s, "test signature"_s, "test key id"_s, earliestTimeToSend() });
 }
 
 static void addUnattributedPCMv3(WebCore::SQLiteDatabase& database)
@@ -163,7 +163,7 @@ static void addUnattributedPCMv3(WebCore::SQLiteDatabase& database)
 
     constexpr auto insertUnattributedPrivateClickMeasurementQueryV3 = "INSERT OR REPLACE INTO UnattributedPrivateClickMeasurement (sourceSiteDomainID, destinationSiteDomainID, "
         "sourceID, timeOfAdClick, token, signature, keyID) VALUES (?, ?, ?, ?, ?, ?, ?)"_s;
-    addValuesToTable<7>(database, insertUnattributedPrivateClickMeasurementQueryV3, { 2, 3, 43, 1.0, "test token", "test signature", "test key id" });
+    addValuesToTable<7>(database, insertUnattributedPrivateClickMeasurementQueryV3, { 2, 3, 43, 1.0, "test token"_s, "test signature"_s, "test key id"_s });
 }
 
 static void addUnattributedPCMv4(WebCore::SQLiteDatabase& database)
@@ -180,11 +180,11 @@ static void addUnattributedPCMv4(WebCore::SQLiteDatabase& database)
         "sourceID, timeOfAdClick, token, signature, keyID, sourceApplicationBundleID) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"_s;
     
 #if PLATFORM(MAC)
-    auto bundleID = "com.apple.Safari";
+    auto bundleID = "com.apple.Safari"_s;
 #else
-    auto bundleID = "com.apple.mobilesafari";
+    auto bundleID = "com.apple.mobilesafari"_s;
 #endif
-    addValuesToTable<8>(database, insertUnattributedPrivateClickMeasurementQueryV4, { 2, 3, 43, 1.0, "test token", "test signature", "test key id", bundleID });
+    addValuesToTable<8>(database, insertUnattributedPrivateClickMeasurementQueryV4, { 2, 3, 43, 1.0, "test token"_s, "test signature"_s, "test key id"_s, bundleID });
 }
 
 static void addAttributedPCMv4(WebCore::SQLiteDatabase& database)
@@ -202,11 +202,11 @@ static void addAttributedPCMv4(WebCore::SQLiteDatabase& database)
         "sourceID, attributionTriggerData, priority, timeOfAdClick, earliestTimeToSendToSource, token, signature, keyID, earliestTimeToSendToDestination, sourceApplicationBundleID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
 
 #if PLATFORM(MAC)
-    auto bundleID = "com.apple.Safari";
+    auto bundleID = "com.apple.Safari"_s;
 #else
-    auto bundleID = "com.apple.mobilesafari";
+    auto bundleID = "com.apple.mobilesafari"_s;
 #endif
-    addValuesToTable<12>(database, insertAttributedPrivateClickMeasurementQueryV4, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token", "test signature", "test key id", earliestTimeToSend(), bundleID });
+    addValuesToTable<12>(database, insertAttributedPrivateClickMeasurementQueryV4, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token"_s, "test signature"_s, "test key id"_s, earliestTimeToSend(), bundleID });
 }
 
 static void addAttributedPCMv5(WebCore::SQLiteDatabase& database)
@@ -223,11 +223,11 @@ static void addAttributedPCMv5(WebCore::SQLiteDatabase& database)
         "sourceID, attributionTriggerData, priority, timeOfAdClick, earliestTimeToSendToSource, token, signature, keyID, earliestTimeToSendToDestination, sourceApplicationBundleID, destinationToken, destinationSignature, destinationKeyID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
 
 #if PLATFORM(MAC)
-    auto bundleID = "com.apple.Safari";
+    auto bundleID = "com.apple.Safari"_s;
 #else
-    auto bundleID = "com.apple.mobilesafari";
+    auto bundleID = "com.apple.mobilesafari"_s;
 #endif
-    addValuesToTable<15>(database, insertAttributedPrivateClickMeasurementQueryV5, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token", "test signature", "test key id", earliestTimeToSend(), bundleID, "test destination token", "test destination signature", "test destination key id" });
+    addValuesToTable<15>(database, insertAttributedPrivateClickMeasurementQueryV5, { 1, 2, 42, 14, 7, 1.0, earliestTimeToSend(), "test token"_s, "test signature"_s, "test key id"_s, earliestTimeToSend(), bundleID, "test destination token"_s, "test destination signature"_s, "test destination key id"_s });
 }
 
 static RetainPtr<NSString> dumpedPCM(WKWebView *webView)
@@ -330,7 +330,7 @@ static void cleanUp(RetainPtr<WKWebView> webView)
 
 static void createAndPopulateObservedDomainTable(WebCore::SQLiteDatabase& database)
 {
-    auto addObservedDomain = [&](const char* domain) {
+    auto addObservedDomain = [&](ASCIILiteral domain) {
         constexpr auto insertObservedDomainQuery = "INSERT INTO ObservedDomains (registrableDomain, lastSeen, hadUserInteraction,"
         "mostRecentUserInteractionTime, grandfathered, isPrevalent, isVeryPrevalent, dataRecordsRemoved, timesAccessedAsFirstPartyDueToUserInteraction,"
         "timesAccessedAsFirstPartyDueToStorageAccessAPI, isScheduledForAllButCookieDataRemoval) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"_s;
@@ -345,14 +345,14 @@ static void createAndPopulateObservedDomainTable(WebCore::SQLiteDatabase& databa
     "isScheduledForAllButCookieDataRemoval INTEGER NOT NULL)"_s;
 
     EXPECT_TRUE(database.executeCommand(createObservedDomain));
-    addObservedDomain("example.com");
-    addObservedDomain("webkit.org");
-    addObservedDomain("www.webkit.org");
+    addObservedDomain("example.com"_s);
+    addObservedDomain("webkit.org"_s);
+    addObservedDomain("www.webkit.org"_s);
 }
 
 static void createAndPopulatePCMObservedDomainTable(WebCore::SQLiteDatabase& database)
 {
-    auto addObservedDomain = [&](const char* domain) {
+    auto addObservedDomain = [&](ASCIILiteral domain) {
         constexpr auto insertObservedDomainQuery = "INSERT INTO PCMObservedDomains (registrableDomain) VALUES (?)"_s;
         addValuesToTable<1>(database, insertObservedDomainQuery, { domain });
     };
@@ -361,9 +361,9 @@ static void createAndPopulatePCMObservedDomainTable(WebCore::SQLiteDatabase& dat
         "domainID INTEGER PRIMARY KEY, registrableDomain TEXT NOT NULL UNIQUE ON CONFLICT FAIL)"_s;
 
     EXPECT_TRUE(database.executeCommand(createPCMObservedDomain));
-    addObservedDomain("example.com");
-    addObservedDomain("webkit.org");
-    addObservedDomain("www.webkit.org");
+    addObservedDomain("example.com"_s);
+    addObservedDomain("webkit.org"_s);
+    addObservedDomain("www.webkit.org"_s);
 }
 
 void setUpFromResourceLoadStatisticsDatabase(void(*addUnattributedPCM)(WebCore::SQLiteDatabase&), void(*addAttributedPCM)(WebCore::SQLiteDatabase&))

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -7321,7 +7321,7 @@ TEST(ProcessSwap, ResponsePolicyDownloadAfterCOOPProcessSwap)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
-    [webView loadRequest:server.request("/source.html")];
+    [webView loadRequest:server.request("/source.html"_s)];
     Util::run(&done);
     done = false;
 
@@ -7332,7 +7332,7 @@ TEST(ProcessSwap, ResponsePolicyDownloadAfterCOOPProcessSwap)
 
     done = false;
     failed = false;
-    [webView loadRequest:server.request("/destination.html")];
+    [webView loadRequest:server.request("/destination.html"_s)];
     Util::run(&failed);
     failed = false;
     shouldConvertToDownload = false;
@@ -7379,11 +7379,11 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCOOP)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
-    [webView loadRequest:server.request("/source.html")];
+    [webView loadRequest:server.request("/source.html"_s)];
     Util::run(&done);
     done = false;
 
-    [webView loadRequest:server.request("/destination.html")];
+    [webView loadRequest:server.request("/destination.html"_s)];
     Util::run(&done);
     done = false;
 
@@ -7461,7 +7461,7 @@ static void runCOOPProcessSwapTest(ASCIILiteral sourceCOOP, ASCIILiteral sourceC
     failed = false;
     serverRedirected = false;
     numberOfDecidePolicyCalls = 0;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -8343,7 +8343,7 @@ TEST(ProcessSwap, ContentModeInCaseOfCoopProcessSwap)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
-    [webView loadRequest:server.request("/source.html")];
+    [webView loadRequest:server.request("/source.html"_s)];
     Util::run(&done);
     done = false;
 
@@ -8359,7 +8359,7 @@ TEST(ProcessSwap, ContentModeInCaseOfCoopProcessSwap)
 
     auto pid1 = [webView _webProcessIdentifier];
 
-    [webView loadRequest:server.request("/destination.html")];
+    [webView loadRequest:server.request("/destination.html"_s)];
     Util::run(&done);
     done = false;
 
@@ -8418,7 +8418,7 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
-    [webView loadRequest:server1.request("/source.html")];
+    [webView loadRequest:server1.request("/source.html"_s)];
     Util::run(&done);
     done = false;
 
@@ -8434,7 +8434,7 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
 
     auto pid1 = [webView _webProcessIdentifier];
 
-    [webView loadRequest:server2.request("/destination.html")];
+    [webView loadRequest:server2.request("/destination.html"_s)];
     Util::run(&done);
     done = false;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -623,7 +623,7 @@ TEST(ServiceWorkers, RestoreFromDisk)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
 
@@ -639,7 +639,7 @@ TEST(ServiceWorkers, RestoreFromDisk)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -759,7 +759,7 @@ TEST(ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Service Worker activated"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
 
@@ -776,7 +776,7 @@ TEST(ServiceWorkers, InterceptFirstLoadAfterRestoreFromDisk)
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Intercepted by worker"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -808,7 +808,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Service Worker activated"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
 
@@ -826,7 +826,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Intercepted by worker"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -857,7 +857,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
 
     // Register a service worker and activate it.
     expectedMessage = "Service Worker activated"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
 
@@ -875,7 +875,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
 
     // Verify service worker is intercepting load.
     expectedMessage = "Intercepted by worker"_s;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -890,7 +890,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     navigationComplete = false;
 
     // Verify service worker load goes well when policy delegate is ok.
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
     TestWebKitAPI::Util::run(&navigationComplete);
 
     EXPECT_FALSE(navigationFailed);
@@ -904,7 +904,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     navigationComplete = false;
 
     // Verify service worker load fails well when policy delegate is not ok.
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
     TestWebKitAPI::Util::run(&navigationComplete);
 
     EXPECT_TRUE(navigationFailed);
@@ -976,23 +976,23 @@ TEST(ServiceWorkers, SWProcessConnectionCreation)
     RetainPtr<WKWebView> newRegularPageWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Test that a regular page does not trigger a service worker connection to network process if there is no registered service worker.
-    [regularPageWebView loadRequest:server.request("/first.html")];
+    [regularPageWebView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     // Test that a sw scheme page can register a service worker.
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     webView = nullptr;
 
     // Now that a service worker is registered, the regular page should have a service worker connection.
-    [regularPageWebView loadRequest:server.request("/third.html")];
+    [regularPageWebView loadRequest:server.request("/third.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     regularPageWebView = nullptr;
 
-    [newRegularPageWebView loadRequest:server.request("/fourth.html")];
+    [newRegularPageWebView loadRequest:server.request("/fourth.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     newRegularPageWebView = nullptr;
@@ -1077,7 +1077,7 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Load a page that registers a service worker.
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     webView = nullptr;
@@ -1092,7 +1092,7 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:newConfiguration.get()]);
     EXPECT_EQ(1u, webView.get().configuration.processPool._webProcessCountIgnoringPrewarmed);
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -1101,7 +1101,7 @@ TEST(ServiceWorkers, ServiceWorkerProcessCreation)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:newConfiguration.get()]);
     EXPECT_EQ(2u, webView.get().configuration.processPool._webProcessCountIgnoringPrewarmed);
-    [webView loadRequest:server.request("/third.html")];
+    [webView loadRequest:server.request("/third.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -1176,12 +1176,12 @@ TEST(ServiceWorkers, CacheStorageInPrivateBrowsingMode)
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 }
@@ -1329,19 +1329,19 @@ TEST(ServiceWorkers, DifferentSessionsUseDifferentRegistrations)
     });
 
     auto defaultWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    [defaultWebView synchronouslyLoadRequest:server.request("/first.html")];
+    [defaultWebView synchronouslyLoadRequest:server.request("/first.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    [defaultWebView synchronouslyLoadRequest:server.request("/second.html")];
+    [defaultWebView synchronouslyLoadRequest:server.request("/second.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     auto ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    [ephemeralWebView synchronouslyLoadRequest:server.request("/third.html")];
+    [ephemeralWebView synchronouslyLoadRequest:server.request("/third.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -1387,7 +1387,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     while (![[configuration websiteDataStore] _hasRegisteredServiceWorker])
@@ -1395,10 +1395,10 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
-    EXPECT_TRUE(retrievedString.contains("/Caches/com.apple.WebKit.TestWebKitAPI/WebKit/CacheStorage"));
+    EXPECT_TRUE(retrievedString.contains("/Caches/com.apple.WebKit.TestWebKitAPI/WebKit/CacheStorage"_s));
 
     [[configuration websiteDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
@@ -1430,7 +1430,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
     while (![websiteDataStore _hasRegisteredServiceWorker])
@@ -1438,10 +1438,10 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
-    EXPECT_TRUE(retrievedString.contains("\"path\": \"/var/tmp\""));
+    EXPECT_TRUE(retrievedString.contains("\"path\": \"/var/tmp\""_s));
 
     [[configuration websiteDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
@@ -1929,7 +1929,7 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
         protectedProcessPool = webView.get().configuration.processPool;
         protectedWebsiteDataStore = webView.get().configuration.websiteDataStore;
 
-        [webView loadRequest:server.request("/first.html")];
+        [webView loadRequest:server.request("/first.html"_s)];
 
         TestWebKitAPI::Util::run(&done);
         done = false;
@@ -1952,7 +1952,7 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
 
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-        [webView loadRequest:server.request("/second.html")];
+        [webView loadRequest:server.request("/second.html"_s)];
 
         TestWebKitAPI::Util::run(&done);
         done = false;
@@ -1990,7 +1990,7 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
     done = false;
 
     // Normal load to get SW registered.
-    [webView loadRequest:server.request("/first.html")];
+    [webView loadRequest:server.request("/first.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -2013,7 +2013,7 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
 
     [webView.get().configuration.websiteDataStore _sendNetworkProcessDidResume];
 
-    [webView loadRequest:server.request("/second.html")];
+    [webView loadRequest:server.request("/second.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
@@ -2584,7 +2584,7 @@ static bool didStartURLSchemeTask = false;
     NSURL *finalURL = task.request.URL;
 
     NSMutableDictionary* headerDictionary = [NSMutableDictionary dictionary];
-    if (URL(finalURL).string().endsWith(".js"))
+    if (URL(finalURL).string().endsWith(".js"_s))
         [headerDictionary setObject:@"text/javascript" forKey:@"Content-Type"];
     else
         [headerDictionary setObject:@"text/html" forKey:@"Content-Type"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
@@ -435,7 +435,7 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
     setVisible(webView.get());
 
     receivedQuotaDelegateCalled = false;
-    [webView loadRequest:server.request("/main.html")];
+    [webView loadRequest:server.request("/main.html"_s)];
     Util::run(&receivedQuotaDelegateCalled);
 
     [delegate denyQuota];
@@ -445,7 +445,7 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
     Util::run(&receivedMessage);
 
     receivedQuotaDelegateCalled = false;
-    [webView loadRequest:server.request("/main.html#fragment")];
+    [webView loadRequest:server.request("/main.html#fragment"_s)];
     [webView stringByEvaluatingJavaScript:@"doTestAgain()"];
 
     [messageHandler setExpectedMessage: @"start"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
@@ -62,7 +62,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     TestWebKitAPI::Util::run(&readyToContinue);
     EXPECT_WK_STREQ(@"Success", (NSString *)[lastScriptMessage body]);
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("StoreBlobToBeDeleted");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("StoreBlobToBeDeleted"_s);
     NSURL *originURL = [NSURL URLWithString:@"file://"];
     __block NSString *originDirectoryString = nil;
     readyToContinue = false;
@@ -85,7 +85,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     // 1 - Create the path for a fake database that won't actively be in use
     // 2 - Move -wal and -shm files into that directory
     // 3 - Make sure the entire directory is deleted
-    NSString *fakeHash = WebCore::SQLiteFileSystem::computeHashForFileName("FakeDatabasePath");
+    NSString *fakeHash = WebCore::SQLiteFileSystem::computeHashForFileName("FakeDatabasePath"_s);
     NSURL *fakeDatabaseDirectory = [originDirectory URLByAppendingPathComponent:fakeHash];
     NSURL *fakeShmURL = [fakeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"];
     NSURL *fakeWalURL = [fakeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3-shm"];
@@ -141,7 +141,7 @@ TEST(IndexedDB, StoreBlobThenDeleteDatabase)
     TestWebKitAPI::Util::run(&readyToContinue);
     EXPECT_WK_STREQ(@"Success", (NSString *)[lastScriptMessage body]);
 
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("StoreBlobToBeDeleted");
+    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("StoreBlobToBeDeleted"_s);
     NSURL *originURL = [NSURL URLWithString:@"file://"];
     __block NSString *originDirectoryString = nil;
     readyToContinue = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -1291,7 +1291,7 @@ TEST(WKWebViewConfiguration, LoadsSubresources)
 
     {
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-        [webView loadRequest:server.request("/main.html")];
+        [webView loadRequest:server.request("/main.html"_s)];
         TestWebKitAPI::Util::run(&loadedImage);
         TestWebKitAPI::Util::run(&loadedIFrame);
     }
@@ -1304,7 +1304,7 @@ TEST(WKWebViewConfiguration, LoadsSubresources)
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         auto delegate = adoptNS([TestNavigationDelegate new]);
         webView.get().navigationDelegate = delegate.get();
-        [webView loadRequest:server.request("/main.html")];
+        [webView loadRequest:server.request("/main.html"_s)];
         [delegate waitForDidFinishNavigation];
         TestWebKitAPI::Util::spinRunLoop(100);
         EXPECT_FALSE(loadedIFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm
@@ -180,7 +180,7 @@ TEST(WebSocket, CloseCode)
     };
 
     auto webView = adoptNS([WKWebView new]);
-    [webView loadRequest:httpServer.request("/navigateAway")];
+    [webView loadRequest:httpServer.request("/navigateAway"_s)];
     Util::run(&receivedWebSocketClose);
     Vector<uint8_t> expected { 0x3, 0xe9 }; // NSURLSessionWebSocketCloseCodeGoingAway
     appendString(expected, "WebSocket is closed due to suspension.");
@@ -189,14 +189,14 @@ TEST(WebSocket, CloseCode)
     receivedWebSocketClose = false;
     closeData = { };
     expected = { 0xb, 0xb8 }; // 3000
-    [webView loadRequest:httpServer.request("/closeCustomCode")];
+    [webView loadRequest:httpServer.request("/closeCustomCode"_s)];
     Util::run(&receivedWebSocketClose);
     EXPECT_EQ(closeData, expected);
 
     receivedWebSocketClose = false;
     closeData = { };
     expected = { };
-    [webView loadRequest:httpServer.request("/closeNoArguments")];
+    [webView loadRequest:httpServer.request("/closeNoArguments"_s)];
     Util::run(&receivedWebSocketClose);
     EXPECT_EQ(closeData, expected);
 
@@ -204,7 +204,7 @@ TEST(WebSocket, CloseCode)
     closeData = { };
     expected = { 0xb, 0xb9 }; // 3001
     appendString(expected, "custom reason");
-    [webView loadRequest:httpServer.request("/closeBothParameters")];
+    [webView loadRequest:httpServer.request("/closeBothParameters"_s)];
     Util::run(&receivedWebSocketClose);
     EXPECT_EQ(closeData, expected);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -874,7 +874,7 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
 {
     NSURL *indexedDBDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *indexedDBOriginDirectory = [indexedDBDirectory URLByAppendingPathComponent:@"v1/https_webkit.org_0"];
-    static const char indexedDBDatabaseName[] = "TestDatabase";
+    static constexpr auto indexedDBDatabaseName = "TestDatabase"_s;
     NSString *hashedIndexedDBDatabaseName = WebCore::SQLiteFileSystem::computeHashForFileName(indexedDBDatabaseName);
     NSURL *indexedDBDatabaseDirectory = [indexedDBOriginDirectory URLByAppendingPathComponent:hashedIndexedDBDatabaseName];
     NSURL *indexedDBFile = [indexedDBDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -638,7 +638,7 @@ struct ParsedRange {
         size_t min = 0;
         size_t max = 0;
         ASSERT(string.length() > 6);
-        ASSERT(string.startsWith("bytes="));
+        ASSERT(string.startsWith("bytes="_s));
         for (size_t i = 6; i < string.length(); ++i) {
             if (isASCIIDigit(string[i])) {
                 if (parsingMin)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -689,7 +689,7 @@ void InjectedBundlePage::didFinishProgress()
     if (!injectedBundle.testRunner()->shouldDumpProgressFinishedCallback())
         return;
 
-    injectedBundle.outputText("postProgressFinishedNotification\n");
+    injectedBundle.outputText("postProgressFinishedNotification\n"_s);
 }
 
 void InjectedBundlePage::willInjectUserScriptForFrame()
@@ -802,7 +802,7 @@ void InjectedBundlePage::dump()
     auto urlRef = adoptWK(WKBundleFrameCopyURL(frame));
     String url = toWTFString(adoptWK(WKURLCopyString(urlRef.get())));
     auto mimeType = adoptWK(WKBundleFrameCopyMIMETypeForResourceWithURL(frame, urlRef.get()));
-    if (url.find("dumpAsText/") != notFound || WKStringIsEqualToUTF8CString(mimeType.get(), "text/plain"))
+    if (url.find("dumpAsText/"_s) != notFound || WKStringIsEqualToUTF8CString(mimeType.get(), "text/plain"))
         injectedBundle.testRunner()->dumpAsText(false);
 
     StringBuilder stringBuilder;
@@ -990,21 +990,21 @@ void InjectedBundlePage::didDisplayInsecureContentForFrame(WKBundleFrameRef)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFrameLoadCallbacks())
-        injectedBundle.outputText("didDisplayInsecureContent\n");
+        injectedBundle.outputText("didDisplayInsecureContent\n"_s);
 }
 
 void InjectedBundlePage::didRunInsecureContentForFrame(WKBundleFrameRef)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFrameLoadCallbacks())
-        injectedBundle.outputText("didRunInsecureContent\n");
+        injectedBundle.outputText("didRunInsecureContent\n"_s);
 }
 
 void InjectedBundlePage::didDetectXSSForFrame(WKBundleFrameRef)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFrameLoadCallbacks())
-        injectedBundle.outputText("didDetectXSS\n");
+        injectedBundle.outputText("didDetectXSS\n"_s);
 }
 
 void InjectedBundlePage::didInitiateLoadForResource(WKBundlePageRef page, WKBundleFrameRef, uint64_t identifier, WKURLRequestRef request, bool)
@@ -1050,7 +1050,7 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
 
     auto redirectURL = adoptWK(WKURLResponseCopyURL(response));
     if (injectedBundle.isTestRunning() && injectedBundle.testRunner()->willSendRequestReturnsNullOnRedirect() && redirectURL) {
-        injectedBundle.outputText("Returning null for this redirect\n");
+        injectedBundle.outputText("Returning null for this redirect\n"_s);
         return nullptr;
     }
 
@@ -1342,7 +1342,7 @@ void InjectedBundlePage::willAddMessageToConsole(WKStringRef message)
     auto messageString = toWTFString(message);
     messageString = messageString.left(messageString.find(nullCharacter));
 
-    size_t fileProtocolStart = messageString.find("file://");
+    size_t fileProtocolStart = messageString.find("file://"_s);
     if (fileProtocolStart != WTF::notFound) {
         StringView messageStringView { messageString };
         // FIXME: The code below does not handle additional text after url nor multiple urls. This matches DumpRenderTree implementation.
@@ -1648,7 +1648,7 @@ bool InjectedBundlePage::supportsFullScreen(WKBundlePageRef pageRef, WKFullScree
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("supportsFullScreen() == true\n");
+        injectedBundle.outputText("supportsFullScreen() == true\n"_s);
     return true;
 }
 
@@ -1663,7 +1663,7 @@ void InjectedBundlePage::enterFullScreenForElement(WKBundleNodeHandleRef element
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("enterFullScreenForElement()\n");
+        injectedBundle.outputText("enterFullScreenForElement()\n"_s);
 
     if (m_fullscreenState == EnteringFullscreen)
         return;
@@ -1695,7 +1695,7 @@ void InjectedBundlePage::exitFullScreenForElement(WKBundleNodeHandleRef elementR
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("exitFullScreenForElement()\n");
+        injectedBundle.outputText("exitFullScreenForElement()\n"_s);
 
     if (m_fullscreenState == ExitingFullscreen)
         return;
@@ -1719,21 +1719,21 @@ void InjectedBundlePage::beganEnterFullScreen(WKBundlePageRef, WKRect, WKRect)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("beganEnterFullScreen()\n");
+        injectedBundle.outputText("beganEnterFullScreen()\n"_s);
 }
 
 void InjectedBundlePage::beganExitFullScreen(WKBundlePageRef, WKRect, WKRect)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("beganExitFullScreen()\n");
+        injectedBundle.outputText("beganExitFullScreen()\n"_s);
 }
 
 void InjectedBundlePage::closeFullScreen(WKBundlePageRef pageRef)
 {
     auto& injectedBundle = InjectedBundle::singleton();
     if (injectedBundle.testRunner()->shouldDumpFullScreenCallbacks())
-        injectedBundle.outputText("closeFullScreen()\n");
+        injectedBundle.outputText("closeFullScreen()\n"_s);
 
     if (!injectedBundle.testRunner()->hasCustomFullScreenBehavior()) {
         WKBundlePageWillExitFullScreen(pageRef);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1462,7 +1462,7 @@ void TestController::configureContentExtensionForTest(const TestInvocation& test
     if (!contentExtensionsPath)
         contentExtensionsPath = "/tmp/wktr-contentextensions";
 
-    if (!test.urlContains("contentextensions/")) {
+    if (!test.urlContains("contentextensions/"_s)) {
         WKPageSetUserContentExtensionsEnabled(m_mainWebView->page(), false);
         return;
     }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -86,7 +86,7 @@ TestInvocation::TestInvocation(WKURLRef url, const TestOptions& options)
     m_urlString = toWTFString(adoptWK(WKURLCopyString(m_url.get())).get());
 
     // FIXME: Avoid mutating the setting via a test directory like this.
-    m_dumpFrameLoadCallbacks = urlContains("loading/") && !urlContains("://localhost");
+    m_dumpFrameLoadCallbacks = urlContains("loading/"_s) && !urlContains("://localhost"_s);
 }
 
 TestInvocation::~TestInvocation()
@@ -100,7 +100,7 @@ WKURLRef TestInvocation::url() const
     return m_url.get();
 }
 
-bool TestInvocation::urlContains(const char* searchString) const
+bool TestInvocation::urlContains(StringView searchString) const
 {
     return m_urlString.containsIgnoringASCIICase(searchString);
 }
@@ -127,7 +127,7 @@ WTF::Seconds TestInvocation::shortTimeout() const
 
 bool TestInvocation::shouldLogHistoryClientCallbacks() const
 {
-    return urlContains("globalhistory/");
+    return urlContains("globalhistory/"_s);
 }
 
 WKRetainPtr<WKMutableDictionaryRef> TestInvocation::createTestSettingsDictionary()

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -46,7 +46,7 @@ public:
     ~TestInvocation();
 
     WKURLRef url() const;
-    bool urlContains(const char*) const;
+    bool urlContains(StringView) const;
     
     const TestOptions& options() const { return m_options; }
 

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -179,7 +179,7 @@ TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCo
 #if ENABLE(CONTENT_EXTENSIONS)
 void TestController::configureContentExtensionForTest(const TestInvocation& test)
 {
-    if (!test.urlContains("contentextensions/"))
+    if (!test.urlContains("contentextensions/"_s))
         return;
 
     auto testURL = adoptCF(WKURLCopyCFURL(kCFAllocatorDefault, test.url()));


### PR DESCRIPTION
#### 324438e5a9e11f1a0d68227e6c49ee57c19758f5
<pre>
Make the StringView(const char*) constructor explicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=240754">https://bugs.webkit.org/show_bug.cgi?id=240754</a>

Reviewed by NOBODY (OOPS!).

Make the StringView(const char*) constructor explicit, to encourage people to use
ASCIILiteral / &quot;&quot;_s. StringView::fromLatin1() is available when the caller
really has a non-string literal. In a future patch, I will make this constructor
private.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::append):
* Source/WTF/wtf/text/StringView.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp:
(WebCore::toRtpCodecCapability):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::isValidAttributeName):
(WebCore::propertyNameMatchesAttributeName):
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::viewportErrorMessage):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverterCaches::elementHasOwnBackgroundColor):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
* Source/WebCore/html/URLDecomposition.cpp:
(WebCore::URLDecomposition::setPort):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion):
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::PrivateClickMeasurement::parseAttributionRequest):
(WebCore::PrivateClickMeasurement::appStoreURLAdamID):
* Source/WebCore/loader/mac/LoaderNSURLExtras.mm:
(suggestedFilenameWithMIMEType):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getUnmangledInfoLog):
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm:
(WebCore::CDMPrivateMediaSourceAVFObjC::parseKeySystem):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp:
(WebKit::ResourceLoadStatisticsDatabaseStore::migrateDataToPCMDatabaseIfNecessary):
(WebKit::ResourceLoadStatisticsDatabaseStore::aggregatedThirdPartyData const):
* Source/WebKit/NetworkProcess/NetworkSchemeRegistry.cpp:
(WebKit::NetworkSchemeRegistry::shouldTreatURLSchemeAsCORSEnabled):
* Source/WebKit/NetworkProcess/WebStorage/LocalStorageDatabaseTracker.cpp:
(WebKit::LocalStorageDatabaseTracker::LocalStorageDatabaseTracker):
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
(WebKit::NetworkCache::BlobStorage::blobPathForHash const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
* Source/WebKit/Platform/unix/EnvironmentUtilities.cpp:
(WebKit::EnvironmentUtilities::removeValuesEndingWith):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::getProcessIdentifier):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::constructedPathPrefix):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration additionalReadAccessAllowedURLs]):
(-[_WKProcessPoolConfiguration setAdditionalReadAccessAllowedURLs:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::isQuarantinedAndNotUserApproved):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::messageSourceIsValidWebContentProcess):
* Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp:
(WebKit::DeviceIdHashSaltStorage::deleteHashSaltFromDisk):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::SnapshotRemovalTracker::resume):
(WebKit::ViewGestureController::SnapshotRemovalTracker::start):
(WebKit::ViewGestureController::SnapshotRemovalTracker::fireRemovalCallbackImmediately):
(WebKit::ViewGestureController::SnapshotRemovalTracker::watchdogTimerFired):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::savePDFToFileInDownloadsFolder):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::resolvePathsForSandboxExtensions):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
* Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm:
(WebKit::WebProcessProxy::shouldAllowNonValidInjectedCode const):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleSetDatabaseQuota):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::tryLoadingUsingPDFJSHandler):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::streamDidReceiveResponse):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::dumpHistoryItem):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::shouldUsePDFPlugin const):
(WebKit::WebPage::platformCanHandleRequest):
* Source/WebKit/webpushd/AppBundleRequest.mm:
(WebPushD::AppBundleRequest::start):
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::ClientConnection::connectionClosed):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::Daemon::broadcastAllConnectionIdentities):
(WebPushD::Daemon::injectPushMessageForTesting):
(WebPushD::Daemon::injectEncryptedPushMessageForTesting):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(regExpForLabels):
(matchLabelsAgainstString):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(changeWindowScaleIfNeeded):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp:
(TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST):
(TestWebKitAPI::doStaticStringImplTests):
* Tools/TestWebKitAPI/Tests/WTF/StringToIntegerConversion.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp:
(TestWebKitAPI::invalidParts):
(TestWebKitAPI::shouldFail):
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::testUserPassword):
* Tools/TestWebKitAPI/Tests/WTF/UUID.cpp:
(TEST):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/DFACombiner.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/DFAHelpers.h:
(TestWebKitAPI::buildDFAFromPatterns):
* Tools/TestWebKitAPI/Tests/WebCore/DFAMinimizer.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
(TestWebKitAPI::readContentsOfFile):
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/EnvironmentUtilitiesTest.cpp:
(TestWebKitAPI::testStrip):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FTP.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
(TEST):
(runMultipleIndicesTestWithDatabase):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBObjectStoreInfoUpgradeToV2.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm:
(TestWebKitAPI::parseUserAgent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm:
(addAttributedPCMv2):
(addUnattributedPCMv2):
(addAttributedPCMv3):
(addUnattributedPCMv3):
(addUnattributedPCMv4):
(addAttributedPCMv4):
(addAttributedPCMv5):
(createAndPopulateObservedDomainTable):
(createAndPopulatePCMObservedDomainTable):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebSocket.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(ParsedRange::ParsedRange):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::didFinishProgress):
(WTR::InjectedBundlePage::dump):
(WTR::InjectedBundlePage::didDisplayInsecureContentForFrame):
(WTR::InjectedBundlePage::didRunInsecureContentForFrame):
(WTR::InjectedBundlePage::didDetectXSSForFrame):
(WTR::InjectedBundlePage::willSendRequestForFrame):
(WTR::InjectedBundlePage::willAddMessageToConsole):
(WTR::InjectedBundlePage::supportsFullScreen):
(WTR::InjectedBundlePage::enterFullScreenForElement):
(WTR::InjectedBundlePage::exitFullScreenForElement):
(WTR::InjectedBundlePage::beganEnterFullScreen):
(WTR::InjectedBundlePage::beganExitFullScreen):
(WTR::InjectedBundlePage::closeFullScreen):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::configureContentExtensionForTest):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::TestInvocation):
(WTR::TestInvocation::urlContains const):
(WTR::TestInvocation::shouldLogHistoryClientCallbacks const):
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::configureContentExtensionForTest):
</pre>