### PR TITLE
REGRESSION(r294634): Fix unified build with ContentTypeUtilities.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
@@ -25,11 +25,10 @@
 
 #include "config.h"
 #include "ContentTypeUtilities.h"
-
-namespace WebCore {
-
 #include "FourCC.h"
 #include <wtf/Algorithms.h>
+
+namespace WebCore {
 
 bool contentTypeMeetsContainerAndCodecTypeRequirements(const ContentType& type, const std::optional<Vector<String>>& allowedMediaContainerTypes, const std::optional<Vector<String>>& allowedMediaCodecTypes)
 {


### PR DESCRIPTION
#### f8883686379f47cf718a09d888aa1c2f00e4d8b4
<pre>
REGRESSION(r294634): Fix unified build with ContentTypeUtilities.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=241023">https://bugs.webkit.org/show_bug.cgi?id=241023</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/ContentTypeUtilities.cpp:
This file has been added in r294634, but it can break some unified
builds because it made &lt;wtf/Forward.h&gt; included from the WebCore
namespace.
</pre>