### PR TITLE
[GStreamer][WebRTC] Allow backend to keep track of buffered-amount

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -67,7 +67,7 @@ public:
 
     const String& label() const { return m_label; }
     RTCDataChannelState readyState() const {return m_readyState; }
-    size_t bufferedAmount() const { return m_bufferedAmount; }
+    size_t bufferedAmount() const final { return m_bufferedAmount; }
     size_t bufferedAmountLowThreshold() const { return m_bufferedAmountLowThreshold; }
     void setBufferedAmountLowThreshold(size_t value) { m_bufferedAmountLowThreshold = value; }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
@@ -53,6 +53,7 @@ private:
     void didReceiveRawData(const uint8_t* data, size_t size) final { m_connection->didReceiveRawData(m_identifier, data, size); }
     void didDetectError(Ref<RTCError>&& error) final { m_connection->didDetectError(m_identifier, error->errorDetail(), error->message()); }
     void bufferedAmountIsDecreasing(size_t amount) final { m_connection->bufferedAmountIsDecreasing(m_identifier, amount); }
+    size_t bufferedAmount() const final { return 0; }
 
     RTCDataChannelIdentifier m_identifier;
     UniqueRef<RTCDataChannelHandler> m_handler;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -58,9 +58,8 @@ private:
     void onMessageData(GBytes*);
     void onMessageString(const char*);
     void onError(GError*);
-    void onBufferedAmountLow();
     void readyStateChanged();
-
+    void bufferedAmountChanged();
     void checkState();
     void postTask(Function<void()>&&);
 
@@ -80,6 +79,7 @@ private:
 
     Lock m_openLock;
     Condition m_openCondition WTF_GUARDED_BY_LOCK(m_openLock);
+    std::optional<uint64_t> m_cachedBufferedAmount;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
@@ -45,6 +45,7 @@ public:
     virtual void didReceiveRawData(const uint8_t*, size_t) = 0;
     virtual void didDetectError(Ref<RTCError>&&) = 0;
     virtual void bufferedAmountIsDecreasing(size_t) = 0;
+    virtual size_t bufferedAmount() const { return 0; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### af95424cb23375b928bd7f5cc1cd68706c131a99
<pre>
[GStreamer][WebRTC] Allow backend to keep track of buffered-amount
<a href="https://bugs.webkit.org/show_bug.cgi?id=235879">https://bugs.webkit.org/show_bug.cgi?id=235879</a>
&lt;rdar://problem/88561869&gt;

Reviewed by Xabier Rodriguez-Calvar.

The GStreamer data-channel handler now monitors the underlying buffered-amount property and notifies
the client when it decreases. The GstWebRTCDataChannel on-buffered-amount-low cannot be used because
the final decision on firing the bufferedAmountIsDecreasing event depends on the bufferedAmount
value managed by the client (RTCDataChannel).

* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::GStreamerDataChannelHandler):
(WebCore::GStreamerDataChannelHandler::setBufferedAmountLowThreshold):
(WebCore::GStreamerDataChannelHandler::bufferedAmountChanged):
(WebCore::GStreamerDataChannelHandler::onBufferedAmountLow): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:
* Source/WebCore/platform/mediastream/RTCDataChannelHandler.h:
(WebCore::RTCDataChannelHandler::setBufferedAmountLowThreshold):
* Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h:
(WebCore::RTCDataChannelHandlerClient::bufferedAmount const):

Canonical link: <a href="https://commits.webkit.org/251990@main">https://commits.webkit.org/251990@main</a>
</pre>
