### PR TITLE
Generate better ChangeLogs in update-angle script

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -657,7 +657,7 @@ void NetworkDataTaskSoup::authenticateCallback(SoupSession* session, SoupMessage
     // it's proxy authentication and the request URL is HTTPS, because in that case libsoup uses a
     // tunnel internally and the SoupMessage used for the authentication is the tunneling one.
     // See https://bugs.webkit.org/show_bug.cgi?id=175378.
-    if (soupMessage != task->m_soupMessage.get() && (soupMessage->status_code != SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED || !task->m_currentRequest.url().protocolIs("https")))
+    if (soupMessage != task->m_soupMessage.get() && (soupMessage->status_code != SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED || !task->m_currentRequest.url().protocolIs("https"_s)))
         return;
 
     if (task->state() == State::Canceling || task->state() == State::Completed || !task->m_client) {
@@ -1636,7 +1636,7 @@ void NetworkDataTaskSoup::didStartRequest()
 {
 #if USE(SOUP2)
     m_networkLoadMetrics.requestStart = MonotonicTime::now();
-    if (!m_networkLoadMetrics.secureConnectionStart && m_currentRequest.url().protocolIs("https"))
+    if (!m_networkLoadMetrics.secureConnectionStart && m_currentRequest.url().protocolIs("https"_s))
         m_networkLoadMetrics.secureConnectionStart = WebCore::reusedTLSConnectionSentinel;
 #else
     auto* metrics = soup_message_get_metrics(m_soupMessage.get());

--- a/Tools/Scripts/update-angle
+++ b/Tools/Scripts/update-angle
@@ -121,6 +121,13 @@ cleanup_after_successful_rebase_and_exit() {
     echo "Press Enter to continue after fixing build:"
     read -r
     regenerate_changes_diff "origin/main"
+    echo "Generating contents of commit message into commit-message.txt."
+    echo "Be sure to copy out this file's contents and delete it before committing."
+    echo "Update ANGLE to $(git log -1 ${COMMIT_HASH} --format=%cs) (${COMMIT_HASH}))" > commit-message.txt
+    echo "" >> commit-message.txt
+    echo "Contains upstream commits:" >> commit-message.txt
+    echo git log --oneline "$PREVIOUS_ANGLE_COMMIT_HASH".."$COMMIT_HASH" --pretty="%h %s" >> commit-message.txt
+    git log --oneline "$PREVIOUS_ANGLE_COMMIT_HASH".."$COMMIT_HASH" --pretty="%h %s" >> commit-message.txt
     echo "Removing temporary git repository from Source/ThirdParty/ANGLE"
     rm -rf .git
     git add -A .


### PR DESCRIPTION
#### 83c12bcc9d4e1cae1d705493356909e21e90d905
<pre>
Generate better ChangeLogs in update-angle script
<a href="https://bugs.webkit.org/show_bug.cgi?id=238649">https://bugs.webkit.org/show_bug.cgi?id=238649</a>

Patch by Kenneth Russell &lt;kbr@chromium.org &gt; on 2022-05-25
Auto-generate the preferred commit message format during ANGLE rolls
into a commit-message.txt file.

Reviewed by Kimmo Kinnunen.

* Tools/Scripts/update-angle:

Canonical link: <a href="https://commits.webkit.org/251002@main">https://commits.webkit.org/251002@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294872">https://svn.webkit.org/repository/webkit/trunk@294872</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
