### PR TITLE
Handle start/stop conflicts with multiple SVG animators

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedDecoratedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedDecoratedProperty.h
@@ -136,18 +136,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<decltype(*this)>(animated).m_animVal;
+        if (!isAnimating())
+            m_animVal = static_cast<decltype(*this)>(animated).m_animVal;
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -120,18 +120,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedPrimitiveProperty&>(animated).m_animVal;
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedPrimitiveProperty&>(animated).m_animVal;
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.h
@@ -57,7 +57,7 @@ public:
     virtual void startAnimation(SVGAttributeAnimator& animator) { m_animators.add(animator); }
     virtual void stopAnimation(SVGAttributeAnimator& animator) { m_animators.remove(animator); }
     
-    // Attach/Detach the animVal of the traget element's property by the instance element's property.
+    // Attach/Detach the animVal of the target element's property by the instance element's property.
     virtual void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty&) { startAnimation(animator); }
     virtual void instanceStopAnimation(SVGAttributeAnimator& animator) { stopAnimation(animator); }
     

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -99,18 +99,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedPropertyList&>(animated).animVal();
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedPropertyList&>(animated).animVal();
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
     // Visual Studio doesn't seem to see these private constructors from subclasses.

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -115,18 +115,16 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimation(SVGAttributeAnimator& animator, SVGAnimatedProperty& animated) override
     {
-        if (isAnimating())
-            return;
-        m_animVal = static_cast<SVGAnimatedValueProperty&>(animated).animVal();
+        if (!isAnimating())
+            m_animVal = static_cast<SVGAnimatedValueProperty&>(animated).animVal();
         SVGAnimatedProperty::instanceStartAnimation(animator, animated);
     }
 
     void instanceStopAnimation(SVGAttributeAnimator& animator) override
     {
-        if (!isAnimating())
-            return;
-        m_animVal = nullptr;
         SVGAnimatedProperty::instanceStopAnimation(animator);
+        if (!isAnimating())
+            m_animVal = nullptr;
     }
 
 protected:


### PR DESCRIPTION
#### 1c13967d2e01655bb4f4eda324923f2a450296d3
<pre>
Handle start/stop conflicts with multiple SVG animators
<a href="https://bugs.webkit.org/show_bug.cgi?id=241121">https://bugs.webkit.org/show_bug.cgi?id=241121</a>

Reviewed by Said Abou-Hallawa.

While animating an SVG property from multiple animators, and if there
are multiple instance of this property, then starting or stopping a
specific animator can override the shared m_animVal. This patch fixes
that issue by allowing instanceStartAnimation/instanceStopAnimation
to modify m_animVal only in the case where there are no other animators
for this property. The change is performed for each SVG type (Value,
Primitive, Decorated and List).

* Source/WebCore/svg/properties/SVGAnimatedDecoratedProperty.h: Do not
  touch m_animVal if there are other animators for this property.
* Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h: Ditto.
* Source/WebCore/svg/properties/SVGAnimatedProperty.h: Ditto.
* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h: Ditto.
* Source/WebCore/svg/properties/SVGAnimatedValueProperty.h: Fix a typo.

Canonical link: <a href="https://commits.webkit.org/251149@main">https://commits.webkit.org/251149@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295054">https://svn.webkit.org/repository/webkit/trunk@295054</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
