### PR TITLE
PR to test EWS comments on GitHub - Layout 5

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -351,6 +351,9 @@ class MergeQueueFactory(MergeQueueFactoryBase):
         self.addStep(KillOldProcesses())
 
         self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True))
+        self.addStep(RunWebKitTests())
+
+        self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True))
         self.addStep(Canonicalize())
         self.addStep(PushCommitToWebKitRepo())
         self.addStep(SetBuildSummary())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -648,6 +648,8 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'kill-old-processes',
             'validate-change',
+            'layout-tests',
+            'validate-change',
             'canonicalize-commit',
             'push-commit-to-webkit-repo',
             'set-build-summary'


### PR DESCRIPTION
#### 2f9fe6baef7c9a9d729b431cc7f1e0afbe324c64
<pre>
PR to test EWS comments on GitHub - Layout 5
<a href="https://bugs.webkit.org/show_bug.cgi?id=241129">https://bugs.webkit.org/show_bug.cgi?id=241129</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/ews-build/factories.py:
(MergeQueueFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
</pre>

https://github.com/WebKit/WebKit/commit/2f9fe6baef7c9a9d729b431cc7f1e0afbe324c64

| Tests | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/54677 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/53/builds/22172 "Hash 2f9fe6bae for PR 1182 does not build") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16411 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/60280 "Build in-progress") | [❌ 🛠🧪 win](https://ews-build.webkit.org/#/builders/10/builds/102705 "Found 1 new test failure: tttp/tests/websocket/tests/hybi/simple-wss.html") |
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5 "Found 2 webkitpy test failures: webkitbugspy.tests.github_unittest.TestGitHub.test_description, webkitbugspy.tests.github_unittest.TestGitHub.test_get_component") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/52/builds/22935 "Hash 2f9fe6bae for PR 1182 does not build") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/58/builds/16407 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/43436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/59368 "Built successfully") |
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/60588 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/51/builds/20077 "Build in-progress") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-Build-EWS "Waiting in queue, processing hasn't started yet") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/42152 "Passed Tests") |
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/59148 "Passed Tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/53389 "Found 1 new test failure: fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/57/builds/14412 "Found 14 new test failures: fast/canvas/canvas-createPattern-video-loading.html, fast/canvas/canvas-createPattern-video-modify.html, fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgb565.html, fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html, fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html, fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas.html, fast/mediastream/captureStream/canvas2d-heavy-drawing.html, fast/mediastream/captureStream/canvas3d.html, imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-052.html, media/video-canvas-createPattern.html ...") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing hasn't started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/48/builds/23467 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/59/builds/14430 "Found 1 new test failure: fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/50/builds/23205 "Built successfully") | [❌ 🧪 mac-debug-wk1](https://ews-build.webkit.org/#/builders/56/builds/14060 "Found 1 new test failure: fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html") |
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/47/builds/23372 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/10790 "Found 1 new test failure: fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html") |
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/49/builds/23020 "Built successfully") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/54382 "Built successfully") |