### PR TITLE
[Linux] TextureMapperPlatformLayerProxyDMABuf should support different colorspaces

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -153,6 +153,7 @@ endif ()
 
 if (USE_LIBGBM)
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/gbm/DMABufColorSpace.h
         platform/graphics/gbm/DMABufEGLUtilities.h
         platform/graphics/gbm/DMABufFormat.h
         platform/graphics/gbm/DMABufObject.h

--- a/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace WebCore {
+
+enum class DMABufColorSpace : uint32_t {
+    Invalid,
+    SRGB,
+    BT601,
+    BT709,
+    BT2020,
+    SMPTE240M,
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -29,6 +29,7 @@
 
 #if USE(LIBGBM)
 
+#include "DMABufColorSpace.h"
 #include "GBMDevice.h"
 #include <gbm.h>
 

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -43,7 +43,7 @@ struct _WebKitDMABufVideoSinkPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
-#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV12, Y444, Y41B, Y42B, VUYA }"
+#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA }"
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -195,14 +195,55 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     if (!m_imageData)
         return;
 
-    // TODO: this is the BT.601 colorspace conversion matrix. The exact desired colorspace should be included
-    // in the DMABufObject, and the relevant matrix decided based on it. BT.601 should remain the default.
-    static constexpr std::array<GLfloat, 16> s_yuvToRGB {
-        1.164383561643836f,  0.0f,                1.596026785714286f, -0.874202217873451f,
-        1.164383561643836f, -0.391762290094914f, -0.812967647237771f,  0.531667823499146f,
-        1.164383561643836f,  2.017232142857143f, -0.0f,               -1.085630789302022f,
-        0.0f,                0.0f,                0.0f,                1.0f,
+    static constexpr std::array<GLfloat, 16> s_bt601ConversionMatrix {
+        1.164383561643836,  0.0,                1.596026785714286, -0.874202217873451,
+        1.164383561643836, -0.391762290094914, -0.812967647237771,  0.531667823499146,
+        1.164383561643836,  2.017232142857143,  0.0,               -1.085630789302022,
+        0.0,                0.0,                0.0,                1.0,
     };
+
+    static constexpr std::array<GLfloat, 16> s_bt709ConversionMatrix {
+        1.164383561643836,  0.0,                1.792741071428571, -0.972945075016308,
+        1.164383561643836, -0.213248614273730, -0.532909328559444,  0.301482665475862,
+        1.164383561643836,  2.112401785714286,  0.0,               -1.133402217873451,
+        0.0,                0.0,                0.0,                1.0,
+    };
+
+    static constexpr std::array<GLfloat, 16> s_bt2020ConversionMatrix {
+        1.164383561643836,  0.0,                1.678674107142857, -0.915687932159165,
+        1.164383561643836, -0.187326104219343, -0.650424318505057,  0.347458498519301,
+        1.164383561643836,  2.141772321428571,  0.0,               -1.148145075016308,
+        0.0,                0.0,                0.0,                1.0,
+    };
+
+    static constexpr std::array<GLfloat, 16> s_smpte240MConversionMatrix {
+        1.164383561643836,  0.0,                1.793651785714286, -0.973402217873451,
+        1.164383561643836, -0.256532845251675, -0.542724809537390,  0.328136638536074,
+        1.164383561643836,  2.07984375,         0.0,               -1.117059360730593,
+        0.0,                0.0,                0.0,                1.0,
+    };
+
+    // Based on the specified colorspace, a YUV-to-RGB matrix is chosen. The default is the BT.601 matrix.
+    // Invalid or SRGB colorspace defaults to that as well, but in case of RGBA-like formats, the matrix
+    // of course goes unused. This is complemented with the below assert that for those formats the specified
+    // colorspace is either invalid or SRGB.
+    const std::array<GLfloat, 16>& yuvToRGB =
+        [&] {
+            switch (m_object.colorSpace) {
+            case DMABufColorSpace::Invalid:
+            case DMABufColorSpace::SRGB:
+                break;
+            case DMABufColorSpace::BT601:
+                return s_bt601ConversionMatrix;
+            case DMABufColorSpace::BT709:
+                return s_bt709ConversionMatrix;
+            case DMABufColorSpace::BT2020:
+                return s_bt2020ConversionMatrix;
+            case DMABufColorSpace::SMPTE240M:
+                return s_smpte240MConversionMatrix;
+            }
+            return s_bt601ConversionMatrix;
+        }();
 
     TextureMapperGL& texmapGL = static_cast<TextureMapperGL&>(textureMapper);
     auto& data = *m_imageData;
@@ -212,6 +253,8 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     case DMABufFormat::FourCC::XBGR8888:
     case DMABufFormat::FourCC::ARGB8888:
     case DMABufFormat::FourCC::ABGR8888:
+        // Either no colorspace or the SRGB colorspace was defined for this object. Other options are not meaningful.
+        ASSERT(m_object.colorSpace == DMABufColorSpace::Invalid || m_object.colorSpace == DMABufColorSpace::SRGB);
         texmapGL.drawTexture(data.texture[0], m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::I420:
@@ -219,28 +262,28 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     case DMABufFormat::FourCC::Y41B:
     case DMABufFormat::FourCC::Y42B:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[1], data.texture[2] },
-            s_yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
+            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
         break;
     case DMABufFormat::FourCC::YV12:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[2], data.texture[1] },
-            s_yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
+            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
         break;
     case DMABufFormat::FourCC::A420:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[1], data.texture[2] },
-            s_yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, data.texture[3]);
+            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, data.texture[3]);
         break;
     case DMABufFormat::FourCC::NV12:
     case DMABufFormat::FourCC::NV21:
         texmapGL.drawTextureSemiPlanarYUV(std::array<GLuint, 2> { data.texture[0], data.texture[1] },
             (m_object.format.fourcc == DMABufFormat::FourCC::NV21),
-            s_yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::YUY2:
     case DMABufFormat::FourCC::UYVY:
     case DMABufFormat::FourCC::VUYA:
     case DMABufFormat::FourCC::YVYU:
         texmapGL.drawTexturePackedYUV(data.texture[0],
-            s_yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;
     default:
         break;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8065,6 +8065,7 @@ void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::
     mainFrameView()->setScrollPosition(IntPoint(targetRect.minXMinYCorner()));
 }
 
+#if ENABLE(VIDEO)
 void WebPage::extractVideoInElementFullScreen(const HTMLVideoElement& element)
 {
     RefPtr view = element.document().view();
@@ -8090,6 +8091,7 @@ void WebPage::cancelVideoExtractionInElementFullScreen()
 {
     send(Messages::WebPageProxy::CancelVideoExtractionInElementFullScreen());
 }
+#endif // ENABLE(VIDEO)
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_IOS)
 void WebPage::modelInlinePreviewDidLoad(WebCore::GraphicsLayer::PlatformLayerID layerID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1537,8 +1537,10 @@ public:
     void modelInlinePreviewDidFailToLoad(WebCore::GraphicsLayer::PlatformLayerID, const WebCore::ResourceError&);
 #endif
 
+#if ENABLE(VIDEO)
     void extractVideoInElementFullScreen(const WebCore::HTMLVideoElement&);
     void cancelVideoExtractionInElementFullScreen();
+#endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     void shouldAllowImageMarkup(const WebCore::ElementContext&, CompletionHandler<void(bool)>&&) const;


### PR DESCRIPTION
#### 733ff10e75f6da2019decceefb0edd03befd864d
<pre>
[Linux] TextureMapperPlatformLayerProxyDMABuf should support different colorspaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=240633">https://bugs.webkit.org/show_bug.cgi?id=240633</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-05-31
Reviewed by Miguel Gomez and Philippe Normand.

Add the DMABufColorSpace enumeration, covering different colorspaces we
currently can support between decoded GStreamer data and the TextureMapper
DMABuf integration.

DMABufObject gains a DMABufColorSpace member variable, initially of an invalid
value but that can be overridden by whoever is constructing the object.

In MediaPlayerPrivateGStreamer, the desired colorspace can be retrieved from the
GstVideoInfo colorimetry information and set on the DMABufObject.

The colorspace is now respected in TextureMapperPlatformLayerProxyDMABuf,
choosing between different YUV-to-RGB matrices that are to be used when sampling
from the set of plane-assigned textures. The default is the BT.601 conversion
matrix. For RGBA-like formats, no conversion is required, so an assert is placed
to ensure that the colorspace is either unspecified or specified as SRGB.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/gbm/DMABufColorSpace.h: Added.
* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::encode const):
(WebCore::DMABufObject::encode):
(WebCore::DMABufObject::decode):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::colorSpaceForColorimetry):
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/251143@main">https://commits.webkit.org/251143@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295048">https://svn.webkit.org/repository/webkit/trunk@295048</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
