### PR TITLE
[CMake] Cannot link WebKitTestRunner in non-unified builds

### DIFF
--- a/Tools/WebKitTestRunner/CMakeLists.txt
+++ b/Tools/WebKitTestRunner/CMakeLists.txt
@@ -21,10 +21,10 @@ set(WebKitTestRunner_SOURCES
 
 set(WebKitTestRunner_LIBRARIES
     TestRunnerShared
+    WebKit::WebCore
 )
 set(WebKitTestRunner_FRAMEWORKS
     JavaScriptCore
-    WebCore
     WebCoreTestSupport
 )
 


### PR DESCRIPTION
#### bc0eb4c9300d6b74f321e2697b663f6e49247c49
<pre>
[CMake] Cannot link WebKitTestRunner in non-unified builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=240755">https://bugs.webkit.org/show_bug.cgi?id=240755</a>

Reviewed by NOBODY (OOPS!).

* Tools/WebKitTestRunner/CMakeLists.txt: List WebCore::WebCore in
  WebKitTestRunner_LIBARARIES instead of _FRAMEWORKS, which actually
  cases WebCore to be linked in WKTR on all platforms, this avoiding
  hitting missing symbols.
</pre>