### PR TITLE
[WPE][GTK] Build broken with ENABLE_VIDEO=OFF after r292252

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -43,7 +43,7 @@ struct _WebKitDMABufVideoSinkPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
-#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV12, Y444, Y41B, Y42B, VUYA }"
+#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA }"
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8065,6 +8065,7 @@ void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::
     mainFrameView()->setScrollPosition(IntPoint(targetRect.minXMinYCorner()));
 }
 
+#if ENABLE(VIDEO)
 void WebPage::extractVideoInElementFullScreen(const HTMLVideoElement& element)
 {
     RefPtr view = element.document().view();
@@ -8090,6 +8091,7 @@ void WebPage::cancelVideoExtractionInElementFullScreen()
 {
     send(Messages::WebPageProxy::CancelVideoExtractionInElementFullScreen());
 }
+#endif // ENABLE(VIDEO)
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_IOS)
 void WebPage::modelInlinePreviewDidLoad(WebCore::GraphicsLayer::PlatformLayerID layerID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1537,8 +1537,10 @@ public:
     void modelInlinePreviewDidFailToLoad(WebCore::GraphicsLayer::PlatformLayerID, const WebCore::ResourceError&);
 #endif
 
+#if ENABLE(VIDEO)
     void extractVideoInElementFullScreen(const WebCore::HTMLVideoElement&);
     void cancelVideoExtractionInElementFullScreen();
+#endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     void shouldAllowImageMarkup(const WebCore::ElementContext&, CompletionHandler<void(bool)>&&) const;


### PR DESCRIPTION
#### 4fd8a09becdaed6c46414f3cea28a9b5b1515bf2
<pre>
[WPE][GTK] Build broken with ENABLE_VIDEO=OFF after r292252
<a href="https://bugs.webkit.org/show_bug.cgi?id=241123">https://bugs.webkit.org/show_bug.cgi?id=241123</a>

Reviewed by Philippe Normand.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp: Add missing ENABLE(VIDEO) guard.
* Source/WebKit/WebProcess/WebPage/WebPage.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/251142@main">https://commits.webkit.org/251142@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295047">https://svn.webkit.org/repository/webkit/trunk@295047</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
