### PR TITLE
[Modern Media Controls] REGRESSION(r293684) cannot pause `<video>` if `controls` are added after `"play"`

### DIFF
--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play-expected.txt
@@ -1,0 +1,17 @@
+Check that tapping the start button pauses the video if controls are added after it has started playing.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+'play' event.
+PASS shadowRoot.querySelector('button.play-pause') became different from null
+PASS shadowRoot.querySelector('button.play-pause').getBoundingClientRect().width became different from 0
+Tapping start button...
+Waiting for pause...
+PASS media.paused became true
+Checking again...
+PASS media.paused is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play.html
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play.html
@@ -1,0 +1,45 @@
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../resources/media-controls-utils.js"></script>
+<body>
+<video src="../../content/test.mp4" style="position: absolute; left: 0; top: 0; width: 400px;" muted playsinline autoplay></video>
+<script type="text/javascript">
+
+window.jsTestIsAsync = true;
+
+description("Check that tapping the start button pauses the video if controls are added after it has started playing.");
+
+const media = document.querySelector("video");
+const shadowRoot = window.internals.shadowRoot(media);
+
+media.addEventListener("play", async () => {
+    debug("'play' event");
+
+    if (media.controls)
+        return;
+
+    media.controls = true;
+
+    shouldBeFalse("media.paused");
+
+    await shouldBecomeDifferent("shadowRoot.querySelector('button.play-pause')", "null");
+    await shouldBecomeDifferent("shadowRoot.querySelector('button.play-pause').getBoundingClientRect().width", "0");
+
+    debug("Tapping start button...");
+    pressOnElement(shadowRoot.querySelector("button.play-pause"));
+
+    debug("Waiting for pause...");
+    await shouldBecomeEqual("media.paused", "true");
+
+    // Wait to see if the video is still paused.
+    debug("Checking again...");
+    setTimeout(() => {
+        shouldBeTrue("media.paused");
+
+        media.remove();
+        finishJSTest();
+    });
+});
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -34,7 +34,7 @@ class MediaController
 
         this.fullscreenChangeEventType = media.webkitSupportsPresentationMode ? "webkitpresentationmodechanged" : "webkitfullscreenchange";
 
-        this.hasPlayed = false;
+        this.hasPlayed = !media.paused || !!media.played.length;
 
         this.container = shadowRoot.appendChild(document.createElement("div"));
 

--- a/Source/WebCore/Modules/modern-media-controls/media/start-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/start-support.js
@@ -74,7 +74,7 @@ class StartSupport extends MediaControllerSupport
         if (host && host.shouldForceControlsDisplay)
             return true;
 
-        if (this.mediaController.hasPlayed || media.played.length)
+        if (this.mediaController.hasPlayed)
             return false;
 
         if (!media.paused)


### PR DESCRIPTION
#### 050b0786e5b8e8833828c020d9e96f8bd3e47ed4
<pre>
[Modern Media Controls] REGRESSION(r293684) cannot pause `&lt;video&gt;` if `controls` are added after `&quot;play&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=240985">https://bugs.webkit.org/show_bug.cgi?id=240985</a>
&lt;rdar://problem/93822316&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
Actually check if the `media` is playing and/or has played instead of always assuming `false`.

* Source/WebCore/Modules/modern-media-controls/media/start-support.js:
(StartSupport.prototype._shouldShowStartButton):
Drive-by: It&apos;s no longer necessary to check `media.played.length` here it&apos;s part of `mediaController.hasPlayed`.

* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play.html: Added.
* LayoutTests/media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-added-after-play-expected.txt: Added.
</pre>