### PR TITLE
Firing a fetch event should not be blocked on main thread

### DIFF
--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -51,7 +51,7 @@ ServiceWorkerInternals::~ServiceWorkerInternals() = default;
 void ServiceWorkerInternals::setOnline(bool isOnline)
 {
     callOnMainThread([identifier = m_identifier, isOnline] () {
-        if (auto* proxy = SWContextManager::singleton().workerByID(identifier))
+        if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier))
             proxy->notifyNetworkStateChange(isOnline);
     });
 }
@@ -75,7 +75,7 @@ void ServiceWorkerInternals::schedulePushEvent(const String& message, RefPtr<Def
     }
     callOnMainThread([identifier = m_identifier, data = WTFMove(data), weakThis = WeakPtr { *this }, counter]() mutable {
         SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), [identifier, weakThis = WTFMove(weakThis), counter](bool result) mutable {
-            if (auto* proxy = SWContextManager::singleton().workerByID(identifier)) {
+            if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier)) {
                 proxy->thread().runLoop().postTaskForMode([weakThis = WTFMove(weakThis), counter, result](auto&) {
                     if (!weakThis)
                         return;
@@ -169,7 +169,7 @@ void ServiceWorkerInternals::lastNavigationWasAppInitiated(Ref<DeferredPromise>&
     ASSERT(!m_lastNavigationWasAppInitiatedPromise);
     m_lastNavigationWasAppInitiatedPromise = WTFMove(promise);
     callOnMainThread([identifier = m_identifier, weakThis = WeakPtr { *this }]() mutable {
-        if (auto* proxy = SWContextManager::singleton().workerByID(identifier)) {
+        if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier)) {
             proxy->thread().runLoop().postTaskForMode([weakThis = WTFMove(weakThis), appInitiated = proxy->lastNavigationWasAppInitiated()](auto&) {
                 if (!weakThis || !weakThis->m_lastNavigationWasAppInitiatedPromise)
                     return;

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.h
@@ -57,8 +57,8 @@ struct ServiceWorkerClientData {
     uint64_t focusOrder { 0 };
     Vector<String> ancestorOrigins;
 
-    ServiceWorkerClientData isolatedCopy() const &;
-    ServiceWorkerClientData isolatedCopy() &&;
+    WEBCORE_EXPORT ServiceWorkerClientData isolatedCopy() const &;
+    WEBCORE_EXPORT ServiceWorkerClientData isolatedCopy() &&;
 
     WEBCORE_EXPORT static ServiceWorkerClientData from(ScriptExecutionContext&);
 

--- a/Source/WebCore/workers/service/ServiceWorkerContextData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContextData.h
@@ -102,8 +102,8 @@ struct ServiceWorkerContextData {
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<ServiceWorkerContextData> decode(Decoder&);
 
-    ServiceWorkerContextData isolatedCopy() const &;
-    ServiceWorkerContextData isolatedCopy() &&;
+    WEBCORE_EXPORT ServiceWorkerContextData isolatedCopy() const &;
+    WEBCORE_EXPORT ServiceWorkerContextData isolatedCopy() &&;
 };
 
 template<class Encoder>

--- a/Source/WebCore/workers/service/ServiceWorkerData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerData.h
@@ -41,8 +41,8 @@ struct ServiceWorkerData {
     WorkerType type;
     ServiceWorkerRegistrationIdentifier registrationIdentifier;
 
-    ServiceWorkerData isolatedCopy() const &;
-    ServiceWorkerData isolatedCopy() &&;
+    WEBCORE_EXPORT ServiceWorkerData isolatedCopy() const &;
+    WEBCORE_EXPORT ServiceWorkerData isolatedCopy() &&;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<ServiceWorkerData> decode(Decoder&);

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -184,18 +184,53 @@ void ServiceWorkerThreadProxy::notifyNetworkStateChange(bool isOnline)
     }, WorkerRunLoop::defaultMode());
 }
 
+static inline bool isValidFetch(const ResourceRequest& request, const FetchOptions& options, const URL& serviceWorkerURL, const String& referrer)
+{
+    // For exotic service workers, do not enforce checks.
+    if (!serviceWorkerURL.protocolIsInHTTPFamily())
+        return true;
+
+    if (options.mode == FetchOptions::Mode::Navigate) {
+        if (!protocolHostAndPortAreEqual(request.url(), serviceWorkerURL)) {
+            RELEASE_LOG_ERROR(ServiceWorker, "Should not intercept a navigation load that is not same-origin as the service worker URL");
+            RELEASE_ASSERT_WITH_MESSAGE(request.url().host() == serviceWorkerURL.host(), "Hosts do not match");
+            RELEASE_ASSERT_WITH_MESSAGE(request.url().protocol() == serviceWorkerURL.protocol(), "Protocols do not match");
+            RELEASE_ASSERT_WITH_MESSAGE(request.url().port() == serviceWorkerURL.port(), "Ports do not match");
+            return false;
+        }
+        return true;
+    }
+
+    String origin = request.httpOrigin();
+    URL url { origin.isEmpty() ? referrer : origin };
+    if (url.protocolIsInHTTPFamily() && !protocolHostAndPortAreEqual(url, serviceWorkerURL)) {
+        RELEASE_LOG_ERROR(ServiceWorker, "Should not intercept a non navigation load that is not originating from a same-origin context as the service worker URL");
+        ASSERT(url.host() == serviceWorkerURL.host());
+        ASSERT(url.protocol() == serviceWorkerURL.protocol());
+        ASSERT(url.port() == serviceWorkerURL.port());
+        return false;
+    }
+    return true;
+}
+
 void ServiceWorkerThreadProxy::startFetch(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier, Ref<ServiceWorkerFetch::Client>&& client, ResourceRequest&& request, String&& referrer, FetchOptions&& options, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier)
 {
-    RELEASE_LOG(ServiceWorker, "ServiceWorkerThreadProxy::startFetch %llu", fetchIdentifier.toUInt64());
+    ASSERT(!isMainThread());
 
-    auto key = std::make_pair(connectionIdentifier, fetchIdentifier);
+    callOnMainRunLoop([protectedThis = Ref { *this }] {
+        protectedThis->thread().startFetchEventMonitoring();
+    });
 
-    if (m_ongoingFetchTasks.isEmpty())
-        thread().startFetchEventMonitoring();
+    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, client = WTFMove(client), request = request.isolatedCopy(), referrer = WTFMove(referrer).isolatedCopy(), options = WTFMove(options).isolatedCopy(), fetchIdentifier, isServiceWorkerNavigationPreloadEnabled, clientIdentifier = WTFMove(clientIdentifier).isolatedCopy(), resultingClientIdentifier = WTFMove(resultingClientIdentifier).isolatedCopy()] (auto& context) mutable {
+        if (!isValidFetch(request, options, downcast<ServiceWorkerGlobalScope>(context).contextData().scriptURL, referrer)) {
+            client->didNotHandle();
+            return;
+        }
 
-    ASSERT(!m_ongoingFetchTasks.contains(key));
-    m_ongoingFetchTasks.add(key, client.copyRef());
-    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, client = WTFMove(client), request = request.isolatedCopy(), referrer = WTFMove(referrer).isolatedCopy(), options = WTFMove(options).isolatedCopy(), fetchIdentifier, isServiceWorkerNavigationPreloadEnabled, clientIdentifier = WTFMove(clientIdentifier).isolatedCopy(), resultingClientIdentifier = WTFMove(resultingClientIdentifier).isolatedCopy()](auto&) mutable {
+        std::pair key { connectionIdentifier, fetchIdentifier };
+        ASSERT(!m_ongoingFetchTasks.contains(key));
+        m_ongoingFetchTasks.add(key, Ref { client });
+
         thread().queueTaskToFireFetchEvent(WTFMove(client), WTFMove(request), WTFMove(referrer), WTFMove(options), fetchIdentifier, isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
     }, WorkerRunLoop::defaultMode());
 }
@@ -204,14 +239,17 @@ void ServiceWorkerThreadProxy::cancelFetch(SWServerConnectionIdentifier connecti
 {
     RELEASE_LOG(ServiceWorker, "ServiceWorkerThreadProxy::cancelFetch %llu", fetchIdentifier.toUInt64());
 
-    auto client = m_ongoingFetchTasks.take(std::make_pair(connectionIdentifier, fetchIdentifier));
-    if (!client)
-        return;
+    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, fetchIdentifier] (auto&) {
+        auto client = m_ongoingFetchTasks.take({ connectionIdentifier, fetchIdentifier });
+        if (!client)
+            return;
 
-    if (m_ongoingFetchTasks.isEmpty())
-        thread().stopFetchEventMonitoring();
+        if (m_ongoingFetchTasks.isEmpty()) {
+            callOnMainRunLoop([protectedThis] {
+                protectedThis->thread().stopFetchEventMonitoring();
+            });
+        }
 
-    postTaskForModeToWorkerOrWorkletGlobalScope([client = client.releaseNonNull()] (ScriptExecutionContext&) {
         client->cancel();
     }, WorkerRunLoop::defaultMode());
 }
@@ -220,23 +258,26 @@ void ServiceWorkerThreadProxy::cancelFetch(SWServerConnectionIdentifier connecti
 void ServiceWorkerThreadProxy::convertFetchToDownload(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier)
 {
     RELEASE_LOG(ServiceWorker, "ServiceWorkerThreadProxy::convertFetchToDownload %llu", fetchIdentifier.toUInt64());
+    ASSERT(!isMainThread());
 
-    auto client = m_ongoingFetchTasks.take(std::make_pair(connectionIdentifier, fetchIdentifier));
-    if (!client)
-        return;
+    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, fetchIdentifier] (auto&) {
+        auto client = m_ongoingFetchTasks.take({ connectionIdentifier, fetchIdentifier });
+        if (!client)
+            return;
 
-    postTaskForModeToWorkerOrWorkletGlobalScope([client = Ref { *client }] (auto&) {
         client->convertFetchToDownload();
     }, WorkerRunLoop::defaultMode());
 }
 
 void ServiceWorkerThreadProxy::continueDidReceiveFetchResponse(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier)
 {
-    auto client = m_ongoingFetchTasks.get(std::make_pair(connectionIdentifier, fetchIdentifier));
-    if (!client)
-        return;
+    ASSERT(!isMainThread());
 
-    postTaskForModeToWorkerOrWorkletGlobalScope([client = Ref { *client }] (ScriptExecutionContext&) {
+    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, fetchIdentifier] (auto&) {
+        auto client = m_ongoingFetchTasks.get({ connectionIdentifier, fetchIdentifier });
+        if (!client)
+            return;
+
         client->continueDidReceiveResponse();
     }, WorkerRunLoop::defaultMode());
 }
@@ -245,15 +286,24 @@ void ServiceWorkerThreadProxy::removeFetch(SWServerConnectionIdentifier connecti
 {
     RELEASE_LOG(ServiceWorker, "ServiceWorkerThreadProxy::removeFetch %llu", fetchIdentifier.toUInt64());
 
-    m_ongoingFetchTasks.remove(std::make_pair(connectionIdentifier, fetchIdentifier));
+    postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, connectionIdentifier, fetchIdentifier] (auto&) {    m_ongoingFetchTasks.remove(std::make_pair(connectionIdentifier, fetchIdentifier));
 
-    if (m_ongoingFetchTasks.isEmpty())
-        thread().stopFetchEventMonitoring();
+        if (m_ongoingFetchTasks.isEmpty()) {
+            callOnMainRunLoop([protectedThis] {
+                protectedThis->thread().stopFetchEventMonitoring();
+            });
+        }
+    }, WorkerRunLoop::defaultMode());
 }
 
-void ServiceWorkerThreadProxy::postMessageToServiceWorker(MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)
+void ServiceWorkerThreadProxy::fireMessageEvent(MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)
 {
-    thread().willPostTaskToFireMessageEvent();
+    ASSERT(!isMainThread());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }] {
+        protectedThis->thread().willPostTaskToFireMessageEvent();
+    });
+
     thread().runLoop().postTask([this, protectedThis = Ref { *this }, message = WTFMove(message), sourceData = WTFMove(sourceData)](auto&) mutable {
         thread().queueTaskToPostMessage(WTFMove(message), WTFMove(sourceData));
     });
@@ -261,6 +311,7 @@ void ServiceWorkerThreadProxy::postMessageToServiceWorker(MessageWithMessagePort
 
 void ServiceWorkerThreadProxy::fireInstallEvent()
 {
+    ASSERT(isMainThread());
     thread().willPostTaskToFireInstallEvent();
     thread().runLoop().postTask([this, protectedThis = Ref { *this }](auto&) mutable {
         thread().queueTaskToFireInstallEvent();
@@ -269,6 +320,7 @@ void ServiceWorkerThreadProxy::fireInstallEvent()
 
 void ServiceWorkerThreadProxy::fireActivateEvent()
 {
+    ASSERT(isMainThread());
     thread().willPostTaskToFireActivateEvent();
     thread().runLoop().postTask([this, protectedThis = Ref { *this }](auto&) mutable {
         thread().queueTaskToFireActivateEvent();
@@ -277,6 +329,8 @@ void ServiceWorkerThreadProxy::fireActivateEvent()
 
 void ServiceWorkerThreadProxy::didSaveScriptsToDisk(ScriptBuffer&& script, HashMap<URL, ScriptBuffer>&& importedScripts)
 {
+    ASSERT(!isMainThread());
+
     thread().runLoop().postTask([script = WTFMove(script), importedScripts = WTFMove(importedScripts)](auto& context) mutable {
         downcast<ServiceWorkerGlobalScope>(context).didSaveScriptsToDisk(WTFMove(script), WTFMove(importedScripts));
     });
@@ -284,6 +338,8 @@ void ServiceWorkerThreadProxy::didSaveScriptsToDisk(ScriptBuffer&& script, HashM
 
 void ServiceWorkerThreadProxy::firePushEvent(std::optional<Vector<uint8_t>>&& data, CompletionHandler<void(bool)>&& callback)
 {
+    ASSERT(isMainThread());
+
     if (m_ongoingFunctionalEventTasks.isEmpty())
         thread().startFunctionalEventMonitoring();
 
@@ -306,6 +362,8 @@ void ServiceWorkerThreadProxy::firePushEvent(std::optional<Vector<uint8_t>>&& da
 
 void ServiceWorkerThreadProxy::firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData)
 {
+    ASSERT(isMainThread());
+
     thread().willPostTaskToFirePushSubscriptionChangeEvent();
     thread().runLoop().postTask([this, protectedThis = Ref { *this }, newSubscriptionData = crossThreadCopy(WTFMove(newSubscriptionData)), oldSubscriptionData = crossThreadCopy(WTFMove(oldSubscriptionData))](auto&) mutable {
         thread().queueTaskToFirePushSubscriptionChangeEvent(WTFMove(newSubscriptionData), WTFMove(oldSubscriptionData));
@@ -314,6 +372,8 @@ void ServiceWorkerThreadProxy::firePushSubscriptionChangeEvent(std::optional<Pus
 
 void ServiceWorkerThreadProxy::fireNotificationEvent(NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
+    ASSERT(isMainThread());
+
 #if ENABLE(NOTIFICATION_EVENT)
     if (m_ongoingFunctionalEventTasks.isEmpty())
         thread().startFunctionalEventMonitoring();

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -80,14 +80,15 @@ public:
     WEBCORE_EXPORT void continueDidReceiveFetchResponse(SWServerConnectionIdentifier, FetchIdentifier);
     WEBCORE_EXPORT void removeFetch(SWServerConnectionIdentifier, FetchIdentifier);
 
-    void postMessageToServiceWorker(MessageWithMessagePorts&&, ServiceWorkerOrClientData&&);
+    WEBCORE_EXPORT void fireMessageEvent(MessageWithMessagePorts&&, ServiceWorkerOrClientData&&);
+
     void fireInstallEvent();
     void fireActivateEvent();
     void firePushEvent(std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
     void firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     void fireNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
 
-    void didSaveScriptsToDisk(ScriptBuffer&&, HashMap<URL, ScriptBuffer>&& importedScripts);
+    WEBCORE_EXPORT void didSaveScriptsToDisk(ScriptBuffer&&, HashMap<URL, ScriptBuffer>&& importedScripts);
 
     WEBCORE_EXPORT void setLastNavigationWasAppInitiated(bool);
     WEBCORE_EXPORT bool lastNavigationWasAppInitiated();
@@ -118,9 +119,11 @@ private:
     bool m_isTerminatingOrTerminated { false };
 
     ServiceWorkerInspectorProxy m_inspectorProxy;
-    HashMap<std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>> m_ongoingFetchTasks;
     uint64_t m_functionalEventTasksCounter { 0 };
     HashMap<uint64_t, CompletionHandler<void(bool)>> m_ongoingFunctionalEventTasks;
+
+    // Accessed in worker thread.
+    HashMap<std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>> m_ongoingFetchTasks;
 };
 
 } // namespace WebKit

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -117,14 +117,6 @@ void SWServerToContextConnection::claim(ServiceWorkerIdentifier serviceWorkerIde
     callback(server ? server->claim(*worker) : std::nullopt);
 }
 
-void SWServerToContextConnection::skipWaiting(ServiceWorkerIdentifier serviceWorkerIdentifier, CompletionHandler<void()>&& completionHandler)
-{
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
-        worker->skipWaiting();
-
-    completionHandler();
-}
-
 void SWServerToContextConnection::setScriptResource(ServiceWorkerIdentifier serviceWorkerIdentifier, URL&& scriptURL, ServiceWorkerContextData::ImportedScript&& script)
 {
     if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -77,7 +77,6 @@ public:
     WEBCORE_EXPORT void didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>&, ServiceWorkerIdentifier, bool wasSuccessful);
     WEBCORE_EXPORT void didFinishActivation(ServiceWorkerIdentifier);
     WEBCORE_EXPORT void setServiceWorkerHasPendingEvents(ServiceWorkerIdentifier, bool hasPendingEvents);
-    WEBCORE_EXPORT void skipWaiting(ServiceWorkerIdentifier, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void workerTerminated(ServiceWorkerIdentifier);
     WEBCORE_EXPORT void matchAll(uint64_t requestIdentifier, ServiceWorkerIdentifier, const ServiceWorkerClientQueryOptions&);
     WEBCORE_EXPORT void claim(ServiceWorkerIdentifier, CompletionHandler<void(std::optional<ExceptionData>&&)>&&);

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -109,7 +109,7 @@ public:
     void setScriptResource(URL&&, ServiceWorkerContextData::ImportedScript&&);
     void didSaveScriptsToDisk(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
 
-    void skipWaiting();
+    WEBCORE_EXPORT void skipWaiting();
     bool isSkipWaitingFlagSet() const { return m_isSkipWaitingFlagSet; }
 
     WEBCORE_EXPORT static SWServerWorker* existingWorkerForIdentifier(ServiceWorkerIdentifier);

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -265,6 +265,8 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
     SandboxExtension::consumePermanently(parameters.dynamicIOKitExtensionHandles);
 #endif
 
+    populateMobileGestaltCache(WTFMove(parameters.mobileGestaltExtensionHandle));
+
 #if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
     auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
     CGImageSourceSetAllowableTypes(emptyArray.get());

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -61,6 +61,7 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << compilerServiceExtensionHandles;
     encoder << dynamicIOKitExtensionHandles;
 #endif
+    encoder << mobileGestaltExtensionHandle;
 
     encoder << applicationVisibleName;
 }
@@ -111,6 +112,12 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
         return false;
     result.dynamicIOKitExtensionHandles = WTFMove(*dynamicIOKitExtensionHandles);
 #endif
+
+    std::optional<std::optional<SandboxExtension::Handle>> mobileGestaltExtensionHandle;
+    decoder >> mobileGestaltExtensionHandle;
+    if (!mobileGestaltExtensionHandle)
+        return false;
+    result.mobileGestaltExtensionHandle = WTFMove(*mobileGestaltExtensionHandle);
 
     if (!decoder.decode(result.applicationVisibleName))
         return false;

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -61,6 +61,7 @@ struct GPUProcessCreationParameters {
     Vector<SandboxExtension::Handle> compilerServiceExtensionHandles;
     Vector<SandboxExtension::Handle> dynamicIOKitExtensionHandles;
 #endif
+    std::optional<SandboxExtension::Handle> mobileGestaltExtensionHandle;
 
     String applicationVisibleName;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -89,6 +89,14 @@ void WebSWServerToContextConnection::postMessageToServiceWorkerClient(const Scri
         connection->postMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin);
 }
 
+void WebSWServerToContextConnection::skipWaiting(uint64_t requestIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier)
+{
+    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+        worker->skipWaiting();
+
+    send(Messages::WebSWContextManagerConnection::SkipWaitingCompleted { requestIdentifier });
+}
+
 void WebSWServerToContextConnection::close()
 {
     send(Messages::WebSWContextManagerConnection::Close { });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -87,6 +87,7 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     void postMessageToServiceWorkerClient(const WebCore::ScriptExecutionContextIdentifier& destinationIdentifier, const WebCore::MessageWithMessagePorts&, WebCore::ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin);
+    void skipWaiting(uint64_t requestIdentifier, WebCore::ServiceWorkerIdentifier);
 
     // Messages to the SW host WebProcess
     void installServiceWorkerContext(const WebCore::ServiceWorkerContextData&, const WebCore::ServiceWorkerData&, const String& userAgent, WebCore::WorkerThreadMode) final;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -30,7 +30,7 @@ messages -> WebSWServerToContextConnection NotRefCounted {
     DidFinishInstall(std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool wasSuccessful)
     DidFinishActivation(WebCore::ServiceWorkerIdentifier identifier)
     SetServiceWorkerHasPendingEvents(WebCore::ServiceWorkerIdentifier identifier, bool hasPendingEvents)
-    SkipWaiting(WebCore::ServiceWorkerIdentifier identifier) -> ()
+    SkipWaiting(uint64_t matchAllRequestIdentifier, WebCore::ServiceWorkerIdentifier identifier)
     WorkerTerminated(WebCore::ServiceWorkerIdentifier identifier)
     FindClientByVisibleIdentifier(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String clientIdentifier) -> (std::optional<WebCore::ServiceWorkerClientData> data)
     MatchAll(uint64_t matchAllRequestIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, struct WebCore::ServiceWorkerClientQueryOptions options);

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -401,6 +401,11 @@
 (allow mach-lookup (with telemetry)
     (global-name "com.apple.tccd"))
 
+(allow mach-lookup
+    (require-all
+        (extension "com.apple.webkit.extension.mach")
+        (global-name "com.apple.mobilegestalt.xpc")))
+
 ;; <rdar://problem/12413942>
 (allow file-read*
        (well-known-system-group-container-literal "/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"))

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -218,6 +218,12 @@ void AuxiliaryProcess::applyProcessCreationParameters(const AuxiliaryProcessCrea
 #endif
 }
 
+#if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
+void AuxiliaryProcess::populateMobileGestaltCache(std::optional<SandboxExtension::Handle>&&)
+{
+}
+#endif
+
 #if !PLATFORM(COCOA)
 
 #if !OS(UNIX)

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -150,6 +150,8 @@ protected:
     void openDirectoryCacheInvalidated(SandboxExtension::Handle&&);
 #endif
 
+    void populateMobileGestaltCache(std::optional<SandboxExtension::Handle>&& mobileGestaltExtensionHandle);
+
 private:
     virtual bool shouldOverrideQuarantine() { return true; }
 

--- a/Source/WebKit/Shared/ios/AuxiliaryProcessIOS.mm
+++ b/Source/WebKit/Shared/ios/AuxiliaryProcessIOS.mm
@@ -34,6 +34,7 @@
 #import <WebCore/SystemVersion.h>
 #import <mach/mach.h>
 #import <mach/task.h>
+#import <pal/spi/ios/MobileGestaltSPI.h>
 #import <pwd.h>
 #import <stdlib.h>
 #import <sysexits.h>
@@ -49,6 +50,43 @@ void AuxiliaryProcess::initializeSandbox(const AuxiliaryProcessInitializationPar
 void AuxiliaryProcess::setQOS(int, int)
 {
 
+}
+
+void AuxiliaryProcess::populateMobileGestaltCache(std::optional<SandboxExtension::Handle>&& mobileGestaltExtensionHandle)
+{
+    if (!mobileGestaltExtensionHandle)
+        return;
+
+    if (auto extension = SandboxExtension::create(WTFMove(*mobileGestaltExtensionHandle))) {
+        bool ok = extension->consume();
+        ASSERT_UNUSED(ok, ok);
+        // If we have an extension handle for MobileGestalt, it means the MobileGestalt cache is invalid.
+        // In this case, we perform a set of MobileGestalt queries while having access to the daemon,
+        // which will populate the MobileGestalt in-memory cache with correct values.
+        // The set of queries below was determined by finding all possible queries that have cachable
+        // values, and would reach out to the daemon for the answer. That way, the in-memory cache
+        // should be identical to a valid MobileGestalt cache after having queried all of these values.
+        MGGetFloat32Answer(kMGQMainScreenScale, 0);
+        MGGetSInt32Answer(kMGQMainScreenPitch, 0);
+        MGGetSInt32Answer(kMGQMainScreenClass, MGScreenClassPad2);
+        MGGetBoolAnswer(kMGQAppleInternalInstallCapability);
+        MGGetBoolAnswer(kMGQiPadCapability);
+        auto deviceName = adoptCF(MGCopyAnswer(kMGQDeviceName, nullptr));
+        MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
+        MGGetBoolAnswer(kMGQHasExtendedColorDisplay);
+        MGGetFloat32Answer(kMGQDeviceCornerRadius, 0);
+        MGGetBoolAnswer(kMGQSupportsForceTouch);
+
+        auto answer = adoptCF(MGCopyAnswer(kMGQBluetoothCapability, nullptr));
+        answer = MGCopyAnswer(kMGQDeviceProximityCapability, nullptr);
+        answer = MGCopyAnswer(kMGQDeviceSupportsARKit, nullptr);
+        answer = MGCopyAnswer(kMGQTimeSyncCapability, nullptr);
+        answer = MGCopyAnswer(kMGQWAPICapability, nullptr);
+        answer = MGCopyAnswer(kMGQMainDisplayRotation, nullptr);
+
+        ok = extension->revoke();
+        ASSERT_UNUSED(ok, ok);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -39,6 +39,10 @@
 #include <wtf/spi/darwin/SandboxSPI.h>
 #endif
 
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+#import <pal/spi/ios/MobileGestaltSPI.h>
+#endif
+
 namespace WebKit {
 
 AuxiliaryProcessProxy::AuxiliaryProcessProxy(bool alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
@@ -416,6 +420,20 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
     parameters.webKitLoggingChannels = UIProcess::webKitLogLevelString();
 #endif
     return parameters;
+}
+
+std::optional<SandboxExtension::Handle> AuxiliaryProcessProxy::createMobileGestaltSandboxExtensionIfNeeded() const
+{
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+    if (_MGCacheValid())
+        return std::nullopt;
+    
+    RELEASE_LOG_FAULT(Sandbox, "MobileGestalt cache is invalid! Creating a sandbox extension to repopulate cache in memory.");
+
+    return SandboxExtension::createHandleForMachLookup("com.apple.mobilegestalt.xpc"_s, std::nullopt);
+#else
+    return std::nullopt;
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiverMap.h"
 #include "ProcessLauncher.h"
 #include "ResponsivenessTimer.h"
+#include "SandboxExtension.h"
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/ProcessID.h>
 #include <wtf/SystemTracing.h>
@@ -143,6 +144,8 @@ public:
 
     void ref() final { ThreadSafeRefCounted::ref(); }
     void deref() final { ThreadSafeRefCounted::deref(); }
+
+    std::optional<SandboxExtension::Handle> createMobileGestaltSandboxExtensionIfNeeded() const;
 
 protected:
     // ProcessLauncher::Client

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -35,6 +35,7 @@ namespace WebKit {
 
 void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationParameters& parameters)
 {
+    parameters.mobileGestaltExtensionHandle = createMobileGestaltSandboxExtensionIfNeeded();
     parameters.applicationVisibleName = applicationVisibleName();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -384,12 +384,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.contentSizeCategory = RenderThemeCocoa::singleton().contentSizeCategory();
 #endif
 
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
-    if (!_MGCacheValid()) {
-        if (auto handle = SandboxExtension::createHandleForMachLookup("com.apple.mobilegestalt.xpc"_s, std::nullopt))
-            parameters.mobileGestaltExtensionHandle = WTFMove(*handle);
-    }
-#endif
+    parameters.mobileGestaltExtensionHandle = process.createMobileGestaltSandboxExtensionIfNeeded();
 
 #if PLATFORM(MAC)
     if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -90,81 +90,115 @@ WebSWContextManagerConnection::WebSWContextManagerConnection(Ref<IPC::Connection
     , m_userAgent(standardUserAgent())
 #endif
     , m_userContentController(WebUserContentController::getOrCreate(initializationData.userContentControllerIdentifier))
+    , m_queue(WorkQueue::create("WebSWContextManagerConnection queue", WorkQueue::QOS::UserInitiated))
 {
 #if ENABLE(CONTENT_EXTENSIONS)
     m_userContentController->addContentRuleLists(WTFMove(initializationData.contentRuleLists));
 #endif
 
-    updatePreferencesStore(store);
+    WebPage::updatePreferencesGenerated(store);
+    m_preferencesStore = store;
+
     WebProcess::singleton().disableTermination();
 }
 
-WebSWContextManagerConnection::~WebSWContextManagerConnection() = default;
+WebSWContextManagerConnection::~WebSWContextManagerConnection()
+{
+    auto callbacks = WTFMove(m_skipWaitingCallbacks);
+    for (auto& callback : callbacks.values())
+        callback();
+}
 
 void WebSWContextManagerConnection::establishConnection(CompletionHandler<void()>&& completionHandler)
 {
+    m_connectionToNetworkProcess->addWorkQueueMessageReceiver(Messages::WebSWContextManagerConnection::messageReceiverName(), m_queue.get(), *this);
     m_connectionToNetworkProcess->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::EstablishSWContextConnection { m_webPageProxyID, m_registrableDomain, m_serviceWorkerPageIdentifier }, WTFMove(completionHandler), 0);
 }
 
-void WebSWContextManagerConnection::updatePreferencesStore(const WebPreferencesStore& store)
+void WebSWContextManagerConnection::stop()
 {
+    ASSERT(isMainRunLoop());
+
+    m_connectionToNetworkProcess->removeWorkQueueMessageReceiver(Messages::WebSWContextManagerConnection::messageReceiverName());
+}
+
+void WebSWContextManagerConnection::updatePreferencesStore(WebPreferencesStore&& store)
+{
+    if (!isMainRunLoop()) {
+        callOnMainRunLoop([protectedThis = Ref { *this }, store = WTFMove(store).isolatedCopy()]() mutable {
+            protectedThis->updatePreferencesStore(WTFMove(store));
+        });
+        return;
+    }
+
     WebPage::updatePreferencesGenerated(store);
-    m_preferencesStore = store;
+    m_preferencesStore = WTFMove(store);
 }
 
 void WebSWContextManagerConnection::updateAppInitiatedValue(ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
 {
+    ASSERT(isMainRunLoop());
+
     if (auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated == WebCore::LastNavigationWasAppInitiated::Yes);
 }
 
 void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode)
 {
-    auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+    assertIsCurrent(m_queue.get());
 
-    pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
-    pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
-    pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();
-    pageConfiguration.userContentProvider = m_userContentController;
+    callOnMainRunLoopAndWait([this, protectedThis = Ref { *this }, contextData = WTFMove(contextData).isolatedCopy(), workerData = WTFMove(workerData).isolatedCopy(), userAgent = WTFMove(userAgent).isolatedCopy(), workerThreadMode]() mutable {
+    auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+        pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
+        pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
+        pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();
+        pageConfiguration.userContentProvider = m_userContentController;
 #if ENABLE(WEB_RTC)
-    pageConfiguration.libWebRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
+        pageConfiguration.libWebRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
 
-    auto effectiveUserAgent =  WTFMove(userAgent);
-    if (effectiveUserAgent.isNull())
-        effectiveUserAgent = m_userAgent;
+        auto effectiveUserAgent =  WTFMove(userAgent);
+        if (effectiveUserAgent.isNull())
+            effectiveUserAgent = m_userAgent;
 
-    pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, FrameIdentifier::generate(), effectiveUserAgent);
+        pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, FrameIdentifier::generate(), effectiveUserAgent);
 
 #if !RELEASE_LOG_DISABLED
-    auto serviceWorkerIdentifier = contextData.serviceWorkerIdentifier;
+        auto serviceWorkerIdentifier = contextData.serviceWorkerIdentifier;
 #endif
-    
-    auto lastNavigationWasAppInitiated = contextData.lastNavigationWasAppInitiated;
-    auto page = makeUniqueRef<Page>(WTFMove(pageConfiguration));
-    if (m_preferencesStore) {
-        WebPage::updateSettingsGenerated(*m_preferencesStore, page->settings());
-        page->settings().setStorageBlockingPolicy(static_cast<StorageBlockingPolicy>(m_preferencesStore->getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));
-    }
-    page->setupForRemoteWorker(contextData.scriptURL, contextData.registration.key.topOrigin(), contextData.referrerPolicy);
 
-    std::unique_ptr<WebCore::NotificationClient> notificationClient;
+        auto lastNavigationWasAppInitiated = contextData.lastNavigationWasAppInitiated;
+        auto page = makeUniqueRef<Page>(WTFMove(pageConfiguration));
+        if (m_preferencesStore) {
+            WebPage::updateSettingsGenerated(*m_preferencesStore, page->settings());
+            page->settings().setStorageBlockingPolicy(static_cast<StorageBlockingPolicy>(m_preferencesStore->getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));
+        }
+        page->setupForRemoteWorker(contextData.scriptURL, contextData.registration.key.topOrigin(), contextData.referrerPolicy);
+
+        std::unique_ptr<WebCore::NotificationClient> notificationClient;
 #if ENABLE(NOTIFICATIONS)
-    notificationClient = makeUnique<WebNotificationClient>(nullptr);
+        notificationClient = makeUnique<WebNotificationClient>(nullptr);
 #endif
 
-    auto serviceWorkerThreadProxy = ServiceWorkerThreadProxy::create(WTFMove(page), WTFMove(contextData), WTFMove(workerData), WTFMove(effectiveUserAgent), workerThreadMode, WebProcess::singleton().cacheStorageProvider(), WTFMove(notificationClient));
+        auto serviceWorkerThreadProxy = ServiceWorkerThreadProxy::create(WTFMove(page), WTFMove(contextData), WTFMove(workerData), WTFMove(effectiveUserAgent), workerThreadMode, WebProcess::singleton().cacheStorageProvider(), WTFMove(notificationClient));
 
-    if (lastNavigationWasAppInitiated)
-        serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated == WebCore::LastNavigationWasAppInitiated::Yes);
+        if (lastNavigationWasAppInitiated)
+            serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(lastNavigationWasAppInitiated == WebCore::LastNavigationWasAppInitiated::Yes);
 
-    SWContextManager::singleton().registerServiceWorkerThreadForInstall(WTFMove(serviceWorkerThreadProxy));
+        SWContextManager::singleton().registerServiceWorkerThreadForInstall(WTFMove(serviceWorkerThreadProxy));
 
-    RELEASE_LOG(ServiceWorker, "Created service worker %" PRIu64 " in process PID %i", serviceWorkerIdentifier.toUInt64(), getCurrentProcessID());
+        RELEASE_LOG(ServiceWorker, "Created service worker %" PRIu64 " in process PID %i", serviceWorkerIdentifier.toUInt64(), getCurrentProcessID());
+    });
 }
 
 void WebSWContextManagerConnection::setUserAgent(String&& userAgent)
 {
+    if (!isMainThread()) {
+        callOnMainRunLoop([protectedThis = Ref { *this }, userAgent = WTFMove(userAgent).isolatedCopy()]() mutable {
+            protectedThis->setUserAgent(WTFMove(userAgent));
+        });
+        return;
+    }
     m_userAgent = WTFMove(userAgent);
 }
 
@@ -178,64 +212,35 @@ void WebSWContextManagerConnection::serviceWorkerFailedToStart(std::optional<Ser
     m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::ScriptContextFailedToStart { jobDataIdentifier, serviceWorkerIdentifier, exceptionMessage }, 0);
 }
 
-static inline bool isValidFetch(const ResourceRequest& request, const FetchOptions& options, const URL& serviceWorkerURL, const String& referrer)
-{
-    // For exotic service workers, do not enforce checks.
-    if (!serviceWorkerURL.protocolIsInHTTPFamily())
-        return true;
-
-    if (options.mode == FetchOptions::Mode::Navigate) {
-        if (!protocolHostAndPortAreEqual(request.url(), serviceWorkerURL)) {
-            RELEASE_LOG_ERROR(ServiceWorker, "Should not intercept a navigation load that is not same-origin as the service worker URL");
-            RELEASE_ASSERT_WITH_MESSAGE(request.url().host() == serviceWorkerURL.host(), "Hosts do not match");
-            RELEASE_ASSERT_WITH_MESSAGE(request.url().protocol() == serviceWorkerURL.protocol(), "Protocols do not match");
-            RELEASE_ASSERT_WITH_MESSAGE(request.url().port() == serviceWorkerURL.port(), "Ports do not match");
-            return false;
-        }
-        return true;
-    }
-
-    String origin = request.httpOrigin();
-    URL url { origin.isEmpty() ? referrer : origin };
-    if (url.protocolIsInHTTPFamily() && !protocolHostAndPortAreEqual(url, serviceWorkerURL)) {
-        RELEASE_LOG_ERROR(ServiceWorker, "Should not intercept a non navigation load that is not originating from a same-origin context as the service worker URL");
-        ASSERT(url.host() == serviceWorkerURL.host());
-        ASSERT(url.protocol() == serviceWorkerURL.protocol());
-        ASSERT(url.port() == serviceWorkerURL.port());
-        return false;
-    }
-    return true;
-}
-
 void WebSWContextManagerConnection::cancelFetch(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
-    if (auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
+    assertIsCurrent(m_queue.get());
+
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->cancelFetch(serverConnectionIdentifier, fetchIdentifier);
 }
 
 void WebSWContextManagerConnection::continueDidReceiveFetchResponse(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
-    auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier);
-    RELEASE_LOG(ServiceWorker, "WebSWContextManagerConnection::continueDidReceiveFetchResponse for service worker %llu, fetch identifier %llu, has service worker %d", serviceWorkerIdentifier.toUInt64(), fetchIdentifier.toUInt64(), !!serviceWorkerThreadProxy);
+    assertIsCurrent(m_queue.get());
 
-    if (serviceWorkerThreadProxy)
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->continueDidReceiveFetchResponse(serverConnectionIdentifier, fetchIdentifier);
 }
 
 void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceRequest&& request, FetchOptions&& options, IPC::FormDataReference&& formData, String&& referrer, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier)
 {
-    auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier);
+    assertIsCurrent(m_queue.get());
+
+    auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier);
     if (!serviceWorkerThreadProxy) {
         m_connectionToNetworkProcess->send(Messages::ServiceWorkerFetchTask::DidNotHandle { }, fetchIdentifier);
         return;
     }
 
-    serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(request.isAppInitiated());
-
-    if (!isValidFetch(request, options, serviceWorkerThreadProxy->scriptURL(), referrer)) {
-        m_connectionToNetworkProcess->send(Messages::ServiceWorkerFetchTask::DidNotHandle { }, fetchIdentifier);
-        return;
-    }
+    callOnMainRunLoop([serviceWorkerThreadProxy, isAppInitiated = request.isAppInitiated()]() mutable {
+        serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(isAppInitiated);
+    });
 
     auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request.requester() == ResourceRequest::Requester::Main);
 
@@ -243,45 +248,91 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
     serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTFMove(client), WTFMove(request), WTFMove(referrer), WTFMove(options), isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
 }
 
-void WebSWContextManagerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier destinationIdentifier, MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)
+void WebSWContextManagerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier serviceWorkerIdentifier, MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)
 {
-    SWContextManager::singleton().postMessageToServiceWorker(destinationIdentifier, WTFMove(message), WTFMove(sourceData));
+    assertIsCurrent(m_queue.get());
+
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
+        serviceWorkerThreadProxy->fireMessageEvent(WTFMove(message), WTFMove(sourceData));
 }
 
 void WebSWContextManagerConnection::fireInstallEvent(ServiceWorkerIdentifier identifier)
 {
-    SWContextManager::singleton().fireInstallEvent(identifier);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([identifier] {
+        SWContextManager::singleton().fireInstallEvent(identifier);
+    });
 }
 
 void WebSWContextManagerConnection::fireActivateEvent(ServiceWorkerIdentifier identifier)
 {
-    SWContextManager::singleton().fireActivateEvent(identifier);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([identifier] {
+        SWContextManager::singleton().fireActivateEvent(identifier);
+    });
 }
 
 void WebSWContextManagerConnection::firePushEvent(ServiceWorkerIdentifier identifier, const std::optional<IPC::DataReference>& ipcData, CompletionHandler<void(bool)>&& callback)
 {
+    assertIsCurrent(m_queue.get());
+
     std::optional<Vector<uint8_t>> data;
     if (ipcData)
         data = Vector<uint8_t> { ipcData->data(), ipcData->size() };
-    SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), WTFMove(callback));
+
+    auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result) mutable {
+        queue->dispatch([result, callback = WTFMove(callback)]() mutable {
+            callback(result);
+        });
+    };
+
+    callOnMainRunLoop([identifier, data = WTFMove(data), callback = WTFMove(inQueueCallback)]() mutable {
+        SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), WTFMove(callback));
+    });
 }
 
 void WebSWContextManagerConnection::fireNotificationEvent(ServiceWorkerIdentifier identifier, NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
-    SWContextManager::singleton().fireNotificationEvent(identifier, WTFMove(data), eventType, WTFMove(callback));
+    assertIsCurrent(m_queue.get());
+
+    auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result) mutable {
+        queue->dispatch([result, callback = WTFMove(callback)]() mutable {
+            callback(result);
+        });
+    };
+    callOnMainRunLoop([identifier, data = WTFMove(data), eventType, callback = WTFMove(inQueueCallback)]() mutable {
+        SWContextManager::singleton().fireNotificationEvent(identifier, WTFMove(data), eventType, WTFMove(callback));
+    });
 }
 
 void WebSWContextManagerConnection::terminateWorker(ServiceWorkerIdentifier identifier)
 {
-    SWContextManager::singleton().terminateWorker(identifier, SWContextManager::workerTerminationTimeout, nullptr);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([identifier] {
+        SWContextManager::singleton().terminateWorker(identifier, SWContextManager::workerTerminationTimeout, nullptr);
+    });
 }
 
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
-void WebSWContextManagerConnection::didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier identifier, ScriptBuffer&& script, HashMap<URL, ScriptBuffer>&& importedScripts)
+void WebSWContextManagerConnection::didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, ScriptBuffer&& script, HashMap<URL, ScriptBuffer>&& importedScripts)
 {
-    SWContextManager::singleton().didSaveScriptsToDisk(identifier, WTFMove(script), WTFMove(importedScripts));
+    assertIsCurrent(m_queue.get());
+
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
+        serviceWorkerThreadProxy->didSaveScriptsToDisk(WTFMove(script), WTFMove(importedScripts));
 }
 #endif
+
+void WebSWContextManagerConnection::convertFetchToDownload(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
+{
+    assertIsCurrent(m_queue.get());
+
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
+        serviceWorkerThreadProxy->convertFetchToDownload(serverConnectionIdentifier, fetchIdentifier);
+}
 
 void WebSWContextManagerConnection::postMessageToServiceWorkerClient(const ScriptExecutionContextIdentifier& destinationIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin)
 {
@@ -305,7 +356,19 @@ void WebSWContextManagerConnection::setServiceWorkerHasPendingEvents(ServiceWork
 
 void WebSWContextManagerConnection::skipWaiting(ServiceWorkerIdentifier serviceWorkerIdentifier, CompletionHandler<void()>&& callback)
 {
-    m_connectionToNetworkProcess->sendWithAsyncReply(Messages::WebSWServerToContextConnection::SkipWaiting(serviceWorkerIdentifier), WTFMove(callback));
+    auto requestIdentifier = ++m_previousRequestIdentifier;
+    m_skipWaitingCallbacks.add(requestIdentifier, WTFMove(callback));
+    m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::SkipWaiting(requestIdentifier, serviceWorkerIdentifier), 0);
+}
+
+void WebSWContextManagerConnection::skipWaitingCompleted(uint64_t requestIdentifier)
+{
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, requestIdentifier]() mutable {
+        if (auto callback = protectedThis->m_skipWaitingCallbacks.take(requestIdentifier))
+            callback();
+    });
 }
 
 void WebSWContextManagerConnection::setScriptResource(ServiceWorkerIdentifier serviceWorkerIdentifier, const URL& url, const ServiceWorkerContextData::ImportedScript& script)
@@ -332,8 +395,12 @@ void WebSWContextManagerConnection::matchAll(WebCore::ServiceWorkerIdentifier se
 
 void WebSWContextManagerConnection::matchAllCompleted(uint64_t requestIdentifier, Vector<ServiceWorkerClientData>&& clientsData)
 {
-    if (auto callback = m_matchAllRequests.take(requestIdentifier))
-        callback(WTFMove(clientsData));
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, requestIdentifier, clientsData = crossThreadCopy(WTFMove(clientsData))]() mutable {
+        if (auto callback = protectedThis->m_matchAllRequests.take(requestIdentifier))
+            callback(WTFMove(clientsData));
+    });
 }
 
 void WebSWContextManagerConnection::openWindow(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, const URL& url, OpenWindowCallback&& callback)
@@ -372,6 +439,13 @@ void WebSWContextManagerConnection::focus(ScriptExecutionContextIdentifier clien
 
 void WebSWContextManagerConnection::close()
 {
+    if (!isMainRunLoop()) {
+        callOnMainRunLoop([protectedThis = Ref { *this }] {
+            protectedThis->close();
+        });
+        return;
+    }
+
     RELEASE_LOG(ServiceWorker, "Service worker process is requested to stop all service workers (already stopped = %d)", isClosed());
     if (isClosed())
         return;
@@ -385,20 +459,18 @@ void WebSWContextManagerConnection::close()
 
 void WebSWContextManagerConnection::setThrottleState(bool isThrottleable)
 {
-    RELEASE_LOG(ServiceWorker, "Service worker throttleable state is set to %d", isThrottleable);
-    m_isThrottleable = isThrottleable;
-    WebProcess::singleton().setProcessSuppressionEnabled(isThrottleable);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, isThrottleable] {
+        RELEASE_LOG(ServiceWorker, "Service worker throttleable state is set to %d", isThrottleable);
+        protectedThis->m_isThrottleable = isThrottleable;
+        WebProcess::singleton().setProcessSuppressionEnabled(isThrottleable);
+    });
 }
 
 bool WebSWContextManagerConnection::isThrottleable() const
 {
     return m_isThrottleable;
-}
-
-void WebSWContextManagerConnection::convertFetchToDownload(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
-{
-    if (auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
-        serviceWorkerThreadProxy->convertFetchToDownload(serverConnectionIdentifier, fetchIdentifier);
 }
 
 void WebSWContextManagerConnection::didFailHeartBeatCheck(ServiceWorkerIdentifier serviceWorkerIdentifier)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(SERVICE_WORKER)
 
-messages -> WebSWContextManagerConnection NotRefCounted {
+messages -> WebSWContextManagerConnection {
     InstallServiceWorker(struct WebCore::ServiceWorkerContextData contextData, struct WebCore::ServiceWorkerData workerData, String userAgent, enum:bool WebCore::WorkerThreadMode workerThreadMode)
     UpdateAppInitiatedValue(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:bool WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
     StartFetch(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier, WebCore::ResourceRequest request, struct WebCore::FetchOptions options, IPC::FormDataReference requestBody, String referrer, bool isServiceWorkerNavigationPreloadEnabled, String clientIdentifer, String resutlingClientIdentifier)
@@ -39,6 +39,7 @@ messages -> WebSWContextManagerConnection NotRefCounted {
     DidSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::ScriptBuffer script, HashMap<URL, WebCore::ScriptBuffer> importedScripts);
 #endif
     MatchAllCompleted(uint64_t matchAllRequestIdentifier, Vector<WebCore::ServiceWorkerClientData> clientsData)
+    SkipWaitingCompleted(uint64_t matchAllRequestIdentifier)
     SetUserAgent(String userAgent)
     UpdatePreferencesStore(struct WebKit::WebPreferencesStore store)
     Close()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1873,7 +1873,7 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
     switch (workerType) {
     case RemoteWorkerType::ServiceWorker:
 #if ENABLE(SERVICE_WORKER)
-        SWContextManager::singleton().setConnection(makeUnique<WebSWContextManagerConnection>(ipcConnection, WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
+        SWContextManager::singleton().setConnection(WebSWContextManagerConnection::create(ipcConnection, WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
         SWContextManager::singleton().connection()->establishConnection(WTFMove(completionHandler));
 #endif
         break;


### PR DESCRIPTION
#### 194342e29ed6d5f3cb10ec2ced5ba1d7408a1c68
<pre>
Firing a fetch event should not be blocked on main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=241096">https://bugs.webkit.org/show_bug.cgi?id=241096</a>

Patch by Youenn Fablet &lt;youennf@gmail.com &gt; on 2022-06-01
Reviewed by Chris Dumez.

The main thread might be blocked by work done by the web page, like executing JavaScript.
This might delay fetch events handling. This can cause PLT regressions when serving content through a service worker.
To limit the perf penalty, we are now hopping to a work queue to process all WebSWContextManagerConnection messages.
For fetch events and message events, we directly go from that thread to the service worker thread.
For install/activate/push/notification events, we keep going through the main thread as they are not as perf crtical.
Also install/activate should follow the same flow as other events like updatefound which are served through WebSWClientConnection.
We change skipWaiting accordingly to remove races in case the reply would go to main thread directly instead of going through the background work queue.

We do some refactoring to allow getting a ServiceWorkerThreadProxy from a background queue.

* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::didSaveScriptsToDisk): Deleted.
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::skipWaiting): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::startFetch):
(WebCore::ServiceWorkerThreadProxy::convertFetchToDownload):
(WebCore::ServiceWorkerThreadProxy::continueDidReceiveFetchResponse):
(WebCore::ServiceWorkerThreadProxy::fireMessageEvent):
(WebCore::ServiceWorkerThreadProxy::didSaveScriptsToDisk):
(WebCore::ServiceWorkerThreadProxy::firePushEvent):
(WebCore::ServiceWorkerThreadProxy::firePushSubscriptionChangeEvent):
(WebCore::ServiceWorkerThreadProxy::fireNotificationEvent):
(WebCore::ServiceWorkerThreadProxy::willPostTaskToFireMessageEvent): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebKit/Shared/WebPreferencesStore.h
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::skipWaiting):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::~WebSWContextManagerConnection):
(WebKit::WebSWContextManagerConnection::cancelFetch):
(WebKit::WebSWContextManagerConnection::continueDidReceiveFetchResponse):
(WebKit::WebSWContextManagerConnection::postMessageToServiceWorker):
(WebKit::WebSWContextManagerConnection::didSaveScriptsToDisk):
(WebKit::WebSWContextManagerConnection::convertFetchToDownload):
(WebKit::WebSWContextManagerConnection::skipWaiting):
(WebKit::WebSWContextManagerConnection::skipWaitingCompleted):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/251183@main">https://commits.webkit.org/251183@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295088">https://svn.webkit.org/repository/webkit/trunk@295088</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
