### PR TITLE
[WPE] Add gamepad support

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -604,10 +604,6 @@ webkit.org/b/217369 fast/canvas/fill-text-with-font-features.html [ ImageOnlyFai
 
 webkit.org/b/217370 fast/events/setDragImage-element-non-nullable.html [ Failure ]
 
-# ENABLE_GAMEPAD not enabled.
-webkit.org/b/213131 gamepad [ Skip ]
-webkit.org/b/213131 http/tests/misc/gamepads-insecure.html [ Skip ]
-
 # WebXR
 webkit.org/b/225483 [ Release ] imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https.html [ Pass ]
 webkit.org/b/225483 [ Release ] imported/w3c/web-platform-tests/webxr/events_input_sources_change.https.html [ Pass ]

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -140,3 +140,9 @@ if (USE_LIBGBM)
         ${LIBDRM_LIBRARIES}
     )
 endif ()
+
+if (ENABLE_GAMEPAD)
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/gamepad/wpe/WPEGamepadProvider.h
+    )
+endif ()

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -62,6 +62,9 @@ platform/UserAgentQuirks.cpp
 platform/adwaita/ScrollbarThemeAdwaita.cpp
 platform/adwaita/ThemeAdwaita.cpp
 
+platform/gamepad/wpe/WPEGamepad.cpp
+platform/gamepad/wpe/WPEGamepadProvider.cpp
+
 platform/generic/ScrollbarsControllerGeneric.cpp
 
 platform/graphics/ANGLEWebKitBridge.cpp

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 RDK Management  All rights reserved.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEGamepad.h"
+
+#if ENABLE(GAMEPAD)
+
+#include "WPEGamepadProvider.h"
+#include <wpe/wpe.h>
+
+namespace WebCore {
+
+WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadId, unsigned index)
+    : PlatformGamepad(index)
+    , m_buttonValues(WPE_GAMEPAD_BUTTON_COUNT)
+    , m_axisValues(WPE_GAMEPAD_AXIS_COUNT)
+    , m_gamepad(wpe_gamepad_create(provider, gamepadId), wpe_gamepad_destroy)
+{
+    ASSERT(m_gamepad);
+
+    m_connectTime = m_lastUpdateTime = MonotonicTime::now();
+
+    m_id = String::fromUTF8(wpe_gamepad_get_id(m_gamepad.get()));
+    m_mapping = String::fromUTF8("standard");
+
+    static const struct wpe_gamepad_client_interface s_client = {
+        // button_event
+        [](void* data, enum wpe_gamepad_button button, bool pressed) {
+            auto& self = *static_cast<WPEGamepad*>(data);
+            self.buttonPressedOrReleased(static_cast<unsigned>(button), pressed);
+        },
+        // axis_event
+        [](void* data, enum wpe_gamepad_axis axis, double value) {
+            auto& self = *static_cast<WPEGamepad*>(data);
+            self.absoluteAxisChanged(static_cast<unsigned>(axis), value);
+        },
+        nullptr, nullptr, nullptr,
+    };
+    wpe_gamepad_set_client(m_gamepad.get(), &s_client, this);
+}
+
+WPEGamepad::~WPEGamepad()
+{
+    wpe_gamepad_set_client(m_gamepad.get(), nullptr, nullptr);
+}
+
+void WPEGamepad::buttonPressedOrReleased(unsigned button, bool pressed)
+{
+    m_lastUpdateTime = MonotonicTime::now();
+    m_buttonValues[button].setValue(pressed ? 1.0 : 0.0);
+
+    WPEGamepadProvider::singleton().scheduleInputNotification(*this, pressed ? WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes : WPEGamepadProvider::ShouldMakeGamepadsVisible::No);
+}
+
+void WPEGamepad::absoluteAxisChanged(unsigned axis, double value)
+{
+    m_lastUpdateTime = MonotonicTime::now();
+    m_axisValues[axis].setValue(value);
+
+    WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::No);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepad.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 RDK Management  All rights reserved.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+#include "PlatformGamepad.h"
+
+struct wpe_gamepad;
+struct wpe_gamepad_provider;
+
+namespace WebCore {
+
+class WPEGamepad final : public PlatformGamepad {
+public:
+    WPEGamepad(struct wpe_gamepad_provider*, uintptr_t, unsigned);
+    virtual ~WPEGamepad();
+
+    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+
+    const struct wpe_gamepad* wpeGamepad() const { return m_gamepad.get(); }
+
+private:
+    void buttonPressedOrReleased(unsigned, bool);
+    void absoluteAxisChanged(unsigned, double);
+
+    Vector<SharedGamepadValue> m_buttonValues;
+    Vector<SharedGamepadValue> m_axisValues;
+
+    std::unique_ptr<struct wpe_gamepad, void(*)(struct wpe_gamepad*)> m_gamepad;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2020 RDK Management  All rights reserved.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEGamepadProvider.h"
+
+#if ENABLE(GAMEPAD)
+
+#include "GamepadProviderClient.h"
+#include "Logging.h"
+#include "WPEGamepad.h"
+#include <wpe/wpe.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+static const Seconds connectionDelayInterval { 500_ms };
+static const Seconds inputNotificationDelay { 50_ms };
+
+WPEGamepadProvider& WPEGamepadProvider::singleton()
+{
+    static NeverDestroyed<WPEGamepadProvider> sharedProvider;
+    return sharedProvider;
+}
+
+WPEGamepadProvider::WPEGamepadProvider()
+    : m_provider(wpe_gamepad_provider_create(), wpe_gamepad_provider_destroy)
+    , m_initialGamepadsConnectedTimer(RunLoop::current(), this, &WPEGamepadProvider::initialGamepadsConnectedTimerFired)
+    , m_inputNotificationTimer(RunLoop::current(), this, &WPEGamepadProvider::inputNotificationTimerFired)
+{
+    static const struct wpe_gamepad_provider_client_interface s_client = {
+        // connected
+        [](void* data, uintptr_t gamepadId) {
+            auto& provider = *static_cast<WPEGamepadProvider*>(data);
+            provider.gamepadConnected(gamepadId);
+        },
+        // disconnected
+        [](void* data, uintptr_t gamepadId) {
+            auto& provider = *static_cast<WPEGamepadProvider*>(data);
+            provider.gamepadDisconnected(gamepadId);
+        },
+        nullptr, nullptr, nullptr,
+    };
+
+    wpe_gamepad_provider_set_client(m_provider.get(), &s_client, this);
+}
+
+WPEGamepadProvider::~WPEGamepadProvider()
+{
+    wpe_gamepad_provider_set_client(m_provider.get(), nullptr, nullptr);
+}
+
+void WPEGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
+{
+    if (!m_provider)
+        return;
+
+    bool shouldOpenAndScheduleManager = m_clients.isEmpty();
+
+    ASSERT(!m_clients.contains(&client));
+    m_clients.add(&client);
+
+    if (!shouldOpenAndScheduleManager)
+        return;
+
+    ASSERT(m_gamepadVector.isEmpty());
+    ASSERT(m_gamepadMap.isEmpty());
+
+    m_initialGamepadsConnected = false;
+
+    // Any connections we are notified of within the connectionDelayInterval of listening likely represent
+    // devices that were already connected, so we suppress notifying clients of these.
+    m_initialGamepadsConnectedTimer.startOneShot(connectionDelayInterval);
+
+    wpe_gamepad_provider_start(m_provider.get());
+}
+
+void WPEGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
+{
+    if (!m_provider)
+        return;
+
+    ASSERT(m_clients.contains(&client));
+
+    bool shouldCloseAndUnscheduleManager = m_clients.remove(&client) && m_clients.isEmpty();
+    if (!shouldCloseAndUnscheduleManager)
+        return;
+
+    wpe_gamepad_provider_stop(m_provider.get());
+
+    m_gamepadVector.clear();
+    m_gamepadMap.clear();
+    m_initialGamepadsConnectedTimer.stop();
+    m_lastActiveGamepad = nullptr;
+}
+
+void WPEGamepadProvider::gamepadConnected(unsigned id)
+{
+    ASSERT(!m_gamepadMap.get(id));
+    ASSERT(m_provider);
+
+    LOG(Gamepad, "WPEGamepadProvider device %u added", id);
+
+    unsigned index = indexForNewlyConnectedDevice();
+    auto gamepad = makeUnique<WPEGamepad>(m_provider.get(), id, index);
+
+    if (m_gamepadVector.size() <= index)
+        m_gamepadVector.grow(index + 1);
+
+    m_gamepadVector[index] = gamepad.get();
+    m_gamepadMap.set(id, WTFMove(gamepad));
+
+    if (!m_initialGamepadsConnected) {
+        // This added device is the result of us starting to monitor gamepads.
+        // We'll get notified of all connected devices during this current spin of the runloop
+        // and the client should be told they were already connected.
+        // The m_connectionDelayTimer fires in a subsequent spin of the runloop after which
+        // any connection events are actual new devices and can trigger gamepad visibility.
+        if (!m_initialGamepadsConnectedTimer.isActive())
+            m_initialGamepadsConnectedTimer.startOneShot(0_s);
+    }
+
+    auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
+    for (auto& client : m_clients)
+        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+}
+
+void WPEGamepadProvider::gamepadDisconnected(unsigned id)
+{
+    LOG(Gamepad, "WPEGamepadProvider device %u removed", id);
+
+    auto removedGamepad = removeGamepadForId(id);
+    ASSERT(removedGamepad);
+
+    if (removedGamepad->wpeGamepad() == m_lastActiveGamepad)
+        m_lastActiveGamepad = nullptr;
+
+    for (auto& client : m_clients)
+        client->platformGamepadDisconnected(*removedGamepad);
+}
+
+unsigned WPEGamepadProvider::indexForNewlyConnectedDevice()
+{
+    unsigned index = 0;
+    while (index < m_gamepadVector.size() && m_gamepadVector[index])
+        ++index;
+
+    return index;
+}
+
+std::unique_ptr<WPEGamepad> WPEGamepadProvider::removeGamepadForId(unsigned id)
+{
+    auto removedGamepad = m_gamepadMap.take(id);
+    ASSERT(removedGamepad);
+
+    auto index = m_gamepadVector.find(removedGamepad.get());
+    if (index != notFound)
+        m_gamepadVector[index] = nullptr;
+
+    if (removedGamepad->wpeGamepad() == m_lastActiveGamepad)
+        m_lastActiveGamepad = nullptr;
+
+    return removedGamepad;
+}
+
+void WPEGamepadProvider::initialGamepadsConnectedTimerFired()
+{
+    m_initialGamepadsConnected = true;
+}
+
+void WPEGamepadProvider::inputNotificationTimerFired()
+{
+    if (!m_initialGamepadsConnected) {
+        if (!m_inputNotificationTimer.isActive())
+            m_inputNotificationTimer.startOneShot(0_s);
+        return;
+    }
+
+    dispatchPlatformGamepadInputActivity();
+}
+
+void WPEGamepadProvider::scheduleInputNotification(WPEGamepad& gamepad, ShouldMakeGamepadsVisible shouldMakeGamepadsVisible)
+{
+    m_lastActiveGamepad = const_cast<struct wpe_gamepad*>(gamepad.wpeGamepad());
+
+    if (!m_inputNotificationTimer.isActive())
+        m_inputNotificationTimer.startOneShot(inputNotificationDelay);
+
+    if (shouldMakeGamepadsVisible == ShouldMakeGamepadsVisible::Yes)
+        setShouldMakeGamepadsVisibile();
+}
+
+struct wpe_view_backend* WPEGamepadProvider::inputView()
+{
+    if (!m_provider || !m_lastActiveGamepad)
+        return nullptr;
+    return wpe_gamepad_provider_get_view_backend(m_provider.get(), m_lastActiveGamepad);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 RDK Management  All rights reserved.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GAMEPAD)
+
+#include "GamepadProvider.h"
+#include <wtf/HashMap.h>
+#include <wtf/RunLoop.h>
+
+struct wpe_gamepad;
+struct wpe_gamepad_provider;
+struct wpe_view_backend;
+
+namespace WebCore {
+
+class WPEGamepad;
+
+class WPEGamepadProvider final : public GamepadProvider {
+    WTF_MAKE_NONCOPYABLE(WPEGamepadProvider);
+    friend class NeverDestroyed<WPEGamepadProvider>;
+
+public:
+    static WPEGamepadProvider& singleton();
+
+    virtual ~WPEGamepadProvider();
+
+    void startMonitoringGamepads(GamepadProviderClient&) final;
+    void stopMonitoringGamepads(GamepadProviderClient&) final;
+    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+
+    enum class ShouldMakeGamepadsVisible : bool { No,
+        Yes };
+    void scheduleInputNotification(WPEGamepad&, ShouldMakeGamepadsVisible);
+
+    struct wpe_view_backend* inputView();
+
+private:
+    WPEGamepadProvider();
+
+    void gamepadConnected(unsigned);
+    void gamepadDisconnected(unsigned);
+    std::unique_ptr<WPEGamepad> removeGamepadForId(unsigned);
+
+    unsigned indexForNewlyConnectedDevice();
+    void initialGamepadsConnectedTimerFired();
+    void inputNotificationTimerFired();
+
+    Vector<PlatformGamepad*> m_gamepadVector;
+    HashMap<unsigned, std::unique_ptr<WPEGamepad>> m_gamepadMap;
+    bool m_initialGamepadsConnected { false };
+
+    std::unique_ptr<struct wpe_gamepad_provider, void (*)(struct wpe_gamepad_provider*)> m_provider;
+    struct wpe_gamepad* m_lastActiveGamepad { nullptr };
+
+    RunLoop::Timer<WPEGamepadProvider> m_initialGamepadsConnectedTimer;
+    RunLoop::Timer<WPEGamepadProvider> m_inputNotificationTimer;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -204,6 +204,8 @@ UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 
+UIProcess/Gamepad/wpe/UIGamepadProviderWPE.cpp
+
 UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 
 UIProcess/glib/WebPageProxyGLib.cpp

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -39,11 +39,21 @@
 #include "WebPageGroup.h"
 #include "WebProcessPool.h"
 #include <WebCore/CompositionUnderline.h>
+#if ENABLE(GAMEPAD)
+#include <WebCore/WPEGamepadProvider.h>
+#endif
 #include <wpe/wpe.h>
+#include <wtf/NeverDestroyed.h>
 
 using namespace WebKit;
 
 namespace WKWPE {
+
+static Vector<View*>& viewsVector()
+{
+    static NeverDestroyed<Vector<View*>> vector;
+    return vector;
+}
 
 View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseConfiguration)
     : m_client(makeUnique<API::ViewClient>())
@@ -303,10 +313,13 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
     wpe_view_backend_initialize(m_backend);
 
     m_pageProxy->initializeWebPage();
+
+    viewsVector().append(this);
 }
 
 View::~View()
 {
+    viewsVector().removeAll(this);
 #if ENABLE(ACCESSIBILITY)
     if (m_accessible)
         webkitWebViewAccessibleSetWebView(m_accessible.get(), nullptr);
@@ -392,6 +405,13 @@ void View::setViewState(OptionSet<WebCore::ActivityState::Flag> flags)
 
     if (changedFlags)
         m_pageProxy->activityStateDidChange(changedFlags);
+
+    if (!viewsVector().isEmpty() && viewState().contains(WebCore::ActivityState::IsVisible)) {
+        if (viewsVector().first() != this) {
+            viewsVector().removeAll(this);
+            viewsVector().insert(0, this);
+        }
+    }
 }
 
 void View::handleKeyboardEvent(struct wpe_input_keyboard_event* event)
@@ -436,6 +456,37 @@ WebKitWebViewAccessible* View::accessible() const
     if (!m_accessible)
         m_accessible = webkitWebViewAccessibleNew(const_cast<View*>(this));
     return m_accessible.get();
+}
+#endif
+
+#if ENABLE(GAMEPAD)
+WebKit::WebPageProxy* View::platformWebPageProxyForGamepadInput()
+{
+    const auto& views = viewsVector();
+    if (views.isEmpty())
+        return nullptr;
+
+    struct wpe_view_backend* viewBackend = WebCore::WPEGamepadProvider::singleton().inputView();
+
+    size_t index = notFound;
+
+    if (viewBackend) {
+        index = views.findIf([&](View* view) {
+            return view->backend() == viewBackend
+                && view->viewState().contains(WebCore::ActivityState::IsVisible)
+                && view->viewState().contains(WebCore::ActivityState::IsFocused);
+        });
+    } else {
+        index = views.findIf([](View* view) {
+            return view->viewState().contains(WebCore::ActivityState::IsVisible)
+                && view->viewState().contains(WebCore::ActivityState::IsFocused);
+        });
+    }
+
+    if (index != notFound)
+        return &(views[index]->page());
+
+    return nullptr;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.h
@@ -108,6 +108,9 @@ public:
 #endif
 
     WebKit::TouchGestureController& touchGestureController() const { return *m_touchGestureController; }
+#if ENABLE(GAMEPAD)
+    static WebKit::WebPageProxy* platformWebPageProxyForGamepadInput();
+#endif
 
 private:
     View(struct wpe_view_backend*, const API::PageConfiguration&);

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -199,7 +199,7 @@ Vector<GamepadData> UIGamepadProvider::snapshotGamepads()
     });
 }
 
