### PR TITLE
[PlayStation] Enable configurable MemoryPressureHandler on NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.cpp
@@ -57,6 +57,8 @@ void NetworkProcessCreationParameters::encode(IPC::Encoder& encoder) const
 #if USE(SOUP)
     encoder << cookieAcceptPolicy;
     encoder << languages;
+#endif
+#if USE(SOUP) || USE(CURL)
     encoder << memoryPressureHandlerConfiguration;
 #endif
 
@@ -98,7 +100,9 @@ bool NetworkProcessCreationParameters::decode(IPC::Decoder& decoder, NetworkProc
         return false;
     if (!decoder.decode(result.languages))
         return false;
+#endif
 
+#if USE(SOUP) || USE(CURL)
     std::optional<std::optional<MemoryPressureHandler::Configuration>> memoryPressureHandlerConfiguration;
     decoder >> memoryPressureHandlerConfiguration;
     if (!memoryPressureHandlerConfiguration)

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -75,6 +75,9 @@ struct NetworkProcessCreationParameters {
 #if USE(SOUP)
     WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy { WebCore::HTTPCookieAcceptPolicy::AlwaysAccept };
     Vector<String> languages;
+#endif
+
+#if USE(SOUP) || USE(CURL)
     std::optional<MemoryPressureHandler::Configuration> memoryPressureHandlerConfiguration;
 #endif
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1743,7 +1743,7 @@ void NetworkProcessProxy::clearBundleIdentifier(CompletionHandler<void()>&& comp
     sendWithAsyncReply(Messages::NetworkProcess::ClearBundleIdentifier(), WTFMove(completionHandler));
 }
 
-#if USE(SOUP)
+#if USE(SOUP) || USE(CURL)
 void NetworkProcessProxy::didExceedMemoryLimit()
 {
     AuxiliaryProcessProxy::terminate();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -374,7 +374,7 @@ private:
 
     void processAuthenticationChallenge(PAL::SessionID, Ref<AuthenticationChallengeProxy>&&);
 
-#if USE(SOUP)
+#if USE(SOUP) || USE(CURL)
     void didExceedMemoryLimit();
 #endif
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -78,7 +78,7 @@ messages -> NetworkProcessProxy LegacyReceiver {
     
     TriggerBrowsingContextGroupSwitchForNavigation(WebKit::WebPageProxyIdentifier pageIdentifier, uint64_t navigationID, enum:uint8_t WebCore::BrowsingContextGroupSwitchDecision browsingContextGroupSwitchDecision, WebCore::RegistrableDomain responseDomain, WebKit::NetworkResourceLoadIdentifier existingNetworkResourceLoadIdentifierToResume) -> (bool success)
 
-#if USE(SOUP)
+#if USE(SOUP) || USE(CURL)
     DidExceedMemoryLimit()
 #endif
 


### PR DESCRIPTION
<pre>
[PlayStation] Enable configurable MemoryPressureHandler on NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=240962">https://bugs.webkit.org/show_bug.cgi?id=240962</a>

Reviewed by NOBODY (OOPS!).

PlayStation port doesn't enable MemoryPressureHandler yet. Following SOUP port
and enable configurable MemoryPressureHandler in NetworkProcess.

* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.cpp:
(WebKit::NetworkProcessCreationParameters::encode const):
(WebKit::NetworkProcessCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/curl/NetworkProcessCurl.cpp:
(WebKit::NetworkProcess::platformInitializeNetworkProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
</pre>

