### PR TITLE
Enable JSC binary tests on armv7 post-commit buildbots

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -529,7 +529,7 @@ class RunJavaScriptCoreTests(TestWithFailureCount):
         # high enough.
         self.command += self.commandExtra
         # Currently run-javascriptcore-test doesn't support run javascript core test binaries list below remotely
-        if architecture in ['mips', 'armv7', 'aarch64']:
+        if architecture in ['mips', 'aarch64']:
             self.command += ['--no-testmasm', '--no-testair', '--no-testb3', '--no-testdfg', '--no-testapi']
         # Linux bots have currently problems with JSC tests that try to use large amounts of memory.
         # Check: https://bugs.webkit.org/show_bug.cgi?id=175140


### PR DESCRIPTION
#### ce5ba3fc389ac8932b4ff6c62febec2cc71bb161
<pre>
Enable JSC binary tests on armv7 post-commit buildbots
<a href="https://bugs.webkit.org/show_bug.cgi?id=241021">https://bugs.webkit.org/show_bug.cgi?id=241021</a>

Reviewed by Aakash Jain.

The armv7 buildbots are running things, so it should be safe to enable
the binary tests. They have been enabled on EWS for a while.

* Tools/CISupport/build-webkit-org/steps.py:
(RunJavaScriptCoreTests.start):

Canonical link: <a href="https://commits.webkit.org/251905@main">https://commits.webkit.org/251905@main</a>
</pre>
