### PR TITLE
[iOS][GPUP] Only block unused syscalls on newer OS versions

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -714,7 +714,11 @@
 )
 
 (when (defined? 'syscall-unix)
+#if !PLATFORM(IOS) || __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
     (deny syscall-unix (with telemetry))
+#else
+    (allow syscall-unix)
+#endif
     (allow syscall-unix (syscall-number
         SYS___disable_threadsignal
         SYS___mac_syscall
@@ -825,7 +829,11 @@
     (allow syscall-unix (syscall-number SYS_map_with_linking_np)))
 
 (when (defined? 'syscall-mach)
+#if !PLATFORM(IOS) || __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
     (deny syscall-mach (with telemetry))
+#else
+    (allow syscall-mach)
+#endif
     (allow syscall-mach
         (machtrap-number
             MSC__kernelrpc_mach_port_allocate_trap


### PR DESCRIPTION
#### 45b7e1d0db7c98de18933e830aa1068b0000f6d9
<pre>
[iOS][GPUP] Only block unused syscalls on newer OS versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=241045">https://bugs.webkit.org/show_bug.cgi?id=241045</a>

Reviewed by NOBODY (OOPS!).

Only block unused syscalls on newer OS versions, since telemetry has not been inspected for older OS versions,
and since this version of the sandbox will in general not be applied on older OS versions.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
</pre>