### PR TITLE
[ARM][NEON] FELightningNEON.cpp fails to build, NEON fast path seems unused

### DIFF
--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNEON.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNEON.cpp
@@ -49,7 +49,7 @@ short* feLightingConstantsForNeon()
     return s_FELightingConstantsForNeon;
 }
 
-void FELighting::platformApplyNeonWorker(FELightingPaintingDataForNeon* parameters)
+void FELightingSoftwareApplier::platformApplyNeonWorker(FELightingPaintingDataForNeon* parameters)
 {
     neonDrawLighting(parameters);
 }
@@ -464,7 +464,7 @@ TOSTRING(neonDrawLighting) ":" NL
     "b .lightStrengthCalculated" NL
 ); // NOLINT
 
-int FELighting::getPowerCoefficients(float exponent)
+int FELightingSoftwareApplier::getPowerCoefficients(float exponent)
 {
     // Calling a powf function from the assembly code would require to save
     // and reload a lot of NEON registers. Since the base is in range [0..1]

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.h
@@ -25,6 +25,10 @@
 #include "LightSource.h"
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+} // namespace WTF
+
 namespace WebCore {
 
 class DistantLightSource : public LightSource {

--- a/Source/WebCore/platform/graphics/filters/FELighting.h
+++ b/Source/WebCore/platform/graphics/filters/FELighting.h
@@ -35,8 +35,6 @@
 
 namespace WebCore {
 
-struct FELightingPaintingDataForNeon;
-
 class FELighting : public FilterEffect {
 public:
     const Color& lightingColor() const { return m_lightingColor; }
@@ -66,11 +64,6 @@ protected:
     FloatRect calculateImageRect(const Filter&, const FilterImageVector& inputs, const FloatRect& primitiveSubregion) const override;
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
-
-#if CPU(ARM_NEON) && CPU(ARM_TRADITIONAL) && COMPILER(GCC_COMPATIBLE)
-    static int getPowerCoefficients(float exponent);
-    inline void platformApplyNeon(const LightingData&, const LightSource::PaintingData&);
-#endif
 
     Color m_lightingColor;
     float m_surfaceScale;

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.h
@@ -26,6 +26,10 @@
 #include "LightSource.h"
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+} // namespace WTF
+
 namespace WebCore {
 
 class PointLightSource : public LightSource {

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.h
@@ -26,6 +26,10 @@
 #include "LightSource.h"
 #include <wtf/Ref.h>
 
+namespace WTF {
+class TextStream;
+} // namespace WTF
+
 namespace WebCore {
 
 class SpotLightSource : public LightSource {

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class FELighting;
+struct FELightingPaintingDataForNeon;
 
 class FELightingSoftwareApplier final : public FilterEffectConcreteApplier<FELighting> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -132,8 +133,23 @@ private:
 
     static void applyPlatformGenericPaint(const LightingData&, const LightSource::PaintingData&, int startY, int endY);
     static void applyPlatformGenericWorker(ApplyParameters*);
+
+#if CPU(ARM_NEON) && CPU(ARM_TRADITIONAL) && COMPILER(GCC_COMPATIBLE)
+    static int getPowerCoefficients(float exponent);
+    static void platformApplyNeonWorker(FELightingPaintingDataForNeon*);
+    inline static void applyPlatformNeon(const LightingData&, const LightSource::PaintingData&);
+
+    inline static void applyPlatformGeneric(const LightingData& data, const LightSource::PaintingData& paintingData)
+    {
+        applyPlatformNeon(data, paintingData);
+    }
+#else
     static void applyPlatformGeneric(const LightingData&, const LightSource::PaintingData&);
+#endif
+
     static void applyPlatform(const LightingData&);
 };
 
 } // namespace WebCore
+
+#include "FELightingNEON.h"


### PR DESCRIPTION
#### 0d3344e17d258106617b0e6d783d073b188a2548
<pre>
[ARM][NEON] FELightningNEON.cpp fails to build, NEON fast path seems unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=241182">https://bugs.webkit.org/show_bug.cgi?id=241182</a>

Reviewed by NOBODY (OOPS!).

Move the NEON fast path for the SVG lighting filter effects into
FELightingSoftwareApplier, and arrange to actually use them by
forwarding calls to applyPlatformGeneric() into applyPlatformNeon().

Some changes were needed to adapt platformApplyNeon() to the current
state of filters after r286140. This was not detected because the code
bitrotted due to it being guarded with CPU(ARM_TRADITIONAL), which does
not get used much these days: CPU(ARM_THUMB2) is more common. It should
be possible to use the NEON fast paths also in Thumb mode, but that is
left for a follow-up fix.

* Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNEON.cpp:
(WebCore::FELightingSoftwareApplier::platformApplyNeonWorker):
(WebCore::FELightingSoftwareApplier::getPowerCoefficients):
(WebCore::FELighting::platformApplyNeonWorker): Deleted.
(WebCore::FELighting::getPowerCoefficients): Deleted.
* Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNEON.h:
(WebCore::FELightingSoftwareApplier::applyPlatformNeon):
(WebCore::FELighting::platformApplyNeon): Deleted.
* Source/WebCore/platform/graphics/filters/DistantLightSource.h:
* Source/WebCore/platform/graphics/filters/FELighting.h:
* Source/WebCore/platform/graphics/filters/PointLightSource.h:
* Source/WebCore/platform/graphics/filters/SpotLightSource.h:
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h:
</pre>