-#if !PLATFORM(COCOA) && !(USE(MANETTE) && OS(LINUX))
+#if !PLATFORM(COCOA) && !(USE(MANETTE) && OS(LINUX)) && !PLATFORM(WPE)
 
 void UIGamepadProvider::platformSetDefaultGamepadProvider()
 {

--- a/Source/WebKit/UIProcess/Gamepad/wpe/UIGamepadProviderWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/UIGamepadProviderWPE.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UIGamepadProvider.h"
+
+#if ENABLE(GAMEPAD)
+
+#include "WPEView.h"
+
+#include <WebCore/WPEGamepadProvider.h>
+
+using namespace WebCore;
+
+namespace WebKit {
+
+void UIGamepadProvider::platformSetDefaultGamepadProvider()
+{
+    if (GamepadProvider::singleton().isMockGamepadProvider())
+        return;
+
+    GamepadProvider::setSharedProvider(WPEGamepadProvider::singleton());
+}
+
+WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
+{
+    return WKWPE::View::platformWebPageProxyForGamepadInput();
+}
+
+void UIGamepadProvider::platformStopMonitoringInput()
+{
+}
+
+void UIGamepadProvider::platformStartMonitoringInput()
+{
+}
+}
+
+#endif // ENABLE(GAMEPAD)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -84,6 +84,10 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEB_RTC PRIVATE ${ENABLE_EXPERIMENTAL_FE
 WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBGL2 PRIVATE ON)
 WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WEBXR PRIVATE ${ENABLE_EXPERIMENTAL_FEATURES})
 
