### PR TITLE
[Cocoa] Implement accessibility bold setting

### DIFF
--- a/LayoutTests/fast/text/accessibility-bold-expected-mismatch.html
+++ b/LayoutTests/fast/text/accessibility-bold-expected-mismatch.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    internals.settings.setShouldMockBoldSystemFontForAccessibility(false);
+</script>
+</head>
+<body>
+This test makes sure that accessibility bold is applied to font-family: system-ui. The test passes if the text below is bold.
+<p style="font: 24px system-ui;">Hello this is text</p>
+</body>
+</html>

--- a/LayoutTests/fast/text/accessibility-bold-system-font-2-expected.html
+++ b/LayoutTests/fast/text/accessibility-bold-system-font-2-expected.html
@@ -3,7 +3,7 @@
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<body style="font: -apple-system-body; font-weight: 600;">
+<body style="font: -apple-system-body; font-weight: 590;">
 <div id="target" style="font-size: 400%;">Hello</div>
 </body>
 </html>

--- a/LayoutTests/fast/text/accessibility-bold.html
+++ b/LayoutTests/fast/text/accessibility-bold.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    internals.settings.setShouldMockBoldSystemFontForAccessibility(true);
+</script>
+</head>
+<body>
+This test makes sure that accessibility bold is applied to font-family: system-ui. The test passes if the text below is bold.
+<p style="font: 24px system-ui;">Hello this is text</p>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1280,8 +1280,6 @@ webkit.org/b/184783 compositing/ios/overflow-scroll-touch-tiles.html [ Pass Fail
 
 webkit.org/b/179853 [ Debug ] imported/blink/fast/text/international-iteration-simple-text.html [ Pass Failure ]
 
-webkit.org/b/231316 fast/text/accessibility-bold-system-font-2.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/189087 svg/animations/animate-end-attribute-numeric-precision.html [ Pass Failure ]
 
 webkit.org/b/190847 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/unregister-then-register-new-script.https.html [ Pass Failure ] 

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -149,6 +149,7 @@ CFArrayRef CTFontManagerCreateFontDescriptorsFromData(CFDataRef);
 bool CTFontManagerEnableAllUserFonts(bool postFontChangeNotification);
 
 void CTParagraphStyleSetCompositionLanguage(CTParagraphStyleRef, CTCompositionLanguage);
+CGFloat CTFontGetAccessibilityBoldWeightOfWeight(CGFloat);
 
 extern const CFStringRef kCTFontCSSWeightAttribute;
 extern const CFStringRef kCTFontCSSWidthAttribute;

--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,6 +46,9 @@ typedef CF_ENUM(int32_t, AXSIsolatedTreeMode)
 AXSIsolatedTreeMode _AXSIsolatedTreeMode(void);
 void _AXSSetIsolatedTreeMode(AXSIsolatedTreeMode);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+extern CFStringRef kAXSEnhanceTextLegibilityChangedNotification;
+Boolean _AXSEnhanceTextLegibilityEnabled(void);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
@@ -50,6 +50,8 @@ void _AXSSetIsolatedTreeMode(AXSIsolatedTreeMode);
 extern CFStringRef kAXSEnhanceTextLegibilityChangedNotification;
 Boolean _AXSEnhanceTextLegibilityEnabled(void);
 
+extern CFStringRef kAXSApplePreferredContentSizeCategoryNotification;
+
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -827,6 +827,8 @@ void FontCache::platformInit()
 
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kAXSEnhanceTextLegibilityChangedNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
 
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kAXSApplePreferredContentSizeCategoryNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
+
 #if PLATFORM(MAC)
     CFNotificationCenterRef center = CFNotificationCenterGetLocalCenter();
     const CFStringRef notificationName = kCFLocaleCurrentLocaleDidChangeNotification;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -384,7 +384,6 @@ static struct {
 };
 static_assert(WTF_ARRAY_LENGTH(keyframes) > 0);
 
-static inline float normalizeCTWeight(float); // FIXME: Once this is called, delete this forward declaration.
 static inline float normalizeCTWeight(float value)
 {
     if (value < keyframes[0].ctWeight)
@@ -410,7 +409,6 @@ static inline float denormalizeGXWeight(float value)
     return (value + 109.3) / 523.7;
 }
 
-static inline float denormalizeCTWeight(float); // FIXME: Once this is called, delete this forward declaration.
 static inline float denormalizeCTWeight(float value)
 {
     if (value < keyframes[0].cssWeight)
@@ -663,7 +661,9 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
         if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
             slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
         if (shouldEnhanceTextLegibility() && fontIsSystemFont(originalFont)) {
-            // FIXME: Implement this
+            auto ctWeight = denormalizeCTWeight(weight);
+            ctWeight = CTFontGetAccessibilityBoldWeightOfWeight(ctWeight);
+            weight = normalizeCTWeight(ctWeight);
         }
         if (needsConversion) {
             weight = denormalizeGXWeight(weight);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -577,7 +577,6 @@ static bool& platformShouldEnhanceTextLegibility()
     return shouldEnhanceTextLegibility.get();
 }
 
-static inline bool shouldEnhanceTextLegibility(); // FIXME: Once this is called, delete this forward declaration.
 static inline bool shouldEnhanceTextLegibility()
 {
     return platformShouldEnhanceTextLegibility() || FontCache::forCurrentThread().shouldMockBoldSystemFontForAccessibility();
@@ -665,6 +664,9 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
             width = std::max(std::min(width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
         if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
             slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
+        if (shouldEnhanceTextLegibility()) {
+            // FIXME: Implement this
+        }
         if (needsConversion) {
             weight = denormalizeGXWeight(weight);
             width = denormalizeVariationWidth(width);

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -36,6 +36,7 @@
 #include "SystemFontDatabaseCoreText.h"
 #include <CoreText/SFNTLayoutTypes.h>
 #include <pal/spi/cf/CoreTextSPI.h>
+#include <pal/spi/cocoa/AccessibilitySupportSPI.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/MainThread.h>
@@ -753,7 +754,7 @@ static float stretchFromCoreTextTraits(CFDictionaryRef traits)
 
 static void invalidateFontCache();
 
-static void fontCacheRegisteredFontsChangedNotificationCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void *, CFDictionaryRef)
+static void fontCacheRegisteredFontsChangedNotificationCallback(CFNotificationCenterRef, void* observer, CFStringRef, const void*, CFDictionaryRef)
 {
     ASSERT_UNUSED(observer, isMainThread() && observer == &FontCache::forCurrentThread());
 

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -370,6 +370,38 @@ static inline float normalizeGXWeight(float value)
     return 523.7 * value - 109.3;
 }
 
+// These values were experimentally gathered from the various named weights of San Francisco.
+static struct {
+    float ctWeight;
+    float cssWeight;
+} keyframes[] = {
+    { -0.8, 30 },
+    { -0.4, 274 },
+    { 0, 400 },
+    { 0.23, 510 },
+    { 0.3, 590 },
+    { 0.4, 700 },
+    { 0.56, 860 },
+    { 0.62, 1000 },
+};
+static_assert(WTF_ARRAY_LENGTH(keyframes) > 0);
+
+static inline float normalizeCTWeight(float); // FIXME: Once this is called, delete this forward declaration.
+static inline float normalizeCTWeight(float value)
+{
+    if (value < keyframes[0].ctWeight)
+        return keyframes[0].cssWeight;
+    for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyframes) - 1; ++i) {
+        auto& before = keyframes[i];
+        auto& after = keyframes[i + 1];
+        if (value < before.ctWeight || value > after.ctWeight)
+            continue;
+        float ratio = (value - before.ctWeight) / (after.ctWeight - before.ctWeight);
+        return ratio * (after.cssWeight - before.cssWeight) + before.cssWeight;
+    }
+    return keyframes[WTF_ARRAY_LENGTH(keyframes) - 1].cssWeight;
+}
+
 static inline float normalizeSlope(float value)
 {
     return value * 300;
@@ -378,6 +410,22 @@ static inline float normalizeSlope(float value)
 static inline float denormalizeGXWeight(float value)
 {
     return (value + 109.3) / 523.7;
+}
+
+static inline float denormalizeCTWeight(float); // FIXME: Once this is called, delete this forward declaration.
+static inline float denormalizeCTWeight(float value)
+{
+    if (value < keyframes[0].cssWeight)
+        return keyframes[0].ctWeight;
+    for (size_t i = 0; i < WTF_ARRAY_LENGTH(keyframes) - 1; ++i) {
+        auto& before = keyframes[i];
+        auto& after = keyframes[i + 1];
+        if (value < before.cssWeight || value > after.cssWeight)
+            continue;
+        float ratio = (value - before.cssWeight) / (after.cssWeight - before.cssWeight);
+        return ratio * (after.ctWeight - before.ctWeight) + before.ctWeight;
+    }
+    return keyframes[WTF_ARRAY_LENGTH(keyframes) - 1].ctWeight;
 }
 
 static inline float denormalizeSlope(float value)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -765,6 +765,8 @@ void FontCache::platformInit()
 {
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kCTFontManagerRegisteredFontsChangedNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
 
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kAXSEnhanceTextLegibilityChangedNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
+
 #if PLATFORM(MAC)
     CFNotificationCenterRef center = CFNotificationCenterGetLocalCenter();
     const CFStringRef notificationName = kCFLocaleCurrentLocaleDidChangeNotification;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -571,6 +571,18 @@ static void addAttributesForFontPalettes(CFMutableDictionaryRef attributes, cons
     }
 }
 
+static bool& platformShouldEnhanceTextLegibility()
+{
+    static NeverDestroyed<bool> shouldEnhanceTextLegibility = _AXSEnhanceTextLegibilityEnabled();
+    return shouldEnhanceTextLegibility.get();
+}
+
+static inline bool shouldEnhanceTextLegibility(); // FIXME: Once this is called, delete this forward declaration.
+static inline bool shouldEnhanceTextLegibility()
+{
+    return platformShouldEnhanceTextLegibility() || FontCache::forCurrentThread().shouldMockBoldSystemFontForAccessibility();
+}
+
 RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext, bool applyWeightWidthSlopeVariations)
 {
     if (!originalFont)
@@ -1302,6 +1314,8 @@ static void invalidateFontCache()
         FontDatabase::singletonDisallowingUserInstalledFonts().clear();
 
         FontCache::invalidateAllFontCaches();
+
+        platformShouldEnhanceTextLegibility() = _AXSEnhanceTextLegibilityEnabled();
     });
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -364,7 +364,7 @@ static inline bool fontIsSystemFont(CTFontRef font)
 
 // These values were calculated by performing a linear regression on the CSS weights/widths/slopes and Core Text weights/widths/slopes of San Francisco.
 // FIXME: <rdar://problem/31312602> Get the real values from Core Text.
-static inline float normalizeWeight(float value)
+static inline float normalizeGXWeight(float value)
 {
     return 523.7 * value - 109.3;
 }
@@ -374,7 +374,7 @@ static inline float normalizeSlope(float value)
     return value * 300;
 }
 
-static inline float denormalizeWeight(float value)
+static inline float denormalizeGXWeight(float value)
 {
     return (value + 109.3) / 523.7;
 }
@@ -605,7 +605,7 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
         if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
             slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
         if (needsConversion) {
-            weight = denormalizeWeight(weight);
+            weight = denormalizeGXWeight(weight);
             width = denormalizeVariationWidth(width);
             slope = denormalizeSlope(slope);
         }
@@ -1064,7 +1064,7 @@ static VariationCapabilities variationCapabilitiesForFontDescriptor(CTFontDescri
 
     if (FontType(font.get()).variationType == FontType::VariationType::TrueTypeGX && !optOutFromGXNormalization) {
         if (result.weight)
-            result.weight = { { normalizeWeight(result.weight.value().minimum), normalizeWeight(result.weight.value().maximum) } };
+            result.weight = { { normalizeGXWeight(result.weight.value().minimum), normalizeGXWeight(result.weight.value().maximum) } };
         if (result.width)
             result.width = { { normalizeVariationWidth(result.width.value().minimum), normalizeVariationWidth(result.width.value().maximum) } };
         if (result.slope)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -352,7 +352,6 @@ VariationDefaultsMap defaultVariationValues(CTFontRef font, ShouldLocalizeAxisNa
     return result;
 }
 
-#if USE(NON_VARIABLE_SYSTEM_FONT)
 static inline bool fontIsSystemFont(CTFontRef font)
 {
     if (isSystemFont(font))
@@ -361,7 +360,6 @@ static inline bool fontIsSystemFont(CTFontRef font)
     auto name = adoptCF(CTFontCopyPostScriptName(font));
     return fontNameIsSystemFont(name.get());
 }
-#endif
 
 // These values were calculated by performing a linear regression on the CSS weights/widths/slopes and Core Text weights/widths/slopes of San Francisco.
 // FIXME: <rdar://problem/31312602> Get the real values from Core Text.
@@ -664,7 +662,7 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
             width = std::max(std::min(width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
         if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
             slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
-        if (shouldEnhanceTextLegibility()) {
+        if (shouldEnhanceTextLegibility() && fontIsSystemFont(originalFont)) {
             // FIXME: Implement this
         }
         if (needsConversion) {

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,6 @@ RetainPtr<CTFontRef> createFontForInstalledFonts(CTFontDescriptorRef, CGFloat si
 RetainPtr<CTFontRef> createFontForInstalledFonts(CTFontRef, AllowUserInstalledFonts);
 void addAttributesForWebFonts(CFMutableDictionaryRef attributes, AllowUserInstalledFonts);
 RetainPtr<CFSetRef> installedFontMandatoryAttributes(AllowUserInstalledFonts);
-
 VariationDefaultsMap defaultVariationValues(CTFontRef, ShouldLocalizeAxisNames);
-}
+
+} // namespace WebCore


### PR DESCRIPTION
This is a patch stack for the following patches. This stack represents r291846 (which got rolled out in r292859), but split into pieces, and with a few slight tweaks to improve performance.

```
commit f85aa9ca745e77871f115523f09b17d01cea0512
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:51:34 2022 -0700

    [Cocoa] Add test for accessibility bold preference
    https://bugs.webkit.org/show_bug.cgi?id=239374
    
    Reviewed by Alan Bujtas.
    
    * LayoutTests/fast/text/accessibility-bold-expected-mismatch.html: Added.
    * LayoutTests/fast/text/accessibility-bold-system-font-2-expected.html:
    * LayoutTests/fast/text/accessibility-bold.html: Added.
    * LayoutTests/platform/ios-wk2/TestExpectations:

commit 5b7821311ec746410305d15dbb22095836cfcc55
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:50:22 2022 -0700

    [Cocoa] Implement accessibility bold setting
    https://bugs.webkit.org/show_bug.cgi?id=239373
    
    Reviewed by Alan Bujtas.
    
    If the font is a system font and the accessibility bold setting is enabled, bump up the
    weight of the font.
    
    No new tests yet - one will be added in a subsequent patch.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::normalizeCTWeight):
    (WebCore::preparePlatformFont):

commit 45a5866aea37ef6a05d9849cf83b723520e917a6
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:49:27 2022 -0700

    [Cocoa] Check if the font is the system font to implement the accessibility bold setting
    https://bugs.webkit.org/show_bug.cgi?id=239371
    
    Reviewed by Alan Bujtas.
    
    This is a part of the feature to implement the accessibility bold feature.
    I'm splitting up the implementation into small pieces to try to determine which
    piece causes a performance regression.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::fontIsSystemFont):
    (WebCore::preparePlatformFont):

commit b6818317d50ef6ba0f0f34b26678f3c7da29905a
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:48:34 2022 -0700

    [Cocoa] Check if the accessibility bold setting is enabled during font creation
    https://bugs.webkit.org/show_bug.cgi?id=239369
    
    Reviewed by Alan Bujtas.
    
    This is a part of the feature to implement the accessibility bold feature.
    I'm splitting up the implementation into small pieces to try to determine which
    piece causes a performance regression.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::preparePlatformFont):

commit 9fa82eb7305a13d66544dd62572b42fe0a293e19
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:47:47 2022 -0700

    [Cocoa] Shadow the platform accessibility bold setting state
    https://bugs.webkit.org/show_bug.cgi?id=239368
    
    Reviewed by Alan Bujtas.
    
    We don't want to call an _AX***() function often if we can help it, so we stash its
    return value in a NeverDestroyed, and we update its value in invalidateFontCache().
    This is in preparation for implementing accessibility bold support.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::platformShouldEnhanceTextLegibility):
    (WebCore::shouldEnhanceTextLegibility):
    (WebCore::invalidateFontCache):

commit 80a6fe70238c94ffba8d66e1af198a56e681c588
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:46:59 2022 -0700

    [Cocoa] Add CSS / Core Text weight normalization functions
    https://bugs.webkit.org/show_bug.cgi?id=239367
    
    Reviewed by Alan Bujtas.
    
    These functions will be necessary when we call CTFontGetAccessibilityBoldWeightOfWeight().
    hat function operates in Core Text weights, but we operate in CSS weights in WebKit.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::normalizeCTWeight):
    (WebCore::denormalizeCTWeight):

commit 2108c2e639c9d3dc2a0aa26ba1bb6ffac194d72f
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:46:04 2022 -0700

    [Cocoa] Listen for the bold accessibility setting change notification
    https://bugs.webkit.org/show_bug.cgi?id=239365
    
    Reviewed by Alan Bujtas.
    
    This will cause a relayout (because of https://bugs.webkit.org/show_bug.cgi?id=238483).
    However, the relayout will be identical because accessibility bold has yet to be
    implemented (see https://bugs.webkit.org/show_bug.cgi?id=237817).
    
    No new tests because there is no behavior change (yet).
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::FontCache::platformInit):

commit 2cd5103e68b639ecbcc04457a28f84ddcaa88b8c
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:44:45 2022 -0700

    [Cocoa] Add SPI declarations for handling accessibility bold setting
    https://bugs.webkit.org/show_bug.cgi?id=239364
    
    Reviewed by Alan Bujtas.
    
    This is in preparation of a subsequent patch which will use these functions.
    This is split out into a separate patch because the original patch caused a
    performance regression, and I'm having trouble figuring out why, so I'm
    splitting it up into a few tiny pieces.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
    * Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h:
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::fontCacheRegisteredFontsChangedNotificationCallback):
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:

commit 4d0e2dc0e49e9ad9313a4a661ca70d87afb57402
Author: Myles C. Maxfield <mmaxfield@apple.com>
Date:   Thu May 26 11:43:06 2022 -0700

    [Cocoa] Rename [de]normalizeWeight() to [de]normalizeGXWeight()
    https://bugs.webkit.org/show_bug.cgi?id=239363
    
    Reviewed by Alan Bujtas.
    
    Weights are measured in 3 different scales:
    1. CSS weights (1 - 999)
    2. Core Text weights (-1.0 - 1.0)
    3. TrueType GX weights (0.0ish to 2.0ish, it's not really defined, only the "default" value
           of 1.0 is defined).
    
    Our current functions convert between CSS weights and TrueType GX weights, so this makes that more
    clear. A subsequent patch will add conversions between CSS weights and Core Text weights.
    
    No new tests because there is no behavior change.
    
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::normalizeGXWeight):
    (WebCore::denormalizeGXWeight):
    (WebCore::preparePlatformFont):
    (WebCore::variationCapabilitiesForFontDescriptor):
    (WebCore::normalizeWeight): Deleted.
    (WebCore::denormalizeWeight): Deleted.
```