### PR TITLE
PR to test EWS comments on GitHub - Layout 3

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -351,6 +351,9 @@ class MergeQueueFactory(MergeQueueFactoryBase):
         self.addStep(KillOldProcesses())
 
         self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True))
+        self.addStep(RunWebKitTests())
+
+        self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True))
         self.addStep(Canonicalize())
         self.addStep(PushCommitToWebKitRepo())
         self.addStep(SetBuildSummary())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -648,6 +648,8 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'kill-old-processes',
             'validate-change',
+            'layout-tests',
+            'validate-change',
             'canonicalize-commit',
             'push-commit-to-webkit-repo',
             'set-build-summary'


### PR DESCRIPTION
#### c4f5598c97d2f1fd6e54ed323fa784559d113073
<pre>
PR to test EWS comments on GitHub - Layout 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=241039">https://bugs.webkit.org/show_bug.cgi?id=241039</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/ews-build/factories.py:
(MergeQueueFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
</pre>
https://github.com/WebKit/WebKit/commit/c4f5598c97d2f1fd6e54ed323fa784559d113073
🛠 Builders: 
[❌ ios](https://ews-build.webkit.org/#/builders/53/builds/22172) [✅ mac](https://ews-build.webkit.org/#/builders/55/builds/16411) [✅ mac-debug](https://ews-build.webkit.org/#/builders/58/builds/16407) [⏳ mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11994) [❌ ios-sim](https://ews-build.webkit.org/#/builders/52/builds/22935) [✅ tv](https://ews-build.webkit.org/#/builders/48/builds/23467) [✅ tv-sim](https://ews-build.webkit.org/#/builders/50/builds/23205) [✅ watch](https://ews-build.webkit.org/#/builders/47/builds/23372) [✅ watch-sim](https://ews-build.webkit.org/#/builders/49/builds/23020) [✅ gtk](https://ews-build.webkit.org/#/builders/36/builds/43436) [✅ wpe](https://ews-build.webkit.org/#/builders/8/builds/60280) [❌ win](https://ews-build.webkit.org/#/builders/10/builds/102705) [✅ wincairo](https://ews-build.webkit.org/#/builders/12/builds/59368) 



🧪 Testers:
 [❌ ios-wk2](https://ews-build.webkit.org/#/builders/51/builds/20077) [❌ mac-wk1](https://ews-build.webkit.org/#/builders/57/builds/14412) [❌ mac-wk2](https://ews-build.webkit.org/#/builders/59/builds/14430) [❌ mac-debug-wk1](https://ews-build.webkit.org/#/builders/56/builds/14060) [❌ mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/10790) [❌ api-ios](https://ews-build.webkit.org/#/builders/9/builds/53389) [✅ api-mac](https://ews-build.webkit.org/#/builders/3/builds/54382) [✅ api-gtk](https://ews-build.webkit.org/#/builders/34/builds/42152)


Other:
 [❌ style](https://ews-build.webkit.org/#/builders/6/builds/54677) [❌ webkitpy](https://ews-build.webkit.org/#/builders/5)[✅ bindings](https://ews-build.webkit.org/#/builders/11/builds/59148) [✅ webkitperl](https://ews-build.webkit.org/#/builders/19/builds/60588) [⏳ services](https://ews-build.webkit.org/#/builders/20)
<details>

### ❌ 🛠🧪 win
Found 1 new test failure
 http/tests/websocket/tests/hybi/simple-wss.html

### ❌ 🧪 mac-wk1
Found 5 new test failures
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...

### ❌ 🧪 mac-wk2
Found 5 new test failures
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...

### ❌ 🧪 mac-debug-wk1
Found 5 new test failures
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...

### ❌ 🧪 mac-AS-debug-wk2
Found 5 new test failures
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...
 fast/overflow/inline-block-scroll-overflow.html...


</details>