### PR TITLE
Revert "Use the Clang .alt_entry directive to allow use of global labels in LLInt asm."

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2020 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -562,6 +562,7 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
     SYMBOL_STRING(label) ":\n"
 #endif
 
+<<<<<<< HEAD
 #define OFFLINE_ASM_GLOBAL_LABEL(label) \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, OFFLINE_ASM_ALT_ENTRY_DIRECTIVE)
 
@@ -574,6 +575,9 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 #define OFFLINE_ASM_LOCAL_LABEL(label) \
     LOCAL_LABEL_STRING(label) ":\n" \
     OFFLINE_ASM_ALT_GLOBAL_LABEL(label)
+=======
+#define OFFLINE_ASM_LOCAL_LABEL(label)   LOCAL_LABEL_STRING(label) ":\n"
+>>>>>>> parent of 5f4ebedda089 (Use the Clang .alt_entry directive to allow use of global labels in LLInt asm.)
 
 #if OS(LINUX)
 #define OFFLINE_ASM_OPCODE_DEBUG_LABEL(label)  #label ":\n"


### PR DESCRIPTION
#### 289b992fc7e9b4941d0ee0492e20a805f1fe279b
<pre>
Revert &quot;Use the Clang .alt_entry directive to allow use of global labels in LLInt asm.&quot;

This reverts commit 5f4ebedda0897afe59b886f369f830e60ca9c976.

Unreviewed revert
This reverts because of build failure on archive builders.
</pre>