### PR TITLE
Simplify MediaPlayerPrivateRemote::RequestResource API

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp
@@ -203,19 +203,21 @@ std::unique_ptr<TextureMapperPlatformLayerBuffer> GstVideoFrameHolder::platformL
             yuvPlaneOffset[i] = GST_VIDEO_INFO_COMP_POFFSET(&m_videoFrame.info, i);
         }
 
-        std::array<GLfloat, 9> yuvToRgb;
+        std::array<GLfloat, 16> yuvToRgb;
         if (gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(&m_videoFrame.info), GST_VIDEO_COLORIMETRY_BT709)) {
             yuvToRgb = {
-                1.164f,  0.0f,    1.787f,
-                1.164f, -0.213f, -0.531f,
-                1.164f,  2.112f,  0.0f
+                1.164383561643836f, -0.0f,                1.792741071428571f, -0.972945075016308f,
+                1.164383561643836f, -0.213248614273739f, -0.532909328559444f,  0.301482665475862f,
+                1.164383561643836f,  2.112401785714286f, -0.0f,               -1.133402217873451f,
+                0.0f,                0.0f,                0.0f,                1.0f,
             };
         } else {
             // Default to bt601. This is the same behaviour as GStreamer's glcolorconvert element.
             yuvToRgb = {
-                1.164f,  0.0f,    1.596f,
-                1.164f, -0.391f, -0.813f,
-                1.164f,  2.018f,  0.0f
+                1.164383561643836f,  0.0f,                1.596026785714286f, -0.874202217873451f,
+                1.164383561643836f, -0.391762290094914f, -0.812967647237771f,  0.531667823499146f,
+                1.164383561643836f,  2.017232142857143f, -0.0f,               -1.085630789302022f,
+                0.0f,                0.0f,                0.0f,                1.0f,
             };
         }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTextureCopierGStreamer.cpp
@@ -260,7 +260,7 @@ bool VideoTextureCopierGStreamer::copyVideoTextureToPlatformTexture(TextureMappe
                 glUniform1i(m_shaderProgram->samplerALocation(), texture.yuvPlane[3]);
                 break;
             }
-            glUniformMatrix3fv(m_shaderProgram->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&texture.yuvToRgbMatrix[0]));
+            glUniformMatrix4fv(m_shaderProgram->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&texture.yuvToRgbMatrix[0]));
 
             for (int i = texture.numberOfPlanes - 1; i >= 0; --i) {
                 glActiveTexture(GL_TEXTURE0 + i);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -542,7 +542,7 @@ static void prepareTransformationMatrixWithFlags(TransformationMatrix& patternTr
         patternTransform.translate(0, -1);
 }
 
-void TextureMapperGL::drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges)
+void TextureMapperGL::drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges)
 {
     bool useRect = flags & ShouldUseARBTextureRect;
     bool useAntialiasing = m_enableEdgeDistanceAntialiasing
@@ -601,11 +601,11 @@ void TextureMapperGL::drawTexturePlanarYUV(const std::array<GLuint, 3>& textures
         texturesAndSamplers.append({*alphaPlane, program->samplerALocation() });
 
     glUseProgram(program->programID());
-    glUniformMatrix3fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
+    glUniformMatrix4fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
     drawTexturedQuadWithProgram(program.get(), texturesAndSamplers, flags, textureSize, targetRect, modelViewMatrix, opacity);
 }
 
-void TextureMapperGL::drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges)
+void TextureMapperGL::drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges)
 {
     bool useRect = flags & ShouldUseARBTextureRect;
     bool useAntialiasing = m_enableEdgeDistanceAntialiasing
@@ -658,11 +658,11 @@ void TextureMapperGL::drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& text
     };
 
     glUseProgram(program->programID());
-    glUniformMatrix3fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
+    glUniformMatrix4fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
     drawTexturedQuadWithProgram(program.get(), texturesAndSamplers, flags, textureSize, targetRect, modelViewMatrix, opacity);
 }
 
