### PR TITLE
Reflection for FrozenArray<Element> caching invariant

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative-expected.txt
@@ -50,7 +50,7 @@ PASS Changing the ID of an element causes the content attribute to become out of
 PASS Reparenting an element into a descendant shadow scope hides the element reference.
 PASS Reparenting referenced element cannot cause retargeting of reference.
 PASS Element reference set in invalid scope remains intact throughout move to valid scope.
-FAIL aria-labelledby. assert_equals: check idl attribute caching after parsing expected [Element node <div id="billingElement">Billing</div>, Element node <div id="nameElement">Name</div>] but got [Element node <div id="billingElement">Billing</div>, Element node <div id="nameElement">Name</div>]
+PASS aria-labelledby.
 PASS aria-controls.
 PASS aria-describedby.
 PASS aria-flowto.
@@ -62,4 +62,5 @@ PASS Reparenting.
 PASS Attaching element reference before it's inserted into the DOM.
 PASS Cross-document references and moves.
 PASS Adopting element keeps references.
+PASS Caching invariant different attributes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative.html
@@ -730,6 +730,38 @@
     }, "Adopting element keeps references.");
   </script>
 
+  <div id="cachingInvariantMain"></div>
+  <div id="cachingInvariantElement1"></div>
+  <div id="cachingInvariantElement2"></div>
+  <div id="cachingInvariantElement3"></div>
+  <div id="cachingInvariantElement4"></div>
+  <div id="cachingInvariantElement5"></div>
+
+  <script>
+    test(function(t) {
+      cachingInvariantMain.ariaControlsElements = [cachingInvariantElement1, cachingInvariantElement2];
+      cachingInvariantMain.ariaDescribedByElements = [cachingInvariantElement3, cachingInvariantElement4];
+      cachingInvariantMain.ariaDetailsElements = [cachingInvariantElement5];
+      cachingInvariantMain.ariaFlowToElements = [cachingInvariantElement1, cachingInvariantElement3];
+      cachingInvariantMain.ariaLabelledByElements = [cachingInvariantElement2, cachingInvariantElement4];
+      cachingInvariantMain.ariaOwnsElements = [cachingInvariantElement1, cachingInvariantElement2, cachingInvariantElement3];
+
+      let ariaControlsElementsArray = cachingInvariantMain.ariaControlsElements;
+      let ariaDescribedByElementsArray = cachingInvariantMain.ariaDescribedByElements;
+      let ariaDetailsElementsArray = cachingInvariantMain.ariaDetailsElements;
+      let ariaFlowToElementsArray = cachingInvariantMain.ariaFlowToElements;
+      let ariaLabelledByElementsArray = cachingInvariantMain.ariaLabelledByElements;
+      let ariaOwnsElementsArray = cachingInvariantMain.ariaOwnsElements;
+
+      assert_equals(ariaControlsElementsArray, cachingInvariantMain.ariaControlsElements, "Caching invariant for ariaControlsElements");
+      assert_equals(ariaDescribedByElementsArray, cachingInvariantMain.ariaDescribedByElements, "Caching invariant for ariaDescribedByElements");
+      assert_equals(ariaDetailsElementsArray, cachingInvariantMain.ariaDetailsElements, "Caching invariant for ariaDetailsElements");
+      assert_equals(ariaFlowToElementsArray, cachingInvariantMain.ariaFlowToElements, "Caching invariant for ariaFlowToElements");
+      assert_equals(ariaLabelledByElementsArray, cachingInvariantMain.ariaLabelledByElements, "Caching invariant for ariaLabelledByElements");
+      assert_equals(ariaOwnsElementsArray, cachingInvariantMain.ariaOwnsElements, "Caching invariant for ariaOwnsElements");
+    }, "Caching invariant different attributes.");
+  </script>
+
   <!-- TODO(chrishall): add additional GC test covering:
        if an element is in an invalid scope but attached to the document, it's
        not GC'd;

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -81,4 +81,17 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<E
     return createNewElementWrapper(globalObject, WTFMove(element));
 }
 
