### PR TITLE
[GStreamear] DMABufVideoSink can already handle Y41B

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -43,11 +43,11 @@ struct _WebKitDMABufVideoSinkPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
-#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV12, Y444, Y42B, VUYA }"
+#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV12, Y444, Y41B, Y42B, VUYA }"
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):
-//     YUY2, YVYU, UYVY, VYUY, AYUV, Y41B
+//     YUY2, YVYU, UYVY, VYUY, AYUV
 
 #define webkit_dmabuf_video_sink_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitDMABufVideoSink, webkit_dmabuf_video_sink, GST_TYPE_BIN,


### PR DESCRIPTION
#### 216411d9ba99d24b4feb2e0a655963b34bfb42ba
<pre>
[GStreamear] DMABufVideoSink can already handle Y41B
<a href="https://bugs.webkit.org/show_bug.cgi?id=240946">https://bugs.webkit.org/show_bug.cgi?id=240946</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-05-26
Reviewed by Philippe Normand.

In GStreamer-specific DMABufVideoSink, Y41B multi-planar format was listed as
problematic and not included in the list of formats that are supported by
default. In reality, it&apos;s handled properly already and works, so it&apos;s moved over
to the list of supported formats.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:

Canonical link: <a href="https://commits.webkit.org/251004@main">https://commits.webkit.org/251004@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294874">https://svn.webkit.org/repository/webkit/trunk@294874</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
