### PR TITLE
[Linux] GBMBufferSwapchain should only conditionally create linear-formatted buffer objects

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h
@@ -64,9 +64,15 @@ public:
     ~GBMBufferSwapchain();
 
     struct BufferDescription {
+        enum Flags : uint32_t {
+            NoFlags = 0,
+            LinearStorage = 1 << 0,
+        };
+
         DMABufFormat format { };
         uint32_t width { 0 };
         uint32_t height  { 0 };
+        uint32_t flags { NoFlags };
     };
 
     class Buffer : public ThreadSafeRefCounted<Buffer> {

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -98,6 +98,7 @@ bool GraphicsContextGLANGLE::makeContextCurrent()
                 .format = DMABufFormat::create(uint32_t(contextAttributes().alpha ? DMABufFormat::FourCC::ARGB8888 : DMABufFormat::FourCC::XRGB8888)),
                 .width = std::clamp<uint32_t>(size.width(), 0, UINT_MAX),
                 .height = std::clamp<uint32_t>(size.height(), 0, UINT_MAX),
+                .flags = GBMBufferSwapchain::BufferDescription::NoFlags,
             });
 
         GLenum textureTarget = drawingBufferTextureTarget();

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3140,10 +3140,12 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
     }
 
     // If the decoder is exporting raw memory, we have to use the swapchain to allocate appropriate buffers
-    // and copy over the data for each plane.
+    // and copy over the data for each plane. For that to work, linear-storage buffer is required.
     GBMBufferSwapchain::BufferDescription bufferDescription {
-        DMABufFormat::create(fourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo))),
-        static_cast<uint32_t>GST_VIDEO_INFO_WIDTH(&videoInfo), static_cast<uint32_t>GST_VIDEO_INFO_HEIGHT(&videoInfo),
+        .format = DMABufFormat::create(fourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo))),
+        .width = static_cast<uint32_t>GST_VIDEO_INFO_WIDTH(&videoInfo),
+        .height = static_cast<uint32_t>GST_VIDEO_INFO_HEIGHT(&videoInfo),
+        .flags = GBMBufferSwapchain::BufferDescription::LinearStorage,
     };
     if (bufferDescription.format.fourcc == DMABufFormat::FourCC::Invalid)
         return;


### PR DESCRIPTION
#### 149693853cb995c3b94d199d0d68dfa8c6e7597e
<pre>
[Linux] GBMBufferSwapchain should only conditionally create linear-formatted buffer objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=240637">https://bugs.webkit.org/show_bug.cgi?id=240637</a>

Reviewed by Adrian Perez de Castro.

Spawning new gbm_bo objects should not default to requesting linear-storage
buffers. Instead, these should only be created when necessary, e.g. when
copying software-decoded video data into these buffers.

By default, no GBM flags are used. When required, the linear-storage requirement
is enscribed in the new flags field of the GBMBufferSwapchain::BufferDescription
object and acted upon in the GBMBufferSwapchain::getBuffer() call, using the
GBM_BO_USE_LINEAR flag in the gbm_bo_create() call.

The DMABuf-specific sink in MediaPlayerPrivateGStreamer is the only place at the
moment where linear-storage buffers are used since software-decoded material
originates here and is stored in linear memory.

* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::getBuffer):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLANGLE::makeContextCurrent):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):

Canonical link: <a href="https://commits.webkit.org/250959@main">https://commits.webkit.org/250959@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294803">https://svn.webkit.org/repository/webkit/trunk@294803</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