+template<typename Visitor>
+void JSElement::visitAdditionalChildren(Visitor& visitor)
+{
+    if (auto* cachedMap = wrapped().cachedAttrAssociatedElementsMapIfExists()) {
+        for (auto& cachedValue : cachedMap->values()) {
+            if (cachedValue)
+                cachedValue->visit(visitor);
+        }
+    }
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSElement);
+
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -39,6 +39,7 @@ class JSValueInWrappedObject {
     // It must be neither copyable nor movable. Changing this will break concurrent GC.
     WTF_MAKE_NONCOPYABLE(JSValueInWrappedObject);
     WTF_MAKE_NONMOVABLE(JSValueInWrappedObject);
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     JSValueInWrappedObject(JSC::JSValue = { });
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5349,6 +5349,9 @@ sub GenerateAttributeGetterBodyDefinition
 
         my $globalObjectReference = $attribute->isStatic ? "*jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)" : "*thisObject.globalObject()";
         my $toJSExpression = NativeToJSValueUsingReferences($attribute, $interface, "${functionName}(" . join(", ", @arguments) . ")", $globalObjectReference);
+        if ($attribute->extendedAttributes->{"Reflect"} and $baseFunctionName eq "getElementsArrayAttribute") {
+            $toJSExpression = "${functionName}(" . join(", ", @arguments) . ", lexicalGlobalObject, ${globalObjectReference})";
+        }
         push(@$outputArray, "    auto& impl = thisObject.wrapped();\n") unless $attribute->isStatic or $attribute->extendedAttributes->{ForwardToMapLike} or $attribute->extendedAttributes->{ForwardToSetLike};
 
         if (!IsReadonly($attribute)) {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -3960,7 +3960,7 @@ static inline JSValue jsTestObj_reflectedElementsArrayAttrGetter(JSGlobalObject&
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLFrozenArray<IDLInterface<Element>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.getElementsArrayAttribute(WebCore::HTMLNames::reflectedelementsarrayattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (impl.getElementsArrayAttribute(WebCore::HTMLNames::reflectedelementsarrayattrAttr, lexicalGlobalObject, *thisObject.globalObject())));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedElementsArrayAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -30,6 +30,8 @@
 #include "EventOptions.h"
 #include "FocusOptions.h"
 #include "HitTestRequest.h"
+#include "JSDOMGlobalObject.h"
+#include "JSValueInWrappedObject.h"
 #include "QualifiedName.h"
 #include "RenderPtr.h"
 #include "ScrollTypes.h"
@@ -94,6 +96,7 @@ struct SecurityPolicyViolationEventInit;
 struct ShadowRootInit;
 
 using ExplicitlySetAttrElementsMap = HashMap<QualifiedName, Vector<WeakPtr<Element>>>;
+using CachedAttrAssociatedElementsMap = HashMap<QualifiedName, std::unique_ptr<JSValueInWrappedObject>>;
 
 namespace Style {
 class Resolver;
@@ -125,7 +128,8 @@ public:
     WEBCORE_EXPORT void setUnsignedIntegralAttribute(const QualifiedName& attributeName, unsigned value);
     WEBCORE_EXPORT Element* getElementAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
-    WEBCORE_EXPORT std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT JSC::JSValue getElementsArrayAttribute(const QualifiedName& attributeName, JSC::JSGlobalObject&, WebCore::JSDOMGlobalObject&);
+    std::optional<Vector<RefPtr<Element>>> getElementsArrayAttributeInternal(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& value);
 
     // Call this to get the value of an attribute that is known not to be the style
@@ -676,6 +680,7 @@ public:
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
     ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;
+    CachedAttrAssociatedElementsMap* cachedAttrAssociatedElementsMapIfExists() const;
 
 protected:
     Element(const QualifiedName&, Document&, ConstructionType);

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -22,6 +22,7 @@
     CustomToJSObject,
     DOMJIT,
     JSCustomHeader,
+    JSCustomMarkFunction,
     JSGenerateToNativeObject,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -43,6 +43,7 @@ struct SameSizeAsElementRareData : NodeRareData {
 #endif
     void* resizeObserverData;
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
+    CachedAttrAssociatedElementsMap cachedAttrAssociatedElementsMap;
 };
 
 static_assert(sizeof(ElementRareData) == sizeof(SameSizeAsElementRareData), "ElementRareData should stay small");

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -26,6 +26,7 @@
 #include "DatasetDOMStringMap.h"
 #include "ElementAnimationRareData.h"
 #include "IntersectionObserver.h"
+#include "JSValueInWrappedObject.h"
 #include "KeyframeEffectStack.h"
 #include "NamedNodeMap.h"
 #include "NodeRareData.h"
@@ -108,6 +109,7 @@ public:
 #endif
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap() { return m_explicitlySetAttrElementsMap; }
+    CachedAttrAssociatedElementsMap& cachedAttrAssociatedElementsMap() { return m_cachedAttrAssociatedElementsMap; }
 
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
@@ -151,6 +153,8 @@ public:
             result.add(UseType::Nonce);
         if (!m_explicitlySetAttrElementsMap.isEmpty())
             result.add(UseType::ExplicitlySetAttrElementsMap);
+        if (!m_cachedAttrAssociatedElementsMap.isEmpty())
+            result.add(UseType::CachedAttrAssociatedElementsMap);
         return result;
     }
 #endif
@@ -185,6 +189,7 @@ private:
     AtomString m_nonce;
 
     ExplicitlySetAttrElementsMap m_explicitlySetAttrElementsMap;
+    CachedAttrAssociatedElementsMap m_cachedAttrAssociatedElementsMap;
 
     void releasePseudoElement(PseudoElement*);
 };

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -266,6 +266,7 @@ public:
         Nonce = 1 << 17,
         ComputedStyleMap = 1 << 18,
         ExplicitlySetAttrElementsMap = 1 << 19,
+        CachedAttrAssociatedElementsMap = 1 << 20,
     };
 #endif
 


### PR DESCRIPTION
#### 346727c8b5d9289a14e1f20e008ae48b4367b3bd
<pre>
Reflection for FrozenArray&lt;Element&gt; caching invariant
<a href="https://bugs.webkit.org/show_bug.cgi?id=240563">https://bugs.webkit.org/show_bug.cgi?id=240563</a>

Reviewed by NOBODY (OOPS!).

This patch implements the caching layer described in the spec PR
for reflection of FrozenArray&lt;T&gt; attributes:
<a href="https://github.com/whatwg/html/pull/3917">https://github.com/whatwg/html/pull/3917</a>
Which fixes the test cases that were checking for:
el.ariaDescribedByElements === el.ariaDescribedByElements

This patch stores a new map in ElementRareData, where we stored
the computed Vector in a JSValueInWrappedObject.
It adds a new method Element::getElementsArrayAttribute()
that is the one in charge of dealing with the cached values.

This tweaks the bindings code generator, so we can return
a JSValue in Element::getElementsArrayAttribute().

This also adds JSCustomMarkFunction in Element.idl,
so we can visit the cached map in JSElement::visitAdditionalChildren().

Apart from that this adds a new test case on the WPT test.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/aria-element-reflection.tentative.html:
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::JSElement::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateAttributeGetterBodyDefinition):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::jsTestObj_reflectedElementsArrayAttrGetter):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cachedAttrAssociatedElementsMapIfExists const):
(WebCore::Element::getElementsArrayAttribute):
(WebCore::Element::getElementsArrayAttributeInternal const):
(WebCore::Element::getElementsArrayAttribute const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::cachedAttrAssociatedElementsMap):
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/dom/NodeRareData.h:
</pre>