### PR TITLE
Add Nikita Vasilyev's GitHub username to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -5203,9 +5203,11 @@
    },
    {
       "emails" : [
-         "nvasilyev@apple.com"
+         "nvasilyev@apple.com",
+         "me@elv1s.ru"
       ],
       "expertise" : "Web Inspector",
+      "github" : "NV",
       "name" : "Nikita Vasilyev",
       "nicks" : [
          "NVI",


### PR DESCRIPTION
#### bb3c1c5e0b6c7493eb2dc6a5931bf772d0bb2998
<pre>
Add Nikita Vasilyev&apos;s GitHub username to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=241158">https://bugs.webkit.org/show_bug.cgi?id=241158</a>

Patch by Nikita Vasilyev &lt;me@elv1s.ru &gt; on 2022-05-31
Reviewed by Jonathan Bedard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/251164@main">https://commits.webkit.org/251164@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295069">https://svn.webkit.org/repository/webkit/trunk@295069</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