+if (WPE_VERSION VERSION_GREATER_EQUAL 1.13.90)
+    WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_GAMEPAD PUBLIC ON)
+endif ()
+
 # Public options specific to the WPE port. Do not add any options here unless
 # there is a strong reason we should support changing the value of the option,
 # and the option is not relevant to other WebKit ports.
@@ -199,6 +203,10 @@ if (ENABLE_ACCESSIBILITY)
     endif ()
 endif ()
 
+if (ENABLE_GAMEPAD AND (NOT (WPE_VERSION VERSION_GREATER_EQUAL 1.13.90)))
+    message(FATAL_ERROR "libwpe>=1.13.90 is required for ENABLE_GAMEPAD")
+endif ()
+
 if (USE_JPEGXL)
     find_package(JPEGXL)
     if (NOT JPEGXL_FOUND)
@@ -252,11 +260,13 @@ endif ()
 
 
 if (ENABLE_WEBXR)
+    if (NOT ENABLE_GAMEPAD)
+        message(FATAL_ERROR "Gamepad is required to be enabled for WebXR support.")
+    endif ()
     find_package(OpenXR 1.0.9)
     if (NOT OPENXR_FOUND)
         message(FATAL_ERROR "OpenXR is required to enable WebXR support.")
     endif ()
-    SET_AND_EXPOSE_TO_BUILD(ENABLE_GAMEPAD ON)
     SET_AND_EXPOSE_TO_BUILD(USE_OPENXR ${OpenXR_FOUND})
     SET_AND_EXPOSE_TO_BUILD(XR_USE_PLATFORM_EGL TRUE)
     SET_AND_EXPOSE_TO_BUILD(XR_USE_GRAPHICS_API_OPENGL TRUE)


