### PR TITLE
Web Inspector: Timelines Tab: Screenshots: the selected image should be on top in the overview

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedDecoratedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedDecoratedProperty.h
@@ -136,18 +136,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<decltype(*this)>(animated).m_animVal;
+        if (!isAnimating())
+            m_animVal = static_cast<decltype(*this)>(animated).m_animVal;
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -120,18 +120,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedPrimitiveProperty&>(animated).m_animVal;
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedPrimitiveProperty&>(animated).m_animVal;
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.h
@@ -57,7 +57,7 @@ public:
     virtual void startAnimation(SVGAttributeAnimator& animator) { m_animators.add(animator); }
     virtual void stopAnimation(SVGAttributeAnimator& animator) { m_animators.remove(animator); }
     
-    // Attach/Detach the animVal of the traget element's property by the instance element's property.
+    // Attach/Detach the animVal of the target element's property by the instance element's property.
     virtual void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty&) { startAnimation(animator); }
     virtual void instanceStopAnimation(SVGAttributeAnimator& animator) { stopAnimation(animator); }
     

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -99,18 +99,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedPropertyList&>(animated).animVal();
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedPropertyList&>(animated).animVal();
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
     // Visual Studio doesn't seem to see these private constructors from subclasses.

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -115,18 +115,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedValueProperty&>(animated).animVal();
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedValueProperty&>(animated).animVal();
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:

--- a/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.css
@@ -35,5 +35,6 @@ body .timeline-overview > .graphs-container > .timeline-overview-graph.screensho
 }
 
 .timeline-overview-graph.screenshots > img.selected {
+    z-index: 1;
     border: 1px solid var(--glyph-color-active);
 }


### PR DESCRIPTION
#### c7412259e5f02dbf390a1ac7771d44c05172b6f0
<pre>
Web Inspector: Timelines Tab: Screenshots: the selected image should be on top in the overview
<a href="https://bugs.webkit.org/show_bug.cgi?id=240878">https://bugs.webkit.org/show_bug.cgi?id=240878</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.css:
(.timeline-overview-graph.screenshots  &gt; img.selected):

Canonical link: <a href="https://commits.webkit.org/251150@main">https://commits.webkit.org/251150@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295055">https://svn.webkit.org/repository/webkit/trunk@295055</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
