### PR TITLE
Layout Test Failures: Fix field order

### DIFF
--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -201,11 +201,11 @@ Structure::Structure(VM& vm, JSGlobalObject* globalObject, JSValue prototype, co
     , m_outOfLineTypeFlags(typeInfo.outOfLineTypeFlags())
     , m_inlineCapacity(inlineCapacity)
     , m_bitField(0)
+    , m_propertyHash(0)
     , m_globalObject(vm, this, globalObject, WriteBarrier<JSGlobalObject>::MayBeNull)
     , m_prototype(vm, this, prototype)
     , m_classInfo(classInfo)
     , m_transitionWatchpointSet(IsWatched)
-    , m_propertyHash(0)
 {
     setDictionaryKind(NoneDictionaryKind);
     setIsPinnedPropertyTable(false);
@@ -244,10 +244,10 @@ Structure::Structure(VM& vm, CreatingEarlyCellTag)
     : JSCell(CreatingEarlyCell)
     , m_inlineCapacity(0)
     , m_bitField(0)
+    , m_propertyHash(0)
     , m_prototype(vm, this, jsNull())
     , m_classInfo(info())
     , m_transitionWatchpointSet(IsWatched)
-    , m_propertyHash(0)
 {
     setDictionaryKind(NoneDictionaryKind);
     setIsPinnedPropertyTable(false);
@@ -284,11 +284,11 @@ Structure::Structure(VM& vm, Structure* previous)
     : JSCell(vm, vm.structureStructure.get())
     , m_inlineCapacity(previous->m_inlineCapacity)
     , m_bitField(0)
+    , m_propertyHash(previous->m_propertyHash)
+    , m_seenProperties(previous->m_seenProperties)
     , m_prototype(vm, this, previous->m_prototype.get())
     , m_classInfo(previous->m_classInfo)
     , m_transitionWatchpointSet(IsWatched)
-    , m_propertyHash(previous->m_propertyHash)
-    , m_seenProperties(previous->m_seenProperties)
 {
     setDictionaryKind(previous->dictionaryKind());
     setIsPinnedPropertyTable(false);

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -966,6 +966,12 @@ private:
 
     uint32_t m_bitField;
 
+    uint16_t m_transitionOffset;
+    uint16_t m_maxOffset;
+
+    uint32_t m_propertyHash;
+    TinyBloomFilter m_seenProperties;
+
     WriteBarrier<JSGlobalObject> m_globalObject;
     WriteBarrier<Unknown> m_prototype;
     mutable WriteBarrier<StructureChain> m_cachedPrototypeChain;
@@ -985,12 +991,6 @@ private:
     mutable InlineWatchpointSet m_transitionWatchpointSet;
 
     static_assert(firstOutOfLineOffset < 256);
-
-    uint16_t m_transitionOffset;
-    uint16_t m_maxOffset;
-
-    uint32_t m_propertyHash;
-    TinyBloomFilter m_seenProperties;
 
     friend class VMInspector;
     friend class JSDollarVMHelper;


### PR DESCRIPTION
#### cc70eda927163e6c6adcb0d21e689b57c1a60855
<pre>
Layout Test Failures: Fix field order
<a href="https://bugs.webkit.org/show_bug.cgi?id=240407">https://bugs.webkit.org/show_bug.cgi?id=240407</a>

Reviewed by NOBODY (OOPS!).

We have 2% RAMification regression on iOS, which needs a memory performance improvement. To work towards resolving this regression, this patch is to reduce JS object&apos;s structure size from 112 bytes to 96 bytes for iOS systems.

1. We can reduce 36-bit addresses into 4 bytes when dealing with pointers that have 16-byte alignment.
2. StructureID can be removed from StructureIDBlob since we can directly compute the id by encoding the Structure pointer.

CompactPtr and CompactRefPtr classes are introduced for pointers, which can achieve 8 bytes in MacOS and 4 bytes in iOS.

* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/expected.js:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* PerformanceTests/RexBench/OfflineAssembler/expected.js:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/bytecode/GetByValHistory.h:
(JSC::GetByValHistory::observe):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::AbstractHeapRepository):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::genericAddPointer):
(JSC::ConservativeRoots::genericAddSpan):
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/heap/HeapSnapshot.h:
* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::findGCObjectPointersForMarking):
(JSC::HeapUtil::isPointerGCObjectJSCell):
(JSC::HeapUtil::isValueGCObject):
* Source/JavaScriptCore/heap/MarkedBlockSet.h:
(JSC::MarkedBlockSet::add):
(JSC::MarkedBlockSet::recomputeFilter):
(JSC::MarkedBlockSet::filter const):
* Source/JavaScriptCore/heap/TinyBloomFilter.h:
(JSC::TinyBloomFilter&lt;Bits&gt;::TinyBloomFilter):
(JSC::TinyBloomFilter&lt;Bits&gt;::add):
(JSC::TinyBloomFilter&lt;Bits&gt;::ruleOut const):
(JSC::TinyBloomFilter&lt;Bits&gt;::reset):
(JSC::TinyBloomFilter::TinyBloomFilter): Deleted.
(JSC::TinyBloomFilter::add): Deleted.
(JSC::TinyBloomFilter::ruleOut const): Deleted.
(JSC::TinyBloomFilter::reset): Deleted.
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
(JSC::AssemblyHelpers::emitEncodeStructure):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
(JSC::AssemblyHelpers::loadCompactPtr):
(JSC::AssemblyHelpers::branchCompactPtr):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::generateOpGetFromScopeThunk):
(JSC::JIT::emit_op_put_to_scope):
* Source/JavaScriptCore/runtime/ClassInfo.h:
(JSC::ClassInfo::offsetOfParentClass): Deleted.
(JSC::ClassInfo::isSubClassOf const): Deleted.
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::processUnverifiedStackTraces):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::id const):
(JSC::Structure::typeInfoBlob const):
(JSC::Structure::classInfoForCells const):
(JSC::Structure::indexingModeIncludingHistoryOffset):
(JSC::Structure::objectInitializationBlob const): Deleted.
(JSC::Structure::idBlob const): Deleted.
(JSC::Structure::structureIDOffset): Deleted.
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::get):
(JSC::Structure::add):
* Source/JavaScriptCore/runtime/TypeInfoBlob.h: Renamed from Source/JavaScriptCore/runtime/StructureIDBlob.h.
(JSC::TypeInfoBlob::TypeInfoBlob):
(JSC::TypeInfoBlob::operator=):
(JSC::TypeInfoBlob::indexingModeIncludingHistory const):
(JSC::TypeInfoBlob::fencedIndexingModeIncludingHistory):
(JSC::TypeInfoBlob::setIndexingModeIncludingHistory):
(JSC::TypeInfoBlob::type const):
(JSC::TypeInfoBlob::inlineTypeFlags const):
(JSC::TypeInfoBlob::typeInfo const):
(JSC::TypeInfoBlob::blob const):
(JSC::TypeInfoBlob::indexingModeIncludingHistoryOffset):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CompactPtr.h: Added.
(WTF::CompactPtr::CompactPtr):
(WTF::CompactPtr::operator* const):
(WTF::CompactPtr::operator-&gt; const):
(WTF::CompactPtr::operator! const):
(WTF::CompactPtr::operator bool const):
(WTF::CompactPtr::operator=):
(WTF::CompactPtr::get const):
(WTF::CompactPtr::set):
(WTF::CompactPtr::exchange):
(WTF::CompactPtr::swap):
(WTF::CompactPtr::encode):
(WTF::CompactPtr::encode const):
(WTF::CompactPtr::decode const):
(WTF::GetPtrHelper&lt;CompactPtr&lt;T&gt;&gt;::getPtr):
(WTF::CompactPtrTraits::exchange):
(WTF::CompactPtrTraits::swap):
(WTF::CompactPtrTraits::unwrap):
(WTF::CompactPtrTraits::hashTableDeletedValue):
(WTF::CompactPtrTraits::isHashTableDeletedValue):
* Source/WTF/wtf/CompactRefPtr.h: Copied from Source/JavaScriptCore/heap/HeapSnapshot.h.
* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/AlignedRefLogger.h: Copied from Source/JavaScriptCore/heap/TinyBloomFilter.h.
(TestWebKitAPI::DerivedAlignedRefLogger::DerivedAlignedRefLogger):
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::f1):
(TestWebKitAPI::returnConstRefCountedRef):
(TestWebKitAPI::returnRefCountedRef):
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::CompactRefPtrCheckingAlignedRefLogger):
(TestWebKitAPI::loggerName):
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::ref):
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::deref):
* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST):
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/expected.js:

