### PR TITLE
[GStreamer] DMABufVideoSink fails to list NV21 as a supported format

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -43,7 +43,7 @@ struct _WebKitDMABufVideoSinkPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
-#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV12, Y444, Y41B, Y42B, VUYA }"
+#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA }"
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):


### PR DESCRIPTION
#### a8da22068a1a8b8d985df5dfbbe94cbab40bc89d
<pre>
[GStreamer] DMABufVideoSink fails to list NV21 as a supported format
<a href="https://bugs.webkit.org/show_bug.cgi?id=241119">https://bugs.webkit.org/show_bug.cgi?id=241119</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-05-31
Reviewed by Miguel Gomez and Philippe Normand.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
NV12 is listed twice in the DMABufVideoSink&apos;s list of supported formats. This
is a typo, one of those was supposed to be NV21, a different-but-similar format
that works just fine.

Canonical link: <a href="https://commits.webkit.org/251141@main">https://commits.webkit.org/251141@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295046">https://svn.webkit.org/repository/webkit/trunk@295046</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