-void TextureMapperGL::drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges)
+void TextureMapperGL::drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges)
 {
     bool useRect = flags & ShouldUseARBTextureRect;
     bool useAntialiasing = m_enableEdgeDistanceAntialiasing
@@ -713,7 +713,7 @@ void TextureMapperGL::drawTexturePackedYUV(GLuint texture, const std::array<GLfl
     };
 
     glUseProgram(program->programID());
-    glUniformMatrix3fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
+    glUniformMatrix4fv(program->yuvToRgbLocation(), 1, GL_FALSE, static_cast<const GLfloat *>(&yuvToRgbMatrix[0]));
     drawTexturedQuadWithProgram(program.get(), texturesAndSamplers, flags, textureSize, targetRect, modelViewMatrix, opacity);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
@@ -68,9 +68,9 @@ public:
     void drawNumber(int number, const Color&, const FloatPoint&, const TransformationMatrix&) override;
     void drawTexture(const BitmapTexture&, const FloatRect&, const TransformationMatrix&, float opacity, unsigned exposedEdges) override;
     virtual void drawTexture(GLuint texture, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
-    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 9>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
+    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
     void drawSolidColor(const FloatRect&, const TransformationMatrix&, const Color&, bool) override;
     void clearColor(const Color&) override;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
@@ -51,7 +51,7 @@ public:
         std::array<GLuint, 4> planes;
         std::array<unsigned, 4> yuvPlane;
         std::array<unsigned, 4> yuvPlaneOffset;
-        std::array<GLfloat, 9> yuvToRgbMatrix;
+        std::array<GLfloat, 16> yuvToRgbMatrix;
     };
     struct ExternalOESTexture {
         GLuint id;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -197,10 +197,11 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
 
     // TODO: this is the BT.601 colorspace conversion matrix. The exact desired colorspace should be included
     // in the DMABufObject, and the relevant matrix decided based on it. BT.601 should remain the default.
-    static constexpr std::array<GLfloat, 9> s_yuvToRGB {
-        1.164f,  0.0f,    1.596f,
-        1.164f, -0.391f, -0.813f,
-        1.164f,  2.018f,  0.0f
+    static constexpr std::array<GLfloat, 16> s_yuvToRGB {
+        1.164383561643836f,  0.0f,                1.596026785714286f, -0.874202217873451f,
+        1.164383561643836f, -0.391762290094914f, -0.812967647237771f,  0.531667823499146f,
+        1.164383561643836f,  2.017232142857143f, -0.0f,               -1.085630789302022f,
+        0.0f,                0.0f,                0.0f,                1.0f,
     };
 
     TextureMapperGL& texmapGL = static_cast<TextureMapperGL&>(textureMapper);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -238,7 +238,7 @@ static const char* fragmentTemplateCommon =
         uniform SamplerExternalOESType s_externalOESTexture;
         uniform float u_opacity;
         uniform float u_filterAmount;
-        uniform mat3 u_yuvToRgb;
+        uniform mat4 u_yuvToRgb;
         uniform vec2 u_blurRadius;
         uniform vec2 u_shadowOffset;
         uniform vec4 u_color;
@@ -269,9 +269,8 @@ static const char* fragmentTemplateCommon =
 
         vec3 yuvToRgb(float y, float u, float v)
         {
-            // yuv is either bt601 or bt709 so the offset is the same
-            vec3 yuv = vec3(y - 0.0625, u - 0.5, v - 0.5);
-            return yuv * u_yuvToRgb;
+            vec4 rgb = vec4(y, u, v, 1.0) * u_yuvToRgb;
+            return rgb.xyz;
         }
         void applyTextureYUV(inout vec4 color, vec2 texCoord)
         {

--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -904,56 +904,42 @@
             (allow mach-message-send (with telemetry)))))
             
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
-    (deny syscall-mach (with telemetry))
+    (allow syscall-mach (with telemetry))
     (allow syscall-mach (machtrap-number
         MSC__kernelrpc_mach_port_allocate_trap
         MSC__kernelrpc_mach_port_construct_trap
         MSC__kernelrpc_mach_port_deallocate_trap
         MSC__kernelrpc_mach_port_destruct_trap
         MSC__kernelrpc_mach_port_extract_member_trap
-        MSC__kernelrpc_mach_port_get_attributes_trap
         MSC__kernelrpc_mach_port_guard_trap
         MSC__kernelrpc_mach_port_insert_member_trap
         MSC__kernelrpc_mach_port_insert_right_trap
         MSC__kernelrpc_mach_port_mod_refs_trap
         MSC__kernelrpc_mach_port_request_notification_trap
         MSC__kernelrpc_mach_port_type_trap
-        MSC__kernelrpc_mach_port_unguard_trap
         MSC__kernelrpc_mach_vm_allocate_trap
         MSC__kernelrpc_mach_vm_deallocate_trap
         MSC__kernelrpc_mach_vm_map_trap
         MSC__kernelrpc_mach_vm_protect_trap
-        MSC__kernelrpc_mach_vm_purgable_control_trap
         MSC_host_create_mach_voucher_trap
         MSC_host_self_trap
-        MSC_iokit_user_client_trap
-        MSC_mach_generate_activity_id
         MSC_mach_msg_trap
-        MSC_mach_msg2_trap
         MSC_mach_reply_port
         MSC_mach_voucher_extract_attr_recipe_trap
-        MSC_mk_timer_arm
-        MSC_mk_timer_cancel
-        MSC_mk_timer_create
-        MSC_mk_timer_destroy
         MSC_pid_for_task
         MSC_semaphore_signal_trap
-        MSC_semaphore_timedwait_trap
         MSC_semaphore_wait_trap
         MSC_swtch_pri
         MSC_syscall_thread_switch
-        MSC_task_name_for_pid
-        MSC_task_self_trap
         MSC_thread_get_special_reply_port)))
 #endif // HAVE(SANDBOX_MESSAGE_FILTERING)
 
 (when (defined? 'syscall-unix)
-    (deny syscall-unix (with telemetry))
+    (allow syscall-unix (with telemetry))
     (allow syscall-unix (syscall-number
         SYS___channel_open
         SYS___disable_threadsignal
         SYS___mac_syscall
-        SYS___pthread_canceled
         SYS___pthread_kill
         SYS___pthread_sigmask
         SYS___semwait_signal
@@ -995,7 +981,6 @@
         SYS_gettimeofday
         SYS_getuid
         SYS_getxattr
-        SYS_guarded_open_np
         SYS_issetugid
         SYS_kdebug_trace
         SYS_kdebug_trace64
@@ -1039,8 +1024,6 @@
         SYS_readlink
         SYS_rename
         SYS_sendto
-        SYS_setrlimit
-        SYS_setsockopt
         SYS_sigaltstack
         SYS_sigprocmask
         SYS_socket

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -302,9 +302,7 @@ RefPtr<PlatformMediaResource> RemoteMediaPlayerProxy::requestResource(ResourceRe
     auto remoteMediaResource = RemoteMediaResource::create(remoteMediaResourceManager, *this, remoteMediaResourceIdentifier);
     remoteMediaResourceManager.addMediaResource(remoteMediaResourceIdentifier, remoteMediaResource);
 
-    m_webProcessConnection->sendWithAsyncReply(Messages::MediaPlayerPrivateRemote::RequestResource(remoteMediaResourceIdentifier, request, options), [remoteMediaResource]() {
-        remoteMediaResource->setReady(true);
-    }, m_id);
+    m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::RequestResource(remoteMediaResourceIdentifier, request, options), m_id);
 
     return remoteMediaResource;
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResource.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResource.h
@@ -48,9 +48,6 @@ public:
     static Ref<RemoteMediaResource> create(RemoteMediaResourceManager&, RemoteMediaPlayerProxy&, RemoteMediaResourceIdentifier);
     ~RemoteMediaResource();
 
-    bool ready() const { return m_ready; }
-    void setReady(bool ready) { m_ready = ready; }
-
     // PlatformMediaResource
     void stop() final;
     bool didPassAccessControlCheck() const final;
@@ -70,7 +67,6 @@ private:
     WeakPtr<RemoteMediaPlayerProxy> m_remoteMediaPlayerProxy;
     RemoteMediaResourceIdentifier m_id;
     bool m_didPassAccessControlCheck { false };
-    bool m_ready { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -61,7 +61,7 @@ void RemoteMediaResourceManager::removeMediaResource(RemoteMediaResourceIdentifi
 void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier identifier, const ResourceResponse& response, bool didPassAccessControlCheck, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready()) {
+    if (!resource) {
         completionHandler(ShouldContinuePolicyCheck::No);
         return;
     }
@@ -72,7 +72,7 @@ void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier 
 void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier identifier, ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready()) {
+    if (!resource) {
         completionHandler({ });
         return;
     }
@@ -83,7 +83,7 @@ void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier 
 void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready())
+    if (!resource)
         return;
 
     resource->dataSent(bytesSent, totalBytesToBeSent);
@@ -92,7 +92,7 @@ void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifi
 void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, const SharedMemory::IPCHandle& bufferHandle)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready())
+    if (!resource)
         return;
 
     auto sharedMemory = SharedMemory::map(bufferHandle.handle, SharedMemory::Protection::ReadOnly);
@@ -104,7 +104,7 @@ void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier iden
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready())
+    if (!resource)
         return;
 
     resource->accessControlCheckFailed(error);
@@ -113,7 +113,7 @@ void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIde
 void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready())
+    if (!resource)
         return;
 
     resource->loadFailed(error);
@@ -122,7 +122,7 @@ void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identi
 void RemoteMediaResourceManager::loadFinished(RemoteMediaResourceIdentifier identifier, const NetworkLoadMetrics& metrics)
 {
     auto* resource = m_remoteMediaResources.get(identifier);
-    if (!resource || !resource->ready())
+    if (!resource)
         return;
 
     resource->loadFinished(metrics);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1442,13 +1442,12 @@ void MediaPlayerPrivateRemote::playerContentBoxRectChanged(const LayoutRect& con
     connection().send(Messages::RemoteMediaPlayerProxy::PlayerContentBoxRectChanged(contentRect), m_id);
 }
 
-void MediaPlayerPrivateRemote::requestResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, WebCore::ResourceRequest&& request, WebCore::PlatformMediaResourceLoader::LoadOptions options, CompletionHandler<void()>&& completionHandler)
+void MediaPlayerPrivateRemote::requestResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, WebCore::ResourceRequest&& request, WebCore::PlatformMediaResourceLoader::LoadOptions options)
 {
     ASSERT(!m_mediaResources.contains(remoteMediaResourceIdentifier));
     auto resource = m_mediaResourceLoader->requestResource(WTFMove(request), options);
 
     if (!resource) {
-        completionHandler();
         // FIXME: Get the error from MediaResourceLoader::requestResource.
         connection().send(Messages::RemoteMediaResourceManager::LoadFailed(remoteMediaResourceIdentifier, { ResourceError::Type::Cancellation }), 0);
         return;
@@ -1456,8 +1455,6 @@ void MediaPlayerPrivateRemote::requestResource(RemoteMediaResourceIdentifier rem
     // PlatformMediaResource owns the PlatformMediaResourceClient
     resource->setClient(adoptRef(*new RemoteMediaResourceProxy(connection(), *resource, remoteMediaResourceIdentifier)));
     m_mediaResources.add(remoteMediaResourceIdentifier, WTFMove(resource));
-
-    completionHandler();
 }
 
 void MediaPlayerPrivateRemote::sendH2Ping(const URL& url, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -147,7 +147,7 @@ public:
     void updateGenericCue(TrackPrivateRemoteIdentifier, WebCore::GenericCueData&&);
     void removeGenericCue(TrackPrivateRemoteIdentifier, WebCore::GenericCueData&&);
 
-    void requestResource(RemoteMediaResourceIdentifier, WebCore::ResourceRequest&&, WebCore::PlatformMediaResourceLoader::LoadOptions, CompletionHandler<void()>&&);
+    void requestResource(RemoteMediaResourceIdentifier, WebCore::ResourceRequest&&, WebCore::PlatformMediaResourceLoader::LoadOptions);
     void removeResource(RemoteMediaResourceIdentifier);
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&);
     void resourceNotSupported();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -68,7 +68,7 @@ messages -> MediaPlayerPrivateRemote NotRefCounted {
     UpdateGenericCue(WebKit::TrackPrivateRemoteIdentifier trackID, struct WebCore::GenericCueData cue)
     RemoveGenericCue(WebKit::TrackPrivateRemoteIdentifier trackID, struct WebCore::GenericCueData cue)
 
-    RequestResource(WebKit::RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, WebCore::ResourceRequest request, enum:uint8_t WebCore::PlatformMediaResourceLoader::LoadOptions options) -> ()
+    RequestResource(WebKit::RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, WebCore::ResourceRequest request, enum:uint8_t WebCore::PlatformMediaResourceLoader::LoadOptions options)
     RemoveResource(WebKit::RemoteMediaResourceIdentifier remoteMediaResourceIdentifier)
     SendH2Ping(URL url) -> (Expected<Seconds, WebCore::ResourceError> result)
     ResourceNotSupported()


### PR DESCRIPTION
#### 5fc004efa83b180dca1740566d49c025f38335ed
<pre>
Simplify MediaPlayerPrivateRemote::RequestResource API
<a href="https://bugs.webkit.org/show_bug.cgi?id=240999">https://bugs.webkit.org/show_bug.cgi?id=240999</a>
&lt;rdar://94012261 &gt;

Reviewed by Eric Carlson.

When the GPU Process&apos; MediaPlayerProxy needs to allocate a new MediaResource it sends
a message to the content process via the MediaPlayerPrivateRemote::RequestResource
IPC call with a RemoteMediaResourceIdentifier which will then respond to indicate that
the MediaResource is now &quot;ready&quot;.

There&apos;s two scenarios possible here:
Either the creation of the media resource in the content process is successful or it&apos;s not.

If it&apos;s successful the content process will start sending data starting by a call to the
GPU&apos;s RemoteMediaResourceManager responseReceived
Or it will fail and call RemoteMediaResourceManager::LoadFailed.

The RemoteMediaResourceManager will only accept incoming data once the MediaResource&apos;s
ready status is true, and if you&apos;re only working on the main thread, it will always be,
as the Content Process&apos; RequestResource response will always be received before either
a LoadFailed or ResponseReceived call.
Under these conditions, the ready status is totally redundant. Testing that the
RemoteMediaResource exists in the MediaResourceManager&apos;s map is sufficient.

However, if we want to parallelise networking operations so that ResponseReceived and
LoadFailed will be called on a secondary thread as introduced in bug 235353;
the &quot;ready&quot; flag becomes problematic as the response from a RequestResource is handled
on the main thread.
The multi-threaded nature of the work means that the RequestResource response could be
received only after LoadFailed or ResponseReceived message; and if that&apos;s the case
those two messages will be dropped.

This can be seen with the intermittent failures occurring with media/video-src-blob-replay.html test.

So we remove this concept of RemoteMediaResource::ready as at best it serves no purpose.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::requestResource):
* Source/WebKit/GPUProcess/media/RemoteMediaResource.h:
(WebKit::RemoteMediaResource::ready const): Deleted.
(WebKit::RemoteMediaResource::setReady): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::responseReceived):
(WebKit::RemoteMediaResourceManager::redirectReceived):
(WebKit::RemoteMediaResourceManager::dataSent):
(WebKit::RemoteMediaResourceManager::dataReceived):
(WebKit::RemoteMediaResourceManager::accessControlCheckFailed):
(WebKit::RemoteMediaResourceManager::loadFailed):
(WebKit::RemoteMediaResourceManager::loadFinished):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::requestResource):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:

Canonical link: <a href="https://commits.webkit.org/251048@main">https://commits.webkit.org/251048@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@294937">https://svn.webkit.org/repository/webkit/trunk@294937</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