Layout Test Failures: Revert CompactPtr, CompactRefPtr, and TinyBloomFilter

* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::classInfoForCells const):

Layout Test Failures: Revert CompactPtr Completely

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/runtime/ClassInfo.h:
(): Deleted.
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::get):
(JSC::Structure::add):

Layout Test Failures: Revert StructureIDBlob

Reviewed by NOBODY (OOPS!).

* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/expected.js:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* PerformanceTests/RexBench/OfflineAssembler/expected.js:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::AbstractHeapRepository):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::generateOpGetFromScopeThunk):
(JSC::JIT::emit_op_put_to_scope):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::id const):
(JSC::Structure::objectInitializationBlob const):
(JSC::Structure::idBlob const):
(JSC::Structure::structureIDOffset):
(JSC::Structure::indexingModeIncludingHistoryOffset):
(JSC::Structure::typeInfoBlob const): Deleted.
* Source/JavaScriptCore/runtime/StructureIDBlob.h: Renamed from Source/JavaScriptCore/runtime/TypeInfoBlob.h.
(JSC::StructureIDBlob::StructureIDBlob):
(JSC::StructureIDBlob::operator=):
(JSC::StructureIDBlob::structureID const):
(JSC::StructureIDBlob::indexingModeIncludingHistory const):
(JSC::StructureIDBlob::fencedIndexingModeIncludingHistory):
(JSC::StructureIDBlob::setIndexingModeIncludingHistory):
(JSC::StructureIDBlob::type const):
(JSC::StructureIDBlob::inlineTypeFlags const):
(JSC::StructureIDBlob::typeInfo const):
(JSC::StructureIDBlob::blobExcludingStructureID const):
(JSC::StructureIDBlob::blob const):
(JSC::StructureIDBlob::structureIDOffset):
(JSC::StructureIDBlob::indexingModeIncludingHistoryOffset):
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/LowLevelInterpreter64.asm:
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/LowLevelInterpreter64.js:
* Websites/browserbench.org/JetStream2.0/RexBench/OfflineAssembler/expected.js:

