### PR TITLE
[Wasm-GC] Introduce array types

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -1,0 +1,167 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testArrayDeclaration() {
+  instantiate(`
+    (module
+      (type (array i32))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (array (mut i32)))
+    )
+  `);
+
+  /*
+   * invalid element type
+   * (module
+   *   (type (array <invalid>))
+   * )
+   */
+  assert.throws(
+    () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x84\x80\x80\x80\x00\x01\x5e\xff\x02")),
+    WebAssembly.CompileError,
+    "Module doesn't parse at byte 17: can't get array's element Type"
+  )
+
+  /*
+   * invalid mut value 0x02
+   * (module
+   *   (type (array (<invalid> i32)))
+   * )
+   */
+  assert.throws(
+    () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x84\x80\x80\x80\x00\x01\x5e\x7f\x02")),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 18: invalid array mutability: 0x02"
+  )
+
+  instantiate(`
+    (module
+      (type (array i32))
+      (func (result (ref null 0)) (ref.null 0))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (array i32))
+      (func (result arrayref) (ref.null 0))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (array i32))
+        (func (result (ref null 0)) (ref.null array))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. RefNull is not a RefNull, in function at index 0"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (array i32))
+        (func (result funcref) (ref.null 0))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. RefNull is not a RefNull, in function at index 0"
+  );
+}
+
+function testArrayJS() {
+  // JS API behavior not specified yet, import/export error for now.
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (array i64))
+          (func (export "f") (result (ref null 0))
+            (ref.null 0))
+        )
+      `);
+      m.exports.f();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (array externref))
+          (func (export "f") (param (ref null 0)))
+        )
+      `);
+      m.exports.f(null);
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (array f32))
+          (import "m" "f" (func (param (ref null 0))))
+          (func (export "g") (call 0 (ref.null 0)))
+        )
+      `, { m: { f: (x) => { return; } } });
+      m.exports.g();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (array i32))
+          (import "m" "f" (func (result (ref null 0))))
+          (func (export "g") (call 0) drop)
+        )
+      `, { m: { f: (x) => { return null; } } });
+      m.exports.g();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  // JS API behavior not specified yet, setting global errors for now.
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (array i32))
+          (global (export "g") (mut (ref null 0)) (ref.null 0))
+        )
+      `);
+      m.exports.g.value = 42;
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+}
+
+testArrayDeclaration();
+testArrayJS();

