### PR TITLE
[WPE][GTK] Missing API to pass client-side messages to new pages on the web extension side

### DIFF
--- a/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
@@ -31,6 +31,7 @@
 #include <wtf/RefPtr.h>
 
 namespace WebKit {
+class WebPageProxy;
 class WebProcessPool;
 }
 
@@ -44,6 +45,9 @@ public:
     virtual void didReceiveMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, API::Object*) { }
     virtual void didReceiveSynchronousMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler) { completionHandler(nullptr); }
     virtual RefPtr<API::Object> getInjectedBundleInitializationUserData(WebKit::WebProcessPool&) { return nullptr; }
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    virtual RefPtr<API::Object> getInjectedBundleInitializationUserDataByPage(WebKit::WebProcessPool&, WebKit::WebPageProxy&) { return nullptr; }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
@@ -174,6 +174,17 @@ private:
         return API::String::create(String::fromUTF8(dataString.get()));
     }
 
+    RefPtr<API::Object> getInjectedBundleInitializationUserDataByPage(WebProcessPool&, WebPageProxy& page) override
+    {
+        if (WebKitWebView* webView = webkitWebContextGetWebViewForPage(m_webContext, &page))
+            if (!webkitWebViewHasMainResource(webView)) {
+                GRefPtr<GVariant> data = webkitWebViewInitializeWebExtensions(webView);
+                GUniquePtr<gchar> dataString(g_variant_print(data.get(), TRUE));
+                return API::String::create(String::fromUTF8(dataString.get()));
+            }
+        return nullptr;
+    }
+
     WebKitWebContext* m_webContext;
 };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -124,3 +124,6 @@ void webkitWebViewDeleteSurrounding(WebKitWebView*, int offset, unsigned charact
 void webkitWebViewSetIsWebProcessResponsive(WebKitWebView*, bool);
 
 guint createShowOptionMenuSignal(WebKitWebViewClass*);
+
+GVariant* webkitWebViewInitializeWebExtensions(WebKitWebView*);
+bool webkitWebViewHasMainResource(WebKitWebView*);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebView.h
@@ -293,9 +293,7 @@ struct _WebKitWebViewClass {
                                                 WebKitWebProcessTerminationReason reason);
     gboolean   (* user_message_received)       (WebKitWebView               *web_view,
                                                 WebKitUserMessage           *message);
-
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
+    void       (* initialize_web_extensions)   (WebKitWebView               *web_view);
 };
 
 WEBKIT_API GType
@@ -638,6 +636,11 @@ webkit_web_view_get_display_capture_state            (WebKitWebView             
 WEBKIT_API void
 webkit_web_view_set_display_capture_state            (WebKitWebView             *web_view,
                                                       WebKitMediaCaptureState    state);
+
+WEBKIT_API void
+webkit_web_view_set_web_extensions_initialization_user_data
+                                                    (WebKitWebView              *web_view,
+                                                     GVariant                   *user_data);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebView.h
@@ -270,6 +270,7 @@ struct _WebKitWebViewClass {
     gboolean       (* show_option_menu)            (WebKitWebView               *web_view,
                                                     WebKitOptionMenu            *menu,
                                                     WebKitRectangle             *rectangle);
+    void           (* initialize_web_extensions)   (WebKitWebView               *web_view);
 
     /*< private >*/
     void (*_webkit_reserved0) (void);
@@ -277,7 +278,6 @@ struct _WebKitWebViewClass {
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
     void (*_webkit_reserved4) (void);
-    void (*_webkit_reserved5) (void);
 };
 
 WEBKIT_API GType
@@ -615,6 +615,10 @@ webkit_web_view_get_display_capture_state            (WebKitWebView             
 WEBKIT_API void
 webkit_web_view_set_display_capture_state            (WebKitWebView             *web_view,
                                                       WebKitMediaCaptureState    state);
+WEBKIT_API void
+webkit_web_view_set_web_extensions_initialization_user_data
+                                                    (WebKitWebView              *web_view,
+                                                     GVariant                   *user_data);
 
 G_END_DECLS
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionPrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionPrivate.h
@@ -26,4 +26,5 @@
 
 WebKitWebExtension* webkitWebExtensionCreate(WebKit::InjectedBundle*);
 void webkitWebExtensionDidReceiveUserMessage(WebKitWebExtension*, WebKit::UserMessage&&);
+void webkitWebExtensionDidInitializeWebExtension(WebKitWebExtension*, API::Object*);
 WK_EXPORT void webkitWebExtensionSetGarbageCollectOnPageDestroy(WebKitWebExtension*);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -396,6 +396,9 @@ private:
     WebProcess();
     ~WebProcess();
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    void initializeWebExtensions(const UserData&);
+#endif
     void initializeWebProcess(WebProcessCreationParameters&&);
     void platformInitializeWebProcess(WebProcessCreationParameters&);
     void setWebsiteDataStoreParameters(WebProcessDataStoreParameters&&);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -21,6 +21,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebProcess LegacyReceiver NotRefCounted {
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    InitializeWebExtensions(WebKit::UserData userData);
+#endif
     InitializeWebProcess(struct WebKit::WebProcessCreationParameters processCreationParameters)
     SetWebsiteDataStoreParameters(struct WebKit::WebProcessDataStoreParameters parameters)
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -77,6 +77,12 @@ namespace WebKit {
 
 using namespace WebCore;
 
+void WebProcess::initializeWebExtensions(const UserData& userData)
+{
+    if (auto* extension = WebKitExtensionManager::singleton().extension())
+        webkitWebExtensionDidInitializeWebExtension(extension, transformHandlesToObjects(userData.object()).get());
+}
+
 void WebProcess::stopRunLoop()
 {
     // Pages are normally closed after Close message is received from the UI


### PR DESCRIPTION
#### b1f6ab59d937c89e9a31525a3ae3c2bafadadfdd
<pre>
[WPE][GTK] Missing API to pass client-side messages to new pages on the web extension side
<a href="https://bugs.webkit.org/show_bug.cgi?id=238598">https://bugs.webkit.org/show_bug.cgi?id=238598</a>

The WebProcessPool sends a Messages::WebProcess::InitializeWebExtensions
with serialized UserData information every time that a
DidInitiateLoadForResource message is being received from a
WebProcess for a WebKitWebView what still doesn&apos;t have a main
resource loaded.

The WebProcessPool contructs the UserData message using the data from the
priv-&gt;webExtensionsInitializationUserData in the WebKitWebView.
It requires of a new getInjectedBundleInitializationUserDataByPage()
method in the InjectedBundle API.

A WebKitWebView can update the priv-&gt;webExtensionsInitializationUserData by
listening the &quot;initialize-web-extensions&quot; signal and use the
webkit_web_view_set_web_extensions_initialization_user_data()

The WebProcess receives the InitializeWebExtensions message and
triggers an &quot;initialize-web-extensions&quot; signal for the
WebKitWebExtension.

A WebKitWebExtension can get the UserData message by listening the
&quot;initialize-web-extensions&quot; signal.

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/API/APIInjectedBundleClient.h:
(API::InjectedBundleClient::getInjectedBundleInitializationUserDataByPage):
* Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
(webkit_web_view_set_web_extensions_initialization_user_data):
(webkitWebViewHasMainResource):
(webkitWebViewInitializeWebExtensions):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebView.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebView.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::handleMessage):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp:
(parseUserData):
(webkitWebExtensionDidInitializeWebExtension):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtensionPrivate.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::initializeWebExtensions):
</pre>