Layout Test Failures: Revert TinyBloomFilter Completely

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/bytecode/GetByValHistory.h:
(JSC::GetByValHistory::observe):
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::genericAddPointer):
(JSC::ConservativeRoots::genericAddSpan):
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/heap/HeapSnapshot.h:
* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::findGCObjectPointersForMarking):
(JSC::HeapUtil::isPointerGCObjectJSCell):
(JSC::HeapUtil::isValueGCObject):
* Source/JavaScriptCore/heap/MarkedBlockSet.h:
(JSC::MarkedBlockSet::add):
(JSC::MarkedBlockSet::recomputeFilter):
(JSC::MarkedBlockSet::filter const):
* Source/JavaScriptCore/heap/TinyBloomFilter.h:
(JSC::TinyBloomFilter::TinyBloomFilter):
(JSC::TinyBloomFilter::add):
(JSC::TinyBloomFilter::ruleOut const):
(JSC::TinyBloomFilter::reset):
(JSC::TinyBloomFilter&lt;Bits&gt;::TinyBloomFilter): Deleted.
(JSC::TinyBloomFilter&lt;Bits&gt;::add): Deleted.
(JSC::TinyBloomFilter&lt;Bits&gt;::ruleOut const): Deleted.
(JSC::TinyBloomFilter&lt;Bits&gt;::reset): Deleted.
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::processUnverifiedStackTraces):
* Source/JavaScriptCore/runtime/Structure.h:

Layout Test Failures: Revert CompactPtr and CompactRefPtr completely

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/WTF/wtf/CompactPtr.h:
(WTF::CompactPtr::CompactPtr): Deleted.
(WTF::CompactPtr::operator* const): Deleted.
(WTF::CompactPtr::operator-&gt; const): Deleted.
(WTF::CompactPtr::operator! const): Deleted.
(WTF::CompactPtr::operator bool const): Deleted.
(WTF::CompactPtr::operator=): Deleted.
(WTF::CompactPtr::get const): Deleted.
(WTF::CompactPtr::set): Deleted.
(WTF::CompactPtr::exchange): Deleted.
(WTF::CompactPtr::swap): Deleted.
(WTF::CompactPtr::encode): Deleted.
(WTF::CompactPtr::encode const): Deleted.
(WTF::CompactPtr::decode const): Deleted.
(WTF::GetPtrHelper&lt;CompactPtr&lt;T&gt;&gt;::getPtr): Deleted.
(WTF::CompactPtrTraits::exchange): Deleted.
(WTF::CompactPtrTraits::swap): Deleted.
(WTF::CompactPtrTraits::unwrap): Deleted.
(WTF::CompactPtrTraits::hashTableDeletedValue): Deleted.
(WTF::CompactPtrTraits::isHashTableDeletedValue): Deleted.
* Source/WTF/wtf/CompactRefPtr.h:
* Tools/TestWebKitAPI/Tests/WTF/AlignedRefLogger.h:
(): Deleted.
(TestWebKitAPI::DerivedAlignedRefLogger::DerivedAlignedRefLogger): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp:
(TestWebKitAPI::TEST): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp:
(TestWebKitAPI::TEST): Deleted.
(TestWebKitAPI::f1): Deleted.
(): Deleted.
(TestWebKitAPI::returnConstRefCountedRef): Deleted.
(TestWebKitAPI::returnRefCountedRef): Deleted.
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::CompactRefPtrCheckingAlignedRefLogger): Deleted.
(TestWebKitAPI::loggerName): Deleted.
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::ref): Deleted.
(TestWebKitAPI::CompactRefPtrCheckingAlignedRefLogger::deref): Deleted.

Layout Test Failures: Clean UP!!!!

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
(JSC::AssemblyHelpers::emitEncodeStructure): Deleted.
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::emitStoreStructureWithTypeInfo):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::generateOpGetFromScopeThunk):
(JSC::JIT::emit_op_put_to_scope):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:

Layout Test Failures: Revert alignas(16) StringImpl

Reviewed by NOBODY (OOPS!).

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CompactPtr.h: Removed.
* Source/WTF/wtf/CompactRefPtr.h: Removed.
* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/AlignedRefLogger.h: Removed.
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp: Removed.
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp: Removed.
* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST):

Layout Test Failures: Fix field order

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
</pre>