### PR DESCRIPTION
#### ab0e24752e11bbdb584662dcd5369ce17f4da1de
<pre>
[WPE] Add gamepad support
<a href="https://bugs.webkit.org/show_bug.cgi?id=230630">https://bugs.webkit.org/show_bug.cgi?id=230630</a>

With gamepad support in libwpe[1] is possible to communicate gamepads events between the
application (cog, for example) and WPEWebKit. This patch are the changes required to attend that
communication and enable the gamepad support in WPE port.

1. <a href="https://github.com/WebPlatformForEmbedded/libwpe/pull/88">https://github.com/WebPlatformForEmbedded/libwpe/pull/88</a>

Reviewed by Adrian Perez de Castro.

* LayoutTests/platform/wpe/TestExpectations: Enable skipped tests.
* Source/WebCore/PlatformWPE.cmake: Add headers if enabled.
* Source/WebCore/SourcesWPE.txt: Add source files.
* Source/WebCore/platform/gamepad/wpe/WPEGamepad.cpp: Added.
(WebCore::WPEGamepad::WPEGamepad):
(WebCore::WPEGamepad::~WPEGamepad):
(WebCore::WPEGamepad::buttonPressedOrReleased):
(WebCore::WPEGamepad::absoluteAxisChanged):
* Source/WebCore/platform/gamepad/wpe/WPEGamepad.h: Added.
* Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.cpp: Added.
(WebCore::WPEGamepadProvider::singleton):
(WebCore::WPEGamepadProvider::WPEGamepadProvider):
(WebCore::WPEGamepadProvider::~WPEGamepadProvider):
(WebCore::WPEGamepadProvider::startMonitoringGamepads):
(WebCore::WPEGamepadProvider::stopMonitoringGamepads):
(WebCore::WPEGamepadProvider::gamepadConnected):
(WebCore::WPEGamepadProvider::gamepadDisconnected):
(WebCore::WPEGamepadProvider::indexForNewlyConnectedDevice):
(WebCore::WPEGamepadProvider::removeGamepadForId):
(WebCore::WPEGamepadProvider::initialGamepadsConnectedTimerFired):
(WebCore::WPEGamepadProvider::inputNotificationTimerFired):
(WebCore::WPEGamepadProvider::scheduleInputNotification):
(WebCore::WPEGamepadProvider::inputView):
* Source/WebCore/platform/gamepad/wpe/WPEGamepadProvider.h: Added.
* Source/WebKit/SourcesWPE.txt: Add source files.
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp: Reports the view where gamepad currently operates.
(WKWPE::m_backend):
(WKWPE::View::~View):
(WKWPE::View::setViewState):
(WKWPE::View::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/API/wpe/WPEView.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/UIGamepadProviderWPE.cpp: Added.
(WebKit::UIGamepadProvider::platformSetDefaultGamepadProvider):
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
(WebKit::UIGamepadProvider::platformStopMonitoringInput):
(WebKit::UIGamepadProvider::platformStartMonitoringInput):
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/253720@main">https://commits.webkit.org/253720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e79f0c207f737824efee8436e574b989610645

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95633 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149384 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29243 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25619 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90868 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23616 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73690 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23655 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78925 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66660 "Found 1 new API test failure: /WebKit2Gtk/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27005 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12779 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72371 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13793 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36659 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75155 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33072 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16630 "Passed tests") | 
<!--EWS-Status-Bubble-End-->