--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -21,7 +21,20 @@ function testRecDeclaration() {
 
   instantiate(`
     (module
+      (rec (type (func)) (type (array i32)))
+    )
+  `);
+
+  instantiate(`
+    (module
       (rec (type (func)) (type (struct)))
+      (func (type 0))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec (type (func)) (type (array f32)))
       (func (type 0))
     )
   `);
@@ -30,6 +43,17 @@ function testRecDeclaration() {
     () => compile(`
       (module
         (rec (type (struct)) (type (func)))
+        (func (type 0))
+      )
+    `),
+    WebAssembly.CompileError,
+    "type signature was not a function signature"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec (type (array i64)) (type (func)))
         (func (type 0))
       )
     `),

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -16,8 +16,10 @@
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64" },
         "ref":       { "type": "varint7", "value":  -21, "b3type": "B3::Int64" },
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
+        "arrayref":  { "type": "varint7", "value":  -26, "b3type": "B3::Int64" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "array":     { "type": "varint7", "value":  -34, "b3type": "B3::Void" },
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -127,6 +127,13 @@ inline bool isI31ref(Type type)
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::I31ref);
 }
 
+inline bool isArrayref(Type type)
+{
+    if (!Options::useWebAssemblyGC())
+        return false;
+    return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Arrayref);
+}
+
 inline Type funcrefType()
 {
     if (Options::useWebAssemblyTypedFunctionReferences())
@@ -146,7 +153,7 @@ inline bool isRefWithTypeIndex(Type type)
     if (!Options::useWebAssemblyTypedFunctionReferences())
         return false;
 
-    return isRefType(type) && !isExternref(type) && !isFuncref(type) && !isI31ref(type);
+    return isRefType(type) && !isExternref(type) && !isFuncref(type) && !isI31ref(type) && !isArrayref(type);
 }
 
 inline bool isTypeIndexHeapType(int32_t heapType)
@@ -162,8 +169,13 @@ inline bool isSubtype(Type sub, Type parent)
     if (sub.isNullable() && !parent.isNullable())
         return false;
 
-    if ((sub.isRef() || sub.isRefNull()) && isFuncref(parent))
-        return true;
+    if (isRefWithTypeIndex(sub)) {
+        if (TypeInformation::get(sub.index).is<ArrayType>() && isArrayref(parent))
+            return true;
+
+        if (TypeInformation::get(sub.index).is<FunctionSignature>() && isFuncref(parent))
+            return true;
+    }
 
     if (sub.isRef() && parent.isRefNull() && sub.index == parent.index)
         return true;
@@ -178,6 +190,7 @@ inline bool isValidHeapTypeKind(TypeKind kind)
     case TypeKind::Externref:
         return true;
     case TypeKind::I31ref:
+    case TypeKind::Arrayref:
         return Options::useWebAssemblyGC();
     default:
         break;

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -660,6 +660,8 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
             RELEASE_ASSERT_NOT_REACHED();
@@ -720,6 +722,8 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
             RELEASE_ASSERT_NOT_REACHED();
@@ -752,6 +756,8 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
             RELEASE_ASSERT_NOT_REACHED();
@@ -812,6 +818,8 @@ auto LLIntGenerator::callInformationForCallee(const FunctionSignature& signature
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
             RELEASE_ASSERT_NOT_REACHED();
@@ -865,6 +873,8 @@ auto LLIntGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
         case TypeKind::Void:
         case TypeKind::Func:
         case TypeKind::Struct:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -341,7 +341,7 @@ ALWAYS_INLINE bool Parser<SuccessType>::parseValueType(const ModuleInformation& 
 
     TypeKind typeKind = static_cast<TypeKind>(kind);
     TypeIndex typeIndex = 0;
-    if (Options::useWebAssemblyTypedFunctionReferences() && (typeKind == TypeKind::Funcref || typeKind == TypeKind::Externref || typeKind == TypeKind::I31ref)) {
+    if (Options::useWebAssemblyTypedFunctionReferences() && (typeKind == TypeKind::Funcref || typeKind == TypeKind::Externref || typeKind == TypeKind::I31ref || typeKind == TypeKind::Arrayref)) {
         typeIndex = static_cast<TypeIndex>(typeKind);
         typeKind = TypeKind::RefNull;
     } else if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -71,6 +71,7 @@ private:
 
     PartialResult WARN_UNUSED_RETURN parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
+    PartialResult WARN_UNUSED_RETURN parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
 
     PartialResult WARN_UNUSED_RETURN validateElementTableIdx(uint32_t);

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -140,6 +140,8 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Array:
+            case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
@@ -223,6 +225,8 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Void:
             case TypeKind::Func:
             case TypeKind::Struct:
+            case TypeKind::Array:
+            case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -16,8 +16,10 @@
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64" },
         "ref":       { "type": "varint7", "value":  -21, "b3type": "B3::Int64" },
         "i31ref":    { "type": "varint7", "value":  -22, "b3type": "B3::Void" },
+        "arrayref":  { "type": "varint7", "value":  -26, "b3type": "B3::Int64" },
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void" },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void" },
+        "array":     { "type": "varint7", "value":  -34, "b3type": "B3::Void" },
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void" },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void" }
     },


### PR DESCRIPTION
#### fa3d441596d43e14b9ce4b6dff3b38e9d7b81bc3
<pre>
[Wasm-GC] Introduce array types
<a href="https://bugs.webkit.org/show_bug.cgi?id=240980">https://bugs.webkit.org/show_bug.cgi?id=240980</a>

Reviewed by Justin Michaud.

Adds support for creating type definitions for Wasm GC array types.
Also adds support for the `arrayref` type, which is the supertype of all
array references. The patch does not yet add support for operations
which create arrays (except for the null array reference) or access
them.

* JSTests/wasm/gc/arrays.js: Added.
(module):
(testArrayDeclaration):
* JSTests/wasm/gc/rec.js:
(testRecDeclaration):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isArrayref):
(JSC::Wasm::isRefWithTypeIndex):
(JSC::Wasm::isSubtype):
(JSC::Wasm::isValidHeapTypeKind):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseArrayType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::dump const):
(JSC::Wasm::ArrayType::toString const):
(JSC::Wasm::ArrayType::dump const):
(JSC::Wasm::computeStructTypeHash):
(JSC::Wasm::computeArrayTypeHash):
(JSC::Wasm::TypeDefinition::hash const):
(JSC::Wasm::TypeDefinition::tryCreateArrayType):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::ArrayParameterTypes::hash):
(JSC::Wasm::ArrayParameterTypes::equal):
(JSC::Wasm::ArrayParameterTypes::translate):
(JSC::Wasm::TypeInformation::typeDefinitionForStruct):
(JSC::Wasm::TypeInformation::typeDefinitionForArray):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::FieldType::operator== const):
(JSC::Wasm::FieldType::operator!= const):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::StructType::field const):
(JSC::Wasm::StructType::getField):
(JSC::Wasm::StructType::storage):
(JSC::Wasm::StructType::storage const):
(JSC::Wasm::ArrayType::ArrayType):
(JSC::Wasm::ArrayType::elementType const):
(JSC::Wasm::ArrayType::getElementType):
(JSC::Wasm::ArrayType::storage):
(JSC::Wasm::ArrayType::storage const):
(JSC::Wasm::TypeDefinition::TypeDefinition):
(JSC::Wasm::TypeDefinition::allocatedStructSize):
(JSC::Wasm::TypeDefinition::allocatedArraySize):
(JSC::Wasm::StructField::operator== const): Deleted.
(JSC::Wasm::StructField::operator!= const): Deleted.
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/254455@main">https://commits.webkit.org/254455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01409749923521ef3fb92d860a4da1bc24f768a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/88998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/33562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/19862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98288 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/154649 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32067 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/27652 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/92810 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/94638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25462 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/75962 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25394 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68363 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/80712 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/29858 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14393 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/74500 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/29589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15370 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3120 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38312 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/77361 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/31718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34465 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17136 "Passed tests") | 
<!--EWS-Status-Bubble-End-->