### PR TITLE
Fix input[type=search] with appearance: textfield focus outline-offset

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1246,7 +1246,7 @@ nobr {
 
 /* states */
 
-:focus-visible {
+:not(input, textarea, select):focus-visible {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     outline: auto 3px -webkit-focus-ring-color;
 #else
@@ -1254,20 +1254,8 @@ nobr {
 #endif
 }
 
-/* Read-only text fields do not show a focus ring but do still receive focus */
-html:focus, body:focus, input[readonly]:focus, applet:focus, embed:focus, iframe:focus, object:focus {
-    outline: none;
-}
-
-#if !defined(WTF_PLATFORM_IOS_FAMILY) || !WTF_PLATFORM_IOS_FAMILY
-input:focus, textarea:focus, select:focus {
-    outline-offset: -2px;
-}
-#endif
-
-input:is([type="button"], [type="checkbox"], [type="file"], [type="hidden"], [type="image"], [type="radio"], [type="reset"], [type="search"], [type="submit"]):focus,
-input[type="file"]:focus::file-selector-button {
-    outline-offset: 0;
+:is(input:not([readonly]), textarea, select):focus-visible {
+    outline-style: auto;
 }
 
 a:any-link {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -284,6 +284,8 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
     case InnerSpinButtonPart:
         return adjustInnerSpinButtonStyle(style, element);
 #endif
+    case ListboxPart:
+        return adjustListboxStyle(style, element);
     case TextFieldPart:
         return adjustTextFieldStyle(style, element);
     case TextAreaPart:
@@ -1076,12 +1078,22 @@ bool RenderTheme::paintColorWell(const RenderObject& box, const PaintInfo& paint
 
 #endif
 
-void RenderTheme::adjustTextFieldStyle(RenderStyle&, const Element*) const
+void RenderTheme::adjustListboxStyle(RenderStyle& style, const Element*) const
 {
+    if (style.outlineStyleIsAuto() == OutlineIsAuto::On)
+        style.setOutlineOffset(-2);
 }
 
-void RenderTheme::adjustTextAreaStyle(RenderStyle&, const Element*) const
+void RenderTheme::adjustTextFieldStyle(RenderStyle& style, const Element*) const
 {
+    if (style.outlineStyleIsAuto() == OutlineIsAuto::On)
+        style.setOutlineOffset(-2);
+}
+
+void RenderTheme::adjustTextAreaStyle(RenderStyle& style, const Element*) const
+{
+    if (style.outlineStyleIsAuto() == OutlineIsAuto::On)
+        style.setOutlineOffset(-2);
 }
 
 void RenderTheme::adjustMenuListStyle(RenderStyle& style, const Element*) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -340,6 +340,8 @@ protected:
     virtual bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&);
 #endif
 
+    virtual void adjustListboxStyle(RenderStyle&, const Element*) const;
+
 #if ENABLE(DATALIST_ELEMENT)
     virtual void adjustListButtonStyle(RenderStyle&, const Element*) const;
     virtual bool paintListButton(const RenderObject&, const PaintInfo&, const FloatRect&) { return true; }

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -93,6 +93,8 @@ private:
 
     void paintFileUploadIconDecorations(const RenderObject& inputRenderer, const RenderObject& buttonRenderer, const PaintInfo&, const IntRect&, Icon*, FileUploadDecorations) override;
 
+    void adjustListboxStyle(RenderStyle&, const Element*) const final { };
+
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;
     void paintTextFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
     void adjustTextAreaStyle(RenderStyle&, const Element*) const final;


### PR DESCRIPTION
#### 63b44aa5315de654b0188710957a4a98f455f73b
<pre>
Fix input[type=search] with appearance: textfield focus outline-offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=241102">https://bugs.webkit.org/show_bug.cgi?id=241102</a>
&lt;rdar://94116168&gt;

Reviewed by Antti Koivisto.

Removed hardcoded UA sheet rules in favor of RenderTheme methods that are tied to the element&apos;s appearance.
This way, an input[type=search] with appearance: textfield will get the correct outline-offset of -2px.

* Source/WebCore/css/html.css:
(:not(input, textarea, select):focus-visible):
(:is(input:not([readonly]), textarea, select):focus-visible):
(:focus-visible): Deleted.
(html:focus, body:focus, input[readonly]:focus, applet:focus, embed:focus, iframe:focus, object:focus): Deleted.
This rule has been made obsolete since the global :focus rule was changed to :focus-visible

(#if !defined(WTF_PLATFORM_IOS_FAMILY) || !WTF_PLATFORM_IOS_FAMILY): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::adjustListboxStyle const):
(WebCore::RenderTheme::adjustTextFieldStyle const):
(WebCore::RenderTheme::adjustTextAreaStyle const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderThemeIOS.h:
</pre>