### PR TITLE
[Soup] USE(SOUP2) build fix after 250730@main

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -657,7 +657,7 @@ void NetworkDataTaskSoup::authenticateCallback(SoupSession* session, SoupMessage
     // it's proxy authentication and the request URL is HTTPS, because in that case libsoup uses a
     // tunnel internally and the SoupMessage used for the authentication is the tunneling one.
     // See https://bugs.webkit.org/show_bug.cgi?id=175378.
-    if (soupMessage != task->m_soupMessage.get() && (soupMessage->status_code != SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED || !task->m_currentRequest.url().protocolIs("https")))
+    if (soupMessage != task->m_soupMessage.get() && (soupMessage->status_code != SOUP_STATUS_PROXY_AUTHENTICATION_REQUIRED || !task->m_currentRequest.url().protocolIs("https"_s)))
         return;
 
     if (task->state() == State::Canceling || task->state() == State::Completed || !task->m_client) {
@@ -1636,7 +1636,7 @@ void NetworkDataTaskSoup::didStartRequest()
 {
 #if USE(SOUP2)
     m_networkLoadMetrics.requestStart = MonotonicTime::now();
-    if (!m_networkLoadMetrics.secureConnectionStart && m_currentRequest.url().protocolIs("https"))
+    if (!m_networkLoadMetrics.secureConnectionStart && m_currentRequest.url().protocolIs("https"_s))
         m_networkLoadMetrics.secureConnectionStart = WebCore::reusedTLSConnectionSentinel;
 #else
     auto* metrics = soup_message_get_metrics(m_soupMessage.get());


### PR DESCRIPTION
#### e8b60970a1974cf5d5adaf36342783fbe7850132
<pre>
[Soup] USE(SOUP2) build fix after 250730@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=240943">https://bugs.webkit.org/show_bug.cgi?id=240943</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-05-25
Unreviewed build fix for USE(SOUP2), switching to string literals in a couple of
places where URL::protocolIs() is expecting them.

* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::authenticateCallback):
(WebKit::NetworkDataTaskSoup::didStartRequest):

Canonical link: <a href="https://commits.webkit.org/251001@main">https://commits.webkit.org/251001@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294871">https://svn.webkit.org/repository/webkit/trunk@294871</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
