### PR TITLE
Add WebKit SPI to specify User Agent details for preconnect

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2593,6 +2593,13 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
         _page->disableURLSchemeCheckInDataDetectors();
 }
 
+- (void)_setUserAgentDetailsForPreconnect:(NSString *)applicationName desktopUserAgent:(BOOL)desktopUserAgent
+{
+    THROW_IF_SUSPENDED;
+    if (_page)
+        _page->setUserAgentDetailsForPreconnect(applicationName, desktopUserAgent);
+}
+
 - (void)_switchFromStaticFontRegistryToUserFontRegistry
 {
     THROW_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -409,6 +409,8 @@ for this property.
 
 - (void)_disableURLSchemeCheckInDataDetectors WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
+- (void)_setUserAgentDetailsForPreconnect:(NSString *)applicationName desktopUserAgent:(BOOL)desktopUserAgent WK_API_AVAILABLE(ios(WK_IOS_TBA));
+
 /*! @abstract If the WKWebView was created with _shouldAllowUserInstalledFonts = NO,
  the web process will automatically use an in-process font registry, and its sandbox
  will be restricted to forbid access to fontd. Otherwise, the web process will use

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -64,6 +64,7 @@
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/SearchPopupMenuCocoa.h>
 #import <WebCore/TextAlternativeWithRange.h>
+#import <WebCore/UserAgent.h>
 #import <WebCore/ValidationBubble.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockPtr.h>
@@ -860,6 +861,14 @@ void WebPageProxy::disableURLSchemeCheckInDataDetectors() const
 void WebPageProxy::switchFromStaticFontRegistryToUserFontRegistry()
 {
     process().send(Messages::WebProcess::SwitchFromStaticFontRegistryToUserFontRegistry(process().fontdMachExtensionHandle(SandboxExtension::MachBootstrapOptions::EnableMachBootstrap)), 0);
+}
+
+void WebPageProxy::setUserAgentDetailsForPreconnect(const String& applicationName, bool useDesktopUserAgent)
+{
+    auto type = useDesktopUserAgent ? UserAgentType::Desktop : UserAgentType::Default;
+    auto customUserAgent = standardUserAgentWithApplicationName(applicationName, emptyString(), type);
+    if (customUserAgent != userAgent())
+        setCustomUserAgent(customUserAgent);
 }
 
 NSDictionary *WebPageProxy::contentsOfUserInterfaceItem(NSString *userInterfaceItem)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4704,7 +4704,8 @@ void WebPageProxy::preconnectTo(const URL& url)
 
     auto storedCredentialsPolicy = m_canUseCredentialStorage ? WebCore::StoredCredentialsPolicy::Use : WebCore::StoredCredentialsPolicy::DoNotUse;
 
-    websiteDataStore().networkProcess().preconnectTo(sessionID(), identifier(), webPageID(), url, userAgent(), storedCredentialsPolicy, isNavigatingToAppBoundDomain(), m_lastNavigationWasAppInitiated ? LastNavigationWasAppInitiated::Yes : LastNavigationWasAppInitiated::No);
+    auto userAgentString = customUserAgent().isEmpty() ? userAgent() : customUserAgent();
+    websiteDataStore().networkProcess().preconnectTo(sessionID(), identifier(), webPageID(), url, userAgentString, storedCredentialsPolicy, isNavigatingToAppBoundDomain(), m_lastNavigationWasAppInitiated ? LastNavigationWasAppInitiated::Yes : LastNavigationWasAppInitiated::No);
 }
 
 void WebPageProxy::setCanUseCredentialStorage(bool canUseCredentialStorage)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1918,6 +1918,7 @@ public:
 
     void grantAccessToAssetServices();
     void revokeAccessToAssetServices();
+    void setUserAgentDetailsForPreconnect(const String& applicationName, bool useDesktopUserAgent);
     void switchFromStaticFontRegistryToUserFontRegistry();
 
     void disableURLSchemeCheckInDataDetectors() const;


### PR DESCRIPTION
#### ea195112c2d2e72e6c1bcac383532a94c9d1dcd8
<pre>
Add WebKit SPI to specify User Agent details for preconnect
<a href="https://bugs.webkit.org/show_bug.cgi?id=240818">https://bugs.webkit.org/show_bug.cgi?id=240818</a>

Reviewed by NOBODY (OOPS!).

Add WebKit SPI to specify application name and whether a desktop user agent should be used in the preconnect.
This is in preparation of fixing the issue where we are always preconnecting with the incorrect user agent on
iPad. This causes the preconnected socket to be unused, and is a page load performance issue.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setUserAgentDetailsForPreconnect:desktopUserAgent:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
(-[WKWebView _dataTaskWithRequest:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setUserAgentDetailsForPreconnect):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preconnectTo):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre>