### PR TITLE
[commits.webkit.org] Treat integer as revision

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 0)
+version = Version(0, 7, 1)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
@@ -22,6 +22,7 @@
 
 import json
 import re
+import sys
 
 from flask import abort, current_app, json as fjson, redirect, Flask, Response
 from reporelaypy import Database
@@ -180,6 +181,11 @@ class CheckoutRoute(AuthedBlueprint):
         self.add_url_rule('/changeset/<path:revision>/webkit', 'trac', self.trac, methods=('GET',))
 
     def commit(self, ref=None):
+        import redis
+
+        if ref and isinstance(ref, str) and ref.isnumeric():
+            ref = 'r{}'.format(ref)
+
         try:
             retrieved = self.database.get(ref)
             if retrieved:

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
@@ -131,6 +131,23 @@ class CheckoutRouteUnittest(testing.PathTestCase):
             self.assertEqual(response.json(), reference)
 
     @mock_app
+    def test_json_integer(self, app=None, client=None):
+        self.maxDiff = None
+        with mocks.local.Git(self.path, git_svn=True) as repo:
+            app.register_blueprint(CheckoutRoute(
+                Checkout(path=self.path, url=repo.remote, sentinal=False),
+                redirectors=[Redirector('https://trac.webkit.org')],
+            ))
+            reference = Commit.Encoder().default(repo.commits['main'][3])
+            reference['message'] = reference['message'].rstrip()
+
+            response = client.get('8/json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()['hash'], reference['hash'])
+            self.assertEqual(response.json()['identifier'], reference['identifier'])
+            self.assertEqual(response.json()['revision'], reference['revision'])
+
+    @mock_app
     def test_redirect(self, app=None, client=None):
         with mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.0',
+    version='0.7.1',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 121c1760a2ef3585e888ecd26c44b908d2ff2c7d
<pre>
[commits.webkit.org] Treat integer as revision
<a href="https://bugs.webkit.org/show_bug.cgi?id=241011">https://bugs.webkit.org/show_bug.cgi?id=241011</a>
&lt;rdar://problem/94031994&gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(CheckoutRoute.commit): Convert integer to r-prefixed revision.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py:
(CheckoutRouteUnittest.test_json_integer): Added.
* Tools/Scripts/libraries/reporelaypy/setup.py: Bump version.
</pre>