### PR TITLE
Remove 'Intrinsic Margins' feature from WebKit with flag.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4791,11 +4791,6 @@ webkit.org/b/217529 imported/w3c/web-platform-tests/css/css-flexbox/canvas-conta
 # Multicolumn does not paint the horizontal overflow area of a relative child.
 webkit.org/b/41796 imported/w3c/web-platform-tests/css/css-contain/contain-size-monolithic-002.html [ ImageOnlyFailure ]
 
-# Buttons with auto width and height has extra, intrinsic margins (see addIntrinsicMargins in StyleAdjuster).
-# webkit.org/b/238587 may address this.
-imported/w3c/web-platform-tests/css/css-contain/contain-size-button-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002.html [ ImageOnlyFailure ]
-
 # Scrollbar displays are different.
 imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS button.stringAttributeValue('AXVisibleContentRect') is '{0.00, 0.00, 800.00, 600.00}'
-PASS frameButton.stringAttributeValue('AXVisibleContentRect') is '{62.00, 10.00, 200.00, 200.00}'
+PASS frameButton.stringAttributeValue('AXVisibleContentRect') is '{56.00, 10.00, 200.00, 200.00}'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html
+++ b/LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html
@@ -26,7 +26,7 @@
         function startTest() {
         	var iframe = document.getElementById("iframe");
         	frameButton = iframe.contentWindow.accessibilityController.accessibleElementById("frame-button");
-            shouldBe("frameButton.stringAttributeValue('AXVisibleContentRect')", "'{62.00, 10.00, 200.00, 200.00}'");
+            shouldBe("frameButton.stringAttributeValue('AXVisibleContentRect')", "'{56.00, 10.00, 200.00, 200.00}'");
         	finishJSTest();
         }
     }

--- a/LayoutTests/editing/pasteboard/4944770-2.html
+++ b/LayoutTests/editing/pasteboard/4944770-2.html
@@ -6,7 +6,7 @@
 
 <script>
 var copy = document.getElementById("copy");
-doubleClick(copy.offsetLeft, copy.offsetTop);
+doubleClick(copy.offsetLeft - 2, copy.offsetTop - 2);
 document.execCommand("Copy");
 
 var paste = document.getElementById("paste");

--- a/LayoutTests/fast/flexbox/clear-overflow-before-scroll-update-expected.txt
+++ b/LayoutTests/fast/flexbox/clear-overflow-before-scroll-update-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x43
-  RenderBlock {HTML} at (0,0) size 800x43
-    RenderDeprecatedFlexibleBox {BODY} at (8,8) size 784x27
-      RenderBlock (anonymous) at (0,0) size 33x27
-        RenderText {#text} at (19,4) size 4x18
-          text run at (19,4) width 4: " "
-        RenderBlock {SPAN} at (23,8) size 10x10 [bgcolor=#FF0000]
+layer at (0,0) size 800x39
+  RenderBlock {HTML} at (0,0) size 800x39
+    RenderDeprecatedFlexibleBox {BODY} at (8,8) size 784x23
+      RenderBlock (anonymous) at (0,0) size 29x23
+        RenderText {#text} at (15,2) size 4x18
+          text run at (15,2) width 4: " "
+        RenderBlock {SPAN} at (19,6) size 10x10 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 15x23 clip at (15,15) size 5x13
-  RenderMenuList {SELECT} at (2,2) size 15x23 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
+layer at (8,8) size 15x23 clip at (13,13) size 5x13
+  RenderMenuList {SELECT} at (0,0) size 15x23 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
     RenderBlock (anonymous) at (5,5) size 5x13
       RenderText at (-9999,0) size 0x13
         text run at (-9999,0) width 0: " "

--- a/LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button-expected.txt
+++ b/LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button-expected.txt
@@ -1,15 +1,14 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x81
-  RenderBlock {HTML} at (0,0) size 800x81
-    RenderBody {BODY} at (8,16) size 784x57
+layer at (0,0) size 800x77
+  RenderBlock {HTML} at (0,0) size 800x77
+    RenderBody {BODY} at (8,16) size 784x53
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 582x18
           text run at (0,0) width 196: "This tests that the Credit Card "
           text run at (195,0) width 387: "AutoFill button renders. It can only be tested in the test tool."
-      RenderBlock {DIV} at (0,34) size 784x23
-        RenderTextControl {INPUT} at (2,2) size 147x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-          RenderFlexibleBox {DIV} at (3,3) size 141x13
+      RenderBlock {DIV} at (0,34) size 784x19
+        RenderTextControl {INPUT} at (0,0) size 146x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]          RenderFlexibleBox {DIV} at (3,3) size 141x13
             RenderBlock {DIV} at (0,0) size 114x13
         RenderText {#text} at (150,2) size 5x18
           text run at (150,2) width 5: " "

--- a/LayoutTests/fast/forms/button-with-float-expected.html
+++ b/LayoutTests/fast/forms/button-with-float-expected.html
@@ -8,7 +8,6 @@
         padding: 0;
         background-color: buttonface;
         float: left;
-        margin: 2px;
     }
 
     .margin {

--- a/LayoutTests/fast/forms/listbox-clip-expected.txt
+++ b/LayoutTests/fast/forms/listbox-clip-expected.txt
@@ -3,6 +3,6 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderListBox {SELECT} at (0,2) size 100x85 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderListBox {SELECT} at (0,0) size 100x85 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/fast/forms/option-mouseevents-expected.txt
+++ b/LayoutTests/fast/forms/option-mouseevents-expected.txt
@@ -75,15 +75,15 @@ PASS: event type should be mousedown and is
 PASS: event target should be [object HTMLSelectElement] and is
 PASS: event.pageX should be 22 and is
 PASS: event.pageY should be 448 and is
-PASS: event.offsetX should be 12 and is
-PASS: event.offsetY should be 38 and is
+PASS: event.offsetX should be 14 and is
+PASS: event.offsetY should be 40 and is
 PASS: event.x should be 22 and is
 PASS: event.y should be 448 and is
 PASS: event type should be mousedown and is
 PASS: event target should be [object HTMLSelectElement] and is
 PASS: event.pageX should be 22 and is
 PASS: event.pageY should be 448 and is
-PASS: event.offsetX should be 12 and is
-PASS: event.offsetY should be 38 and is
+PASS: event.offsetX should be 14 and is
+PASS: event.offsetY should be 40 and is
 PASS: event.x should be 22 and is
 PASS: event.y should be 448 and is

--- a/LayoutTests/fast/forms/option-mouseevents.html
+++ b/LayoutTests/fast/forms/option-mouseevents.html
@@ -38,8 +38,8 @@ function mouseeventverify2(event, x, y, offsetX, offsetY, target, type)
     shouldBe("event target", event.target, target);
     shouldBe("event.pageX", event.pageX, x);
     shouldBe("event.pageY", event.pageY, y);
-    shouldBe("event.offsetX", event.offsetX, offsetX);
-    shouldBe("event.offsetY", event.offsetY, offsetY);
+    shouldBe("event.offsetX", event.offsetX, offsetX + 2);
+    shouldBe("event.offsetY", event.offsetY, offsetY + 2);
     shouldBe("event.x", event.x, x);
     shouldBe("event.y", event.y, y);
 }

--- a/LayoutTests/fast/multicol/flexbox-rows-expected.html
+++ b/LayoutTests/fast/multicol/flexbox-rows-expected.html
@@ -28,6 +28,7 @@
         }
         
         input {
+            margin: 2px;
             margin-left: 1em;
         }
         

--- a/LayoutTests/fast/multicol/flexbox-rows.html
+++ b/LayoutTests/fast/multicol/flexbox-rows.html
@@ -34,6 +34,7 @@
         }
         
         input {
+            margin: 2px;
             margin-left: 1em;
         }
         

--- a/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test-expected.txt
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test-expected.txt
@@ -8,7 +8,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 div display height = 111
-Mouse moved to (30, 378)
+Mouse moved to (28, 376)
 PASS Page did not receive wheel events.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe-expected.txt
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe-expected.txt
@@ -7,7 +7,7 @@ Tests that a select doesn't consume wheel events when scroll is latched to main 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-Mouse moved to (30, 127)
+Mouse moved to (28, 125)
 PASS Select did not receive wheel events.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/scrolling/latching/scroll-select-latched-select-expected.txt
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-latched-select-expected.txt
@@ -8,7 +8,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 div display height = 111
-Mouse moved to (30, 238)
+Mouse moved to (28, 236)
 PASS Page did not receive wheel events.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fullscreen/full-screen-placeholder-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-placeholder-expected.txt
@@ -4,14 +4,14 @@ Two
 EVENT(webkitfullscreenchange)
 EXPECTED (document.webkitCurrentFullScreenElement == '[object HTMLDivElement]') OK
 EXPECTED (one.offsetLeft == '68') OK
-EXPECTED (one.offsetTop == '48') OK
+EXPECTED (one.offsetTop == '45') OK
 EXPECTED (two.offsetLeft == '8') OK
-EXPECTED (two.offsetTop == '108') OK
+EXPECTED (two.offsetTop == '105') OK
 EVENT(webkitfullscreenchange)
 EXPECTED (document.webkitCurrentFullScreenElement == 'null') OK
 EXPECTED (one.offsetLeft == '68') OK
-EXPECTED (one.offsetTop == '48') OK
+EXPECTED (one.offsetTop == '45') OK
 EXPECTED (two.offsetLeft == '8') OK
-EXPECTED (two.offsetTop == '108') OK
+EXPECTED (two.offsetTop == '105') OK
 END OF TEST
 

--- a/LayoutTests/platform/ios-wk2/editing/pasteboard/pasting-tabs-expected.txt
+++ b/LayoutTests/platform/ios-wk2/editing/pasteboard/pasting-tabs-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
           text run at (0,0) width 663: "This tests copying plain text with tabs and pasting it into an editable region using paste and match tyle. "
           text run at (662,0) width 121: "The tabs should be"
           text run at (0,20) width 67: "preserved."
-      RenderBlock (anonymous) at (0,56) size 784x38
+      RenderBlock (anonymous) at (0,56) size 784x34
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,94) size 784x20
+      RenderBlock {DIV} at (0,90) size 784x20
         RenderText {#text} at (0,0) size 39x19
           text run at (0,0) width 39: "Tab->"
         RenderInline {SPAN} at (0,0) size 26x19

--- a/LayoutTests/platform/ios-wk2/fast/block/margin-collapse/103-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/block/margin-collapse/103-expected.txt
@@ -1,11 +1,11 @@
-layer at (0,0) size 800x1753
+layer at (0,0) size 800x1739
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x1753
-  RenderBlock {HTML} at (0,0) size 800x1753
-    RenderBody {BODY} at (8,20) size 784x1713 [bgcolor=#A6A972]
-      RenderBlock {DIV} at (91,0) size 602x1713 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
+layer at (0,0) size 800x1739
+  RenderBlock {HTML} at (0,0) size 800x1739
+    RenderBody {BODY} at (8,20) size 784x1699 [bgcolor=#A6A972]
+      RenderBlock {DIV} at (91,0) size 602x1699 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,31) size 600x70
-        RenderBlock {DIV} at (1,114) size 600x1527
+        RenderBlock {DIV} at (1,114) size 600x1513
           RenderBlock {P} at (20,0) size 560x80 [color=#333333]
             RenderText {#text} at (0,2) size 523x36
               text run at (0,2) width 523: "We are trying to understand how UVic students perform Shakespeare related research for"
@@ -22,7 +22,7 @@ layer at (0,0) size 800x1753
           RenderBlock {P} at (20,93) size 560x21 [color=#333333]
             RenderText {#text} at (0,2) size 463x16
               text run at (0,2) width 463: "Please take the time to carefully review and complete the following questions."
-          RenderBlock {FORM} at (20,138) size 560x1356
+          RenderBlock {FORM} at (20,138) size 560x1342
             RenderBlock {H2} at (0,0) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 202x17
                 text run at (0,0) width 202: "PERSONAL INFORMATION"

--- a/LayoutTests/platform/ios-wk2/fast/forms/textAreaLineHeight-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/forms/textAreaLineHeight-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x1241
+layer at (0,0) size 800x1233
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x1241
-  RenderBlock {HTML} at (0,0) size 800x1242
-    RenderBody {BODY} at (8,8) size 784x1218
+layer at (0,0) size 800x1233
+  RenderBlock {HTML} at (0,0) size 800x1234
+    RenderBody {BODY} at (8,8) size 784x1210
       RenderBlock (anonymous) at (0,0) size 784x20
         RenderText {#text} at (0,0) size 278x19
           text run at (0,0) width 278: "line-height settings not reflected in textarea"

--- a/LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x278
+      RenderBlock {CENTER} at (0,0) size 784x270
         RenderTable {TABLE} at (0,0) size 784x20
           RenderTableSection {TBODY} at (0,0) size 784x20
             RenderTableRow {TR} at (0,0) size 784x16
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,20) size 784x40
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
-        RenderBlock {DIV} at (0,60) size 784x113 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,60) size 784x105 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (215,2) size 354x24
             RenderTableSection {TBODY} at (0,0) size 354x24
               RenderTableRow {TR} at (0,0) size 354x24
@@ -110,7 +110,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x12 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x12
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,75) size 780x36
+          RenderBlock (anonymous) at (2,67) size 780x36
             RenderBR {BR} at (390,0) size 0x19
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -124,7 +124,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,20) size 4x15
                 text run at (459,20) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,173) size 784x76
+        RenderBlock (anonymous) at (0,165) size 784x76
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
           RenderBR {BR} at (392,40) size 0x19

--- a/LayoutTests/platform/ios/editing/selection/3690703-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690703-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x278
+      RenderBlock {CENTER} at (0,0) size 784x270
         RenderTable {TABLE} at (0,0) size 784x20
           RenderTableSection {TBODY} at (0,0) size 784x20
             RenderTableRow {TR} at (0,0) size 784x16
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,20) size 784x40
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
-        RenderBlock {DIV} at (0,60) size 784x113 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,60) size 784x105 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (215,2) size 354x24
             RenderTableSection {TBODY} at (0,0) size 354x24
               RenderTableRow {TR} at (0,0) size 354x24
@@ -112,7 +112,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x12 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x12
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,75) size 780x36
+          RenderBlock (anonymous) at (2,67) size 780x36
             RenderBR {BR} at (390,0) size 0x19
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -126,7 +126,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,20) size 4x15
                 text run at (459,20) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,173) size 784x76
+        RenderBlock (anonymous) at (0,165) size 784x76
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
           RenderBR {BR} at (392,40) size 0x19

--- a/LayoutTests/platform/ios/editing/selection/3690719-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690719-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x278
+      RenderBlock {CENTER} at (0,0) size 784x270
         RenderTable {TABLE} at (0,0) size 784x20
           RenderTableSection {TBODY} at (0,0) size 784x20
             RenderTableRow {TR} at (0,0) size 784x16
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,20) size 784x40
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
-        RenderBlock {DIV} at (0,60) size 784x113 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,60) size 784x105 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (215,2) size 354x24
             RenderTableSection {TBODY} at (0,0) size 354x24
               RenderTableRow {TR} at (0,0) size 354x24
@@ -104,7 +104,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x12 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x12
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,75) size 780x36
+          RenderBlock (anonymous) at (2,67) size 780x36
             RenderBR {BR} at (390,0) size 0x19
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -118,7 +118,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,20) size 4x15
                 text run at (459,20) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,173) size 784x76
+        RenderBlock (anonymous) at (0,165) size 784x76
           RenderBR {BR} at (392,0) size 0x19
           RenderBR {BR} at (392,20) size 0x19
           RenderBR {BR} at (392,40) size 0x19

--- a/LayoutTests/platform/ios/fast/block/float/float-avoidance-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/float/float-avoidance-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2570
+layer at (0,0) size 800x2526
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2570
-  RenderBlock {HTML} at (0,0) size 800x2570
-    RenderBody {BODY} at (8,8) size 784x2554
+layer at (0,0) size 800x2526
+  RenderBlock {HTML} at (0,0) size 800x2526
+    RenderBody {BODY} at (8,8) size 784x2510
       RenderBlock (anonymous) at (0,0) size 784x40
         RenderText {#text} at (0,0) size 782x39
           text run at (0,0) width 547: "Test of objects that avoid floats to see what they do with percentage and auto widths. "
@@ -302,7 +302,7 @@ layer at (0,0) size 800x2570
         RenderBlock {HR} at (110,38) size 100x2 [border: (1px inset #000000)]
         RenderBlock (anonymous) at (10,48) size 200x20
           RenderBR {BR} at (100,0) size 0x19
-layer at (118,1448) size 100x120
+layer at (118,1420) size 100x120
   RenderBlock (floating) {DIV} at (110,30) size 100x120
     RenderText {#text} at (0,0) size 100x119
       text run at (0,0) width 63: "This is an"
@@ -311,13 +311,13 @@ layer at (118,1448) size 100x120
       text run at (0,60) width 92: "enough text to"
       text run at (0,80) width 100: "have to wrap to"
       text run at (0,100) width 92: "multiple lines."
-layer at (18,1672) size 200x60
-  RenderBlock (floating) {DIV} at (10,54) size 200x60
+layer at (18,1640) size 200x60
+  RenderBlock (floating) {DIV} at (10,50) size 200x60
     RenderText {#text} at (0,0) size 175x59
       text run at (0,0) width 174: "This is an overflow section"
       text run at (0,20) width 175: "with enough text to have to"
       text run at (0,40) width 144: "wrap to multiple lines."
-layer at (118,1792) size 100x120
+layer at (118,1760) size 100x120
   RenderBlock {DIV} at (110,30) size 100x120
     RenderText {#text} at (0,0) size 100x119
       text run at (0,0) width 63: "This is an"
@@ -326,7 +326,7 @@ layer at (118,1792) size 100x120
       text run at (0,60) width 92: "enough text to"
       text run at (0,80) width 100: "have to wrap to"
       text run at (0,100) width 92: "multiple lines."
-layer at (118,2012) size 100x120
+layer at (118,1980) size 100x120
   RenderBlock {DIV} at (110,30) size 100x120
     RenderText {#text} at (0,0) size 100x119
       text run at (0,0) width 63: "This is an"

--- a/LayoutTests/platform/ios/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/continuationCrash-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,41) size 784x21
         RenderText {#text} at (0,0) size 180x19
           text run at (0,0) width 180: "Click the following buttons."
-      RenderBlock {OL} at (0,77) size 784x185
+      RenderBlock {OL} at (0,77) size 784x182
         RenderListItem {LI} at (40,0) size 744x20
           RenderListMarker at (-21,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 199x19

--- a/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt
@@ -57,7 +57,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (95,4) size 17x16 [bgcolor=#FFFFFF03]
         RenderText {#text} at (113,3) size 9x19
           text run at (113,3) width 9: "b"
-      RenderBlock {DIV} at (10,446) size 450x24 [border: (1px solid #FF0000)]
+      RenderBlock {DIV} at (10,440) size 450x24 [border: (1px solid #FF0000)]
         RenderText {#text} at (1,3) size 8x19
           text run at (1,3) width 8: "a"
         RenderBlock {INPUT} at (10,4) size 17x16 [bgcolor=#FFFFFF03]

--- a/LayoutTests/platform/ios/fast/forms/button-generated-content-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/button-generated-content-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x292
-  RenderBlock {HTML} at (0,0) size 800x292
-    RenderBody {BODY} at (8,16) size 784x268
+layer at (0,0) size 800x266
+  RenderBlock {HTML} at (0,0) size 800x266
+    RenderBody {BODY} at (8,16) size 784x242
       RenderBlock {P} at (0,0) size 784x40
         RenderText {#text} at (0,0) size 322x19
           text run at (0,0) width 299: "This is a test of generated content in <button> "

--- a/LayoutTests/platform/ios/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/form-element-geometry-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x650
+layer at (0,0) size 800x627
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x650
-  RenderBlock {HTML} at (0,0) size 800x650
-    RenderBody {BODY} at (8,8) size 784x634
+layer at (0,0) size 800x627
+  RenderBlock {HTML} at (0,0) size 800x627
+    RenderBody {BODY} at (8,8) size 784x611
       RenderBlock {H1} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 420x36
           text run at (0,1) width 420: "Form Element Geometry Tests"

--- a/LayoutTests/platform/ios/fast/forms/menulist-option-wrap-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/menulist-option-wrap-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
             text run at (360,0) width 273: "Native popup with size=\"1\" wraps options"
         RenderText {#text} at (632,0) size 5x19
           text run at (632,0) width 5: "."
-      RenderBlock {P} at (0,36) size 784x21
+      RenderBlock {P} at (0,36) size 784x20
         RenderText {#text} at (0,0) size 36x19
           text run at (0,0) width 36: "With "
         RenderInline {TT} at (0,0) size 63x14
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
             RenderText at (0,0) size 173x14
               text run at (0,0) width 173: "Very long option that does not fit"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,73) size 784x21
+      RenderBlock {P} at (0,72) size 784x20
         RenderText {#text} at (0,0) size 56x19
           text run at (0,0) width 56: "Without "
         RenderInline {TT} at (0,0) size 33x14

--- a/LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (160,0) size 414x19
           text run at (160,0) width 212: " will be pasted into the textfield. "
           text run at (371,0) width 203: "All richness should be stripped."
-      RenderBlock {OL} at (0,61) size 784x40
+      RenderBlock {OL} at (0,58) size 784x40
         RenderListItem {LI} at (40,0) size 744x20
           RenderListMarker at (-21,0) size 16x19: "1"
           RenderText {#text} at (0,0) size 332x19
@@ -34,7 +34,7 @@ layer at (0,0) size 800x600
           RenderListMarker at (-21,0) size 16x19: "2"
           RenderText {#text} at (0,0) size 331x19
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
-layer at (15,13) size 587x14
+layer at (15,12) size 587x14
   RenderBlock {DIV} at (6,3) size 588x15
     RenderText {#text} at (0,0) size 464x14
       text run at (0,0) width 464: "This styled text, and link will be pasted into the textfield. All richness should be stripped."

--- a/LayoutTests/platform/ios/fast/table/text-field-baseline-expected.txt
+++ b/LayoutTests/platform/ios/fast/table/text-field-baseline-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x449
-  RenderBlock {HTML} at (0,0) size 800x449
-    RenderBody {BODY} at (8,16) size 784x417
+layer at (0,0) size 800x428
+  RenderBlock {HTML} at (0,0) size 800x428
+    RenderBody {BODY} at (8,16) size 784x396
       RenderBlock {P} at (0,0) size 784x40
         RenderText {#text} at (0,0) size 177x19
           text run at (0,0) width 177: "This is a regression test for "

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/45621-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/45621-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x145
-  RenderBlock {HTML} at (0,0) size 800x145
-    RenderBody {BODY} at (8,13) size 784x124
+layer at (0,0) size 800x141
+  RenderBlock {HTML} at (0,0) size 800x141
+    RenderBody {BODY} at (8,13) size 784x120
       RenderBlock {PRE} at (0,0) size 784x42
         RenderText {#text} at (0,0) size 164x42
           text run at (0,0) width 118: "table width=50%"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x156
-        RenderTableSection {TBODY} at (0,0) size 784x156
+      RenderTable {TABLE} at (0,0) size 784x152
+        RenderTableSection {TBODY} at (0,0) size 784x152
           RenderTableRow {TR} at (0,0) size 784x82
             RenderTableCell {TD} at (0,0) size 785x82 [r=0 c=0 rs=1 cs=4]
               RenderBR {BR} at (392,1) size 1x19

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2672
+layer at (0,0) size 800x2666
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2672
-  RenderBlock {HTML} at (0,0) size 800x2673
-    RenderBody {BODY} at (8,21) size 784x2636 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x2666
+  RenderBlock {HTML} at (0,0) size 800x2667
+    RenderBody {BODY} at (8,21) size 784x2630 [bgcolor=#FFFFFF]
       RenderBlock {H1} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 361x36
           text run at (0,1) width 361: "Table Inheritance Tests - 1"
@@ -209,7 +209,7 @@ layer at (0,0) size 800x2672
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (135,0) size 5x19
           text run at (135,0) width 5: "."
-      RenderBlock {P} at (0,2506) size 784x21
+      RenderBlock {P} at (0,2500) size 784x21
         RenderText {#text} at (0,0) size 64x19
           text run at (0,0) width 64: "Up to the "
         RenderInline {A} at (0,0) size 99x19 [color=#0000EE]
@@ -217,13 +217,13 @@ layer at (0,0) size 800x2672
             text run at (63,0) width 99: "Evil Tests Page"
         RenderText {#text} at (161,0) size 5x19
           text run at (161,0) width 5: "."
-      RenderBlock {P} at (0,2542) size 784x21
+      RenderBlock {P} at (0,2536) size 784x21
         RenderText {#text} at (0,0) size 63x19
           text run at (0,0) width 63: "Bugzilla: "
         RenderInline {A} at (0,0) size 64x19 [color=#0000EE]
           RenderText {#text} at (62,0) size 64x19
             text run at (62,0) width 64: "Bug 1044"
-      RenderBlock {P} at (0,2578) size 784x21
+      RenderBlock {P} at (0,2572) size 784x21
         RenderText {#text} at (0,0) size 177x19
           text run at (0,0) width 177: "This page is maintained by "
         RenderInline {A} at (0,0) size 79x19 [color=#0000EE]

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug44505-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug44505-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x646
+layer at (0,0) size 800x640
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x646
-  RenderBlock {HTML} at (0,0) size 800x646
-    RenderBody {BODY} at (8,8) size 784x630 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x640
+  RenderBlock {HTML} at (0,0) size 800x640
+    RenderBody {BODY} at (8,8) size 784x624 [bgcolor=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 308x56 [border: (1px outset #808080)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
@@ -25,19 +25,19 @@ layer at (0,0) size 800x646
         RenderTableSection {TBODY} at (1,1) size 298x54
           RenderTableRow {TR} at (0,2) size 298x24
           RenderTableRow {TR} at (0,28) size 298x24
-      RenderTable {TABLE} at (0,224) size 300x60 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x58
-          RenderTableRow {TR} at (0,2) size 298x28
-          RenderTableRow {TR} at (0,32) size 298x24
-      RenderTable {TABLE} at (0,284) size 300x60 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x58
-          RenderTableRow {TR} at (0,2) size 298x28
-          RenderTableRow {TR} at (0,32) size 298x24
-      RenderTable {TABLE} at (0,344) size 300x98 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,224) size 300x57 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x55
+          RenderTableRow {TR} at (0,2) size 298x25
+          RenderTableRow {TR} at (0,29) size 298x24
+      RenderTable {TABLE} at (0,281) size 300x57 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x55
+          RenderTableRow {TR} at (0,2) size 298x25
+          RenderTableRow {TR} at (0,29) size 298x24
+      RenderTable {TABLE} at (0,338) size 300x98 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x96
           RenderTableRow {TR} at (0,2) size 298x48
           RenderTableRow {TR} at (0,52) size 298x42
-      RenderTable {TABLE} at (0,536) size 300x94 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,530) size 300x94 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x92
           RenderTableRow {TR} at (0,2) size 298x62
           RenderTableRow {TR} at (0,66) size 298x24

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug59354-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug59354-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 468x154 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 466x152
-          RenderTableRow {TR} at (0,0) size 466x152
-            RenderTableCell {TD} at (0,0) size 466x152 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (1,1) size 464x150 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 462x148
+      RenderTable {TABLE} at (0,0) size 468x150 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 466x148
+          RenderTableRow {TR} at (0,0) size 466x148
+            RenderTableCell {TD} at (0,0) size 466x148 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (1,1) size 464x146 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 462x144
                   RenderTableRow {TR} at (0,1) size 462x30
                     RenderTableCell {TD} at (1,1) size 140x30 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (5,5) size 130x19

--- a/LayoutTests/platform/ios/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {BLOCKQUOTE} at (40,0) size 704x126
-        RenderBlock {CENTER} at (0,0) size 704x126
+      RenderBlock {BLOCKQUOTE} at (40,0) size 704x123
+        RenderBlock {CENTER} at (0,0) size 704x123
           RenderTable {TABLE} at (297,0) size 110x86 [border: (2.50px none #808080)]
             RenderTableSection {TBODY} at (2,2) size 104x82
               RenderTableRow {TR} at (0,0) size 104x27

--- a/LayoutTests/platform/ios/tables/mozilla/core/margins-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/core/margins-expected.txt
@@ -29,10 +29,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 194x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x19
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,132) size 784x20
+      RenderBlock (anonymous) at (0,128) size 784x20
         RenderText {#text} at (0,0) size 186x19
           text run at (0,0) width 186: "outer auto inner align=center"
-      RenderTable {TABLE} at (0,152) size 44x42 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,148) size 44x42 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 40x38
           RenderTableRow {TR} at (0,2) size 40x34
             RenderTableCell {TD} at (2,2) size 36x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -42,10 +42,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x19
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,194) size 784x20
+      RenderBlock (anonymous) at (0,190) size 784x20
         RenderText {#text} at (0,0) size 220x19
           text run at (0,0) width 220: "outer width=50 inner align=center"
-      RenderTable {TABLE} at (0,214) size 44x42 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,210) size 44x42 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 40x38
           RenderTableRow {TR} at (0,2) size 40x34
             RenderTableCell {TD} at (2,2) size 36x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -55,10 +55,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x19
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,256) size 784x20
+      RenderBlock (anonymous) at (0,252) size 784x20
         RenderText {#text} at (0,0) size 232x19
           text run at (0,0) width 232: "outer width=50 inner margin-left:50"
-      RenderTable {TABLE} at (0,276) size 94x42 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,272) size 94x42 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 90x38
           RenderTableRow {TR} at (0,2) size 90x34
             RenderTableCell {TD} at (2,2) size 86x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -68,10 +68,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x19
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,318) size 784x20
+      RenderBlock (anonymous) at (0,314) size 784x20
         RenderText {#text} at (0,0) size 228x19
           text run at (0,0) width 228: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,338) size 400x42 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,334) size 400x42 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x38
           RenderTableRow {TR} at (0,2) size 396x34
             RenderTableCell {TD} at (2,2) size 116x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (119,7) size 276x24 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x19
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,380) size 784x20
+      RenderBlock (anonymous) at (0,376) size 784x20
         RenderText {#text} at (0,0) size 228x19
           text run at (0,0) width 228: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,400) size 400x42 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,396) size 400x42 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x38
           RenderTableRow {TR} at (0,2) size 396x34
             RenderTableCell {TD} at (2,2) size 169x34 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -100,6 +100,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (172,7) size 223x24 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x19
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,442) size 784x20
+      RenderBlock (anonymous) at (0,438) size 784x20
         RenderText {#text} at (0,0) size 20x19
           text run at (0,0) width 20: "-->"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 600x310 [bgcolor=#FFC0CB]
-        RenderTableSection {TBODY} at (0,0) size 600x310
+      RenderTable {TABLE} at (0,0) size 600x306 [bgcolor=#FFC0CB]
+        RenderTableSection {TBODY} at (0,0) size 600x306
           RenderTableRow {TR} at (0,0) size 600x20
             RenderTableCell {TD} at (0,0) size 601x20 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=3]
               RenderText {#text} at (0,0) size 8x19
@@ -53,12 +53,12 @@ layer at (0,0) size 800x600
                 text run at (48,20) width 287: "This will allow you to select a starting point "
                 text run at (334,20) width 71: "and enter a"
                 text run at (0,40) width 204: "radius with new feature criteria."
-          RenderTableRow {TR} at (0,210) size 600x20
-            RenderTableCell {TD} at (155,210) size 446x20 [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,206) size 600x20
+            RenderTableCell {TD} at (155,206) size 446x20 [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x19
                 text run at (0,0) width 4: " "
-          RenderTableRow {TR} at (0,230) size 600x80
-            RenderTableCell {TD} at (155,230) size 446x80 [r=9 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,226) size 600x80
+            RenderTableCell {TD} at (155,226) size 446x80 [r=9 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 419x79
                 text run at (0,0) width 419: "All information provided is deemed reliable but is not guaranteed"
                 text run at (0,20) width 93: "and should be "

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
@@ -1,17 +1,17 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x79
-  RenderBlock {HTML} at (0,0) size 800x79
-    RenderBody {BODY} at (8,8) size 784x63
-      RenderTable {TABLE} at (0,0) size 392x63 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 392x63
-          RenderTableRow {TR} at (0,0) size 392x23
-            RenderTableCell {TD} at (0,0) size 392x23 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
-              RenderTextControl {INPUT} at (0,2) size 403x20 [bgcolor=#FFC0CB]
+layer at (0,0) size 800x75
+  RenderBlock {HTML} at (0,0) size 800x75
+    RenderBody {BODY} at (8,8) size 784x59
+      RenderTable {TABLE} at (0,0) size 392x59 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 392x59
+          RenderTableRow {TR} at (0,0) size 392x19
+            RenderTableCell {TD} at (0,0) size 392x19 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
+              RenderTextControl {INPUT} at (0,0) size 403x20 [bgcolor=#FFC0CB]
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,23) size 392x40
-            RenderTableCell {TD} at (0,23) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,19) size 392x40
+            RenderTableCell {TD} at (0,19) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 392x40 [bgcolor=#00FFFF]
               RenderText {#text} at (0,0) size 0x0
-layer at (14,12) size 392x14
+layer at (14,10) size 392x14
   RenderBlock {DIV} at (5,2) size 393x15

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x152
+      RenderBlock {CENTER} at (0,0) size 784x144
         RenderTable {TABLE} at (339,0) size 106x88
           RenderTableSection {THEAD} at (0,0) size 105x22
             RenderTableRow {TR} at (0,0) size 105x22

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x154
+      RenderBlock {CENTER} at (0,0) size 784x146
         RenderTable {TABLE} at (338,0) size 108x90 [border: (0.50px outset #808080)]
           RenderTableSection {THEAD} at (0,0) size 107x23
             RenderTableRow {TR} at (0,0) size 106x23

--- a/LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt
+++ b/LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt
@@ -9,7 +9,7 @@
       (children 1
         (GraphicsLayer
           (offsetFromRenderer width=-5 height=-4)
-          (position 5.00 6.00)
+          (position 3.00 4.00)
           (anchor 0.51 0.46)
           (bounds 126.00 28.00)
           (drawsContent 1)

--- a/LayoutTests/platform/mac/css2.1/20110323/replaced-elements-001-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/20110323/replaced-elements-001-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x166
-  RenderBlock {HTML} at (0,0) size 800x166
-    RenderBody {BODY} at (8,16) size 784x134
+layer at (0,0) size 800x162
+  RenderBlock {HTML} at (0,0) size 800x162
+    RenderBody {BODY} at (8,16) size 784x130
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 609x18
           text run at (0,0) width 609: "Below, there should be 2 orange boxes horizontally centered within their respective green bars."
-      RenderBlock {DIV} at (16,34) size 752x42 [bgcolor=#008000]
+      RenderBlock {DIV} at (16,34) size 752x40 [bgcolor=#008000]
         RenderBlock (anonymous) at (0,0) size 752x18
           RenderText {#text} at (0,0) size 36x18
             text run at (0,0) width 36: "         "
-        RenderButton {INPUT} at (368,20) size 16x22 [color=#000000D8] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
-      RenderBlock {FORM} at (0,92) size 784x42
-        RenderBlock {DIV} at (16,0) size 752x42 [bgcolor=#008000]
+        RenderButton {INPUT} at (368,18) size 16x22 [color=#000000D8] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
+      RenderBlock {FORM} at (0,90) size 784x40
+        RenderBlock {DIV} at (16,0) size 752x40 [bgcolor=#008000]
           RenderBlock (anonymous) at (0,0) size 752x18
             RenderText {#text} at (0,0) size 36x18
               text run at (0,0) width 36: "         "
-          RenderButton {INPUT} at (368,20) size 16x22 [color=#000000D8] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]
+          RenderButton {INPUT} at (368,18) size 16x22 [color=#000000D8] [bgcolor=#FFA500] [border: (2px outset #C0C0C0)]

--- a/LayoutTests/platform/mac/css3/flexbox/button-expected.txt
+++ b/LayoutTests/platform/mac/css3/flexbox/button-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x249
-  RenderBlock {HTML} at (0,0) size 800x249
-    RenderBody {BODY} at (8,8) size 784x233
+layer at (0,0) size 800x241
+  RenderBlock {HTML} at (0,0) size 800x241
+    RenderBody {BODY} at (8,8) size 784x225
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 778x36
           text run at (0,0) width 410: "Test for empty buttons, which inherit from RenderFlexibleBox. "
@@ -14,23 +14,23 @@ layer at (0,0) size 800x249
         RenderText {#text} at (571,18) size 5x18
           text run at (571,18) width 5: "."
       RenderBlock {HR} at (0,44) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,54) size 784x59
+      RenderBlock (anonymous) at (0,54) size 784x55
         RenderText {#text} at (0,0) size 81x18
           text run at (0,0) width 81: "Simple case."
         RenderBR {BR} at (80,0) size 1x18
-        RenderButton {BUTTON} at (2,20) size 16x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
-        RenderBR {BR} at (20,18) size 0x18
-        RenderButton {INPUT} at (2,39) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
-        RenderBR {BR} at (20,40) size 0x18
-      RenderBlock {HR} at (0,121) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,131) size 784x102
+        RenderButton {BUTTON} at (0,20) size 16x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderBR {BR} at (16,18) size 0x18
+        RenderButton {INPUT} at (0,36) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderBR {BR} at (16,37) size 0x18
+      RenderBlock {HR} at (0,117) size 784x2 [border: (1px inset #000000)]
+      RenderBlock (anonymous) at (0,127) size 784x98
         RenderText {#text} at (0,0) size 744x36
           text run at (0,0) width 744: "Empty <button> and <input type=button> with overflow: scroll;. The presence of the scrollbar should not shrink the"
           text run at (0,18) width 45: "button."
         RenderBR {BR} at (44,18) size 1x18
-        RenderBR {BR} at (35,36) size 0x18
-        RenderBR {BR} at (35,70) size 0x18
-layer at (10,187) size 31x20 clip at (12,187) size 12x5
-  RenderButton {BUTTON} at (2,48) size 31x20 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
-layer at (10,221) size 31x18 clip at (10,221) size 16x3
-  RenderButton {INPUT} at (2,82) size 31x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderBR {BR} at (31,36) size 0x18
+        RenderBR {BR} at (31,68) size 0x18
+layer at (8,183) size 31x20 clip at (10,183) size 12x5
+  RenderButton {BUTTON} at (0,48) size 31x20 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+layer at (8,215) size 31x18 clip at (8,215) size 16x3
+  RenderButton {INPUT} at (0,80) size 31x18 [color=#000000D8] [bgcolor=#C0C0C0]

--- a/LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 517x18
           text run at (0,0) width 517: "This tests for a bug where the first newline entered into a text area would be lost."
-      RenderBlock (anonymous) at (0,34) size 784x36
+      RenderBlock (anonymous) at (0,34) size 784x32
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,44) size 161x32 clip at (11,45) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,42) size 161x32 clip at (9,43) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x26
       RenderText {#text} at (0,0) size 0x13
         text run at (0,0) width 0: " "

--- a/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt
@@ -25,11 +25,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 784: "Note, this test can fail due to user specific spell checking data. If the user has previously dismissed 'message' as the correct"
           text run at (0,18) width 747: "spelling of 'mesage' several times, the spell checker will not provide 'notational' as a suggestion anymore. To fix this,"
           text run at (0,36) width 242: "remove all files in ~/Library/Spelling."
-      RenderBlock (anonymous) at (0,122) size 784x140
+      RenderBlock (anonymous) at (0,122) size 784x136
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,132) size 581x136 clip at (11,133) size 579x134
-  RenderTextControl {TEXTAREA} at (2,2) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,130) size 581x136 clip at (9,131) size 579x134
+  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 575x13
       RenderText {#text} at (0,0) size 54x13
         text run at (0,0) width 54: "mesage m"

--- a/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt
@@ -25,11 +25,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 784: "Note, this test can fail due to user specific spell checking data. If the user has previously dismissed 'message' as the correct"
           text run at (0,18) width 747: "spelling of 'mesage' several times, the spell checker will not provide 'notational' as a suggestion anymore. To fix this,"
           text run at (0,36) width 242: "remove all files in ~/Library/Spelling."
-      RenderBlock (anonymous) at (0,122) size 784x140
+      RenderBlock (anonymous) at (0,122) size 784x136
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,132) size 581x136 clip at (11,133) size 579x134
-  RenderTextControl {TEXTAREA} at (2,2) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,130) size 581x136 clip at (9,131) size 579x134
+  RenderTextControl {TEXTAREA} at (0,0) size 581x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 575x26
       RenderText {#text} at (0,0) size 45x13
         text run at (0,0) width 45: "mesage "

--- a/LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt
@@ -16,19 +16,19 @@ layer at (0,0) size 800x600
           text run at (0,0) width 673: "This tests for a bug when creating markup for a selection that contained unrendered nodes with children. "
           text run at (672,0) width 109: "You should see a"
           text run at (0,18) width 253: "picture of abe followed by a select box."
-      RenderBlock {DIV} at (0,52) size 784x110
+      RenderBlock {DIV} at (0,52) size 784x108
         RenderImage {IMG} at (0,0) size 76x103
         RenderText {#text} at (76,89) size 4x18
           text run at (76,89) width 4: " "
-        RenderMenuList {SELECT} at (82,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (80,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 51x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
-      RenderBlock (anonymous) at (0,162) size 784x110
+      RenderBlock (anonymous) at (0,160) size 784x108
         RenderImage {IMG} at (0,0) size 76x103
         RenderText {#text} at (76,89) size 4x18
           text run at (76,89) width 4: " "
-        RenderMenuList {SELECT} at (82,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (80,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 51x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt
@@ -8,17 +8,17 @@ layer at (0,0) size 800x600
           text run at (0,0) width 420: "This tests smart paste of a fragment that ends in a select element. "
           text run at (419,0) width 342: "There should be no spaces added because the paste is"
           text run at (0,18) width 219: "performed in an empty paragraph."
-      RenderBlock {DIV} at (0,52) size 784x22
-        RenderText {#text} at (0,1) size 22x18
-          text run at (0,1) width 22: "foo"
-        RenderMenuList {SELECT} at (23,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,52) size 784x19
+        RenderText {#text} at (0,0) size 22x18
+          text run at (0,0) width 22: "foo"
+        RenderMenuList {SELECT} at (21,1) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
-      RenderBlock {DIV} at (0,74) size 784x22
-        RenderText {#text} at (0,1) size 22x18
-          text run at (0,1) width 22: "foo"
-        RenderMenuList {SELECT} at (23,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,71) size 784x19
+        RenderText {#text} at (0,0) size 22x18
+          text run at (0,0) width 22: "foo"
+        RenderMenuList {SELECT} at (21,1) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt
@@ -8,18 +8,12 @@ layer at (0,0) size 800x600
           text run at (0,0) width 420: "This tests smart paste of a fragment that ends in a select element. "
           text run at (419,0) width 321: "There should be spaces added before and after the"
           text run at (0,18) width 106: "inserted content."
-      RenderBlock {DIV} at (0,52) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 38x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,52) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 38x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
-      RenderBlock {DIV} at (0,74) size 784x22
-        RenderText {#text} at (0,1) size 12x18
-          text run at (0,1) width 12: "x "
-        RenderMenuList {SELECT} at (14,2) size 38x18 [color=#000000D8] [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (0,0) size 38x18
-            RenderText at (8,2) size 6x13
-              text run at (8,2) width 6: "1"
-        RenderText {#text} at (54,1) size 12x18
-          text run at (54,1) width 12: " x"
-caret: position 1 of child 2 {#text} of child 4 {DIV} of body
+      RenderBlock {DIV} at (0,70) size 784x18
+        RenderText {#text} at (0,0) size 16x18
+          text run at (0,0) width 16: "xx"
+caret: position 1 of child 0 {#text} of child 4 {DIV} of body

--- a/LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt
@@ -18,9 +18,9 @@ layer at (0,0) size 800x600
           text run at (0,0) width 663: "This tests copying plain text with tabs and pasting it into an editable region using paste and match tyle. "
           text run at (662,0) width 121: "The tabs should be"
           text run at (0,18) width 67: "preserved."
-      RenderBlock (anonymous) at (0,52) size 784x36
+      RenderBlock (anonymous) at (0,52) size 784x32
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,88) size 784x18
+      RenderBlock {DIV} at (0,84) size 784x18
         RenderText {#text} at (0,0) size 39x18
           text run at (0,0) width 39: "Tab->"
         RenderInline {SPAN} at (0,0) size 26x18
@@ -28,8 +28,8 @@ layer at (0,0) size 800x600
             text run at (38,0) width 26: "\x{9}"
         RenderText {#text} at (64,0) size 39x18
           text run at (64,0) width 39: "<-Tab"
-layer at (10,62) size 161x32 clip at (11,63) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,60) size 161x32 clip at (9,61) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 82x13
         text run at (0,0) width 82: "Tab->\x{9}<-Tab"

--- a/LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x258
+      RenderBlock {CENTER} at (0,0) size 784x252
         RenderTable {TABLE} at (0,0) size 784x19
           RenderTableSection {TBODY} at (0,0) size 784x19
             RenderTableRow {TR} at (0,0) size 784x15
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,19) size 784x36
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
-        RenderBlock {DIV} at (0,55) size 784x105 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,55) size 784x99 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (214,2) size 355x23
             RenderTableSection {TBODY} at (0,0) size 355x23
               RenderTableRow {TR} at (0,0) size 355x23
@@ -110,7 +110,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x13 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x13
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,70) size 780x33
+          RenderBlock (anonymous) at (2,64) size 780x33
             RenderBR {BR} at (390,0) size 0x18
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -124,7 +124,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,18) size 4x15
                 text run at (459,18) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,160) size 784x69
+        RenderBlock (anonymous) at (0,154) size 784x69
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
           RenderBR {BR} at (392,36) size 0x18

--- a/LayoutTests/platform/mac/editing/selection/3690703-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690703-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x258
+      RenderBlock {CENTER} at (0,0) size 784x252
         RenderTable {TABLE} at (0,0) size 784x19
           RenderTableSection {TBODY} at (0,0) size 784x19
             RenderTableRow {TR} at (0,0) size 784x15
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,19) size 784x36
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
-        RenderBlock {DIV} at (0,55) size 784x105 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,55) size 784x99 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (214,2) size 355x23
             RenderTableSection {TBODY} at (0,0) size 355x23
               RenderTableRow {TR} at (0,0) size 355x23
@@ -112,7 +112,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x13 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x13
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,70) size 780x33
+          RenderBlock (anonymous) at (2,64) size 780x33
             RenderBR {BR} at (390,0) size 0x18
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -126,7 +126,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,18) size 4x15
                 text run at (459,18) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,160) size 784x69
+        RenderBlock (anonymous) at (0,154) size 784x69
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
           RenderBR {BR} at (392,36) size 0x18

--- a/LayoutTests/platform/mac/editing/selection/3690719-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/3690719-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,3) size 784x581 [bgcolor=#FFFFFF]
-      RenderBlock {CENTER} at (0,0) size 784x258
+      RenderBlock {CENTER} at (0,0) size 784x252
         RenderTable {TABLE} at (0,0) size 784x19
           RenderTableSection {TBODY} at (0,0) size 784x19
             RenderTableRow {TR} at (0,0) size 784x15
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
         RenderBlock (anonymous) at (0,19) size 784x36
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
-        RenderBlock {DIV} at (0,55) size 784x105 [border: (2px solid #AAAAFF)]
+        RenderBlock {DIV} at (0,55) size 784x99 [border: (2px solid #AAAAFF)]
           RenderTable {TABLE} at (214,2) size 355x23
             RenderTableSection {TBODY} at (0,0) size 355x23
               RenderTableRow {TR} at (0,0) size 355x23
@@ -104,7 +104,7 @@ layer at (0,0) size 800x600
                     RenderInline {A} at (0,0) size 65x13 [color=#0000CC]
                       RenderText {#text} at (5,26) size 65x13
                         text run at (5,26) width 65: "Language Tools"
-          RenderBlock (anonymous) at (2,70) size 780x33
+          RenderBlock (anonymous) at (2,64) size 780x33
             RenderBR {BR} at (390,0) size 0x18
             RenderInline {FONT} at (0,0) size 146x15
               RenderInline {FONT} at (0,0) size 30x15 [color=#FF0000]
@@ -118,7 +118,7 @@ layer at (0,0) size 800x600
               RenderText {#text} at (459,18) size 4x15
                 text run at (459,18) width 4: "."
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,160) size 784x69
+        RenderBlock (anonymous) at (0,154) size 784x69
           RenderBR {BR} at (392,0) size 0x18
           RenderBR {BR} at (392,18) size 0x18
           RenderBR {BR} at (392,36) size 0x18

--- a/LayoutTests/platform/mac/editing/selection/4397952-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/4397952-expected.txt
@@ -12,12 +12,12 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 578x18
           text run at (0,0) width 271: "This tests caret movement across buttons. "
           text run at (270,0) width 308: "The caret should be just after the second button."
-      RenderBlock {DIV} at (0,34) size 784x22
-        RenderButton {INPUT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock {DIV} at (0,34) size 784x18
+        RenderButton {INPUT} at (0,0) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 20x13
             RenderText at (0,0) size 20x13
               text run at (0,0) width 20: "Foo"
-        RenderButton {INPUT} at (41,2) size 35x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (35,0) size 35x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 18x13
             RenderText at (0,0) size 18x13
               text run at (0,0) width 18: "Bar"

--- a/LayoutTests/platform/mac/editing/selection/5240265-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/5240265-expected.txt
@@ -9,13 +9,13 @@ layer at (0,0) size 800x600
           text run at (0,18) width 476: "selection from the editable region. To run it manually, click on the button. "
           text run at (475,18) width 298: "The editable region should not be focused, but"
           text run at (0,36) width 246: "the text inside of it should be selected."
-      RenderBlock (anonymous) at (0,70) size 784x22
-        RenderButton {INPUT} at (2,2) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock (anonymous) at (0,70) size 784x18
+        RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 62x13
             RenderText at (0,0) size 62x13
               text run at (0,0) width 62: "Click on me"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,92) size 784x18
+      RenderBlock {DIV} at (0,88) size 784x18
         RenderText {#text} at (0,0) size 182x18
           text run at (0,0) width 182: "This text should be selected."
 selection start: position 0 of child 0 {#text} of child 4 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 784x96 [border: (5px solid #FF0000)]
-        RenderMenuList {SELECT} at (39,39) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,0) size 784x93 [border: (5px solid #FF0000)]
+        RenderMenuList {SELECT} at (37,38) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 53x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
-        RenderText {#text} at (94,38) size 27x18
-          text run at (94,38) width 27: "blaa"
+        RenderText {#text} at (90,37) size 27x18
+          text run at (90,37) width 27: "blaa"
 caret: position 0 of child 0 {SELECT} of child 0 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/select-across-readonly-input-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-across-readonly-input-1-expected.txt
@@ -11,15 +11,15 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 745x36
           text run at (0,0) width 745: "To manually test, select text by a mouse drag starting in \"hello\" and ending in \"world\". Selection should only extend"
           text run at (0,18) width 158: "inside the input element."
-      RenderBlock {DIV} at (0,104) size 784x28
-        RenderTextControl {INPUT} at (0,2) size 59x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (58,6) size 5x18
-          text run at (58,6) width 5: " "
+      RenderBlock {DIV} at (0,104) size 784x24
+        RenderTextControl {INPUT} at (0,0) size 59x24 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (58,4) size 5x18
+          text run at (58,4) width 5: " "
         RenderInline {SPAN} at (0,0) size 39x18
-          RenderText {#text} at (62,6) size 39x18
-            text run at (62,6) width 39: "world"
+          RenderText {#text} at (62,4) size 39x18
+            text run at (62,4) width 39: "world"
         RenderText {#text} at (0,0) size 0x0
-layer at (11,117) size 53x18
+layer at (11,115) size 53x18
   RenderBlock {DIV} at (3,3) size 53x18
     RenderText {#text} at (0,0) size 35x18
       text run at (0,0) width 35: "hello"

--- a/LayoutTests/platform/mac/editing/selection/select-box-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-box-expected.txt
@@ -60,14 +60,14 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 706x18
           text run at (0,0) width 300: "This tests caret movement across a select box. "
           text run at (299,0) width 407: "The caret should skip over the select box as if it were an image."
-      RenderBlock {DIV} at (0,34) size 784x22
-        RenderBlock {DIV} at (0,0) size 784x22
-          RenderText {#text} at (0,1) size 73x18
-            text run at (0,1) width 73: "select box: "
-          RenderMenuList {SELECT} at (74,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,34) size 784x19
+        RenderBlock {DIV} at (0,0) size 784x19
+          RenderText {#text} at (0,0) size 73x18
+            text run at (0,0) width 73: "select box: "
+          RenderMenuList {SELECT} at (72,1) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 38x18
               RenderText at (8,2) size 6x13
                 text run at (8,2) width 6: "1"
-          RenderText {#text} at (114,1) size 68x18
-            text run at (114,1) width 68: " the end ..."
+          RenderText {#text} at (110,0) size 68x18
+            text run at (110,0) width 68: " the end ..."
 caret: position 1 of child 0 {#text} of child 1 {DIV} of child 3 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x600
           text run at (0,0) width 333: "This tests paragraphBoundary selection navigation. "
           text run at (332,0) width 432: "The caret should be at the end of the paragraph below, just after the"
           text run at (0,18) width 69: "select box."
-      RenderBlock {DIV} at (0,52) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 37x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,52) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 37x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 37x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt
@@ -1,34 +1,34 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x138
-  RenderBlock {HTML} at (0,0) size 800x138
-    RenderBody {BODY} at (8,16) size 784x114
+layer at (0,0) size 800x132
+  RenderBlock {HTML} at (0,0) size 800x132
+    RenderBody {BODY} at (8,16) size 784x108
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 566x18
           text run at (0,0) width 566: "To PASS this test case the text of the button label should not be selected in the selection."
-      RenderBlock {DIV} at (0,34) size 784x80
-        RenderBlock (anonymous) at (0,0) size 784x40
+      RenderBlock {DIV} at (0,34) size 784x74
+        RenderBlock (anonymous) at (0,0) size 784x37
           RenderText {#text} at (0,0) size 50x18
             text run at (0,0) width 50: "Buttons"
           RenderBR {BR} at (49,0) size 1x18
-          RenderText {#text} at (0,19) size 61x18
-            text run at (0,19) width 61: "with text "
-          RenderButton {INPUT} at (62,20) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderText {#text} at (0,18) size 61x18
+            text run at (0,18) width 61: "with text "
+          RenderButton {INPUT} at (60,19) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
             RenderBlock (anonymous) at (8,2) size 44x13
               RenderText at (0,0) size 44x13
                 text run at (0,0) width 44: "too little"
-          RenderText {#text} at (123,19) size 59x18
-            text run at (123,19) width 59: " too little"
-        RenderBlock {DIV} at (0,40) size 784x22
-          RenderText {#text} at (0,1) size 56x18
-            text run at (0,1) width 56: "and text "
-          RenderButton {INPUT} at (57,2) size 66x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderText {#text} at (119,18) size 59x18
+            text run at (119,18) width 59: " too little"
+        RenderBlock {DIV} at (0,37) size 784x19
+          RenderText {#text} at (0,0) size 56x18
+            text run at (0,0) width 56: "and text "
+          RenderButton {INPUT} at (55,1) size 66x18 [color=#000000D8] [bgcolor=#C0C0C0]
             RenderBlock (anonymous) at (8,2) size 50x13
               RenderText at (0,0) size 50x13
                 text run at (0,0) width 50: "too much"
-          RenderText {#text} at (124,1) size 65x18
-            text run at (124,1) width 65: " too much"
-        RenderBlock (anonymous) at (0,62) size 784x18
+          RenderText {#text} at (120,0) size 65x18
+            text run at (120,0) width 65: " too much"
+        RenderBlock (anonymous) at (0,56) size 784x18
           RenderText {#text} at (0,0) size 250x18
             text run at (0,0) width 250: "Should not be selected in the selection."
 selection start: position 0 of child 0 {#text} of child 1 {P} of body

--- a/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2386
+layer at (0,0) size 785x2342
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2386
-  RenderBlock {HTML} at (0,0) size 785x2386
-    RenderBody {BODY} at (8,8) size 769x2370
+layer at (0,0) size 785x2342
+  RenderBlock {HTML} at (0,0) size 785x2342
+    RenderBody {BODY} at (8,8) size 769x2326
       RenderBlock (anonymous) at (0,0) size 769x36
         RenderText {#text} at (0,0) size 753x36
           text run at (0,0) width 546: "Test of objects that avoid floats to see what they do with percentage and auto widths. "
@@ -311,13 +311,13 @@ layer at (118,1356) size 100x108
       text run at (0,54) width 92: "enough text to"
       text run at (0,72) width 100: "have to wrap to"
       text run at (0,90) width 92: "multiple lines."
-layer at (18,1560) size 200x54
-  RenderBlock (floating) {DIV} at (10,50) size 200x54
+layer at (18,1528) size 200x54
+  RenderBlock (floating) {DIV} at (10,46) size 200x54
     RenderText {#text} at (0,0) size 175x54
       text run at (0,0) width 173: "This is an overflow section"
       text run at (0,18) width 175: "with enough text to have to"
       text run at (0,36) width 144: "wrap to multiple lines."
-layer at (118,1670) size 100x108
+layer at (118,1638) size 100x108
   RenderBlock {DIV} at (110,28) size 100x108
     RenderText {#text} at (0,0) size 100x108
       text run at (0,0) width 63: "This is an"
@@ -326,7 +326,7 @@ layer at (118,1670) size 100x108
       text run at (0,54) width 92: "enough text to"
       text run at (0,72) width 100: "have to wrap to"
       text run at (0,90) width 92: "multiple lines."
-layer at (118,1870) size 100x108
+layer at (118,1838) size 100x108
   RenderBlock {DIV} at (110,28) size 100x108
     RenderText {#text} at (0,0) size 100x108
       text run at (0,0) width 63: "This is an"

--- a/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
@@ -1,11 +1,11 @@
-layer at (0,0) size 785x1721
+layer at (0,0) size 785x1707
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1721
-  RenderBlock {HTML} at (0,0) size 785x1721
-    RenderBody {BODY} at (8,20) size 769x1681 [bgcolor=#A6A972]
-      RenderBlock {DIV} at (83,0) size 603x1681 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
+layer at (0,0) size 785x1707
+  RenderBlock {HTML} at (0,0) size 785x1707
+    RenderBody {BODY} at (8,20) size 769x1667 [bgcolor=#A6A972]
+      RenderBlock {DIV} at (83,0) size 603x1667 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,31) size 600x70
-        RenderBlock {DIV} at (1,114) size 600x1495
+        RenderBlock {DIV} at (1,114) size 600x1481
           RenderBlock {P} at (20,0) size 560x80 [color=#333333]
             RenderText {#text} at (0,2) size 523x35
               text run at (0,2) width 523: "We are trying to understand how UVic students perform Shakespeare related research for"
@@ -22,7 +22,7 @@ layer at (0,0) size 785x1721
           RenderBlock {P} at (20,93) size 560x21 [color=#333333]
             RenderText {#text} at (0,2) size 463x15
               text run at (0,2) width 463: "Please take the time to carefully review and complete the following questions."
-          RenderBlock {FORM} at (20,138) size 560x1324
+          RenderBlock {FORM} at (20,138) size 560x1310
             RenderBlock {H2} at (0,0) size 560x16 [color=#333333]
               RenderText {#text} at (0,0) size 202x16
                 text run at (0,0) width 202: "PERSONAL INFORMATION"
@@ -30,74 +30,74 @@ layer at (0,0) size 785x1721
               RenderText {#text} at (0,2) size 67x15
                 text run at (0,2) width 67: "Your Name*"
             RenderTextControl {INPUT} at (325,26) size 186x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderBlock (floating) {SPAN} at (0,47) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,46) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 119x15
                 text run at (0,2) width 119: "Your e-mail address*"
-            RenderTextControl {INPUT} at (325,47) size 186x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderBlock (floating) {SPAN} at (0,68) size 325x20 [color=#333333]
+            RenderTextControl {INPUT} at (325,45) size 186x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderBlock (floating) {SPAN} at (0,66) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 127x15
                 text run at (0,2) width 127: "Your degree program*"
-            RenderMenuList {SELECT} at (325,68) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,64) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 87x13
                   text run at (8,2) width 87: "Program options"
-            RenderBlock (floating) {SPAN} at (0,88) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,86) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 110x15
                 text run at (0,2) width 110: "Your year of study*"
-            RenderMenuList {SELECT} at (325,88) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,82) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 122x13
                   text run at (8,2) width 122: "Years you've been here"
-            RenderBlock (floating) {SPAN} at (0,108) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,106) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 153x15
                 text run at (0,2) width 153: "Shakespeare classes taken"
-            RenderMenuList {SELECT} at (325,108) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,100) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 74x13
                   text run at (8,2) width 74: "Number taken"
-            RenderBlock {P} at (0,139) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,131) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 157x15
                 text run at (0,2) width 157: "* indicates a required field"
-            RenderBlock {H2} at (0,184) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,176) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 298x16
                 text run at (0,0) width 298: "SHAKESPEARE RESEARCH QUESTIONS"
-            RenderBlock (floating) {SPAN} at (0,210) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,202) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 323x15
                 text run at (0,2) width 323: "What percentage of your research time is spent online?"
-            RenderMenuList {SELECT} at (325,210) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,202) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 106x13
                   text run at (8,2) width 106: "Percentages of time"
-            RenderBlock (floating) {SPAN} at (0,230) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,222) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 300x35
                 text run at (0,2) width 300: "What is holding you back from doing more research"
                 text run at (0,22) width 41: "online?"
-            RenderMenuList {SELECT} at (325,230) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,220) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 45x13
                   text run at (8,2) width 45: "Reasons"
-            RenderBlock (floating) {SPAN} at (0,250) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,242) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 220x15
                 text run at (0,2) width 220: "Your research is primarily focused on:"
-            RenderBlock {SPAN} at (325,250) size 180x21 [color=#333333]
+            RenderBlock {SPAN} at (325,238) size 180x21 [color=#333333]
               RenderBlock {INPUT} at (2,4) size 12x12 [color=#000000]
               RenderText {#text} at (16,2) size 30x15
                 text run at (16,2) width 30: "Texts"
-            RenderBlock {SPAN} at (325,270) size 180x21 [color=#333333]
+            RenderBlock {SPAN} at (325,258) size 180x21 [color=#333333]
               RenderBlock {INPUT} at (2,4) size 12x12 [color=#000000]
               RenderText {#text} at (16,2) size 133x15
                 text run at (16,2) width 133: "Performance materials"
-            RenderBlock {SPAN} at (325,290) size 180x21 [color=#333333]
+            RenderBlock {SPAN} at (325,278) size 180x21 [color=#333333]
               RenderBlock {INPUT} at (2,4) size 12x12 [color=#000000]
               RenderText {#text} at (16,2) size 21x15
                 text run at (16,2) width 21: "n/a"
-            RenderBlock {H2} at (0,335) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,323) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 373x16
                 text run at (0,0) width 373: "INTERNET SHAKESPEARE EDITIONS QUESTIONS"
-            RenderBlock (floating) {SPAN} at (0,361) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,349) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 304x15
                 text run at (0,2) width 304: "Have you used UVic's Internet Shakespeare Editions?"
-            RenderBlock {SPAN} at (325,361) size 180x21 [color=#333333]
+            RenderBlock {SPAN} at (325,349) size 180x21 [color=#333333]
               RenderText {#text} at (0,2) size 19x15
                 text run at (0,2) width 19: "Yes"
               RenderBlock {INPUT} at (20,4) size 13x12 [color=#000000]
@@ -106,77 +106,77 @@ layer at (0,0) size 785x1721
                 text run at (38,2) width 16: "No"
               RenderBlock {INPUT} at (55,4) size 13x12 [color=#000000]
               RenderText {#text} at (0,0) size 0x0
-            RenderBlock {P} at (0,394) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,382) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 378x15
                 text run at (0,2) width 378: "-- If you answered no to this question, skip to the next section --"
-            RenderBlock (floating) {SPAN} at (0,427) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,415) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 275x15
                 text run at (0,2) width 275: "Which area of the ISE did you find most useful?"
-            RenderMenuList {SELECT} at (325,427) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,415) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 100x13
                   text run at (8,2) width 100: "Sections of the ISE"
-            RenderBlock (floating) {SPAN} at (0,447) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,435) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 251x15
                 text run at (0,2) width 251: "How did you find the navigation of the ISE?"
-            RenderMenuList {SELECT} at (325,447) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,433) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 91x13
                   text run at (8,2) width 91: "Level of difficulty"
-            RenderBlock (floating) {SPAN} at (0,467) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,455) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 208x15
                 text run at (0,2) width 208: "Please describe your use of the ISE."
-            RenderBlock {H2} at (0,621) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,607) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 290x16
                 text run at (0,0) width 290: "TOOLS IN DEVELOPMENT QUESTIONS"
-            RenderBlock {P} at (0,651) size 560x61 [color=#333333]
+            RenderBlock {P} at (0,637) size 560x61 [color=#333333]
               RenderText {#text} at (0,2) size 554x55
                 text run at (0,2) width 451: "We are in the process of both making new material available and developing "
                 text run at (450,2) width 104: "new tools to view"
                 text run at (0,22) width 352: "and extrapolate information from Shakespeare's works. The "
                 text run at (351,22) width 159: "following images are visual"
                 text run at (0,42) width 344: "representations of some of the ideas being thrown around."
-            RenderBlock {P} at (0,724) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,710) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 339x15
                 text run at (0,2) width 339: "Please review them carefully and provide feedback below"
-            RenderBlock (floating) {SPAN} at (0,757) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,743) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 144x15
                 text run at (0,2) width 144: "Your comments on Fig. 1"
-            RenderBlock (floating) {SPAN} at (0,888) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,874) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 144x15
                 text run at (0,2) width 144: "Your comments on Fig. 2"
-            RenderBlock (floating) {SPAN} at (0,1019) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,1005) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 144x15
                 text run at (0,2) width 144: "Your comments on Fig. 3"
-            RenderBlock {H2} at (0,1170) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,1156) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 143x16
                 text run at (0,0) width 143: "OTHER FEEDBACK"
-            RenderBlock (floating) {SPAN} at (0,1196) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,1182) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 222x15
                 text run at (0,2) width 222: "Please enter any other thoughts here."
-          RenderBlock {P} at (20,1474) size 560x21 [color=#333333]
+          RenderBlock {P} at (20,1460) size 560x21 [color=#333333]
             RenderText {#text} at (0,2) size 231x15
               text run at (0,2) width 231: "Thank you for your time filling this out."
-        RenderBlock {DIV} at (1,1628) size 600x52 [border: (1px dashed #A6A972) none]
+        RenderBlock {DIV} at (1,1614) size 600x52 [border: (1px dashed #A6A972) none]
           RenderBlock {SPAN} at (0,16) size 600x20 [color=#333333]
             RenderText {#text} at (247,2) size 106x15
               text run at (247,2) width 106: "\x{A9}2003 Kevin Davis"
 layer at (441,302) size 180x13
   RenderBlock {DIV} at (3,3) size 180x13
-layer at (441,323) size 180x13
+layer at (441,321) size 180x13
   RenderBlock {DIV} at (3,3) size 180x13
-layer at (113,764) size 506x106 clip at (114,765) size 504x104
-  RenderTextControl {TEXTAREA} at (0,490) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,750) size 506x106 clip at (114,751) size 504x104
+  RenderTextControl {TEXTAREA} at (0,476) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x13
-layer at (113,1051) size 506x106 clip at (114,1052) size 504x104
-  RenderTextControl {TEXTAREA} at (0,777) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1037) size 506x106 clip at (114,1038) size 504x104
+  RenderTextControl {TEXTAREA} at (0,763) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x13
-layer at (113,1182) size 506x106 clip at (114,1183) size 504x104
-  RenderTextControl {TEXTAREA} at (0,908) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1168) size 506x106 clip at (114,1169) size 504x104
+  RenderTextControl {TEXTAREA} at (0,894) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x13
-layer at (113,1313) size 506x106 clip at (114,1314) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1039) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1299) size 506x106 clip at (114,1300) size 504x104
+  RenderTextControl {TEXTAREA} at (0,1025) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x13
-layer at (113,1490) size 506x106 clip at (114,1491) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1216) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1476) size 506x106 clip at (114,1477) size 504x104
+  RenderTextControl {TEXTAREA} at (0,1202) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x13

--- a/LayoutTests/platform/mac/fast/block/positioning/inline-block-relposition-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/positioning/inline-block-relposition-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x38
-  RenderBlock {HTML} at (0,0) size 800x38
-    RenderBody {BODY} at (8,8) size 784x22
+layer at (0,0) size 800x34
+  RenderBlock {HTML} at (0,0) size 800x34
+    RenderBody {BODY} at (8,8) size 784x18
       RenderText {#text} at (0,0) size 0x0
-layer at (8,10) size 100x18
-  RenderButton {BUTTON} at (0,2) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+layer at (8,8) size 100x18
+  RenderButton {BUTTON} at (0,0) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
     RenderBlock (anonymous) at (8,2) size 84x13
       RenderText {#text} at (19,0) size 46x13
         text run at (19,0) width 46: "Click Me"
-layer at (88,25) size 23x13
+layer at (88,23) size 23x13
   RenderBlock (positioned) {DIV} at (79,15) size 24x13
     RenderText {#text} at (0,0) size 24x13
       text run at (0,0) width 24: "Now"

--- a/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,39) size 784x19
         RenderText {#text} at (0,0) size 180x18
           text run at (0,0) width 180: "Click the following buttons."
-      RenderBlock {OL} at (0,73) size 784x167
+      RenderBlock {OL} at (0,73) size 784x164
         RenderListItem {LI} at (40,0) size 744x18
           RenderListMarker at (-20,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 199x18

--- a/LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt
@@ -33,38 +33,38 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (1,21) size 782x20 [border: (1px dotted #0000FF)]
           RenderText {#text} at (1,1) size 86x18
             text run at (1,1) width 86: "Lorem ipsum"
-      RenderBlock (anonymous) at (0,270) size 784x40
+      RenderBlock (anonymous) at (0,270) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (2,20) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 86x13
             RenderText at (0,0) size 86x13
               text run at (0,0) width 86: "Negative margin"
-        RenderText {#text} at (105,19) size 5x18
-          text run at (105,19) width 5: " "
-        RenderButton {INPUT} at (111,20) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderText {#text} at (101,18) size 5x18
+          text run at (101,18) width 5: " "
+        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 81x13
             RenderText at (0,0) size 81x13
               text run at (0,0) width 81: "Positive margin"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,326) size 784x18
+      RenderBlock {P} at (0,323) size 784x18
         RenderText {#text} at (0,0) size 458x18
           text run at (0,0) width 458: "Dynamic case (automatically testing positive --> negative --> positive):"
-      RenderBlock {DIV} at (0,360) size 784x72 [border: (1px solid #008000)]
+      RenderBlock {DIV} at (0,357) size 784x72 [border: (1px solid #008000)]
         RenderBlock {DIV} at (1,11) size 782x20 [border: (1px solid #0000FF)]
           RenderText {#text} at (1,1) size 86x18
             text run at (1,1) width 86: "Lorem ipsum"
         RenderBlock {DIV} at (1,41) size 782x20 [border: (1px dotted #0000FF)]
           RenderText {#text} at (1,1) size 86x18
             text run at (1,1) width 86: "Lorem ipsum"
-      RenderBlock (anonymous) at (0,432) size 784x40
+      RenderBlock (anonymous) at (0,429) size 784x37
         RenderBR {BR} at (0,0) size 0x18
-        RenderButton {INPUT} at (2,20) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,19) size 102x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 86x13
             RenderText at (0,0) size 86x13
               text run at (0,0) width 86: "Negative margin"
-        RenderText {#text} at (105,19) size 5x18
-          text run at (105,19) width 5: " "
-        RenderButton {INPUT} at (111,20) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderText {#text} at (101,18) size 5x18
+          text run at (101,18) width 5: " "
+        RenderButton {INPUT} at (105,19) size 97x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 81x13
             RenderText at (0,0) size 81x13
               text run at (0,0) width 81: "Positive margin"

--- a/LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt
@@ -1,92 +1,92 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x400
-  RenderBlock {HTML} at (0,0) size 800x400
-    RenderBody {BODY} at (8,8) size 784x384
+layer at (0,0) size 800x376
+  RenderBlock {HTML} at (0,0) size 800x376
+    RenderBody {BODY} at (8,8) size 784x360
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 664x18
           text run at (0,0) width 664: "The text in the button, popup menu and list box should have the same case as in the accompanying text."
-      RenderBlock {DIV} at (0,18) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 72x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,18) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 72x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 72x18
             RenderText at (8,2) size 36x13
               text run at (8,2) width 36: "HELLO"
-        RenderText {#text} at (76,40) size 4x18
-          text run at (76,40) width 4: " "
-        RenderListBox {SELECT} at (82,2) size 58x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (142,40) size 4x18
-          text run at (142,40) width 4: " "
+        RenderText {#text} at (72,36) size 4x18
+          text run at (72,36) width 4: " "
+        RenderListBox {SELECT} at (76,0) size 58x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (134,36) size 4x18
+          text run at (134,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 116x18
-          RenderText {#text} at (146,40) size 116x18
-            text run at (146,40) width 116: "HELLO WORLD"
+          RenderText {#text} at (138,36) size 116x18
+            text run at (138,36) width 116: "HELLO WORLD"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,79) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 68x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,75) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 68x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 68x18
             RenderText at (8,2) size 34x13
               text run at (8,2) width 34: "HeLLo"
-        RenderText {#text} at (72,40) size 4x18
-          text run at (72,40) width 4: " "
-        RenderListBox {SELECT} at (78,2) size 54x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (134,40) size 4x18
-          text run at (134,40) width 4: " "
+        RenderText {#text} at (68,36) size 4x18
+          text run at (68,36) width 4: " "
+        RenderListBox {SELECT} at (72,0) size 54x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (126,36) size 4x18
+          text run at (126,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 101x18
-          RenderText {#text} at (138,40) size 101x18
-            text run at (138,40) width 101: "HeLLo WoRLd"
+          RenderText {#text} at (130,36) size 101x18
+            text run at (130,36) width 101: "HeLLo WoRLd"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,140) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,132) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 60x18
             RenderText at (8,2) size 26x13
               text run at (8,2) width 26: "hello"
-        RenderText {#text} at (64,40) size 4x18
-          text run at (64,40) width 4: " "
-        RenderListBox {SELECT} at (70,2) size 46x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (118,40) size 4x18
-          text run at (118,40) width 4: " "
+        RenderText {#text} at (60,36) size 4x18
+          text run at (60,36) width 4: " "
+        RenderListBox {SELECT} at (64,0) size 46x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (110,36) size 4x18
+          text run at (110,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 74x18
-          RenderText {#text} at (122,40) size 74x18
-            text run at (122,40) width 74: "hello world"
+          RenderText {#text} at (114,36) size 74x18
+            text run at (114,36) width 74: "hello world"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,201) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,189) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 60x18
             RenderText at (8,2) size 15x13
               text run at (8,2) width 15: "SS"
-        RenderText {#text} at (64,40) size 4x18
-          text run at (64,40) width 4: " "
-        RenderListBox {SELECT} at (70,2) size 46x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (118,40) size 4x18
-          text run at (118,40) width 4: " "
+        RenderText {#text} at (60,36) size 4x18
+          text run at (60,36) width 4: " "
+        RenderListBox {SELECT} at (64,0) size 46x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (110,36) size 4x18
+          text run at (110,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 58x18
-          RenderText {#text} at (122,40) size 58x18
-            text run at (122,40) width 58: "SS SSSS"
+          RenderText {#text} at (114,36) size 58x18
+            text run at (114,36) width 58: "SS SSSS"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,262) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,246) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 45x18
             RenderText at (8,2) size 7x13
               text run at (8,2) width 7: "\x{DF}"
-        RenderText {#text} at (49,40) size 4x18
-          text run at (49,40) width 4: " "
-        RenderListBox {SELECT} at (55,2) size 31x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (88,40) size 4x18
-          text run at (88,40) width 4: " "
+        RenderText {#text} at (45,36) size 4x18
+          text run at (45,36) width 4: " "
+        RenderListBox {SELECT} at (49,0) size 31x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (80,36) size 4x18
+          text run at (80,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 28x18
-          RenderText {#text} at (92,40) size 28x18
-            text run at (92,40) width 28: "\x{DF} \x{DF}\x{DF}"
+          RenderText {#text} at (84,36) size 28x18
+            text run at (84,36) width 28: "\x{DF} \x{DF}\x{DF}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,323) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,303) size 784x57
+        RenderMenuList {SELECT} at (0,37) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 45x18
             RenderText at (8,2) size 7x13
               text run at (8,2) width 7: "\x{DF}"
-        RenderText {#text} at (49,40) size 4x18
-          text run at (49,40) width 4: " "
-        RenderListBox {SELECT} at (55,2) size 31x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (88,40) size 4x18
-          text run at (88,40) width 4: " "
+        RenderText {#text} at (45,36) size 4x18
+          text run at (45,36) width 4: " "
+        RenderListBox {SELECT} at (49,0) size 31x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (80,36) size 4x18
+          text run at (80,36) width 4: " "
         RenderInline {SPAN} at (0,0) size 28x18
-          RenderText {#text} at (92,40) size 28x18
-            text run at (92,40) width 28: "\x{DF} \x{DF}\x{DF}"
+          RenderText {#text} at (84,36) size 28x18
+            text run at (84,36) width 28: "\x{DF} \x{DF}\x{DF}"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (582,26) size 77x22 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 73x18
                 text run at (2,2) width 73: "col 3 row 3"
-      RenderBlock (anonymous) at (0,52) size 784x22
-        RenderButton {BUTTON} at (2,2) size 360x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,52) size 784x18
+        RenderButton {BUTTON} at (0,0) size 360x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 344x13
             RenderText {#text} at (0,0) size 344x13
               text run at (0,0) width 344: "Click me to test manually. The first column should grow to 500px."

--- a/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
@@ -25,11 +25,11 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (169,36) size 1x18
         RenderText {#text} at (0,54) size 176x18
           text run at (0,54) width 176: "hasDefaultText: SUCCESS"
-layer at (10,10) size 161x32 clip at (11,11) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 161x32 clip at (9,9) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
-layer at (179,10) size 161x32 clip at (180,11) size 159x30
-  RenderTextControl {TEXTAREA} at (171,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (173,8) size 161x32 clip at (174,9) size 159x30
+  RenderTextControl {TEXTAREA} at (165,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 63x13
         text run at (0,0) width 63: "Default Text"

--- a/LayoutTests/platform/mac/fast/dynamic/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/dynamic/008-expected.txt
@@ -1,12 +1,12 @@
-layer at (0,0) size 785x676
+layer at (0,0) size 785x672
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x676
-  RenderBlock {HTML} at (0,0) size 785x676
-    RenderBody {BODY} at (8,8) size 769x660
+layer at (0,0) size 785x672
+  RenderBlock {HTML} at (0,0) size 785x672
+    RenderBody {BODY} at (8,8) size 769x656
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 301x656 clip at (11,11) size 299x654
-  RenderTextControl {TEXTAREA} at (2,2) size 301x656 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 301x656 clip at (9,9) size 299x654
+  RenderTextControl {TEXTAREA} at (0,0) size 301x656 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 295x13
       RenderText {#text} at (0,0) size 62x13
         text run at (0,0) width 62: "Sample text"

--- a/LayoutTests/platform/mac/fast/dynamic/positioned-movement-with-positioned-children-expected.txt
+++ b/LayoutTests/platform/mac/fast/dynamic/positioned-movement-with-positioned-children-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 98: "You should not"
           text run at (0,18) width 99: "see this. Resize"
           text run at (0,36) width 79: "the window."
-layer at (8,8) size 100x122
-  RenderBlock (positioned) {DIV} at (0,0) size 100x122
+layer at (8,8) size 100x118
+  RenderBlock (positioned) {DIV} at (0,0) size 100x118
     RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]
-    RenderBlock (anonymous) at (0,100) size 100x22
-      RenderButton {BUTTON} at (2,2) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+    RenderBlock (anonymous) at (0,100) size 100x18
+      RenderButton {BUTTON} at (0,0) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 35x13
           RenderText {#text} at (0,0) size 35x13
             text run at (0,0) width 35: "Button"

--- a/LayoutTests/platform/mac/fast/events/shadow-event-path-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/events/shadow-event-path-2-expected.txt
@@ -3,81 +3,45 @@ This test records target and relatedTarget at each element while dispatching a m
 
 Content:<div id="detailsContainer"><input id="target" type="file"></div>
 
+mouseover@input#target
+    target:input#target
+    relatedTarget:null
+
+mouseover@div#detailsContainer
+    target:input#target
+    relatedTarget:null
+
+mouseover@body
+    target:input#target
+    relatedTarget:null
+
 mouseover@html
-    target:html
+    target:input#target
     relatedTarget:null
 
 mouseover@document
-    target:html
+    target:input#target
     relatedTarget:null
 
 mouseover@window
-    target:html
+    target:input#target
     relatedTarget:null
 
 mouseenter@html
     target:html
     relatedTarget:null
 
-mousemove@html
-    target:html
-    relatedTarget:null
-
-mousemove@document
-    target:html
-    relatedTarget:null
-
-mousemove@window
-    target:html
-    relatedTarget:null
-
-mouseout@html
-    target:html
-    relatedTarget:input#target
-
-mouseout@document
-    target:html
-    relatedTarget:input#target
-
-mouseout@window
-    target:html
-    relatedTarget:input#target
-
-mouseover@input#target
-    target:input#target
-    relatedTarget:html
-
-mouseover@div#detailsContainer
-    target:input#target
-    relatedTarget:html
-
-mouseover@body
-    target:input#target
-    relatedTarget:html
-
-mouseover@html
-    target:input#target
-    relatedTarget:html
-
-mouseover@document
-    target:input#target
-    relatedTarget:html
-
-mouseover@window
-    target:input#target
-    relatedTarget:html
-
 mouseenter@body
     target:body
-    relatedTarget:html
+    relatedTarget:null
 
 mouseenter@div#detailsContainer
     target:div#detailsContainer
-    relatedTarget:html
+    relatedTarget:null
 
 mouseenter@input#target
     target:input#target
-    relatedTarget:html
+    relatedTarget:null
 
 mousemove@input#target
     target:input#target

--- a/LayoutTests/platform/mac/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/001-expected.txt
@@ -9,12 +9,12 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,58) size 784x87 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 780x82
           RenderTableRow {TR} at (0,0) size 780x82
-            RenderTableCell {TD} at (0,0) size 135x82 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (3,1) size 129x80 [bgcolor=#FFFFFF] [border: (40px solid #FF0000)]
+            RenderTableCell {TD} at (0,0) size 131x82 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 129x80 [bgcolor=#FFFFFF] [border: (40px solid #FF0000)]
                 RenderBlock (anonymous) at (40,40) size 49x16
                   RenderText at (8,1) size 20x13
                     text run at (8,1) width 20: "Foo"
-            RenderTableCell {TD} at (135,40) size 645x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (131,40) size 649x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
       RenderBlock {P} at (0,160) size 784x25
         RenderTable {TABLE} at (0,0) size 784x24 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x20
@@ -29,37 +29,37 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (0,0) size 18x20 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                 RenderBlock {INPUT} at (3,4) size 12x12
               RenderTableCell {TD} at (18,9) size 762x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-      RenderBlock {P} at (0,240) size 784x29
-        RenderTable {TABLE} at (0,0) size 784x28 [border: (2px outset #808080)]
-          RenderTableSection {TBODY} at (2,2) size 780x24
-            RenderTableRow {TR} at (0,0) size 780x24
-              RenderTableCell {TD} at (0,0) size 42x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock {P} at (0,240) size 784x25
+        RenderTable {TABLE} at (0,0) size 784x24 [border: (2px outset #808080)]
+          RenderTableSection {TBODY} at (2,2) size 780x20
+            RenderTableRow {TR} at (0,0) size 780x20
+              RenderTableCell {TD} at (0,0) size 38x20 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 36x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 20x13
                     RenderText at (0,0) size 20x13
                       text run at (0,0) width 20: "Foo"
-              RenderTableCell {TD} at (41,11) size 739x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-      RenderBlock {P} at (0,284) size 784x268
+              RenderTableCell {TD} at (37,9) size 743x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+      RenderBlock {P} at (0,280) size 784x268
         RenderTable {TABLE} at (0,0) size 784x91 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x87
             RenderTableRow {TR} at (0,0) size 780x87
-              RenderTableCell {TD} at (0,0) size 118x87 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,1) size 112x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
+              RenderTableCell {TD} at (0,0) size 114x87 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 112x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
                   RenderBlock (anonymous) at (46,42) size 20x13
                     RenderText at (0,0) size 20x13
                       text run at (0,0) width 20: "Foo"
-              RenderTableCell {TD} at (117,42) size 663x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (113,42) size 667x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
         RenderTable {TABLE} at (0,91) size 784x91 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x87
             RenderTableRow {TR} at (0,0) size 780x87
-              RenderTableCell {TD} at (0,0) size 168x87 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,1) size 162x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
+              RenderTableCell {TD} at (0,0) size 164x87 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 162x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
                   RenderBlock (anonymous) at (46,42) size 70x13
                     RenderText at (0,0) size 70x13
                       text run at (0,0) width 70: "Submit a bug"
-              RenderTableCell {TD} at (167,42) size 613x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (163,42) size 617x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
         RenderBlock (anonymous) at (0,182) size 784x85
-          RenderButton {INPUT} at (2,0) size 112x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
+          RenderButton {INPUT} at (0,0) size 112x85 [color=#000000D8] [bgcolor=#C0C0C0] [border: (40px solid #FF0000)]
             RenderBlock (anonymous) at (46,42) size 20x13
               RenderText at (0,0) size 20x13
                 text run at (0,0) width 20: "Foo"

--- a/LayoutTests/platform/mac/fast/forms/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/003-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,0) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 58x18
           RenderText at (8,2) size 27x13
             text run at (8,2) width 27: "Hello"
-      RenderBlock (anonymous) at (0,20) size 784x18
+      RenderBlock (anonymous) at (0,18) size 784x18
         RenderText {#text} at (0,0) size 297x18
           text run at (0,0) width 297: "This text should be *below* the select widget."

--- a/LayoutTests/platform/mac/fast/forms/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/004-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,1) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 58x18
           RenderText at (8,2) size 27x13
             text run at (8,2) width 27: "Hello"
-      RenderText {#text} at (62,1) size 4x18
-        text run at (62,1) width 4: " "
-      RenderMenuList {SELECT} at (68,2) size 79x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderText {#text} at (58,0) size 4x18
+        text run at (58,0) width 4: " "
+      RenderMenuList {SELECT} at (62,1) size 79x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 79x18
           RenderText at (8,2) size 48x13
             text run at (8,2) width 48: "Goodbye"

--- a/LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt
@@ -61,7 +61,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (91,5) size 13x12
         RenderText {#text} at (105,1) size 9x18
           text run at (105,1) width 9: "b"
-      RenderBlock {DIV} at (10,405) size 450x21 [border: (1px solid #FF0000)]
+      RenderBlock {DIV} at (10,397) size 450x21 [border: (1px solid #FF0000)]
         RenderText {#text} at (1,1) size 8x18
           text run at (1,1) width 8: "a"
         RenderBlock {INPUT} at (10,5) size 13x12

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt
@@ -1,96 +1,96 @@
-layer at (0,0) size 785x1466
+layer at (0,0) size 785x1426
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1466
-  RenderBlock {HTML} at (0,0) size 785x1466
-    RenderBody {BODY} at (0,0) size 785x1466
-      RenderIFrame {IFRAME} at (0,0) size 785x762
-        layer at (0,0) size 785x762
-          RenderView at (0,0) size 785x762
-        layer at (0,0) size 785x737
-          RenderBlock {HTML} at (0,0) size 785x737
-            RenderBody {BODY} at (0,5) size 785x732
+layer at (0,0) size 785x1426
+  RenderBlock {HTML} at (0,0) size 785x1426
+    RenderBody {BODY} at (0,0) size 785x1426
+      RenderIFrame {IFRAME} at (0,0) size 785x742
+        layer at (0,0) size 785x742
+          RenderView at (0,0) size 785x742
+        layer at (0,0) size 785x717
+          RenderBlock {HTML} at (0,0) size 785x717
+            RenderBody {BODY} at (0,5) size 785x712
               RenderBlock {DIV} at (0,0) size 785x18
                 RenderText {#text} at (0,0) size 196x18
                   text run at (0,0) width 196: "CompatMode: CSS1Compat"
-              RenderBlock (anonymous) at (0,23) size 785x709
-                RenderBlock {DIV} at (0,30) size 167x55 [border: (1px solid #0000FF)]
+              RenderBlock (anonymous) at (0,23) size 785x689
+                RenderBlock {DIV} at (0,30) size 163x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,12) size 80x0
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (167,30) size 167x55 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (163,30) size 163x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 78x14
                       text run at (0,0) width 78: "disabled: \"true\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (334,0) size 183x85 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (326,0) size 179x81 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 79x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 79: "\"padding:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (517,20) size 163x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (505,20) size 159x61 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 73: "\"padding:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,119) size 183x85 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,111) size 183x85 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 74: "\"margin:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (183,139) size 163x65 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,131) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"margin:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (346,135) size 82x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (346,131) size 82x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 68: "\"width:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (428,85) size 104x119 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (428,81) size 104x115 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 74: "padding:20px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (532,125) size 82x79 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (532,121) size 82x75 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 63x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 56: "padding:0\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (614,105) size 167x99 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (614,97) size 163x99 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 71x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 71: "\"height:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,218) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,210) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 66x42
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (82,262) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,258) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 92x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 92: "\"overflow:hidden\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (249,247) size 167x84 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (245,243) size 163x80 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 86x28
                       text run at (0,0) width 26: "style:"
                       text run at (0,14) width 86: "\"overflow:scroll\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (416,204) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (408,196) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 87x56
                       text run at (0,0) width 26: "style:"
@@ -98,7 +98,7 @@ layer at (0,0) size 785x1466
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (498,204) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (490,196) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 81x56
                       text run at (0,0) width 26: "style:"
@@ -106,21 +106,21 @@ layer at (0,0) size 785x1466
                       text run at (0,28) width 59: "width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (580,218) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (572,210) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 74x42
                       text run at (0,0) width 74: "cols: \"5\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (662,218) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (654,210) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 78x42
                       text run at (0,0) width 78: "rows: \"4\", style:"
                       text run at (0,14) width 63: "\"width:60px;"
                       text run at (0,28) width 66: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (0,331) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,323) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 75x56
                       text run at (0,0) width 75: "cols: \"5\", rows:"
@@ -128,84 +128,84 @@ layer at (0,0) size 785x1466
                       text run at (0,28) width 63: "\"width:60px;"
                       text run at (0,42) width 66: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (82,403) size 82x55 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,399) size 82x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (164,390) size 167x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (164,386) size 163x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (331,403) size 82x55 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (327,399) size 82x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 45x14
                       text run at (0,0) width 45: "cols: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (413,338) size 167x120 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (409,334) size 163x116 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (580,363) size 82x95 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (572,359) size 82x91 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 75x28
                       text run at (0,0) width 75: "cols: \"5\", rows:"
                       text run at (0,14) width 19: "\"4\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,458) size 167x70 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,450) size 163x66 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 57x14
                       text run at (0,0) width 57: "wrap: \"off\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (167,473) size 167x55 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (163,465) size 163x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 65x14
                       text run at (0,0) width 65: "wrap: \"hard\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (334,473) size 167x55 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (326,465) size 163x51 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 62x14
                       text run at (0,0) width 62: "wrap: \"soft\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (501,459) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (489,451) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 72x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 72: "space:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,528) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,516) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 65x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 54: "space:pre\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (167,528) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (163,516) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 78x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 78: "space:prewrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (334,528) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (326,516) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 74: "space:nowrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (501,528) size 167x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (489,516) size 163x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 76x28
                       text run at (0,0) width 65: "style: \"white-"
                       text run at (0,14) width 76: "space:pre-line\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,625) size 167x84 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,609) size 163x80 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 70x28
                       text run at (0,0) width 63: "style: \"word-"
                       text run at (0,14) width 70: "wrap:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (167,597) size 167x112 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (163,581) size 163x108 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 65x56
                       text run at (0,0) width 57: "wrap: \"off\","
@@ -213,13 +213,13 @@ layer at (0,0) size 785x1466
                       text run at (0,28) width 50: "space:pre-"
                       text run at (0,42) width 32: "wrap\","
                   RenderBR {BR} at (81,43) size 0x14
-        layer at (3,75) size 161x32 clip at (4,76) size 159x30
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,73) size 161x32 clip at (2,74) size 159x30
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 98x13
                 text run at (0,0) width 98: "Lorem ipsum dolor"
-        layer at (170,75) size 161x32 clip at (171,76) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (164,73) size 161x32 clip at (165,74) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -228,8 +228,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,59) size 177x48 clip at (338,60) size 160x46 scrollHeight 72
-          RenderTextControl {TEXTAREA} at (3,31) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,57) size 177x48 clip at (328,58) size 160x46 scrollHeight 72
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -238,8 +238,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (520,79) size 157x28 clip at (521,80) size 140x26 scrollHeight 52
-          RenderTextControl {TEXTAREA} at (3,31) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (506,77) size 157x28 clip at (507,78) size 140x26 scrollHeight 52
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -248,7 +248,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (11,186) size 161x32 clip at (12,187) size 144x30 scrollHeight 56
+        layer at (11,178) size 161x32 clip at (12,179) size 144x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (11,39) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -258,7 +258,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (184,196) size 161x32 clip at (185,197) size 144x30 scrollHeight 56
+        layer at (184,188) size 161x32 clip at (185,189) size 144x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -268,8 +268,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (347,194) size 66x32 clip at (348,195) size 49x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (1,31) size 66x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (347,188) size 66x32 clip at (348,189) size 49x30 scrollHeight 147
+          RenderTextControl {TEXTAREA} at (1,29) size 66x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 33: "Lorem"
@@ -287,8 +287,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (429,158) size 102x68 clip at (430,159) size 85x66 scrollHeight 183
-          RenderTextControl {TEXTAREA} at (1,45) size 102x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (429,152) size 102x68 clip at (430,153) size 85x66 scrollHeight 183
+          RenderTextControl {TEXTAREA} at (1,43) size 102x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (21,21) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 33: "Lorem"
@@ -306,8 +306,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (533,198) size 62x28 clip at (534,199) size 45x26 scrollHeight 143
-          RenderTextControl {TEXTAREA} at (1,45) size 62x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (533,192) size 62x28 clip at (534,193) size 45x26 scrollHeight 143
+          RenderTextControl {TEXTAREA} at (1,43) size 62x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 45x143
               RenderText {#text} at (0,0) size 44x143
                 text run at (0,0) width 33: "Lorem"
@@ -325,8 +325,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (617,162) size 161x66 clip at (618,163) size 159x64
-          RenderTextControl {TEXTAREA} at (3,29) size 161x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (615,154) size 161x66 clip at (616,155) size 159x64
+          RenderTextControl {TEXTAREA} at (1,29) size 161x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -335,7 +335,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,289) size 66x66 clip at (2,290) size 49x64 scrollHeight 147
+        layer at (1,281) size 66x66 clip at (2,282) size 49x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -354,8 +354,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (85,321) size 161x32 clip at (86,322) size 159x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (83,315) size 161x32 clip at (84,316) size 159x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -364,8 +364,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (252,306) size 161x47 clip at (253,307) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (246,300) size 161x47 clip at (247,301) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -374,7 +374,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (417,289) size 66x66 clip at (418,290) size 64x64 scrollHeight 134
+        layer at (409,281) size 66x66 clip at (410,282) size 64x64 scrollHeight 134
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 60x130
               RenderText {#text} at (0,0) size 60x130
@@ -392,7 +392,7 @@ layer at (0,0) size 785x1466
                 text run at (0,91) width 56: "abcdefghij"
                 text run at (0,104) width 60: "klmnopqrst"
                 text run at (0,117) width 13: "uv"
-        layer at (499,289) size 66x66 clip at (500,290) size 49x49 scrollHeight 147
+        layer at (491,281) size 66x66 clip at (492,282) size 49x49 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -411,7 +411,7 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (581,289) size 66x66 clip at (582,290) size 49x64 scrollHeight 147
+        layer at (573,281) size 66x66 clip at (574,282) size 49x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -430,7 +430,7 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (663,289) size 66x66 clip at (664,290) size 49x64 scrollHeight 147
+        layer at (655,281) size 66x66 clip at (656,282) size 49x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -449,7 +449,7 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (1,416) size 66x66 clip at (2,417) size 49x64 scrollHeight 147
+        layer at (1,408) size 66x66 clip at (2,409) size 49x64 scrollHeight 147
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x143
               RenderText {#text} at (0,0) size 44x143
@@ -468,8 +468,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (85,448) size 42x32 clip at (86,449) size 25x30 scrollHeight 329
-          RenderTextControl {TEXTAREA} at (3,17) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (83,442) size 42x32 clip at (84,443) size 25x30 scrollHeight 329
+          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 21x325
               RenderText {#text} at (0,0) size 21x325
                 text run at (0,0) width 17: "Lor"
@@ -501,8 +501,8 @@ layer at (0,0) size 785x1466
                 text run at (0,286) width 20: "nop"
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
-        layer at (167,435) size 161x45 clip at (168,436) size 144x43 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (165,429) size 161x45 clip at (166,430) size 144x43 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -511,8 +511,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (334,448) size 70x32 clip at (335,449) size 53x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (3,17) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (328,442) size 70x32 clip at (329,443) size 53x30 scrollHeight 147
+          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
                 text run at (0,0) width 33: "Lorem"
@@ -530,8 +530,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (416,383) size 161x97 clip at (417,384) size 159x95
-          RenderTextControl {TEXTAREA} at (3,17) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (410,377) size 161x97 clip at (411,378) size 159x95
+          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -540,8 +540,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (583,422) size 56x58 clip at (584,423) size 39x56 scrollHeight 186
-          RenderTextControl {TEXTAREA} at (3,31) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (573,416) size 56x58 clip at (574,417) size 39x56 scrollHeight 186
+          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 35x182
               RenderText {#text} at (0,0) size 35x182
                 text run at (0,0) width 33: "Lorem"
@@ -562,13 +562,13 @@ layer at (0,0) size 785x1466
                 text run at (0,143) width 32: "fghijkl"
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
-        layer at (3,503) size 161x47 clip at (4,504) size 159x30 scrollWidth 430
-          RenderTextControl {TEXTAREA} at (3,17) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,493) size 161x47 clip at (2,494) size 159x30 scrollWidth 430
+          RenderTextControl {TEXTAREA} at (1,15) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (170,518) size 161x32 clip at (171,519) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (164,508) size 161x32 clip at (165,509) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -577,8 +577,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,518) size 161x32 clip at (338,519) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,508) size 161x32 clip at (328,509) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -587,8 +587,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (504,518) size 161x32 clip at (505,519) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (490,508) size 161x32 clip at (491,509) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -611,14 +611,14 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,587) size 161x32 clip at (338,588) size 144x15 scrollWidth 427 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,573) size 161x32 clip at (328,574) size 144x15 scrollWidth 427 scrollHeight 17
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (504,587) size 161x32 clip at (505,588) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (490,573) size 161x32 clip at (491,574) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -867,8 +867,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,59) size 177x48 clip at (338,60) size 160x46 scrollHeight 72
-          RenderTextControl {TEXTAREA} at (3,31) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,57) size 177x48 clip at (328,58) size 160x46 scrollHeight 72
+          RenderTextControl {TEXTAREA} at (1,29) size 177x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (11,11) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -877,8 +877,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (520,79) size 157x28 clip at (521,80) size 140x26 scrollHeight 52
-          RenderTextControl {TEXTAREA} at (3,31) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (506,77) size 157x28 clip at (507,78) size 140x26 scrollHeight 52
+          RenderTextControl {TEXTAREA} at (1,29) size 157x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -887,7 +887,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (11,183) size 161x32 clip at (12,184) size 144x30 scrollHeight 56
+        layer at (11,175) size 161x32 clip at (12,176) size 144x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (11,39) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -897,7 +897,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (184,193) size 161x32 clip at (185,194) size 144x30 scrollHeight 56
+        layer at (184,185) size 161x32 clip at (185,186) size 144x30 scrollHeight 56
           RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
@@ -907,8 +907,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (347,191) size 60x32 clip at (348,192) size 43x30 scrollHeight 173
-          RenderTextControl {TEXTAREA} at (1,31) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (347,185) size 60x32 clip at (348,186) size 43x30 scrollHeight 173
+          RenderTextControl {TEXTAREA} at (1,29) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
                 text run at (0,0) width 33: "Lorem"
@@ -928,8 +928,8 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (429,155) size 60x68 clip at (430,156) size 43x66 scrollHeight 924
-          RenderTextControl {TEXTAREA} at (1,45) size 60x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (429,149) size 60x68 clip at (430,150) size 43x66 scrollHeight 924
+          RenderTextControl {TEXTAREA} at (1,43) size 60x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (21,21) size 3x884
               RenderText {#text} at (0,0) size 11x884
                 text run at (0,0) width 7: "L"
@@ -1000,8 +1000,8 @@ layer at (0,0) size 785x1466
                 text run at (0,845) width 5: "t"
                 text run at (0,858) width 7: "u"
                 text run at (0,871) width 7: "v"
-        layer at (511,195) size 60x28 clip at (512,196) size 43x26 scrollHeight 156
-          RenderTextControl {TEXTAREA} at (1,45) size 60x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (511,189) size 60x28 clip at (512,190) size 43x26 scrollHeight 156
+          RenderTextControl {TEXTAREA} at (1,43) size 60x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 43x156
               RenderText {#text} at (0,0) size 43x156
                 text run at (0,0) width 33: "Lorem"
@@ -1020,8 +1020,8 @@ layer at (0,0) size 785x1466
                 text run at (0,117) width 38: "hijklmn"
                 text run at (0,130) width 41: "opqrstu"
                 text run at (0,143) width 7: "v"
-        layer at (595,165) size 161x60 clip at (596,166) size 159x58
-          RenderTextControl {TEXTAREA} at (3,29) size 161x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (593,157) size 161x60 clip at (594,158) size 159x58
+          RenderTextControl {TEXTAREA} at (1,29) size 161x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1030,7 +1030,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (1,283) size 60x60 clip at (2,284) size 43x58 scrollHeight 173
+        layer at (1,275) size 60x60 clip at (2,276) size 43x58 scrollHeight 173
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
@@ -1051,8 +1051,8 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (85,309) size 161x32 clip at (86,310) size 159x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (83,303) size 161x32 clip at (84,304) size 159x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1061,8 +1061,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (252,294) size 161x47 clip at (253,295) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (246,288) size 161x47 clip at (247,289) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1071,7 +1071,7 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (417,283) size 60x60 clip at (418,284) size 58x58 scrollHeight 134
+        layer at (409,275) size 60x60 clip at (410,276) size 58x58 scrollHeight 134
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 54x130
               RenderText {#text} at (0,0) size 54x130
@@ -1089,7 +1089,7 @@ layer at (0,0) size 785x1466
                 text run at (0,91) width 53: "abcdefghi"
                 text run at (0,104) width 53: "jklmnopqr"
                 text run at (0,117) width 23: "stuv"
-        layer at (499,283) size 60x60 clip at (500,284) size 43x43 scrollHeight 173
+        layer at (491,275) size 60x60 clip at (492,276) size 43x43 scrollHeight 173
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
@@ -1110,7 +1110,7 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (581,283) size 60x60 clip at (582,284) size 43x58 scrollHeight 173
+        layer at (573,275) size 60x60 clip at (574,276) size 43x58 scrollHeight 173
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
@@ -1131,7 +1131,7 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (663,283) size 60x60 clip at (664,284) size 43x58 scrollHeight 173
+        layer at (655,275) size 60x60 clip at (656,276) size 43x58 scrollHeight 173
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
@@ -1152,7 +1152,7 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (1,401) size 60x60 clip at (2,402) size 43x58 scrollHeight 173
+        layer at (1,393) size 60x60 clip at (2,394) size 43x58 scrollHeight 173
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 39x169
               RenderText {#text} at (0,0) size 39x169
@@ -1173,8 +1173,8 @@ layer at (0,0) size 785x1466
                 text run at (0,130) width 38: "ghijklm"
                 text run at (0,143) width 37: "nopqrs"
                 text run at (0,156) width 17: "tuv"
-        layer at (85,427) size 42x32 clip at (86,428) size 25x30 scrollHeight 329
-          RenderTextControl {TEXTAREA} at (3,17) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (83,421) size 42x32 clip at (84,422) size 25x30 scrollHeight 329
+          RenderTextControl {TEXTAREA} at (1,15) size 42x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 21x325
               RenderText {#text} at (0,0) size 21x325
                 text run at (0,0) width 17: "Lor"
@@ -1206,8 +1206,8 @@ layer at (0,0) size 785x1466
                 text run at (0,286) width 20: "nop"
                 text run at (0,299) width 21: "qrst"
                 text run at (0,312) width 13: "uv"
-        layer at (167,414) size 161x45 clip at (168,415) size 144x43 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (165,408) size 161x45 clip at (166,409) size 144x43 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1216,8 +1216,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (334,427) size 70x32 clip at (335,428) size 53x30 scrollHeight 147
-          RenderTextControl {TEXTAREA} at (3,17) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (328,421) size 70x32 clip at (329,422) size 53x30 scrollHeight 147
+          RenderTextControl {TEXTAREA} at (1,15) size 70x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 49x143
               RenderText {#text} at (0,0) size 49x143
                 text run at (0,0) width 33: "Lorem"
@@ -1235,8 +1235,8 @@ layer at (0,0) size 785x1466
                 text run at (0,104) width 43: "abcdefg"
                 text run at (0,117) width 44: "hijklmno"
                 text run at (0,130) width 41: "pqrstuv"
-        layer at (416,362) size 161x97 clip at (417,363) size 159x95
-          RenderTextControl {TEXTAREA} at (3,17) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (410,356) size 161x97 clip at (411,357) size 159x95
+          RenderTextControl {TEXTAREA} at (1,15) size 161x97 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x52
               RenderText {#text} at (0,0) size 155x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1245,8 +1245,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 41: "VWXYZ"
                 text run at (40,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (583,401) size 56x58 clip at (584,402) size 39x56 scrollHeight 186
-          RenderTextControl {TEXTAREA} at (3,31) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (573,395) size 56x58 clip at (574,396) size 39x56 scrollHeight 186
+          RenderTextControl {TEXTAREA} at (1,29) size 56x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 35x182
               RenderText {#text} at (0,0) size 35x182
                 text run at (0,0) width 33: "Lorem"
@@ -1267,13 +1267,13 @@ layer at (0,0) size 785x1466
                 text run at (0,143) width 32: "fghijkl"
                 text run at (0,156) width 30: "mnop"
                 text run at (0,169) width 34: "qrstuv"
-        layer at (3,479) size 161x47 clip at (4,480) size 159x30 scrollWidth 430
-          RenderTextControl {TEXTAREA} at (3,17) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,469) size 161x47 clip at (2,470) size 159x30 scrollWidth 430
+          RenderTextControl {TEXTAREA} at (1,15) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 429x13
                 text run at (0,0) width 429: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (170,494) size 161x32 clip at (171,495) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (164,484) size 161x32 clip at (165,485) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1282,8 +1282,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,494) size 161x32 clip at (338,495) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,484) size 161x32 clip at (328,485) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
@@ -1292,8 +1292,8 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (504,494) size 161x32 clip at (505,495) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (490,484) size 161x32 clip at (491,485) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -1316,14 +1316,14 @@ layer at (0,0) size 785x1466
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (55,26) width 4: " "
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (337,560) size 161x32 clip at (338,561) size 144x15 scrollWidth 427 scrollHeight 17
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (327,546) size 161x32 clip at (328,547) size 144x15 scrollWidth 427 scrollHeight 17
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x13
               RenderText {#text} at (0,0) size 426x13
                 text run at (0,0) width 71: "Lorem ipsum "
                 text run at (70,0) width 356: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (504,560) size 161x32 clip at (505,561) size 144x30 scrollHeight 56
-          RenderTextControl {TEXTAREA} at (3,31) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (490,546) size 161x32 clip at (491,547) size 144x30 scrollHeight 56
+          RenderTextControl {TEXTAREA} at (1,29) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 140x52
               RenderText {#text} at (0,0) size 140x52
                 text run at (0,0) width 71: "Lorem ipsum "
@@ -1331,16 +1331,16 @@ layer at (0,0) size 785x1466
                 text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
                 text run at (0,26) width 56: "TUVWXYZ"
                 text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        layer at (3,654) size 161x47 clip at (4,655) size 144x30 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (3,31) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,636) size 161x47 clip at (2,637) size 144x30 scrollWidth 197 scrollHeight 43
+          RenderTextControl {TEXTAREA} at (1,29) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x39
               RenderText {#text} at (0,0) size 195x39
                 text run at (0,0) width 101: "Lorem ipsum  dolor"
                 text run at (100,0) width 4: " "
                 text run at (0,13) width 195: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,26) width 130: " abcdefghijklmnopqrstuv"
-        layer at (170,654) size 161x47 clip at (171,655) size 144x30 scrollWidth 197 scrollHeight 43
-          RenderTextControl {TEXTAREA} at (3,59) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (164,636) size 161x47 clip at (165,637) size 144x30 scrollWidth 197 scrollHeight 43
+          RenderTextControl {TEXTAREA} at (1,57) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 155x39
               RenderText {#text} at (0,0) size 195x39
                 text run at (0,0) width 101: "Lorem ipsum  dolor"

--- a/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt
@@ -1,290 +1,235 @@
-layer at (0,0) size 785x1065
+layer at (0,0) size 785x1033
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1065
-  RenderBlock {HTML} at (0,0) size 785x1065
+layer at (0,0) size 785x1033
+  RenderBlock {HTML} at (0,0) size 785x1033
     RenderBody {BODY} at (8,8) size 769x584
-      RenderBlock (floating) {DIV} at (0,0) size 352x829 [border: (1px solid #FF0000)]
+      RenderBlock (floating) {DIV} at (0,0) size 352x789 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
           RenderText {#text} at (0,-2) size 179x17
             text run at (0,-2) width 179: "Plain textarea with little content"
-        RenderBlock {DIV} at (1,15) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 14: " B"
-        RenderBlock (anonymous) at (1,56) size 350x14
+        RenderBlock {DIV} at (1,15) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 14: " B"
+        RenderBlock (anonymous) at (1,52) size 350x14
           RenderText {#text} at (0,-2) size 77x17
             text run at (0,-2) width 77: "Plain textarea"
-        RenderBlock {DIV} at (1,70) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 14: " B"
-        RenderBlock (anonymous) at (1,111) size 350x14
+        RenderBlock {DIV} at (1,66) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 14: " B"
+        RenderBlock (anonymous) at (1,103) size 350x14
           RenderText {#text} at (0,-2) size 98x17
             text run at (0,-2) width 98: "Disabled textarea"
-        RenderBlock {DIV} at (1,125) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 14: " B"
-        RenderBlock (anonymous) at (1,166) size 350x14
+        RenderBlock {DIV} at (1,117) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 14: " B"
+        RenderBlock (anonymous) at (1,154) size 350x14
           RenderText {#text} at (0,-2) size 123x17
             text run at (0,-2) width 123: "style=\"padding:10px\""
-        RenderBlock {DIV} at (1,180) size 352x57 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,40) size 14x17
-            text run at (1,40) width 14: "A "
-          RenderText {#text} at (195,40) size 14x17
-            text run at (195,40) width 14: " B"
-        RenderBlock (anonymous) at (1,237) size 350x14
+        RenderBlock {DIV} at (1,168) size 352x53 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,36) size 14x17
+            text run at (1,36) width 14: "A "
+          RenderText {#text} at (191,36) size 14x17
+            text run at (191,36) width 14: " B"
+        RenderBlock (anonymous) at (1,221) size 350x14
           RenderText {#text} at (0,-2) size 116x17
             text run at (0,-2) width 116: "style=\"padding:0px\""
-        RenderBlock {DIV} at (1,251) size 352x37 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,20) size 14x17
-            text run at (1,20) width 14: "A "
-          RenderText {#text} at (175,20) size 14x17
-            text run at (175,20) width 14: " B"
-        RenderBlock (anonymous) at (1,288) size 350x14
+        RenderBlock {DIV} at (1,235) size 352x33 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,16) size 14x17
+            text run at (1,16) width 14: "A "
+          RenderText {#text} at (171,16) size 14x17
+            text run at (171,16) width 14: " B"
+        RenderBlock (anonymous) at (1,268) size 350x14
           RenderText {#text} at (0,-2) size 118x17
             text run at (0,-2) width 118: "style=\"margin:10px\""
-        RenderBlock {DIV} at (1,302) size 352x57 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,282) size 352x57 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,40) size 14x17
             text run at (1,40) width 14: "A "
           RenderText {#text} at (195,40) size 14x17
             text run at (195,40) width 14: " B"
-        RenderBlock (anonymous) at (1,359) size 350x14
+        RenderBlock (anonymous) at (1,339) size 350x14
           RenderText {#text} at (0,-2) size 111x17
             text run at (0,-2) width 111: "style=\"margin:0px\""
-        RenderBlock {DIV} at (1,373) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,353) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (175,20) size 14x17
             text run at (175,20) width 14: " B"
-        RenderBlock (anonymous) at (1,410) size 350x14
+        RenderBlock (anonymous) at (1,390) size 350x14
           RenderText {#text} at (0,-2) size 38x17
             text run at (0,-2) width 38: "cols=3"
-        RenderBlock {DIV} at (1,424) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (60,24) size 14x17
-            text run at (60,24) width 14: " B"
-        RenderBlock (anonymous) at (1,465) size 350x14
+        RenderBlock {DIV} at (1,404) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (56,20) size 14x17
+            text run at (56,20) width 14: " B"
+        RenderBlock (anonymous) at (1,441) size 350x14
           RenderText {#text} at (0,-2) size 43x17
             text run at (0,-2) width 43: "rows=3"
-        RenderBlock {DIV} at (1,479) size 352x54 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,37) size 14x17
-            text run at (1,37) width 14: "A "
-          RenderText {#text} at (179,37) size 14x17
-            text run at (179,37) width 14: " B"
-        RenderBlock (anonymous) at (1,533) size 350x14
+        RenderBlock {DIV} at (1,455) size 352x50 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,33) size 14x17
+            text run at (1,33) width 14: "A "
+          RenderText {#text} at (175,33) size 14x17
+            text run at (175,33) width 14: " B"
+        RenderBlock (anonymous) at (1,505) size 350x14
           RenderText {#text} at (0,-2) size 45x17
             text run at (0,-2) width 45: "cols=10"
-        RenderBlock {DIV} at (1,547) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (109,24) size 14x17
-            text run at (109,24) width 14: " B"
-        RenderBlock (anonymous) at (1,588) size 350x14
+        RenderBlock {DIV} at (1,519) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (105,20) size 14x17
+            text run at (105,20) width 14: " B"
+        RenderBlock (anonymous) at (1,556) size 350x14
           RenderText {#text} at (0,-2) size 50x17
             text run at (0,-2) width 50: "rows=10"
-        RenderBlock {DIV} at (1,602) size 352x145 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,128) size 14x17
-            text run at (1,128) width 14: "A "
-          RenderText {#text} at (179,128) size 14x17
-            text run at (179,128) width 14: " B"
-        RenderBlock (anonymous) at (1,747) size 350x14
+        RenderBlock {DIV} at (1,570) size 352x141 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,124) size 14x17
+            text run at (1,124) width 14: "A "
+          RenderText {#text} at (175,124) size 14x17
+            text run at (175,124) width 14: " B"
+        RenderBlock (anonymous) at (1,711) size 350x14
           RenderText {#text} at (0,-2) size 84x17
             text run at (0,-2) width 84: "cols=5 rows=4"
-        RenderBlock {DIV} at (1,761) size 352x67 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,50) size 14x17
-            text run at (1,50) width 14: "A "
-          RenderText {#text} at (74,50) size 14x17
-            text run at (74,50) width 14: " B"
-      RenderBlock (floating) {DIV} at (352,0) size 352x1057 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,725) size 352x63 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,46) size 14x17
+            text run at (1,46) width 14: "A "
+          RenderText {#text} at (70,46) size 14x17
+            text run at (70,46) width 14: " B"
+      RenderBlock (floating) {DIV} at (352,0) size 352x1025 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
           RenderText {#text} at (0,-2) size 110x17
             text run at (0,-2) width 110: "style=\"width:60px\""
-        RenderBlock {DIV} at (1,15) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (74,24) size 14x17
-            text run at (74,24) width 14: " B"
-        RenderBlock (anonymous) at (1,56) size 350x14
-          RenderText {#text} at (0,-2) size 191x17
-            text run at (0,-2) width 191: "style=\"width:60px;padding:20px\""
-        RenderBlock {DIV} at (1,70) size 352x77 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,60) size 14x17
-            text run at (1,60) width 14: "A "
-          RenderText {#text} at (74,60) size 14x17
-            text run at (74,60) width 14: " B"
-        RenderBlock (anonymous) at (1,147) size 350x14
-          RenderText {#text} at (0,-2) size 170x17
-            text run at (0,-2) width 170: "style=\"width:60px;padding:0\""
-        RenderBlock {DIV} at (1,161) size 352x37 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,15) size 352x37 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,20) size 14x17
             text run at (1,20) width 14: "A "
           RenderText {#text} at (74,20) size 14x17
             text run at (74,20) width 14: " B"
-        RenderBlock (anonymous) at (1,198) size 350x14
+        RenderBlock (anonymous) at (1,52) size 350x14
+          RenderText {#text} at (0,-2) size 191x17
+            text run at (0,-2) width 191: "style=\"width:60px;padding:20px\""
+        RenderBlock {DIV} at (1,66) size 352x73 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,56) size 14x17
+            text run at (1,56) width 14: "A "
+          RenderText {#text} at (74,56) size 14x17
+            text run at (74,56) width 14: " B"
+        RenderBlock (anonymous) at (1,139) size 350x14
+          RenderText {#text} at (0,-2) size 170x17
+            text run at (0,-2) width 170: "style=\"width:60px;padding:0\""
+        RenderBlock {DIV} at (1,153) size 352x33 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,16) size 14x17
+            text run at (1,16) width 14: "A "
+          RenderText {#text} at (74,16) size 14x17
+            text run at (74,16) width 14: " B"
+        RenderBlock (anonymous) at (1,186) size 350x14
           RenderText {#text} at (0,-2) size 113x17
             text run at (0,-2) width 113: "style=\"height:60px\""
-        RenderBlock {DIV} at (1,212) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,200) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
-          RenderText {#text} at (179,48) size 14x17
-            text run at (179,48) width 14: " B"
-        RenderBlock (anonymous) at (1,277) size 350x14
+          RenderText {#text} at (175,48) size 14x17
+            text run at (175,48) width 14: " B"
+        RenderBlock (anonymous) at (1,265) size 350x14
           RenderText {#text} at (0,-2) size 181x17
             text run at (0,-2) width 181: "style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,291) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,279) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,356) size 350x14
+        RenderBlock (anonymous) at (1,344) size 350x14
           RenderText {#text} at (0,-2) size 138x17
             text run at (0,-2) width 138: "style=\"overflow:hidden\""
-        RenderBlock {DIV} at (1,370) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 14: " B"
-        RenderBlock (anonymous) at (1,411) size 350x14
+        RenderBlock {DIV} at (1,358) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 14: " B"
+        RenderBlock (anonymous) at (1,395) size 350x14
           RenderText {#text} at (0,-2) size 131x17
             text run at (0,-2) width 131: "style=\"overflow:scroll\""
-        RenderBlock {DIV} at (1,425) size 352x56 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,39) size 14x17
-            text run at (1,39) width 14: "A "
-          RenderText {#text} at (179,39) size 14x17
-            text run at (179,39) width 14: " B"
-        RenderBlock (anonymous) at (1,481) size 350x14
+        RenderBlock {DIV} at (1,409) size 352x52 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,35) size 14x17
+            text run at (1,35) width 14: "A "
+          RenderText {#text} at (175,35) size 14x17
+            text run at (175,35) width 14: " B"
+        RenderBlock (anonymous) at (1,461) size 350x14
           RenderText {#text} at (0,-2) size 276x17
             text run at (0,-2) width 276: "style=\"overflow:hidden;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,495) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,475) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,560) size 350x14
+        RenderBlock (anonymous) at (1,540) size 350x14
           RenderText {#text} at (0,-2) size 269x17
             text run at (0,-2) width 269: "style=\"overflow:scroll;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,574) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,554) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,639) size 350x14
+        RenderBlock (anonymous) at (1,619) size 350x14
           RenderText {#text} at (0,-2) size 222x17
             text run at (0,-2) width 222: "cols=5 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,653) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,633) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,718) size 350x14
+        RenderBlock (anonymous) at (1,698) size 350x14
           RenderText {#text} at (0,-2) size 226x17
             text run at (0,-2) width 226: "rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,732) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,712) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,797) size 350x14
+        RenderBlock (anonymous) at (1,777) size 350x14
           RenderText {#text} at (0,-2) size 267x17
             text run at (0,-2) width 267: "cols=5 rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,811) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,791) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (74,48) size 14x17
             text run at (74,48) width 14: " B"
-        RenderBlock (anonymous) at (1,876) size 350x14
+        RenderBlock (anonymous) at (1,856) size 350x14
           RenderText {#text} at (0,-2) size 64x17
             text run at (0,-2) width 64: "wrap=\"off\""
-        RenderBlock {DIV} at (1,890) size 352x56 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,39) size 14x17
-            text run at (1,39) width 14: "A "
-          RenderText {#text} at (179,39) size 14x17
-            text run at (179,39) width 5: " "
-            text run at (183,39) width 10: "B"
-        RenderBlock (anonymous) at (1,946) size 350x14
+        RenderBlock {DIV} at (1,870) size 352x52 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,35) size 14x17
+            text run at (1,35) width 14: "A "
+          RenderText {#text} at (175,35) size 14x17
+            text run at (175,35) width 5: " "
+            text run at (179,35) width 10: "B"
+        RenderBlock (anonymous) at (1,922) size 350x14
           RenderText {#text} at (0,-2) size 73x17
             text run at (0,-2) width 73: "wrap=\"hard\""
-        RenderBlock {DIV} at (1,960) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 5: " "
-            text run at (183,24) width 10: "B"
-        RenderBlock (anonymous) at (1,1001) size 350x14
+        RenderBlock {DIV} at (1,936) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 5: " "
+            text run at (179,20) width 10: "B"
+        RenderBlock (anonymous) at (1,973) size 350x14
           RenderText {#text} at (0,-2) size 69x17
             text run at (0,-2) width 69: "wrap=\"soft\""
-        RenderBlock {DIV} at (1,1015) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (179,24) size 14x17
-            text run at (179,24) width 5: " "
-            text run at (183,24) width 10: "B"
-layer at (26,26) size 161x32 clip at (27,27) size 159x30
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,987) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (175,20) size 14x17
+            text run at (175,20) width 5: " "
+            text run at (179,20) width 10: "B"
+layer at (24,24) size 161x32 clip at (25,25) size 159x30
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 98x13
         text run at (0,0) width 98: "Lorem ipsum dolor"
-layer at (26,81) size 161x32 clip at (27,82) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 140x52
-      RenderText {#text} at (0,0) size 140x52
-        text run at (0,0) width 98: "Lorem ipsum dolor"
-        text run at (97,0) width 4: " "
-        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
-        text run at (0,26) width 56: "TUVWXYZ"
-        text run at (55,26) width 4: " "
-        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        text run at (126,39) width 4: " "
-layer at (26,136) size 161x32 clip at (27,137) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
-      RenderText {#text} at (0,0) size 140x52
-        text run at (0,0) width 98: "Lorem ipsum dolor"
-        text run at (97,0) width 4: " "
-        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
-        text run at (0,26) width 56: "TUVWXYZ"
-        text run at (55,26) width 4: " "
-        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        text run at (126,39) width 4: " "
-layer at (26,191) size 177x48 clip at (27,192) size 160x46 scrollHeight 72
-  RenderTextControl {TEXTAREA} at (16,3) size 178x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (11,11) size 140x52
-      RenderText {#text} at (0,0) size 140x52
-        text run at (0,0) width 98: "Lorem ipsum dolor"
-        text run at (97,0) width 4: " "
-        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
-        text run at (0,26) width 56: "TUVWXYZ"
-        text run at (55,26) width 4: " "
-        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        text run at (126,39) width 4: " "
-layer at (26,262) size 157x28 clip at (27,263) size 140x26 scrollHeight 52
-  RenderTextControl {TEXTAREA} at (16,3) size 158x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (1,1) size 140x52
-      RenderText {#text} at (0,0) size 140x52
-        text run at (0,0) width 98: "Lorem ipsum dolor"
-        text run at (97,0) width 4: " "
-        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
-        text run at (0,26) width 56: "TUVWXYZ"
-        text run at (55,26) width 4: " "
-        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        text run at (126,39) width 4: " "
-layer at (34,321) size 161x32 clip at (35,322) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (24,11) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 140x52
-      RenderText {#text} at (0,0) size 140x52
-        text run at (0,0) width 98: "Lorem ipsum dolor"
-        text run at (97,0) width 4: " "
-        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
-        text run at (0,26) width 56: "TUVWXYZ"
-        text run at (55,26) width 4: " "
-        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
-        text run at (126,39) width 4: " "
-layer at (24,382) size 161x32 clip at (25,383) size 144x30 scrollHeight 56
+layer at (24,75) size 161x32 clip at (25,76) size 144x30 scrollHeight 56
   RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
@@ -295,8 +240,63 @@ layer at (24,382) size 161x32 clip at (25,383) size 144x30 scrollHeight 56
         text run at (55,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (26,435) size 42x32 clip at (27,436) size 25x30 scrollHeight 329
-  RenderTextControl {TEXTAREA} at (16,3) size 43x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,126) size 161x32 clip at (25,127) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 140x52 [color=#545454]
+      RenderText {#text} at (0,0) size 140x52
+        text run at (0,0) width 98: "Lorem ipsum dolor"
+        text run at (97,0) width 4: " "
+        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
+        text run at (0,26) width 56: "TUVWXYZ"
+        text run at (55,26) width 4: " "
+        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
+        text run at (126,39) width 4: " "
+layer at (24,177) size 177x48 clip at (25,178) size 160x46 scrollHeight 72
+  RenderTextControl {TEXTAREA} at (14,1) size 178x48 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (11,11) size 140x52
+      RenderText {#text} at (0,0) size 140x52
+        text run at (0,0) width 98: "Lorem ipsum dolor"
+        text run at (97,0) width 4: " "
+        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
+        text run at (0,26) width 56: "TUVWXYZ"
+        text run at (55,26) width 4: " "
+        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
+        text run at (126,39) width 4: " "
+layer at (24,244) size 157x28 clip at (25,245) size 140x26 scrollHeight 52
+  RenderTextControl {TEXTAREA} at (14,1) size 158x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 140x52
+      RenderText {#text} at (0,0) size 140x52
+        text run at (0,0) width 98: "Lorem ipsum dolor"
+        text run at (97,0) width 4: " "
+        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
+        text run at (0,26) width 56: "TUVWXYZ"
+        text run at (55,26) width 4: " "
+        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
+        text run at (126,39) width 4: " "
+layer at (34,301) size 161x32 clip at (35,302) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (24,11) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 140x52
+      RenderText {#text} at (0,0) size 140x52
+        text run at (0,0) width 98: "Lorem ipsum dolor"
+        text run at (97,0) width 4: " "
+        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
+        text run at (0,26) width 56: "TUVWXYZ"
+        text run at (55,26) width 4: " "
+        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
+        text run at (126,39) width 4: " "
+layer at (24,362) size 161x32 clip at (25,363) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 140x52
+      RenderText {#text} at (0,0) size 140x52
+        text run at (0,0) width 98: "Lorem ipsum dolor"
+        text run at (97,0) width 4: " "
+        text run at (0,13) width 140: "ABCDEFGHIJKLMNOPQRS"
+        text run at (0,26) width 56: "TUVWXYZ"
+        text run at (55,26) width 4: " "
+        text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
+        text run at (126,39) width 4: " "
+layer at (24,413) size 42x32 clip at (25,414) size 25x30 scrollHeight 329
+  RenderTextControl {TEXTAREA} at (14,1) size 43x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 21x325
       RenderText {#text} at (0,0) size 21x325
         text run at (0,0) width 17: "Lor"
@@ -329,8 +329,8 @@ layer at (26,435) size 42x32 clip at (27,436) size 25x30 scrollHeight 329
         text run at (0,299) width 21: "qrst"
         text run at (0,312) width 13: "uv"
         text run at (12,312) width 4: " "
-layer at (26,490) size 161x45 clip at (27,491) size 144x43 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (16,3) size 162x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,464) size 161x45 clip at (25,465) size 144x43 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 162x45 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -340,8 +340,8 @@ layer at (26,490) size 161x45 clip at (27,491) size 144x43 scrollHeight 56
         text run at (55,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (26,558) size 91x32 clip at (27,559) size 74x30 scrollHeight 95
-  RenderTextControl {TEXTAREA} at (16,3) size 92x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,528) size 91x32 clip at (25,529) size 74x30 scrollHeight 95
+  RenderTextControl {TEXTAREA} at (14,1) size 92x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 70x91
       RenderText {#text} at (0,0) size 70x91
         text run at (0,0) width 68: "Lorem ipsum"
@@ -355,8 +355,8 @@ layer at (26,558) size 91x32 clip at (27,559) size 74x30 scrollHeight 95
         text run at (0,65) width 64: "abcdefghijkl"
         text run at (0,78) width 63: "mnopqrstuv"
         text run at (62,78) width 4: " "
-layer at (26,613) size 161x136 clip at (27,614) size 159x134
-  RenderTextControl {TEXTAREA} at (16,3) size 162x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,579) size 161x136 clip at (25,580) size 159x134
+  RenderTextControl {TEXTAREA} at (14,1) size 162x136 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -366,8 +366,8 @@ layer at (26,613) size 161x136 clip at (27,614) size 159x134
         text run at (40,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (26,772) size 56x58 clip at (27,773) size 39x56 scrollHeight 186
-  RenderTextControl {TEXTAREA} at (16,3) size 57x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,734) size 56x58 clip at (25,735) size 39x56 scrollHeight 186
+  RenderTextControl {TEXTAREA} at (14,1) size 57x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 35x182
       RenderText {#text} at (0,0) size 35x182
         text run at (0,0) width 33: "Lorem"
@@ -389,8 +389,8 @@ layer at (26,772) size 56x58 clip at (27,773) size 39x56 scrollHeight 186
         text run at (0,156) width 30: "mnop"
         text run at (0,169) width 34: "qrstuv"
         text run at (33,169) width 2: " "
-layer at (376,26) size 60x32 clip at (377,27) size 43x30 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (14,3) size 61x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,24) size 60x32 clip at (377,25) size 43x30 scrollHeight 173
+  RenderTextControl {TEXTAREA} at (14,1) size 61x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
         text run at (0,0) width 33: "Lorem"
@@ -411,8 +411,8 @@ layer at (376,26) size 60x32 clip at (377,27) size 43x30 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (376,81) size 60x68 clip at (377,82) size 43x66 scrollHeight 924
-  RenderTextControl {TEXTAREA} at (14,3) size 61x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,75) size 60x68 clip at (377,76) size 43x66 scrollHeight 924
+  RenderTextControl {TEXTAREA} at (14,1) size 61x68 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (21,21) size 3x884
       RenderText {#text} at (0,0) size 11x884
         text run at (0,0) width 7: "L"
@@ -483,8 +483,8 @@ layer at (376,81) size 60x68 clip at (377,82) size 43x66 scrollHeight 924
         text run at (0,845) width 7: "u"
         text run at (0,858) width 7: "v"
         text run at (0,871) width 3: " "
-layer at (376,172) size 60x28 clip at (377,173) size 43x26 scrollHeight 156
-  RenderTextControl {TEXTAREA} at (14,3) size 61x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,162) size 60x28 clip at (377,163) size 43x26 scrollHeight 156
+  RenderTextControl {TEXTAREA} at (14,1) size 61x28 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (1,1) size 43x156
       RenderText {#text} at (0,0) size 43x156
         text run at (0,0) width 33: "Lorem"
@@ -504,8 +504,8 @@ layer at (376,172) size 60x28 clip at (377,173) size 43x26 scrollHeight 156
         text run at (0,130) width 41: "opqrstu"
         text run at (0,143) width 7: "v"
         text run at (6,143) width 4: " "
-layer at (378,221) size 161x60 clip at (379,222) size 159x58
-  RenderTextControl {TEXTAREA} at (16,1) size 162x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,209) size 161x60 clip at (377,210) size 159x58
+  RenderTextControl {TEXTAREA} at (14,1) size 162x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -515,7 +515,7 @@ layer at (378,221) size 161x60 clip at (379,222) size 159x58
         text run at (40,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (376,300) size 60x60 clip at (377,301) size 43x58 scrollHeight 173
+layer at (376,288) size 60x60 clip at (377,289) size 43x58 scrollHeight 173
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
@@ -537,8 +537,8 @@ layer at (376,300) size 60x60 clip at (377,301) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (378,381) size 161x32 clip at (379,382) size 159x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,367) size 161x32 clip at (377,368) size 159x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x52
       RenderText {#text} at (0,0) size 155x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -548,8 +548,8 @@ layer at (378,381) size 161x32 clip at (379,382) size 159x30 scrollHeight 56
         text run at (40,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (378,436) size 161x47 clip at (379,437) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (16,3) size 162x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,418) size 161x47 clip at (377,419) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (14,1) size 162x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 98: "Lorem ipsum dolor"
@@ -559,7 +559,7 @@ layer at (378,436) size 161x47 clip at (379,437) size 144x30 scrollHeight 56
         text run at (55,26) width 4: " "
         text run at (0,39) width 127: "abcdefghijklmnopqrstuv"
         text run at (126,39) width 4: " "
-layer at (376,504) size 60x60 clip at (377,505) size 58x58 scrollHeight 134
+layer at (376,484) size 60x60 clip at (377,485) size 58x58 scrollHeight 134
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 54x130
       RenderText {#text} at (0,0) size 54x130
@@ -578,7 +578,7 @@ layer at (376,504) size 60x60 clip at (377,505) size 58x58 scrollHeight 134
         text run at (0,104) width 53: "jklmnopqr"
         text run at (0,117) width 23: "stuv"
         text run at (22,117) width 4: " "
-layer at (376,583) size 60x60 clip at (377,584) size 43x43 scrollHeight 173
+layer at (376,563) size 60x60 clip at (377,564) size 43x43 scrollHeight 173
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
@@ -600,7 +600,7 @@ layer at (376,583) size 60x60 clip at (377,584) size 43x43 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (376,662) size 60x60 clip at (377,663) size 43x58 scrollHeight 173
+layer at (376,642) size 60x60 clip at (377,643) size 43x58 scrollHeight 173
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
@@ -622,7 +622,7 @@ layer at (376,662) size 60x60 clip at (377,663) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (376,741) size 60x60 clip at (377,742) size 43x58 scrollHeight 173
+layer at (376,721) size 60x60 clip at (377,722) size 43x58 scrollHeight 173
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
@@ -644,7 +644,7 @@ layer at (376,741) size 60x60 clip at (377,742) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (376,820) size 60x60 clip at (377,821) size 43x58 scrollHeight 173
+layer at (376,800) size 60x60 clip at (377,801) size 43x58 scrollHeight 173
   RenderTextControl {TEXTAREA} at (14,1) size 61x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 39x169
       RenderText {#text} at (0,0) size 39x169
@@ -666,8 +666,8 @@ layer at (376,820) size 60x60 clip at (377,821) size 43x58 scrollHeight 173
         text run at (0,143) width 37: "nopqrs"
         text run at (0,156) width 17: "tuv"
         text run at (16,156) width 4: " "
-layer at (378,901) size 161x47 clip at (379,902) size 144x30 scrollWidth 186 scrollHeight 212
-  RenderTextControl {TEXTAREA} at (16,3) size 162x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,879) size 161x47 clip at (377,880) size 144x30 scrollWidth 186 scrollHeight 212
+  RenderTextControl {TEXTAREA} at (14,1) size 162x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x208
       RenderText {#text} at (0,0) size 185x195
         text run at (0,0) width 4: " "
@@ -701,8 +701,8 @@ layer at (378,901) size 161x47 clip at (379,902) size 144x30 scrollWidth 186 scr
         text run at (0,182) width 185: "This is a text area with wrap=\"soft\""
         text run at (184,182) width 1: " "
       RenderBR {BR} at (0,195) size 0x13
-layer at (378,971) size 161x32 clip at (379,972) size 144x30 scrollHeight 394
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,945) size 161x32 clip at (377,946) size 144x30 scrollHeight 394
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x390
       RenderText {#text} at (0,0) size 121x377
         text run at (0,0) width 4: " "
@@ -764,8 +764,8 @@ layer at (378,971) size 161x32 clip at (379,972) size 144x30 scrollHeight 394
         text run at (0,364) width 64: "wrap=\"soft\""
         text run at (63,364) width 1: " "
       RenderBR {BR} at (0,377) size 0x13
-layer at (378,1026) size 161x32 clip at (379,1027) size 144x30 scrollHeight 394
-  RenderTextControl {TEXTAREA} at (16,3) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,996) size 161x32 clip at (377,997) size 144x30 scrollHeight 394
+  RenderTextControl {TEXTAREA} at (14,1) size 162x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x390
       RenderText {#text} at (0,0) size 121x377
         text run at (0,0) width 4: " "

--- a/LayoutTests/platform/mac/fast/forms/button-cannot-be-nested-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-cannot-be-nested-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x106
-  RenderBlock {HTML} at (0,0) size 800x106
-    RenderBody {BODY} at (8,8) size 784x90
+layer at (0,0) size 800x103
+  RenderBlock {HTML} at (0,0) size 800x103
+    RenderBody {BODY} at (8,8) size 784x87
       RenderBlock {DIV} at (0,0) size 784x18
         RenderInline {A} at (0,0) size 63x18 [color=#0000EE]
           RenderText {#text} at (0,0) size 63x18
             text run at (0,0) width 63: "Bug 6584"
         RenderText {#text} at (62,0) size 379x18
           text run at (62,0) width 379: " REGRESSION: button after unclosed button gives trouble"
-      RenderBlock {P} at (0,34) size 784x22
-        RenderButton {BUTTON} at (2,2) size 37x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {P} at (0,34) size 784x19
+        RenderButton {BUTTON} at (0,1) size 37x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 21x13
             RenderText {#text} at (0,0) size 21x13
               text run at (0,0) width 21: "test"
-        RenderButton {BUTTON} at (42,2) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderButton {BUTTON} at (36,1) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 27x13
             RenderText {#text} at (0,0) size 27x13
               text run at (0,0) width 27: "test2"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,72) size 784x18
+      RenderBlock {DIV} at (0,69) size 784x18
         RenderText {#text} at (0,0) size 613x18
           text run at (0,0) width 613: "There should be two separate buttons instead of button \"test2\" being nested inside button \"test\"."

--- a/LayoutTests/platform/mac/fast/forms/button-generated-content-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-generated-content-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x262
-  RenderBlock {HTML} at (0,0) size 800x262
-    RenderBody {BODY} at (8,16) size 784x238
+layer at (0,0) size 800x238
+  RenderBlock {HTML} at (0,0) size 800x238
+    RenderBody {BODY} at (8,16) size 784x214
       RenderBlock {P} at (0,0) size 784x36
         RenderText {#text} at (0,0) size 322x18
           text run at (0,0) width 299: "This is a test of generated content in <button> "

--- a/LayoutTests/platform/mac/fast/forms/button-inner-block-reuse-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-inner-block-reuse-expected.txt
@@ -22,8 +22,8 @@ layer at (0,0) size 800x600
           text run at (567,0) width 149: "all of the button's other"
           text run at (0,18) width 82: "descendants."
       RenderBlock {HR} at (0,104) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,114) size 784x19
-        RenderButton {BUTTON} at (2,2) size 16x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,114) size 784x15
+        RenderButton {BUTTON} at (0,0) size 16x15 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,7) size 0x0
             RenderBlock (anonymous) at (0,0) size 0x0
               RenderInline {SPAN} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt
@@ -3,49 +3,49 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {BUTTON} at (2,4) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderButton {BUTTON} at (0,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText {#text} at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (80,3) size 5x18
-        text run at (80,3) width 5: " "
-      RenderButton {BUTTON} at (86,4) size 77x18 [color=#FF0000] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderText {#text} at (76,1) size 5x18
+        text run at (76,1) width 5: " "
+      RenderButton {BUTTON} at (80,2) size 77x18 [color=#FF0000] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText {#text} at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (164,3) size 5x18
-        text run at (164,3) width 5: " "
-      RenderButton {BUTTON} at (170,2) size 77x22 [color=#000000D8] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
+      RenderText {#text} at (156,1) size 5x18
+        text run at (156,1) width 5: " "
+      RenderButton {BUTTON} at (160,0) size 77x22 [color=#000000D8] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 61x13
           RenderText {#text} at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (248,3) size 5x18
-        text run at (248,3) width 5: " "
-      RenderButton {BUTTON} at (254,2) size 77x22 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
+      RenderText {#text} at (236,1) size 5x18
+        text run at (236,1) width 5: " "
+      RenderButton {BUTTON} at (240,0) size 77x22 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 61x13
           RenderText {#text} at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (332,3) size 5x18
-        text run at (332,3) width 5: " "
-      RenderButton {INPUT} at (338,4) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderText {#text} at (316,1) size 5x18
+        text run at (316,1) width 5: " "
+      RenderButton {INPUT} at (320,2) size 77x18 [color=#000000D8] [bgcolor=#C0C0C0]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (416,3) size 5x18
-        text run at (416,3) width 5: " "
-      RenderButton {INPUT} at (422,4) size 78x18 [color=#FF0000] [bgcolor=#C0C0C0]
+      RenderText {#text} at (396,1) size 5x18
+        text run at (396,1) width 5: " "
+      RenderButton {INPUT} at (400,2) size 78x18 [color=#FF0000] [bgcolor=#C0C0C0]
         RenderBlock (anonymous) at (8,2) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (501,3) size 5x18
-        text run at (501,3) width 5: " "
-      RenderButton {INPUT} at (507,2) size 77x22 [color=#000000D8] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
+      RenderText {#text} at (477,1) size 5x18
+        text run at (477,1) width 5: " "
+      RenderButton {INPUT} at (481,0) size 77x22 [color=#000000D8] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (585,3) size 5x18
-        text run at (585,3) width 5: " "
-      RenderButton {INPUT} at (591,2) size 77x22 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
+      RenderText {#text} at (557,1) size 5x18
+        text run at (557,1) width 5: " "
+      RenderButton {INPUT} at (561,0) size 77x22 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,4) size 61x13
           RenderText at (0,0) size 61x13
             text run at (0,0) width 61: "Test Button"

--- a/LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt
@@ -16,38 +16,38 @@ layer at (0,0) size 800x600
             text run at (0,18) width 107: "button) elements"
         RenderText {#text} at (106,18) size 5x18
           text run at (106,18) width 5: "."
-      RenderBlock {P} at (0,52) size 784x22
-        RenderButton {BUTTON} at (2,2) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {P} at (0,52) size 784x19
+        RenderButton {BUTTON} at (0,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 66x13
             RenderText {#text} at (0,0) size 66x13
               text run at (0,0) width 66: "UPPERCASE"
-        RenderText {#text} at (85,1) size 5x18
-          text run at (85,1) width 5: " "
-        RenderButton {BUTTON} at (91,2) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderText {#text} at (81,0) size 5x18
+          text run at (81,0) width 5: " "
+        RenderButton {BUTTON} at (85,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 53x13
             RenderText {#text} at (0,0) size 53x13
               text run at (0,0) width 53: "lowercase"
-        RenderText {#text} at (161,1) size 5x18
-          text run at (161,1) width 5: " "
-        RenderButton {BUTTON} at (167,2) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderText {#text} at (153,0) size 5x18
+          text run at (153,0) width 5: " "
+        RenderButton {BUTTON} at (157,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 52x13
             RenderText {#text} at (0,0) size 52x13
               text run at (0,0) width 52: "Capitalize"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,90) size 784x22
-        RenderButton {INPUT} at (2,2) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock {P} at (0,87) size 784x19
+        RenderButton {INPUT} at (0,1) size 82x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 66x13
             RenderText at (0,0) size 66x13
               text run at (0,0) width 66: "UPPERCASE"
-        RenderText {#text} at (85,1) size 5x18
-          text run at (85,1) width 5: " "
-        RenderButton {INPUT} at (91,2) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderText {#text} at (81,0) size 5x18
+          text run at (81,0) width 5: " "
+        RenderButton {INPUT} at (85,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 53x13
             RenderText at (0,0) size 53x13
               text run at (0,0) width 53: "lowercase"
-        RenderText {#text} at (161,1) size 5x18
-          text run at (161,1) width 5: " "
-        RenderButton {INPUT} at (167,2) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderText {#text} at (153,0) size 5x18
+          text run at (153,0) width 5: " "
+        RenderButton {INPUT} at (157,1) size 69x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 52x13
             RenderText at (0,0) size 52x13
               text run at (0,0) width 52: "Capitalize"

--- a/LayoutTests/platform/mac/fast/forms/button-white-space-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-white-space-expected.txt
@@ -13,51 +13,51 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 365x18
           text run at (0,0) width 365: "Buttons should appear next to each other in a single row:"
-      RenderTable {TABLE} at (0,70) size 195x28
-        RenderTableSection {TBODY} at (0,0) size 195x28
-          RenderTableRow {TR} at (0,2) size 195x24
-            RenderTableCell {TD} at (2,2) size 191x24 [r=0 c=0 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderTable {TABLE} at (0,70) size 187x25
+        RenderTableSection {TBODY} at (0,0) size 187x25
+          RenderTableRow {TR} at (0,2) size 187x21
+            RenderTableCell {TD} at (2,2) size 183x21 [r=0 c=0 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,2) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 62x13
                   RenderText {#text} at (0,0) size 62x13
                     text run at (0,0) width 62: "Search Mail"
-              RenderText {#text} at (82,2) size 5x18
-                text run at (82,2) width 5: " "
-              RenderButton {BUTTON} at (88,3) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+              RenderText {#text} at (78,1) size 5x18
+                text run at (78,1) width 5: " "
+              RenderButton {BUTTON} at (82,2) size 100x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
                 RenderBlock (anonymous) at (8,2) size 84x13
                   RenderText {#text} at (0,0) size 84x13
                     text run at (0,0) width 84: "Search the Web"
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,98) size 784x18
+      RenderBlock {DIV} at (0,95) size 784x18
         RenderText {#text} at (0,0) size 193x18
           text run at (0,0) width 193: "Buttons should look identical:"
-      RenderBlock {DIV} at (0,116) size 784x22
-        RenderButton {BUTTON} at (2,2) size 74x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {DIV} at (0,113) size 784x18
+        RenderButton {BUTTON} at (0,0) size 74x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 58x13
             RenderText {#text} at (0,0) size 58x13
               text run at (0,0) width 58: "test button"
-      RenderBlock {DIV} at (0,138) size 784x22
-        RenderButton {BUTTON} at (2,2) size 74x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {DIV} at (0,131) size 784x18
+        RenderButton {BUTTON} at (0,0) size 74x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 58x13
             RenderText {#text} at (0,0) size 58x13
               text run at (0,0) width 24: "test "
               text run at (23,0) width 35: "button"
-      RenderBlock {DIV} at (0,160) size 784x18
+      RenderBlock {DIV} at (0,149) size 784x18
         RenderText {#text} at (0,0) size 353x18
           text run at (0,0) width 353: "Buttons should look identical (ignore vertical spacing):"
-      RenderBlock {DIV} at (0,178) size 784x22
-        RenderButton {BUTTON} at (2,2) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {DIV} at (0,167) size 784x18
+        RenderButton {BUTTON} at (0,0) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 74x13
             RenderText {#text} at (0,0) size 74x13
               text run at (0,0) width 74: "  test  button  "
-      RenderBlock {DIV} at (0,200) size 784x22
-        RenderButton {BUTTON} at (2,2) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {DIV} at (0,185) size 784x18
+        RenderButton {BUTTON} at (0,0) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 74x13
             RenderText {#text} at (0,0) size 74x13
               text run at (0,0) width 74: "  test  button  "
-      RenderBlock {DIV} at (0,235) size 784x22
-        RenderBlock {PRE} at (0,0) size 784x22
-          RenderButton {BUTTON} at (2,2) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {DIV} at (0,216) size 784x18
+        RenderBlock {PRE} at (0,0) size 784x18
+          RenderButton {BUTTON} at (0,0) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 74x13
               RenderText {#text} at (0,0) size 74x13
                 text run at (0,0) width 74: "  test  button  "

--- a/LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt
@@ -21,14 +21,14 @@ layer at (0,0) size 800x600
           text run at (0,0) width 408: "There should not be scroll bars below the popup and the button."
 layer at (8,94) size 100x50
   RenderBlock {DIV} at (0,86) size 100x50
-    RenderMenuList {SELECT} at (0,2) size 80x18 [color=#000000D8] [bgcolor=#FFFFFF]
+    RenderMenuList {SELECT} at (0,0) size 80x18 [color=#000000D8] [bgcolor=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 80x18
         RenderText at (8,2) size 143x13
           text run at (8,2) width 143: "Lorem ipsum dolor sit amet"
     RenderText {#text} at (0,0) size 0x0
 layer at (8,164) size 100x50
   RenderBlock {DIV} at (0,156) size 100x50
-    RenderButton {BUTTON} at (0,2) size 80x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+    RenderButton {BUTTON} at (0,0) size 80x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
       RenderBlock (anonymous) at (8,2) size 64x13
         RenderText {#text} at (0,0) size 143x13
           text run at (0,0) width 143: "Lorem ipsum dolor sit amet"

--- a/LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt
@@ -1,100 +1,100 @@
-layer at (0,0) size 1089x585
+layer at (0,0) size 1073x585
   RenderView at (0,0) size 800x585
 layer at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x569
-      RenderTable {TABLE} at (0,0) size 1082x108
-        RenderTableSection {TBODY} at (0,0) size 1082x108
-          RenderTableRow {TR} at (0,2) size 1082x20
+      RenderTable {TABLE} at (0,0) size 1066x96
+        RenderTableSection {TBODY} at (0,0) size 1066x96
+          RenderTableRow {TR} at (0,2) size 1066x20
             RenderTableCell {TH} at (2,11) size 86x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (89,11) size 247x2 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TH} at (337,2) size 247x20 [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (76,1) size 94x18
-                text run at (76,1) width 94: "text-align:left"
-            RenderTableCell {TH} at (585,2) size 247x20 [r=0 c=3 rs=1 cs=1]
-              RenderText {#text} at (66,1) size 114x18
-                text run at (66,1) width 114: "text-align:center"
-            RenderTableCell {TH} at (833,2) size 247x20 [r=0 c=4 rs=1 cs=1]
-              RenderText {#text} at (71,1) size 104x18
-                text run at (71,1) width 104: "text-align:right"
-          RenderTableRow {TR} at (0,24) size 1082x26
-            RenderTableCell {TH} at (2,36) size 86x2 [r=1 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (89,24) size 247x26 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TH} at (89,11) size 243x2 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (333,2) size 243x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (74,1) size 94x18
+                text run at (74,1) width 94: "text-align:left"
+            RenderTableCell {TH} at (577,2) size 243x20 [r=0 c=3 rs=1 cs=1]
+              RenderText {#text} at (64,1) size 114x18
+                text run at (64,1) width 114: "text-align:center"
+            RenderTableCell {TH} at (821,2) size 243x20 [r=0 c=4 rs=1 cs=1]
+              RenderText {#text} at (69,1) size 104x18
+                text run at (69,1) width 104: "text-align:right"
+          RenderTableRow {TR} at (0,24) size 1066x22
+            RenderTableCell {TH} at (2,34) size 86x2 [r=1 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (89,24) size 243x22 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (337,24) size 247x26 [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (333,24) size 243x22 [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (585,24) size 247x26 [border: (1px solid #000000)] [r=1 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (577,24) size 243x22 [border: (1px solid #000000)] [r=1 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (833,24) size 247x26 [border: (1px solid #000000)] [r=1 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (821,24) size 243x22 [border: (1px solid #000000)] [r=1 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-          RenderTableRow {TR} at (0,52) size 1082x26
-            RenderTableCell {TH} at (2,55) size 86x20 [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,48) size 1066x22
+            RenderTableCell {TH} at (2,49) size 86x20 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 84x18
                 text run at (1,1) width 84: "direction:ltr"
-            RenderTableCell {TD} at (89,52) size 247x26 [border: (1px solid #000000)] [r=2 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (89,48) size 243x22 [border: (1px solid #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (337,52) size 247x26 [border: (1px solid #000000)] [r=2 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (333,48) size 243x22 [border: (1px solid #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (585,52) size 247x26 [border: (1px solid #000000)] [r=2 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (577,48) size 243x22 [border: (1px solid #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (833,52) size 247x26 [border: (1px solid #000000)] [r=2 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (821,48) size 243x22 [border: (1px solid #000000)] [r=2 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (0,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-          RenderTableRow {TR} at (0,80) size 1082x26
-            RenderTableCell {TH} at (2,83) size 86x20 [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,72) size 1066x22
+            RenderTableCell {TH} at (2,73) size 86x20 [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 84x18
                 text run at (1,1) width 84: "direction:rtl"
-            RenderTableCell {TD} at (89,80) size 247x26 [border: (1px solid #000000)] [r=3 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (89,72) size 243x22 [border: (1px solid #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (337,80) size 247x26 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (333,72) size 243x22 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (585,80) size 247x26 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (577,72) size 243x22 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13
                       text run at (0,0) width 62: "Choose File"
-            RenderTableCell {TD} at (833,80) size 247x26 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x18 "no file selected"
+            RenderTableCell {TD} at (821,72) size 243x22 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x18 "no file selected"
                 RenderButton {INPUT} at (160,0) size 78x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 62x13
                     RenderText at (0,0) size 62x13

--- a/LayoutTests/platform/mac/fast/forms/floating-textfield-relayout-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/floating-textfield-relayout-expected.txt
@@ -19,8 +19,8 @@ layer at (0,0) size 800x600
       RenderBlock {HR} at (0,52) size 784x2 [border: (1px inset #000000)]
 layer at (8,70) size 784x0
   RenderBlock (relative positioned) {DIV} at (0,62) size 784x0
-    RenderTextControl {INPUT} at (0,2) size 392x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-layer at (11,75) size 386x13
+    RenderTextControl {INPUT} at (0,0) size 392x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+layer at (11,73) size 386x13
   RenderBlock {DIV} at (3,3) size 386x13
     RenderText {#text} at (0,0) size 17x13
       text run at (0,0) width 17: "foo"

--- a/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x636
+layer at (0,0) size 785x614
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x636
-  RenderBlock {HTML} at (0,0) size 785x636
-    RenderBody {BODY} at (8,8) size 769x620
+layer at (0,0) size 785x614
+  RenderBlock {HTML} at (0,0) size 785x614
+    RenderBody {BODY} at (8,8) size 769x598
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 420x37
           text run at (0,0) width 420: "Form Element Geometry Tests"

--- a/LayoutTests/platform/mac/fast/forms/formmove3-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/formmove3-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x0
         RenderInline {A} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,0) size 784x28
+      RenderBlock {DIV} at (0,0) size 784x24
         RenderBlock (anonymous) at (0,0) size 784x0
           RenderInline {A} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,0) size 784x28
-          RenderTable {TABLE} at (0,0) size 67x28
-            RenderTableSection {TBODY} at (0,0) size 67x28
-              RenderTableRow {TR} at (0,2) size 67x24
-                RenderTableCell {TD} at (2,13) size 2x2 [r=0 c=0 rs=1 cs=1]
-                RenderTableCell {TD} at (6,2) size 59x24 [r=0 c=1 rs=1 cs=1]
-                  RenderButton {INPUT} at (3,3) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderBlock (anonymous) at (0,0) size 784x24
+          RenderTable {TABLE} at (0,0) size 63x24
+            RenderTableSection {TBODY} at (0,0) size 63x24
+              RenderTableRow {TR} at (0,2) size 63x20
+                RenderTableCell {TD} at (2,11) size 2x2 [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (6,2) size 55x20 [r=0 c=1 rs=1 cs=1]
+                  RenderButton {INPUT} at (1,1) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
                     RenderBlock (anonymous) at (8,2) size 37x13
                       RenderText at (0,0) size 37x13
                         text run at (0,0) width 37: "Search"
-        RenderBlock (anonymous) at (0,28) size 784x0
+        RenderBlock (anonymous) at (0,24) size 784x0
           RenderInline {A} at (0,0) size 0x0
           RenderInline {A} at (0,0) size 0x0 [color=#0000EE]
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,28) size 784x18
+      RenderBlock (anonymous) at (0,24) size 784x18
         RenderText {#text} at (0,0) size 107x18
           text run at (0,0) width 107: "Form did submit"

--- a/LayoutTests/platform/mac/fast/forms/input-field-text-truncated-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-field-text-truncated-expected.txt
@@ -7,10 +7,10 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 758x26
           text run at (0,0) width 758: "Text inside input field should not be cut off at the bottom when its font is larger than the body font size. If the descenders in \"something gjpqy\" below are all visible, the test"
           text run at (0,13) width 309: "passes. If they are cut off by the bottom of the input box, the test fails."
-      RenderBlock (anonymous) at (0,37) size 784x25
-        RenderTextControl {INPUT} at (0,2) size 300x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock (anonymous) at (0,37) size 784x21
+        RenderTextControl {INPUT} at (0,0) size 300x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
-layer at (11,50) size 294x15
+layer at (11,48) size 294x15
   RenderBlock {DIV} at (3,3) size 294x15
     RenderText {#text} at (0,0) size 95x15
       text run at (0,0) width 95: "something gjpqy"

--- a/LayoutTests/platform/mac/fast/forms/input-readonly-empty-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-readonly-empty-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (0,2) size 487x18
-        text run at (0,2) width 487: "This tests that empty readonly text fields have the right height and baseline. "
-      RenderTextControl {INPUT} at (489,2) size 146x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderText {#text} at (0,0) size 487x18
+        text run at (0,0) width 487: "This tests that empty readonly text fields have the right height and baseline. "
+      RenderTextControl {INPUT} at (487,0) size 146x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (500,13) size 140x13
+layer at (498,11) size 140x13
   RenderBlock {DIV} at (3,3) size 140x13

--- a/LayoutTests/platform/mac/fast/forms/listbox-hit-test-zoomed-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/listbox-hit-test-zoomed-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (9,9) size 782x582
       RenderBlock (anonymous) at (0,0) size 781x162
-        RenderListBox {SELECT} at (2,0) size 127x162 [bgcolor=#FFFFFF] [border: (12px solid #000000)]
+        RenderListBox {SELECT} at (0,0) size 127x162 [bgcolor=#FFFFFF] [border: (12px solid #000000)]
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,162) size 781x66
         RenderText {#text} at (0,0) size 62x22

--- a/LayoutTests/platform/mac/fast/forms/listbox-scrollbar-incremental-load-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/listbox-scrollbar-incremental-load-expected.txt
@@ -22,6 +22,6 @@ layer at (0,0) size 800x600
           text run at (500,0) width 244: "\x{201C}Seven\x{201D}. The scroller should be at the"
           text run at (0,18) width 155: "bottom of the scroll bar "
           text run at (154,18) width 88: "to reflect this."
-      RenderBlock (anonymous) at (0,104) size 784x61
-        RenderListBox {SELECT} at (2,2) size 49x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,104) size 784x57
+        RenderListBox {SELECT} at (0,0) size 49x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/menulist-clip-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-clip-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (220,18) size 5x18
           text run at (220,18) width 5: "."
       RenderBlock (anonymous) at (0,52) size 784x30
-        RenderMenuList {SELECT} at (2,0) size 49x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderMenuList {SELECT} at (0,0) size 49x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,4) size 47x22
             RenderText at (0,0) size 47x21
               text run at (0,0) width 47: "Apple"

--- a/LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (0,1) size 75x18
-        text run at (0,1) width 75: "Test result: "
-      RenderMenuList {SELECT} at (76,2) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderText {#text} at (0,0) size 75x18
+        text run at (0,0) width 75: "Test result: "
+      RenderMenuList {SELECT} at (74,1) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 60x18
           RenderText at (8,2) size 29x13
             text run at (8,2) width 29: "PASS"

--- a/LayoutTests/platform/mac/fast/forms/menulist-option-wrap-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-option-wrap-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
             text run at (360,0) width 273: "Native popup with size=\"1\" wraps options"
         RenderText {#text} at (632,0) size 5x18
           text run at (632,0) width 5: "."
-      RenderBlock {P} at (0,34) size 784x19
+      RenderBlock {P} at (0,34) size 784x18
         RenderText {#text} at (0,0) size 36x18
           text run at (0,0) width 36: "With "
         RenderInline {TT} at (0,0) size 63x15
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
             RenderText at (0,0) size 173x13
               text run at (0,0) width 173: "Very long option that does not fit"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,69) size 784x19
+      RenderBlock {P} at (0,68) size 784x18
         RenderText {#text} at (0,0) size 56x18
           text run at (0,0) width 56: "Without "
         RenderInline {TT} at (0,0) size 33x15

--- a/LayoutTests/platform/mac/fast/forms/menulist-separator-painting-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-separator-painting-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 784x6 [border: (3px solid #FFFFFF)]
-      RenderBlock (anonymous) at (0,6) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 36x18 [bgcolor=#FFFFFF] [border: (1px solid #008000)]
+      RenderBlock (anonymous) at (0,6) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 36x18 [bgcolor=#FFFFFF] [border: (1px solid #008000)]
           RenderBlock (anonymous) at (1,1) size 34x16
             RenderText at (8,1) size 0x13
               text run at (8,1) width 0: " "

--- a/LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt
@@ -3,25 +3,25 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 69x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,1) size 69x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 69x18
           RenderText at (8,2) size 38x13
             text run at (8,2) width 38: "Default"
-      RenderText {#text} at (73,1) size 4x18
-        text run at (73,1) width 4: " "
-      RenderMenuList {SELECT} at (79,2) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderText {#text} at (69,0) size 4x18
+        text run at (69,0) width 4: " "
+      RenderMenuList {SELECT} at (73,1) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 52x18
           RenderText at (8,2) size 21x13
             text run at (8,2) width 21: "Red"
-      RenderText {#text} at (133,1) size 4x18
-        text run at (133,1) width 4: " "
-      RenderMenuList {SELECT} at (139,2) size 119x18 [bgcolor=#008000] [border: (1px solid #000000)]
+      RenderText {#text} at (125,0) size 4x18
+        text run at (125,0) width 4: " "
+      RenderMenuList {SELECT} at (129,1) size 119x18 [bgcolor=#008000] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (1,1) size 117x16
           RenderText at (8,1) size 88x13
             text run at (8,1) width 88: "Default on green"
-      RenderText {#text} at (260,1) size 4x18
-        text run at (260,1) width 4: " "
-      RenderMenuList {SELECT} at (266,2) size 101x18 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FF0000)]
+      RenderText {#text} at (248,0) size 4x18
+        text run at (248,0) width 4: " "
+      RenderMenuList {SELECT} at (252,1) size 101x18 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 99x16
           RenderText at (8,1) size 70x13
             text run at (8,1) width 70: "Red on green"

--- a/LayoutTests/platform/mac/fast/forms/minWidthPercent-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/minWidthPercent-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 120x29 [bgcolor=#C3D9FF]
-        RenderTable {TABLE} at (0,0) size 120x29
-          RenderTableSection {TBODY} at (0,0) size 120x29
-            RenderTableRow {TR} at (0,2) size 120x25
-              RenderTableCell {TD} at (2,2) size 116x25 [r=0 c=0 rs=1 cs=1]
-                RenderTextControl {INPUT} at (1,3) size 114x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock {DIV} at (0,0) size 120x25 [bgcolor=#C3D9FF]
+        RenderTable {TABLE} at (0,0) size 120x25
+          RenderTableSection {TBODY} at (0,0) size 120x25
+            RenderTableRow {TR} at (0,2) size 120x21
+              RenderTableCell {TD} at (2,2) size 116x21 [r=0 c=0 rs=1 cs=1]
+                RenderTextControl {INPUT} at (1,1) size 114x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (0,0) size 0x0
-layer at (14,16) size 107x13 scrollWidth 112
+layer at (14,14) size 107x13 scrollWidth 112
   RenderBlock {DIV} at (3,3) size 108x13
     RenderText {#text} at (0,0) size 111x13
       text run at (0,0) width 111: "Should fit in blue box"

--- a/LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (160,0) size 413x18
           text run at (160,0) width 211: " will be pasted into the textfield. "
           text run at (370,0) width 203: "All richness should be stripped."
-      RenderBlock {OL} at (0,57) size 784x36
+      RenderBlock {OL} at (0,53) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
           RenderListMarker at (-20,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 332x18
@@ -34,7 +34,7 @@ layer at (0,0) size 800x600
           RenderListMarker at (-20,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 331x18
             text run at (0,0) width 331: "Success: document.execCommand(\"Paste\") == true"
-layer at (11,13) size 594x13
+layer at (11,11) size 594x13
   RenderBlock {DIV} at (3,3) size 594x13
     RenderText {#text} at (0,0) size 464x13
       text run at (0,0) width 464: "This styled text, and link will be pasted into the textfield. All richness should be stripped."

--- a/LayoutTests/platform/mac/fast/forms/search-rtl-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/search-rtl-expected.txt
@@ -45,7 +45,7 @@ layer at (32,47) size 140x13
       text run at (48,0) width 43 RTL: " \x{5D5}\x{5D4}\x{5D9}\x{5D0} \x{5D6}\x{5D4} "
       text run at (90,0) width 14: "he"
       text run at (103,0) width 37 RTL: "\x{5D4}\x{5D5}\x{5D0} \x{5D6}\x{5D4} "
-layer at (32,70) size 210x13
+layer at (30,64) size 210x13
   RenderBlock {DIV} at (0,0) size 210x13
     RenderText {#text} at (77,0) size 133x13
       text run at (77,0) width 23 RTL: " \x{5D5}\x{5D6}\x{5D4}\x{5D5}"
@@ -53,6 +53,6 @@ layer at (32,70) size 210x13
       text run at (118,0) width 43 RTL: " \x{5D5}\x{5D4}\x{5D9}\x{5D0} \x{5D6}\x{5D4} "
       text run at (160,0) width 14: "he"
       text run at (173,0) width 37 RTL: "\x{5D4}\x{5D5}\x{5D0} \x{5D6}\x{5D4} "
-layer at (32,93) size 140x13
+layer at (30,83) size 140x13
   RenderBlock {DIV} at (0,0) size 140x13
 caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 7 {INPUT} of child 3 {P} of body

--- a/LayoutTests/platform/mac/fast/forms/select-background-none-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-background-none-expected.txt
@@ -1,9 +1,9 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x38
-  RenderBlock {HTML} at (0,0) size 800x38
-    RenderBody {BODY} at (8,8) size 784x22 [bgcolor=#666666]
-      RenderMenuList {SELECT} at (2,2) size 39x18 [border: (1px solid #000000)]
+layer at (0,0) size 800x34
+  RenderBlock {HTML} at (0,0) size 800x34
+    RenderBody {BODY} at (8,8) size 784x18 [bgcolor=#666666]
+      RenderMenuList {SELECT} at (0,0) size 39x18 [border: (1px solid #000000)]
         RenderBlock (anonymous) at (1,1) size 37x16
           RenderText at (8,1) size 6x13
             text run at (8,1) width 6: "1"

--- a/LayoutTests/platform/mac/fast/forms/select-change-listbox-size-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-change-listbox-size-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 323x18
           text run at (0,0) width 323: "This list box should be tall enough to fit 6 options."
-      RenderBlock (anonymous) at (0,86) size 784x89
-        RenderListBox {SELECT} at (2,2) size 48x85 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,86) size 784x85
+        RenderListBox {SELECT} at (0,0) size 48x85 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt
@@ -1,16 +1,16 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x90
-  RenderBlock {HTML} at (0,0) size 800x90
-    RenderBody {BODY} at (8,8) size 784x66
-      RenderTable {TABLE} at (0,0) size 66x32 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 64x30
-          RenderTableRow {TR} at (0,2) size 64x26
-            RenderTableCell {TD} at (2,2) size 60x26 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (4,4) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+layer at (0,0) size 800x87
+  RenderBlock {HTML} at (0,0) size 800x87
+    RenderBody {BODY} at (8,8) size 784x63
+      RenderTable {TABLE} at (0,0) size 62x29 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 60x27
+          RenderTableRow {TR} at (0,2) size 60x23
+            RenderTableCell {TD} at (2,2) size 56x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (2,3) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 52x18
                   RenderText at (8,2) size 21x13
                     text run at (8,2) width 21: "test"
-      RenderBlock {P} at (0,48) size 784x18
+      RenderBlock {P} at (0,45) size 784x18
         RenderText {#text} at (0,0) size 459x18
           text run at (0,0) width 459: "The select element in the table above must not spill outside of the table."

--- a/LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt
@@ -15,14 +15,14 @@ layer at (0,0) size 800x600
             text run at (361,0) width 351: "REGRESSION: Disabled pop-up text is not grayed out"
         RenderText {#text} at (711,0) size 5x18
           text run at (711,0) width 5: "."
-      RenderBlock {P} at (0,34) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 158x18 [color=#0000003F] [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,34) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 158x18 [color=#0000003F] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 158x18
             RenderText at (8,2) size 127x13
               text run at (8,2) width 127: "This text should be gray"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,72) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 163x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,68) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 163x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 163x18
             RenderText at (8,2) size 132x13
               text run at (8,2) width 132: "This text should be black"

--- a/LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 70x18
           RenderText at (8,2) size 39x13
             text run at (8,2) width 39: "banana"

--- a/LayoutTests/platform/mac/fast/forms/select-empty-option-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-empty-option-height-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 25x15 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderMenuList {SELECT} at (0,0) size 25x15 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (1,1) size 23x13
           RenderText at (0,0) size 0x13
             text run at (0,0) width 0: " "

--- a/LayoutTests/platform/mac/fast/forms/select-item-background-clip-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-item-background-clip-expected.txt
@@ -17,6 +17,6 @@ layer at (0,0) size 800x600
         RenderText {#text} at (162,18) size 5x18
           text run at (162,18) width 5: "."
       RenderBlock (anonymous) at (0,52) size 784x58
-        RenderListBox {SELECT} at (2,0) size 55x58 [bgcolor=#FFFFFF] [border: (3px solid #0000FF)]
+        RenderListBox {SELECT} at (0,0) size 55x58 [bgcolor=#FFFFFF] [border: (3px solid #0000FF)]
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/select-listbox-multiple-no-focusring-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-listbox-multiple-no-focusring-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x77
-  RenderBlock {HTML} at (0,0) size 800x77
-    RenderBody {BODY} at (8,8) size 784x61
-      RenderListBox {SELECT} at (2,2) size 356x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (0,0) size 800x73
+  RenderBlock {HTML} at (0,0) size 800x73
+    RenderBody {BODY} at (8,8) size 784x57
+      RenderListBox {SELECT} at (0,0) size 356x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/select-non-native-rendering-direction-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-non-native-rendering-direction-expected.txt
@@ -3,19 +3,19 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 784x22
-        RenderText {#text} at (0,1) size 127x18
-          text run at (0,1) width 127: "Left to right select: "
-        RenderMenuList {SELECT} at (128,2) size 115x18 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {DIV} at (0,0) size 784x19
+        RenderText {#text} at (0,0) size 127x18
+          text run at (0,0) width 127: "Left to right select: "
+        RenderMenuList {SELECT} at (126,1) size 115x18 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 112x16
             RenderText at (8,1) size 46x13
               text run at (8,1) width 46: "Alabama"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,22) size 784x22
-        RenderText {#text} at (657,1) size 127x18
-          text run at (657,1) width 10 RTL: ": "
-          text run at (666,1) width 118: "Right to left select"
-        RenderMenuList {SELECT} at (541,2) size 115x18 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {DIV} at (0,19) size 784x19
+        RenderText {#text} at (657,0) size 127x18
+          text run at (657,0) width 10 RTL: ": "
+          text run at (666,0) width 118: "Right to left select"
+        RenderMenuList {SELECT} at (543,1) size 115x18 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 112x16
             RenderText at (58,1) size 46x13
               text run at (58,1) width 46: "Alabama"

--- a/LayoutTests/platform/mac/fast/forms/select-overflow-scroll-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-overflow-scroll-expected.txt
@@ -4,5 +4,5 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 49x113 clip at (11,11) size 47x111
-  RenderListBox {SELECT} at (2,2) size 49x113 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (8,8) size 49x113 clip at (9,9) size 47x111
+  RenderListBox {SELECT} at (0,0) size 49x113 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/mac/fast/forms/select-overflow-scroll-inherited-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-overflow-scroll-inherited-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-layer at (8,8) size 784x132 clip at (8,8) size 769x117
-  RenderBlock {DIV} at (0,0) size 784x132
+layer at (8,8) size 784x128 clip at (8,8) size 769x113
+  RenderBlock {DIV} at (0,0) size 784x128
     RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 49x113 clip at (11,11) size 47x111
-  RenderListBox {SELECT} at (2,2) size 49x113 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (8,8) size 49x113 clip at (9,9) size 47x111
+  RenderListBox {SELECT} at (0,0) size 49x113 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt
@@ -16,118 +16,118 @@ layer at (0,0) size 800x600
             text run at (0,18) width 330: "directionality to match the items in the popup menu"
         RenderText {#text} at (329,18) size 5x18
           text run at (329,18) width 5: "."
-      RenderBlock {DIV} at (0,52) size 784x44
-        RenderBlock {DIV} at (0,0) size 784x22
-          RenderMenuList {SELECT} at (0,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,52) size 784x38
+        RenderBlock {DIV} at (0,0) size 784x19
+          RenderMenuList {SELECT} at (0,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8 RTL: "\x{5D0}"
                 text run at (15,2) width 8: "A"
-          RenderText {#text} at (70,1) size 4x18
-            text run at (70,1) width 4: " "
-          RenderMenuList {SELECT} at (74,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (70,0) size 4x18
+            text run at (70,0) width 4: " "
+          RenderMenuList {SELECT} at (74,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8: "A"
                 text run at (15,2) width 8 RTL: "\x{5D0}"
-          RenderText {#text} at (144,1) size 4x18
-            text run at (144,1) width 4: " "
-          RenderMenuList {SELECT} at (148,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (144,0) size 4x18
+            text run at (144,0) width 4: " "
+          RenderMenuList {SELECT} at (148,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 5: "("
                 text run at (12,2) width 8 RTL: "\x{5D0}"
                 text run at (19,2) width 8: "A"
-          RenderText {#text} at (218,1) size 4x18
-            text run at (218,1) width 4: " "
-          RenderMenuList {SELECT} at (222,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (218,0) size 4x18
+            text run at (218,0) width 4: " "
+          RenderMenuList {SELECT} at (222,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 12: "(A"
                 text run at (19,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {DIV} at (0,22) size 784x22
-          RenderMenuList {SELECT} at (492,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderBlock {DIV} at (0,19) size 784x19
+          RenderMenuList {SELECT} at (492,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8 RTL: "\x{5D0}"
                 text run at (15,2) width 8: "A"
-          RenderText {#text} at (562,1) size 4x18
-            text run at (562,1) width 4: " "
-          RenderMenuList {SELECT} at (566,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (562,0) size 4x18
+            text run at (562,0) width 4: " "
+          RenderMenuList {SELECT} at (566,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8: "A"
                 text run at (15,2) width 8 RTL: "\x{5D0}"
-          RenderText {#text} at (636,1) size 4x18
-            text run at (636,1) width 4: " "
-          RenderMenuList {SELECT} at (640,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (636,0) size 4x18
+            text run at (636,0) width 4: " "
+          RenderMenuList {SELECT} at (640,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 5: "("
                 text run at (12,2) width 8 RTL: "\x{5D0}"
                 text run at (19,2) width 8: "A"
-          RenderText {#text} at (710,1) size 4x18
-            text run at (710,1) width 4: " "
-          RenderMenuList {SELECT} at (714,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (710,0) size 4x18
+            text run at (710,0) width 4: " "
+          RenderMenuList {SELECT} at (714,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 12: "(A"
                 text run at (19,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,96) size 784x44
-        RenderBlock {DIV} at (0,0) size 784x22
-          RenderMenuList {SELECT} at (222,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,90) size 784x38
+        RenderBlock {DIV} at (0,0) size 784x19
+          RenderMenuList {SELECT} at (222,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8: "A"
                 text run at (54,2) width 8 RTL: "\x{5D0}"
-          RenderText {#text} at (218,1) size 4x18
-            text run at (218,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (148,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (218,0) size 4x18
+            text run at (218,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (148,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8 RTL: "\x{5D0}"
                 text run at (54,2) width 8: "A"
-          RenderText {#text} at (144,1) size 4x18
-            text run at (144,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (74,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (144,0) size 4x18
+            text run at (144,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (74,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8: "A"
                 text run at (50,2) width 12 RTL: "(\x{5D0}"
-          RenderText {#text} at (70,1) size 4x18
-            text run at (70,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (0,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (70,0) size 4x18
+            text run at (70,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (0,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8 RTL: "\x{5D0}"
                 text run at (50,2) width 8: "A"
                 text run at (57,2) width 5 RTL: "("
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {DIV} at (0,22) size 784x22
-          RenderMenuList {SELECT} at (714,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderBlock {DIV} at (0,19) size 784x19
+          RenderMenuList {SELECT} at (714,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8: "A"
                 text run at (54,2) width 8 RTL: "\x{5D0}"
-          RenderText {#text} at (710,1) size 4x18
-            text run at (710,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (640,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (710,0) size 4x18
+            text run at (710,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (640,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8 RTL: "\x{5D0}"
                 text run at (54,2) width 8: "A"
-          RenderText {#text} at (636,1) size 4x18
-            text run at (636,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (566,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (636,0) size 4x18
+            text run at (636,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (566,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8: "A"
                 text run at (50,2) width 12 RTL: "(\x{5D0}"
-          RenderText {#text} at (562,1) size 4x18
-            text run at (562,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (492,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderText {#text} at (562,0) size 4x18
+            text run at (562,0) width 4 RTL: " "
+          RenderMenuList {SELECT} at (492,1) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8 RTL: "\x{5D0}"

--- a/LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt
@@ -1,9 +1,9 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x38
-  RenderBlock {HTML} at (0,0) size 800x38
-    RenderBody {BODY} at (8,8) size 784x22
-      RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+layer at (0,0) size 800x35
+  RenderBlock {HTML} at (0,0) size 800x35
+    RenderBody {BODY} at (8,8) size 784x19
+      RenderMenuList {SELECT} at (0,1) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 36x18
           RenderText at (8,2) size 0x13
             text run at (8,2) width 0: " "

--- a/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {FORM} at (0,0) size 784x22
-        RenderButton {INPUT} at (2,2) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock {FORM} at (0,0) size 784x18
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "form"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,38) size 784x36
+      RenderBlock {DIV} at (0,34) size 784x36
         RenderText {#text} at (0,0) size 778x36
           text run at (0,0) width 294: "This tests Targetted frame submission works. "
           text run at (293,0) width 485: "If the test is successful, the text \"SUCCESS\" should be shown in the iframe"
           text run at (0,18) width 43: "below."
-      RenderBlock (anonymous) at (0,74) size 784x154
+      RenderBlock (anonymous) at (0,70) size 784x154
         RenderIFrame {IFRAME} at (0,0) size 304x154 [border: (2px inset #000000)]
           layer at (0,0) size 300x150
             RenderView at (0,0) size 300x150

--- a/LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x1207
+layer at (0,0) size 785x1199
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1207
-  RenderBlock {HTML} at (0,0) size 785x1208
-    RenderBody {BODY} at (8,8) size 769x1184
+layer at (0,0) size 785x1199
+  RenderBlock {HTML} at (0,0) size 785x1200
+    RenderBody {BODY} at (8,8) size 769x1176
       RenderBlock (anonymous) at (0,0) size 769x18
         RenderText {#text} at (0,0) size 277x18
           text run at (0,0) width 277: "line-height settings not reflected in textarea"
@@ -30,28 +30,28 @@ layer at (0,0) size 785x1207
         RenderText {#text} at (1,19) size 400x69
           text run at (1,19) width 400: "Demo text here that wraps a bit and should demonstrate the"
           text run at (1,72) width 154: "goodness of line-height"
-      RenderBlock (anonymous) at (0,767) size 769x417
+      RenderBlock (anonymous) at (0,767) size 769x409
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
         RenderText {#text} at (0,36) size 125x18
           text run at (0,36) width 125: "Un-Styled Textarea"
         RenderBR {BR} at (124,36) size 1x18
-        RenderText {#text} at (165,76) size 4x18
-          text run at (165,76) width 4: " "
+        RenderText {#text} at (161,72) size 4x18
+          text run at (161,72) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderBR {BR} at (0,94) size 0x18
-        RenderText {#text} at (0,112) size 216x18
-          text run at (0,112) width 216: "Totally Blank Un-Styled Textarea"
-        RenderBR {BR} at (215,112) size 1x18
-        RenderText {#text} at (165,152) size 4x18
-          text run at (165,152) width 4: " "
+        RenderBR {BR} at (0,90) size 0x18
+        RenderText {#text} at (0,108) size 216x18
+          text run at (0,108) width 216: "Totally Blank Un-Styled Textarea"
+        RenderBR {BR} at (215,108) size 1x18
+        RenderText {#text} at (161,144) size 4x18
+          text run at (161,144) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderBR {BR} at (0,170) size 0x18
-        RenderText {#text} at (0,188) size 212x18
-          text run at (0,188) width 212: "Totally Blank STYLED Textarea"
-        RenderBR {BR} at (211,188) size 1x18
+        RenderBR {BR} at (0,162) size 0x18
+        RenderText {#text} at (0,180) size 212x18
+          text run at (0,180) width 212: "Totally Blank STYLED Textarea"
+        RenderBR {BR} at (211,180) size 1x18
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,1199) size 769x0
+      RenderBlock {P} at (0,1191) size 769x0
 layer at (8,60) size 406x206 clip at (9,61) size 404x204
   RenderTextControl {TEXTAREA} at (0,18) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x106
@@ -59,8 +59,8 @@ layer at (8,60) size 406x206 clip at (9,61) size 404x204
         text run at (0,18) width 400: "Demo text here that wraps a bit and should demonstrate the"
         text run at (399,18) width 1: " "
         text run at (0,71) width 154: "goodness of line-height"
-layer at (10,831) size 161x32 clip at (11,832) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (2,56) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,829) size 161x32 clip at (9,830) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (0,54) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 140x52
         text run at (0,0) width 139: "Demo text here that wraps"
@@ -70,9 +70,9 @@ layer at (10,831) size 161x32 clip at (11,832) size 144x30 scrollHeight 56
         text run at (0,26) width 87: "demonstrate the"
         text run at (86,26) width 4: " "
         text run at (0,39) width 125: "goodness of line-height"
-layer at (10,907) size 161x32 clip at (11,908) size 159x30
-  RenderTextControl {TEXTAREA} at (2,132) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,901) size 161x32 clip at (9,902) size 159x30
+  RenderTextControl {TEXTAREA} at (0,126) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
-layer at (8,981) size 406x206 clip at (9,982) size 404x204
-  RenderTextControl {TEXTAREA} at (0,206) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
+layer at (8,973) size 406x206 clip at (9,974) size 404x204
+  RenderTextControl {TEXTAREA} at (0,198) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x53

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 390x18
           text run at (0,0) width 390: "Focus field with a placeholder, then type, then delete all text."
-      RenderBlock {DIV} at (0,34) size 784x36
+      RenderBlock {DIV} at (0,34) size 784x32
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,44) size 161x32 clip at (11,45) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,42) size 161x32 clip at (9,43) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderBR {BR} at (0,0) size 0x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]

--- a/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 397x18
           text run at (0,0) width 397: "Focus field with a placeholder, then type, then clear the value."
-      RenderBlock {DIV} at (0,34) size 784x36
+      RenderBlock {DIV} at (0,34) size 784x32
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,44) size 161x32 clip at (11,45) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,42) size 161x32 clip at (9,43) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
     RenderBlock {DIV} at (3,3) size 155x13 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 62x13

--- a/LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt
@@ -7,8 +7,8 @@ layer at (0,0) size 800x600
         text run at (0,0) width 448: "This tests that a scrollbar will appear when text overflows the textarea"
       RenderBR {BR} at (447,0) size 1x18
       RenderText {#text} at (0,0) size 0x0
-layer at (10,28) size 161x84 clip at (11,29) size 144x82 scrollHeight 121
-  RenderTextControl {TEXTAREA} at (2,20) size 161x84 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,26) size 161x84 clip at (9,27) size 144x82 scrollHeight 121
+  RenderTextControl {TEXTAREA} at (0,18) size 161x84 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x117
       RenderText {#text} at (0,0) size 8x52
         text run at (0,0) width 6: "1"

--- a/LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 161x32 clip at (11,11) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 161x32 clip at (9,9) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 63x13
         text run at (0,0) width 63: "Test Passed"

--- a/LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt
+++ b/LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 476x18
           text run at (0,0) width 476: "This test passes if the resize corner icon appears high-resolution in HiDPI."
-      RenderBlock (anonymous) at (0,18) size 784x36
+      RenderBlock (anonymous) at (0,18) size 784x32
         RenderText {#text} at (0,0) size 0x0
-layer at (10,28) size 161x32 clip at (11,29) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,26) size 161x32 clip at (9,27) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13

--- a/LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt
@@ -17,8 +17,8 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details3"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,18) size 784x22
-        RenderButton {INPUT} at (2,2) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock (anonymous) at (0,18) size 784x18
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "click"

--- a/LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt
@@ -19,8 +19,8 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details2"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,36) size 784x22
-        RenderButton {INPUT} at (2,2) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock (anonymous) at (0,36) size 784x18
+        RenderButton {INPUT} at (0,0) size 41x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 25x13
             RenderText at (0,0) size 25x13
               text run at (0,0) width 25: "click"

--- a/LayoutTests/platform/mac/fast/invalid/014-expected.txt
+++ b/LayoutTests/platform/mac/fast/invalid/014-expected.txt
@@ -8,17 +8,17 @@ layer at (0,0) size 800x600
           text run at (0,0) width 289: "Random tests of some bizarre combinations. "
           text run at (288,0) width 324: "H2 should allow a form inside it, but p should not."
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {FORM} at (0,18) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {FORM} at (0,18) size 784x18
+        RenderMenuList {SELECT} at (0,0) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 39x18
             RenderText at (8,2) size 8x13
               text run at (8,2) width 8: "A"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,56) size 784x0
-layer at (470,46) size 47x50
-  RenderBlock (positioned) {H2} at (470,45) size 47x51 [border: (2px solid #008000)]
-    RenderBlock {FORM} at (2,2) size 43x22
-      RenderMenuList {SELECT} at (2,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,52) size 784x0
+layer at (470,46) size 43x46
+  RenderBlock (positioned) {H2} at (470,45) size 43x47 [border: (2px solid #008000)]
+    RenderBlock {FORM} at (2,2) size 39x18
+      RenderMenuList {SELECT} at (0,0) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 39x18
           RenderText at (8,2) size 8x13
             text run at (8,2) width 8: "A"

--- a/LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 785x600
       RenderBlock (anonymous) at (0,0) size 769x18
         RenderText {#text} at (0,0) size 317x18
           text run at (0,0) width 317: "The body should always have a vertical scrollbar."
-      RenderBlock (anonymous) at (0,218) size 769x55
-        RenderText {#text} at (165,37) size 4x18
-          text run at (165,37) width 4: " "
+      RenderBlock (anonymous) at (0,218) size 769x51
+        RenderText {#text} at (161,33) size 4x18
+          text run at (161,33) width 4: " "
         RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 300x100 clip at (8,26) size 285x100 scrollHeight 324
   RenderBlock {DIV} at (0,18) size 300x100
@@ -72,13 +72,13 @@ layer at (8,126) size 300x100 clip at (8,126) size 300x85 scrollWidth 1208
       text run at (0,0) width 496: "X scroll X scroll X scroll X scroll X scroll X scroll X scroll X scroll X scroll "
       text run at (495,0) width 332: "X scroll X scroll X scroll X scroll X scroll X scroll "
       text run at (826,0) width 383: "X scroll X scroll X scroll X scroll X scroll X scroll X scroll"
-layer at (10,243) size 161x32 clip at (11,244) size 144x30
-  RenderTextControl {TEXTAREA} at (2,17) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,241) size 161x32 clip at (9,242) size 144x30
+  RenderTextControl {TEXTAREA} at (0,15) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x13
       RenderText {#text} at (0,0) size 88x13
         text run at (0,0) width 88: "Textarea y-scroll"
-layer at (179,228) size 161x47 clip at (180,229) size 159x30
-  RenderTextControl {TEXTAREA} at (171,2) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (173,226) size 161x47 clip at (174,227) size 159x30
+  RenderTextControl {TEXTAREA} at (165,0) size 161x47 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 88x13
         text run at (0,0) width 88: "Textarea x-scroll"

--- a/LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-layer at (0,42) size 800x558 clip at (0,42) size 785x558 scrollY 282 scrollHeight 840
+layer at (0,42) size 800x558 clip at (0,42) size 785x558 scrollY 278 scrollHeight 836
   RenderBlock (positioned) {DIV} at (0,42) size 800x558
-layer at (0,-240) size 570x840 backgroundClip at (0,42) size 785x558 clip at (0,42) size 785x558
-  RenderBlock (positioned) {DIV} at (0,0) size 571x840
+layer at (0,-236) size 570x836 backgroundClip at (0,42) size 785x558 clip at (0,42) size 785x558
+  RenderBlock (positioned) {DIV} at (0,0) size 571x836
     RenderBlock (anonymous) at (0,0) size 571x18
       RenderText {#text} at (0,0) size 571x18
         text run at (0,0) width 571: "This tests that we can scroll to reveal something in a nested positioned block in overflow."
     RenderBlock {DIV} at (0,18) size 571x800
-    RenderBlock (anonymous) at (0,818) size 571x22
-      RenderButton {INPUT} at (2,2) size 201x18 [color=#000000D8] [bgcolor=#C0C0C0]
+    RenderBlock (anonymous) at (0,818) size 571x18
+      RenderButton {INPUT} at (0,0) size 201x18 [color=#000000D8] [bgcolor=#C0C0C0]
         RenderBlock (anonymous) at (8,2) size 185x13
           RenderText at (0,0) size 185x13
             text run at (0,0) width 185: "If you can see this, test has passed"

--- a/LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt
@@ -22,20 +22,20 @@ layer at (0,0) size 785x1188
                   text run at (0,0) width 89: "overflow:auto"
               RenderBlock {DIV} at (0,18) size 285x600
               RenderBlock {DIV} at (0,768) size 285x500
-          layer at (8,83) size 150x150 clip at (8,83) size 135x150 scrollY 472 scrollHeight 858
+          layer at (8,83) size 150x150 clip at (8,83) size 135x150 scrollY 470 scrollHeight 854
             RenderBlock {DIV} at (0,618) size 150x150
               RenderBlock (anonymous) at (0,0) size 135x18
                 RenderText {#text} at (0,0) size 89x18
                   text run at (0,0) width 89: "overflow:auto"
               RenderBlock {DIV} at (0,18) size 135x500
-              RenderBlock (anonymous) at (0,518) size 135x40
+              RenderBlock (anonymous) at (0,518) size 135x36
                 RenderBR {BR} at (0,0) size 0x18
-                RenderButton {INPUT} at (2,20) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                RenderButton {INPUT} at (0,18) size 51x18 [color=#000000D8] [bgcolor=#C0C0C0]
                   RenderBlock (anonymous) at (8,2) size 35x13
                     RenderText at (0,0) size 35x13
                       text run at (0,0) width 35: "Button"
                 RenderText {#text} at (0,0) size 0x0
-              RenderBlock {DIV} at (0,558) size 135x300
+              RenderBlock {DIV} at (0,554) size 135x300
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,672) size 769x500
 scrolled to 0,4

--- a/LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (165,22) size 255x18
-        text run at (165,22) width 255: " --> This should be outside the textarea."
-layer at (10,10) size 161x32 clip at (11,11) size 159x30
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderText {#text} at (161,18) size 255x18
+        text run at (161,18) width 255: " --> This should be outside the textarea."
+layer at (8,8) size 161x32 clip at (9,9) size 159x30
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 155x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "<!--"

--- a/LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (165,22) size 252x18
-        text run at (165,22) width 252: " This should not be part of the textarea."
-layer at (10,10) size 161x32 clip at (11,11) size 144x30 scrollHeight 56
-  RenderTextControl {TEXTAREA} at (2,2) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderText {#text} at (161,18) size 252x18
+        text run at (161,18) width 252: " This should not be part of the textarea."
+layer at (8,8) size 161x32 clip at (9,9) size 144x30 scrollHeight 56
+  RenderTextControl {TEXTAREA} at (0,0) size 161x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 140x52
       RenderText {#text} at (0,0) size 139x39
         text run at (0,0) width 21: "<!--"

--- a/LayoutTests/platform/mac/fast/repaint/select-option-background-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/select-option-background-color-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
         RenderInline {A} at (0,0) size 310x18 [color=#0000EE]
           RenderText {#text} at (226,0) size 310x18
             text run at (226,0) width 310: "https://bugs.webkit.org/show_bug.cgi?id=49790"
-      RenderBlock (anonymous) at (0,34) size 800x61
-        RenderListBox {SELECT} at (2,2) size 25x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,34) size 800x57
+        RenderListBox {SELECT} at (0,0) size 25x57 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 5x66
-        RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,0) size 5x54
+        RenderMenuList {SELECT} at (0,0) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "
-        RenderMenuList {SELECT} at (2,24) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,18) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "
-        RenderMenuList {SELECT} at (2,46) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,36) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt
@@ -6,48 +6,48 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 315x18
           text run at (0,0) width 315: "The following sets of buttons should not overlap."
-      RenderTable {TABLE} at (0,18) size 784x26
-        RenderTableSection {TBODY} at (0,0) size 784x26
-          RenderTableRow {TR} at (0,1) size 784x24
-            RenderTableCell {TD} at (1,1) size 66x24 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderTable {TABLE} at (0,18) size 784x22
+        RenderTableSection {TBODY} at (0,0) size 784x22
+          RenderTableRow {TR} at (0,1) size 784x20
+            RenderTableCell {TD} at (1,1) size 66x20 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 48x13
                   RenderText at (0,0) size 48x13
                     text run at (0,0) width 48: "New Mail"
-            RenderTableCell {TD} at (67,1) size 48x24 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (67,1) size 48x20 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 30x13
                   RenderText at (0,0) size 30x13
                     text run at (0,0) width 30: "Reply"
-            RenderTableCell {TD} at (115,1) size 65x24 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (115,1) size 65x20 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 46x13
                   RenderText at (0,0) size 46x13
                     text run at (0,0) width 46: "Reply All"
-            RenderTableCell {TD} at (180,3) size 603x20 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (180,1) size 603x20 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x18
                 text run at (1,1) width 4: " "
-      RenderBlock (anonymous) at (0,44) size 784x36
+      RenderBlock (anonymous) at (0,40) size 784x36
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
-      RenderTable {TABLE} at (0,80) size 784x26
-        RenderTableSection {TBODY} at (0,0) size 784x26
-          RenderTableRow {TR} at (0,1) size 784x24
-            RenderTableCell {TD} at (1,1) size 66x24 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderTable {TABLE} at (0,76) size 784x22
+        RenderTableSection {TBODY} at (0,0) size 784x22
+          RenderTableRow {TR} at (0,1) size 784x20
+            RenderTableCell {TD} at (1,1) size 66x20 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 64x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 48x13
                   RenderText at (0,0) size 48x13
                     text run at (0,0) width 48: "New Mail"
-            RenderTableCell {TD} at (67,1) size 48x24 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (67,1) size 48x20 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 30x13
                   RenderText at (0,0) size 30x13
                     text run at (0,0) width 30: "Reply"
-            RenderTableCell {TD} at (115,1) size 65x24 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (115,1) size 65x20 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 62x18 [color=#000000D8] [bgcolor=#C0C0C0]
                 RenderBlock (anonymous) at (8,2) size 46x13
                   RenderText at (0,0) size 46x13
                     text run at (0,0) width 46: "Reply All"
-            RenderTableCell {TD} at (180,3) size 603x20 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (180,1) size 603x20 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x18
                 text run at (1,1) width 4: " "

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 291x18
           text run at (0,0) width 291: "The popup buttons below should not overlap."
-      RenderTable {TABLE} at (0,18) size 784x26
-        RenderTableSection {TBODY} at (0,0) size 784x26
-          RenderTableRow {TR} at (0,1) size 784x24
-            RenderTableCell {TD} at (1,1) size 2x24 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (0,18) size 784x22
+        RenderTableSection {TBODY} at (0,0) size 784x22
+          RenderTableRow {TR} at (0,1) size 784x20
+            RenderTableCell {TD} at (1,1) size 2x20 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 20x13
                     text run at (8,2) width 20: "one"
-            RenderTableCell {TD} at (4,1) size 2x24 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderTableCell {TD} at (4,1) size 2x20 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 19x13
                     text run at (8,2) width 19: "two"
-            RenderTableCell {TD} at (7,1) size 2x24 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderTableCell {TD} at (7,1) size 2x20 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 28x13
                     text run at (8,2) width 28: "three"
-            RenderTableCell {TD} at (10,3) size 773x20 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (10,1) size 773x20 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x18
                 text run at (1,1) width 4: " "

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt
@@ -6,43 +6,43 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 256x18
           text run at (0,0) width 256: "The textareas below should not overlap."
-      RenderTable {TABLE} at (0,18) size 784x40
-        RenderTableSection {TBODY} at (0,0) size 784x40
-          RenderTableRow {TR} at (0,1) size 784x38
-            RenderTableCell {TD} at (1,1) size 8x38 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (10,1) size 8x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (19,1) size 8x38 [r=0 c=2 rs=1 cs=1]
-            RenderTableCell {TD} at (28,10) size 755x20 [r=0 c=3 rs=1 cs=1]
+      RenderTable {TABLE} at (0,18) size 784x36
+        RenderTableSection {TBODY} at (0,0) size 784x36
+          RenderTableRow {TR} at (0,1) size 784x34
+            RenderTableCell {TD} at (1,1) size 8x34 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (10,1) size 8x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (19,1) size 8x34 [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (28,8) size 755x20 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x18
                 text run at (1,1) width 4: " "
-      RenderBlock (anonymous) at (0,58) size 784x36
+      RenderBlock (anonymous) at (0,54) size 784x36
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
-      RenderTable {TABLE} at (0,94) size 784x40
-        RenderTableSection {TBODY} at (0,0) size 784x40
-          RenderTableRow {TR} at (0,1) size 784x38
-            RenderTableCell {TD} at (1,1) size 8x38 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (10,1) size 8x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (19,1) size 8x38 [r=0 c=2 rs=1 cs=1]
-            RenderTableCell {TD} at (28,10) size 755x20 [r=0 c=3 rs=1 cs=1]
+      RenderTable {TABLE} at (0,90) size 784x36
+        RenderTableSection {TBODY} at (0,0) size 784x36
+          RenderTableRow {TR} at (0,1) size 784x34
+            RenderTableCell {TD} at (1,1) size 8x34 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (10,1) size 8x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (19,1) size 8x34 [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (28,8) size 755x20 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x18
                 text run at (1,1) width 4: " "
-layer at (10,30) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (10,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 43
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 7x39
         text run at (0,0) width 7: "o"
         text run at (0,13) width 7: "n"
         text run at (0,26) width 7: "e"
-layer at (19,30) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (19,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 9x39
         text run at (0,0) width 5: "t"
         text run at (0,13) width 9: "w"
         text run at (0,26) width 7: "o"
-layer at (28,30) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (28,28) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x65
       RenderText {#text} at (0,0) size 7x65
         text run at (0,0) width 5: "t"
@@ -50,8 +50,8 @@ layer at (28,30) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
         text run at (0,26) width 5: "r"
         text run at (0,39) width 7: "e"
         text run at (0,52) width 7: "e"
-layer at (10,106) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 173
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (10,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 173
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x169
       RenderText {#text} at (0,0) size 9x169
         text run at (0,0) width 7: "o"
@@ -67,15 +67,15 @@ layer at (10,106) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 1
         text run at (0,130) width 5: "r"
         text run at (0,143) width 7: "e"
         text run at (0,156) width 7: "e"
-layer at (19,106) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (19,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 11 scrollHeight 43
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x39
       RenderText {#text} at (0,0) size 9x39
         text run at (0,0) width 5: "t"
         text run at (0,13) width 9: "w"
         text run at (0,26) width 7: "o"
-layer at (28,106) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
-  RenderTextControl {TEXTAREA} at (1,3) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (28,100) size 6x32 clip at (0,0) size 0x0 scrollWidth 9 scrollHeight 69
+  RenderTextControl {TEXTAREA} at (1,1) size 6x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 0x65
       RenderText {#text} at (0,0) size 7x65
         text run at (0,0) width 5: "t"

--- a/LayoutTests/platform/mac/fast/selectors/064-expected.txt
+++ b/LayoutTests/platform/mac/fast/selectors/064-expected.txt
@@ -1,16 +1,16 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x88
-  RenderBlock {HTML} at (0,0) size 800x88
-    RenderBody {BODY} at (8,16) size 784x56
-      RenderBlock {DIV} at (0,0) size 784x56
+layer at (0,0) size 800x85
+  RenderBlock {HTML} at (0,0) size 800x85
+    RenderBody {BODY} at (8,16) size 784x53
+      RenderBlock {DIV} at (0,0) size 784x53
         RenderBlock {P} at (0,0) size 784x18 [color=#00FF00]
           RenderInline {A} at (0,0) size 286x18 [color=#000000]
             RenderText {#text} at (0,0) size 286x18
               text run at (0,0) width 286: "This text should turn green while it is active."
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {P} at (0,34) size 784x22 [color=#00FF00]
-          RenderButton {BUTTON} at (2,2) size 248x18 [color=#000000] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderBlock {P} at (0,34) size 784x19 [color=#00FF00]
+          RenderButton {BUTTON} at (0,1) size 248x18 [color=#000000] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 232x13
               RenderText {#text} at (0,0) size 232x13
                 text run at (0,0) width 232: "This text should turn green while it is active."

--- a/LayoutTests/platform/mac/fast/table/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/003-expected.txt
@@ -46,7 +46,7 @@ layer at (0,0) size 800x600
                 text run at (1,37) width 56: "nowrap. "
                 text run at (56,37) width 7: "I"
                 text run at (1,55) width 88: "really should."
-      RenderTable {TABLE} at (0,349) size 106x78
+      RenderTable {TABLE} at (0,345) size 106x78
         RenderTableSection {TBODY} at (0,0) size 106x78
           RenderTableRow {TR} at (0,2) size 106x74
             RenderTableCell {TD} at (2,2) size 102x74 [r=0 c=0 rs=1 cs=1]
@@ -57,7 +57,7 @@ layer at (0,0) size 800x600
                   text run at (0,36) width 56: "nowrap. "
                   text run at (55,36) width 7: "I"
                   text run at (0,54) width 88: "really should."
-      RenderTable {TABLE} at (0,427) size 373x24
+      RenderTable {TABLE} at (0,423) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]
@@ -65,7 +65,7 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 147: "I should have nowrap. "
                 text run at (147,1) width 101: "I really should. "
                 text run at (247,1) width 121: "Definitely. Should."
-      RenderTable {TABLE} at (0,451) size 373x24
+      RenderTable {TABLE} at (0,447) size 373x24
         RenderTableSection {TBODY} at (0,0) size 373x24
           RenderTableRow {TR} at (0,2) size 373x20
             RenderTableCell {TD} at (2,2) size 369x20 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/fast/table/append-cells2-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/append-cells2-expected.txt
@@ -75,14 +75,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,36) size 91x18 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x18
                 text run at (0,0) width 4: " "
-      RenderBlock (anonymous) at (0,124) size 784x22
-        RenderButton {BUTTON} at (2,2) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,124) size 784x19
+        RenderButton {BUTTON} at (0,1) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 28x13
             RenderText {#text} at (0,0) size 28x13
               text run at (0,0) width 28: "show"
-        RenderText {#text} at (47,1) size 5x18
-          text run at (47,1) width 5: " "
-        RenderButton {BUTTON} at (53,2) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderText {#text} at (43,0) size 5x18
+          text run at (43,0) width 5: " "
+        RenderButton {BUTTON} at (47,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 23x13
             RenderText {#text} at (0,0) size 23x13
               text run at (0,0) width 23: "hide"

--- a/LayoutTests/platform/mac/fast/table/remove-td-display-none-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/remove-td-display-none-expected.txt
@@ -52,14 +52,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (543,0) size 182x18 [bgcolor=#FFA500] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "4"
-      RenderBlock (anonymous) at (0,88) size 784x22
-        RenderButton {BUTTON} at (2,2) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock (anonymous) at (0,88) size 784x19
+        RenderButton {BUTTON} at (0,1) size 44x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 28x13
             RenderText {#text} at (0,0) size 28x13
               text run at (0,0) width 28: "show"
-        RenderText {#text} at (47,1) size 5x18
-          text run at (47,1) width 5: " "
-        RenderButton {BUTTON} at (53,2) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderText {#text} at (43,0) size 5x18
+          text run at (43,0) width 5: " "
+        RenderButton {BUTTON} at (47,1) size 39x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 23x13
             RenderText {#text} at (0,0) size 23x13
               text run at (0,0) width 23: "hide"

--- a/LayoutTests/platform/mac/fast/table/text-field-baseline-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/text-field-baseline-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x419
-  RenderBlock {HTML} at (0,0) size 800x419
-    RenderBody {BODY} at (8,16) size 784x387
+layer at (0,0) size 800x391
+  RenderBlock {HTML} at (0,0) size 800x391
+    RenderBody {BODY} at (8,16) size 784x359
       RenderBlock {P} at (0,0) size 784x36
         RenderText {#text} at (0,0) size 177x18
           text run at (0,0) width 177: "This is a regression test for "

--- a/LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x544
-  RenderBlock {HTML} at (0,0) size 800x544
-    RenderBody {BODY} at (8,16) size 784x520
+layer at (0,0) size 800x514
+  RenderBlock {HTML} at (0,0) size 800x514
+    RenderBody {BODY} at (8,16) size 784x490
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 709x18
           text run at (0,0) width 497: "Verify that the alignment and writing direction of each selected item matches "
           text run at (496,0) width 213: "the one below the pop-up button."
-      RenderBlock {DIV} at (0,34) size 784x242
+      RenderBlock {DIV} at (0,34) size 784x228
         RenderMenuList {SELECT} at (0,0) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (8,2) size 160x16
@@ -61,14 +61,14 @@ layer at (0,0) size 800x544
               text run at (411,2) width 17: "03"
               text run at (427,2) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
               text run at (463,2) width 29: " fifth"
-        RenderBlock {DIV} at (0,23) size 470x36
+        RenderBlock {DIV} at (0,21) size 470x36
           RenderText {#text} at (297,10) size 163x16
             text run at (297,10) width 33: "First "
             text run at (329,10) width 48 RTL: ") \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA}"
             text run at (376,10) width 18: "03"
             text run at (393,10) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (429,10) width 31: " fifth"
-        RenderMenuList {SELECT} at (0,61) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,57) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (332,2) size 160x16
               text run at (332,2) width 25: "fifth"

--- a/LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
@@ -1,20 +1,20 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x316
-  RenderBlock {HTML} at (0,0) size 800x316
-    RenderBody {BODY} at (8,8) size 784x300
-      RenderBlock {DIV} at (0,0) size 784x300
+layer at (0,0) size 800x300
+  RenderBlock {HTML} at (0,0) size 800x300
+    RenderBody {BODY} at (8,8) size 784x284
+      RenderBlock {DIV} at (0,0) size 784x284
         RenderBlock (anonymous) at (0,0) size 784x36
           RenderText {#text} at (0,0) size 777x36
             text run at (0,0) width 777: "In all four cases below, the exclamation mark should be on the left side of the first line and on the right side of the second"
             text run at (0,18) width 28: "line."
-        RenderBlock {DIV} at (0,36) size 784x264
-          RenderBR {BR} at (375,48) size 0x18
-          RenderBR {BR} at (375,114) size 0x18
-          RenderBR {BR} at (375,180) size 0x18
+        RenderBlock {DIV} at (0,36) size 784x248
+          RenderBR {BR} at (371,44) size 0x18
+          RenderBR {BR} at (371,106) size 0x18
+          RenderBR {BR} at (371,168) size 0x18
           RenderText {#text} at (0,0) size 0x0
-layer at (10,46) size 371x58 clip at (11,47) size 369x56
-  RenderTextControl {TEXTAREA} at (2,2) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,44) size 371x58 clip at (9,45) size 369x56
+  RenderTextControl {TEXTAREA} at (0,0) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 365x39
       RenderText {#text} at (336,0) size 365x26
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
@@ -31,8 +31,8 @@ layer at (10,112) size 371x58 clip at (11,113) size 369x56
         text run at (0,13) width 29: "hello!"
         text run at (28,13) width 1: " "
       RenderBR {BR} at (0,26) size 0x13
-layer at (10,178) size 371x58 clip at (11,179) size 369x56
-  RenderTextControl {TEXTAREA} at (2,134) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,168) size 371x58 clip at (9,169) size 369x56
+  RenderTextControl {TEXTAREA} at (0,124) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 365x39
       RenderText {#text} at (336,0) size 365x26
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
@@ -40,8 +40,8 @@ layer at (10,178) size 371x58 clip at (11,179) size 369x56
         text run at (0,13) width 29: "hello!"
         text run at (28,13) width 1: " "
       RenderBR {BR} at (0,26) size 0x13
-layer at (10,244) size 371x58 clip at (11,245) size 369x56
-  RenderTextControl {TEXTAREA} at (2,200) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,230) size 371x58 clip at (9,231) size 369x56
+  RenderTextControl {TEXTAREA} at (0,186) size 371x58 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 365x39
       RenderText {#text} at (336,0) size 365x26
         text run at (336,0) width 29 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"

--- a/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -4,11 +4,11 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderFrameSet {FRAMESET} at (0,0) size 800x600
       RenderFrame {FRAME} at (0,0) size 800x534
-        layer at (0,0) size 785x1554
+        layer at (0,0) size 785x1538
           RenderView at (0,0) size 785x534
-        layer at (0,0) size 785x1554
-          RenderBlock {HTML} at (0,0) size 785x1554
-            RenderBody {BODY} at (8,8) size 769x1514
+        layer at (0,0) size 785x1538
+          RenderBlock {HTML} at (0,0) size 785x1538
+            RenderBody {BODY} at (8,8) size 769x1498
               RenderBlock (anonymous) at (0,0) size 769x259
                 RenderText {#text} at (0,0) size 751x185
                   text run at (0,0) width 679: "This is test page that we navigate to as part of testing"

--- a/LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {xhtml:div} at (0,0) size 580x18
         RenderText {#text} at (0,0) size 81x18
           text run at (0,0) width 81: "This is a test"
-      RenderBlock (anonymous) at (0,18) size 580x40
+      RenderBlock (anonymous) at (0,18) size 580x37
         RenderInline {xhtml:a} at (0,0) size 68x18 [color=#0000EE]
           RenderText {#text} at (0,0) size 68x18
             text run at (0,0) width 68: "and a link."
         RenderBR {xhtml:br} at (67,0) size 1x18
-        RenderButton {xhtml:input} at (2,20) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {xhtml:input} at (0,18) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
         RenderText {#text} at (0,0) size 0x0
     RenderSVGRect {rect} at (9,9) size 582x382 [stroke={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=580.00] [height=380.00]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/45621-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/45621-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x144
-  RenderBlock {HTML} at (0,0) size 800x144
-    RenderBody {BODY} at (8,13) size 784x123
+layer at (0,0) size 800x140
+  RenderBlock {HTML} at (0,0) size 800x140
+    RenderBody {BODY} at (8,13) size 784x119
       RenderBlock {PRE} at (0,0) size 784x45
         RenderText {#text} at (0,0) size 164x45
           text run at (0,0) width 118: "table width=50%"
@@ -11,13 +11,13 @@ layer at (0,0) size 800x144
           text run at (93,15) width 1: " "
           text run at (0,30) width 164: "    input width=100% "
           text run at (163,30) width 1: " "
-      RenderTable {TABLE} at (0,58) size 392x47 [bgcolor=#C0C0C0] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 390x45
-          RenderTableRow {TR} at (0,2) size 390x41
-            RenderTableCell {TD} at (2,2) size 386x41 [bgcolor=#AABBFF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTextControl {INPUT} at (9,11) size 374x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTable {TABLE} at (0,58) size 392x43 [bgcolor=#C0C0C0] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 390x41
+          RenderTableRow {TR} at (0,2) size 390x37
+            RenderTableCell {TD} at (2,2) size 386x37 [bgcolor=#AABBFF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTextControl {INPUT} at (9,9) size 374x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,105) size 784x18
+      RenderBlock (anonymous) at (0,101) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-layer at (23,88) size 368x13
+layer at (23,86) size 368x13
   RenderBlock {DIV} at (3,3) size 368x13

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x138
-        RenderTableSection {TBODY} at (0,0) size 784x138
+      RenderTable {TABLE} at (0,0) size 784x134
+        RenderTableSection {TBODY} at (0,0) size 784x134
           RenderTableRow {TR} at (0,0) size 784x74
             RenderTableCell {TD} at (0,0) size 785x74 [r=0 c=0 rs=1 cs=4]
               RenderBR {BR} at (392,1) size 1x18

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 149x56
-        RenderTableSection {TBODY} at (0,0) size 149x56
-          RenderTableRow {TR} at (0,2) size 149x52
-            RenderTableCell {TD} at (2,2) size 145x52 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (1,1) size 143x0
+      RenderTable {TABLE} at (0,0) size 145x52
+        RenderTableSection {TBODY} at (0,0) size 145x52
+          RenderTableRow {TR} at (0,2) size 145x48
+            RenderTableCell {TD} at (2,2) size 141x48 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (1,1) size 139x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,1) size 143x50
-                RenderTable {TABLE} at (0,0) size 143x50
-                  RenderTableSection {TBODY} at (0,0) size 143x50
-                    RenderTableRow {TR} at (0,2) size 143x46
-                      RenderTableCell {TD} at (2,2) size 139x46 [r=0 c=0 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 137x44
-                          RenderTableSection {TBODY} at (0,0) size 137x44
-                            RenderTableRow {TR} at (0,2) size 137x40
-                              RenderTableCell {TD} at (2,2) size 133x40 [r=0 c=0 rs=1 cs=1]
-                                RenderBlock {FORM} at (1,1) size 131x22
-                                  RenderButton {INPUT} at (2,2) size 127x18 [color=#000000D8] [bgcolor=#C0C0C0]
+              RenderBlock (anonymous) at (1,1) size 139x46
+                RenderTable {TABLE} at (0,0) size 139x46
+                  RenderTableSection {TBODY} at (0,0) size 139x46
+                    RenderTableRow {TR} at (0,2) size 139x42
+                      RenderTableCell {TD} at (2,2) size 135x42 [r=0 c=0 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 133x40
+                          RenderTableSection {TBODY} at (0,0) size 133x40
+                            RenderTableRow {TR} at (0,2) size 133x36
+                              RenderTableCell {TD} at (2,2) size 129x36 [r=0 c=0 rs=1 cs=1]
+                                RenderBlock {FORM} at (1,1) size 127x18
+                                  RenderButton {INPUT} at (0,0) size 127x18 [color=#000000D8] [bgcolor=#C0C0C0]
                                     RenderBlock (anonymous) at (8,2) size 111x13
                                       RenderText at (0,0) size 111x13
                                         text run at (0,0) width 111: "ApplyForThisPosition"
                                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,51) size 143x0
+              RenderBlock (anonymous) at (1,47) size 139x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt
@@ -6,141 +6,141 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 287x18
           text run at (0,0) width 287: "border=\"0\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,18) size 784x36 [bgcolor=#DDDD33]
-        RenderTableSection {TBODY} at (0,0) size 784x36
-          RenderTableRow {TR} at (0,0) size 784x36
-            RenderTableCell {TD} at (0,18) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 760x36 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (772,18) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,54) size 784x18
+      RenderTable {TABLE} at (0,18) size 784x32 [bgcolor=#DDDD33]
+        RenderTableSection {TBODY} at (0,0) size 784x32
+          RenderTableRow {TR} at (0,0) size 784x32
+            RenderTableCell {TD} at (0,16) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x32 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,16) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,50) size 784x18
         RenderText {#text} at (0,0) size 211x18
           text run at (0,0) width 211: "cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,72) size 784x36 [bgcolor=#CCCCFF]
-        RenderTableSection {TBODY} at (0,0) size 784x36
-          RenderTableRow {TR} at (0,0) size 784x36
-            RenderTableCell {TD} at (0,18) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 760x36 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (772,18) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,108) size 784x18
+      RenderTable {TABLE} at (0,68) size 784x32 [bgcolor=#CCCCFF]
+        RenderTableSection {TBODY} at (0,0) size 784x32
+          RenderTableRow {TR} at (0,0) size 784x32
+            RenderTableCell {TD} at (0,16) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x32 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,16) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,100) size 784x18
         RenderText {#text} at (0,0) size 105x18
           text run at (0,0) width 105: "cellpadding=\"0\""
-      RenderTable {TABLE} at (0,126) size 784x40 [bgcolor=#FF9999]
-        RenderTableSection {TBODY} at (0,0) size 784x40
-          RenderTableRow {TR} at (0,2) size 784x36
-            RenderTableCell {TD} at (2,20) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 752x36 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (770,20) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,166) size 784x18
+      RenderTable {TABLE} at (0,118) size 784x36 [bgcolor=#FF9999]
+        RenderTableSection {TBODY} at (0,0) size 784x36
+          RenderTableRow {TR} at (0,2) size 784x32
+            RenderTableCell {TD} at (2,18) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x32 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,18) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,154) size 784x18
         RenderText {#text} at (0,0) size 181x18
           text run at (0,0) width 181: "border=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,184) size 784x40 [bgcolor=#AAEEBB]
-        RenderTableSection {TBODY} at (0,0) size 784x40
-          RenderTableRow {TR} at (0,2) size 784x36
-            RenderTableCell {TD} at (2,20) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 752x36 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (770,20) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,224) size 784x18
+      RenderTable {TABLE} at (0,172) size 784x36 [bgcolor=#AAEEBB]
+        RenderTableSection {TBODY} at (0,0) size 784x36
+          RenderTableRow {TR} at (0,2) size 784x32
+            RenderTableCell {TD} at (2,18) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x32 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,18) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,208) size 784x18
         RenderInline {FONT} at (0,0) size 31x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 31x18
             text run at (0,0) width 31: "right"
         RenderText {#text} at (30,0) size 77x18
           text run at (30,0) width 77: " border=\"0\""
-      RenderTable {TABLE} at (0,242) size 784x42 [bgcolor=#FFCCEE]
-        RenderTableSection {TBODY} at (0,0) size 784x42
-          RenderTableRow {TR} at (0,2) size 784x38
-            RenderTableCell {TD} at (2,20) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 748x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,20) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,284) size 784x18
+      RenderTable {TABLE} at (0,226) size 784x38 [bgcolor=#FFCCEE]
+        RenderTableSection {TBODY} at (0,0) size 784x38
+          RenderTableRow {TR} at (0,2) size 784x34
+            RenderTableCell {TD} at (2,18) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,18) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,264) size 784x18
         RenderInline {FONT} at (0,0) size 31x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 31x18
             text run at (0,0) width 31: "right"
         RenderText {#text} at (30,0) size 109x18
           text run at (30,0) width 109: " cellpadding=\"1\""
-      RenderTable {TABLE} at (0,302) size 784x42 [bgcolor=#66DDFF]
-        RenderTableSection {TBODY} at (0,0) size 784x42
-          RenderTableRow {TR} at (0,2) size 784x38
-            RenderTableCell {TD} at (2,20) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 748x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,20) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,344) size 784x18
+      RenderTable {TABLE} at (0,282) size 784x38 [bgcolor=#66DDFF]
+        RenderTableSection {TBODY} at (0,0) size 784x38
+          RenderTableRow {TR} at (0,2) size 784x34
+            RenderTableCell {TD} at (2,18) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,18) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,320) size 784x18
         RenderInline {FONT} at (0,0) size 31x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 31x18
             text run at (0,0) width 31: "right"
         RenderText {#text} at (30,0) size 291x18
           text run at (30,0) width 291: " border=\"1\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,362) size 784x40 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x38
-          RenderTableRow {TR} at (0,0) size 782x38
-            RenderTableCell {TD} at (0,18) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (14,0) size 754x38 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,18) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,402) size 784x18
+      RenderTable {TABLE} at (0,338) size 784x36 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x34
+          RenderTableRow {TR} at (0,0) size 782x34
+            RenderTableCell {TD} at (0,16) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (14,0) size 754x34 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,16) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,374) size 784x18
         RenderInline {FONT} at (0,0) size 31x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 31x18
             text run at (0,0) width 31: "right"
         RenderText {#text} at (30,0) size 183x18
           text run at (30,0) width 183: " border=\"1\" cellspacing=\"0\""
-      RenderTable {TABLE} at (0,420) size 784x42 [bgcolor=#FFCC66] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x40
-          RenderTableRow {TR} at (0,0) size 782x40
-            RenderTableCell {TD} at (0,18) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,0) size 750x40 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (766,18) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,462) size 784x18
+      RenderTable {TABLE} at (0,392) size 784x38 [bgcolor=#FFCC66] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x36
+          RenderTableRow {TR} at (0,0) size 782x36
+            RenderTableCell {TD} at (0,16) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,0) size 750x36 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (766,16) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,430) size 784x18
         RenderInline {FONT} at (0,0) size 31x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 31x18
             text run at (0,0) width 31: "right"
         RenderText {#text} at (30,0) size 77x18
           text run at (30,0) width 77: " border=\"1\""
-      RenderTable {TABLE} at (0,480) size 784x46 [bgcolor=#CCFF33] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x44
-          RenderTableRow {TR} at (0,2) size 782x40
-            RenderTableCell {TD} at (2,20) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (20,2) size 742x40 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (764,20) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-layer at (20,28) size 760x32 clip at (21,29) size 758x30
-  RenderTextControl {TEXTAREA} at (0,2) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderTable {TABLE} at (0,448) size 784x42 [bgcolor=#CCFF33] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x40
+          RenderTableRow {TR} at (0,2) size 782x36
+            RenderTableCell {TD} at (2,18) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (20,2) size 742x36 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (764,18) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+layer at (20,26) size 760x32 clip at (21,27) size 758x30
+  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 754x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (20,82) size 760x32 clip at (21,83) size 758x30
-  RenderTextControl {TEXTAREA} at (0,2) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (20,76) size 760x32 clip at (21,77) size 758x30
+  RenderTextControl {TEXTAREA} at (0,0) size 760x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 754x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (24,138) size 752x32 clip at (25,139) size 750x30
-  RenderTextControl {TEXTAREA} at (0,2) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,128) size 752x32 clip at (25,129) size 750x30
+  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (24,196) size 752x32 clip at (25,197) size 750x30
-  RenderTextControl {TEXTAREA} at (0,2) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,182) size 752x32 clip at (25,183) size 750x30
+  RenderTextControl {TEXTAREA} at (0,0) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (27,255) size 746x32 clip at (28,256) size 744x30
-  RenderTextControl {TEXTAREA} at (1,3) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,237) size 746x32 clip at (28,238) size 744x30
+  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (27,315) size 746x32 clip at (28,316) size 744x30
-  RenderTextControl {TEXTAREA} at (1,3) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,293) size 746x32 clip at (28,294) size 744x30
+  RenderTextControl {TEXTAREA} at (1,1) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (24,374) size 752x32 clip at (25,375) size 750x30
-  RenderTextControl {TEXTAREA} at (1,3) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,348) size 752x32 clip at (25,349) size 750x30
+  RenderTextControl {TEXTAREA} at (1,1) size 752x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 746x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (27,433) size 746x32 clip at (28,434) size 744x30
-  RenderTextControl {TEXTAREA} at (2,4) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,403) size 746x32 clip at (28,404) size 744x30
+  RenderTextControl {TEXTAREA} at (2,2) size 746x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 740x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"
-layer at (31,495) size 738x32 clip at (32,496) size 736x30
-  RenderTextControl {TEXTAREA} at (2,4) size 738x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (31,461) size 738x32 clip at (32,462) size 736x30
+  RenderTextControl {TEXTAREA} at (2,2) size 738x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 732x13
       RenderText {#text} at (0,0) size 21x13
         text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x685
+layer at (0,0) size 785x678
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x685
-  RenderBlock {HTML} at (0,0) size 785x685
-    RenderBody {BODY} at (8,21) size 769x648
+layer at (0,0) size 785x678
+  RenderBlock {HTML} at (0,0) size 785x678
+    RenderBody {BODY} at (8,21) size 769x641
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 311x37
           text run at (0,0) width 311: "Generic Table Tests - 1"
@@ -91,7 +91,7 @@ layer at (0,0) size 785x685
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (135,0) size 5x18
           text run at (135,0) width 5: "."
-      RenderBlock {P} at (0,561) size 769x19
+      RenderBlock {P} at (0,554) size 769x19
         RenderText {#text} at (0,0) size 64x18
           text run at (0,0) width 64: "Up to the "
         RenderInline {A} at (0,0) size 99x18 [color=#0000EE]
@@ -99,7 +99,7 @@ layer at (0,0) size 785x685
             text run at (63,0) width 99: "Evil Tests Page"
         RenderText {#text} at (161,0) size 5x18
           text run at (161,0) width 5: "."
-      RenderBlock {P} at (0,595) size 769x19
+      RenderBlock {P} at (0,588) size 769x19
         RenderText {#text} at (0,0) size 177x18
           text run at (0,0) width 177: "This page is maintained by "
         RenderInline {A} at (0,0) size 79x18 [color=#0000EE]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2589
+layer at (0,0) size 785x2582
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2589
-  RenderBlock {HTML} at (0,0) size 785x2590
-    RenderBody {BODY} at (8,21) size 769x2553 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x2582
+  RenderBlock {HTML} at (0,0) size 785x2583
+    RenderBody {BODY} at (8,21) size 769x2546 [bgcolor=#FFFFFF]
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 361x37
           text run at (0,0) width 361: "Table Inheritance Tests - 1"
@@ -209,7 +209,7 @@ layer at (0,0) size 785x2589
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (135,0) size 5x18
           text run at (135,0) width 5: "."
-      RenderBlock {P} at (0,2431) size 769x19
+      RenderBlock {P} at (0,2424) size 769x19
         RenderText {#text} at (0,0) size 64x18
           text run at (0,0) width 64: "Up to the "
         RenderInline {A} at (0,0) size 99x18 [color=#0000EE]
@@ -217,13 +217,13 @@ layer at (0,0) size 785x2589
             text run at (63,0) width 99: "Evil Tests Page"
         RenderText {#text} at (161,0) size 5x18
           text run at (161,0) width 5: "."
-      RenderBlock {P} at (0,2465) size 769x19
+      RenderBlock {P} at (0,2458) size 769x19
         RenderText {#text} at (0,0) size 63x18
           text run at (0,0) width 63: "Bugzilla: "
         RenderInline {A} at (0,0) size 64x18 [color=#0000EE]
           RenderText {#text} at (62,0) size 64x18
             text run at (62,0) width 64: "Bug 1044"
-      RenderBlock {P} at (0,2499) size 769x19
+      RenderBlock {P} at (0,2492) size 769x19
         RenderText {#text} at (0,0) size 177x18
           text run at (0,0) width 177: "This page is maintained by "
         RenderInline {A} at (0,0) size 79x18 [color=#0000EE]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (192,0) size 400x48 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x46
-          RenderTableRow {TR} at (0,2) size 398x42
-            RenderTableCell {TD} at (2,2) size 394x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x22
-                RenderMenuList {SELECT} at (2,2) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (192,0) size 400x44 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x42
+          RenderTableRow {TR} at (0,2) size 398x38
+            RenderTableCell {TD} at (2,2) size 394x38 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x18
+                RenderMenuList {SELECT} at (0,0) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 54x18
                     RenderText at (8,2) size 23x13
                       text run at (8,2) width 23: "Test"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt
@@ -3,24 +3,24 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 439x82 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 437x80
-          RenderTableRow {TR} at (0,2) size 437x52
-            RenderTableCell {TD} at (2,17) size 141x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 439x78 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 437x76
+          RenderTableRow {TR} at (0,2) size 437x48
+            RenderTableCell {TD} at (2,15) size 146x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18
                 text run at (2,2) width 31: "Blah"
-            RenderTableCell {TD} at (144,2) size 291x52 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (111,2) size 68x48 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 65x46
-                  RenderTableRow {TR} at (0,2) size 65x42
-                    RenderTableCell {TD} at (2,2) size 61x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                      RenderBlock {FORM} at (2,2) size 57x22
-                        RenderButton {INPUT} at (2,2) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderTableCell {TD} at (149,2) size 286x48 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (111,2) size 63x44 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 61x42
+                  RenderTableRow {TR} at (0,2) size 61x38
+                    RenderTableCell {TD} at (2,2) size 57x38 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                      RenderBlock {FORM} at (2,2) size 53x18
+                        RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
                           RenderBlock (anonymous) at (8,2) size 37x13
                             RenderText at (0,0) size 37x13
                               text run at (0,0) width 37: "Submit"
                         RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,56) size 437x22
-            RenderTableCell {TD} at (2,56) size 433x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,52) size 437x22
+            RenderTableCell {TD} at (2,52) size 433x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 429x18
                 text run at (2,2) width 429: "This line is only here to separate the two columns in the row above"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt
@@ -3,15 +3,15 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x50
+      RenderBlock {FORM} at (0,0) size 784x46
         RenderTable {TABLE} at (0,0) size 32x28 [border: (1px outset #808080)]
           RenderTableSection {TBODY} at (1,1) size 30x26
             RenderTableRow {TR} at (0,2) size 30x22
               RenderTableCell {TD} at (2,2) size 26x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 22x18
                   text run at (2,2) width 22: "foo"
-        RenderBlock (anonymous) at (0,28) size 784x22
-          RenderButton {INPUT} at (2,2) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderBlock (anonymous) at (0,28) size 784x18
+          RenderButton {INPUT} at (0,0) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
             RenderBlock (anonymous) at (8,2) size 37x13
               RenderText at (0,0) size 37x13
                 text run at (0,0) width 37: "Submit"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug44505-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug44505-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x610
+layer at (0,0) size 785x604
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x610
-  RenderBlock {HTML} at (0,0) size 785x610
-    RenderBody {BODY} at (8,8) size 769x594 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x604
+  RenderBlock {HTML} at (0,0) size 785x604
+    RenderBody {BODY} at (8,8) size 769x588 [bgcolor=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 308x52 [border: (1px outset #808080)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
@@ -25,19 +25,19 @@ layer at (0,0) size 785x610
         RenderTableSection {TBODY} at (1,1) size 298x50
           RenderTableRow {TR} at (0,2) size 298x22
           RenderTableRow {TR} at (0,26) size 298x22
-      RenderTable {TABLE} at (0,208) size 300x56 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x54
-          RenderTableRow {TR} at (0,2) size 298x26
-          RenderTableRow {TR} at (0,30) size 298x22
-      RenderTable {TABLE} at (0,264) size 300x56 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x54
-          RenderTableRow {TR} at (0,2) size 298x26
-          RenderTableRow {TR} at (0,30) size 298x22
-      RenderTable {TABLE} at (0,320) size 300x94 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,208) size 300x53 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x51
+          RenderTableRow {TR} at (0,2) size 298x23
+          RenderTableRow {TR} at (0,27) size 298x22
+      RenderTable {TABLE} at (0,261) size 300x53 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x51
+          RenderTableRow {TR} at (0,2) size 298x23
+          RenderTableRow {TR} at (0,27) size 298x22
+      RenderTable {TABLE} at (0,314) size 300x94 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x92
           RenderTableRow {TR} at (0,2) size 298x46
           RenderTableRow {TR} at (0,50) size 298x40
-      RenderTable {TABLE} at (0,504) size 300x90 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,498) size 300x90 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x88
           RenderTableRow {TR} at (0,2) size 298x60
           RenderTableRow {TR} at (0,64) size 298x22
@@ -105,97 +105,97 @@ layer at (167,191) size 138x22 clip at (168,192) size 136x20
   RenderTableCell {TD} at (158,26) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,219) size 154x26 clip at (12,220) size 152x24 scrollWidth 201
-  RenderTableCell {TD} at (2,2) size 154x26 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 150x22
-      RenderButton {BUTTON} at (0,2) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+layer at (11,219) size 154x23 clip at (12,220) size 152x21 scrollWidth 201
+  RenderTableCell {TD} at (2,2) size 154x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 150x19
+      RenderButton {BUTTON} at (0,1) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 184x13
           RenderText {#text} at (74,0) size 36x13
             text run at (74,0) width 36: "button"
-layer at (167,219) size 138x26 clip at (168,220) size 136x24
-  RenderTableCell {TD} at (158,4) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (167,219) size 138x23 clip at (168,220) size 136x21
+  RenderTableCell {TD} at (158,2) size 138x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+    RenderText {#text} at (2,2) size 4x19
+      text run at (2,3) width 4: " "
+layer at (11,244) size 154x22 clip at (12,245) size 152x20
+  RenderTableCell {TD} at (2,27) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,247) size 154x22 clip at (12,248) size 152x20
-  RenderTableCell {TD} at (2,30) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (167,244) size 138x22 clip at (168,245) size 136x20
+  RenderTableCell {TD} at (158,27) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (167,247) size 138x22 clip at (168,248) size 136x20
-  RenderTableCell {TD} at (158,30) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
-    RenderText {#text} at (2,2) size 4x18
-      text run at (2,2) width 4: " "
-layer at (11,275) size 281x26 clip at (12,276) size 279x24
-  RenderTableCell {TD} at (2,2) size 281x26 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 277x22
-      RenderButton {BUTTON} at (0,2) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+layer at (11,272) size 281x23 clip at (12,273) size 279x21
+  RenderTableCell {TD} at (2,2) size 281x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 277x19
+      RenderButton {BUTTON} at (0,1) size 200x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
         RenderBlock (anonymous) at (8,2) size 184x13
           RenderText {#text} at (74,0) size 36x13
             text run at (74,0) width 36: "button"
-layer at (294,275) size 11x26 clip at (295,276) size 9x24
-  RenderTableCell {TD} at (284,4) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (294,272) size 11x23 clip at (295,273) size 9x21
+  RenderTableCell {TD} at (284,2) size 13x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+    RenderText {#text} at (2,2) size 4x19
+      text run at (2,3) width 4: " "
+layer at (11,297) size 281x22 clip at (12,298) size 279x20
+  RenderTableCell {TD} at (2,27) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,303) size 281x22 clip at (12,304) size 279x20
-  RenderTableCell {TD} at (2,30) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (294,297) size 11x22 clip at (295,298) size 9x20
+  RenderTableCell {TD} at (284,27) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (294,303) size 11x22 clip at (295,304) size 9x20
-  RenderTableCell {TD} at (284,30) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
-    RenderText {#text} at (2,2) size 4x18
-      text run at (2,2) width 4: " "
-layer at (11,331) size 172x46 clip at (12,332) size 170x44 scrollWidth 216
+layer at (11,325) size 172x46 clip at (12,326) size 170x44 scrollWidth 216
   RenderTableCell {TD} at (2,2) size 172x46 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {DIV} at (11,11) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 21x18
         text run at (3,3) width 21: "div"
-layer at (185,331) size 120x46 clip at (186,332) size 118x44
+layer at (185,325) size 120x46 clip at (186,326) size 118x44
   RenderTableCell {TD} at (176,5) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (11,379) size 172x40 clip at (12,380) size 170x38
+layer at (11,373) size 172x40 clip at (12,374) size 170x38
   RenderTableCell {TD} at (2,50) size 172x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (185,379) size 120x40 clip at (186,380) size 118x38
+layer at (185,373) size 120x40 clip at (186,374) size 118x38
   RenderTableCell {TD} at (176,50) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (8,422) size 300x90 clip at (9,423) size 298x88
-  RenderTable {TABLE} at (0,414) size 300x90 [border: (1px outset #808080)]
+layer at (8,416) size 300x90 clip at (9,417) size 298x88
+  RenderTable {TABLE} at (0,408) size 300x90 [border: (1px outset #808080)]
     RenderTableSection {TBODY} at (1,1) size 298x88
       RenderTableRow {TR} at (0,2) size 298x60
       RenderTableRow {TR} at (0,64) size 298x22
-layer at (11,425) size 154x60 clip at (12,426) size 152x58 scrollWidth 207
+layer at (11,419) size 154x60 clip at (12,420) size 152x58 scrollWidth 207
   RenderTableCell {TD} at (2,2) size 154x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 28x18
         text run at (3,3) width 28: "para"
-layer at (167,425) size 138x60 clip at (168,426) size 136x58
+layer at (167,419) size 138x60 clip at (168,420) size 136x58
   RenderTableCell {TD} at (158,21) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,487) size 154x22 clip at (12,488) size 152x20
+layer at (11,481) size 154x22 clip at (12,482) size 152x20
   RenderTableCell {TD} at (2,64) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (167,487) size 138x22 clip at (168,488) size 136x20
+layer at (167,481) size 138x22 clip at (168,482) size 136x20
   RenderTableCell {TD} at (158,64) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,515) size 254x60 clip at (12,516) size 252x58
+layer at (11,509) size 254x60 clip at (12,510) size 252x58
   RenderTableCell {TD} at (2,2) size 254x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 28x18
         text run at (3,3) width 28: "para"
-layer at (267,515) size 38x60 clip at (268,516) size 36x58
+layer at (267,509) size 38x60 clip at (268,510) size 36x58
   RenderTableCell {TD} at (258,21) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,577) size 254x22 clip at (12,578) size 252x20
+layer at (11,571) size 254x22 clip at (12,572) size 252x20
   RenderTableCell {TD} at (2,64) size 254x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (267,577) size 38x22 clip at (268,578) size 36x20
+layer at (267,571) size 38x22 clip at (268,572) size 36x20
   RenderTableCell {TD} at (258,64) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt
@@ -1,20 +1,20 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x86
-  RenderBlock {HTML} at (0,0) size 800x86
-    RenderBody {BODY} at (8,8) size 784x70
-      RenderBlock {FORM} at (0,0) size 784x44
-        RenderButton {INPUT} at (2,2) size 154x18 [color=#000000D8] [bgcolor=#C0C0C0]
+layer at (0,0) size 800x80
+  RenderBlock {HTML} at (0,0) size 800x80
+    RenderBody {BODY} at (8,8) size 784x64
+      RenderBlock {FORM} at (0,0) size 784x38
+        RenderButton {INPUT} at (0,1) size 154x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 138x13
             RenderText at (0,0) size 138x13
               text run at (0,0) width 138: "(1) Fill cell with long string"
-        RenderBR {BR} at (157,1) size 1x18
-        RenderButton {INPUT} at (2,24) size 160x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderBR {BR} at (153,0) size 1x18
+        RenderButton {INPUT} at (0,20) size 160x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 144x13
             RenderText at (0,0) size 144x13
               text run at (0,0) width 144: "(2) Fill cell with short string"
-        RenderBR {BR} at (163,23) size 1x18
-      RenderTable {TABLE} at (0,44) size 83x26
+        RenderBR {BR} at (159,19) size 1x18
+      RenderTable {TABLE} at (0,38) size 83x26
         RenderTableSection {TBODY} at (0,0) size 83x26
           RenderTableRow {TR} at (0,2) size 83x22
             RenderTableCell {TD} at (2,2) size 79x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x110
-  RenderBlock {HTML} at (0,0) size 800x110
-    RenderBody {BODY} at (8,8) size 784x94
-      RenderBlock {FORM} at (0,0) size 784x38
-        RenderButton {INPUT} at (2,0) size 254x18 [color=#000000D8] [bgcolor=#C0C0C0]
+layer at (0,0) size 800x106
+  RenderBlock {HTML} at (0,0) size 800x106
+    RenderBody {BODY} at (8,8) size 784x90
+      RenderBlock {FORM} at (0,0) size 784x36
+        RenderButton {INPUT} at (0,0) size 254x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 238x13
             RenderText at (0,0) size 238x13
               text run at (0,0) width 238: "[Step 1] Set cell width to 60px (nothing seen)"
-        RenderButton {INPUT} at (2,20) size 259x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,18) size 259x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 243x13
             RenderText at (0,0) size 243x13
               text run at (0,0) width 243: "[Step 2] Set cell width to 20px (garbage seen)"
-      RenderTable {TABLE} at (0,40) size 34x54
+      RenderTable {TABLE} at (0,36) size 34x54
         RenderTableSection {TBODY} at (0,0) size 34x54
           RenderTableRow {TR} at (0,2) size 34x24
             RenderTableCell {TD} at (2,2) size 14x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x118
-  RenderBlock {HTML} at (0,0) size 800x118
-    RenderBody {BODY} at (8,8) size 784x102
-      RenderBlock {FORM} at (0,0) size 784x38
-        RenderButton {INPUT} at (2,0) size 179x18 [color=#000000D8] [bgcolor=#C0C0C0]
+layer at (0,0) size 800x114
+  RenderBlock {HTML} at (0,0) size 800x114
+    RenderBody {BODY} at (8,8) size 784x98
+      RenderBlock {FORM} at (0,0) size 784x36
+        RenderButton {INPUT} at (0,0) size 179x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 163x13
             RenderText at (0,0) size 163x13
               text run at (0,0) width 163: "[Step 1] Set cell height to 60px"
-        RenderButton {INPUT} at (2,20) size 180x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderButton {INPUT} at (0,18) size 180x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 164x13
             RenderText at (0,0) size 164x13
               text run at (0,0) width 164: "[Step 2] Set cell height to 20px"
-      RenderTable {TABLE} at (0,40) size 42x62
+      RenderTable {TABLE} at (0,36) size 42x62
         RenderTableSection {TBODY} at (0,0) size 42x62
           RenderTableRow {TR} at (0,2) size 42x28
             RenderTableCell {TD} at (2,2) size 18x28 [border: (4px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug59354-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug59354-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 468x146 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 466x144
-          RenderTableRow {TR} at (0,0) size 466x144
-            RenderTableCell {TD} at (0,0) size 466x144 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (1,1) size 464x142 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 462x140
+      RenderTable {TABLE} at (0,0) size 468x142 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 466x140
+          RenderTableRow {TR} at (0,0) size 466x140
+            RenderTableCell {TD} at (0,0) size 466x140 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (1,1) size 464x138 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 462x136
                   RenderTableRow {TR} at (0,1) size 462x28
                     RenderTableCell {TD} at (1,1) size 140x28 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (5,5) size 130x18

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug68912-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug68912-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 480x18
           text run at (0,0) width 480: "This test case creates a TR element then tries to assign to the cells property"
-      RenderBlock {P} at (0,34) size 784x22
-        RenderText {#text} at (0,1) size 42x18
-          text run at (0,1) width 42: "Crash "
-        RenderButton {BUTTON} at (43,2) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+      RenderBlock {P} at (0,34) size 784x19
+        RenderText {#text} at (0,0) size 42x18
+          text run at (0,0) width 42: "Crash "
+        RenderButton {BUTTON} at (41,1) size 90x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
           RenderBlock (anonymous) at (8,2) size 74x13
             RenderText {#text} at (0,0) size 74x13
               text run at (0,0) width 74: "TR.cells = null"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 52x42 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 50x40
-          RenderTableRow {TR} at (0,2) size 50x36
-            RenderTableCell {TD} at (2,2) size 46x36 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 42x32 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 40x30
-                  RenderTableRow {TR} at (0,2) size 40x26
-                    RenderTableCell {TD} at (2,13) size 4x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                    RenderTableCell {TD} at (8,2) size 24x26 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                      RenderButton {INPUT} at (4,4) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
-                    RenderTableCell {TD} at (34,13) size 4x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 48x38 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 46x36
+          RenderTableRow {TR} at (0,2) size 46x32
+            RenderTableCell {TD} at (2,2) size 42x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 38x28 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 36x26
+                  RenderTableRow {TR} at (0,2) size 36x22
+                    RenderTableCell {TD} at (2,11) size 4x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                    RenderTableCell {TD} at (8,2) size 20x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                      RenderButton {INPUT} at (2,2) size 16x18 [color=#000000D8] [bgcolor=#C0C0C0]
+                    RenderTableCell {TD} at (30,11) size 4x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {BLOCKQUOTE} at (40,0) size 704x118
-        RenderBlock {CENTER} at (0,0) size 704x118
+      RenderBlock {BLOCKQUOTE} at (40,0) size 704x115
+        RenderBlock {CENTER} at (0,0) size 704x115
           RenderTable {TABLE} at (297,0) size 110x80 [border: (2px none #808080)]
             RenderTableSection {TBODY} at (2,2) size 104x75
               RenderTableRow {TR} at (0,0) size 104x25
@@ -28,14 +28,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (36,50) size 68x25 [border: (3px groove #0000FF)] [r=2 c=1 rs=1 cs=1]
                   RenderText {#text} at (4,4) size 60x18
                     text run at (4,4) width 60: "6:00 a.m."
-          RenderBlock {P} at (0,96) size 704x22
-            RenderButton {INPUT} at (287,2) size 63x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderBlock {P} at (0,96) size 704x19
+            RenderButton {INPUT} at (289,1) size 63x18 [color=#000000D8] [bgcolor=#C0C0C0]
               RenderBlock (anonymous) at (8,2) size 46x13
                 RenderText at (0,0) size 46x13
                   text run at (0,0) width 46: "separate"
-            RenderText {#text} at (351,1) size 5x18
-              text run at (351,1) width 5: " "
-            RenderButton {INPUT} at (357,2) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderText {#text} at (351,0) size 5x18
+              text run at (351,0) width 5: " "
+            RenderButton {INPUT} at (355,1) size 60x18 [color=#000000D8] [bgcolor=#C0C0C0]
               RenderBlock (anonymous) at (8,2) size 44x13
                 RenderText at (0,0) size 44x13
                   text run at (0,0) width 44: "collapse"

--- a/LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt
@@ -6,20 +6,20 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 191x18
           text run at (0,0) width 191: "outer width=400 align=center"
-      RenderTable {TABLE} at (192,18) size 400x48 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x46
-          RenderTableRow {TR} at (0,2) size 398x42
-            RenderTableCell {TD} at (2,2) size 394x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x22
-                RenderMenuList {SELECT} at (2,2) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (192,18) size 400x44 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x42
+          RenderTableRow {TR} at (0,2) size 398x38
+            RenderTableCell {TD} at (2,2) size 394x38 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x18
+                RenderMenuList {SELECT} at (0,0) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 54x18
                     RenderText at (8,2) size 23x13
                       text run at (8,2) width 23: "Test"
                 RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,66) size 784x18
+      RenderBlock (anonymous) at (0,62) size 784x18
         RenderText {#text} at (0,0) size 301x18
           text run at (0,0) width 301: "outer width=400 inner width=200 align=center"
-      RenderTable {TABLE} at (0,84) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,80) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 392x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -29,10 +29,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 194x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x18
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,124) size 784x18
+      RenderBlock (anonymous) at (0,120) size 784x18
         RenderText {#text} at (0,0) size 186x18
           text run at (0,0) width 186: "outer auto inner align=center"
-      RenderTable {TABLE} at (0,142) size 44x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,138) size 44x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 40x36
           RenderTableRow {TR} at (0,2) size 40x32
             RenderTableCell {TD} at (2,2) size 36x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -42,10 +42,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x18
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,182) size 784x18
+      RenderBlock (anonymous) at (0,178) size 784x18
         RenderText {#text} at (0,0) size 220x18
           text run at (0,0) width 220: "outer width=50 inner align=center"
-      RenderTable {TABLE} at (0,200) size 44x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,196) size 44x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 40x36
           RenderTableRow {TR} at (0,2) size 40x32
             RenderTableCell {TD} at (2,2) size 36x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -55,10 +55,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x18
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,240) size 784x18
+      RenderBlock (anonymous) at (0,236) size 784x18
         RenderText {#text} at (0,0) size 232x18
           text run at (0,0) width 232: "outer width=50 inner margin-left:50"
-      RenderTable {TABLE} at (0,258) size 94x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,254) size 94x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 90x36
           RenderTableRow {TR} at (0,2) size 90x32
             RenderTableCell {TD} at (2,2) size 86x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -68,10 +68,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 26x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 22x18
                         text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,298) size 784x18
+      RenderBlock (anonymous) at (0,294) size 784x18
         RenderText {#text} at (0,0) size 228x18
           text run at (0,0) width 228: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,316) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,312) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 116x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (119,7) size 276x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x18
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,356) size 784x18
+      RenderBlock (anonymous) at (0,352) size 784x18
         RenderText {#text} at (0,0) size 228x18
           text run at (0,0) width 228: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,374) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,370) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 169x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -100,6 +100,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (172,7) size 223x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x18
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,414) size 784x18
+      RenderBlock (anonymous) at (0,410) size 784x18
         RenderText {#text} at (0,0) size 20x18
           text run at (0,0) width 20: "-->"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 600x280 [bgcolor=#FFC0CB]
-        RenderTableSection {TBODY} at (0,0) size 600x280
+      RenderTable {TABLE} at (0,0) size 600x276 [bgcolor=#FFC0CB]
+        RenderTableSection {TBODY} at (0,0) size 600x276
           RenderTableRow {TR} at (0,0) size 600x18
             RenderTableCell {TD} at (0,0) size 601x18 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=3]
               RenderText {#text} at (0,0) size 8x18
@@ -17,35 +17,35 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,36) size 156x18 [bgcolor=#00FFFF] [r=2 c=0 rs=40 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "3"
-          RenderTableRow {TR} at (0,36) size 600x28
-            RenderTableCell {TD} at (155,36) size 446x28 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (0,0) size 440x28
-                RenderTableSection {TBODY} at (0,0) size 440x28
-                  RenderTableRow {TR} at (0,2) size 440x24
-                    RenderTableCell {TD} at (2,2) size 217x24 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (3,3) size 95x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderTableRow {TR} at (0,36) size 600x24
+            RenderTableCell {TD} at (155,36) size 446x24 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (0,0) size 440x24
+                RenderTableSection {TBODY} at (0,0) size 440x24
+                  RenderTableRow {TR} at (0,2) size 440x20
+                    RenderTableCell {TD} at (2,2) size 217x20 [r=0 c=0 rs=1 cs=1]
+                      RenderButton {INPUT} at (1,1) size 95x18 [color=#000000D8] [bgcolor=#C0C0C0]
                         RenderBlock (anonymous) at (8,2) size 79x13
                           RenderText at (0,0) size 79x13
                             text run at (0,0) width 79: "Submit Criteria"
-                    RenderTableCell {TD} at (221,4) size 217x20 [r=0 c=1 rs=1 cs=1]
+                    RenderTableCell {TD} at (221,2) size 217x20 [r=0 c=1 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 8x18
                         text run at (1,1) width 8: "4"
-          RenderTableRow {TR} at (0,64) size 600x18
-            RenderTableCell {TD} at (155,64) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,60) size 600x18
+            RenderTableCell {TD} at (155,60) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "5"
-          RenderTableRow {TR} at (0,82) size 600x36
-            RenderTableCell {TD} at (155,82) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,78) size 600x36
+            RenderTableCell {TD} at (155,78) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 436x36
                 text run at (0,0) width 263: "If you have entered your feature criteria, "
                 text run at (262,0) width 174: "press the \"Submit Criteria\""
                 text run at (0,18) width 88: "button above."
-          RenderTableRow {TR} at (0,118) size 600x18
-            RenderTableCell {TD} at (155,118) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,114) size 600x18
+            RenderTableCell {TD} at (155,114) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "6"
-          RenderTableRow {TR} at (0,136) size 600x54
-            RenderTableCell {TD} at (155,136) size 446x54 [r=7 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,132) size 600x54
+            RenderTableCell {TD} at (155,132) size 446x54 [r=7 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 433x54
                 text run at (0,0) width 267: "If you want to do a radius search instead, "
                 text run at (266,0) width 167: "press the \"Radius Search\""
@@ -53,12 +53,12 @@ layer at (0,0) size 800x600
                 text run at (48,18) width 287: "This will allow you to select a starting point "
                 text run at (334,18) width 71: "and enter a"
                 text run at (0,36) width 204: "radius with new feature criteria."
-          RenderTableRow {TR} at (0,190) size 600x18
-            RenderTableCell {TD} at (155,190) size 446x18 [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,186) size 600x18
+            RenderTableCell {TD} at (155,186) size 446x18 [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x18
                 text run at (0,0) width 4: " "
-          RenderTableRow {TR} at (0,208) size 600x72
-            RenderTableCell {TD} at (155,208) size 446x72 [r=9 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,204) size 600x72
+            RenderTableCell {TD} at (155,204) size 446x72 [r=9 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 419x72
                 text run at (0,0) width 419: "All information provided is deemed reliable but is not guaranteed"
                 text run at (0,18) width 93: "and should be "

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -1,21 +1,21 @@
-layer at (0,0) size 785x1443
+layer at (0,0) size 785x1436
   RenderView at (0,0) size 785x600
-layer at (8,8) size 769x1435
-  RenderBlock {HTML} at (8,8) size 769x1435 [bgcolor=#008000] [border: (16px solid #00FF00)]
-    RenderTable at (16,16) size 737x1403
-      RenderTableSection (anonymous) at (0,0) size 737x1403
-        RenderTableRow (anonymous) at (0,0) size 737x1403
-          RenderTableCell {HEAD} at (0,0) size 242x472 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
-            RenderBlock {META} at (21,37) size 200x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,55) size 200x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,73) size 200x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,91) size 200x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {TITLE} at (21,109) size 200x56 [border: (1px dotted #FFFFFF)]
+layer at (8,8) size 769x1428
+  RenderBlock {HTML} at (8,8) size 769x1428 [bgcolor=#008000] [border: (16px solid #00FF00)]
+    RenderTable at (16,16) size 737x1396
+      RenderTableSection (anonymous) at (0,0) size 737x1396
+        RenderTableRow (anonymous) at (0,0) size 737x1396
+          RenderTableCell {HEAD} at (0,0) size 246x472 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
+            RenderBlock {META} at (21,37) size 204x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,55) size 204x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,73) size 204x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,91) size 204x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {TITLE} at (21,109) size 204x56 [border: (1px dotted #FFFFFF)]
               RenderText {#text} at (1,1) size 188x54
                 text run at (1,1) width 188: "Evil Tests: Rendering BODY"
                 text run at (1,19) width 163: "and HEAD as children of"
                 text run at (1,37) width 67: "HTML - 2"
-            RenderBlock {STYLE} at (21,181) size 200x254 [border: (1px dotted #FFFFFF)]
+            RenderBlock {STYLE} at (21,181) size 204x254 [border: (1px dotted #FFFFFF)]
               RenderText {#text} at (1,1) size 196x252
                 text run at (1,1) width 83: "/* Layout */ "
                 text run at (83,1) width 112: "HTML { display:"
@@ -38,8 +38,8 @@ layer at (8,8) size 769x1435
                 text run at (1,217) width 12: "} "
                 text run at (12,217) width 151: "BODY { color: yellow;"
                 text run at (1,235) width 124: "background: teal; }"
-          RenderTableCell {BODY} at (242,41) size 495x1362 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
-            RenderBlock {H1} at (21,53) size 453x76 [border: (1px dotted #FFFF00)]
+          RenderTableCell {BODY} at (246,41) size 491x1355 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+            RenderBlock {H1} at (21,53) size 449x76 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 152x37
                 text run at (1,1) width 152: "Rendering "
               RenderInline {CODE} at (0,0) size 63x30
@@ -58,7 +58,7 @@ layer at (8,8) size 769x1435
                   text run at (156,43) width 64: "HTML"
               RenderText {#text} at (219,38) size 44x37
                 text run at (219,38) width 44: " - 2"
-            RenderBlock {P} at (21,161) size 453x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,161) size 449x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 393x18
                 text run at (1,1) width 393: "If you have any comments to make regarding this test, e-mail"
               RenderInline {A} at (0,0) size 186x18 [color=#0000EE]
@@ -66,11 +66,11 @@ layer at (8,8) size 769x1435
                   text run at (1,19) width 186: "py8ieh=eviltests@bath.ac.uk"
               RenderText {#text} at (186,19) size 5x18
                 text run at (186,19) width 5: "."
-            RenderBlock {DL} at (21,215) size 453x92 [border: (1px dotted #FFFF00)]
-              RenderBlock {DT} at (1,1) size 451x18
+            RenderBlock {DL} at (21,215) size 449x92 [border: (1px dotted #FFFF00)]
+              RenderBlock {DT} at (1,1) size 447x18
                 RenderText {#text} at (0,0) size 83x18
                   text run at (0,0) width 83: "Prerequisites"
-              RenderBlock {DD} at (41,19) size 411x72
+              RenderBlock {DD} at (41,19) size 407x72
                 RenderText {#text} at (0,0) size 392x54
                   text run at (0,0) width 392: "Browsers that are subjected to this test should support the the"
                   text run at (0,18) width 388: "background, padding, margin, border and color properties of"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
@@ -1,17 +1,17 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x75
-  RenderBlock {HTML} at (0,0) size 800x75
-    RenderBody {BODY} at (8,8) size 784x59
-      RenderTable {TABLE} at (0,0) size 392x59 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 392x59
-          RenderTableRow {TR} at (0,0) size 392x19
-            RenderTableCell {TD} at (0,0) size 392x19 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
-              RenderTextControl {INPUT} at (0,2) size 394x15 [bgcolor=#FFC0CB]
+layer at (0,0) size 800x71
+  RenderBlock {HTML} at (0,0) size 800x71
+    RenderBody {BODY} at (8,8) size 784x55
+      RenderTable {TABLE} at (0,0) size 392x55 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 392x55
+          RenderTableRow {TR} at (0,0) size 392x15
+            RenderTableCell {TD} at (0,0) size 392x15 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
+              RenderTextControl {INPUT} at (0,0) size 394x15 [bgcolor=#FFC0CB]
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,19) size 392x40
-            RenderTableCell {TD} at (0,19) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,15) size 392x40
+            RenderTableCell {TD} at (0,15) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 392x40 [bgcolor=#00FFFF]
               RenderText {#text} at (0,0) size 0x0
-layer at (9,11) size 392x13
+layer at (9,9) size 392x13
   RenderBlock {DIV} at (1,1) size 392x13

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
@@ -32,14 +32,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,158) size 41x22 [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 37x18
                 text run at (2,2) width 37: "row 3"
-      RenderBlock (anonymous) at (0,240) size 784x22
-        RenderButton {INPUT} at (2,2) size 55x18 [color=#000000D8] [bgcolor=#C0C0C0]
+      RenderBlock (anonymous) at (0,240) size 784x19
+        RenderButton {INPUT} at (0,1) size 55x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 39x13
             RenderText at (0,0) size 39x13
               text run at (0,0) width 39: "expand"
-        RenderText {#text} at (58,1) size 5x18
-          text run at (58,1) width 5: " "
-        RenderButton {INPUT} at (64,2) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0]
+        RenderText {#text} at (54,0) size 5x18
+          text run at (54,0) width 5: " "
+        RenderButton {INPUT} at (58,1) size 43x18 [color=#000000D8] [bgcolor=#C0C0C0]
           RenderBlock (anonymous) at (8,2) size 27x13
             RenderText at (0,0) size 27x13
               text run at (0,0) width 27: "sizes"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x140
+      RenderBlock {CENTER} at (0,0) size 784x132
         RenderTable {TABLE} at (339,0) size 106x80
           RenderTableSection {THEAD} at (0,0) size 105x20
             RenderTableRow {TR} at (0,0) size 105x20

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x142
+      RenderBlock {CENTER} at (0,0) size 784x134
         RenderTable {TABLE} at (338,0) size 108x82 [border: none]
           RenderTableSection {THEAD} at (0,0) size 106x21
             RenderTableRow {TR} at (0,0) size 106x21

--- a/LayoutTests/platform/win/css2.1/20110323/replaced-elements-001-expected.txt
+++ b/LayoutTests/platform/win/css2.1/20110323/replaced-elements-001-expected.txt
@@ -1,19 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x164
-  RenderBlock {HTML} at (0,0) size 800x164
-    RenderBody {BODY} at (8,16) size 784x132
+layer at (0,0) size 800x160
+  RenderBlock {HTML} at (0,0) size 800x160
+    RenderBody {BODY} at (8,16) size 784x128
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 598x18
           text run at (0,0) width 598: "Below, there should be 2 orange boxes horizontally centered within their respective green bars."
-      RenderBlock {DIV} at (16,34) size 752x41 [bgcolor=#008000]
+      RenderBlock {DIV} at (16,34) size 752x39 [bgcolor=#008000]
         RenderBlock (anonymous) at (0,0) size 752x18
           RenderText {#text} at (0,0) size 36x18
             text run at (0,0) width 36: "         "
-        RenderButton {INPUT} at (368,20) size 16x21 [bgcolor=#FFA500] [border: (2px outset #F0F0F0)]
-      RenderBlock {FORM} at (0,91) size 784x41
-        RenderBlock {DIV} at (16,0) size 752x41 [bgcolor=#008000]
+        RenderButton {INPUT} at (368,18) size 16x21 [bgcolor=#FFA500] [border: (2px outset #F0F0F0)]
+      RenderBlock {FORM} at (0,89) size 784x39
+        RenderBlock {DIV} at (16,0) size 752x39 [bgcolor=#008000]
           RenderBlock (anonymous) at (0,0) size 752x18
             RenderText {#text} at (0,0) size 36x18
               text run at (0,0) width 36: "         "
-          RenderButton {INPUT} at (368,20) size 16x21 [bgcolor=#FFA500] [border: (2px outset #F0F0F0)]
+          RenderButton {INPUT} at (368,18) size 16x21 [bgcolor=#FFA500] [border: (2px outset #F0F0F0)]

--- a/LayoutTests/platform/win/fast/block/float/float-avoidance-expected.txt
+++ b/LayoutTests/platform/win/fast/block/float/float-avoidance-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2387
+layer at (0,0) size 785x2343
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2387
-  RenderBlock {HTML} at (0,0) size 785x2387
-    RenderBody {BODY} at (8,8) size 769x2371
+layer at (0,0) size 785x2343
+  RenderBlock {HTML} at (0,0) size 785x2343
+    RenderBody {BODY} at (8,8) size 769x2327
       RenderBlock (anonymous) at (0,0) size 769x36
         RenderText {#text} at (0,0) size 765x36
           text run at (0,0) width 538: "Test of objects that avoid floats to see what they do with percentage and auto widths. "
@@ -12,84 +12,84 @@ layer at (0,0) size 785x2387
       RenderBlock (anonymous) at (0,54) size 769x18
         RenderText {#text} at (0,0) size 507x18
           text run at (0,0) width 507: "The inline-level button should be below the select and fill the width of the block."
-      RenderBlock {P} at (0,88) size 220x86 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,88) size 220x78 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
         RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (10,53) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (10,47) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 184x15
             RenderText at (86,0) size 12x15
               text run at (86,0) width 12: "Hi"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,190) size 769x18
+      RenderBlock (anonymous) at (0,182) size 769x18
         RenderText {#text} at (0,0) size 473x18
           text run at (0,0) width 473: "The floating button with a percentage width should be even with the select."
-      RenderBlock {P} at (0,224) size 220x63 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,216) size 220x59 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
         RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,30) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (110,28) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 84x15
             RenderText at (36,0) size 12x15
               text run at (36,0) width 12: "Hi"
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (210,28) size 0x18
-      RenderBlock (anonymous) at (0,303) size 769x18
+      RenderBlock (anonymous) at (0,291) size 769x18
         RenderText {#text} at (0,0) size 462x18
           text run at (0,0) width 462: "The block-level button with an auto width should be even with the select."
-      RenderBlock {P} at (0,337) size 220x81 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,325) size 220x77 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,30) size 28x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (110,28) size 28x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 12x15
             RenderText at (0,0) size 12x15
               text run at (0,0) width 12: "Hi"
-        RenderBlock (anonymous) at (10,53) size 200x18
+        RenderBlock (anonymous) at (10,49) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,434) size 769x18
+      RenderBlock (anonymous) at (0,418) size 769x18
         RenderText {#text} at (0,0) size 495x18
           text run at (0,0) width 495: "The block-level button with a percentage width should be even with the select."
-      RenderBlock {P} at (0,468) size 220x81 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,452) size 220x77 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderButton {INPUT} at (110,30) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (110,28) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 84x15
             RenderText at (36,0) size 12x15
               text run at (36,0) width 12: "Hi"
-        RenderBlock (anonymous) at (10,53) size 200x18
+        RenderBlock (anonymous) at (10,49) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,565) size 769x18
+      RenderBlock (anonymous) at (0,545) size 769x18
         RenderText {#text} at (0,0) size 463x18
           text run at (0,0) width 463: "The floating table with a percentage width should be even with the select."
-      RenderBlock {P} at (0,599) size 220x68 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,579) size 220x68 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
@@ -102,20 +102,20 @@ layer at (0,0) size 785x2387
                   text run at (2,2) width 36: "Table"
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (210,28) size 0x18
-      RenderBlock (anonymous) at (0,683) size 769x36
+      RenderBlock (anonymous) at (0,663) size 769x36
         RenderText {#text} at (0,0) size 755x36
           text run at (0,0) width 755: "The floating table with an auto width should be even with the select and shrinks to use the available line width. THIS IS"
           text run at (0,18) width 166: "CURRENTLY BUGGY."
-      RenderBlock {P} at (0,735) size 220x127 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,715) size 220x123 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
         RenderText {#text} at (0,0) size 0x0
-        RenderTable {TABLE} at (10,51) size 200x66 [border: (2px outset #808080)]
+        RenderTable {TABLE} at (10,47) size 200x66 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 196x62
             RenderTableRow {TR} at (0,2) size 196x58
               RenderTableCell {TD} at (2,2) size 192x58 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -125,21 +125,21 @@ layer at (0,0) size 785x2387
                   text run at (2,38) width 90: "previous float."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (110,28) size 0x18
-      RenderBlock (anonymous) at (0,878) size 769x18
+      RenderBlock (anonymous) at (0,854) size 769x18
         RenderText {#text} at (0,0) size 730x18
           text run at (0,0) width 578: "The block-level table below has a percentage width and should still be even with the select. "
           text run at (578,0) width 152: "It spills out of the block."
-      RenderBlock {P} at (0,912) size 220x145 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,888) size 220x141 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderTable {TABLE} at (10,51) size 200x66 [border: (2px outset #808080)]
+        RenderTable {TABLE} at (10,47) size 200x66 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 196x62
             RenderTableRow {TR} at (0,2) size 196x58
               RenderTableCell {TD} at (2,2) size 192x58 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -147,18 +147,18 @@ layer at (0,0) size 785x2387
                   text run at (2,2) width 159: "Floating table that should"
                   text run at (2,20) width 161: "shrink so it can be next to"
                   text run at (2,38) width 90: "previous float."
-        RenderBlock (anonymous) at (10,117) size 200x18
+        RenderBlock (anonymous) at (10,113) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,1073) size 769x18
+      RenderBlock (anonymous) at (0,1045) size 769x18
         RenderText {#text} at (0,0) size 743x18
           text run at (0,0) width 545: "The block-level table below has an auto width and should still be even with the select. "
           text run at (545,0) width 198: "It shrinks to fit inside the block."
-      RenderBlock {P} at (0,1107) size 220x176 [border: (10px solid #FF0000)]
+      RenderBlock {P} at (0,1079) size 220x176 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
@@ -176,75 +176,75 @@ layer at (0,0) size 785x2387
                   text run at (2,92) width 32: "float."
         RenderBlock (anonymous) at (10,148) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,1299) size 769x18
+      RenderBlock (anonymous) at (0,1271) size 769x18
         RenderText {#text} at (0,0) size 538x18
           text run at (0,0) width 538: "The floating overflow section with a percentage width should be even with the select."
-      RenderBlock {DIV} at (0,1317) size 220x146 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,1289) size 220x146 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (210,28) size 0x18
-      RenderBlock (anonymous) at (0,1463) size 769x36
+      RenderBlock (anonymous) at (0,1435) size 769x36
         RenderText {#text} at (0,0) size 728x36
           text run at (0,0) width 728: "The floating overflow section with an auto width should be even with the select and shrinks to use the available line"
           text run at (0,18) width 268: "width. THIS IS CURRENTLY BUGGY."
-      RenderBlock {DIV} at (0,1499) size 220x115 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,1471) size 220x111 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (110,28) size 0x18
-      RenderBlock (anonymous) at (0,1614) size 769x18
+      RenderBlock (anonymous) at (0,1582) size 769x18
         RenderText {#text} at (0,0) size 649x18
           text run at (0,0) width 649: "The block-level overflow section below has a percentage width and should still be even with the select."
-      RenderBlock {DIV} at (0,1632) size 220x164 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,1600) size 220x164 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
         RenderBlock (anonymous) at (10,136) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,1796) size 769x36
+      RenderBlock (anonymous) at (0,1764) size 769x36
         RenderText {#text} at (0,0) size 752x36
           text run at (0,0) width 620: "The block-level overflow section below has an auto width and should still be even with the select. "
           text run at (620,0) width 132: "It shrinks to fit inside"
           text run at (0,18) width 62: "the block."
-      RenderBlock {DIV} at (0,1832) size 220x164 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,1800) size 220x164 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
         RenderBlock (anonymous) at (10,136) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,1996) size 769x18
+      RenderBlock (anonymous) at (0,1964) size 769x18
         RenderText {#text} at (0,0) size 446x18
           text run at (0,0) width 446: "The floating hr with a percentage width should be even with the select."
-      RenderBlock {DIV} at (0,2014) size 220x61 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,1982) size 220x57 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
@@ -252,15 +252,15 @@ layer at (0,0) size 785x2387
         RenderBlock (floating) {HR} at (112,30) size 82x2 [border: (1px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (196,28) size 0x18
-      RenderBlock (anonymous) at (0,2075) size 769x36
+      RenderBlock (anonymous) at (0,2039) size 769x36
         RenderText {#text} at (0,0) size 750x36
           text run at (0,0) width 750: "The floating hr below should still be even with the select and shrinks to use its intrinsic width (which is basically like 1-"
           text run at (0,18) width 33: "2px)."
-      RenderBlock {DIV} at (0,2111) size 220x61 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,2075) size 220x57 [border: (10px solid #FF0000)]
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (70,24) size 0x0
-        RenderMenuList {SELECT} at (10,30) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,28) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "One"
@@ -268,32 +268,32 @@ layer at (0,0) size 785x2387
         RenderBlock (floating) {HR} at (112,30) size 2x2 [border: (1px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (116,28) size 0x18
-      RenderBlock (anonymous) at (0,2172) size 769x18
+      RenderBlock (anonymous) at (0,2132) size 769x18
         RenderText {#text} at (0,0) size 557x18
           text run at (0,0) width 557: "The block-level hr below has a percentage width and should still be even with the select."
-      RenderBlock {DIV} at (0,2190) size 220x89 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,2150) size 220x85 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {HR} at (10,51) size 202x2 [border: (1px inset #000000)]
-        RenderBlock (anonymous) at (10,61) size 200x18
+        RenderBlock {HR} at (10,47) size 202x2 [border: (1px inset #000000)]
+        RenderBlock (anonymous) at (10,57) size 200x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock (anonymous) at (0,2279) size 769x18
+      RenderBlock (anonymous) at (0,2235) size 769x18
         RenderText {#text} at (0,0) size 623x18
           text run at (0,0) width 528: "The block-level hr below has an auto width and should still be even with the select. "
           text run at (528,0) width 95: "It shrinks to fit."
-      RenderBlock {DIV} at (0,2297) size 220x74 [border: (10px solid #FF0000)]
+      RenderBlock {DIV} at (0,2253) size 220x74 [border: (10px solid #FF0000)]
         RenderBlock (anonymous) at (10,10) size 200x18
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (60,14) size 0x0
-          RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (4,2) size 75x15
               RenderText at (0,0) size 24x15
                 text run at (0,0) width 24: "One"
@@ -301,7 +301,7 @@ layer at (0,0) size 785x2387
         RenderBlock {HR} at (110,36) size 100x2 [border: (1px inset #000000)]
         RenderBlock (anonymous) at (10,46) size 200x18
           RenderBR {BR} at (100,0) size 0x18
-layer at (118,1353) size 100x108
+layer at (118,1325) size 100x108
   RenderBlock (floating) {DIV} at (110,28) size 100x108
     RenderText {#text} at (0,0) size 98x108
       text run at (0,0) width 61: "This is an"
@@ -310,13 +310,13 @@ layer at (118,1353) size 100x108
       text run at (0,54) width 90: "enough text to"
       text run at (0,72) width 98: "have to wrap to"
       text run at (0,90) width 88: "multiple lines."
-layer at (18,1558) size 200x54
-  RenderBlock (floating) {DIV} at (10,51) size 200x54
+layer at (18,1526) size 200x54
+  RenderBlock (floating) {DIV} at (10,47) size 200x54
     RenderText {#text} at (0,0) size 172x54
       text run at (0,0) width 170: "This is an overflow section"
       text run at (0,18) width 172: "with enough text to have to"
       text run at (0,36) width 140: "wrap to multiple lines."
-layer at (118,1668) size 100x108
+layer at (118,1636) size 100x108
   RenderBlock {DIV} at (110,28) size 100x108
     RenderText {#text} at (0,0) size 98x108
       text run at (0,0) width 61: "This is an"
@@ -325,7 +325,7 @@ layer at (118,1668) size 100x108
       text run at (0,54) width 90: "enough text to"
       text run at (0,72) width 98: "have to wrap to"
       text run at (0,90) width 88: "multiple lines."
-layer at (118,1868) size 100x108
+layer at (118,1836) size 100x108
   RenderBlock {DIV} at (110,28) size 100x108
     RenderText {#text} at (0,0) size 98x108
       text run at (0,0) width 61: "This is an"

--- a/LayoutTests/platform/win/fast/block/float/overhanging-tall-block-expected.txt
+++ b/LayoutTests/platform/win/fast/block/float/overhanging-tall-block-expected.txt
@@ -6,6 +6,6 @@ layer at (0,0) size 800x33554431
       RenderBlock {DIV} at (0,0) size 784x33554431
       RenderBlock {DIV} at (0,33554431) size 784x0
       RenderBlock {DIV} at (0,33554431) size 784x0
-layer at (10,11) size 179x33554431 backgroundClip at (10,11) size 179x33554421 clip at (11,12) size 177x33554420
-  RenderTextControl {TEXTAREA} at (2,3) size 179x33554428 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,9) size 179x33554431 backgroundClip at (8,9) size 179x33554423 clip at (9,10) size 177x33554422
+  RenderTextControl {TEXTAREA} at (0,1) size 179x33554430 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15

--- a/LayoutTests/platform/win/fast/block/margin-collapse/103-expected.txt
+++ b/LayoutTests/platform/win/fast/block/margin-collapse/103-expected.txt
@@ -1,11 +1,11 @@
-layer at (0,0) size 785x1740
+layer at (0,0) size 785x1726
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1740
-  RenderBlock {HTML} at (0,0) size 785x1740
-    RenderBody {BODY} at (8,20) size 769x1700 [bgcolor=#A6A972]
-      RenderBlock {DIV} at (83,0) size 603x1700 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
+layer at (0,0) size 785x1726
+  RenderBlock {HTML} at (0,0) size 785x1726
+    RenderBody {BODY} at (8,20) size 769x1686 [bgcolor=#A6A972]
+      RenderBlock {DIV} at (83,0) size 603x1686 [bgcolor=#FDFDE9] [border: (1px solid #000000)]
         RenderBlock {DIV} at (1,31) size 600x70
-        RenderBlock {DIV} at (1,114) size 600x1514
+        RenderBlock {DIV} at (1,114) size 600x1500
           RenderBlock {P} at (20,0) size 560x80 [color=#333333]
             RenderText {#text} at (0,2) size 520x35
               text run at (0,2) width 520: "We are trying to understand how UVic students perform Shakespeare related research for"
@@ -22,7 +22,7 @@ layer at (0,0) size 785x1740
           RenderBlock {P} at (20,93) size 560x21 [color=#333333]
             RenderText {#text} at (0,2) size 463x15
               text run at (0,2) width 463: "Please take the time to carefully review and complete the following questions."
-          RenderBlock {FORM} at (20,138) size 560x1343
+          RenderBlock {FORM} at (20,138) size 560x1329
             RenderBlock {H2} at (0,0) size 560x16 [color=#333333]
               RenderText {#text} at (0,0) size 201x16
                 text run at (0,0) width 201: "PERSONAL INFORMATION"
@@ -30,74 +30,74 @@ layer at (0,0) size 785x1740
               RenderText {#text} at (0,2) size 68x15
                 text run at (0,2) width 68: "Your Name*"
             RenderTextControl {INPUT} at (325,26) size 184x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderBlock (floating) {SPAN} at (0,49) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,47) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 120x15
                 text run at (0,2) width 120: "Your e-mail address*"
-            RenderTextControl {INPUT} at (325,49) size 184x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-            RenderBlock (floating) {SPAN} at (0,72) size 325x20 [color=#333333]
+            RenderTextControl {INPUT} at (325,47) size 184x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderBlock (floating) {SPAN} at (0,68) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 128x15
                 text run at (0,2) width 128: "Your degree program*"
-            RenderMenuList {SELECT} at (325,72) size 180x19 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,68) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 94x15
                   text run at (0,0) width 94: "Program options"
-            RenderBlock (floating) {SPAN} at (0,93) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,88) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 110x15
                 text run at (0,2) width 110: "Your year of study*"
-            RenderMenuList {SELECT} at (325,93) size 180x19 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,87) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 133x15
                   text run at (0,0) width 133: "Years you've been here"
-            RenderBlock (floating) {SPAN} at (0,114) size 325x20 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,108) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 152x15
                 text run at (0,2) width 152: "Shakespeare classes taken"
-            RenderMenuList {SELECT} at (325,114) size 180x19 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,106) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 80x15
                   text run at (0,0) width 80: "Number taken"
-            RenderBlock {P} at (0,146) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,138) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 156x15
                 text run at (0,2) width 156: "* indicates a required field"
-            RenderBlock {H2} at (0,191) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,183) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 298x16
                 text run at (0,0) width 298: "SHAKESPEARE RESEARCH QUESTIONS"
-            RenderBlock (floating) {SPAN} at (0,217) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,209) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 321x15
                 text run at (0,2) width 321: "What percentage of your research time is spent online?"
-            RenderMenuList {SELECT} at (325,217) size 180x20 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,209) size 180x20 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 115x15
                   text run at (0,0) width 115: "Percentages of time"
-            RenderBlock (floating) {SPAN} at (0,238) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,229) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 300x35
                 text run at (0,2) width 300: "What is holding you back from doing more research"
                 text run at (0,22) width 41: "online?"
-            RenderMenuList {SELECT} at (325,238) size 180x20 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,228) size 180x20 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 51x15
                   text run at (0,0) width 51: "Reasons"
-            RenderBlock (floating) {SPAN} at (0,259) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,249) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 220x15
                 text run at (0,2) width 220: "Your research is primarily focused on:"
-            RenderBlock {SPAN} at (325,259) size 180x23 [color=#333333]
+            RenderBlock {SPAN} at (325,247) size 180x23 [color=#333333]
               RenderBlock {INPUT} at (5,3) size 13x13 [color=#000000]
               RenderText {#text} at (21,4) size 32x15
                 text run at (21,4) width 32: "Texts"
-            RenderBlock {SPAN} at (325,281) size 180x23 [color=#333333]
+            RenderBlock {SPAN} at (325,269) size 180x23 [color=#333333]
               RenderBlock {INPUT} at (5,3) size 13x13 [color=#000000]
               RenderText {#text} at (21,4) size 133x15
                 text run at (21,4) width 133: "Performance materials"
-            RenderBlock {SPAN} at (325,303) size 180x23 [color=#333333]
+            RenderBlock {SPAN} at (325,291) size 180x23 [color=#333333]
               RenderBlock {INPUT} at (5,3) size 13x13 [color=#000000]
               RenderText {#text} at (21,4) size 21x15
                 text run at (21,4) width 21: "n/a"
-            RenderBlock {H2} at (0,350) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,338) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 374x16
                 text run at (0,0) width 374: "INTERNET SHAKESPEARE EDITIONS QUESTIONS"
-            RenderBlock (floating) {SPAN} at (0,376) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,364) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 302x15
                 text run at (0,2) width 302: "Have you used UVic's Internet Shakespeare Editions?"
-            RenderBlock {SPAN} at (325,376) size 180x23 [color=#333333]
+            RenderBlock {SPAN} at (325,364) size 180x23 [color=#333333]
               RenderText {#text} at (0,4) size 19x15
                 text run at (0,4) width 19: "Yes"
               RenderBlock {INPUT} at (24,3) size 13x13 [color=#000000]
@@ -106,77 +106,77 @@ layer at (0,0) size 785x1740
                 text run at (44,4) width 15: "No"
               RenderBlock {INPUT} at (64,3) size 13x13 [color=#000000]
               RenderText {#text} at (0,0) size 0x0
-            RenderBlock {P} at (0,411) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,399) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 378x15
                 text run at (0,2) width 378: "-- If you answered no to this question, skip to the next section --"
-            RenderBlock (floating) {SPAN} at (0,444) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,432) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 274x15
                 text run at (0,2) width 274: "Which area of the ISE did you find most useful?"
-            RenderMenuList {SELECT} at (325,444) size 180x20 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,432) size 180x20 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 111x15
                   text run at (0,0) width 111: "Sections of the ISE"
-            RenderBlock (floating) {SPAN} at (0,465) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,452) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 252x15
                 text run at (0,2) width 252: "How did you find the navigation of the ISE?"
-            RenderMenuList {SELECT} at (325,465) size 180x20 [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,451) size 180x20 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (4,2) size 155x15
                 RenderText at (0,0) size 97x15
                   text run at (0,0) width 97: "Level of difficulty"
-            RenderBlock (floating) {SPAN} at (0,486) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,472) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 206x15
                 text run at (0,2) width 206: "Please describe your use of the ISE."
-            RenderBlock {H2} at (0,640) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,626) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 291x16
                 text run at (0,0) width 291: "TOOLS IN DEVELOPMENT QUESTIONS"
-            RenderBlock {P} at (0,670) size 560x61 [color=#333333]
+            RenderBlock {P} at (0,656) size 560x61 [color=#333333]
               RenderText {#text} at (0,2) size 556x55
                 text run at (0,2) width 453: "We are in the process of both making new material available and developing "
                 text run at (453,2) width 103: "new tools to view"
                 text run at (0,22) width 354: "and extrapolate information from Shakespeare's works. The "
                 text run at (354,22) width 160: "following images are visual"
                 text run at (0,42) width 343: "representations of some of the ideas being thrown around."
-            RenderBlock {P} at (0,743) size 560x21 [color=#333333]
+            RenderBlock {P} at (0,729) size 560x21 [color=#333333]
               RenderText {#text} at (0,2) size 337x15
                 text run at (0,2) width 337: "Please review them carefully and provide feedback below"
-            RenderBlock (floating) {SPAN} at (0,776) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,762) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 145x15
                 text run at (0,2) width 145: "Your comments on Fig. 1"
-            RenderBlock (floating) {SPAN} at (0,907) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,893) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 145x15
                 text run at (0,2) width 145: "Your comments on Fig. 2"
-            RenderBlock (floating) {SPAN} at (0,1038) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,1024) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 145x15
                 text run at (0,2) width 145: "Your comments on Fig. 3"
-            RenderBlock {H2} at (0,1189) size 560x17 [color=#333333]
+            RenderBlock {H2} at (0,1175) size 560x17 [color=#333333]
               RenderText {#text} at (0,0) size 143x16
                 text run at (0,0) width 143: "OTHER FEEDBACK"
-            RenderBlock (floating) {SPAN} at (0,1215) size 325x21 [color=#333333]
+            RenderBlock (floating) {SPAN} at (0,1201) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 220x15
                 text run at (0,2) width 220: "Please enter any other thoughts here."
-          RenderBlock {P} at (20,1493) size 560x21 [color=#333333]
+          RenderBlock {P} at (20,1479) size 560x21 [color=#333333]
             RenderText {#text} at (0,2) size 233x15
               text run at (0,2) width 233: "Thank you for your time filling this out."
-        RenderBlock {DIV} at (1,1647) size 600x52 [border: (1px dashed #A6A972) none]
+        RenderBlock {DIV} at (1,1633) size 600x52 [border: (1px dashed #A6A972) none]
           RenderBlock {SPAN} at (0,16) size 600x20 [color=#333333]
             RenderText {#text} at (247,2) size 106x15
               text run at (247,2) width 106: "\x{A9}2003 Kevin Davis"
 layer at (440,302) size 180x15
   RenderBlock {DIV} at (2,3) size 180x15
-layer at (440,325) size 180x15
+layer at (440,323) size 180x15
   RenderBlock {DIV} at (2,3) size 180x15
-layer at (113,783) size 506x106 clip at (114,784) size 504x104
-  RenderTextControl {TEXTAREA} at (0,509) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,769) size 506x106 clip at (114,770) size 504x104
+  RenderTextControl {TEXTAREA} at (0,495) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x15
-layer at (113,1070) size 506x106 clip at (114,1071) size 504x104
-  RenderTextControl {TEXTAREA} at (0,796) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1056) size 506x106 clip at (114,1057) size 504x104
+  RenderTextControl {TEXTAREA} at (0,782) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x15
-layer at (113,1201) size 506x106 clip at (114,1202) size 504x104
-  RenderTextControl {TEXTAREA} at (0,927) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1187) size 506x106 clip at (114,1188) size 504x104
+  RenderTextControl {TEXTAREA} at (0,913) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x15
-layer at (113,1332) size 506x106 clip at (114,1333) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1058) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1318) size 506x106 clip at (114,1319) size 504x104
+  RenderTextControl {TEXTAREA} at (0,1044) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x15
-layer at (113,1509) size 506x106 clip at (114,1510) size 504x104
-  RenderTextControl {TEXTAREA} at (0,1235) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (113,1495) size 506x106 clip at (114,1496) size 504x104
+  RenderTextControl {TEXTAREA} at (0,1221) size 506x107 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 500x15

--- a/LayoutTests/platform/win/fast/block/positioning/inline-block-relposition-expected.txt
+++ b/LayoutTests/platform/win/fast/block/positioning/inline-block-relposition-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,8) size 784x25
+layer at (0,0) size 800x37
+  RenderBlock {HTML} at (0,0) size 800x37
+    RenderBody {BODY} at (8,8) size 784x21
       RenderText {#text} at (0,0) size 0x0
-layer at (8,10) size 100x21
-  RenderButton {BUTTON} at (0,2) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (8,8) size 100x21
+  RenderButton {BUTTON} at (0,0) size 100x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
     RenderBlock (anonymous) at (8,3) size 84x15
       RenderText {#text} at (17,0) size 50x15
         text run at (17,0) width 50: "Click Me"
-layer at (86,28) size 25x15
+layer at (86,26) size 25x15
   RenderBlock (positioned) {DIV} at (78,18) size 25x15
     RenderText {#text} at (0,0) size 25x15
       text run at (0,0) width 25: "Now"

--- a/LayoutTests/platform/win/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/win/fast/css/continuationCrash-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,39) size 784x19
         RenderText {#text} at (0,0) size 176x18
           text run at (0,0) width 176: "Click the following buttons."
-      RenderBlock {OL} at (0,73) size 784x170
+      RenderBlock {OL} at (0,73) size 784x166
         RenderListItem {LI} at (40,0) size 744x18
           RenderListMarker at (-20,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 193x18
@@ -46,20 +46,20 @@ layer at (0,0) size 800x600
           RenderListMarker at (-20,0) size 16x18: "8"
           RenderText {#text} at (0,0) size 201x18
             text run at (0,0) width 201: "2. 3. will not crash Safari either."
-        RenderBlock (anonymous) at (40,144) size 744x25
-          RenderButton {INPUT} at (2,2) size 141x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock (anonymous) at (40,144) size 744x21
+          RenderButton {INPUT} at (0,0) size 141x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 125x15
               RenderText at (0,0) size 125x15
                 text run at (0,0) width 125: "1. Set outline property"
-          RenderText {#text} at (145,3) size 4x18
-            text run at (145,3) width 4: " "
-          RenderButton {INPUT} at (151,2) size 144x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderText {#text} at (141,1) size 4x18
+            text run at (141,1) width 4: " "
+          RenderButton {INPUT} at (145,0) size 144x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 128x15
               RenderText at (0,0) size 128x15
                 text run at (0,0) width 128: "2. Set display property"
-          RenderText {#text} at (297,3) size 4x18
-            text run at (297,3) width 4: " "
-          RenderButton {INPUT} at (303,2) size 158x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderText {#text} at (289,1) size 4x18
+            text run at (289,1) width 4: " "
+          RenderButton {INPUT} at (293,0) size 158x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 142x15
               RenderText at (0,0) size 142x15
                 text run at (0,0) width 142: "3. Replace span-element"

--- a/LayoutTests/platform/win/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (582,26) size 76x22 [border: (1px inset #808080)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 72x18
                 text run at (2,2) width 72: "col 3 row 3"
-      RenderBlock (anonymous) at (0,52) size 784x25
-        RenderButton {BUTTON} at (2,2) size 386x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,52) size 784x21
+        RenderButton {BUTTON} at (0,0) size 386x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 370x15
             RenderText {#text} at (0,0) size 370x15
               text run at (0,0) width 370: "Click me to test manually. The first column should grow to 500px."

--- a/LayoutTests/platform/win/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt
@@ -3,17 +3,17 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x46
-        RenderText {#text} at (183,24) size 4x18
-          text run at (183,24) width 4: " "
-        RenderText {#text} at (370,24) size 4x18
-          text run at (370,24) width 4: " "
-        RenderButton {INPUT} at (376,23) size 50x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {FORM} at (0,0) size 784x40
+        RenderText {#text} at (179,20) size 4x18
+          text run at (179,20) width 4: " "
+        RenderText {#text} at (362,20) size 4x18
+          text run at (362,20) width 4: " "
+        RenderButton {INPUT} at (366,19) size 50x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 34x15
             RenderText at (0,0) size 34x15
               text run at (0,0) width 34: "Reset"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,62) size 784x72
+      RenderBlock {P} at (0,56) size 784x72
         RenderText {#text} at (0,0) size 358x18
           text run at (0,0) width 358: "This test verifies that textarea controls are properly reset. "
         RenderBR {BR} at (358,14) size 0x0
@@ -25,11 +25,11 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (175,50) size 0x0
         RenderText {#text} at (0,54) size 176x18
           text run at (0,54) width 176: "hasDefaultText: SUCCESS"
-layer at (10,10) size 179x34 clip at (11,11) size 177x32
-  RenderTextControl {TEXTAREA} at (2,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 179x34 clip at (9,9) size 177x32
+  RenderTextControl {TEXTAREA} at (0,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
-layer at (197,10) size 179x34 clip at (198,11) size 177x32
-  RenderTextControl {TEXTAREA} at (189,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (191,8) size 179x34 clip at (192,9) size 177x32
+  RenderTextControl {TEXTAREA} at (183,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderText {#text} at (0,0) size 96x15
         text run at (0,0) width 96: "Default Text"

--- a/LayoutTests/platform/win/fast/dynamic/008-expected.txt
+++ b/LayoutTests/platform/win/fast/dynamic/008-expected.txt
@@ -1,12 +1,12 @@
-layer at (0,0) size 785x774
+layer at (0,0) size 785x770
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x774
-  RenderBlock {HTML} at (0,0) size 785x774
-    RenderBody {BODY} at (8,8) size 769x758
+layer at (0,0) size 785x770
+  RenderBlock {HTML} at (0,0) size 785x770
+    RenderBody {BODY} at (8,8) size 769x754
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 339x754 clip at (11,11) size 337x752
-  RenderTextControl {TEXTAREA} at (2,2) size 339x754 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 339x754 clip at (9,9) size 337x752
+  RenderTextControl {TEXTAREA} at (0,0) size 339x754 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 335x15
       RenderText {#text} at (0,0) size 88x15
         text run at (0,0) width 88: "Sample text"

--- a/LayoutTests/platform/win/fast/dynamic/positioned-movement-with-positioned-children-expected.txt
+++ b/LayoutTests/platform/win/fast/dynamic/positioned-movement-with-positioned-children-expected.txt
@@ -8,11 +8,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 98: "You should not"
           text run at (0,18) width 96: "see this. Resize"
           text run at (0,36) width 79: "the window."
-layer at (8,8) size 100x125
-  RenderBlock (positioned) {DIV} at (0,0) size 100x125
+layer at (8,8) size 100x121
+  RenderBlock (positioned) {DIV} at (0,0) size 100x121
     RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]
-    RenderBlock (anonymous) at (0,100) size 100x25
-      RenderButton {BUTTON} at (2,2) size 54x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+    RenderBlock (anonymous) at (0,100) size 100x21
+      RenderButton {BUTTON} at (0,0) size 54x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 38x15
           RenderText {#text} at (0,0) size 38x15
             text run at (0,0) width 38: "Button"

--- a/LayoutTests/platform/win/fast/flexbox/clear-overflow-before-scroll-update-expected.txt
+++ b/LayoutTests/platform/win/fast/flexbox/clear-overflow-before-scroll-update-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x45
-  RenderBlock {HTML} at (0,0) size 800x45
-    RenderDeprecatedFlexibleBox {BODY} at (8,8) size 784x29
-      RenderBlock (anonymous) at (0,0) size 28x29
-        RenderText {#text} at (14,5) size 4x18
-          text run at (14,5) width 4: " "
-        RenderBlock {SPAN} at (18,9) size 10x10 [bgcolor=#FF0000]
+layer at (0,0) size 800x41
+  RenderBlock {HTML} at (0,0) size 800x41
+    RenderDeprecatedFlexibleBox {BODY} at (8,8) size 784x25
+      RenderBlock (anonymous) at (0,0) size 24x25
+        RenderText {#text} at (10,3) size 4x18
+          text run at (10,3) width 4: " "
+        RenderBlock {SPAN} at (14,7) size 10x10 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 10x25 clip at (0,0) size 0x0 scrollWidth 1
-  RenderMenuList {SELECT} at (2,2) size 10x25 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
+layer at (8,8) size 10x25 clip at (0,0) size 0x0 scrollWidth 1
+  RenderMenuList {SELECT} at (0,0) size 10x25 [bgcolor=#FFFFFF] [border: (5px solid #000000)]
     RenderBlock (anonymous) at (5,5) size 0x15
       RenderText at (-9999,0) size 0x15
         text run at (-9999,0) width 0: " "

--- a/LayoutTests/platform/win/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/001-expected.txt
@@ -9,12 +9,12 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,58) size 784x106 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 780x101
           RenderTableRow {TR} at (0,0) size 780x101
-            RenderTableCell {TD} at (0,0) size 133x101 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (3,1) size 127x99 [bgcolor=#FFFFFF] [border: (40px solid #FF0000)]
+            RenderTableCell {TD} at (0,0) size 129x101 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 127x99 [bgcolor=#FFFFFF] [border: (40px solid #FF0000)]
                 RenderBlock (anonymous) at (44,42) size 22x15
                   RenderText at (0,0) size 22x15
                     text run at (0,0) width 22: "Foo"
-            RenderTableCell {TD} at (133,49) size 647x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (129,49) size 651x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
       RenderBlock {P} at (0,179) size 784x25
         RenderTable {TABLE} at (0,0) size 784x24 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x20
@@ -29,37 +29,37 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (0,0) size 23x17 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                 RenderBlock {INPUT} at (6,4) size 13x12
               RenderTableCell {TD} at (23,7) size 757x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-      RenderBlock {P} at (0,256) size 784x32
-        RenderTable {TABLE} at (0,0) size 784x31 [border: (2px outset #808080)]
-          RenderTableSection {TBODY} at (2,2) size 780x27
-            RenderTableRow {TR} at (0,0) size 780x27
-              RenderTableCell {TD} at (0,0) size 44x27 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {P} at (0,256) size 784x28
+        RenderTable {TABLE} at (0,0) size 784x27 [border: (2px outset #808080)]
+          RenderTableSection {TBODY} at (2,2) size 780x23
+            RenderTableRow {TR} at (0,0) size 780x23
+              RenderTableCell {TD} at (0,0) size 40x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 22x15
                     RenderText at (0,0) size 22x15
                       text run at (0,0) width 22: "Foo"
-              RenderTableCell {TD} at (44,12) size 736x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-      RenderBlock {P} at (0,303) size 784x259
+              RenderTableCell {TD} at (40,10) size 740x3 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+      RenderBlock {P} at (0,299) size 784x259
         RenderTable {TABLE} at (0,0) size 784x88 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x84
             RenderTableRow {TR} at (0,0) size 780x84
-              RenderTableCell {TD} at (0,0) size 120x84 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,1) size 114x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
+              RenderTableCell {TD} at (0,0) size 116x84 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 114x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
                   RenderBlock (anonymous) at (46,41) size 22x15
                     RenderText at (0,0) size 22x15
                       text run at (0,0) width 22: "Foo"
-              RenderTableCell {TD} at (120,41) size 660x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (116,41) size 664x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
         RenderTable {TABLE} at (0,88) size 784x88 [border: (2px outset #808080)]
           RenderTableSection {TBODY} at (2,2) size 780x84
             RenderTableRow {TR} at (0,0) size 780x84
-              RenderTableCell {TD} at (0,0) size 173x84 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,1) size 167x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
+              RenderTableCell {TD} at (0,0) size 169x84 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 167x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
                   RenderBlock (anonymous) at (46,41) size 75x15
                     RenderText at (0,0) size 75x15
                       text run at (0,0) width 75: "Submit a bug"
-              RenderTableCell {TD} at (173,41) size 607x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (169,41) size 611x2 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
         RenderBlock (anonymous) at (0,176) size 784x82
-          RenderButton {INPUT} at (2,0) size 114x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
+          RenderButton {INPUT} at (0,0) size 114x82 [bgcolor=#F0F0F0] [border: (40px solid #FF0000)]
             RenderBlock (anonymous) at (46,41) size 22x15
               RenderText at (0,0) size 22x15
                 text run at (0,0) width 22: "Foo"

--- a/LayoutTests/platform/win/fast/forms/003-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/003-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,0) size 54x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 54x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 29x15
           RenderText at (0,0) size 29x15
             text run at (0,0) width 29: "Hello"
-      RenderBlock (anonymous) at (0,21) size 784x18
+      RenderBlock (anonymous) at (0,19) size 784x18
         RenderText {#text} at (0,0) size 292x18
           text run at (0,0) width 292: "This text should be *below* the select widget."

--- a/LayoutTests/platform/win/fast/forms/004-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/004-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 54x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 54x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 29x15
           RenderText at (0,0) size 29x15
             text run at (0,0) width 29: "Hello"
-      RenderText {#text} at (58,2) size 4x18
-        text run at (58,2) width 4: " "
-      RenderMenuList {SELECT} at (64,2) size 77x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (54,0) size 4x18
+        text run at (54,0) width 4: " "
+      RenderMenuList {SELECT} at (58,0) size 77x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 52x15
           RenderText at (0,0) size 52x15
             text run at (0,0) width 52: "Goodbye"

--- a/LayoutTests/platform/win/fast/forms/basic-buttons-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/basic-buttons-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x366
-  RenderBlock {HTML} at (0,0) size 800x366
-    RenderBody {BODY} at (8,8) size 784x350
+layer at (0,0) size 800x338
+  RenderBlock {HTML} at (0,0) size 800x338
+    RenderBody {BODY} at (8,8) size 784x322
       RenderBlock (anonymous) at (0,0) size 784x72
         RenderText {#text} at (0,0) size 538x18
           text run at (0,0) width 538: "Tests for basic button rendering. Creates a table with seven columns and seven rows. "
@@ -14,8 +14,8 @@ layer at (0,0) size 800x366
           text run at (0,36) width 649: "with text (\"foo\") and then uses six different paddings to make sure each of the buttons render properly. "
         RenderBR {BR} at (649,36) size 0x18
         RenderBR {BR} at (0,54) size 0x18
-      RenderTable {TABLE} at (0,72) size 684x278
-        RenderTableSection {TBODY} at (0,0) size 684x278
+      RenderTable {TABLE} at (0,72) size 684x250
+        RenderTableSection {TBODY} at (0,0) size 684x250
           RenderTableRow {TR} at (0,0) size 684x20
             RenderTableCell {TD} at (0,0) size 169x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 42x18
@@ -32,136 +32,136 @@ layer at (0,0) size 800x366
             RenderTableCell {TD} at (518,0) size 166x20 [r=0 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 164x18
                 text run at (1,1) width 164: "(offsetH,W) (clientH, -W)"
-          RenderTableRow {TR} at (0,20) size 684x27
-            RenderTableCell {TD} at (0,23) size 169x21 [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,20) size 684x23
+            RenderTableCell {TD} at (0,21) size 169x21 [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 53x19
                 text run at (1,2) width 53: "(default)"
-            RenderTableCell {TD} at (169,20) size 60x27 [r=1 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 26x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,20) size 60x23 [r=1 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 26x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,23) size 157x21 [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,21) size 157x21 [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(21, 26) (17, 22)"
-            RenderTableCell {TD} at (386,20) size 132x27 [r=1 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 34x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,20) size 132x23 [r=1 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 34x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,23) size 166x21 [r=1 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,21) size 166x21 [r=1 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(21, 34) (17, 30)"
-          RenderTableRow {TR} at (0,47) size 684x25
-            RenderTableCell {TD} at (0,49) size 169x21 [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,43) size 684x21
+            RenderTableCell {TD} at (0,43) size 169x21 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 67x19
                 text run at (1,2) width 67: "padding: 0"
-            RenderTableCell {TD} at (169,47) size 60x25 [r=2 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 14x19 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,43) size 60x21 [r=2 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 14x19 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (2,2) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,49) size 157x21 [r=2 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,43) size 157x21 [r=2 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(19, 14) (15, 10)"
-            RenderTableCell {TD} at (386,47) size 132x25 [r=2 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 22x19 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,43) size 132x21 [r=2 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 22x19 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (2,2) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,49) size 166x21 [r=2 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,43) size 166x21 [r=2 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(19, 22) (15, 18)"
-          RenderTableRow {TR} at (0,72) size 684x51
-            RenderTableCell {TD} at (0,87) size 169x21 [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,64) size 684x47
+            RenderTableCell {TD} at (0,77) size 169x21 [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 88x19
                 text run at (1,2) width 88: "padding: 10%"
-            RenderTableCell {TD} at (169,79) size 60x37 [r=3 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 26x31 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,71) size 60x33 [r=3 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 26x31 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (7,7) size 11x16
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,87) size 157x21 [r=3 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,77) size 157x21 [r=3 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(31, 26) (27, 22)"
-            RenderTableCell {TD} at (386,72) size 132x51 [r=3 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 48x45 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,64) size 132x47 [r=3 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 48x45 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (15,15) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,87) size 166x21 [r=3 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,77) size 166x21 [r=3 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(45, 48) (41, 44)"
-          RenderTableRow {TR} at (0,123) size 684x29
-            RenderTableCell {TD} at (0,127) size 169x21 [r=4 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,111) size 684x25
+            RenderTableCell {TD} at (0,113) size 169x21 [r=4 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 83x19
                 text run at (1,2) width 83: "padding: 2px"
-            RenderTableCell {TD} at (169,123) size 60x29 [r=4 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 18x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,111) size 60x25 [r=4 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 18x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (4,4) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,127) size 157x21 [r=4 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,113) size 157x21 [r=4 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(23, 18) (19, 14)"
-            RenderTableCell {TD} at (386,123) size 132x29 [r=4 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 26x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,111) size 132x25 [r=4 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 26x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (4,4) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,127) size 166x21 [r=4 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,113) size 166x21 [r=4 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(23, 26) (19, 22)"
-          RenderTableRow {TR} at (0,152) size 684x30
-            RenderTableCell {TD} at (0,157) size 169x20 [r=5 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,136) size 684x26
+            RenderTableCell {TD} at (0,139) size 169x20 [r=5 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 167x18
                 text run at (1,1) width 167: "padding: 2px 6px 3px 6px"
-            RenderTableCell {TD} at (169,152) size 60x30 [r=5 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 26x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,136) size 60x26 [r=5 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 26x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,4) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,157) size 157x20 [r=5 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,139) size 157x20 [r=5 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x18
                 text run at (1,1) width 104: "(24, 26) (20, 22)"
-            RenderTableCell {TD} at (386,152) size 132x30 [r=5 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 34x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,136) size 132x26 [r=5 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 34x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,4) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,157) size 166x20 [r=5 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,139) size 166x20 [r=5 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x18
                 text run at (1,1) width 104: "(24, 34) (20, 30)"
-          RenderTableRow {TR} at (0,182) size 684x31
-            RenderTableCell {TD} at (0,187) size 169x21 [r=6 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,162) size 684x27
+            RenderTableCell {TD} at (0,165) size 169x21 [r=6 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 111x19
                 text run at (1,2) width 111: "padding: 3px 7px"
-            RenderTableCell {TD} at (169,182) size 60x31 [r=6 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 28x25 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,162) size 60x27 [r=6 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 28x25 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (9,5) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,187) size 157x21 [r=6 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,165) size 157x21 [r=6 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(25, 28) (21, 24)"
-            RenderTableCell {TD} at (386,182) size 132x31 [r=6 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 36x25 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,162) size 132x27 [r=6 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 36x25 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (9,5) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,187) size 166x21 [r=6 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,165) size 166x21 [r=6 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(25, 36) (21, 32)"
-          RenderTableRow {TR} at (0,213) size 684x65
-            RenderTableCell {TD} at (0,235) size 169x21 [r=7 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,189) size 684x61
+            RenderTableCell {TD} at (0,209) size 169x21 [r=7 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 91x19
                 text run at (1,2) width 91: "padding: 20px"
-            RenderTableCell {TD} at (169,213) size 60x65 [r=7 c=1 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 54x59 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (169,189) size 60x61 [r=7 c=1 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 54x59 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (22,22) size 10x15
                   RenderImage {IMG} at (0,2) size 10x10
-            RenderTableCell {TD} at (229,235) size 157x21 [r=7 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (229,209) size 157x21 [r=7 c=2 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(59, 54) (55, 50)"
-            RenderTableCell {TD} at (386,213) size 132x65 [r=7 c=3 rs=1 cs=1]
-              RenderButton {INPUT} at (3,3) size 62x59 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (386,189) size 132x61 [r=7 c=3 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 62x59 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (22,22) size 18x15
                   RenderText at (0,0) size 18x15
                     text run at (0,0) width 18: "foo"
-            RenderTableCell {TD} at (518,235) size 166x21 [r=7 c=4 rs=1 cs=1]
+            RenderTableCell {TD} at (518,209) size 166x21 [r=7 c=4 rs=1 cs=1]
               RenderText {#text} at (1,1) size 104x19
                 text run at (1,2) width 104: "(59, 62) (55, 58)"

--- a/LayoutTests/platform/win/fast/forms/basic-inputs-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/basic-inputs-expected.txt
@@ -57,7 +57,7 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (97,4) size 13x13
         RenderText {#text} at (113,3) size 8x18
           text run at (113,3) width 8: "b"
-      RenderBlock {DIV} at (10,410) size 450x22 [border: (1px solid #FF0000)]
+      RenderBlock {DIV} at (10,402) size 450x22 [border: (1px solid #FF0000)]
         RenderText {#text} at (1,3) size 7x18
           text run at (1,3) width 7: "a"
         RenderBlock {INPUT} at (13,4) size 13x13

--- a/LayoutTests/platform/win/fast/forms/basic-selects-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/basic-selects-expected.txt
@@ -1,174 +1,174 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x506
-  RenderBlock {HTML} at (0,0) size 800x506
-    RenderBody {BODY} at (8,8) size 784x490
-      RenderBlock {DIV} at (0,0) size 784x490 [border: (1px solid #FF0000)]
-        RenderText {#text} at (1,3) size 164x18
-          text run at (1,3) width 164: "Whitespace in option text:"
-        RenderMenuList {SELECT} at (167,3) size 49x19 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x466
+  RenderBlock {HTML} at (0,0) size 800x466
+    RenderBody {BODY} at (8,8) size 784x450
+      RenderBlock {DIV} at (0,0) size 784x450 [border: (1px solid #FF0000)]
+        RenderText {#text} at (1,1) size 164x18
+          text run at (1,1) width 164: "Whitespace in option text:"
+        RenderMenuList {SELECT} at (165,1) size 49x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 24x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "f o o"
-        RenderText {#text} at (218,3) size 7x18
-          text run at (218,3) width 7: "a"
-        RenderMenuList {SELECT} at (227,3) size 49x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (214,1) size 7x18
+          text run at (214,1) width 7: "a"
+        RenderMenuList {SELECT} at (221,1) size 49x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 24x15
             RenderText at (0,0) size 24x15
               text run at (0,0) width 24: "f o o"
-        RenderText {#text} at (278,3) size 8x18
-          text run at (278,3) width 8: "b"
-        RenderBR {BR} at (286,3) size 0x18
-        RenderBR {BR} at (1,23) size 0x18
-        RenderText {#text} at (1,42) size 135x18
-          text run at (1,42) width 135: "Simple select control:"
-        RenderMenuList {SELECT} at (138,42) size 43x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (270,1) size 8x18
+          text run at (270,1) width 8: "b"
+        RenderBR {BR} at (278,1) size 0x18
+        RenderBR {BR} at (1,19) size 0x18
+        RenderText {#text} at (1,36) size 135x18
+          text run at (1,36) width 135: "Simple select control:"
+        RenderMenuList {SELECT} at (136,36) size 43x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 18x15
             RenderText at (0,0) size 18x15
               text run at (0,0) width 18: "foo"
-        RenderText {#text} at (183,42) size 7x18
-          text run at (183,42) width 7: "a"
-        RenderMenuList {SELECT} at (192,42) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+        RenderText {#text} at (179,36) size 7x18
+          text run at (179,36) width 7: "a"
+        RenderMenuList {SELECT} at (186,36) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 18x15
             RenderText at (0,0) size 18x15
               text run at (0,0) width 18: "foo"
-        RenderText {#text} at (237,42) size 8x18
-          text run at (237,42) width 8: "b"
-        RenderBR {BR} at (245,42) size 0x18
-        RenderBR {BR} at (1,62) size 0x18
-        RenderText {#text} at (1,81) size 194x18
-          text run at (1,81) width 194: "Line-height should be ignored:"
-        RenderMenuList {SELECT} at (197,81) size 43x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (229,36) size 8x18
+          text run at (229,36) width 8: "b"
+        RenderBR {BR} at (237,36) size 0x18
+        RenderBR {BR} at (1,54) size 0x18
+        RenderText {#text} at (1,71) size 194x18
+          text run at (1,71) width 194: "Line-height should be ignored:"
+        RenderMenuList {SELECT} at (195,71) size 43x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 18x15
             RenderText at (0,0) size 18x15
               text run at (0,0) width 18: "foo"
-        RenderText {#text} at (242,81) size 7x18
-          text run at (242,81) width 7: "a"
-        RenderMenuList {SELECT} at (251,81) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "bar"
-        RenderText {#text} at (296,81) size 8x18
-          text run at (296,81) width 8: "b"
-        RenderBR {BR} at (304,81) size 0x18
-        RenderBR {BR} at (1,101) size 0x18
-        RenderText {#text} at (1,120) size 434x18
-          text run at (1,120) width 434: "Padding should be respected, the arrow button shouldn't change size:"
-        RenderMenuList {SELECT} at (437,120) size 43x19 [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (482,120) size 7x18
-          text run at (482,120) width 7: "a"
-        RenderMenuList {SELECT} at (491,120) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (536,120) size 8x18
-          text run at (536,120) width 8: "b"
-        RenderBR {BR} at (544,120) size 0x18
-        RenderBR {BR} at (1,140) size 0x18
-        RenderText {#text} at (1,167) size 176x18
-          text run at (1,167) width 176: "Border should be respected:"
-        RenderMenuList {SELECT} at (179,159) size 59x35 [bgcolor=#FFFFFF] [border: (8px solid #33CCFF)]
-          RenderBlock (anonymous) at (12,10) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (240,167) size 7x18
-          text run at (240,167) width 7: "a"
-        RenderMenuList {SELECT} at (249,159) size 59x35 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (8px solid #33CCFF)]
-          RenderBlock (anonymous) at (12,10) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (310,167) size 8x18
-          text run at (310,167) width 8: "b"
-        RenderBR {BR} at (318,167) size 0x18
-        RenderBR {BR} at (1,195) size 0x18
-        RenderText {#text} at (1,218) size 116x18
-          text run at (1,218) width 116: "Border + padding:"
-        RenderMenuList {SELECT} at (119,214) size 51x27 [bgcolor=#FFFFFF] [border: (4px solid #33CCFF)]
-          RenderBlock (anonymous) at (8,6) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (172,218) size 7x18
-          text run at (172,218) width 7: "a"
-        RenderMenuList {SELECT} at (181,214) size 51x27 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (4px solid #33CCFF)]
-          RenderBlock (anonymous) at (8,6) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (234,218) size 8x18
-          text run at (234,218) width 8: "b"
-        RenderBR {BR} at (242,218) size 0x18
-        RenderBR {BR} at (1,242) size 0x18
-        RenderText {#text} at (1,259) size 481x18
-          text run at (1,259) width 481: "Height larger than font-size, button should grow, text baseline should center:"
-        RenderMenuList {SELECT} at (484,259) size 43x19 [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (529,259) size 7x18
-          text run at (529,259) width 7: "a"
-        RenderMenuList {SELECT} at (538,259) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (583,259) size 8x18
-          text run at (583,259) width 8: "b"
-        RenderBR {BR} at (591,259) size 0x18
-        RenderBR {BR} at (1,277) size 0x18
-        RenderText {#text} at (1,294) size 502x18
-          text run at (1,294) width 502: "Heigh smaller than font-size, whole select shrinks and is baselined with the text:"
-        RenderMenuList {SELECT} at (505,294) size 43x19 [bgcolor=#FFFFFF]
-          RenderBlock (anonymous) at (4,2) size 18x15
-            RenderText at (0,0) size 18x15
-              text run at (0,0) width 18: "foo"
-        RenderText {#text} at (550,294) size 7x18
-          text run at (550,294) width 7: "a"
-        RenderMenuList {SELECT} at (559,294) size 43x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (238,71) size 7x18
+          text run at (238,71) width 7: "a"
+        RenderMenuList {SELECT} at (245,71) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 18x15
             RenderText at (0,0) size 18x15
               text run at (0,0) width 18: "bar"
-        RenderText {#text} at (604,294) size 8x18
-          text run at (604,294) width 8: "b"
-        RenderBR {BR} at (612,294) size 0x18
-        RenderBR {BR} at (1,312) size 0x18
-        RenderText {#text} at (1,328) size 168x18
-          text run at (1,328) width 168: "select control with size=0: "
-        RenderBR {BR} at (169,328) size 0x18
-        RenderMenuList {SELECT} at (3,347) size 202x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (288,71) size 8x18
+          text run at (288,71) width 8: "b"
+        RenderBR {BR} at (296,71) size 0x18
+        RenderBR {BR} at (1,89) size 0x18
+        RenderText {#text} at (1,106) size 434x18
+          text run at (1,106) width 434: "Padding should be respected, the arrow button shouldn't change size:"
+        RenderMenuList {SELECT} at (435,106) size 43x19 [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (478,106) size 7x18
+          text run at (478,106) width 7: "a"
+        RenderMenuList {SELECT} at (485,106) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (528,106) size 8x18
+          text run at (528,106) width 8: "b"
+        RenderBR {BR} at (536,106) size 0x18
+        RenderBR {BR} at (1,124) size 0x18
+        RenderText {#text} at (1,149) size 176x18
+          text run at (1,149) width 176: "Border should be respected:"
+        RenderMenuList {SELECT} at (177,141) size 59x35 [bgcolor=#FFFFFF] [border: (8px solid #33CCFF)]
+          RenderBlock (anonymous) at (12,10) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (236,149) size 7x18
+          text run at (236,149) width 7: "a"
+        RenderMenuList {SELECT} at (243,141) size 59x35 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (8px solid #33CCFF)]
+          RenderBlock (anonymous) at (12,10) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (302,149) size 8x18
+          text run at (302,149) width 8: "b"
+        RenderBR {BR} at (310,149) size 0x18
+        RenderBR {BR} at (1,175) size 0x18
+        RenderText {#text} at (1,196) size 116x18
+          text run at (1,196) width 116: "Border + padding:"
+        RenderMenuList {SELECT} at (117,192) size 51x27 [bgcolor=#FFFFFF] [border: (4px solid #33CCFF)]
+          RenderBlock (anonymous) at (8,6) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (168,196) size 7x18
+          text run at (168,196) width 7: "a"
+        RenderMenuList {SELECT} at (175,192) size 51x27 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (4px solid #33CCFF)]
+          RenderBlock (anonymous) at (8,6) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (226,196) size 8x18
+          text run at (226,196) width 8: "b"
+        RenderBR {BR} at (234,196) size 0x18
+        RenderBR {BR} at (1,218) size 0x18
+        RenderText {#text} at (1,235) size 481x18
+          text run at (1,235) width 481: "Height larger than font-size, button should grow, text baseline should center:"
+        RenderMenuList {SELECT} at (482,235) size 43x19 [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (525,235) size 7x18
+          text run at (525,235) width 7: "a"
+        RenderMenuList {SELECT} at (532,235) size 43x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (575,235) size 8x18
+          text run at (575,235) width 8: "b"
+        RenderBR {BR} at (583,235) size 0x18
+        RenderBR {BR} at (1,253) size 0x18
+        RenderText {#text} at (1,270) size 502x18
+          text run at (1,270) width 502: "Heigh smaller than font-size, whole select shrinks and is baselined with the text:"
+        RenderMenuList {SELECT} at (503,270) size 43x19 [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "foo"
+        RenderText {#text} at (546,270) size 7x18
+          text run at (546,270) width 7: "a"
+        RenderMenuList {SELECT} at (553,270) size 43x19 [bgcolor=#FFFFFF]
+          RenderBlock (anonymous) at (4,2) size 18x15
+            RenderText at (0,0) size 18x15
+              text run at (0,0) width 18: "bar"
+        RenderText {#text} at (596,270) size 8x18
+          text run at (596,270) width 8: "b"
+        RenderBR {BR} at (604,270) size 0x18
+        RenderBR {BR} at (1,288) size 0x18
+        RenderText {#text} at (1,304) size 168x18
+          text run at (1,304) width 168: "select control with size=0: "
+        RenderBR {BR} at (169,304) size 0x18
+        RenderMenuList {SELECT} at (1,321) size 202x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 177x15
             RenderText at (0,0) size 77x15
               text run at (0,0) width 77: "Future Series"
-        RenderText {#text} at (207,347) size 4x18
-          text run at (207,347) width 4: " "
+        RenderText {#text} at (203,321) size 4x18
+          text run at (203,321) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderText {#text} at (1,367) size 168x18
-          text run at (1,367) width 168: "select control with size=1: "
-        RenderBR {BR} at (169,367) size 0x18
-        RenderMenuList {SELECT} at (3,386) size 202x19 [bgcolor=#FFFFFF]
+        RenderText {#text} at (1,339) size 168x18
+          text run at (1,339) width 168: "select control with size=1: "
+        RenderBR {BR} at (169,339) size 0x18
+        RenderMenuList {SELECT} at (1,356) size 202x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 177x15
             RenderText at (0,0) size 77x15
               text run at (0,0) width 77: "Future Series"
-        RenderText {#text} at (207,386) size 4x18
-          text run at (207,386) width 4: " "
+        RenderText {#text} at (203,356) size 4x18
+          text run at (203,356) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderText {#text} at (1,406) size 165x18
-          text run at (1,406) width 165: "Non-styled select control: "
-        RenderBR {BR} at (166,406) size 0x18
-        RenderMenuList {SELECT} at (3,425) size 204x21 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderText {#text} at (1,374) size 165x18
+          text run at (1,374) width 165: "Non-styled select control: "
+        RenderBR {BR} at (166,374) size 0x18
+        RenderMenuList {SELECT} at (1,391) size 204x21 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (5,3) size 177x15
             RenderText at (0,0) size 77x15
               text run at (0,0) width 77: "Future Series"
-        RenderText {#text} at (209,426) size 4x18
-          text run at (209,426) width 4: " "
+        RenderText {#text} at (205,392) size 4x18
+          text run at (205,392) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderText {#text} at (1,447) size 290x18
-          text run at (1,447) width 290: "Styled select control with large border-radius: "
-        RenderBR {BR} at (291,447) size 0x18
-        RenderMenuList {SELECT} at (3,466) size 204x21 [bgcolor=#33CCFF] [border: (1px solid #000000)]
+        RenderText {#text} at (1,411) size 290x18
+          text run at (1,411) width 290: "Styled select control with large border-radius: "
+        RenderBR {BR} at (291,411) size 0x18
+        RenderMenuList {SELECT} at (1,428) size 204x21 [bgcolor=#33CCFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (5,3) size 177x15
             RenderText at (0,0) size 77x15
               text run at (0,0) width 77: "Future Series"
-        RenderText {#text} at (209,467) size 4x18
-          text run at (209,467) width 4: " "
+        RenderText {#text} at (205,429) size 4x18
+          text run at (205,429) width 4: " "
         RenderBR {BR} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/basic-textareas-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/basic-textareas-expected.txt
@@ -1,96 +1,96 @@
-layer at (0,0) size 785x1567
+layer at (0,0) size 785x1527
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1567
-  RenderBlock {HTML} at (0,0) size 785x1567
-    RenderBody {BODY} at (0,0) size 785x1567
-      RenderIFrame {IFRAME} at (0,0) size 785x803
-        layer at (0,0) size 785x803
-          RenderView at (0,0) size 785x803
-        layer at (0,0) size 785x803
-          RenderBlock {HTML} at (0,0) size 785x803
-            RenderBody {BODY} at (0,5) size 785x798
+layer at (0,0) size 785x1527
+  RenderBlock {HTML} at (0,0) size 785x1527
+    RenderBody {BODY} at (0,0) size 785x1527
+      RenderIFrame {IFRAME} at (0,0) size 785x783
+        layer at (0,0) size 785x783
+          RenderView at (0,0) size 785x783
+        layer at (0,0) size 785x783
+          RenderBlock {HTML} at (0,0) size 785x783
+            RenderBody {BODY} at (0,5) size 785x778
               RenderBlock {DIV} at (0,0) size 785x18
                 RenderText {#text} at (0,0) size 196x18
                   text run at (0,0) width 196: "CompatMode: CSS1Compat"
-              RenderBlock (anonymous) at (0,23) size 785x775
-                RenderBlock {DIV} at (0,30) size 187x59 [border: (1px solid #0000FF)]
+              RenderBlock (anonymous) at (0,23) size 785x755
+                RenderBlock {DIV} at (0,30) size 183x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,12) size 80x0
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (187,30) size 187x59 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,30) size 183x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 76x14
                       text run at (0,0) width 76: "disabled: \"true\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (374,0) size 203x89 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (366,0) size 199x85 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 78x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 78: "\"padding:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (577,20) size 183x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (565,20) size 179x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 72x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 72: "\"padding:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,123) size 203x89 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,115) size 203x89 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 73: "\"margin:10px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (203,143) size 183x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (203,135) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 67x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 67: "\"margin:0px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (386,139) size 82x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (386,135) size 82x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 67x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 67: "\"width:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (468,89) size 104x123 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (468,85) size 104x119 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 73x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 73: "padding:20px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (572,129) size 82x83 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (572,125) size 82x79 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 62x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 55: "padding:0\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (0,240) size 187x99 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,232) size 183x99 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 69x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 69: "\"height:60px\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (187,226) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,218) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 64x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (269,266) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (265,262) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 91x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 91: "\"overflow:hidden\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (456,251) size 187x88 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (448,247) size 183x84 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 85x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 85: "\"overflow:scroll\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (643,212) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (631,204) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 86x56
                       text run at (0,0) width 25: "style:"
@@ -98,7 +98,7 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 57: "width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (0,339) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,331) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 80x56
                       text run at (0,0) width 25: "style:"
@@ -106,21 +106,21 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 57: "width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (82,353) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,345) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 72x42
                       text run at (0,0) width 72: "cols: \"5\", style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (164,353) size 82x113 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (164,345) size 82x113 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 77x42
                       text run at (0,0) width 77: "rows: \"4\", style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,29) size 0x14
-                RenderBlock {DIV} at (246,339) size 82x127 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (246,331) size 82x127 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 74x56
                       text run at (0,0) width 74: "cols: \"5\", rows:"
@@ -128,97 +128,97 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 62: "\"width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,43) size 0x14
-                RenderBlock {DIV} at (328,407) size 82x59 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (328,403) size 82x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 44x14
                       text run at (0,0) width 44: "cols: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (410,392) size 187x74 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (410,388) size 183x70 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"3\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (597,407) size 83x59 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (593,403) size 82x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 44x14
                       text run at (0,0) width 44: "cols: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (0,466) size 187x134 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,458) size 183x130 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"7\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (187,497) size 82x103 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,489) size 82x99 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 74: "cols: \"5\", rows:"
                       text run at (0,14) width 19: "\"4\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (269,526) size 187x74 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (265,518) size 183x70 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 57x14
                       text run at (0,0) width 57: "wrap: \"off\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (456,541) size 187x59 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (448,533) size 183x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 64x14
                       text run at (0,0) width 64: "wrap: \"hard\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (0,614) size 187x59 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,602) size 183x55 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 61x14
                       text run at (0,0) width 61: "wrap: \"soft\","
                   RenderBR {BR} at (81,1) size 0x14
-                RenderBlock {DIV} at (187,600) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,588) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 70x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 70: "space:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (374,600) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (366,588) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 63x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 52: "space:pre\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (561,600) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (549,588) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 76x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 76: "space:prewrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (0,702) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,686) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 73: "space:nowrap\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (187,702) size 187x73 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (183,686) size 183x69 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 73: "space:pre-line\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (374,687) size 187x88 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (366,671) size 183x84 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 62: "style: \"word-"
                       text run at (0,14) width 68: "wrap:normal\","
                   RenderBR {BR} at (81,15) size 0x14
-                RenderBlock {DIV} at (561,673) size 187x102 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (549,657) size 183x98 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 80x42
                       text run at (0,0) width 57: "wrap: \"off\","
                       text run at (0,14) width 63: "style: \"white-"
                       text run at (0,28) width 80: "space:pre-wrap\","
                   RenderBR {BR} at (81,29) size 0x14
-        layer at (3,75) size 181x36 clip at (4,76) size 179x34
-          RenderTextControl {TEXTAREA} at (3,17) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,73) size 181x36 clip at (2,74) size 179x34
+          RenderTextControl {TEXTAREA} at (1,15) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 136x15
                 text run at (0,0) width 136: "Lorem ipsum dolor"
-        layer at (190,75) size 181x36 clip at (191,76) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,17) size 181x36 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
+        layer at (184,73) size 181x36 clip at (185,74) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,15) size 181x36 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75 [color=#545454]
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -228,8 +228,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (377,59) size 197x52 clip at (378,60) size 180x50 scrollHeight 95
-          RenderTextControl {TEXTAREA} at (3,31) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (367,57) size 197x52 clip at (368,58) size 180x50 scrollHeight 95
+          RenderTextControl {TEXTAREA} at (1,29) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (11,11) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -239,8 +239,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (580,79) size 177x32 clip at (581,80) size 160x30 scrollHeight 75
-          RenderTextControl {TEXTAREA} at (3,31) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (566,77) size 177x32 clip at (567,78) size 160x30 scrollHeight 75
+          RenderTextControl {TEXTAREA} at (1,29) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -250,7 +250,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (11,190) size 181x36 clip at (12,191) size 164x34 scrollHeight 79
+        layer at (11,182) size 181x36 clip at (12,183) size 164x34 scrollHeight 79
           RenderTextControl {TEXTAREA} at (11,39) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
@@ -261,7 +261,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (204,200) size 181x36 clip at (205,201) size 164x34 scrollHeight 79
+        layer at (204,192) size 181x36 clip at (205,193) size 164x34 scrollHeight 79
           RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
@@ -272,8 +272,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (387,198) size 66x36 clip at (388,199) size 49x34 scrollHeight 214
-          RenderTextControl {TEXTAREA} at (1,31) size 66x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (387,192) size 66x36 clip at (388,193) size 49x34 scrollHeight 214
+          RenderTextControl {TEXTAREA} at (1,29) size 66x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
                 text run at (0,0) width 40: "Lorem"
@@ -294,8 +294,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (469,162) size 102x72 clip at (470,163) size 85x70 scrollHeight 250
-          RenderTextControl {TEXTAREA} at (1,45) size 102x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (469,156) size 102x72 clip at (470,157) size 85x70 scrollHeight 250
+          RenderTextControl {TEXTAREA} at (1,43) size 102x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (21,21) size 45x210
               RenderText {#text} at (0,0) size 45x210
                 text run at (0,0) width 40: "Lorem"
@@ -316,8 +316,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (573,202) size 62x32 clip at (574,203) size 45x30 scrollHeight 210
-          RenderTextControl {TEXTAREA} at (1,45) size 62x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (573,196) size 62x32 clip at (574,197) size 45x30 scrollHeight 210
+          RenderTextControl {TEXTAREA} at (1,43) size 62x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 45x210
               RenderText {#text} at (0,0) size 45x210
                 text run at (0,0) width 40: "Lorem"
@@ -338,8 +338,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (3,297) size 181x66 clip at (4,298) size 164x64 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,29) size 181x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,289) size 181x66 clip at (2,290) size 164x64 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -349,7 +349,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (188,297) size 66x66 clip at (189,298) size 49x64 scrollHeight 214
+        layer at (184,289) size 66x66 clip at (185,290) size 49x64 scrollHeight 214
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
@@ -371,8 +371,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (272,325) size 181x36 clip at (273,326) size 179x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (266,319) size 181x36 clip at (267,320) size 179x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x75
               RenderText {#text} at (0,0) size 168x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -382,8 +382,8 @@ layer at (0,0) size 785x1567
                 text run at (40,30) width 8: " "
                 text run at (0,45) width 168: "abcdefghijklmnopqrstu"
                 text run at (0,60) width 8: "v"
-        layer at (459,310) size 181x51 clip at (460,311) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,31) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (449,304) size 181x51 clip at (450,305) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -393,7 +393,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (644,297) size 66x66 clip at (645,298) size 64x64 scrollHeight 169
+        layer at (632,289) size 66x66 clip at (633,290) size 64x64 scrollHeight 169
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 60x165
               RenderText {#text} at (0,0) size 56x165
@@ -412,7 +412,7 @@ layer at (0,0) size 785x1567
                 text run at (0,120) width 56: "hijklmn"
                 text run at (0,135) width 56: "opqrstu"
                 text run at (0,150) width 8: "v"
-        layer at (1,424) size 66x66 clip at (2,425) size 49x49 scrollHeight 214
+        layer at (1,416) size 66x66 clip at (2,417) size 49x49 scrollHeight 214
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
@@ -434,7 +434,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (83,424) size 66x66 clip at (84,425) size 49x64 scrollHeight 214
+        layer at (83,416) size 66x66 clip at (84,417) size 49x64 scrollHeight 214
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
@@ -456,7 +456,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (165,424) size 66x66 clip at (166,425) size 49x64 scrollHeight 214
+        layer at (165,416) size 66x66 clip at (166,417) size 49x64 scrollHeight 214
           RenderTextControl {TEXTAREA} at (1,43) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
@@ -478,7 +478,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (247,424) size 66x66 clip at (248,425) size 49x64 scrollHeight 214
+        layer at (247,416) size 66x66 clip at (248,417) size 49x64 scrollHeight 214
           RenderTextControl {TEXTAREA} at (1,57) size 66x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 45x210
               RenderText {#text} at (0,0) size 45x210
@@ -500,8 +500,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (331,452) size 45x36 clip at (332,453) size 28x34 scrollHeight 349
-          RenderTextControl {TEXTAREA} at (3,17) size 45x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (329,446) size 45x36 clip at (330,447) size 28x34 scrollHeight 349
+          RenderTextControl {TEXTAREA} at (1,15) size 45x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 24x345
               RenderText {#text} at (0,0) size 24x345
                 text run at (0,0) width 24: "Lor"
@@ -531,8 +531,8 @@ layer at (0,0) size 785x1567
                 text run at (0,300) width 24: "pqr"
                 text run at (0,315) width 24: "stu"
                 text run at (0,330) width 8: "v"
-        layer at (413,437) size 181x51 clip at (414,438) size 164x49 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,17) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (411,431) size 181x51 clip at (412,432) size 164x49 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,15) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -542,8 +542,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (600,452) size 77x36 clip at (601,453) size 60x34 scrollHeight 169
-          RenderTextControl {TEXTAREA} at (3,17) size 77x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (594,446) size 77x36 clip at (595,447) size 60x34 scrollHeight 169
+          RenderTextControl {TEXTAREA} at (1,15) size 77x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 56x165
               RenderText {#text} at (0,0) size 56x165
                 text run at (0,0) width 40: "Lorem"
@@ -561,8 +561,8 @@ layer at (0,0) size 785x1567
                 text run at (0,120) width 56: "hijklmn"
                 text run at (0,135) width 56: "opqrstu"
                 text run at (0,150) width 8: "v"
-        layer at (3,511) size 181x111 clip at (4,512) size 179x109
-          RenderTextControl {TEXTAREA} at (3,17) size 181x111 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,501) size 181x111 clip at (2,502) size 179x109
+          RenderTextControl {TEXTAREA} at (1,15) size 181x111 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x75
               RenderText {#text} at (0,0) size 168x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -572,8 +572,8 @@ layer at (0,0) size 785x1567
                 text run at (40,30) width 8: " "
                 text run at (0,45) width 168: "abcdefghijklmnopqrstu"
                 text run at (0,60) width 8: "v"
-        layer at (190,556) size 61x66 clip at (191,557) size 44x64 scrollHeight 214
-          RenderTextControl {TEXTAREA} at (3,31) size 61x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (184,546) size 61x66 clip at (185,547) size 44x64 scrollHeight 214
+          RenderTextControl {TEXTAREA} at (1,29) size 61x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 40x210
               RenderText {#text} at (0,0) size 40x210
                 text run at (0,0) width 40: "Lorem"
@@ -594,13 +594,13 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (272,571) size 181x51 clip at (273,572) size 179x34 scrollWidth 546
-          RenderTextControl {TEXTAREA} at (3,17) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (266,561) size 181x51 clip at (267,562) size 179x34 scrollWidth 546
+          RenderTextControl {TEXTAREA} at (1,15) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 544x15
                 text run at (0,0) width 544: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (459,586) size 181x36 clip at (460,587) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,17) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (449,576) size 181x36 clip at (450,577) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,15) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -610,8 +610,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (3,659) size 181x36 clip at (4,660) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,17) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,645) size 181x36 clip at (2,646) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,15) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -621,8 +621,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (190,659) size 181x36 clip at (191,660) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (184,645) size 181x36 clip at (185,646) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 96: "Lorem ipsum "
@@ -631,16 +631,16 @@ layer at (0,0) size 785x1567
                 text run at (0,30) width 48: "UVWXYZ"
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (377,659) size 181x36 clip at (378,660) size 164x34 scrollHeight 64
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (367,645) size 181x36 clip at (368,646) size 164x34 scrollHeight 64
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 160x60
                 text run at (0,0) width 160: "Lorem ipsum  dolor A"
                 text run at (0,15) width 160: "BCDEFGHIJKLMNOPQRSTU"
                 text run at (0,30) width 160: "VWXYZ abcdefghijklmn"
                 text run at (0,45) width 64: "opqrstuv"
-        layer at (564,659) size 181x36 clip at (565,660) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (550,645) size 181x36 clip at (551,646) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -650,14 +650,14 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (3,761) size 181x36 clip at (4,762) size 179x19 scrollWidth 538
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,743) size 181x36 clip at (2,744) size 179x19 scrollWidth 538
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 536x15
                 text run at (0,0) width 96: "Lorem ipsum "
                 text run at (96,0) width 440: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (190,761) size 181x36 clip at (191,762) size 164x34 scrollHeight 79
-          RenderTextControl {TEXTAREA} at (3,31) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (184,743) size 181x36 clip at (185,744) size 164x34 scrollHeight 79
+          RenderTextControl {TEXTAREA} at (1,29) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 96: "Lorem ipsum "
@@ -666,8 +666,8 @@ layer at (0,0) size 785x1567
                 text run at (0,30) width 48: "UVWXYZ"
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (377,746) size 181x51 clip at (378,747) size 164x34 scrollWidth 210 scrollHeight 64
-          RenderTextControl {TEXTAREA} at (3,31) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (367,728) size 181x51 clip at (368,729) size 164x34 scrollWidth 210 scrollHeight 64
+          RenderTextControl {TEXTAREA} at (1,29) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 208x60
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -675,8 +675,8 @@ layer at (0,0) size 785x1567
                 text run at (0,15) width 208: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,30) width 8: " "
                 text run at (0,45) width 176: "abcdefghijklmnopqrstuv"
-        layer at (564,746) size 181x51 clip at (565,747) size 164x34 scrollWidth 210 scrollHeight 64
-          RenderTextControl {TEXTAREA} at (3,45) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (550,728) size 181x51 clip at (551,729) size 164x34 scrollWidth 210 scrollHeight 64
+          RenderTextControl {TEXTAREA} at (1,43) size 181x51 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 208x60
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -684,94 +684,94 @@ layer at (0,0) size 785x1567
                 text run at (0,15) width 208: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,30) width 8: " "
                 text run at (0,45) width 176: "abcdefghijklmnopqrstuv"
-      RenderIFrame {IFRAME} at (0,803) size 785x764
-        layer at (0,0) size 785x764
-          RenderView at (0,0) size 785x764
-        layer at (0,0) size 785x764
-          RenderBlock {HTML} at (0,0) size 785x764
-            RenderBody {BODY} at (0,5) size 785x759
+      RenderIFrame {IFRAME} at (0,783) size 785x744
+        layer at (0,0) size 785x744
+          RenderView at (0,0) size 785x744
+        layer at (0,0) size 785x744
+          RenderBlock {HTML} at (0,0) size 785x744
+            RenderBody {BODY} at (0,5) size 785x739
               RenderBlock {DIV} at (0,0) size 785x18
                 RenderText {#text} at (0,0) size 193x18
                   text run at (0,0) width 193: "CompatMode: BackCompat"
-              RenderBlock (anonymous) at (0,23) size 785x736
-                RenderBlock {DIV} at (0,46) size 185x40 [border: (1px solid #0000FF)]
+              RenderBlock (anonymous) at (0,23) size 785x716
+                RenderBlock {DIV} at (0,46) size 181x36 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x0
                   RenderBR {BR} at (81,1) size 0x0
-                RenderBlock {DIV} at (185,32) size 185x54 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (181,32) size 181x50 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 76x14
                       text run at (0,0) width 76: "disabled: \"true\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (370,0) size 203x86 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (362,0) size 199x82 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 78x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 78: "\"padding:10px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (573,20) size 183x66 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (561,20) size 179x62 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 72x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 72: "\"padding:0px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (0,122) size 201x84 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,114) size 201x84 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 73: "\"margin:10px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (201,142) size 181x64 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (201,134) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 67x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 67: "\"margin:0px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (382,138) size 82x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (382,134) size 82x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 67x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 67: "\"width:60px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (464,86) size 82x120 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (464,82) size 82x116 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 73x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 73: "padding:20px\","
                   RenderBR {BR} at (81,40) size 0x0
-                RenderBlock {DIV} at (546,126) size 82x80 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (546,122) size 82x76 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 62x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 55: "padding:0\","
                   RenderBR {BR} at (81,40) size 0x0
-                RenderBlock {DIV} at (0,234) size 185x90 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,226) size 181x90 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 69x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 69: "\"height:60px\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (185,220) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (181,212) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 64x42
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,40) size 0x0
-                RenderBlock {DIV} at (267,256) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (263,252) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 91x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 91: "\"overflow:hidden\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (452,241) size 185x83 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (444,237) size 181x79 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 85x28
                       text run at (0,0) width 25: "style:"
                       text run at (0,14) width 85: "\"overflow:scroll\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (637,206) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (625,198) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 86x56
                       text run at (0,0) width 25: "style:"
@@ -779,7 +779,7 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 57: "width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,54) size 0x0
-                RenderBlock {DIV} at (0,324) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,316) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 80x56
                       text run at (0,0) width 25: "style:"
@@ -787,21 +787,21 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 57: "width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,54) size 0x0
-                RenderBlock {DIV} at (82,338) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (82,330) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 72x42
                       text run at (0,0) width 72: "cols: \"5\", style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,40) size 0x0
-                RenderBlock {DIV} at (164,338) size 82x104 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (164,330) size 82x104 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 77x42
                       text run at (0,0) width 77: "rows: \"4\", style:"
                       text run at (0,14) width 62: "\"width:60px;"
                       text run at (0,28) width 64: "height:60px\","
                   RenderBR {BR} at (81,40) size 0x0
-                RenderBlock {DIV} at (246,324) size 82x118 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (246,316) size 82x118 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x56
                     RenderText {#text} at (0,0) size 74x56
                       text run at (0,0) width 74: "cols: \"5\", rows:"
@@ -809,97 +809,97 @@ layer at (0,0) size 785x1567
                       text run at (0,28) width 62: "\"width:60px;"
                       text run at (0,42) width 64: "height:60px\","
                   RenderBR {BR} at (81,54) size 0x0
-                RenderBlock {DIV} at (328,388) size 82x54 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (328,384) size 82x50 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 44x14
                       text run at (0,0) width 44: "cols: \"3\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (410,373) size 185x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (410,369) size 181x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"3\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (595,388) size 82x54 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (591,384) size 82x50 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 44x14
                       text run at (0,0) width 44: "cols: \"7\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (0,442) size 185x129 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,434) size 181x125 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 49x14
                       text run at (0,0) width 49: "rows: \"7\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (185,473) size 82x98 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (181,465) size 82x94 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 74x28
                       text run at (0,0) width 74: "cols: \"5\", rows:"
                       text run at (0,14) width 19: "\"4\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (267,502) size 185x69 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (263,494) size 181x65 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 57x14
                       text run at (0,0) width 57: "wrap: \"off\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (452,517) size 185x54 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (444,509) size 181x50 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 64x14
                       text run at (0,0) width 64: "wrap: \"hard\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (0,585) size 185x54 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,573) size 181x50 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x14
                     RenderText {#text} at (0,0) size 61x14
                       text run at (0,0) width 61: "wrap: \"soft\","
                   RenderBR {BR} at (81,12) size 0x0
-                RenderBlock {DIV} at (185,571) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (181,559) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 70x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 70: "space:normal\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (370,571) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (362,559) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 63x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 52: "space:pre\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (555,571) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (543,559) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 76x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 76: "space:prewrap\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (0,668) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (0,652) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 73: "space:nowrap\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (185,668) size 185x68 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (181,652) size 181x64 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 73x28
                       text run at (0,0) width 63: "style: \"white-"
                       text run at (0,14) width 73: "space:pre-line\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (370,653) size 185x83 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (362,637) size 181x79 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x28
                     RenderText {#text} at (0,0) size 68x28
                       text run at (0,0) width 62: "style: \"word-"
                       text run at (0,14) width 68: "wrap:normal\","
                   RenderBR {BR} at (81,26) size 0x0
-                RenderBlock {DIV} at (555,639) size 185x97 [border: (1px solid #0000FF)]
+                RenderBlock {DIV} at (543,623) size 181x93 [border: (1px solid #0000FF)]
                   RenderBlock {SPAN} at (1,1) size 80x42
                     RenderText {#text} at (0,0) size 80x42
                       text run at (0,0) width 57: "wrap: \"off\","
                       text run at (0,14) width 63: "style: \"white-"
                       text run at (0,28) width 80: "space:pre-wrap\","
                   RenderBR {BR} at (81,40) size 0x0
-        layer at (3,77) size 179x34 clip at (4,78) size 177x32
-          RenderTextControl {TEXTAREA} at (3,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,75) size 179x34 clip at (2,76) size 177x32
+          RenderTextControl {TEXTAREA} at (1,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 136x15
                 text run at (0,0) width 136: "Lorem ipsum dolor"
-        layer at (188,77) size 179x34 clip at (189,78) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,17) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
+        layer at (182,75) size 179x34 clip at (183,76) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,15) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75 [color=#545454]
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -909,8 +909,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (373,59) size 197x52 clip at (374,60) size 180x50 scrollHeight 95
-          RenderTextControl {TEXTAREA} at (3,31) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (363,57) size 197x52 clip at (364,58) size 180x50 scrollHeight 95
+          RenderTextControl {TEXTAREA} at (1,29) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (11,11) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -920,8 +920,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (576,79) size 177x32 clip at (577,80) size 160x30 scrollHeight 75
-          RenderTextControl {TEXTAREA} at (3,31) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (562,77) size 177x32 clip at (563,78) size 160x30 scrollHeight 75
+          RenderTextControl {TEXTAREA} at (1,29) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -931,7 +931,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (11,189) size 179x34 clip at (12,190) size 162x32 scrollHeight 77
+        layer at (11,181) size 179x34 clip at (12,182) size 162x32 scrollHeight 77
           RenderTextControl {TEXTAREA} at (11,39) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
@@ -942,7 +942,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (202,199) size 179x34 clip at (203,200) size 162x32 scrollHeight 77
+        layer at (202,191) size 179x34 clip at (203,192) size 162x32 scrollHeight 77
           RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
@@ -953,8 +953,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (383,197) size 60x34 clip at (384,198) size 43x32 scrollHeight 212
-          RenderTextControl {TEXTAREA} at (1,31) size 60x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (383,191) size 60x34 clip at (384,192) size 43x32 scrollHeight 212
+          RenderTextControl {TEXTAREA} at (1,29) size 60x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
                 text run at (0,0) width 40: "Lorem"
@@ -975,8 +975,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (465,159) size 60x72 clip at (466,160) size 43x70 scrollHeight 1060
-          RenderTextControl {TEXTAREA} at (1,45) size 60x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (465,153) size 60x72 clip at (466,154) size 43x70 scrollHeight 1060
+          RenderTextControl {TEXTAREA} at (1,43) size 60x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (21,21) size 3x1020
               RenderText {#text} at (0,0) size 8x1020
                 text run at (0,0) width 8: "L"
@@ -1047,8 +1047,8 @@ layer at (0,0) size 785x1567
                 text run at (0,975) width 8: "t"
                 text run at (0,990) width 8: "u"
                 text run at (0,1005) width 8: "v"
-        layer at (547,199) size 60x32 clip at (548,200) size 43x30 scrollHeight 210
-          RenderTextControl {TEXTAREA} at (1,45) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (547,193) size 60x32 clip at (548,194) size 43x30 scrollHeight 210
+          RenderTextControl {TEXTAREA} at (1,43) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (1,1) size 43x210
               RenderText {#text} at (0,0) size 43x210
                 text run at (0,0) width 40: "Lorem"
@@ -1069,8 +1069,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (3,291) size 179x60 clip at (4,292) size 162x58 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,29) size 179x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,283) size 179x60 clip at (2,284) size 162x58 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1080,7 +1080,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (186,291) size 60x60 clip at (187,292) size 43x58 scrollHeight 212
+        layer at (182,283) size 60x60 clip at (183,284) size 43x58 scrollHeight 212
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
@@ -1102,8 +1102,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (270,315) size 179x34 clip at (271,316) size 177x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (264,309) size 179x34 clip at (265,310) size 177x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x75
               RenderText {#text} at (0,0) size 168x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1113,8 +1113,8 @@ layer at (0,0) size 785x1567
                 text run at (40,30) width 8: " "
                 text run at (0,45) width 168: "abcdefghijklmnopqrstu"
                 text run at (0,60) width 8: "v"
-        layer at (455,300) size 179x49 clip at (456,301) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,31) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (445,294) size 179x49 clip at (446,295) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1124,7 +1124,7 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (638,291) size 60x60 clip at (639,292) size 58x58 scrollHeight 167
+        layer at (626,283) size 60x60 clip at (627,284) size 58x58 scrollHeight 167
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 56x165
               RenderText {#text} at (0,0) size 56x165
@@ -1143,7 +1143,7 @@ layer at (0,0) size 785x1567
                 text run at (0,120) width 56: "hijklmn"
                 text run at (0,135) width 56: "opqrstu"
                 text run at (0,150) width 8: "v"
-        layer at (1,409) size 60x60 clip at (2,410) size 43x43 scrollHeight 212
+        layer at (1,401) size 60x60 clip at (2,402) size 43x43 scrollHeight 212
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
@@ -1165,7 +1165,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (83,409) size 60x60 clip at (84,410) size 43x58 scrollHeight 212
+        layer at (83,401) size 60x60 clip at (84,402) size 43x58 scrollHeight 212
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
@@ -1187,7 +1187,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (165,409) size 60x60 clip at (166,410) size 43x58 scrollHeight 212
+        layer at (165,401) size 60x60 clip at (166,402) size 43x58 scrollHeight 212
           RenderTextControl {TEXTAREA} at (1,43) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
@@ -1209,7 +1209,7 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (247,409) size 60x60 clip at (248,410) size 43x58 scrollHeight 212
+        layer at (247,401) size 60x60 clip at (248,402) size 43x58 scrollHeight 212
           RenderTextControl {TEXTAREA} at (1,57) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 41x210
               RenderText {#text} at (0,0) size 41x210
@@ -1231,8 +1231,8 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (331,433) size 43x34 clip at (332,434) size 26x32 scrollHeight 347
-          RenderTextControl {TEXTAREA} at (3,17) size 43x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (329,427) size 43x34 clip at (330,428) size 26x32 scrollHeight 347
+          RenderTextControl {TEXTAREA} at (1,15) size 43x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 24x345
               RenderText {#text} at (0,0) size 24x345
                 text run at (0,0) width 24: "Lor"
@@ -1262,8 +1262,8 @@ layer at (0,0) size 785x1567
                 text run at (0,300) width 24: "pqr"
                 text run at (0,315) width 24: "stu"
                 text run at (0,330) width 8: "v"
-        layer at (413,418) size 179x49 clip at (414,419) size 162x47 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,17) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (411,412) size 179x49 clip at (412,413) size 162x47 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,15) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1273,8 +1273,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (598,433) size 75x34 clip at (599,434) size 58x32 scrollHeight 167
-          RenderTextControl {TEXTAREA} at (3,17) size 75x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (592,427) size 75x34 clip at (593,428) size 58x32 scrollHeight 167
+          RenderTextControl {TEXTAREA} at (1,15) size 75x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 56x165
               RenderText {#text} at (0,0) size 56x165
                 text run at (0,0) width 40: "Lorem"
@@ -1292,8 +1292,8 @@ layer at (0,0) size 785x1567
                 text run at (0,120) width 56: "hijklmn"
                 text run at (0,135) width 56: "opqrstu"
                 text run at (0,150) width 8: "v"
-        layer at (3,487) size 179x109 clip at (4,488) size 177x107
-          RenderTextControl {TEXTAREA} at (3,17) size 179x109 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,477) size 179x109 clip at (2,478) size 177x107
+          RenderTextControl {TEXTAREA} at (1,15) size 179x109 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x75
               RenderText {#text} at (0,0) size 168x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1303,8 +1303,8 @@ layer at (0,0) size 785x1567
                 text run at (40,30) width 8: " "
                 text run at (0,45) width 168: "abcdefghijklmnopqrstu"
                 text run at (0,60) width 8: "v"
-        layer at (188,532) size 59x64 clip at (189,533) size 42x62 scrollHeight 212
-          RenderTextControl {TEXTAREA} at (3,31) size 59x64 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (182,522) size 59x64 clip at (183,523) size 42x62 scrollHeight 212
+          RenderTextControl {TEXTAREA} at (1,29) size 59x64 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 40x210
               RenderText {#text} at (0,0) size 40x210
                 text run at (0,0) width 40: "Lorem"
@@ -1325,13 +1325,13 @@ layer at (0,0) size 785x1567
                 text run at (0,165) width 40: "klmno"
                 text run at (0,180) width 40: "pqrst"
                 text run at (0,195) width 16: "uv"
-        layer at (270,547) size 179x49 clip at (271,548) size 177x32 scrollWidth 546
-          RenderTextControl {TEXTAREA} at (3,17) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (264,537) size 179x49 clip at (265,538) size 177x32 scrollWidth 546
+          RenderTextControl {TEXTAREA} at (1,15) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 544x15
                 text run at (0,0) width 544: "Lorem ipsum  dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (455,562) size 179x34 clip at (456,563) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,17) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (445,552) size 179x34 clip at (446,553) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,15) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1341,8 +1341,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (3,630) size 179x34 clip at (4,631) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,17) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,616) size 179x34 clip at (2,617) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,15) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1352,8 +1352,8 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (188,630) size 179x34 clip at (189,631) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (182,616) size 179x34 clip at (183,617) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 96: "Lorem ipsum "
@@ -1362,16 +1362,16 @@ layer at (0,0) size 785x1567
                 text run at (0,30) width 48: "UVWXYZ"
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (373,630) size 179x34 clip at (374,631) size 162x32 scrollHeight 62
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (363,616) size 179x34 clip at (364,617) size 162x32 scrollHeight 62
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 160x60
                 text run at (0,0) width 160: "Lorem ipsum  dolor A"
                 text run at (0,15) width 160: "BCDEFGHIJKLMNOPQRSTU"
                 text run at (0,30) width 160: "VWXYZ abcdefghijklmn"
                 text run at (0,45) width 64: "opqrstuv"
-        layer at (558,630) size 179x34 clip at (559,631) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (544,616) size 179x34 clip at (545,617) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1381,14 +1381,14 @@ layer at (0,0) size 785x1567
                 text run at (48,30) width 8: " "
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (3,727) size 179x34 clip at (4,728) size 177x17 scrollWidth 538
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (1,709) size 179x34 clip at (2,710) size 177x17 scrollWidth 538
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 175x15
               RenderText {#text} at (0,0) size 536x15
                 text run at (0,0) width 96: "Lorem ipsum "
                 text run at (96,0) width 440: "dolor ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuv"
-        layer at (188,727) size 179x34 clip at (189,728) size 162x32 scrollHeight 77
-          RenderTextControl {TEXTAREA} at (3,31) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (182,709) size 179x34 clip at (183,710) size 162x32 scrollHeight 77
+          RenderTextControl {TEXTAREA} at (1,29) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x75
               RenderText {#text} at (0,0) size 160x75
                 text run at (0,0) width 96: "Lorem ipsum "
@@ -1397,8 +1397,8 @@ layer at (0,0) size 785x1567
                 text run at (0,30) width 48: "UVWXYZ"
                 text run at (0,45) width 160: "abcdefghijklmnopqrst"
                 text run at (0,60) width 16: "uv"
-        layer at (373,712) size 179x49 clip at (374,713) size 162x32 scrollWidth 210 scrollHeight 62
-          RenderTextControl {TEXTAREA} at (3,31) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (363,694) size 179x49 clip at (364,695) size 162x32 scrollWidth 210 scrollHeight 62
+          RenderTextControl {TEXTAREA} at (1,29) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 208x60
                 text run at (0,0) width 144: "Lorem ipsum  dolor"
@@ -1406,8 +1406,8 @@ layer at (0,0) size 785x1567
                 text run at (0,15) width 208: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                 text run at (0,30) width 8: " "
                 text run at (0,45) width 176: "abcdefghijklmnopqrstuv"
-        layer at (558,712) size 179x49 clip at (559,713) size 162x32 scrollWidth 210 scrollHeight 62
-          RenderTextControl {TEXTAREA} at (3,45) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        layer at (544,694) size 179x49 clip at (545,695) size 162x32 scrollWidth 210 scrollHeight 62
+          RenderTextControl {TEXTAREA} at (1,43) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
             RenderBlock {DIV} at (3,3) size 160x60
               RenderText {#text} at (0,0) size 208x60
                 text run at (0,0) width 144: "Lorem ipsum  dolor"

--- a/LayoutTests/platform/win/fast/forms/basic-textareas-quirks-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/basic-textareas-quirks-expected.txt
@@ -1,295 +1,235 @@
-layer at (0,0) size 785x1085
+layer at (0,0) size 785x1053
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1085
-  RenderBlock {HTML} at (0,0) size 785x1085
+layer at (0,0) size 785x1053
+  RenderBlock {HTML} at (0,0) size 785x1053
     RenderBody {BODY} at (8,8) size 769x584
-      RenderBlock (floating) {DIV} at (0,0) size 352x879 [border: (1px solid #FF0000)]
+      RenderBlock (floating) {DIV} at (0,0) size 352x839 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
           RenderText {#text} at (0,-2) size 181x17
             text run at (0,-2) width 181: "Plain textarea with little content"
-        RenderBlock {DIV} at (1,15) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 13: " B"
-        RenderBlock (anonymous) at (1,58) size 350x14
-          RenderText {#text} at (0,-2) size 77x17
-            text run at (0,-2) width 77: "Plain textarea"
-        RenderBlock {DIV} at (1,72) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 13: " B"
-        RenderBlock (anonymous) at (1,115) size 350x14
-          RenderText {#text} at (0,-2) size 97x17
-            text run at (0,-2) width 97: "Disabled textarea"
-        RenderBlock {DIV} at (1,129) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 13: " B"
-        RenderBlock (anonymous) at (1,172) size 350x14
-          RenderText {#text} at (0,-2) size 123x17
-            text run at (0,-2) width 123: "style=\"padding:10px\""
-        RenderBlock {DIV} at (1,186) size 352x61 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,44) size 14x17
-            text run at (1,44) width 14: "A "
-          RenderText {#text} at (216,44) size 13x17
-            text run at (216,44) width 13: " B"
-        RenderBlock (anonymous) at (1,247) size 350x14
-          RenderText {#text} at (0,-2) size 116x17
-            text run at (0,-2) width 116: "style=\"padding:0px\""
-        RenderBlock {DIV} at (1,261) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (196,24) size 13x17
-            text run at (196,24) width 13: " B"
-        RenderBlock (anonymous) at (1,302) size 350x14
-          RenderText {#text} at (0,-2) size 118x17
-            text run at (0,-2) width 118: "style=\"margin:10px\""
-        RenderBlock {DIV} at (1,316) size 352x59 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,42) size 14x17
-            text run at (1,42) width 14: "A "
-          RenderText {#text} at (214,42) size 13x17
-            text run at (214,42) width 13: " B"
-        RenderBlock (anonymous) at (1,375) size 350x14
-          RenderText {#text} at (0,-2) size 111x17
-            text run at (0,-2) width 111: "style=\"margin:0px\""
-        RenderBlock {DIV} at (1,389) size 352x39 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,15) size 352x39 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,22) size 14x17
             text run at (1,22) width 14: "A "
           RenderText {#text} at (194,22) size 13x17
             text run at (194,22) width 13: " B"
-        RenderBlock (anonymous) at (1,428) size 350x14
+        RenderBlock (anonymous) at (1,54) size 350x14
+          RenderText {#text} at (0,-2) size 77x17
+            text run at (0,-2) width 77: "Plain textarea"
+        RenderBlock {DIV} at (1,68) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 13: " B"
+        RenderBlock (anonymous) at (1,107) size 350x14
+          RenderText {#text} at (0,-2) size 97x17
+            text run at (0,-2) width 97: "Disabled textarea"
+        RenderBlock {DIV} at (1,121) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 13: " B"
+        RenderBlock (anonymous) at (1,160) size 350x14
+          RenderText {#text} at (0,-2) size 123x17
+            text run at (0,-2) width 123: "style=\"padding:10px\""
+        RenderBlock {DIV} at (1,174) size 352x57 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,40) size 14x17
+            text run at (1,40) width 14: "A "
+          RenderText {#text} at (212,40) size 13x17
+            text run at (212,40) width 13: " B"
+        RenderBlock (anonymous) at (1,231) size 350x14
+          RenderText {#text} at (0,-2) size 116x17
+            text run at (0,-2) width 116: "style=\"padding:0px\""
+        RenderBlock {DIV} at (1,245) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (192,20) size 13x17
+            text run at (192,20) width 13: " B"
+        RenderBlock (anonymous) at (1,282) size 350x14
+          RenderText {#text} at (0,-2) size 118x17
+            text run at (0,-2) width 118: "style=\"margin:10px\""
+        RenderBlock {DIV} at (1,296) size 352x59 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,42) size 14x17
+            text run at (1,42) width 14: "A "
+          RenderText {#text} at (214,42) size 13x17
+            text run at (214,42) width 13: " B"
+        RenderBlock (anonymous) at (1,355) size 350x14
+          RenderText {#text} at (0,-2) size 111x17
+            text run at (0,-2) width 111: "style=\"margin:0px\""
+        RenderBlock {DIV} at (1,369) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 13: " B"
+        RenderBlock (anonymous) at (1,408) size 350x14
           RenderText {#text} at (0,-2) size 37x17
             text run at (0,-2) width 37: "cols=3"
-        RenderBlock {DIV} at (1,442) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (62,26) size 13x17
-            text run at (62,26) width 13: " B"
-        RenderBlock (anonymous) at (1,485) size 350x14
+        RenderBlock {DIV} at (1,422) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (58,22) size 13x17
+            text run at (58,22) width 13: " B"
+        RenderBlock (anonymous) at (1,461) size 350x14
           RenderText {#text} at (0,-2) size 42x17
             text run at (0,-2) width 42: "rows=3"
-        RenderBlock {DIV} at (1,499) size 352x58 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,41) size 14x17
-            text run at (1,41) width 14: "A "
-          RenderText {#text} at (198,41) size 13x17
-            text run at (198,41) width 13: " B"
-        RenderBlock (anonymous) at (1,557) size 350x14
+        RenderBlock {DIV} at (1,475) size 352x54 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,37) size 14x17
+            text run at (1,37) width 14: "A "
+          RenderText {#text} at (194,37) size 13x17
+            text run at (194,37) width 13: " B"
+        RenderBlock (anonymous) at (1,529) size 350x14
           RenderText {#text} at (0,-2) size 44x17
             text run at (0,-2) width 44: "cols=10"
-        RenderBlock {DIV} at (1,571) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (118,26) size 13x17
-            text run at (118,26) width 13: " B"
-        RenderBlock (anonymous) at (1,614) size 350x14
+        RenderBlock {DIV} at (1,543) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (114,22) size 13x17
+            text run at (114,22) width 13: " B"
+        RenderBlock (anonymous) at (1,582) size 350x14
           RenderText {#text} at (0,-2) size 49x17
             text run at (0,-2) width 49: "rows=10"
-        RenderBlock {DIV} at (1,628) size 352x163 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,146) size 14x17
-            text run at (1,146) width 14: "A "
-          RenderText {#text} at (198,146) size 13x17
-            text run at (198,146) width 13: " B"
-        RenderBlock (anonymous) at (1,791) size 350x14
+        RenderBlock {DIV} at (1,596) size 352x159 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,142) size 14x17
+            text run at (1,142) width 14: "A "
+          RenderText {#text} at (194,142) size 13x17
+            text run at (194,142) width 13: " B"
+        RenderBlock (anonymous) at (1,755) size 350x14
           RenderText {#text} at (0,-2) size 83x17
             text run at (0,-2) width 83: "cols=5 rows=4"
-        RenderBlock {DIV} at (1,805) size 352x73 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,56) size 14x17
-            text run at (1,56) width 14: "A "
-          RenderText {#text} at (78,56) size 13x17
-            text run at (78,56) width 13: " B"
-      RenderBlock (floating) {DIV} at (352,0) size 352x1077 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,769) size 352x69 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,52) size 14x17
+            text run at (1,52) width 14: "A "
+          RenderText {#text} at (74,52) size 13x17
+            text run at (74,52) width 13: " B"
+      RenderBlock (floating) {DIV} at (352,0) size 352x1045 [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (1,1) size 350x14
           RenderText {#text} at (0,-2) size 110x17
             text run at (0,-2) width 110: "style=\"width:60px\""
-        RenderBlock {DIV} at (1,15) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (75,26) size 13x17
-            text run at (75,26) width 13: " B"
-        RenderBlock (anonymous) at (1,58) size 350x14
+        RenderBlock {DIV} at (1,15) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (75,22) size 13x17
+            text run at (75,22) width 13: " B"
+        RenderBlock (anonymous) at (1,54) size 350x14
           RenderText {#text} at (0,-2) size 191x17
             text run at (0,-2) width 191: "style=\"width:60px;padding:20px\""
-        RenderBlock {DIV} at (1,72) size 352x81 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,64) size 14x17
-            text run at (1,64) width 14: "A "
-          RenderText {#text} at (75,64) size 13x17
-            text run at (75,64) width 13: " B"
-        RenderBlock (anonymous) at (1,153) size 350x14
+        RenderBlock {DIV} at (1,68) size 352x77 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,60) size 14x17
+            text run at (1,60) width 14: "A "
+          RenderText {#text} at (75,60) size 13x17
+            text run at (75,60) width 13: " B"
+        RenderBlock (anonymous) at (1,145) size 350x14
           RenderText {#text} at (0,-2) size 170x17
             text run at (0,-2) width 170: "style=\"width:60px;padding:0\""
-        RenderBlock {DIV} at (1,167) size 352x41 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,24) size 14x17
-            text run at (1,24) width 14: "A "
-          RenderText {#text} at (75,24) size 13x17
-            text run at (75,24) width 13: " B"
-        RenderBlock (anonymous) at (1,208) size 350x14
+        RenderBlock {DIV} at (1,159) size 352x37 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,20) size 14x17
+            text run at (1,20) width 14: "A "
+          RenderText {#text} at (75,20) size 13x17
+            text run at (75,20) width 13: " B"
+        RenderBlock (anonymous) at (1,196) size 350x14
           RenderText {#text} at (0,-2) size 113x17
             text run at (0,-2) width 113: "style=\"height:60px\""
-        RenderBlock {DIV} at (1,222) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,210) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
-          RenderText {#text} at (198,48) size 13x17
-            text run at (198,48) width 13: " B"
-        RenderBlock (anonymous) at (1,287) size 350x14
+          RenderText {#text} at (194,48) size 13x17
+            text run at (194,48) width 13: " B"
+        RenderBlock (anonymous) at (1,275) size 350x14
           RenderText {#text} at (0,-2) size 181x17
             text run at (0,-2) width 181: "style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,301) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,289) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,366) size 350x14
+        RenderBlock (anonymous) at (1,354) size 350x14
           RenderText {#text} at (0,-2) size 139x17
             text run at (0,-2) width 139: "style=\"overflow:hidden\""
-        RenderBlock {DIV} at (1,380) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 13: " B"
-        RenderBlock (anonymous) at (1,423) size 350x14
+        RenderBlock {DIV} at (1,368) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 13: " B"
+        RenderBlock (anonymous) at (1,407) size 350x14
           RenderText {#text} at (0,-2) size 132x17
             text run at (0,-2) width 132: "style=\"overflow:scroll\""
-        RenderBlock {DIV} at (1,437) size 352x58 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,41) size 14x17
-            text run at (1,41) width 14: "A "
-          RenderText {#text} at (198,41) size 13x17
-            text run at (198,41) width 13: " B"
-        RenderBlock (anonymous) at (1,495) size 350x14
+        RenderBlock {DIV} at (1,421) size 352x54 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,37) size 14x17
+            text run at (1,37) width 14: "A "
+          RenderText {#text} at (194,37) size 13x17
+            text run at (194,37) width 13: " B"
+        RenderBlock (anonymous) at (1,475) size 350x14
           RenderText {#text} at (0,-2) size 278x17
             text run at (0,-2) width 278: "style=\"overflow:hidden;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,509) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,489) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,574) size 350x14
+        RenderBlock (anonymous) at (1,554) size 350x14
           RenderText {#text} at (0,-2) size 271x17
             text run at (0,-2) width 271: "style=\"overflow:scroll;width:60px;height:60px\""
-        RenderBlock {DIV} at (1,588) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,568) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,653) size 350x14
+        RenderBlock (anonymous) at (1,633) size 350x14
           RenderText {#text} at (0,-2) size 222x17
             text run at (0,-2) width 222: "cols=5 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,667) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,647) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,732) size 350x14
+        RenderBlock (anonymous) at (1,712) size 350x14
           RenderText {#text} at (0,-2) size 227x17
             text run at (0,-2) width 227: "rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,746) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,726) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,811) size 350x14
+        RenderBlock (anonymous) at (1,791) size 350x14
           RenderText {#text} at (0,-2) size 268x17
             text run at (0,-2) width 268: "cols=5 rows=4 style=\"width:60px;height:60px\""
-        RenderBlock {DIV} at (1,825) size 352x65 [border: (1px solid #FF0000)]
+        RenderBlock {DIV} at (1,805) size 352x65 [border: (1px solid #FF0000)]
           RenderText {#text} at (1,48) size 14x17
             text run at (1,48) width 14: "A "
           RenderText {#text} at (75,48) size 13x17
             text run at (75,48) width 13: " B"
-        RenderBlock (anonymous) at (1,890) size 350x14
+        RenderBlock (anonymous) at (1,870) size 350x14
           RenderText {#text} at (0,-2) size 65x17
             text run at (0,-2) width 65: "wrap=\"off\""
-        RenderBlock {DIV} at (1,904) size 352x58 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,41) size 14x17
-            text run at (1,41) width 14: "A "
-          RenderText {#text} at (198,41) size 13x17
-            text run at (198,41) width 4: " "
-            text run at (202,41) width 9: "B"
-        RenderBlock (anonymous) at (1,962) size 350x14
+        RenderBlock {DIV} at (1,884) size 352x54 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,37) size 14x17
+            text run at (1,37) width 14: "A "
+          RenderText {#text} at (194,37) size 13x17
+            text run at (194,37) width 4: " "
+            text run at (198,37) width 9: "B"
+        RenderBlock (anonymous) at (1,938) size 350x14
           RenderText {#text} at (0,-2) size 73x17
             text run at (0,-2) width 73: "wrap=\"hard\""
-        RenderBlock {DIV} at (1,976) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 4: " "
-            text run at (202,26) width 9: "B"
-        RenderBlock (anonymous) at (1,1019) size 350x14
+        RenderBlock {DIV} at (1,952) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 4: " "
+            text run at (198,22) width 9: "B"
+        RenderBlock (anonymous) at (1,991) size 350x14
           RenderText {#text} at (0,-2) size 69x17
             text run at (0,-2) width 69: "wrap=\"soft\""
-        RenderBlock {DIV} at (1,1033) size 352x43 [border: (1px solid #FF0000)]
-          RenderText {#text} at (1,26) size 14x17
-            text run at (1,26) width 14: "A "
-          RenderText {#text} at (198,26) size 13x17
-            text run at (198,26) width 4: " "
-            text run at (202,26) width 9: "B"
-layer at (26,26) size 179x34 clip at (27,27) size 177x32
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1005) size 352x39 [border: (1px solid #FF0000)]
+          RenderText {#text} at (1,22) size 14x17
+            text run at (1,22) width 14: "A "
+          RenderText {#text} at (194,22) size 13x17
+            text run at (194,22) width 4: " "
+            text run at (198,22) width 9: "B"
+layer at (24,24) size 179x34 clip at (25,25) size 177x32
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderText {#text} at (0,0) size 136x15
         text run at (0,0) width 136: "Lorem ipsum dolor"
-layer at (26,83) size 179x34 clip at (27,84) size 162x32 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 160x75
-      RenderText {#text} at (0,0) size 160x75
-        text run at (0,0) width 136: "Lorem ipsum dolor"
-        text run at (136,0) width 8: " "
-        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
-        text run at (0,30) width 48: "UVWXYZ"
-        text run at (48,30) width 8: " "
-        text run at (0,45) width 160: "abcdefghijklmnopqrst"
-        text run at (0,60) width 16: "uv"
-        text run at (16,60) width 8: " "
-layer at (26,140) size 179x34 clip at (27,141) size 162x32 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 160x75 [color=#545454]
-      RenderText {#text} at (0,0) size 160x75
-        text run at (0,0) width 136: "Lorem ipsum dolor"
-        text run at (136,0) width 8: " "
-        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
-        text run at (0,30) width 48: "UVWXYZ"
-        text run at (48,30) width 8: " "
-        text run at (0,45) width 160: "abcdefghijklmnopqrst"
-        text run at (0,60) width 16: "uv"
-        text run at (16,60) width 8: " "
-layer at (26,197) size 197x52 clip at (27,198) size 180x50 scrollHeight 95
-  RenderTextControl {TEXTAREA} at (17,3) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (11,11) size 160x75
-      RenderText {#text} at (0,0) size 160x75
-        text run at (0,0) width 136: "Lorem ipsum dolor"
-        text run at (136,0) width 8: " "
-        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
-        text run at (0,30) width 48: "UVWXYZ"
-        text run at (48,30) width 8: " "
-        text run at (0,45) width 160: "abcdefghijklmnopqrst"
-        text run at (0,60) width 16: "uv"
-        text run at (16,60) width 8: " "
-layer at (26,272) size 177x32 clip at (27,273) size 160x30 scrollHeight 75
-  RenderTextControl {TEXTAREA} at (17,3) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (1,1) size 160x75
-      RenderText {#text} at (0,0) size 160x75
-        text run at (0,0) width 136: "Lorem ipsum dolor"
-        text run at (136,0) width 8: " "
-        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
-        text run at (0,30) width 48: "UVWXYZ"
-        text run at (48,30) width 8: " "
-        text run at (0,45) width 160: "abcdefghijklmnopqrst"
-        text run at (0,60) width 16: "uv"
-        text run at (16,60) width 8: " "
-layer at (34,335) size 179x34 clip at (35,336) size 162x32 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (25,11) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
-    RenderBlock {DIV} at (3,3) size 160x75
-      RenderText {#text} at (0,0) size 160x75
-        text run at (0,0) width 136: "Lorem ipsum dolor"
-        text run at (136,0) width 8: " "
-        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
-        text run at (0,30) width 48: "UVWXYZ"
-        text run at (48,30) width 8: " "
-        text run at (0,45) width 160: "abcdefghijklmnopqrst"
-        text run at (0,60) width 16: "uv"
-        text run at (16,60) width 8: " "
-layer at (24,398) size 179x34 clip at (25,399) size 162x32 scrollHeight 77
+layer at (24,77) size 179x34 clip at (25,78) size 162x32 scrollHeight 77
   RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x75
       RenderText {#text} at (0,0) size 160x75
@@ -301,8 +241,68 @@ layer at (24,398) size 179x34 clip at (25,399) size 162x32 scrollHeight 77
         text run at (0,45) width 160: "abcdefghijklmnopqrst"
         text run at (0,60) width 16: "uv"
         text run at (16,60) width 8: " "
-layer at (26,453) size 43x34 clip at (27,454) size 26x32 scrollHeight 347
-  RenderTextControl {TEXTAREA} at (17,3) size 43x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,130) size 179x34 clip at (25,131) size 162x32 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 160x75 [color=#545454]
+      RenderText {#text} at (0,0) size 160x75
+        text run at (0,0) width 136: "Lorem ipsum dolor"
+        text run at (136,0) width 8: " "
+        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
+        text run at (0,30) width 48: "UVWXYZ"
+        text run at (48,30) width 8: " "
+        text run at (0,45) width 160: "abcdefghijklmnopqrst"
+        text run at (0,60) width 16: "uv"
+        text run at (16,60) width 8: " "
+layer at (24,183) size 197x52 clip at (25,184) size 180x50 scrollHeight 95
+  RenderTextControl {TEXTAREA} at (15,1) size 197x52 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (11,11) size 160x75
+      RenderText {#text} at (0,0) size 160x75
+        text run at (0,0) width 136: "Lorem ipsum dolor"
+        text run at (136,0) width 8: " "
+        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
+        text run at (0,30) width 48: "UVWXYZ"
+        text run at (48,30) width 8: " "
+        text run at (0,45) width 160: "abcdefghijklmnopqrst"
+        text run at (0,60) width 16: "uv"
+        text run at (16,60) width 8: " "
+layer at (24,254) size 177x32 clip at (25,255) size 160x30 scrollHeight 75
+  RenderTextControl {TEXTAREA} at (15,1) size 177x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 160x75
+      RenderText {#text} at (0,0) size 160x75
+        text run at (0,0) width 136: "Lorem ipsum dolor"
+        text run at (136,0) width 8: " "
+        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
+        text run at (0,30) width 48: "UVWXYZ"
+        text run at (48,30) width 8: " "
+        text run at (0,45) width 160: "abcdefghijklmnopqrst"
+        text run at (0,60) width 16: "uv"
+        text run at (16,60) width 8: " "
+layer at (34,315) size 179x34 clip at (35,316) size 162x32 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (25,11) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 160x75
+      RenderText {#text} at (0,0) size 160x75
+        text run at (0,0) width 136: "Lorem ipsum dolor"
+        text run at (136,0) width 8: " "
+        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
+        text run at (0,30) width 48: "UVWXYZ"
+        text run at (48,30) width 8: " "
+        text run at (0,45) width 160: "abcdefghijklmnopqrst"
+        text run at (0,60) width 16: "uv"
+        text run at (16,60) width 8: " "
+layer at (24,378) size 179x34 clip at (25,379) size 162x32 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+    RenderBlock {DIV} at (3,3) size 160x75
+      RenderText {#text} at (0,0) size 160x75
+        text run at (0,0) width 136: "Lorem ipsum dolor"
+        text run at (136,0) width 8: " "
+        text run at (0,15) width 160: "ABCDEFGHIJKLMNOPQRST"
+        text run at (0,30) width 48: "UVWXYZ"
+        text run at (48,30) width 8: " "
+        text run at (0,45) width 160: "abcdefghijklmnopqrst"
+        text run at (0,60) width 16: "uv"
+        text run at (16,60) width 8: " "
+layer at (24,431) size 43x34 clip at (25,432) size 26x32 scrollHeight 347
+  RenderTextControl {TEXTAREA} at (15,1) size 43x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 24x345
       RenderText {#text} at (0,0) size 24x345
         text run at (0,0) width 24: "Lor"
@@ -333,8 +333,8 @@ layer at (26,453) size 43x34 clip at (27,454) size 26x32 scrollHeight 347
         text run at (0,315) width 24: "stu"
         text run at (0,330) width 8: "v"
         text run at (8,330) width 8: " "
-layer at (26,510) size 179x49 clip at (27,511) size 162x47 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,3) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,484) size 179x49 clip at (25,485) size 162x47 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x75
       RenderText {#text} at (0,0) size 160x75
         text run at (0,0) width 136: "Lorem ipsum dolor"
@@ -345,8 +345,8 @@ layer at (26,510) size 179x49 clip at (27,511) size 162x47 scrollHeight 77
         text run at (0,45) width 160: "abcdefghijklmnopqrst"
         text run at (0,60) width 16: "uv"
         text run at (16,60) width 8: " "
-layer at (26,582) size 99x34 clip at (27,583) size 82x32 scrollHeight 137
-  RenderTextControl {TEXTAREA} at (17,3) size 99x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,552) size 99x34 clip at (25,553) size 82x32 scrollHeight 137
+  RenderTextControl {TEXTAREA} at (15,1) size 99x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 80x135
       RenderText {#text} at (0,0) size 80x135
         text run at (0,0) width 40: "Lorem"
@@ -363,8 +363,8 @@ layer at (26,582) size 99x34 clip at (27,583) size 82x32 scrollHeight 137
         text run at (0,105) width 80: "klmnopqrst"
         text run at (0,120) width 16: "uv"
         text run at (16,120) width 8: " "
-layer at (26,639) size 179x154 clip at (27,640) size 177x152
-  RenderTextControl {TEXTAREA} at (17,3) size 179x154 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,605) size 179x154 clip at (25,606) size 177x152
+  RenderTextControl {TEXTAREA} at (15,1) size 179x154 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x75
       RenderText {#text} at (0,0) size 168x75
         text run at (0,0) width 136: "Lorem ipsum dolor"
@@ -375,8 +375,8 @@ layer at (26,639) size 179x154 clip at (27,640) size 177x152
         text run at (0,45) width 168: "abcdefghijklmnopqrstu"
         text run at (0,60) width 8: "v"
         text run at (8,60) width 8: " "
-layer at (26,816) size 59x64 clip at (27,817) size 42x62 scrollHeight 212
-  RenderTextControl {TEXTAREA} at (17,3) size 59x64 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,778) size 59x64 clip at (25,779) size 42x62 scrollHeight 212
+  RenderTextControl {TEXTAREA} at (15,1) size 59x64 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 40x210
       RenderText {#text} at (0,0) size 40x210
         text run at (0,0) width 40: "Lorem"
@@ -398,8 +398,8 @@ layer at (26,816) size 59x64 clip at (27,817) size 42x62 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (376,26) size 60x34 clip at (377,27) size 43x32 scrollHeight 212
-  RenderTextControl {TEXTAREA} at (15,3) size 60x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,24) size 60x34 clip at (377,25) size 43x32 scrollHeight 212
+  RenderTextControl {TEXTAREA} at (15,1) size 60x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
         text run at (0,0) width 40: "Lorem"
@@ -421,8 +421,8 @@ layer at (376,26) size 60x34 clip at (377,27) size 43x32 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (376,83) size 60x72 clip at (377,84) size 43x70 scrollHeight 1060
-  RenderTextControl {TEXTAREA} at (15,3) size 60x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,77) size 60x72 clip at (377,78) size 43x70 scrollHeight 1060
+  RenderTextControl {TEXTAREA} at (15,1) size 60x72 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (21,21) size 3x1020
       RenderText {#text} at (0,0) size 8x1020
         text run at (0,0) width 8: "L"
@@ -493,8 +493,8 @@ layer at (376,83) size 60x72 clip at (377,84) size 43x70 scrollHeight 1060
         text run at (0,975) width 8: "u"
         text run at (0,990) width 8: "v"
         text run at (0,1005) width 3: " "
-layer at (376,178) size 60x32 clip at (377,179) size 43x30 scrollHeight 210
-  RenderTextControl {TEXTAREA} at (15,3) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,168) size 60x32 clip at (377,169) size 43x30 scrollHeight 210
+  RenderTextControl {TEXTAREA} at (15,1) size 60x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (1,1) size 43x210
       RenderText {#text} at (0,0) size 43x210
         text run at (0,0) width 40: "Lorem"
@@ -516,8 +516,8 @@ layer at (376,178) size 60x32 clip at (377,179) size 43x30 scrollHeight 210
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (378,231) size 179x60 clip at (379,232) size 162x58 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,1) size 179x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,219) size 179x60 clip at (377,220) size 162x58 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x75
       RenderText {#text} at (0,0) size 160x75
         text run at (0,0) width 136: "Lorem ipsum dolor"
@@ -528,7 +528,7 @@ layer at (378,231) size 179x60 clip at (379,232) size 162x58 scrollHeight 77
         text run at (0,45) width 160: "abcdefghijklmnopqrst"
         text run at (0,60) width 16: "uv"
         text run at (16,60) width 8: " "
-layer at (376,310) size 60x60 clip at (377,311) size 43x58 scrollHeight 212
+layer at (376,298) size 60x60 clip at (377,299) size 43x58 scrollHeight 212
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
@@ -551,8 +551,8 @@ layer at (376,310) size 60x60 clip at (377,311) size 43x58 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (378,391) size 179x34 clip at (379,392) size 177x32 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,377) size 179x34 clip at (377,378) size 177x32 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x75
       RenderText {#text} at (0,0) size 168x75
         text run at (0,0) width 136: "Lorem ipsum dolor"
@@ -563,8 +563,8 @@ layer at (378,391) size 179x34 clip at (379,392) size 177x32 scrollHeight 77
         text run at (0,45) width 168: "abcdefghijklmnopqrstu"
         text run at (0,60) width 8: "v"
         text run at (8,60) width 8: " "
-layer at (378,448) size 179x49 clip at (379,449) size 162x32 scrollHeight 77
-  RenderTextControl {TEXTAREA} at (17,3) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,430) size 179x49 clip at (377,431) size 162x32 scrollHeight 77
+  RenderTextControl {TEXTAREA} at (15,1) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x75
       RenderText {#text} at (0,0) size 160x75
         text run at (0,0) width 136: "Lorem ipsum dolor"
@@ -575,7 +575,7 @@ layer at (378,448) size 179x49 clip at (379,449) size 162x32 scrollHeight 77
         text run at (0,45) width 160: "abcdefghijklmnopqrst"
         text run at (0,60) width 16: "uv"
         text run at (16,60) width 8: " "
-layer at (376,518) size 60x60 clip at (377,519) size 58x58 scrollHeight 167
+layer at (376,498) size 60x60 clip at (377,499) size 58x58 scrollHeight 167
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 56x165
       RenderText {#text} at (0,0) size 56x165
@@ -595,7 +595,7 @@ layer at (376,518) size 60x60 clip at (377,519) size 58x58 scrollHeight 167
         text run at (0,135) width 56: "opqrstu"
         text run at (0,150) width 8: "v"
         text run at (8,150) width 8: " "
-layer at (376,597) size 60x60 clip at (377,598) size 43x43 scrollHeight 212
+layer at (376,577) size 60x60 clip at (377,578) size 43x43 scrollHeight 212
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
@@ -618,7 +618,7 @@ layer at (376,597) size 60x60 clip at (377,598) size 43x43 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (376,676) size 60x60 clip at (377,677) size 43x58 scrollHeight 212
+layer at (376,656) size 60x60 clip at (377,657) size 43x58 scrollHeight 212
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
@@ -641,7 +641,7 @@ layer at (376,676) size 60x60 clip at (377,677) size 43x58 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (376,755) size 60x60 clip at (377,756) size 43x58 scrollHeight 212
+layer at (376,735) size 60x60 clip at (377,736) size 43x58 scrollHeight 212
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
@@ -664,7 +664,7 @@ layer at (376,755) size 60x60 clip at (377,756) size 43x58 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (376,834) size 60x60 clip at (377,835) size 43x58 scrollHeight 212
+layer at (376,814) size 60x60 clip at (377,815) size 43x58 scrollHeight 212
   RenderTextControl {TEXTAREA} at (15,1) size 60x60 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 41x210
       RenderText {#text} at (0,0) size 41x210
@@ -687,8 +687,8 @@ layer at (376,834) size 60x60 clip at (377,835) size 43x58 scrollHeight 212
         text run at (0,180) width 40: "pqrst"
         text run at (0,195) width 16: "uv"
         text run at (16,195) width 8: " "
-layer at (378,915) size 179x49 clip at (379,916) size 162x32 scrollWidth 290 scrollHeight 242
-  RenderTextControl {TEXTAREA} at (17,3) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,893) size 179x49 clip at (377,894) size 162x32 scrollWidth 290 scrollHeight 242
+  RenderTextControl {TEXTAREA} at (15,1) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x240
       RenderText {#text} at (0,0) size 288x225
         text run at (0,0) width 8: " "
@@ -722,8 +722,8 @@ layer at (378,915) size 179x49 clip at (379,916) size 162x32 scrollWidth 290 scr
         text run at (0,210) width 288: "This is a text area with wrap=\"soft\""
         text run at (288,210) width 0: " "
       RenderBR {BR} at (0,225) size 0x15
-layer at (378,987) size 179x34 clip at (379,988) size 162x32 scrollHeight 452
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,961) size 179x34 clip at (377,962) size 162x32 scrollHeight 452
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x450
       RenderText {#text} at (0,0) size 160x435
         text run at (0,0) width 8: " "
@@ -785,8 +785,8 @@ layer at (378,987) size 179x34 clip at (379,988) size 162x32 scrollHeight 452
         text run at (0,420) width 128: "with wrap=\"soft\""
         text run at (128,420) width 0: " "
       RenderBR {BR} at (0,435) size 0x15
-layer at (378,1044) size 179x34 clip at (379,1045) size 162x32 scrollHeight 452
-  RenderTextControl {TEXTAREA} at (17,3) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (376,1014) size 179x34 clip at (377,1015) size 162x32 scrollHeight 452
+  RenderTextControl {TEXTAREA} at (15,1) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x450
       RenderText {#text} at (0,0) size 160x435
         text run at (0,0) width 8: " "

--- a/LayoutTests/platform/win/fast/forms/blankbuttons-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/blankbuttons-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {INPUT} at (2,2) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {INPUT} at (0,0) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 41x15
           RenderText at (0,0) size 41x15
             text run at (0,0) width 41: "Submit"
-      RenderBR {BR} at (61,17) size 0x0
-      RenderButton {INPUT} at (2,27) size 50x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBR {BR} at (57,15) size 0x0
+      RenderButton {INPUT} at (0,21) size 50x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 34x15
           RenderText at (0,0) size 34x15
             text run at (0,0) width 34: "Reset"
-      RenderBR {BR} at (54,42) size 0x0
+      RenderBR {BR} at (50,36) size 0x0

--- a/LayoutTests/platform/win/fast/forms/button-align-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-align-expected.txt
@@ -6,36 +6,36 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 598x18
           text run at (0,0) width 598: "The following button elements should all be rendered on the left, with their text center justified."
-      RenderBlock (anonymous) at (0,34) size 784x100
-        RenderButton {BUTTON} at (0,2) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,34) size 784x84
+        RenderButton {BUTTON} at (0,0) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 284x15
             RenderText {#text} at (48,0) size 188x15
               text run at (48,0) width 188: "This is should be center justified."
-        RenderText {#text} at (300,3) size 4x18
-          text run at (300,3) width 4: " "
+        RenderText {#text} at (300,1) size 4x18
+          text run at (300,1) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (0,27) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,21) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 284x15
             RenderText {#text} at (48,0) size 188x15
               text run at (48,0) width 188: "This is should be center justified."
-        RenderText {#text} at (300,28) size 4x18
-          text run at (300,28) width 4: " "
+        RenderText {#text} at (300,22) size 4x18
+          text run at (300,22) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (0,52) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,42) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 284x15
             RenderText {#text} at (48,0) size 188x15
               text run at (48,0) width 188: "This is should be center justified."
-        RenderText {#text} at (300,53) size 4x18
-          text run at (300,53) width 4: " "
+        RenderText {#text} at (300,43) size 4x18
+          text run at (300,43) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (0,77) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,63) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 284x15
             RenderText {#text} at (48,0) size 188x15
               text run at (48,0) width 188: "This is should be center justified."
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,134) size 784x25
-        RenderButton {BUTTON} at (0,2) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,118) size 784x21
+        RenderButton {BUTTON} at (0,0) size 300x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 284x15
             RenderText {#text} at (48,0) size 188x15
               text run at (48,0) width 188: "This is should be center justified."

--- a/LayoutTests/platform/win/fast/forms/button-cannot-be-nested-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-cannot-be-nested-expected.txt
@@ -1,24 +1,24 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x109
-  RenderBlock {HTML} at (0,0) size 800x109
-    RenderBody {BODY} at (8,8) size 784x93
+layer at (0,0) size 800x105
+  RenderBlock {HTML} at (0,0) size 800x105
+    RenderBody {BODY} at (8,8) size 784x89
       RenderBlock {DIV} at (0,0) size 784x18
         RenderInline {A} at (0,0) size 63x18 [color=#0000EE]
           RenderText {#text} at (0,0) size 63x18
             text run at (0,0) width 63: "Bug 6584"
         RenderText {#text} at (63,0) size 374x18
           text run at (63,0) width 374: " REGRESSION: button after unclosed button gives trouble"
-      RenderBlock {P} at (0,34) size 784x25
-        RenderButton {BUTTON} at (2,2) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {P} at (0,34) size 784x21
+        RenderButton {BUTTON} at (0,0) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 22x15
             RenderText {#text} at (0,0) size 22x15
               text run at (0,0) width 22: "test"
-        RenderButton {BUTTON} at (44,2) size 45x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (38,0) size 45x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 29x15
             RenderText {#text} at (0,0) size 29x15
               text run at (0,0) width 29: "test2"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,75) size 784x18
+      RenderBlock {DIV} at (0,71) size 784x18
         RenderText {#text} at (0,0) size 602x18
           text run at (0,0) width 602: "There should be two separate buttons instead of button \"test2\" being nested inside button \"test\"."

--- a/LayoutTests/platform/win/fast/forms/button-generated-content-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-generated-content-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x286
-  RenderBlock {HTML} at (0,0) size 800x286
-    RenderBody {BODY} at (8,16) size 784x262
+layer at (0,0) size 800x254
+  RenderBlock {HTML} at (0,0) size 800x254
+    RenderBody {BODY} at (8,16) size 784x230
       RenderBlock {P} at (0,0) size 784x36
         RenderText {#text} at (0,0) size 314x18
           text run at (0,0) width 292: "This is a test of generated content in <button> "
@@ -18,126 +18,126 @@ layer at (0,0) size 800x286
         RenderText {#text} at (430,18) size 4x18
           text run at (430,18) width 4: "."
       RenderBlock {HR} at (0,52) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,62) size 784x200
-        RenderButton {BUTTON} at (2,2) size 52x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,62) size 784x168
+        RenderButton {BUTTON} at (0,0) size 52x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 36x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
-        RenderText {#text} at (56,3) size 4x18
-          text run at (56,3) width 4: " "
-        RenderButton {BUTTON} at (62,2) size 88x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (52,1) size 4x18
+          text run at (52,1) width 4: " "
+        RenderButton {BUTTON} at (56,0) size 88x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 72x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
             RenderText {#text} at (36,0) size 36x15
               text run at (36,0) width 36: "button"
-        RenderText {#text} at (152,3) size 4x18
-          text run at (152,3) width 4: " "
+        RenderText {#text} at (144,1) size 4x18
+          text run at (144,1) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,27) size 42x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,21) size 42x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 26x15
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (0,0) size 26x15
                 text run at (0,0) width 26: "after"
-        RenderText {#text} at (46,28) size 4x18
-          text run at (46,28) width 4: " "
-        RenderButton {BUTTON} at (52,27) size 78x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (42,22) size 4x18
+          text run at (42,22) width 4: " "
+        RenderButton {BUTTON} at (46,21) size 78x21 [color=#0000FF] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 62x15
             RenderText {#text} at (0,0) size 36x15
               text run at (0,0) width 36: "button"
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (36,0) size 26x15
                 text run at (36,0) width 26: "after"
-        RenderText {#text} at (132,28) size 4x18
-          text run at (132,28) width 4: " "
+        RenderText {#text} at (124,22) size 4x18
+          text run at (124,22) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,64) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
-        RenderText {#text} at (20,53) size 4x18
-          text run at (20,53) width 4: " "
-        RenderButton {BUTTON} at (26,52) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,54) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (16,43) size 4x18
+          text run at (16,43) width 4: " "
+        RenderButton {BUTTON} at (20,42) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 36x15
             RenderText {#text} at (0,0) size 36x15
               text run at (0,0) width 36: "button"
-        RenderText {#text} at (80,53) size 4x18
-          text run at (80,53) width 4: " "
+        RenderText {#text} at (72,43) size 4x18
+          text run at (72,43) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,89) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
-        RenderText {#text} at (20,78) size 4x18
-          text run at (20,78) width 4: " "
-        RenderButton {BUTTON} at (26,77) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,75) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (16,64) size 4x18
+          text run at (16,64) width 4: " "
+        RenderButton {BUTTON} at (20,63) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 36x15
             RenderText {#text} at (0,0) size 36x15
               text run at (0,0) width 36: "button"
-        RenderText {#text} at (80,78) size 4x18
-          text run at (80,78) width 4: " "
+        RenderText {#text} at (72,64) size 4x18
+          text run at (72,64) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,102) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,84) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 36x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
-        RenderText {#text} at (56,103) size 4x18
-          text run at (56,103) width 4: " "
-        RenderButton {BUTTON} at (62,102) size 88x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (52,85) size 4x18
+          text run at (52,85) width 4: " "
+        RenderButton {BUTTON} at (56,84) size 88x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 72x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
             RenderText {#text} at (36,0) size 36x15
               text run at (36,0) width 36: "button"
-        RenderText {#text} at (152,103) size 4x18
-          text run at (152,103) width 4: " "
+        RenderText {#text} at (144,85) size 4x18
+          text run at (144,85) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,127) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,105) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 26x15
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (0,0) size 26x15
                 text run at (0,0) width 26: "after"
-        RenderText {#text} at (46,128) size 4x18
-          text run at (46,128) width 4: " "
-        RenderButton {BUTTON} at (52,127) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (42,106) size 4x18
+          text run at (42,106) width 4: " "
+        RenderButton {BUTTON} at (46,105) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 62x15
             RenderText {#text} at (0,0) size 36x15
               text run at (0,0) width 36: "button"
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (36,0) size 26x15
                 text run at (36,0) width 26: "after"
-        RenderText {#text} at (132,128) size 4x18
-          text run at (132,128) width 4: " "
+        RenderText {#text} at (124,106) size 4x18
+          text run at (124,106) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,152) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,126) size 52x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 36x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
-        RenderText {#text} at (56,153) size 4x18
-          text run at (56,153) width 4: " "
-        RenderButton {BUTTON} at (62,152) size 88x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (52,127) size 4x18
+          text run at (52,127) width 4: " "
+        RenderButton {BUTTON} at (56,126) size 88x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 72x15
             RenderInline (generated) at (0,0) size 36x15
               RenderText at (0,0) size 36x15
                 text run at (0,0) width 36: "before"
             RenderText {#text} at (36,0) size 36x15
               text run at (36,0) width 36: "button"
-        RenderText {#text} at (152,153) size 4x18
-          text run at (152,153) width 4: " "
+        RenderText {#text} at (144,127) size 4x18
+          text run at (144,127) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderButton {BUTTON} at (2,177) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {BUTTON} at (0,147) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 26x15
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (0,0) size 26x15
                 text run at (0,0) width 26: "after"
-        RenderText {#text} at (46,178) size 4x18
-          text run at (46,178) width 4: " "
-        RenderButton {BUTTON} at (52,177) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (42,148) size 4x18
+          text run at (42,148) width 4: " "
+        RenderButton {BUTTON} at (46,147) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 62x15
             RenderText {#text} at (0,0) size 36x15
               text run at (0,0) width 36: "button"
             RenderInline (generated) at (0,0) size 26x15
               RenderText at (36,0) size 26x15
                 text run at (36,0) width 26: "after"
-        RenderText {#text} at (132,178) size 4x18
-          text run at (132,178) width 4: " "
+        RenderText {#text} at (124,148) size 4x18
+          text run at (124,148) width 4: " "
         RenderBR {BR} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/button-inner-block-reuse-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-inner-block-reuse-expected.txt
@@ -22,8 +22,8 @@ layer at (0,0) size 800x600
           text run at (559,0) width 144: "all of the button's other"
           text run at (0,18) width 80: "descendants."
       RenderBlock {HR} at (0,104) size 784x2 [border: (1px inset #000000)]
-      RenderBlock (anonymous) at (0,114) size 784x10
-        RenderButton {BUTTON} at (2,2) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,114) size 784x6
+        RenderButton {BUTTON} at (0,0) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 0x0
             RenderBlock (anonymous) at (0,0) size 0x0
               RenderInline {SPAN} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/button-positioned-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-positioned-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-layer at (10,10) size 159x21
-  RenderButton {BUTTON} at (10,10) size 159x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (8,8) size 159x21
+  RenderButton {BUTTON} at (8,8) size 159x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
     RenderBlock (anonymous) at (8,3) size 143x15
       RenderText {#text} at (0,0) size 143x15
         text run at (0,0) width 143: "This button is positioned."
-layer at (10,10) size 182x21
-  RenderButton {INPUT} at (10,10) size 182x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (8,8) size 182x21
+  RenderButton {INPUT} at (8,8) size 182x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
     RenderBlock (anonymous) at (8,3) size 166x15
       RenderText at (0,0) size 166x15
         text run at (0,0) width 166: "This button is also positioned"

--- a/LayoutTests/platform/win/fast/forms/button-sizes-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-sizes-expected.txt
@@ -3,109 +3,109 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {BUTTON} at (0,9) size 41x12 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {BUTTON} at (0,8) size 41x12 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 25x6
           RenderText {#text} at (0,0) size 25x6
             text run at (0,0) width 25: "Test Button"
-      RenderText {#text} at (41,3) size 4x18
-        text run at (41,3) width 4: " "
-      RenderButton {BUTTON} at (45,8) size 47x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (41,2) size 4x18
+        text run at (41,2) width 4: " "
+      RenderButton {BUTTON} at (45,7) size 47x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 31x7
           RenderText {#text} at (0,0) size 31x7
             text run at (0,0) width 31: "Test Button"
-      RenderText {#text} at (92,3) size 4x18
-        text run at (92,3) width 4: " "
-      RenderButton {BUTTON} at (96,8) size 53x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (92,2) size 4x18
+        text run at (92,2) width 4: " "
+      RenderButton {BUTTON} at (96,7) size 53x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 37x7
           RenderText {#text} at (0,0) size 37x7
             text run at (0,0) width 37: "Test Button"
-      RenderText {#text} at (149,3) size 4x18
-        text run at (149,3) width 4: " "
-      RenderButton {BUTTON} at (153,7) size 54x15 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (149,2) size 4x18
+        text run at (149,2) width 4: " "
+      RenderButton {BUTTON} at (153,6) size 54x15 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 38x9
           RenderText {#text} at (0,0) size 38x9
             text run at (0,0) width 38: "Test Button"
-      RenderText {#text} at (207,3) size 4x18
-        text run at (207,3) width 4: " "
-      RenderButton {BUTTON} at (211,6) size 63x16 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (207,2) size 4x18
+        text run at (207,2) width 4: " "
+      RenderButton {BUTTON} at (211,5) size 63x16 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 47x10
           RenderText {#text} at (0,0) size 47x10
             text run at (0,0) width 47: "Test Button"
-      RenderText {#text} at (274,3) size 4x18
-        text run at (274,3) width 4: " "
-      RenderButton {BUTTON} at (278,5) size 70x17 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (274,2) size 4x18
+        text run at (274,2) width 4: " "
+      RenderButton {BUTTON} at (278,4) size 70x17 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 54x11
           RenderText {#text} at (0,0) size 54x11
             text run at (0,0) width 54: "Test Button"
-      RenderText {#text} at (348,3) size 4x18
-        text run at (348,3) width 4: " "
-      RenderButton {BUTTON} at (354,4) size 72x18 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (348,2) size 4x18
+        text run at (348,2) width 4: " "
+      RenderButton {BUTTON} at (352,3) size 72x18 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 56x12
           RenderText {#text} at (0,0) size 56x12
             text run at (0,0) width 56: "Test Button"
-      RenderText {#text} at (428,3) size 4x18
-        text run at (428,3) width 4: " "
-      RenderButton {INPUT} at (434,2) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (424,2) size 4x18
+        text run at (424,2) width 4: " "
+      RenderButton {INPUT} at (428,1) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (519,3) size 4x18
-        text run at (519,3) width 4: " "
-      RenderButton {BUTTON} at (525,3) size 77x20 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (511,2) size 4x18
+        text run at (511,2) width 4: " "
+      RenderButton {BUTTON} at (515,2) size 77x20 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 61x14
           RenderText {#text} at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (604,3) size 4x18
-        text run at (604,3) width 4: " "
-      RenderButton {BUTTON} at (610,2) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (592,2) size 4x18
+        text run at (592,2) width 4: " "
+      RenderButton {BUTTON} at (596,1) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText {#text} at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (695,3) size 4x18
-        text run at (695,3) width 4: " "
-      RenderButton {BUTTON} at (2,32) size 89x22 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (679,2) size 4x18
+        text run at (679,2) width 4: " "
+      RenderButton {BUTTON} at (683,0) size 89x22 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 73x16
           RenderText {#text} at (0,0) size 73x16
             text run at (0,0) width 73: "Test Button"
-      RenderText {#text} at (93,34) size 4x18
-        text run at (93,34) width 4: " "
-      RenderButton {BUTTON} at (99,31) size 91x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (772,2) size 4x18
+        text run at (772,2) width 4: " "
+      RenderButton {BUTTON} at (0,27) size 91x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 75x17
           RenderText {#text} at (0,0) size 75x17
             text run at (0,0) width 75: "Test Button"
-      RenderText {#text} at (192,34) size 4x18
-        text run at (192,34) width 4: " "
-      RenderButton {BUTTON} at (198,30) size 97x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (91,30) size 4x18
+        text run at (91,30) width 4: " "
+      RenderButton {BUTTON} at (95,26) size 97x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 81x18
           RenderText {#text} at (0,0) size 81x18
             text run at (0,0) width 81: "Test Button"
-      RenderText {#text} at (297,34) size 4x18
-        text run at (297,34) width 4: " "
-      RenderButton {BUTTON} at (303,29) size 102x26 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (192,30) size 4x18
+        text run at (192,30) width 4: " "
+      RenderButton {BUTTON} at (196,25) size 102x26 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 86x20
           RenderText {#text} at (0,0) size 86x20
             text run at (0,0) width 86: "Test Button"
-      RenderText {#text} at (407,34) size 4x18
-        text run at (407,34) width 4: " "
-      RenderButton {BUTTON} at (413,28) size 108x27 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (298,30) size 4x18
+        text run at (298,30) width 4: " "
+      RenderButton {BUTTON} at (302,24) size 108x27 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 92x21
           RenderText {#text} at (0,0) size 92x21
             text run at (0,0) width 92: "Test Button"
-      RenderText {#text} at (523,34) size 4x18
-        text run at (523,34) width 4: " "
-      RenderButton {BUTTON} at (529,27) size 115x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (410,30) size 4x18
+        text run at (410,30) width 4: " "
+      RenderButton {BUTTON} at (414,23) size 115x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 99x22
           RenderText {#text} at (0,0) size 99x22
             text run at (0,0) width 99: "Test Button"
-      RenderText {#text} at (646,34) size 4x18
-        text run at (646,34) width 4: " "
-      RenderButton {BUTTON} at (652,27) size 118x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (529,30) size 4x18
+        text run at (529,30) width 4: " "
+      RenderButton {BUTTON} at (533,23) size 118x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 102x22
           RenderText {#text} at (0,0) size 102x22
             text run at (0,0) width 102: "Test Button"
-      RenderText {#text} at (772,34) size 4x18
-        text run at (772,34) width 4: " "
-      RenderButton {BUTTON} at (2,59) size 126x29 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (651,30) size 4x18
+        text run at (651,30) width 4: " "
+      RenderButton {BUTTON} at (655,22) size 126x29 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 110x23
           RenderText {#text} at (0,0) size 110x23
             text run at (0,0) width 110: "Test Button"

--- a/LayoutTests/platform/win/fast/forms/button-style-color-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-style-color-expected.txt
@@ -3,49 +3,49 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {BUTTON} at (2,2) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {BUTTON} at (0,0) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText {#text} at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (87,3) size 4x18
-        text run at (87,3) width 4: " "
-      RenderButton {BUTTON} at (93,2) size 83x21 [color=#FF0000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (83,1) size 4x18
+        text run at (83,1) width 4: " "
+      RenderButton {BUTTON} at (87,0) size 83x21 [color=#FF0000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText {#text} at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (178,3) size 4x18
-        text run at (178,3) width 4: " "
-      RenderButton {BUTTON} at (184,2) size 83x21 [bgcolor=#008000] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (170,1) size 4x18
+        text run at (170,1) width 4: " "
+      RenderButton {BUTTON} at (174,0) size 83x21 [bgcolor=#008000] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText {#text} at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (269,3) size 4x18
-        text run at (269,3) width 4: " "
-      RenderButton {BUTTON} at (275,2) size 83x21 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (257,1) size 4x18
+        text run at (257,1) width 4: " "
+      RenderButton {BUTTON} at (261,0) size 83x21 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText {#text} at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (360,3) size 4x18
-        text run at (360,3) width 4: " "
-      RenderButton {INPUT} at (366,2) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (344,1) size 4x18
+        text run at (344,1) width 4: " "
+      RenderButton {INPUT} at (348,0) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (451,3) size 4x18
-        text run at (451,3) width 4: " "
-      RenderButton {INPUT} at (457,2) size 83x21 [color=#FF0000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (431,1) size 4x18
+        text run at (431,1) width 4: " "
+      RenderButton {INPUT} at (435,0) size 83x21 [color=#FF0000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (542,3) size 4x18
-        text run at (542,3) width 4: " "
-      RenderButton {INPUT} at (548,2) size 83x21 [bgcolor=#008000] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (518,1) size 4x18
+        text run at (518,1) width 4: " "
+      RenderButton {INPUT} at (522,0) size 83x21 [bgcolor=#008000] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (633,3) size 4x18
-        text run at (633,3) width 4: " "
-      RenderButton {INPUT} at (639,2) size 83x21 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (605,1) size 4x18
+        text run at (605,1) width 4: " "
+      RenderButton {INPUT} at (609,0) size 83x21 [color=#FF0000] [bgcolor=#008000] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"

--- a/LayoutTests/platform/win/fast/forms/button-table-styles-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-table-styles-expected.txt
@@ -7,136 +7,136 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 342x18
           text run at (0,0) width 342: "This tests that buttons don't honor table display styles. "
         RenderBR {BR} at (342,14) size 0x0
-      RenderButton {INPUT} at (2,20) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {INPUT} at (0,18) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 76x15
           RenderText at (0,0) size 76x15
             text run at (0,0) width 76: "display: table"
-      RenderButton {INPUT} at (2,43) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {INPUT} at (0,39) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 76x15
           RenderText at (0,0) size 76x15
             text run at (0,0) width 76: "display: table"
-      RenderBlock (anonymous) at (0,66) size 784x405
+      RenderBlock (anonymous) at (0,60) size 784x369
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
-        RenderButton {INPUT} at (2,38) size 126x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (0,36) size 126x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 110x15
             RenderText at (0,0) size 110x15
               text run at (0,0) width 110: "display: inline-table"
-        RenderText {#text} at (130,39) size 4x18
-          text run at (130,39) width 4: " "
-        RenderButton {INPUT} at (136,38) size 126x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (126,37) size 4x18
+          text run at (126,37) width 4: " "
+        RenderButton {INPUT} at (130,36) size 126x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 110x15
             RenderText at (0,0) size 110x15
               text run at (0,0) width 110: "display: inline-table"
-        RenderText {#text} at (264,39) size 4x18
-          text run at (264,39) width 4: " "
-        RenderBR {BR} at (268,53) size 0x0
-        RenderBR {BR} at (0,61) size 0x18
-        RenderButton {INPUT} at (2,81) size 152x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (256,37) size 4x18
+          text run at (256,37) width 4: " "
+        RenderBR {BR} at (260,51) size 0x0
+        RenderBR {BR} at (0,57) size 0x18
+        RenderButton {INPUT} at (0,75) size 152x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 136x15
             RenderText at (0,0) size 136x15
               text run at (0,0) width 136: "display: table-row-group"
-        RenderText {#text} at (156,82) size 4x18
-          text run at (156,82) width 4: " "
-        RenderButton {INPUT} at (162,81) size 152x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (152,76) size 4x18
+          text run at (152,76) width 4: " "
+        RenderButton {INPUT} at (156,75) size 152x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 136x15
             RenderText at (0,0) size 136x15
               text run at (0,0) width 136: "display: table-row-group"
-        RenderText {#text} at (316,82) size 4x18
-          text run at (316,82) width 4: " "
-        RenderBR {BR} at (320,96) size 0x0
-        RenderBR {BR} at (0,104) size 0x18
-        RenderButton {INPUT} at (2,124) size 171x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (308,76) size 4x18
+          text run at (308,76) width 4: " "
+        RenderBR {BR} at (312,90) size 0x0
+        RenderBR {BR} at (0,96) size 0x18
+        RenderButton {INPUT} at (0,114) size 171x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 155x15
             RenderText at (0,0) size 155x15
               text run at (0,0) width 155: "display: table-header-group"
-        RenderText {#text} at (175,125) size 4x18
-          text run at (175,125) width 4: " "
-        RenderButton {INPUT} at (181,124) size 171x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (171,115) size 4x18
+          text run at (171,115) width 4: " "
+        RenderButton {INPUT} at (175,114) size 171x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 155x15
             RenderText at (0,0) size 155x15
               text run at (0,0) width 155: "display: table-header-group"
-        RenderText {#text} at (354,125) size 4x18
-          text run at (354,125) width 4: " "
-        RenderBR {BR} at (358,139) size 0x0
-        RenderBR {BR} at (0,147) size 0x18
-        RenderButton {INPUT} at (2,167) size 165x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (346,115) size 4x18
+          text run at (346,115) width 4: " "
+        RenderBR {BR} at (350,129) size 0x0
+        RenderBR {BR} at (0,135) size 0x18
+        RenderButton {INPUT} at (0,153) size 165x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 149x15
             RenderText at (0,0) size 149x15
               text run at (0,0) width 149: "display: table-footer-group"
-        RenderText {#text} at (169,168) size 4x18
-          text run at (169,168) width 4: " "
-        RenderButton {INPUT} at (175,167) size 165x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (165,154) size 4x18
+          text run at (165,154) width 4: " "
+        RenderButton {INPUT} at (169,153) size 165x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 149x15
             RenderText at (0,0) size 149x15
               text run at (0,0) width 149: "display: table-footer-group"
-        RenderText {#text} at (342,168) size 4x18
-          text run at (342,168) width 4: " "
-        RenderBR {BR} at (346,182) size 0x0
-        RenderBR {BR} at (0,190) size 0x18
-        RenderButton {INPUT} at (2,210) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (334,154) size 4x18
+          text run at (334,154) width 4: " "
+        RenderBR {BR} at (338,168) size 0x0
+        RenderBR {BR} at (0,174) size 0x18
+        RenderButton {INPUT} at (0,192) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 100x15
             RenderText at (0,0) size 100x15
               text run at (0,0) width 100: "display: table-row"
-        RenderText {#text} at (120,211) size 4x18
-          text run at (120,211) width 4: " "
-        RenderButton {INPUT} at (126,210) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (116,193) size 4x18
+          text run at (116,193) width 4: " "
+        RenderButton {INPUT} at (120,192) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 100x15
             RenderText at (0,0) size 100x15
               text run at (0,0) width 100: "display: table-row"
-        RenderText {#text} at (244,211) size 4x18
-          text run at (244,211) width 4: " "
-        RenderBR {BR} at (248,225) size 0x0
-        RenderBR {BR} at (0,233) size 0x18
-        RenderButton {INPUT} at (2,253) size 174x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (236,193) size 4x18
+          text run at (236,193) width 4: " "
+        RenderBR {BR} at (240,207) size 0x0
+        RenderBR {BR} at (0,213) size 0x18
+        RenderButton {INPUT} at (0,231) size 174x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 158x15
             RenderText at (0,0) size 158x15
               text run at (0,0) width 158: "display: table-column-group"
-        RenderText {#text} at (178,254) size 4x18
-          text run at (178,254) width 4: " "
-        RenderButton {INPUT} at (184,253) size 174x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (174,232) size 4x18
+          text run at (174,232) width 4: " "
+        RenderButton {INPUT} at (178,231) size 174x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 158x15
             RenderText at (0,0) size 158x15
               text run at (0,0) width 158: "display: table-column-group"
-        RenderText {#text} at (360,254) size 4x18
-          text run at (360,254) width 4: " "
-        RenderBR {BR} at (364,268) size 0x0
-        RenderBR {BR} at (0,276) size 0x18
-        RenderButton {INPUT} at (2,296) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (352,232) size 4x18
+          text run at (352,232) width 4: " "
+        RenderBR {BR} at (356,246) size 0x0
+        RenderBR {BR} at (0,252) size 0x18
+        RenderButton {INPUT} at (0,270) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 122x15
             RenderText at (0,0) size 122x15
               text run at (0,0) width 122: "display: table-column"
-        RenderText {#text} at (142,297) size 4x18
-          text run at (142,297) width 4: " "
-        RenderButton {INPUT} at (148,296) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (138,271) size 4x18
+          text run at (138,271) width 4: " "
+        RenderButton {INPUT} at (142,270) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 122x15
             RenderText at (0,0) size 122x15
               text run at (0,0) width 122: "display: table-column"
-        RenderText {#text} at (288,297) size 4x18
-          text run at (288,297) width 4: " "
-        RenderBR {BR} at (292,311) size 0x0
-        RenderBR {BR} at (0,319) size 0x18
-        RenderButton {INPUT} at (2,339) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (280,271) size 4x18
+          text run at (280,271) width 4: " "
+        RenderBR {BR} at (284,285) size 0x0
+        RenderBR {BR} at (0,291) size 0x18
+        RenderButton {INPUT} at (0,309) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 100x15
             RenderText at (0,0) size 100x15
               text run at (0,0) width 100: "display: table-cell"
-        RenderText {#text} at (120,340) size 4x18
-          text run at (120,340) width 4: " "
-        RenderButton {INPUT} at (126,339) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (116,310) size 4x18
+          text run at (116,310) width 4: " "
+        RenderButton {INPUT} at (120,309) size 116x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 100x15
             RenderText at (0,0) size 100x15
               text run at (0,0) width 100: "display: table-cell"
-        RenderText {#text} at (244,340) size 4x18
-          text run at (244,340) width 4: " "
-        RenderBR {BR} at (248,354) size 0x0
-        RenderBR {BR} at (0,362) size 0x18
-        RenderButton {INPUT} at (2,382) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (236,310) size 4x18
+          text run at (236,310) width 4: " "
+        RenderBR {BR} at (240,324) size 0x0
+        RenderBR {BR} at (0,330) size 0x18
+        RenderButton {INPUT} at (0,348) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 122x15
             RenderText at (0,0) size 122x15
               text run at (0,0) width 122: "display: table-caption"
-        RenderText {#text} at (142,383) size 4x18
-          text run at (142,383) width 4: " "
-        RenderButton {INPUT} at (148,382) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (138,349) size 4x18
+          text run at (138,349) width 4: " "
+        RenderButton {INPUT} at (142,348) size 138x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 122x15
             RenderText at (0,0) size 122x15
               text run at (0,0) width 122: "display: table-caption"

--- a/LayoutTests/platform/win/fast/forms/button-text-transform-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-text-transform-expected.txt
@@ -16,38 +16,38 @@ layer at (0,0) size 800x600
             text run at (0,18) width 104: "button) elements"
         RenderText {#text} at (104,18) size 4x18
           text run at (104,18) width 4: "."
-      RenderBlock {P} at (0,52) size 784x25
-        RenderButton {BUTTON} at (2,2) size 97x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {P} at (0,52) size 784x21
+        RenderButton {BUTTON} at (0,0) size 97x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 81x15
             RenderText {#text} at (0,0) size 81x15
               text run at (0,0) width 81: "UPPERCASE"
-        RenderText {#text} at (101,3) size 4x18
-          text run at (101,3) width 4: " "
-        RenderButton {BUTTON} at (107,2) size 74x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (97,1) size 4x18
+          text run at (97,1) width 4: " "
+        RenderButton {BUTTON} at (101,0) size 74x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 58x15
             RenderText {#text} at (0,0) size 58x15
               text run at (0,0) width 58: "lowercase"
-        RenderText {#text} at (183,3) size 4x18
-          text run at (183,3) width 4: " "
-        RenderButton {BUTTON} at (189,2) size 73x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (175,1) size 4x18
+          text run at (175,1) width 4: " "
+        RenderButton {BUTTON} at (179,0) size 73x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 57x15
             RenderText {#text} at (0,0) size 57x15
               text run at (0,0) width 57: "Capitalize"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,93) size 784x25
-        RenderButton {INPUT} at (2,2) size 97x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {P} at (0,89) size 784x21
+        RenderButton {INPUT} at (0,0) size 97x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 81x15
             RenderText at (0,0) size 81x15
               text run at (0,0) width 81: "UPPERCASE"
-        RenderText {#text} at (101,3) size 4x18
-          text run at (101,3) width 4: " "
-        RenderButton {INPUT} at (107,2) size 74x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (97,1) size 4x18
+          text run at (97,1) width 4: " "
+        RenderButton {INPUT} at (101,0) size 74x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 58x15
             RenderText at (0,0) size 58x15
               text run at (0,0) width 58: "lowercase"
-        RenderText {#text} at (183,3) size 4x18
-          text run at (183,3) width 4: " "
-        RenderButton {INPUT} at (189,2) size 73x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (175,1) size 4x18
+          text run at (175,1) width 4: " "
+        RenderButton {INPUT} at (179,0) size 73x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 57x15
             RenderText at (0,0) size 57x15
               text run at (0,0) width 57: "Capitalize"

--- a/LayoutTests/platform/win/fast/forms/button-white-space-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/button-white-space-expected.txt
@@ -13,51 +13,51 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 358x18
           text run at (0,0) width 358: "Buttons should appear next to each other in a single row:"
-      RenderTable {TABLE} at (0,70) size 209x31
-        RenderTableSection {TBODY} at (0,0) size 209x31
-          RenderTableRow {TR} at (0,2) size 209x27
-            RenderTableCell {TD} at (2,2) size 205x27 [r=0 c=0 rs=1 cs=1]
-              RenderButton {BUTTON} at (3,3) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderTable {TABLE} at (0,70) size 201x27
+        RenderTableSection {TBODY} at (0,0) size 201x27
+          RenderTableRow {TR} at (0,2) size 201x23
+            RenderTableCell {TD} at (2,2) size 197x23 [r=0 c=0 rs=1 cs=1]
+              RenderButton {BUTTON} at (1,1) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 68x15
                   RenderText {#text} at (0,0) size 68x15
                     text run at (0,0) width 68: "Search Mail"
-              RenderText {#text} at (89,4) size 4x18
-                text run at (89,4) width 4: " "
-              RenderButton {BUTTON} at (95,3) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+              RenderText {#text} at (85,2) size 4x18
+                text run at (85,2) width 4: " "
+              RenderButton {BUTTON} at (89,1) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 91x15
                   RenderText {#text} at (0,0) size 91x15
                     text run at (0,0) width 91: "Search the Web"
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,101) size 784x18
+      RenderBlock {DIV} at (0,97) size 784x18
         RenderText {#text} at (0,0) size 188x18
           text run at (0,0) width 188: "Buttons should look identical:"
-      RenderBlock {DIV} at (0,119) size 784x25
-        RenderButton {BUTTON} at (2,2) size 77x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,115) size 784x21
+        RenderButton {BUTTON} at (0,0) size 77x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 61x15
             RenderText {#text} at (0,0) size 61x15
               text run at (0,0) width 61: "test button"
-      RenderBlock {DIV} at (0,144) size 784x25
-        RenderButton {BUTTON} at (2,2) size 77x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,136) size 784x21
+        RenderButton {BUTTON} at (0,0) size 77x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 61x15
             RenderText {#text} at (0,0) size 61x15
               text run at (0,0) width 25: "test "
               text run at (25,0) width 36: "button"
-      RenderBlock {DIV} at (0,169) size 784x18
+      RenderBlock {DIV} at (0,157) size 784x18
         RenderText {#text} at (0,0) size 344x18
           text run at (0,0) width 344: "Buttons should look identical (ignore vertical spacing):"
-      RenderBlock {DIV} at (0,187) size 784x25
-        RenderButton {BUTTON} at (2,2) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,175) size 784x21
+        RenderButton {BUTTON} at (0,0) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 76x15
             RenderText {#text} at (0,0) size 76x15
               text run at (0,0) width 76: "  test  button  "
-      RenderBlock {DIV} at (0,212) size 784x25
-        RenderButton {BUTTON} at (2,2) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,196) size 784x21
+        RenderButton {BUTTON} at (0,0) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 76x15
             RenderText {#text} at (0,0) size 76x15
               text run at (0,0) width 76: "  test  button  "
-      RenderBlock {DIV} at (0,250) size 784x25
-        RenderBlock {PRE} at (0,0) size 784x25
-          RenderButton {BUTTON} at (2,2) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {DIV} at (0,230) size 784x21
+        RenderBlock {PRE} at (0,0) size 784x21
+          RenderButton {BUTTON} at (0,0) size 92x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 76x15
               RenderText {#text} at (0,0) size 76x15
                 text run at (0,0) width 76: "  test  button  "

--- a/LayoutTests/platform/win/fast/forms/control-clip-overflow-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/control-clip-overflow-expected.txt
@@ -21,14 +21,14 @@ layer at (0,0) size 800x600
           text run at (0,0) width 402: "There should not be scroll bars below the popup and the button."
 layer at (8,94) size 100x50
   RenderBlock {DIV} at (0,86) size 100x50
-    RenderMenuList {SELECT} at (0,2) size 80x19 [bgcolor=#FFFFFF]
+    RenderMenuList {SELECT} at (0,0) size 80x19 [bgcolor=#FFFFFF]
       RenderBlock (anonymous) at (4,2) size 55x15
         RenderText at (0,0) size 154x15
           text run at (0,0) width 154: "Lorem ipsum dolor sit amet"
     RenderText {#text} at (0,0) size 0x0
 layer at (8,164) size 100x50
   RenderBlock {DIV} at (0,156) size 100x50
-    RenderButton {BUTTON} at (0,2) size 80x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+    RenderButton {BUTTON} at (0,0) size 80x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
       RenderBlock (anonymous) at (8,3) size 64x15
         RenderText {#text} at (0,0) size 154x15
           text run at (0,0) width 154: "Lorem ipsum dolor sit amet"

--- a/LayoutTests/platform/win/fast/forms/disabled-select-change-index-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/disabled-select-change-index-expected.txt
@@ -3,55 +3,55 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 61x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 61x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 36x15
             text run at (0,0) width 36: "PASS"
-      RenderBR {BR} at (65,16) size 0x0
-      RenderMenuList {SELECT} at (2,25) size 61x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+      RenderBR {BR} at (61,14) size 0x0
+      RenderMenuList {SELECT} at (0,19) size 61x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 36x15
             text run at (0,0) width 36: "PASS"
-      RenderBR {BR} at (65,39) size 0x0
-      RenderMenuList {SELECT} at (2,48) size 61x19 [bgcolor=#FFFFFF]
+      RenderBR {BR} at (61,33) size 0x0
+      RenderMenuList {SELECT} at (0,38) size 61x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 36x15
             text run at (0,0) width 36: "PASS"
-      RenderBR {BR} at (65,62) size 0x0
-      RenderMenuList {SELECT} at (2,71) size 61x19 [bgcolor=#FFFFFF]
+      RenderBR {BR} at (61,52) size 0x0
+      RenderMenuList {SELECT} at (0,57) size 61x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 36x15
             text run at (0,0) width 36: "PASS"
-      RenderBR {BR} at (65,85) size 0x0
-      RenderListBox {SELECT} at (2,94) size 57x65 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBR {BR} at (61,154) size 0x0
-      RenderListBox {SELECT} at (2,163) size 57x65 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBR {BR} at (61,223) size 0x0
-      RenderListBox {SELECT} at (2,232) size 57x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBR {BR} at (61,292) size 0x0
-      RenderListBox {SELECT} at (2,301) size 57x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBR {BR} at (61,361) size 0x0
-      RenderText {#text} at (0,368) size 486x18
-        text run at (0,368) width 486: "PASS: sel1 correctly set to selectedIndex 1 by sel1.options[1].selected = true."
-      RenderBR {BR} at (486,382) size 0x0
-      RenderText {#text} at (0,386) size 438x18
-        text run at (0,386) width 438: "PASS: sel2 correctly set to selectedIndex 1 by sel2.selectedIndex = 1."
-      RenderBR {BR} at (438,400) size 0x0
-      RenderText {#text} at (0,404) size 486x18
-        text run at (0,404) width 486: "PASS: sel3 correctly set to selectedIndex 1 by sel3.options[1].selected = true."
-      RenderBR {BR} at (486,418) size 0x0
-      RenderText {#text} at (0,422) size 438x18
-        text run at (0,422) width 438: "PASS: sel4 correctly set to selectedIndex 1 by sel4.selectedIndex = 1."
-      RenderBR {BR} at (438,436) size 0x0
-      RenderText {#text} at (0,440) size 486x18
-        text run at (0,440) width 486: "PASS: sel5 correctly set to selectedIndex 1 by sel5.options[1].selected = true."
-      RenderBR {BR} at (486,454) size 0x0
-      RenderText {#text} at (0,458) size 438x18
-        text run at (0,458) width 438: "PASS: sel6 correctly set to selectedIndex 1 by sel6.selectedIndex = 1."
-      RenderBR {BR} at (438,472) size 0x0
-      RenderText {#text} at (0,476) size 486x18
-        text run at (0,476) width 486: "PASS: sel7 correctly set to selectedIndex 1 by sel7.options[1].selected = true."
-      RenderBR {BR} at (486,490) size 0x0
-      RenderText {#text} at (0,494) size 438x18
-        text run at (0,494) width 438: "PASS: sel8 correctly set to selectedIndex 1 by sel8.selectedIndex = 1."
-      RenderBR {BR} at (438,508) size 0x0
+      RenderBR {BR} at (61,71) size 0x0
+      RenderListBox {SELECT} at (0,76) size 57x65 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBR {BR} at (57,134) size 0x0
+      RenderListBox {SELECT} at (0,141) size 57x65 [color=#6D6D6D] [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBR {BR} at (57,199) size 0x0
+      RenderListBox {SELECT} at (0,206) size 57x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBR {BR} at (57,264) size 0x0
+      RenderListBox {SELECT} at (0,271) size 57x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBR {BR} at (57,329) size 0x0
+      RenderText {#text} at (0,336) size 486x18
+        text run at (0,336) width 486: "PASS: sel1 correctly set to selectedIndex 1 by sel1.options[1].selected = true."
+      RenderBR {BR} at (486,350) size 0x0
+      RenderText {#text} at (0,354) size 438x18
+        text run at (0,354) width 438: "PASS: sel2 correctly set to selectedIndex 1 by sel2.selectedIndex = 1."
+      RenderBR {BR} at (438,368) size 0x0
+      RenderText {#text} at (0,372) size 486x18
+        text run at (0,372) width 486: "PASS: sel3 correctly set to selectedIndex 1 by sel3.options[1].selected = true."
+      RenderBR {BR} at (486,386) size 0x0
+      RenderText {#text} at (0,390) size 438x18
+        text run at (0,390) width 438: "PASS: sel4 correctly set to selectedIndex 1 by sel4.selectedIndex = 1."
+      RenderBR {BR} at (438,404) size 0x0
+      RenderText {#text} at (0,408) size 486x18
+        text run at (0,408) width 486: "PASS: sel5 correctly set to selectedIndex 1 by sel5.options[1].selected = true."
+      RenderBR {BR} at (486,422) size 0x0
+      RenderText {#text} at (0,426) size 438x18
+        text run at (0,426) width 438: "PASS: sel6 correctly set to selectedIndex 1 by sel6.selectedIndex = 1."
+      RenderBR {BR} at (438,440) size 0x0
+      RenderText {#text} at (0,444) size 486x18
+        text run at (0,444) width 486: "PASS: sel7 correctly set to selectedIndex 1 by sel7.options[1].selected = true."
+      RenderBR {BR} at (486,458) size 0x0
+      RenderText {#text} at (0,462) size 438x18
+        text run at (0,462) width 438: "PASS: sel8 correctly set to selectedIndex 1 by sel8.selectedIndex = 1."
+      RenderBR {BR} at (438,476) size 0x0

--- a/LayoutTests/platform/win/fast/forms/file/file-input-direction-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/file/file-input-direction-expected.txt
@@ -1,100 +1,100 @@
-layer at (0,0) size 1087x585
+layer at (0,0) size 1071x585
   RenderView at (0,0) size 800x585
 layer at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 800x585
     RenderBody {BODY} at (8,8) size 784x569
-      RenderTable {TABLE} at (0,0) size 1079x117
-        RenderTableSection {TBODY} at (0,0) size 1079x117
-          RenderTableRow {TR} at (0,2) size 1079x20
+      RenderTable {TABLE} at (0,0) size 1063x105
+        RenderTableSection {TBODY} at (0,0) size 1063x105
+          RenderTableRow {TR} at (0,2) size 1063x20
             RenderTableCell {TH} at (2,11) size 83x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TH} at (87,11) size 246x2 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TH} at (335,2) size 246x20 [r=0 c=2 rs=1 cs=1]
-              RenderText {#text} at (78,1) size 90x18
-                text run at (78,1) width 90: "text-align:left"
-            RenderTableCell {TH} at (583,2) size 246x20 [r=0 c=3 rs=1 cs=1]
-              RenderText {#text} at (68,1) size 110x18
-                text run at (68,1) width 110: "text-align:center"
-            RenderTableCell {TH} at (831,2) size 246x20 [r=0 c=4 rs=1 cs=1]
-              RenderText {#text} at (72,1) size 102x18
-                text run at (72,1) width 102: "text-align:right"
-          RenderTableRow {TR} at (0,24) size 1079x29
-            RenderTableCell {TH} at (2,37) size 83x3 [r=1 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (87,24) size 246x29 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TH} at (87,11) size 242x2 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TH} at (331,2) size 242x20 [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (76,1) size 90x18
+                text run at (76,1) width 90: "text-align:left"
+            RenderTableCell {TH} at (575,2) size 242x20 [r=0 c=3 rs=1 cs=1]
+              RenderText {#text} at (66,1) size 110x18
+                text run at (66,1) width 110: "text-align:center"
+            RenderTableCell {TH} at (819,2) size 242x20 [r=0 c=4 rs=1 cs=1]
+              RenderText {#text} at (70,1) size 102x18
+                text run at (70,1) width 102: "text-align:right"
+          RenderTableRow {TR} at (0,24) size 1063x25
+            RenderTableCell {TH} at (2,35) size 83x3 [r=1 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (87,24) size 242x25 [border: (1px solid #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (335,24) size 246x29 [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (331,24) size 242x25 [border: (1px solid #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (583,24) size 246x29 [border: (1px solid #000000)] [r=1 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (575,24) size 242x25 [border: (1px solid #000000)] [r=1 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (831,24) size 246x29 [border: (1px solid #000000)] [r=1 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (819,24) size 242x25 [border: (1px solid #000000)] [r=1 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-          RenderTableRow {TR} at (0,55) size 1079x29
-            RenderTableCell {TH} at (2,59) size 83x21 [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,51) size 1063x25
+            RenderTableCell {TH} at (2,53) size 83x21 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 81x19
                 text run at (1,2) width 81: "direction:ltr"
-            RenderTableCell {TD} at (87,55) size 246x29 [border: (1px solid #000000)] [r=2 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (87,51) size 242x25 [border: (1px solid #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (335,55) size 246x29 [border: (1px solid #000000)] [r=2 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (331,51) size 242x25 [border: (1px solid #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (583,55) size 246x29 [border: (1px solid #000000)] [r=2 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (575,51) size 242x25 [border: (1px solid #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (831,55) size 246x29 [border: (1px solid #000000)] [r=2 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (819,51) size 242x25 [border: (1px solid #000000)] [r=2 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (0,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-          RenderTableRow {TR} at (0,86) size 1079x29
-            RenderTableCell {TH} at (2,90) size 83x21 [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,78) size 1063x25
+            RenderTableCell {TH} at (2,80) size 83x21 [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 81x19
                 text run at (1,2) width 81: "direction:rtl"
-            RenderTableCell {TD} at (87,86) size 246x29 [border: (1px solid #000000)] [r=3 c=1 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (87,78) size 242x25 [border: (1px solid #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (154,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (335,86) size 246x29 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (331,78) size 242x25 [border: (1px solid #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (154,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (583,86) size 246x29 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (575,78) size 242x25 [border: (1px solid #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (154,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15
                       text run at (0,0) width 68: "Choose File"
-            RenderTableCell {TD} at (831,86) size 246x29 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
-              RenderFileUploadControl {INPUT} at (4,4) size 238x21 "no file selected"
+            RenderTableCell {TD} at (819,78) size 242x25 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
+              RenderFileUploadControl {INPUT} at (2,2) size 238x21 "no file selected"
                 RenderButton {INPUT} at (154,0) size 84x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 68x15
                     RenderText at (0,0) size 68x15

--- a/LayoutTests/platform/win/fast/forms/file/file-input-disabled-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/file/file-input-disabled-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x63
-        RenderBlock (anonymous) at (0,0) size 784x63
+      RenderBlock {FORM} at (0,0) size 784x59
+        RenderBlock (anonymous) at (0,0) size 784x59
           RenderBlock {INPUT} at (4,3) size 13x13
           RenderInline {B} at (0,0) size 75x18
             RenderText {#text} at (20,2) size 75x18
               text run at (20,2) width 75: "Attach File"
           RenderBR {BR} at (95,16) size 0x0
           RenderBR {BR} at (0,20) size 0x18
-          RenderText {#text} at (0,41) size 86x18
-            text run at (0,41) width 86: "  Select File:  "
-          RenderFileUploadControl {INPUT} at (88,40) size 238x21 "no file selected"
+          RenderText {#text} at (0,39) size 86x18
+            text run at (0,39) width 86: "  Select File:  "
+          RenderFileUploadControl {INPUT} at (86,38) size 238x21 "no file selected"
             RenderButton {INPUT} at (0,0) size 84x21 [color=#6D6D6D] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
               RenderBlock (anonymous) at (8,3) size 68x15
                 RenderText at (0,0) size 68x15
                   text run at (0,0) width 68: "Choose File"
-          RenderBR {BR} at (328,55) size 0x0
-        RenderTable {TABLE} at (0,63) size 0x0
+          RenderBR {BR} at (324,53) size 0x0
+        RenderTable {TABLE} at (0,59) size 0x0

--- a/LayoutTests/platform/win/fast/forms/floating-textfield-relayout-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/floating-textfield-relayout-expected.txt
@@ -19,8 +19,8 @@ layer at (0,0) size 800x600
       RenderBlock {HR} at (0,52) size 784x2 [border: (1px inset #000000)]
 layer at (8,70) size 784x0
   RenderBlock (relative positioned) {DIV} at (0,62) size 784x0
-    RenderTextControl {INPUT} at (0,2) size 392x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-layer at (10,75) size 388x15
+    RenderTextControl {INPUT} at (0,0) size 392x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+layer at (10,73) size 388x15
   RenderBlock {DIV} at (2,3) size 388x15
     RenderText {#text} at (0,0) size 18x15
       text run at (0,0) width 18: "foo"

--- a/LayoutTests/platform/win/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/form-element-geometry-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x665
+layer at (0,0) size 785x642
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x665
-  RenderBlock {HTML} at (0,0) size 785x665
-    RenderBody {BODY} at (8,8) size 769x649
+layer at (0,0) size 785x642
+  RenderBlock {HTML} at (0,0) size 785x642
+    RenderBody {BODY} at (8,8) size 769x626
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 422x37
           text run at (0,0) width 422: "Form Element Geometry Tests"

--- a/LayoutTests/platform/win/fast/forms/formmove3-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/formmove3-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x0
         RenderInline {A} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,0) size 784x31
+      RenderBlock {DIV} at (0,0) size 784x27
         RenderBlock (anonymous) at (0,0) size 784x0
           RenderInline {A} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
-        RenderBlock (anonymous) at (0,0) size 784x31
-          RenderTable {TABLE} at (0,0) size 71x31
-            RenderTableSection {TBODY} at (0,0) size 71x31
-              RenderTableRow {TR} at (0,2) size 71x27
-                RenderTableCell {TD} at (2,14) size 2x3 [r=0 c=0 rs=1 cs=1]
-                RenderTableCell {TD} at (6,2) size 63x27 [r=0 c=1 rs=1 cs=1]
-                  RenderButton {INPUT} at (3,3) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock (anonymous) at (0,0) size 784x27
+          RenderTable {TABLE} at (0,0) size 67x27
+            RenderTableSection {TBODY} at (0,0) size 67x27
+              RenderTableRow {TR} at (0,2) size 67x23
+                RenderTableCell {TD} at (2,12) size 2x3 [r=0 c=0 rs=1 cs=1]
+                RenderTableCell {TD} at (6,2) size 59x23 [r=0 c=1 rs=1 cs=1]
+                  RenderButton {INPUT} at (1,1) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                     RenderBlock (anonymous) at (8,3) size 41x15
                       RenderText at (0,0) size 41x15
                         text run at (0,0) width 41: "Search"
-        RenderBlock (anonymous) at (0,31) size 784x0
+        RenderBlock (anonymous) at (0,27) size 784x0
           RenderInline {A} at (0,0) size 0x0
           RenderInline {A} at (0,0) size 0x0 [color=#0000EE]
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,31) size 784x18
+      RenderBlock (anonymous) at (0,27) size 784x18
         RenderText {#text} at (0,0) size 104x18
           text run at (0,0) width 104: "Form did submit"

--- a/LayoutTests/platform/win/fast/forms/hidden-listbox-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/hidden-listbox-expected.txt
@@ -6,5 +6,5 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 510x18
         text run at (0,0) width 510: "This tests that the whole listbox control is hidden when visibility is set to hidden. "
       RenderBR {BR} at (510,14) size 0x0
-      RenderListBox {SELECT} at (2,20) size 190x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderListBox {SELECT} at (0,18) size 190x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/input-appearance-disabled-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-appearance-disabled-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 397x18
         text run at (0,0) width 397: "This tests that text can not be inserted into a disabled text field. "
       RenderBR {BR} at (397,14) size 0x0
-      RenderTextControl {INPUT} at (2,20) size 149x21 [bgcolor=#EBEBE4] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 149x21 [bgcolor=#EBEBE4] [border: (2px inset #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (12,31) size 145x15
+layer at (10,29) size 145x15
   RenderBlock {DIV} at (2,3) size 145x15 [color=#545454]
     RenderText {#text} at (0,0) size 73x15
       text run at (0,0) width 73: "Test Passed"

--- a/LayoutTests/platform/win/fast/forms/input-appearance-readonly-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-appearance-readonly-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 400x18
         text run at (0,0) width 400: "This tests that text can not be inserted into a readonly text field. "
       RenderBR {BR} at (400,14) size 0x0
-      RenderTextControl {INPUT} at (2,20) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (12,31) size 145x15
+layer at (10,29) size 145x15
   RenderBlock {DIV} at (2,3) size 145x15
     RenderText {#text} at (0,0) size 73x15
       text run at (0,0) width 73: "Test Passed"

--- a/LayoutTests/platform/win/fast/forms/input-button-sizes-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-button-sizes-expected.txt
@@ -3,103 +3,103 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {INPUT} at (0,10) size 41x12 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderButton {INPUT} at (0,9) size 41x12 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 25x6
           RenderText at (0,0) size 25x6
             text run at (0,0) width 25: "Test Button"
-      RenderText {#text} at (41,4) size 4x18
-        text run at (41,4) width 4: " "
-      RenderButton {INPUT} at (45,9) size 47x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (41,3) size 4x18
+        text run at (41,3) width 4: " "
+      RenderButton {INPUT} at (45,8) size 47x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 31x7
           RenderText at (0,0) size 31x7
             text run at (0,0) width 31: "Test Button"
-      RenderText {#text} at (92,4) size 4x18
-        text run at (92,4) width 4: " "
-      RenderButton {INPUT} at (96,9) size 53x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (92,3) size 4x18
+        text run at (92,3) width 4: " "
+      RenderButton {INPUT} at (96,8) size 53x13 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 37x7
           RenderText at (0,0) size 37x7
             text run at (0,0) width 37: "Test Button"
-      RenderText {#text} at (149,4) size 4x18
-        text run at (149,4) width 4: " "
-      RenderButton {INPUT} at (153,8) size 54x15 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (149,3) size 4x18
+        text run at (149,3) width 4: " "
+      RenderButton {INPUT} at (153,7) size 54x15 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 38x9
           RenderText at (0,0) size 38x9
             text run at (0,0) width 38: "Test Button"
-      RenderText {#text} at (207,4) size 4x18
-        text run at (207,4) width 4: " "
-      RenderButton {INPUT} at (211,7) size 63x16 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (207,3) size 4x18
+        text run at (207,3) width 4: " "
+      RenderButton {INPUT} at (211,6) size 63x16 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 47x10
           RenderText at (0,0) size 47x10
             text run at (0,0) width 47: "Test Button"
-      RenderText {#text} at (274,4) size 4x18
-        text run at (274,4) width 4: " "
-      RenderButton {INPUT} at (278,6) size 70x17 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (274,3) size 4x18
+        text run at (274,3) width 4: " "
+      RenderButton {INPUT} at (278,5) size 70x17 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 54x11
           RenderText at (0,0) size 54x11
             text run at (0,0) width 54: "Test Button"
-      RenderText {#text} at (348,4) size 4x18
-        text run at (348,4) width 4: " "
-      RenderButton {INPUT} at (354,5) size 72x18 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (348,3) size 4x18
+        text run at (348,3) width 4: " "
+      RenderButton {INPUT} at (352,4) size 72x18 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 56x12
           RenderText at (0,0) size 56x12
             text run at (0,0) width 56: "Test Button"
-      RenderText {#text} at (428,4) size 4x18
-        text run at (428,4) width 4: " "
-      RenderButton {INPUT} at (434,4) size 77x20 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (424,3) size 4x18
+        text run at (424,3) width 4: " "
+      RenderButton {INPUT} at (428,3) size 77x20 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (513,4) size 4x18
-        text run at (513,4) width 4: " "
-      RenderButton {INPUT} at (519,3) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (505,3) size 4x18
+        text run at (505,3) width 4: " "
+      RenderButton {INPUT} at (509,2) size 83x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 67x15
           RenderText at (0,0) size 67x15
             text run at (0,0) width 67: "Test Button"
-      RenderText {#text} at (604,4) size 4x18
-        text run at (604,4) width 4: " "
-      RenderButton {INPUT} at (610,2) size 89x22 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (592,3) size 4x18
+        text run at (592,3) width 4: " "
+      RenderButton {INPUT} at (596,1) size 89x22 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 73x16
           RenderText at (0,0) size 73x16
             text run at (0,0) width 73: "Test Button"
-      RenderText {#text} at (701,4) size 4x18
-        text run at (701,4) width 4: " "
-      RenderButton {INPUT} at (2,32) size 91x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (685,3) size 4x18
+        text run at (685,3) width 4: " "
+      RenderButton {INPUT} at (689,0) size 91x23 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 75x17
           RenderText at (0,0) size 75x17
             text run at (0,0) width 75: "Test Button"
-      RenderText {#text} at (95,35) size 4x18
-        text run at (95,35) width 4: " "
-      RenderButton {INPUT} at (101,31) size 97x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (780,3) size 4x18
+        text run at (780,3) width 4: " "
+      RenderButton {INPUT} at (0,27) size 97x24 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 81x18
           RenderText at (0,0) size 81x18
             text run at (0,0) width 81: "Test Button"
-      RenderText {#text} at (200,35) size 4x18
-        text run at (200,35) width 4: " "
-      RenderButton {INPUT} at (206,30) size 102x26 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (97,31) size 4x18
+        text run at (97,31) width 4: " "
+      RenderButton {INPUT} at (101,26) size 102x26 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 86x20
           RenderText at (0,0) size 86x20
             text run at (0,0) width 86: "Test Button"
-      RenderText {#text} at (310,35) size 4x18
-        text run at (310,35) width 4: " "
-      RenderButton {INPUT} at (316,29) size 108x27 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (203,31) size 4x18
+        text run at (203,31) width 4: " "
+      RenderButton {INPUT} at (207,25) size 108x27 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 92x21
           RenderText at (0,0) size 92x21
             text run at (0,0) width 92: "Test Button"
-      RenderText {#text} at (426,35) size 4x18
-        text run at (426,35) width 4: " "
-      RenderButton {INPUT} at (432,28) size 115x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (315,31) size 4x18
+        text run at (315,31) width 4: " "
+      RenderButton {INPUT} at (319,24) size 115x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 99x22
           RenderText at (0,0) size 99x22
             text run at (0,0) width 99: "Test Button"
-      RenderText {#text} at (549,35) size 4x18
-        text run at (549,35) width 4: " "
-      RenderButton {INPUT} at (555,28) size 118x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (434,31) size 4x18
+        text run at (434,31) width 4: " "
+      RenderButton {INPUT} at (438,24) size 118x28 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 102x22
           RenderText at (0,0) size 102x22
             text run at (0,0) width 102: "Test Button"
-      RenderText {#text} at (675,35) size 4x18
-        text run at (675,35) width 4: " "
-      RenderButton {INPUT} at (2,60) size 126x29 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (556,31) size 4x18
+        text run at (556,31) width 4: " "
+      RenderButton {INPUT} at (560,23) size 126x29 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 110x23
           RenderText at (0,0) size 110x23
             text run at (0,0) width 110: "Test Button"

--- a/LayoutTests/platform/win/fast/forms/input-field-text-truncated-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-field-text-truncated-expected.txt
@@ -7,10 +7,10 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 778x26
           text run at (0,0) width 778: "Text inside input field should not be cut off at the bottom when its font is larger than the body font size. If the descenders in \"something gjpqy\" below are all visible, the"
           text run at (0,13) width 343: "test passes. If they are cut off by the bottom of the input box, the test fails."
-      RenderBlock (anonymous) at (0,37) size 784x24
-        RenderTextControl {INPUT} at (0,2) size 300x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock (anonymous) at (0,37) size 784x20
+        RenderTextControl {INPUT} at (0,0) size 300x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
-layer at (10,50) size 296x14
+layer at (10,48) size 296x14
   RenderBlock {DIV} at (2,3) size 296x14
     RenderText {#text} at (0,0) size 90x14
       text run at (0,0) width 90: "something gjpqy"

--- a/LayoutTests/platform/win/fast/forms/input-first-letter-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-first-letter-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 585x18
         text run at (0,0) width 585: "This test passes if it doesn't crash and if the Submit button does not honor the first-letter style."
       RenderBR {BR} at (585,14) size 0x0
-      RenderButton {INPUT} at (2,20) size 57x21 [border: (2px outset #F0F0F0)]
+      RenderButton {INPUT} at (0,18) size 57x21 [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 41x15
           RenderText at (0,0) size 41x15
             text run at (0,0) width 41: "Submit"

--- a/LayoutTests/platform/win/fast/forms/input-readonly-autoscroll-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-readonly-autoscroll-expected.txt
@@ -14,14 +14,14 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,34) size 784x18
         RenderText {#text} at (0,0) size 351x18
           text run at (0,0) width 351: "Readonly text fields don't scroll when selecting content."
-      RenderBlock (anonymous) at (0,68) size 784x25
-        RenderTextControl {INPUT} at (2,2) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock (anonymous) at (0,68) size 784x21
+        RenderTextControl {INPUT} at (0,0) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,93) size 784x18
+      RenderBlock {DIV} at (0,89) size 784x18
         RenderText {#text} at (0,0) size 87x18
           text run at (0,0) width 87: "ScrollLeft: 22"
         RenderBR {BR} at (87,14) size 0x0
-layer at (12,81) size 145x15 scrollX 22 scrollWidth 167
+layer at (10,79) size 145x15 scrollX 22 scrollWidth 167
   RenderBlock {DIV} at (2,3) size 145x15
     RenderText {#text} at (0,0) size 167x15
       text run at (0,0) width 167: "abcdefghijklmnopqrstuvwxyz"

--- a/LayoutTests/platform/win/fast/forms/input-readonly-dimmed-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-readonly-dimmed-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 455x18
         text run at (0,0) width 455: "This tests that the border of a readonly text field should appear dimmed. "
       RenderBR {BR} at (455,14) size 0x0
-      RenderTextControl {INPUT} at (2,20) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTextControl {INPUT} at (0,18) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (12,31) size 145x15 scrollWidth 171
+layer at (10,29) size 145x15 scrollWidth 171
   RenderBlock {DIV} at (2,3) size 145x15
     RenderText {#text} at (0,0) size 171x15
       text run at (0,0) width 171: "This border should be dimmed"

--- a/LayoutTests/platform/win/fast/forms/input-readonly-empty-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/input-readonly-empty-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (0,3) size 476x18
-        text run at (0,3) width 476: "This tests that empty readonly text fields have the right height and baseline. "
-      RenderTextControl {INPUT} at (478,2) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderText {#text} at (0,1) size 476x18
+        text run at (0,1) width 476: "This tests that empty readonly text fields have the right height and baseline. "
+      RenderTextControl {INPUT} at (476,0) size 149x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
       RenderText {#text} at (0,0) size 0x0
-layer at (488,13) size 145x15
+layer at (486,11) size 145x15
   RenderBlock {DIV} at (2,3) size 145x15

--- a/LayoutTests/platform/win/fast/forms/listbox-bidi-align-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/listbox-bidi-align-expected.txt
@@ -1,74 +1,74 @@
-layer at (0,0) size 808x585
-  RenderView at (0,0) size 800x585
-layer at (0,0) size 800x552
-  RenderBlock {HTML} at (0,0) size 800x552
-    RenderBody {BODY} at (8,8) size 784x536
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x528
+  RenderBlock {HTML} at (0,0) size 800x528
+    RenderBody {BODY} at (8,8) size 784x512
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 597x18
           text run at (0,0) width 597: "This test verifies the visual alignment of items in a select element while changing text direction."
         RenderBR {BR} at (597,0) size 0x18
         RenderText {#text} at (0,18) size 426x18
           text run at (0,18) width 426: "All the items in the following select elements should be left-aligned."
-      RenderTable {TABLE} at (0,36) size 720x148
-        RenderTableSection {TBODY} at (0,0) size 720x148
-          RenderTableRow {TR} at (0,2) size 720x71
-            RenderTableCell {TD} at (2,2) size 169x71 [r=0 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (173,2) size 186x71 [r=0 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (361,2) size 169x71 [r=0 c=2 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (532,2) size 186x71 [r=0 c=3 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-          RenderTableRow {TR} at (0,75) size 720x71
-            RenderTableCell {TD} at (2,75) size 169x71 [r=1 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (173,75) size 186x71 [r=1 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBlock (anonymous) at (0,184) size 784x18
+      RenderTable {TABLE} at (0,36) size 704x140
+        RenderTableSection {TBODY} at (0,0) size 704x140
+          RenderTableRow {TR} at (0,2) size 704x67
+            RenderTableCell {TD} at (2,2) size 165x67 [r=0 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (169,2) size 182x67 [r=0 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (353,2) size 165x67 [r=0 c=2 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (520,2) size 182x67 [r=0 c=3 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+          RenderTableRow {TR} at (0,71) size 704x67
+            RenderTableCell {TD} at (2,71) size 165x67 [r=1 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 163x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (169,71) size 182x67 [r=1 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 180x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,176) size 784x18
         RenderText {#text} at (0,0) size 435x18
           text run at (0,0) width 435: "All the items in the following select elements should be right-aligned."
-      RenderTable {TABLE} at (0,202) size 712x148
-        RenderTableSection {TBODY} at (0,0) size 712x148
-          RenderTableRow {TR} at (0,2) size 712x71
-            RenderTableCell {TD} at (2,2) size 176x71 [r=0 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (180,2) size 175x71 [r=0 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (357,2) size 176x71 [r=0 c=2 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (535,2) size 175x71 [r=0 c=3 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-          RenderTableRow {TR} at (0,75) size 712x71
-            RenderTableCell {TD} at (2,75) size 176x71 [r=1 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (180,75) size 175x71 [r=1 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBlock (anonymous) at (0,350) size 784x18
+      RenderTable {TABLE} at (0,194) size 696x140
+        RenderTableSection {TBODY} at (0,0) size 696x140
+          RenderTableRow {TR} at (0,2) size 696x67
+            RenderTableCell {TD} at (2,2) size 172x67 [r=0 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (176,2) size 171x67 [r=0 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (349,2) size 172x67 [r=0 c=2 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (523,2) size 171x67 [r=0 c=3 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+          RenderTableRow {TR} at (0,71) size 696x67
+            RenderTableCell {TD} at (2,71) size 172x67 [r=1 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 170x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (176,71) size 171x67 [r=1 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 169x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,334) size 784x18
         RenderText {#text} at (0,0) size 444x18
           text run at (0,0) width 444: "All the items in the following select elements should be center-aligned."
-      RenderTable {TABLE} at (0,368) size 754x75
-        RenderTableSection {TBODY} at (0,0) size 754x75
-          RenderTableRow {TR} at (0,2) size 754x71
-            RenderTableCell {TD} at (2,2) size 187x71 [r=0 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 181x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (191,2) size 185x71 [r=0 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 179x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (378,2) size 187x71 [r=0 c=2 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 181x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (567,2) size 185x71 [r=0 c=3 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 179x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderBlock (anonymous) at (0,443) size 784x18
+      RenderTable {TABLE} at (0,352) size 738x71
+        RenderTableSection {TBODY} at (0,0) size 738x71
+          RenderTableRow {TR} at (0,2) size 738x67
+            RenderTableCell {TD} at (2,2) size 183x67 [r=0 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 181x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (187,2) size 181x67 [r=0 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 179x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (370,2) size 183x67 [r=0 c=2 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 181x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (555,2) size 181x67 [r=0 c=3 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 179x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,423) size 784x18
         RenderText {#text} at (0,0) size 290x18
           text run at (0,0) width 290: "The following tables check mixed alignments."
-      RenderTable {TABLE} at (0,461) size 800x75
-        RenderTableSection {TBODY} at (0,0) size 800x75
-          RenderTableRow {TR} at (0,2) size 800x71
-            RenderTableCell {TD} at (2,2) size 182x71 [r=0 c=0 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 176x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (186,2) size 182x71 [r=0 c=1 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 176x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (370,2) size 213x71 [r=0 c=2 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 207x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-            RenderTableCell {TD} at (585,2) size 213x71 [r=0 c=3 rs=1 cs=1]
-              RenderListBox {SELECT} at (3,3) size 207x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderTable {TABLE} at (0,441) size 784x71
+        RenderTableSection {TBODY} at (0,0) size 784x71
+          RenderTableRow {TR} at (0,2) size 784x67
+            RenderTableCell {TD} at (2,2) size 178x67 [r=0 c=0 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 176x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (182,2) size 178x67 [r=0 c=1 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 176x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (362,2) size 209x67 [r=0 c=2 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 207x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+            RenderTableCell {TD} at (573,2) size 209x67 [r=0 c=3 rs=1 cs=1]
+              RenderListBox {SELECT} at (1,1) size 207x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/win/fast/forms/listbox-hit-test-zoomed-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/listbox-hit-test-zoomed-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x585
   RenderBlock {HTML} at (0,0) size 800x585
     RenderBody {BODY} at (9,9) size 782x561
       RenderBlock (anonymous) at (0,0) size 781x162
-        RenderListBox {SELECT} at (2,0) size 141x162 [bgcolor=#FFFFFF] [border: (12px solid #000000)]
+        RenderListBox {SELECT} at (0,0) size 141x162 [bgcolor=#FFFFFF] [border: (12px solid #000000)]
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,162) size 781x118
         RenderBlock (anonymous) at (0,0) size 781x66
@@ -20,6 +20,6 @@ layer at (0,0) size 800x585
         RenderBlock {PRE} at (0,81) size 781x37
           RenderText {#text} at (0,0) size 1150x18
             text run at (0,0) width 1150: "     Expected: false,false,false,false,false,false,true,false,false,false,false,false,false,false,false,false,false"
-          RenderBR {BR} at (1150,14) size 0x0
+          RenderBR {BR} at (1150,13) size 0x0
           RenderText {#text} at (0,18) size 1130x18
             text run at (0,18) width 1130: "     Actual: false,false,false,false,false,true,false,false,false,false,false,false,false,false,false,false,false"

--- a/LayoutTests/platform/win/fast/forms/listbox-scrollbar-incremental-load-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/listbox-scrollbar-incremental-load-expected.txt
@@ -22,6 +22,6 @@ layer at (0,0) size 800x600
           text run at (493,0) width 287: "\x{201C}Seven\x{201D}. The scroller should be at the bottom"
           text run at (0,18) width 102: "of the scroll bar "
           text run at (102,18) width 85: "to reflect this."
-      RenderBlock (anonymous) at (0,104) size 784x69
-        RenderListBox {SELECT} at (2,2) size 58x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,104) size 784x65
+        RenderListBox {SELECT} at (0,0) size 58x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/listbox-width-change-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/listbox-width-change-expected.txt
@@ -6,5 +6,5 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 650x18
         text run at (0,0) width 650: "This tests that when a list box's options get updated, the list box will recalculate its width, and relayout. "
       RenderBR {BR} at (0,0) size 0x0
-      RenderListBox {SELECT} at (2,20) size 204x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderListBox {SELECT} at (0,18) size 204x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/menulist-clip-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-clip-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (215,18) size 4x18
           text run at (215,18) width 4: "."
       RenderBlock (anonymous) at (0,52) size 784x30
-        RenderMenuList {SELECT} at (2,0) size 48x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderMenuList {SELECT} at (0,0) size 48x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,4) size 46x22
             RenderText at (0,0) size 46x21
               text run at (0,0) width 46: "Apple"

--- a/LayoutTests/platform/win/fast/forms/menulist-deselect-update-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-deselect-update-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (0,2) size 73x18
-        text run at (0,2) width 73: "Test result: "
-      RenderMenuList {SELECT} at (75,2) size 61x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (0,0) size 73x18
+        text run at (0,0) width 73: "Test result: "
+      RenderMenuList {SELECT} at (73,0) size 61x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 36x15
             text run at (0,0) width 36: "PASS"

--- a/LayoutTests/platform/win/fast/forms/menulist-option-wrap-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-option-wrap-expected.txt
@@ -15,28 +15,28 @@ layer at (0,0) size 800x600
             text run at (358,0) width 269: "Native popup with size=\"1\" wraps options"
         RenderText {#text} at (627,0) size 4x18
           text run at (627,0) width 4: "."
-      RenderBlock {P} at (0,34) size 784x21
-        RenderText {#text} at (0,1) size 35x18
-          text run at (0,1) width 35: "With "
+      RenderBlock {P} at (0,34) size 784x18
+        RenderText {#text} at (0,0) size 35x18
+          text run at (0,0) width 35: "With "
         RenderInline {TT} at (0,0) size 64x15
           RenderText {#text} at (35,3) size 64x15
             text run at (35,3) width 64: "size=\"1\""
-        RenderText {#text} at (99,1) size 8x18
-          text run at (99,1) width 8: ": "
-        RenderMenuList {SELECT} at (107,2) size 100x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderText {#text} at (99,0) size 8x18
+          text run at (99,0) width 8: ": "
+        RenderMenuList {SELECT} at (107,1) size 100x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 98x15
             RenderText at (0,0) size 183x15
               text run at (0,0) width 183: "Very long option that does not fit"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,71) size 784x21
-        RenderText {#text} at (0,1) size 55x18
-          text run at (0,1) width 55: "Without "
+      RenderBlock {P} at (0,68) size 784x18
+        RenderText {#text} at (0,0) size 55x18
+          text run at (0,0) width 55: "Without "
         RenderInline {TT} at (0,0) size 32x15
           RenderText {#text} at (55,3) size 32x15
             text run at (55,3) width 32: "size"
-        RenderText {#text} at (87,1) size 8x18
-          text run at (87,1) width 8: ": "
-        RenderMenuList {SELECT} at (95,2) size 100x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderText {#text} at (87,0) size 8x18
+          text run at (87,0) width 8: ": "
+        RenderMenuList {SELECT} at (95,1) size 100x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 98x15
             RenderText at (0,0) size 183x15
               text run at (0,0) width 183: "Very long option that does not fit"

--- a/LayoutTests/platform/win/fast/forms/menulist-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-restrict-line-height-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 417x18
         text run at (0,0) width 417: "This tests that we don't honor line-height for styled popup buttons."
       RenderBR {BR} at (417,14) size 0x0
-      RenderMenuList {SELECT} at (2,20) size 204x21 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderMenuList {SELECT} at (0,18) size 204x21 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (5,3) size 177x15
           RenderText at (0,0) size 177x15
             text run at (0,0) width 177: "This text should not be clipped."

--- a/LayoutTests/platform/win/fast/forms/menulist-separator-painting-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-separator-painting-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 784x6 [border: (3px solid #FFFFFF)]
-      RenderBlock (anonymous) at (0,6) size 784x25
-        RenderMenuList {SELECT} at (2,2) size 27x21 [bgcolor=#FFFFFF] [border: (1px solid #008000)]
+      RenderBlock (anonymous) at (0,6) size 784x21
+        RenderMenuList {SELECT} at (0,0) size 27x21 [bgcolor=#FFFFFF] [border: (1px solid #008000)]
           RenderBlock (anonymous) at (5,3) size 0x15
             RenderText at (0,0) size 0x15
               text run at (0,0) width 0: " "

--- a/LayoutTests/platform/win/fast/forms/menulist-style-color-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-style-color-expected.txt
@@ -3,25 +3,25 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,3) size 66x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,1) size 66x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 41x15
           RenderText at (0,0) size 41x15
             text run at (0,0) width 41: "Default"
-      RenderText {#text} at (70,3) size 4x18
-        text run at (70,3) width 4: " "
-      RenderMenuList {SELECT} at (76,3) size 48x19 [color=#FF0000] [bgcolor=#FFFFFF]
+      RenderText {#text} at (66,1) size 4x18
+        text run at (66,1) width 4: " "
+      RenderMenuList {SELECT} at (70,1) size 48x19 [color=#FF0000] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 23x15
           RenderText at (0,0) size 23x15
             text run at (0,0) width 23: "Red"
-      RenderText {#text} at (126,3) size 4x18
-        text run at (126,3) width 4: " "
-      RenderMenuList {SELECT} at (132,2) size 120x21 [bgcolor=#008000] [border: (1px solid #000000)]
+      RenderText {#text} at (118,1) size 4x18
+        text run at (118,1) width 4: " "
+      RenderMenuList {SELECT} at (122,0) size 120x21 [bgcolor=#008000] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (5,3) size 93x15
           RenderText at (0,0) size 93x15
             text run at (0,0) width 93: "Default on green"
-      RenderText {#text} at (254,3) size 4x18
-        text run at (254,3) width 4: " "
-      RenderMenuList {SELECT} at (260,2) size 102x21 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FF0000)]
+      RenderText {#text} at (242,1) size 4x18
+        text run at (242,1) width 4: " "
+      RenderMenuList {SELECT} at (246,0) size 102x21 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FF0000)]
         RenderBlock (anonymous) at (5,3) size 75x15
           RenderText at (0,0) size 75x15
             text run at (0,0) width 75: "Red on green"

--- a/LayoutTests/platform/win/fast/forms/menulist-width-change-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/menulist-width-change-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock (anonymous) at (0,0) size 784x59
+      RenderBlock (anonymous) at (0,0) size 784x55
         RenderText {#text} at (0,0) size 663x18
           text run at (0,0) width 663: "This tests that when an option is dynamically added to a menu list, and it is too long for the current width,"
         RenderBR {BR} at (663,14) size 0x0
         RenderText {#text} at (0,18) size 364x18
           text run at (0,18) width 364: "that the select automatically recalculates the correct width."
         RenderBR {BR} at (364,32) size 0x0
-        RenderMenuList {SELECT} at (2,38) size 135x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,36) size 135x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 110x15
             RenderText at (0,0) size 31x15
               text run at (0,0) width 31: "Short"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,59) size 784x0
+      RenderBlock {DIV} at (0,55) size 784x0

--- a/LayoutTests/platform/win/fast/forms/minWidthPercent-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/minWidthPercent-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 120x31 [bgcolor=#C3D9FF]
-        RenderTable {TABLE} at (0,0) size 120x31
-          RenderTableSection {TBODY} at (0,0) size 120x31
-            RenderTableRow {TR} at (0,2) size 120x27
-              RenderTableCell {TD} at (2,2) size 116x27 [r=0 c=0 rs=1 cs=1]
-                RenderTextControl {INPUT} at (1,3) size 114x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderBlock {DIV} at (0,0) size 120x27 [bgcolor=#C3D9FF]
+        RenderTable {TABLE} at (0,0) size 120x27
+          RenderTableSection {TBODY} at (0,0) size 120x27
+            RenderTableRow {TR} at (0,2) size 120x23
+              RenderTableCell {TD} at (2,2) size 116x23 [r=0 c=0 rs=1 cs=1]
+                RenderTextControl {INPUT} at (1,1) size 114x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
                 RenderText {#text} at (0,0) size 0x0
-layer at (13,16) size 109x15 scrollWidth 119
+layer at (13,14) size 109x15 scrollWidth 119
   RenderBlock {DIV} at (2,3) size 110x15
     RenderText {#text} at (0,0) size 118x15
       text run at (0,0) width 118: "Should fit in blue box"

--- a/LayoutTests/platform/win/fast/forms/onselect-textarea-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/onselect-textarea-expected.txt
@@ -10,11 +10,11 @@ After setSelectionRange(5, 10): textarea selection start: 5 end: 10
 
 Double clicking to make selection for textarea
 onselect fired for textarea
-After double clicking: textarea selection start: 0 end: 8
+After double clicking: textarea selection start: 8 end: 9
 
 Calling blur on textarea
-After blur: textarea selection start: 0 end: 8
+After blur: textarea selection start: 8 end: 9
 
 Calling focus on textarea
-After focus: textarea selection start: 0 end: 8
+After focus: textarea selection start: 8 end: 9
 

--- a/LayoutTests/platform/win/fast/forms/option-script-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/option-script-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         text run at (0,18) width 109: "TEST FAILED: "
         text run at (109,18) width 316: "If the popup menu says \"document.write('Text')\". "
       RenderBR {BR} at (425,32) size 0x0
-      RenderMenuList {SELECT} at (2,38) size 51x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,36) size 51x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 26x15
           RenderText at (0,0) size 26x15
             text run at (0,0) width 26: "Text"

--- a/LayoutTests/platform/win/fast/forms/option-strip-whitespace-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/option-strip-whitespace-expected.txt
@@ -6,36 +6,36 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 403x18
           text run at (0,0) width 403: "All of these selects should have the same amount of whitespace."
-      RenderBlock (anonymous) at (0,34) size 784x279
-        RenderText {#text} at (0,48) size 71x18
-          text run at (0,48) width 71: "Five Tabs: "
-        RenderListBox {SELECT} at (73,2) size 78x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (153,62) size 0x0
-        RenderBR {BR} at (0,69) size 0x18
-        RenderText {#text} at (0,135) size 84x18
-          text run at (0,135) width 84: "Five Spaces: "
-        RenderListBox {SELECT} at (86,89) size 78x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (166,149) size 0x0
-        RenderBR {BR} at (0,156) size 0x18
-        RenderText {#text} at (0,176) size 298x18
-          text run at (0,176) width 298: "Five Spaces (with leading/trailing whitespace): "
-        RenderMenuList {SELECT} at (300,176) size 97x19 [bgcolor=#FFFFFF]
+      RenderBlock (anonymous) at (0,34) size 784x259
+        RenderText {#text} at (0,44) size 71x18
+          text run at (0,44) width 71: "Five Tabs: "
+        RenderListBox {SELECT} at (71,0) size 78x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (149,58) size 0x0
+        RenderBR {BR} at (0,65) size 0x18
+        RenderText {#text} at (0,127) size 84x18
+          text run at (0,127) width 84: "Five Spaces: "
+        RenderListBox {SELECT} at (84,83) size 78x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (162,141) size 0x0
+        RenderBR {BR} at (0,148) size 0x18
+        RenderText {#text} at (0,166) size 298x18
+          text run at (0,166) width 298: "Five Spaces (with leading/trailing whitespace): "
+        RenderMenuList {SELECT} at (298,166) size 97x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 72x15
             RenderText at (0,0) size 72x15
               text run at (0,0) width 72: "Five Spaces"
-        RenderBR {BR} at (399,190) size 0x0
-        RenderBR {BR} at (0,197) size 0x18
-        RenderText {#text} at (0,217) size 285x18
-          text run at (0,217) width 285: "Five Tabs (with leading/trailing whitespace): "
-        RenderMenuList {SELECT} at (287,217) size 82x19 [bgcolor=#FFFFFF]
+        RenderBR {BR} at (395,180) size 0x0
+        RenderBR {BR} at (0,185) size 0x18
+        RenderText {#text} at (0,203) size 285x18
+          text run at (0,203) width 285: "Five Tabs (with leading/trailing whitespace): "
+        RenderMenuList {SELECT} at (285,203) size 82x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 57x15
             RenderText at (0,0) size 57x15
               text run at (0,0) width 57: "Five Tabs"
-        RenderBR {BR} at (371,231) size 0x0
-        RenderBR {BR} at (0,238) size 0x18
-        RenderText {#text} at (0,258) size 126x18
-          text run at (0,258) width 126: "Mixed Whitespace: "
-        RenderMenuList {SELECT} at (128,258) size 82x19 [bgcolor=#FFFFFF]
+        RenderBR {BR} at (367,217) size 0x0
+        RenderBR {BR} at (0,222) size 0x18
+        RenderText {#text} at (0,240) size 126x18
+          text run at (0,240) width 126: "Mixed Whitespace: "
+        RenderMenuList {SELECT} at (126,240) size 82x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 57x15
             RenderText at (0,0) size 57x15
               text run at (0,0) width 57: "Five Tabs"

--- a/LayoutTests/platform/win/fast/forms/option-text-clip-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/option-text-clip-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 702x18
         text run at (0,0) width 702: "This tests that the option text is clipped properly, and doesn't spill over into the arrow part of the popup control. "
       RenderBR {BR} at (702,14) size 0x0
-      RenderMenuList {SELECT} at (0,20) size 150x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,18) size 150x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 125x15
           RenderText at (0,0) size 144x15
             text run at (0,0) width 144: "12345 6789 ABCD EFGH"

--- a/LayoutTests/platform/win/fast/forms/plaintext-mode-2-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/plaintext-mode-2-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock (anonymous) at (0,0) size 784x25
-        RenderTextControl {INPUT} at (0,2) size 600x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderText {#text} at (600,3) size 4x18
-          text run at (600,3) width 4: " "
-        RenderBR {BR} at (604,17) size 0x0
-      RenderBlock {DIV} at (0,25) size 784x18
+      RenderBlock (anonymous) at (0,0) size 784x21
+        RenderTextControl {INPUT} at (0,0) size 600x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+        RenderText {#text} at (600,1) size 4x18
+          text run at (600,1) width 4: " "
+        RenderBR {BR} at (604,15) size 0x0
+      RenderBlock {DIV} at (0,21) size 784x18
         RenderText {#text} at (0,0) size 32x18
           text run at (0,0) width 32: "This "
         RenderInline {B} at (0,0) size 66x18
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (157,0) size 403x18
           text run at (157,0) width 205: " will be pasted into the textfield. "
           text run at (362,0) width 198: "All richness should be stripped."
-      RenderBlock {OL} at (0,59) size 784x36
+      RenderBlock {OL} at (0,55) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
           RenderListMarker at (-20,0) size 16x18: "1"
           RenderText {#text} at (0,0) size 328x18
@@ -34,7 +34,7 @@ layer at (0,0) size 800x600
           RenderListMarker at (-20,0) size 16x18: "2"
           RenderText {#text} at (0,0) size 326x18
             text run at (0,0) width 326: "Success: document.execCommand(\"Paste\") == true"
-layer at (10,13) size 596x15
+layer at (10,11) size 596x15
   RenderBlock {DIV} at (2,3) size 596x15
     RenderText {#text} at (0,0) size 498x15
       text run at (0,0) width 498: "This styled text, and link will be pasted into the textfield. All richness should be stripped."

--- a/LayoutTests/platform/win/fast/forms/select-align-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-align-expected.txt
@@ -6,43 +6,43 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 575x18
           text run at (0,0) width 575: "The following select elements should all be rendered on the left, with their text left justified."
-      RenderBlock (anonymous) at (0,34) size 784x115
-        RenderMenuList {SELECT} at (0,2) size 300x19 [bgcolor=#FFFFFF]
+      RenderBlock (anonymous) at (0,34) size 784x95
+        RenderMenuList {SELECT} at (0,0) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."
-        RenderText {#text} at (300,2) size 4x18
-          text run at (300,2) width 4: " "
+        RenderText {#text} at (300,0) size 4x18
+          text run at (300,0) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (0,25) size 300x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,19) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."
-        RenderText {#text} at (300,25) size 4x18
-          text run at (300,25) width 4: " "
+        RenderText {#text} at (300,19) size 4x18
+          text run at (300,19) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (0,48) size 300x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,38) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."
-        RenderText {#text} at (300,48) size 4x18
-          text run at (300,48) width 4: " "
+        RenderText {#text} at (300,38) size 4x18
+          text run at (300,38) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (0,71) size 300x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,57) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."
-        RenderText {#text} at (300,71) size 4x18
-          text run at (300,71) width 4: " "
+        RenderText {#text} at (300,57) size 4x18
+          text run at (300,57) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (0,94) size 300x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,76) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,149) size 784x23
-        RenderMenuList {SELECT} at (0,2) size 300x19 [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,129) size 784x19
+        RenderMenuList {SELECT} at (0,0) size 300x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 275x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "This is should be left justified."

--- a/LayoutTests/platform/win/fast/forms/select-background-none-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-background-none-expected.txt
@@ -1,9 +1,9 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,8) size 784x25 [bgcolor=#666666]
-      RenderMenuList {SELECT} at (2,2) size 34x21 [border: (1px solid #000000)]
+layer at (0,0) size 800x37
+  RenderBlock {HTML} at (0,0) size 800x37
+    RenderBody {BODY} at (8,8) size 784x21 [bgcolor=#666666]
+      RenderMenuList {SELECT} at (0,0) size 34x21 [border: (1px solid #000000)]
         RenderBlock (anonymous) at (5,3) size 7x15
           RenderText at (0,0) size 7x15
             text run at (0,0) width 7: "1"

--- a/LayoutTests/platform/win/fast/forms/select-baseline-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-baseline-expected.txt
@@ -6,43 +6,43 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 462x18
         text run at (0,0) width 462: "This tests that empty select controls and buttons have the correct baseline."
       RenderBR {BR} at (462,14) size 0x0
-      RenderMenuList {SELECT} at (2,21) size 25x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,19) size 25x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 0x15
           RenderText at (0,0) size 0x15
             text run at (0,0) width 0: " "
-      RenderText {#text} at (29,21) size 29x18
-        text run at (29,21) width 29: " test "
-      RenderMenuList {SELECT} at (60,21) size 47x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (25,19) size 29x18
+        text run at (25,19) width 29: " test "
+      RenderMenuList {SELECT} at (54,19) size 47x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 22x15
           RenderText at (0,0) size 22x15
             text run at (0,0) width 22: "test"
-      RenderText {#text} at (109,21) size 4x18
-        text run at (109,21) width 4: " "
-      RenderMenuList {SELECT} at (115,20) size 27x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #00008B)]
+      RenderText {#text} at (101,19) size 4x18
+        text run at (101,19) width 4: " "
+      RenderMenuList {SELECT} at (105,18) size 27x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #00008B)]
         RenderBlock (anonymous) at (5,3) size 0x15
           RenderText at (0,0) size 0x15
             text run at (0,0) width 0: " "
-      RenderText {#text} at (144,21) size 29x18
-        text run at (144,21) width 29: " test "
-      RenderMenuList {SELECT} at (175,20) size 49x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #00008B)]
+      RenderText {#text} at (132,19) size 29x18
+        text run at (132,19) width 29: " test "
+      RenderMenuList {SELECT} at (161,18) size 49x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #00008B)]
         RenderBlock (anonymous) at (5,3) size 22x15
           RenderText at (0,0) size 22x15
             text run at (0,0) width 22: "test"
-      RenderText {#text} at (226,21) size 4x18
-        text run at (226,21) width 4: " "
-      RenderButton {BUTTON} at (232,32) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
-      RenderText {#text} at (250,21) size 4x18
-        text run at (250,21) width 4: " "
-      RenderButton {BUTTON} at (256,20) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (210,19) size 4x18
+        text run at (210,19) width 4: " "
+      RenderButton {BUTTON} at (214,30) size 16x6 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (230,19) size 4x18
+        text run at (230,19) width 4: " "
+      RenderButton {BUTTON} at (234,18) size 38x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 22x15
           RenderText {#text} at (0,0) size 22x15
             text run at (0,0) width 22: "test"
-      RenderText {#text} at (296,21) size 4x18
-        text run at (296,21) width 4: " "
-      RenderButton {BUTTON} at (302,32) size 16x6 [color=#00008B] [bgcolor=#ADD8E6] [border: (2px outset #F0F0F0)]
-      RenderText {#text} at (320,21) size 4x18
-        text run at (320,21) width 4: " "
-      RenderButton {BUTTON} at (326,20) size 38x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (272,19) size 4x18
+        text run at (272,19) width 4: " "
+      RenderButton {BUTTON} at (276,30) size 16x6 [color=#00008B] [bgcolor=#ADD8E6] [border: (2px outset #F0F0F0)]
+      RenderText {#text} at (292,19) size 4x18
+        text run at (292,19) width 4: " "
+      RenderButton {BUTTON} at (296,18) size 38x21 [color=#00008B] [bgcolor=#ADD8E6] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 22x15
           RenderText {#text} at (0,0) size 22x15
             text run at (0,0) width 22: "test"

--- a/LayoutTests/platform/win/fast/forms/select-block-background-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-block-background-expected.txt
@@ -7,4 +7,4 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 539x18
           text run at (0,0) width 539: "This tests that backgrounds for list box items draw correctly when a list box is a block"
         RenderBR {BR} at (539,14) size 0x0
-      RenderListBox {SELECT} at (2,20) size 54x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderListBox {SELECT} at (0,18) size 54x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/win/fast/forms/select-change-listbox-size-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-change-listbox-size-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 316x18
           text run at (0,0) width 316: "This list box should be tall enough to fit 6 options."
-      RenderBlock (anonymous) at (0,86) size 784x101
-        RenderListBox {SELECT} at (2,2) size 54x97 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,86) size 784x97
+        RenderListBox {SELECT} at (0,0) size 54x97 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/select-change-listbox-to-popup-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-change-listbox-to-popup-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 441x18
         text run at (0,0) width 441: "This tests that you can dynamically change a list box to a popup menu"
       RenderBR {BR} at (441,14) size 0x0
-      RenderMenuList {SELECT} at (2,20) size 223x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,18) size 223x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 198x15
           RenderText at (0,0) size 198x15
             text run at (0,0) width 198: "This should turn into a popup menu"

--- a/LayoutTests/platform/win/fast/forms/select-change-popup-to-listbox-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-change-popup-to-listbox-expected.txt
@@ -6,5 +6,5 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 449x18
         text run at (0,0) width 449: "This tests that you can dynamically change a popup menu to a list box. "
       RenderBR {BR} at (449,14) size 0x0
-      RenderListBox {SELECT} at (2,20) size 190x81 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderListBox {SELECT} at (0,18) size 190x81 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/select-dirty-parent-pref-widths-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-dirty-parent-pref-widths-expected.txt
@@ -1,16 +1,16 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x91
-  RenderBlock {HTML} at (0,0) size 800x91
-    RenderBody {BODY} at (8,8) size 784x67
-      RenderTable {TABLE} at (0,0) size 61x33 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 59x31
-          RenderTableRow {TR} at (0,2) size 59x27
-            RenderTableCell {TD} at (2,2) size 55x27 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (4,4) size 47x19 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x87
+  RenderBlock {HTML} at (0,0) size 800x87
+    RenderBody {BODY} at (8,8) size 784x63
+      RenderTable {TABLE} at (0,0) size 57x29 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 55x27
+          RenderTableRow {TR} at (0,2) size 55x23
+            RenderTableCell {TD} at (2,2) size 51x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (2,2) size 47x19 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (4,2) size 22x15
                   RenderText at (0,0) size 22x15
                     text run at (0,0) width 22: "test"
-      RenderBlock {P} at (0,49) size 784x18
+      RenderBlock {P} at (0,45) size 784x18
         RenderText {#text} at (0,0) size 447x18
           text run at (0,0) width 447: "The select element in the table above must not spill outside of the table."

--- a/LayoutTests/platform/win/fast/forms/select-disabled-appearance-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-disabled-appearance-expected.txt
@@ -15,14 +15,14 @@ layer at (0,0) size 800x600
             text run at (358,0) width 347: "REGRESSION: Disabled pop-up text is not grayed out"
         RenderText {#text} at (705,0) size 4x18
           text run at (705,0) width 4: "."
-      RenderBlock {P} at (0,34) size 784x23
-        RenderMenuList {SELECT} at (2,2) size 161x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,34) size 784x19
+        RenderMenuList {SELECT} at (0,0) size 161x19 [color=#6D6D6D] [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 136x15
             RenderText at (0,0) size 136x15
               text run at (0,0) width 136: "This text should be gray"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,73) size 784x23
-        RenderMenuList {SELECT} at (2,2) size 167x19 [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,69) size 784x19
+        RenderMenuList {SELECT} at (0,0) size 167x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 142x15
             RenderText at (0,0) size 142x15
               text run at (0,0) width 142: "This text should be black"

--- a/LayoutTests/platform/win/fast/forms/select-element-focus-ring-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-element-focus-ring-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 67x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 67x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 42x15
           RenderText at (0,0) size 42x15
             text run at (0,0) width 42: "banana"

--- a/LayoutTests/platform/win/fast/forms/select-empty-option-height-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-empty-option-height-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 27x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderMenuList {SELECT} at (0,0) size 27x17 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (1,1) size 25x15
           RenderText at (0,0) size 0x15
             text run at (0,0) width 0: " "

--- a/LayoutTests/platform/win/fast/forms/select-initial-position-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-initial-position-expected.txt
@@ -6,50 +6,50 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 93x18
         text run at (0,0) width 93: "initial selected:"
       RenderBR {BR} at (93,14) size 0x0
-      RenderListBox {SELECT} at (2,20) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderText {#text} at (156,66) size 4x18
-        text run at (156,66) width 4: " "
-      RenderBR {BR} at (160,80) size 0x0
-      RenderText {#text} at (0,87) size 161x18
-        text run at (0,87) width 161: "dynamic selected change:"
-      RenderBR {BR} at (161,101) size 0x0
-      RenderListBox {SELECT} at (2,107) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderText {#text} at (156,153) size 4x18
-        text run at (156,153) width 4: " "
+      RenderListBox {SELECT} at (0,18) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderText {#text} at (152,62) size 4x18
+        text run at (152,62) width 4: " "
+      RenderBR {BR} at (156,76) size 0x0
+      RenderText {#text} at (0,83) size 161x18
+        text run at (0,83) width 161: "dynamic selected change:"
+      RenderBR {BR} at (161,97) size 0x0
+      RenderListBox {SELECT} at (0,101) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderText {#text} at (152,145) size 4x18
+        text run at (152,145) width 4: " "
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (0,0) size 0x0
-      RenderText {#text} at (0,174) size 211x18
-        text run at (0,174) width 211: "dynamic insert of selected option:"
-      RenderBR {BR} at (211,188) size 0x0
-      RenderListBox {SELECT} at (2,194) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-      RenderText {#text} at (156,240) size 4x18
-        text run at (156,240) width 4: " "
-      RenderBR {BR} at (160,254) size 0x0
-      RenderText {#text} at (0,261) size 93x18
-        text run at (0,261) width 93: "initial selected:"
-      RenderBR {BR} at (93,275) size 0x0
-      RenderMenuList {SELECT} at (2,281) size 156x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (0,166) size 211x18
+        text run at (0,166) width 211: "dynamic insert of selected option:"
+      RenderBR {BR} at (211,180) size 0x0
+      RenderListBox {SELECT} at (0,184) size 152x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderText {#text} at (152,228) size 4x18
+        text run at (152,228) width 4: " "
+      RenderBR {BR} at (156,242) size 0x0
+      RenderText {#text} at (0,249) size 93x18
+        text run at (0,249) width 93: "initial selected:"
+      RenderBR {BR} at (93,263) size 0x0
+      RenderMenuList {SELECT} at (0,267) size 156x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 131x15
           RenderText at (0,0) size 131x15
             text run at (0,0) width 131: "this should be selected"
-      RenderText {#text} at (160,281) size 4x18
-        text run at (160,281) width 4: " "
-      RenderBR {BR} at (164,295) size 0x0
-      RenderText {#text} at (0,302) size 161x18
-        text run at (0,302) width 161: "dynamic selected change:"
-      RenderBR {BR} at (161,316) size 0x0
-      RenderMenuList {SELECT} at (2,322) size 156x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (156,267) size 4x18
+        text run at (156,267) width 4: " "
+      RenderBR {BR} at (160,281) size 0x0
+      RenderText {#text} at (0,286) size 161x18
+        text run at (0,286) width 161: "dynamic selected change:"
+      RenderBR {BR} at (161,300) size 0x0
+      RenderMenuList {SELECT} at (0,304) size 156x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 131x15
           RenderText at (0,0) size 131x15
             text run at (0,0) width 131: "this should be selected"
-      RenderText {#text} at (160,322) size 4x18
-        text run at (160,322) width 4: " "
+      RenderText {#text} at (156,304) size 4x18
+        text run at (156,304) width 4: " "
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (0,0) size 0x0
-      RenderText {#text} at (0,343) size 211x18
-        text run at (0,343) width 211: "dynamic insert of selected option:"
-      RenderBR {BR} at (211,357) size 0x0
-      RenderMenuList {SELECT} at (2,363) size 156x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (0,323) size 211x18
+        text run at (0,323) width 211: "dynamic insert of selected option:"
+      RenderBR {BR} at (211,337) size 0x0
+      RenderMenuList {SELECT} at (0,341) size 156x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 131x15
           RenderText at (0,0) size 131x15
             text run at (0,0) width 131: "this should be selected"

--- a/LayoutTests/platform/win/fast/forms/select-item-background-clip-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-item-background-clip-expected.txt
@@ -17,6 +17,6 @@ layer at (0,0) size 800x600
         RenderText {#text} at (158,18) size 4x18
           text run at (158,18) width 4: "."
       RenderBlock (anonymous) at (0,52) size 784x64
-        RenderListBox {SELECT} at (2,0) size 60x64 [bgcolor=#FFFFFF] [border: (3px solid #0000FF)]
+        RenderListBox {SELECT} at (0,0) size 60x64 [bgcolor=#FFFFFF] [border: (3px solid #0000FF)]
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/select-list-box-with-height-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-list-box-with-height-expected.txt
@@ -7,5 +7,5 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 365x18
           text run at (0,0) width 365: "The select below has a size of 3, but a much larger height."
       RenderBlock (anonymous) at (0,34) size 784x250
-        RenderListBox {SELECT} at (2,0) size 64x250 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderListBox {SELECT} at (0,0) size 64x250 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/select-listbox-multiple-no-focusring-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-listbox-multiple-no-focusring-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x85
-  RenderBlock {HTML} at (0,0) size 800x85
-    RenderBody {BODY} at (8,8) size 784x69
-      RenderListBox {SELECT} at (2,2) size 372x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (0,0) size 800x81
+  RenderBlock {HTML} at (0,0) size 800x81
+    RenderBody {BODY} at (8,8) size 784x65
+      RenderListBox {SELECT} at (0,0) size 372x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/select-overflow-scroll-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-overflow-scroll-expected.txt
@@ -4,5 +4,5 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 58x129 clip at (11,11) size 56x127
-  RenderListBox {SELECT} at (2,2) size 58x129 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (8,8) size 58x129 clip at (9,9) size 56x127
+  RenderListBox {SELECT} at (0,0) size 58x129 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/win/fast/forms/select-overflow-scroll-inherited-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-overflow-scroll-inherited-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-layer at (8,8) size 784x148 clip at (8,8) size 769x133
-  RenderBlock {DIV} at (0,0) size 784x148
+layer at (8,8) size 784x144 clip at (8,8) size 769x129
+  RenderBlock {DIV} at (0,0) size 784x144
     RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 58x129 clip at (11,11) size 56x127
-  RenderListBox {SELECT} at (2,2) size 58x129 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+layer at (8,8) size 58x129 clip at (9,9) size 56x127
+  RenderListBox {SELECT} at (0,0) size 58x129 [bgcolor=#FFFFFF] [border: (1px inset #808080)]

--- a/LayoutTests/platform/win/fast/forms/select-selected-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-selected-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 270x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 270x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 245x15
           RenderText at (0,0) size 176x15
             text run at (0,0) width 176: "should see this option selected"

--- a/LayoutTests/platform/win/fast/forms/select-style-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select-style-expected.txt
@@ -7,66 +7,66 @@ layer at (0,0) size 800x600
         text run at (0,0) width 250: "This tests that styled popups look right. "
         text run at (250,0) width 304: "(Aqua for now- later, we will honor the styling)."
       RenderBR {BR} at (554,14) size 0x0
-      RenderMenuList {SELECT} at (2,20) size 49x21 [bgcolor=#FF0000] [border: (1px solid #000000)]
+      RenderMenuList {SELECT} at (0,18) size 49x21 [bgcolor=#FF0000] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (5,3) size 22x15
           RenderText at (0,0) size 22x15
             text run at (0,0) width 22: "test"
-      RenderText {#text} at (53,21) size 4x18
-        text run at (53,21) width 4: " "
-      RenderBR {BR} at (57,35) size 0x0
-      RenderText {#text} at (0,43) size 528x18
-        text run at (0,43) width 528: "This tests that background color is white by default regardless of the parent element."
-      RenderBR {BR} at (528,57) size 0x0
-      RenderInline {SPAN} at (0,0) size 65x28 [bgcolor=#FF0000]
+      RenderText {#text} at (49,19) size 4x18
+        text run at (49,19) width 4: " "
+      RenderBR {BR} at (53,33) size 0x0
+      RenderText {#text} at (0,39) size 528x18
+        text run at (0,39) width 528: "This tests that background color is white by default regardless of the parent element."
+      RenderBR {BR} at (528,53) size 0x0
+      RenderInline {SPAN} at (0,0) size 61x28 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (7,63) size 47x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (5,57) size 47x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 22x15
             RenderText at (0,0) size 22x15
               text run at (0,0) width 22: "test"
-        RenderText {#text} at (56,63) size 4x18
-          text run at (56,63) width 4: " "
+        RenderText {#text} at (52,57) size 4x18
+          text run at (52,57) width 4: " "
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (0,0) size 0x0
-      RenderText {#text} at (0,84) size 625x18
-        text run at (0,84) width 625: "This tests that background color is inherited from the parent if background-color:inherit is specified."
-      RenderBR {BR} at (625,98) size 0x0
-      RenderInline {SPAN} at (0,0) size 67x28 [bgcolor=#FF0000]
+      RenderText {#text} at (0,76) size 625x18
+        text run at (0,76) width 625: "This tests that background color is inherited from the parent if background-color:inherit is specified."
+      RenderBR {BR} at (625,90) size 0x0
+      RenderInline {SPAN} at (0,0) size 63x28 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (7,104) size 49x21 [border: (1px solid #000000)]
+        RenderMenuList {SELECT} at (5,94) size 49x21 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (5,3) size 22x15
             RenderText at (0,0) size 22x15
               text run at (0,0) width 22: "test"
-        RenderText {#text} at (58,105) size 4x18
-          text run at (58,105) width 4: " "
+        RenderText {#text} at (54,95) size 4x18
+          text run at (54,95) width 4: " "
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (0,0) size 0x0
-      RenderText {#text} at (0,127) size 637x18
-        text run at (0,127) width 637: "This tests that background color is the same as the parent if background-color:transparent is specified."
-      RenderBR {BR} at (637,141) size 0x0
-      RenderInline {SPAN} at (0,0) size 67x28 [bgcolor=#FF0000]
+      RenderText {#text} at (0,115) size 637x18
+        text run at (0,115) width 637: "This tests that background color is the same as the parent if background-color:transparent is specified."
+      RenderBR {BR} at (637,129) size 0x0
+      RenderInline {SPAN} at (0,0) size 63x28 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (7,147) size 49x21 [border: (1px solid #000000)]
+        RenderMenuList {SELECT} at (5,133) size 49x21 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (5,3) size 22x15
             RenderText at (0,0) size 22x15
               text run at (0,0) width 22: "test"
-        RenderText {#text} at (58,148) size 4x18
-          text run at (58,148) width 4: " "
+        RenderText {#text} at (54,134) size 4x18
+          text run at (54,134) width 4: " "
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (0,0) size 0x0
-      RenderText {#text} at (0,170) size 498x18
-        text run at (0,170) width 498: "This tests that background is white if only background-image:none is specified."
-      RenderBR {BR} at (498,184) size 0x0
-      RenderMenuList {SELECT} at (2,190) size 47x19 [bgcolor=#FFFFFF]
+      RenderText {#text} at (0,154) size 498x18
+        text run at (0,154) width 498: "This tests that background is white if only background-image:none is specified."
+      RenderBR {BR} at (498,168) size 0x0
+      RenderMenuList {SELECT} at (0,172) size 47x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 22x15
           RenderText at (0,0) size 22x15
             text run at (0,0) width 22: "test"
-      RenderText {#text} at (51,190) size 4x18
-        text run at (51,190) width 4: " "
-      RenderBR {BR} at (55,204) size 0x0
-      RenderText {#text} at (0,211) size 418x18
-        text run at (0,211) width 418: "This tests that the image specified for background-image is visible."
-      RenderBR {BR} at (418,225) size 0x0
-      RenderMenuList {SELECT} at (2,231) size 49x21 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderText {#text} at (47,172) size 4x18
+        text run at (47,172) width 4: " "
+      RenderBR {BR} at (51,186) size 0x0
+      RenderText {#text} at (0,191) size 418x18
+        text run at (0,191) width 418: "This tests that the image specified for background-image is visible."
+      RenderBR {BR} at (418,205) size 0x0
+      RenderMenuList {SELECT} at (0,209) size 49x21 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
         RenderBlock (anonymous) at (5,3) size 22x15
           RenderText at (0,0) size 22x15
             text run at (0,0) width 22: "test"

--- a/LayoutTests/platform/win/fast/forms/select/optgroup-rendering-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/select/optgroup-rendering-expected.txt
@@ -1,14 +1,14 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x364
-  RenderBlock {HTML} at (0,0) size 800x364
-    RenderBody {BODY} at (8,8) size 784x348
-      RenderBlock {FORM} at (0,0) size 784x348
-        RenderListBox {SELECT} at (2,2) size 83x321 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (87,304) size 4x18
-          text run at (87,304) width 4: " "
-        RenderBR {BR} at (91,304) size 0x18
-        RenderMenuList {SELECT} at (2,327) size 70x19 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x356
+  RenderBlock {HTML} at (0,0) size 800x356
+    RenderBody {BODY} at (8,8) size 784x340
+      RenderBlock {FORM} at (0,0) size 784x340
+        RenderListBox {SELECT} at (0,0) size 83x321 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (83,300) size 4x18
+          text run at (83,300) width 4: " "
+        RenderBR {BR} at (87,300) size 0x18
+        RenderMenuList {SELECT} at (0,321) size 70x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 45x15
             RenderText at (0,0) size 33x15
               text run at (0,0) width 33: "Three"

--- a/LayoutTests/platform/win/fast/forms/selectlist-minsize-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/selectlist-minsize-expected.txt
@@ -1,9 +1,9 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x39
-  RenderBlock {HTML} at (0,0) size 800x39
-    RenderBody {BODY} at (8,8) size 784x23
-      RenderMenuList {SELECT} at (2,2) size 25x19 [bgcolor=#FFFFFF]
+layer at (0,0) size 800x35
+  RenderBlock {HTML} at (0,0) size 800x35
+    RenderBody {BODY} at (8,8) size 784x19
+      RenderMenuList {SELECT} at (0,0) size 25x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 0x15
           RenderText at (0,0) size 0x15
             text run at (0,0) width 0: " "

--- a/LayoutTests/platform/win/fast/forms/stuff-on-my-optgroup-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/stuff-on-my-optgroup-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 61x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 61x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 24x15
             text run at (0,0) width 24: "One"
-      RenderBR {BR} at (65,16) size 0x0
-      RenderMenuList {SELECT} at (2,25) size 61x19 [bgcolor=#FFFFFF]
+      RenderBR {BR} at (61,14) size 0x0
+      RenderMenuList {SELECT} at (0,19) size 61x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 36x15
           RenderText at (0,0) size 24x15
             text run at (0,0) width 24: "One"

--- a/LayoutTests/platform/win/fast/forms/textAreaLineHeight-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textAreaLineHeight-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x1215
+layer at (0,0) size 785x1207
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1215
-  RenderBlock {HTML} at (0,0) size 785x1216
-    RenderBody {BODY} at (8,8) size 769x1192
+layer at (0,0) size 785x1207
+  RenderBlock {HTML} at (0,0) size 785x1208
+    RenderBody {BODY} at (8,8) size 769x1184
       RenderBlock (anonymous) at (0,0) size 769x18
         RenderText {#text} at (0,0) size 269x18
           text run at (0,0) width 269: "line-height settings not reflected in textarea"
@@ -30,28 +30,28 @@ layer at (0,0) size 785x1215
         RenderText {#text} at (1,19) size 382x69
           text run at (1,19) width 382: "Demo text here that wraps a bit and should demonstrate"
           text run at (1,72) width 182: "the goodness of line-height"
-      RenderBlock (anonymous) at (0,767) size 769x425
+      RenderBlock (anonymous) at (0,767) size 769x417
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
         RenderText {#text} at (0,36) size 124x18
           text run at (0,36) width 124: "Un-Styled Textarea"
         RenderBR {BR} at (124,36) size 0x18
-        RenderText {#text} at (185,80) size 4x18
-          text run at (185,80) width 4: " "
+        RenderText {#text} at (181,76) size 4x18
+          text run at (181,76) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderBR {BR} at (0,98) size 0x18
-        RenderText {#text} at (0,116) size 215x18
-          text run at (0,116) width 215: "Totally Blank Un-Styled Textarea"
-        RenderBR {BR} at (215,116) size 0x18
-        RenderText {#text} at (185,160) size 4x18
-          text run at (185,160) width 4: " "
+        RenderBR {BR} at (0,94) size 0x18
+        RenderText {#text} at (0,112) size 215x18
+          text run at (0,112) width 215: "Totally Blank Un-Styled Textarea"
+        RenderBR {BR} at (215,112) size 0x18
+        RenderText {#text} at (181,152) size 4x18
+          text run at (181,152) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderBR {BR} at (0,178) size 0x18
-        RenderText {#text} at (0,196) size 213x18
-          text run at (0,196) width 213: "Totally Blank STYLED Textarea"
-        RenderBR {BR} at (213,196) size 0x18
+        RenderBR {BR} at (0,170) size 0x18
+        RenderText {#text} at (0,188) size 213x18
+          text run at (0,188) width 213: "Totally Blank STYLED Textarea"
+        RenderBR {BR} at (213,188) size 0x18
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,1207) size 769x0
+      RenderBlock {P} at (0,1199) size 769x0
 layer at (8,60) size 406x206 clip at (9,61) size 404x204
   RenderTextControl {TEXTAREA} at (0,18) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x106
@@ -59,8 +59,8 @@ layer at (8,60) size 406x206 clip at (9,61) size 404x204
         text run at (0,18) width 382: "Demo text here that wraps a bit and should demonstrate"
         text run at (382,18) width 5: " "
         text run at (0,71) width 182: "the goodness of line-height"
-layer at (10,831) size 181x36 clip at (11,832) size 164x34 scrollHeight 79
-  RenderTextControl {TEXTAREA} at (2,56) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,829) size 181x36 clip at (9,830) size 164x34 scrollHeight 79
+  RenderTextControl {TEXTAREA} at (0,54) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x75
       RenderText {#text} at (0,0) size 160x75
         text run at (0,0) width 152: "Demo text here that"
@@ -72,9 +72,9 @@ layer at (10,831) size 181x36 clip at (11,832) size 164x34 scrollHeight 79
         text run at (0,45) width 120: "the goodness of"
         text run at (120,45) width 8: " "
         text run at (0,60) width 88: "line-height"
-layer at (10,911) size 181x36 clip at (11,912) size 179x34
-  RenderTextControl {TEXTAREA} at (2,136) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,905) size 181x36 clip at (9,906) size 179x34
+  RenderTextControl {TEXTAREA} at (0,130) size 181x36 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
-layer at (8,989) size 406x206 clip at (9,990) size 404x204
-  RenderTextControl {TEXTAREA} at (0,214) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
+layer at (8,981) size 406x206 clip at (9,982) size 404x204
+  RenderTextControl {TEXTAREA} at (0,206) size 406x206 [bgcolor=#FFFFFF] [border: (1px dotted #C0C0C0)]
     RenderBlock {DIV} at (3,3) size 400x53

--- a/LayoutTests/platform/win/fast/forms/textarea-align-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-align-expected.txt
@@ -6,41 +6,41 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 624x18
           text run at (0,0) width 624: "The following textarea elements should all be rendered on the left, with their text aligned to the left."
-      RenderBlock (anonymous) at (0,34) size 784x164
-        RenderText {#text} at (423,24) size 4x18
-          text run at (423,24) width 4: " "
+      RenderBlock (anonymous) at (0,34) size 784x148
+        RenderText {#text} at (419,20) size 4x18
+          text run at (419,20) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderText {#text} at (423,66) size 4x18
-          text run at (423,66) width 4: " "
+        RenderText {#text} at (419,58) size 4x18
+          text run at (419,58) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
-        RenderText {#text} at (423,108) size 4x18
-          text run at (423,108) width 4: " "
+        RenderText {#text} at (419,96) size 4x18
+          text run at (419,96) width 4: " "
         RenderBR {BR} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,198) size 784x38
-layer at (10,44) size 419x34 clip at (11,45) size 417x32
-  RenderTextControl {TEXTAREA} at (2,2) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderBlock {DIV} at (0,182) size 784x34
+layer at (8,42) size 419x34 clip at (9,43) size 417x32
+  RenderTextControl {TEXTAREA} at (0,0) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x15
       RenderText {#text} at (0,0) size 304x15
         text run at (0,0) width 304: "This is should be aligned to the left."
-layer at (10,86) size 419x34 clip at (11,87) size 417x32
-  RenderTextControl {TEXTAREA} at (2,44) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,80) size 419x34 clip at (9,81) size 417x32
+  RenderTextControl {TEXTAREA} at (0,38) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x15
       RenderText {#text} at (0,0) size 304x15
         text run at (0,0) width 304: "This is should be aligned to the left."
-layer at (10,128) size 419x34 clip at (11,129) size 417x32
-  RenderTextControl {TEXTAREA} at (2,86) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,118) size 419x34 clip at (9,119) size 417x32
+  RenderTextControl {TEXTAREA} at (0,76) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x15
       RenderText {#text} at (0,0) size 304x15
         text run at (0,0) width 304: "This is should be aligned to the left."
-layer at (10,170) size 419x34 clip at (11,171) size 417x32
-  RenderTextControl {TEXTAREA} at (2,128) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,156) size 419x34 clip at (9,157) size 417x32
+  RenderTextControl {TEXTAREA} at (0,114) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x15
       RenderText {#text} at (0,0) size 304x15
         text run at (0,0) width 304: "This is should be aligned to the left."
-layer at (10,208) size 419x34 clip at (11,209) size 417x32
-  RenderTextControl {TEXTAREA} at (2,2) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,190) size 419x34 clip at (9,191) size 417x32
+  RenderTextControl {TEXTAREA} at (0,0) size 419x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x15
       RenderText {#text} at (0,0) size 304x15
         text run at (0,0) width 304: "This is should be aligned to the left."

--- a/LayoutTests/platform/win/fast/forms/textarea-placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-placeholder-pseudo-style-expected.txt
@@ -6,33 +6,33 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 328x18
         text run at (0,0) width 328: "This tests that you can set the placeholder text color."
       RenderBR {BR} at (328,14) size 0x0
-      RenderText {#text} at (183,42) size 4x18
-        text run at (183,42) width 4: " "
-      RenderText {#text} at (370,42) size 4x18
-        text run at (370,42) width 4: " "
-      RenderText {#text} at (557,42) size 4x18
-        text run at (557,42) width 4: " "
+      RenderText {#text} at (179,38) size 4x18
+        text run at (179,38) width 4: " "
+      RenderText {#text} at (362,38) size 4x18
+        text run at (362,38) width 4: " "
+      RenderText {#text} at (545,38) size 4x18
+        text run at (545,38) width 4: " "
       RenderText {#text} at (0,0) size 0x0
-layer at (10,28) size 179x34 clip at (11,29) size 177x32
-  RenderTextControl {TEXTAREA} at (2,20) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,26) size 179x34 clip at (9,27) size 177x32
+  RenderTextControl {TEXTAREA} at (0,18) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
     RenderBlock {DIV} at (3,3) size 175x15 [color=#640000]
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "text"
-layer at (197,28) size 179x34 clip at (198,29) size 177x32
-  RenderTextControl {TEXTAREA} at (189,20) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
+layer at (191,26) size 179x34 clip at (192,27) size 177x32
+  RenderTextControl {TEXTAREA} at (183,18) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15 [color=#545454]
     RenderBlock {DIV} at (3,3) size 175x15 [color=#640000]
       RenderText {#text} at (0,0) size 104x15
         text run at (0,0) width 104: "disabled text"
-layer at (384,28) size 179x34 clip at (385,29) size 177x32
-  RenderTextControl {TEXTAREA} at (376,20) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (374,26) size 179x34 clip at (375,27) size 177x32
+  RenderTextControl {TEXTAREA} at (366,18) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
     RenderBlock {DIV} at (3,3) size 175x15 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 56x15
         text run at (0,0) width 56: "default"
-layer at (571,28) size 179x34 clip at (572,29) size 177x32
-  RenderTextControl {TEXTAREA} at (563,20) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
+layer at (557,26) size 179x34 clip at (558,27) size 177x32
+  RenderTextControl {TEXTAREA} at (549,18) size 179x34 [bgcolor=#EBEBE4] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15 [color=#545454]
     RenderBlock {DIV} at (3,3) size 175x15 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 128x15

--- a/LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-1-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-1-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 382x18
           text run at (0,0) width 382: "Focus field with a placeholder, then type, then delete all text."
-      RenderBlock {DIV} at (0,34) size 784x38
+      RenderBlock {DIV} at (0,34) size 784x34
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,44) size 179x34 clip at (11,45) size 177x32
-  RenderTextControl {TEXTAREA} at (2,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,42) size 179x34 clip at (9,43) size 177x32
+  RenderTextControl {TEXTAREA} at (0,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderBR {BR} at (0,0) size 0x15
     RenderBlock {DIV} at (3,3) size 175x15 [color=#A9A9A9]

--- a/LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-2-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-2-expected.txt
@@ -6,11 +6,11 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 390x18
           text run at (0,0) width 390: "Focus field with a placeholder, then type, then clear the value."
-      RenderBlock {DIV} at (0,34) size 784x38
+      RenderBlock {DIV} at (0,34) size 784x34
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (10,44) size 179x34 clip at (11,45) size 177x32
-  RenderTextControl {TEXTAREA} at (2,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,42) size 179x34 clip at (9,43) size 177x32
+  RenderTextControl {TEXTAREA} at (0,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
     RenderBlock {DIV} at (3,3) size 175x15 [color=#A9A9A9]
       RenderText {#text} at (0,0) size 88x15

--- a/LayoutTests/platform/win/fast/forms/textarea-scrollbar-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-scrollbar-expected.txt
@@ -7,8 +7,8 @@ layer at (0,0) size 800x600
         text run at (0,0) width 442: "This tests that a scrollbar will appear when text overflows the textarea "
       RenderBR {BR} at (442,14) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (10,28) size 179x94 clip at (11,29) size 162x92 scrollHeight 137
-  RenderTextControl {TEXTAREA} at (2,20) size 179x94 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,26) size 179x94 clip at (9,27) size 162x92 scrollHeight 137
+  RenderTextControl {TEXTAREA} at (0,18) size 179x94 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x135
       RenderText {#text} at (0,0) size 8x60
         text run at (0,0) width 8: "1"

--- a/LayoutTests/platform/win/fast/forms/textarea-scrolled-type-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-scrolled-type-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock (anonymous) at (0,0) size 784x135
+      RenderBlock (anonymous) at (0,0) size 784x131
         RenderText {#text} at (0,0) size 502x18
           text run at (0,0) width 502: "This tests that typing in a scrolled textarea does not cause unnecessary scrolling."
         RenderBR {BR} at (502,14) size 0x0
-        RenderText {#text} at (183,117) size 4x18
-          text run at (183,117) width 4: " "
-        RenderBR {BR} at (187,131) size 0x0
-      RenderBlock {DIV} at (0,135) size 784x0
-layer at (10,28) size 179x109 clip at (11,29) size 162x107 scrollY 210 scrollHeight 317
-  RenderTextControl {TEXTAREA} at (2,20) size 179x109 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+        RenderText {#text} at (179,113) size 4x18
+          text run at (179,113) width 4: " "
+        RenderBR {BR} at (183,127) size 0x0
+      RenderBlock {DIV} at (0,131) size 784x0
+layer at (8,26) size 179x109 clip at (9,27) size 162x107 scrollY 210 scrollHeight 317
+  RenderTextControl {TEXTAREA} at (0,18) size 179x109 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x315
       RenderText {#text} at (0,0) size 56x300
         text run at (0,0) width 8: "1"

--- a/LayoutTests/platform/win/fast/forms/textarea-setinnerhtml-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/textarea-setinnerhtml-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,0) size 0x0
-layer at (10,10) size 179x34 clip at (11,11) size 177x32
-  RenderTextControl {TEXTAREA} at (2,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,8) size 179x34 clip at (9,9) size 177x32
+  RenderTextControl {TEXTAREA} at (0,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderText {#text} at (0,0) size 88x15
         text run at (0,0) width 88: "Test Passed"

--- a/LayoutTests/platform/win/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/win/fast/html/details-replace-summary-child-expected.txt
@@ -8,17 +8,17 @@ layer at (0,0) size 800x600
           RenderDetailsMarker {DIV} at (0,3) size 11x11: down
           RenderText {#text} at (16,0) size 5x18
             text run at (16,0) width 5: " "
-          RenderBlock {SPAN} at (20,2) size 65x15
+          RenderBlock {SPAN} at (20,3) size 65x15
             RenderText {#text} at (0,0) size 64x15
               text run at (0,0) width 64: "Details1"
           RenderText {#text} at (84,0) size 5x18
             text run at (84,0) width 5: " "
-          RenderBlock {SPAN} at (88,2) size 65x15
+          RenderBlock {SPAN} at (88,3) size 65x15
             RenderText {#text} at (0,0) size 64x15
               text run at (0,0) width 64: "Details3"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,18) size 784x25
-        RenderButton {INPUT} at (2,2) size 43x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,18) size 784x21
+        RenderButton {INPUT} at (0,0) size 43x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 27x15
             RenderText at (0,0) size 27x15
               text run at (0,0) width 27: "click"

--- a/LayoutTests/platform/win/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/win/fast/html/details-replace-text-expected.txt
@@ -9,18 +9,18 @@ layer at (0,0) size 800x600
           RenderText {#text} at (16,0) size 62x18
             text run at (16,0) width 62: "Summary"
         RenderBlock (anonymous) at (0,18) size 784x18
-          RenderBlock {SPAN} at (0,2) size 64x15
+          RenderBlock {SPAN} at (0,3) size 64x15
             RenderText {#text} at (0,0) size 64x15
               text run at (0,0) width 64: "Details1"
           RenderText {#text} at (64,0) size 4x18
             text run at (64,0) width 4: " "
           RenderText {#text} at (0,0) size 0x0
-          RenderBlock {SPAN} at (68,2) size 64x15
+          RenderBlock {SPAN} at (68,3) size 64x15
             RenderText {#text} at (0,0) size 64x15
               text run at (0,0) width 64: "Details2"
           RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,36) size 784x25
-        RenderButton {INPUT} at (2,2) size 43x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,36) size 784x21
+        RenderButton {INPUT} at (0,0) size 43x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 27x15
             RenderText at (0,0) size 27x15
               text run at (0,0) width 27: "click"

--- a/LayoutTests/platform/win/fast/invalid/014-expected.txt
+++ b/LayoutTests/platform/win/fast/invalid/014-expected.txt
@@ -8,17 +8,17 @@ layer at (0,0) size 800x600
           text run at (0,0) width 282: "Random tests of some bizarre combinations. "
           text run at (282,0) width 317: "H2 should allow a form inside it, but p should not."
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {FORM} at (0,18) size 784x23
-        RenderMenuList {SELECT} at (2,2) size 34x19 [bgcolor=#FFFFFF]
+      RenderBlock {FORM} at (0,18) size 784x19
+        RenderMenuList {SELECT} at (0,0) size 34x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 9x15
             RenderText at (0,0) size 9x15
               text run at (0,0) width 9: "A"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {P} at (0,57) size 784x0
-layer at (470,46) size 42x51
-  RenderBlock (positioned) {H2} at (470,45) size 42x52 [border: (2px solid #008000)]
-    RenderBlock {FORM} at (2,2) size 38x23
-      RenderMenuList {SELECT} at (2,2) size 34x19 [bgcolor=#FFFFFF]
+      RenderBlock {P} at (0,53) size 784x0
+layer at (470,46) size 38x47
+  RenderBlock (positioned) {H2} at (470,45) size 38x48 [border: (2px solid #008000)]
+    RenderBlock {FORM} at (2,2) size 34x19
+      RenderMenuList {SELECT} at (0,0) size 34x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 9x15
           RenderText at (0,0) size 9x15
             text run at (0,0) width 9: "A"

--- a/LayoutTests/platform/win/fast/overflow/overflow-x-y-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/overflow-x-y-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 785x600
       RenderBlock (anonymous) at (0,0) size 769x18
         RenderText {#text} at (0,0) size 312x18
           text run at (0,0) width 312: "The body should always have a vertical scrollbar."
-      RenderBlock (anonymous) at (0,218) size 769x57
-        RenderText {#text} at (183,39) size 4x18
-          text run at (183,39) width 4: " "
+      RenderBlock (anonymous) at (0,218) size 769x53
+        RenderText {#text} at (179,35) size 4x18
+          text run at (179,35) width 4: " "
         RenderText {#text} at (0,0) size 0x0
 layer at (8,26) size 300x100 clip at (8,26) size 285x100 scrollHeight 324
   RenderBlock {DIV} at (0,18) size 300x100
@@ -72,13 +72,13 @@ layer at (8,126) size 300x100 clip at (8,126) size 300x85 scrollWidth 1184
       text run at (0,0) width 486: "X scroll X scroll X scroll X scroll X scroll X scroll X scroll X scroll X scroll "
       text run at (486,0) width 324: "X scroll X scroll X scroll X scroll X scroll X scroll "
       text run at (810,0) width 374: "X scroll X scroll X scroll X scroll X scroll X scroll X scroll"
-layer at (10,243) size 179x34 clip at (11,244) size 162x32
-  RenderTextControl {TEXTAREA} at (2,17) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,241) size 179x34 clip at (9,242) size 162x32
+  RenderTextControl {TEXTAREA} at (0,15) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 160x15
       RenderText {#text} at (0,0) size 136x15
         text run at (0,0) width 136: "Textarea y-scroll"
-layer at (197,228) size 179x49 clip at (198,229) size 177x32
-  RenderTextControl {TEXTAREA} at (189,2) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (191,226) size 179x49 clip at (192,227) size 177x32
+  RenderTextControl {TEXTAREA} at (183,0) size 179x49 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderText {#text} at (0,0) size 136x15
         text run at (0,0) width 136: "Textarea x-scroll"

--- a/LayoutTests/platform/win/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-layer at (0,42) size 800x558 clip at (0,42) size 785x558 scrollY 285 scrollHeight 843
+layer at (0,42) size 800x558 clip at (0,42) size 785x558 scrollY 281 scrollHeight 839
   RenderBlock (positioned) {DIV} at (0,42) size 800x558
-layer at (0,-243) size 560x843 backgroundClip at (0,42) size 785x558 clip at (0,42) size 785x558
-  RenderBlock (positioned) {DIV} at (0,0) size 560x843
+layer at (0,-239) size 560x839 backgroundClip at (0,42) size 785x558 clip at (0,42) size 785x558
+  RenderBlock (positioned) {DIV} at (0,0) size 560x839
     RenderBlock (anonymous) at (0,0) size 560x18
       RenderText {#text} at (0,0) size 560x18
         text run at (0,0) width 560: "This tests that we can scroll to reveal something in a nested positioned block in overflow."
     RenderBlock {DIV} at (0,18) size 560x800
-    RenderBlock (anonymous) at (0,818) size 560x25
-      RenderButton {INPUT} at (2,2) size 218x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+    RenderBlock (anonymous) at (0,818) size 560x21
+      RenderButton {INPUT} at (0,0) size 218x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 202x15
           RenderText at (0,0) size 202x15
             text run at (0,0) width 202: "If you can see this, test has passed"

--- a/LayoutTests/platform/win/fast/overflow/scrollRevealButton-expected.txt
+++ b/LayoutTests/platform/win/fast/overflow/scrollRevealButton-expected.txt
@@ -22,20 +22,20 @@ layer at (0,0) size 785x1188
                   text run at (0,0) width 88: "overflow:auto"
               RenderBlock {DIV} at (0,18) size 285x600
               RenderBlock {DIV} at (0,768) size 285x500
-          layer at (8,83) size 150x150 clip at (8,83) size 135x150 scrollY 474 scrollHeight 861
+          layer at (8,83) size 150x150 clip at (8,83) size 135x150 scrollY 472 scrollHeight 857
             RenderBlock {DIV} at (0,618) size 150x150
               RenderBlock (anonymous) at (0,0) size 135x18
                 RenderText {#text} at (0,0) size 88x18
                   text run at (0,0) width 88: "overflow:auto"
               RenderBlock {DIV} at (0,18) size 135x500
-              RenderBlock (anonymous) at (0,518) size 135x43
+              RenderBlock (anonymous) at (0,518) size 135x39
                 RenderBR {BR} at (0,0) size 0x18
-                RenderButton {INPUT} at (2,20) size 54x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+                RenderButton {INPUT} at (0,18) size 54x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 38x15
                     RenderText at (0,0) size 38x15
                       text run at (0,0) width 38: "Button"
                 RenderText {#text} at (0,0) size 0x0
-              RenderBlock {DIV} at (0,561) size 135x300
+              RenderBlock {DIV} at (0,557) size 135x300
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,672) size 769x500
 scrolled to 0,6

--- a/LayoutTests/platform/win/fast/parser/document-write-option-expected.txt
+++ b/LayoutTests/platform/win/fast/parser/document-write-option-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 333x19 [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 333x19 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (4,2) size 308x15
           RenderText at (0,0) size 308x15
             text run at (0,0) width 308: "This is a very long string so it makes the select bigger."

--- a/LayoutTests/platform/win/fast/parser/entity-comment-in-textarea-expected.txt
+++ b/LayoutTests/platform/win/fast/parser/entity-comment-in-textarea-expected.txt
@@ -3,10 +3,10 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderText {#text} at (183,24) size 249x18
-        text run at (183,24) width 249: " --> This should be outside the textarea."
-layer at (10,10) size 179x34 clip at (11,11) size 177x32
-  RenderTextControl {TEXTAREA} at (2,2) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderText {#text} at (179,20) size 249x18
+        text run at (179,20) width 249: " --> This should be outside the textarea."
+layer at (8,8) size 179x34 clip at (9,9) size 177x32
+  RenderTextControl {TEXTAREA} at (0,0) size 179x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "<!--"

--- a/LayoutTests/platform/win/fast/repaint/select-option-background-color-expected.txt
+++ b/LayoutTests/platform/win/fast/repaint/select-option-background-color-expected.txt
@@ -9,6 +9,6 @@ layer at (0,0) size 800x600
         RenderInline {A} at (0,0) size 305x18 [color=#0000EE]
           RenderText {#text} at (220,0) size 305x18
             text run at (220,0) width 305: "https://bugs.webkit.org/show_bug.cgi?id=49790"
-      RenderBlock (anonymous) at (0,34) size 800x69
-        RenderListBox {SELECT} at (2,2) size 30x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+      RenderBlock (anonymous) at (0,34) size 800x65
+        RenderListBox {SELECT} at (0,0) size 30x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/replaced/three-selects-break-expected.txt
+++ b/LayoutTests/platform/win/fast/replaced/three-selects-break-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {DIV} at (0,0) size 5x69
-        RenderMenuList {SELECT} at (2,2) size 25x19 [bgcolor=#FFFFFF]
+      RenderBlock {DIV} at (0,0) size 5x57
+        RenderMenuList {SELECT} at (0,0) size 25x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 0x15
             RenderText at (0,0) size 0x15
               text run at (0,0) width 0: " "
-        RenderMenuList {SELECT} at (2,25) size 25x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,19) size 25x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 0x15
             RenderText at (0,0) size 0x15
               text run at (0,0) width 0: " "
-        RenderMenuList {SELECT} at (2,48) size 25x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,38) size 25x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 0x15
             RenderText at (0,0) size 0x15
               text run at (0,0) width 0: " "

--- a/LayoutTests/platform/win/fast/replaced/width100percent-button-expected.txt
+++ b/LayoutTests/platform/win/fast/replaced/width100percent-button-expected.txt
@@ -6,48 +6,48 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 309x18
           text run at (0,0) width 309: "The following sets of buttons should not overlap."
-      RenderTable {TABLE} at (0,18) size 784x29
-        RenderTableSection {TBODY} at (0,0) size 784x29
-          RenderTableRow {TR} at (0,1) size 784x27
-            RenderTableCell {TD} at (1,1) size 70x27 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 68x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderTable {TABLE} at (0,18) size 784x25
+        RenderTableSection {TBODY} at (0,0) size 784x25
+          RenderTableRow {TR} at (0,1) size 784x23
+            RenderTableCell {TD} at (1,1) size 70x23 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 68x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 52x15
                   RenderText at (0,0) size 52x15
                     text run at (0,0) width 52: "New Mail"
-            RenderTableCell {TD} at (72,1) size 51x27 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 49x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (72,1) size 51x23 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 49x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 33x15
                   RenderText at (0,0) size 33x15
                     text run at (0,0) width 33: "Reply"
-            RenderTableCell {TD} at (124,1) size 69x27 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 67x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (124,1) size 69x23 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 67x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 51x15
                   RenderText at (0,0) size 51x15
                     text run at (0,0) width 51: "Reply All"
-            RenderTableCell {TD} at (194,4) size 589x21 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (194,2) size 589x21 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x19
                 text run at (1,2) width 4: " "
-      RenderBlock (anonymous) at (0,47) size 784x36
+      RenderBlock (anonymous) at (0,43) size 784x36
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
-      RenderTable {TABLE} at (0,83) size 784x29
-        RenderTableSection {TBODY} at (0,0) size 784x29
-          RenderTableRow {TR} at (0,1) size 784x27
-            RenderTableCell {TD} at (1,1) size 70x27 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 68x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderTable {TABLE} at (0,79) size 784x25
+        RenderTableSection {TBODY} at (0,0) size 784x25
+          RenderTableRow {TR} at (0,1) size 784x23
+            RenderTableCell {TD} at (1,1) size 70x23 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 68x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 52x15
                   RenderText at (0,0) size 52x15
                     text run at (0,0) width 52: "New Mail"
-            RenderTableCell {TD} at (72,1) size 51x27 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 49x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (72,1) size 51x23 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 49x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 33x15
                   RenderText at (0,0) size 33x15
                     text run at (0,0) width 33: "Reply"
-            RenderTableCell {TD} at (124,1) size 69x27 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,3) size 67x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (124,1) size 69x23 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 67x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 51x15
                   RenderText at (0,0) size 51x15
                     text run at (0,0) width 51: "Reply All"
-            RenderTableCell {TD} at (194,4) size 589x21 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (194,2) size 589x21 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x19
                 text run at (1,2) width 4: " "

--- a/LayoutTests/platform/win/fast/replaced/width100percent-menulist-expected.txt
+++ b/LayoutTests/platform/win/fast/replaced/width100percent-menulist-expected.txt
@@ -6,24 +6,24 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 287x18
           text run at (0,0) width 287: "The popup buttons below should not overlap."
-      RenderTable {TABLE} at (0,18) size 784x27
-        RenderTableSection {TBODY} at (0,0) size 784x27
-          RenderTableRow {TR} at (0,1) size 784x25
-            RenderTableCell {TD} at (1,1) size 27x25 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 25x19 [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (0,18) size 784x23
+        RenderTableSection {TBODY} at (0,0) size 784x23
+          RenderTableRow {TR} at (0,1) size 784x21
+            RenderTableCell {TD} at (1,1) size 27x21 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 25x19 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (4,2) size 0x15
                   RenderText at (0,0) size 21x15
                     text run at (0,0) width 21: "one"
-            RenderTableCell {TD} at (29,1) size 27x25 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 25x19 [bgcolor=#FFFFFF]
+            RenderTableCell {TD} at (29,1) size 27x21 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 25x19 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (4,2) size 0x15
                   RenderText at (0,0) size 20x15
                     text run at (0,0) width 20: "two"
-            RenderTableCell {TD} at (57,1) size 27x25 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 25x19 [bgcolor=#FFFFFF]
+            RenderTableCell {TD} at (57,1) size 27x21 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,1) size 25x19 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (4,2) size 0x15
                   RenderText at (0,0) size 29x15
                     text run at (0,0) width 29: "three"
-            RenderTableCell {TD} at (85,3) size 698x21 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (85,1) size 698x21 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x19
                 text run at (1,2) width 4: " "

--- a/LayoutTests/platform/win/fast/selectors/064-expected.txt
+++ b/LayoutTests/platform/win/fast/selectors/064-expected.txt
@@ -1,16 +1,16 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x91
-  RenderBlock {HTML} at (0,0) size 800x91
-    RenderBody {BODY} at (8,16) size 784x59
-      RenderBlock {DIV} at (0,0) size 784x59
+layer at (0,0) size 800x87
+  RenderBlock {HTML} at (0,0) size 800x87
+    RenderBody {BODY} at (8,16) size 784x55
+      RenderBlock {DIV} at (0,0) size 784x55
         RenderBlock {P} at (0,0) size 784x18 [color=#00FF00]
           RenderInline {A} at (0,0) size 279x18 [color=#000000]
             RenderText {#text} at (0,0) size 279x18
               text run at (0,0) width 279: "This text should turn green while it is active."
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {P} at (0,34) size 784x25 [color=#00FF00]
-          RenderButton {BUTTON} at (2,2) size 264x21 [color=#000000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock {P} at (0,34) size 784x21 [color=#00FF00]
+          RenderButton {BUTTON} at (0,0) size 264x21 [color=#000000] [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 248x15
               RenderText {#text} at (0,0) size 248x15
                 text run at (0,0) width 248: "This text should turn green while it is active."

--- a/LayoutTests/platform/win/fast/table/003-expected.txt
+++ b/LayoutTests/platform/win/fast/table/003-expected.txt
@@ -3,40 +3,40 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x53
-        RenderTableSection {TBODY} at (0,0) size 784x53
-          RenderTableRow {TR} at (0,2) size 784x27
-            RenderTableCell {TD} at (2,5) size 52x21 [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 784x49
+        RenderTableSection {TBODY} at (0,0) size 784x49
+          RenderTableRow {TR} at (0,2) size 784x23
+            RenderTableCell {TD} at (2,3) size 52x21 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 37x19
                 text run at (1,2) width 37: "URL:"
-            RenderTableCell {TD} at (55,2) size 728x27 [r=0 c=1 rs=1 cs=1]
-              RenderTextControl {INPUT} at (1,3) size 725x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-          RenderTableRow {TR} at (0,31) size 784x20
-            RenderTableCell {TD} at (2,31) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
+            RenderTableCell {TD} at (55,2) size 728x23 [r=0 c=1 rs=1 cs=1]
+              RenderTextControl {INPUT} at (1,1) size 725x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+          RenderTableRow {TR} at (0,27) size 784x20
+            RenderTableCell {TD} at (2,27) size 781x20 [bgcolor=#FF0000] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (1,1) size 253x18
                 text run at (1,1) width 253: "Alongwordtogiveyouanicebigminwidth."
-      RenderTable {TABLE} at (0,53) size 100x100 [bgcolor=#FF0000] [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,49) size 100x100 [bgcolor=#FF0000] [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 96x96
           RenderTableRow {TR} at (0,2) size 96x92
             RenderTableCell {TD} at (2,46) size 92x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-      RenderTable {TABLE} at (0,153) size 195x120 [border: (2px outset #808080)]
-        RenderTableSection {TBODY} at (2,2) size 191x116
-          RenderTableRow {TR} at (0,2) size 191x22
-            RenderTableCell {TD} at (2,2) size 187x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,149) size 191x120 [border: (2px outset #808080)]
+        RenderTableSection {TBODY} at (2,2) size 187x116
+          RenderTableRow {TR} at (0,2) size 187x22
+            RenderTableCell {TD} at (2,2) size 183x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 31x18
                 text run at (2,2) width 31: "hello"
-          RenderTableRow {TR} at (0,26) size 191x22
-            RenderTableCell {TD} at (2,26) size 187x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 187x22
+            RenderTableCell {TD} at (2,26) size 183x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 67x18
                 text run at (2,2) width 67: "more hello"
-          RenderTableRow {TR} at (0,50) size 191x22
-            RenderTableCell {TD} at (2,50) size 187x22 [border: (1px inset #808080)] [r=2 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,50) size 187x22
+            RenderTableCell {TD} at (2,50) size 183x22 [border: (1px inset #808080)] [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 37x18
                 text run at (2,2) width 37: "world"
-          RenderTableRow {TR} at (0,74) size 191x40
-            RenderTableCell {TD} at (2,76) size 187x36 [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,74) size 187x40
+            RenderTableCell {TD} at (2,76) size 183x36 [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,273) size 106x78
+      RenderTable {TABLE} at (0,269) size 106x78
         RenderTableSection {TBODY} at (0,0) size 106x78
           RenderTableRow {TR} at (0,2) size 106x74
             RenderTableCell {TD} at (2,2) size 102x74 [r=0 c=0 rs=1 cs=1]
@@ -46,7 +46,7 @@ layer at (0,0) size 800x600
                 text run at (1,37) width 56: "nowrap. "
                 text run at (57,37) width 44: "I really"
                 text run at (1,55) width 46: "should."
-      RenderTable {TABLE} at (0,351) size 106x78
+      RenderTable {TABLE} at (0,347) size 106x78
         RenderTableSection {TBODY} at (0,0) size 106x78
           RenderTableRow {TR} at (0,2) size 106x74
             RenderTableCell {TD} at (2,2) size 102x74 [r=0 c=0 rs=1 cs=1]
@@ -57,7 +57,7 @@ layer at (0,0) size 800x600
                   text run at (0,36) width 56: "nowrap. "
                   text run at (56,36) width 44: "I really"
                   text run at (0,54) width 46: "should."
-      RenderTable {TABLE} at (0,429) size 369x24
+      RenderTable {TABLE} at (0,425) size 369x24
         RenderTableSection {TBODY} at (0,0) size 369x24
           RenderTableRow {TR} at (0,2) size 369x20
             RenderTableCell {TD} at (2,2) size 365x20 [r=0 c=0 rs=1 cs=1]
@@ -65,7 +65,7 @@ layer at (0,0) size 800x600
                 text run at (1,1) width 145: "I should have nowrap. "
                 text run at (146,1) width 98: "I really should. "
                 text run at (244,1) width 120: "Definitely. Should."
-      RenderTable {TABLE} at (0,453) size 369x24
+      RenderTable {TABLE} at (0,449) size 369x24
         RenderTableSection {TBODY} at (0,0) size 369x24
           RenderTableRow {TR} at (0,2) size 369x20
             RenderTableCell {TD} at (2,2) size 365x20 [r=0 c=0 rs=1 cs=1]
@@ -74,8 +74,8 @@ layer at (0,0) size 800x600
                   text run at (0,0) width 145: "I should have nowrap. "
                   text run at (145,0) width 98: "I really should. "
                   text run at (243,0) width 120: "Definitely. Should."
-layer at (67,16) size 720x15
+layer at (67,14) size 720x15
   RenderBlock {DIV} at (2,3) size 721x15
-layer at (16,241) size 179x32 clip at (17,242) size 177x30
-  RenderTextControl {TEXTAREA} at (4,2) size 179x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (14,237) size 179x32 clip at (15,238) size 177x30
+  RenderTextControl {TEXTAREA} at (2,2) size 179x32 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 175x15

--- a/LayoutTests/platform/win/fast/table/append-cells2-expected.txt
+++ b/LayoutTests/platform/win/fast/table/append-cells2-expected.txt
@@ -75,14 +75,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,36) size 91x18 [r=2 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x18
                 text run at (0,0) width 4: " "
-      RenderBlock (anonymous) at (0,124) size 784x25
-        RenderButton {BUTTON} at (2,2) size 46x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,124) size 784x21
+        RenderButton {BUTTON} at (0,0) size 46x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 30x15
             RenderText {#text} at (0,0) size 30x15
               text run at (0,0) width 30: "show"
-        RenderText {#text} at (50,3) size 4x18
-          text run at (50,3) width 4: " "
-        RenderButton {BUTTON} at (56,2) size 40x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (46,1) size 4x18
+          text run at (46,1) width 4: " "
+        RenderButton {BUTTON} at (50,0) size 40x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 24x15
             RenderText {#text} at (0,0) size 24x15
               text run at (0,0) width 24: "hide"

--- a/LayoutTests/platform/win/fast/table/remove-td-display-none-expected.txt
+++ b/LayoutTests/platform/win/fast/table/remove-td-display-none-expected.txt
@@ -52,14 +52,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (543,0) size 182x18 [bgcolor=#FFA500] [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "4"
-      RenderBlock (anonymous) at (0,88) size 784x25
-        RenderButton {BUTTON} at (2,2) size 46x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,88) size 784x21
+        RenderButton {BUTTON} at (0,0) size 46x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 30x15
             RenderText {#text} at (0,0) size 30x15
               text run at (0,0) width 30: "show"
-        RenderText {#text} at (50,3) size 4x18
-          text run at (50,3) width 4: " "
-        RenderButton {BUTTON} at (56,2) size 40x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (46,1) size 4x18
+          text run at (46,1) width 4: " "
+        RenderButton {BUTTON} at (50,0) size 40x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 24x15
             RenderText {#text} at (0,0) size 24x15
               text run at (0,0) width 24: "hide"

--- a/LayoutTests/platform/win/fast/table/text-field-baseline-expected.txt
+++ b/LayoutTests/platform/win/fast/table/text-field-baseline-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x433
-  RenderBlock {HTML} at (0,0) size 800x433
-    RenderBody {BODY} at (8,16) size 784x401
+layer at (0,0) size 800x405
+  RenderBlock {HTML} at (0,0) size 800x405
+    RenderBody {BODY} at (8,16) size 784x373
       RenderBlock {P} at (0,0) size 784x36
         RenderText {#text} at (0,0) size 172x18
           text run at (0,0) width 172: "This is a regression test for "

--- a/LayoutTests/platform/win/fast/text/international/bidi-listbox-atsui-expected.txt
+++ b/LayoutTests/platform/win/fast/text/international/bidi-listbox-atsui-expected.txt
@@ -9,37 +9,37 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (580,14) size 0x0
         RenderText {#text} at (0,18) size 566x18
           text run at (0,18) width 566: "The order of the text below each list box should match the order of the select's option text."
-      RenderBlock (anonymous) at (0,52) size 784x87
+      RenderBlock (anonymous) at (0,52) size 784x83
         RenderText {#text} at (0,0) size 97x18
           text run at (0,0) width 97: "1) direction: rtl;"
         RenderBR {BR} at (97,14) size 0x0
-        RenderListBox {SELECT} at (2,20) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,80) size 0x0
-      RenderBlock {DIV} at (0,139) size 100x19
+        RenderListBox {SELECT} at (0,18) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,76) size 0x0
+      RenderBlock {DIV} at (0,135) size 100x19
         RenderText {#text} at (18,1) size 82x18
           text run at (18,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
           text run at (78,1) width 22: "a\x{300}bc"
-      RenderBlock (anonymous) at (0,158) size 784x105
+      RenderBlock (anonymous) at (0,154) size 784x101
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 97x18
           text run at (0,18) width 97: "2) direction: ltr;"
         RenderBR {BR} at (97,32) size 0x0
-        RenderListBox {SELECT} at (2,38) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,98) size 0x0
-      RenderBlock {DIV} at (0,263) size 100x19
+        RenderListBox {SELECT} at (0,36) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,94) size 0x0
+      RenderBlock {DIV} at (0,255) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "a\x{300}bc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,282) size 784x105
+      RenderBlock (anonymous) at (0,274) size 784x101
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 70x18
           text run at (0,18) width 70: "3) No style"
         RenderBR {BR} at (70,32) size 0x0
-        RenderListBox {SELECT} at (2,38) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,98) size 0x0
-      RenderBlock {DIV} at (0,387) size 100x19
+        RenderListBox {SELECT} at (0,36) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,94) size 0x0
+      RenderBlock {DIV} at (0,375) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "a\x{300}bc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,406) size 784x18
+      RenderBlock (anonymous) at (0,394) size 784x18
         RenderBR {BR} at (0,0) size 0x18

--- a/LayoutTests/platform/win/fast/text/international/bidi-listbox-expected.txt
+++ b/LayoutTests/platform/win/fast/text/international/bidi-listbox-expected.txt
@@ -9,37 +9,37 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (451,14) size 0x0
         RenderText {#text} at (0,18) size 566x18
           text run at (0,18) width 566: "The order of the text below each list box should match the order of the select's option text."
-      RenderBlock (anonymous) at (0,52) size 784x87
+      RenderBlock (anonymous) at (0,52) size 784x83
         RenderText {#text} at (0,0) size 97x18
           text run at (0,0) width 97: "1) direction: rtl;"
         RenderBR {BR} at (97,14) size 0x0
-        RenderListBox {SELECT} at (2,20) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,80) size 0x0
-      RenderBlock {DIV} at (0,139) size 100x19
+        RenderListBox {SELECT} at (0,18) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,76) size 0x0
+      RenderBlock {DIV} at (0,135) size 100x19
         RenderText {#text} at (18,1) size 82x18
           text run at (18,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
           text run at (78,1) width 22: "abc"
-      RenderBlock (anonymous) at (0,158) size 784x105
+      RenderBlock (anonymous) at (0,154) size 784x101
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 97x18
           text run at (0,18) width 97: "2) direction: ltr;"
         RenderBR {BR} at (97,32) size 0x0
-        RenderListBox {SELECT} at (2,38) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,98) size 0x0
-      RenderBlock {DIV} at (0,263) size 100x19
+        RenderListBox {SELECT} at (0,36) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,94) size 0x0
+      RenderBlock {DIV} at (0,255) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "abc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,282) size 784x105
+      RenderBlock (anonymous) at (0,274) size 784x101
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 70x18
           text run at (0,18) width 70: "3) No style"
         RenderBR {BR} at (70,32) size 0x0
-        RenderListBox {SELECT} at (2,38) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderBR {BR} at (93,98) size 0x0
-      RenderBlock {DIV} at (0,387) size 100x19
+        RenderListBox {SELECT} at (0,36) size 89x65 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderBR {BR} at (89,94) size 0x0
+      RenderBlock {DIV} at (0,375) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "abc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,406) size 784x18
+      RenderBlock (anonymous) at (0,394) size 784x18
         RenderBR {BR} at (0,0) size 0x18

--- a/LayoutTests/platform/win/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/win/fast/text/international/bidi-menulist-expected.txt
@@ -10,49 +10,49 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,18) size 774x36
           text run at (0,18) width 774: "The order of the text below each popup button should match the order of the select's option text, and the order of the text in"
           text run at (0,36) width 106: "the popup menu."
-      RenderBlock (anonymous) at (0,70) size 784x41
+      RenderBlock (anonymous) at (0,70) size 784x37
         RenderText {#text} at (0,0) size 275x18
           text run at (0,0) width 275: "1) direction: rtl; -webkit-rtl-ordering: logical"
         RenderBR {BR} at (275,14) size 0x0
-        RenderMenuList {SELECT} at (0,20) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,18) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (21,2) size 75x15
             RenderText at (7,0) size 68x15
               text run at (7,0) width 47 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
               text run at (54,0) width 21: "abc"
-        RenderBR {BR} at (100,34) size 0x0
-      RenderBlock {DIV} at (0,111) size 100x19
+        RenderBR {BR} at (100,32) size 0x0
+      RenderBlock {DIV} at (0,107) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "abc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,130) size 784x59
+      RenderBlock (anonymous) at (0,126) size 784x55
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 113x18
           text run at (0,18) width 113: "2) text-align: right"
         RenderBR {BR} at (113,32) size 0x0
-        RenderMenuList {SELECT} at (0,38) size 200x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,36) size 200x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 175x15
             RenderText at (0,0) size 68x15
               text run at (0,0) width 21: "abc"
               text run at (21,0) width 47 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-        RenderBR {BR} at (200,52) size 0x0
-      RenderBlock {DIV} at (0,189) size 200x19
+        RenderBR {BR} at (200,50) size 0x0
+      RenderBlock {DIV} at (0,181) size 200x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "abc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,208) size 784x59
+      RenderBlock (anonymous) at (0,200) size 784x55
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 70x18
           text run at (0,18) width 70: "3) No style"
         RenderBR {BR} at (70,32) size 0x0
-        RenderMenuList {SELECT} at (0,38) size 100x19 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,36) size 100x19 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 75x15
             RenderText at (0,0) size 68x15
               text run at (0,0) width 21: "abc"
               text run at (21,0) width 47 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-        RenderBR {BR} at (100,52) size 0x0
-      RenderBlock {DIV} at (0,267) size 100x19
+        RenderBR {BR} at (100,50) size 0x0
+      RenderBlock {DIV} at (0,255) size 100x19
         RenderText {#text} at (0,1) size 82x18
           text run at (0,1) width 22: "abc"
           text run at (22,1) width 60 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
-      RenderBlock (anonymous) at (0,286) size 784x18
+      RenderBlock (anonymous) at (0,274) size 784x18
         RenderBR {BR} at (0,0) size 0x18

--- a/LayoutTests/platform/win/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
+++ b/LayoutTests/platform/win/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x552
-  RenderBlock {HTML} at (0,0) size 800x552
-    RenderBody {BODY} at (8,16) size 784x528
+layer at (0,0) size 800x522
+  RenderBlock {HTML} at (0,0) size 800x522
+    RenderBody {BODY} at (8,16) size 784x498
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 695x18
           text run at (0,0) width 486: "Verify that the alignment and writing direction of each selected item matches "
           text run at (486,0) width 209: "the one below the pop-up button."
-      RenderBlock {DIV} at (0,34) size 784x246
+      RenderBlock {DIV} at (0,34) size 784x232
         RenderMenuList {SELECT} at (0,0) size 500x22 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 475x18
             RenderText at (0,0) size 179x18
@@ -16,14 +16,14 @@ layer at (0,0) size 800x552
               text run at (91,0) width 18: "03"
               text run at (109,0) width 41 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
               text run at (150,0) width 29: " fifth"
-        RenderBlock {DIV} at (0,24) size 470x36
+        RenderBlock {DIV} at (0,22) size 470x36
           RenderText {#text} at (10,10) size 163x16
             text run at (10,10) width 32: "First "
             text run at (41,10) width 49 RTL: ") \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA}"
             text run at (89,10) width 17: "03"
             text run at (105,10) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (141,10) width 32: " fifth"
-        RenderMenuList {SELECT} at (0,62) size 500x22 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,58) size 500x22 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (4,2) size 475x18
             RenderText at (0,0) size 179x18
               text run at (0,0) width 25: "fifth"
@@ -61,14 +61,14 @@ layer at (0,0) size 800x552
               text run at (387,0) width 18: "03"
               text run at (405,0) width 41 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
               text run at (446,0) width 29: " fifth"
-        RenderBlock {DIV} at (0,24) size 470x36
+        RenderBlock {DIV} at (0,22) size 470x36
           RenderText {#text} at (297,10) size 163x16
             text run at (297,10) width 33: "First "
             text run at (329,10) width 48 RTL: ") \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA}"
             text run at (376,10) width 18: "03"
             text run at (393,10) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (429,10) width 31: " fifth"
-        RenderMenuList {SELECT} at (0,62) size 500x22 [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,58) size 500x22 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (21,2) size 475x18
             RenderText at (296,0) size 179x18
               text run at (296,0) width 25: "fifth"

--- a/LayoutTests/platform/win/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
+++ b/LayoutTests/platform/win/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt
@@ -1,51 +1,51 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x348
-  RenderBlock {HTML} at (0,0) size 800x348
-    RenderBody {BODY} at (8,8) size 784x332
-      RenderBlock {DIV} at (0,0) size 784x332
+layer at (0,0) size 800x332
+  RenderBlock {HTML} at (0,0) size 800x332
+    RenderBody {BODY} at (8,8) size 784x316
+      RenderBlock {DIV} at (0,0) size 784x316
         RenderBlock (anonymous) at (0,0) size 784x36
           RenderText {#text} at (0,0) size 761x36
             text run at (0,0) width 761: "In all four cases below, the exclamation mark should be on the left side of the first line and on the right side of the second"
             text run at (0,18) width 27: "line."
-        RenderBlock {DIV} at (0,36) size 784x296
-          RenderBR {BR} at (425,56) size 0x18
-          RenderBR {BR} at (425,130) size 0x18
-          RenderBR {BR} at (425,204) size 0x18
+        RenderBlock {DIV} at (0,36) size 784x280
+          RenderBR {BR} at (421,52) size 0x18
+          RenderBR {BR} at (421,122) size 0x18
+          RenderBR {BR} at (421,192) size 0x18
           RenderText {#text} at (0,0) size 0x0
-layer at (10,46) size 421x66 clip at (11,47) size 419x64
-  RenderTextControl {TEXTAREA} at (2,2) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,44) size 421x66 clip at (9,45) size 419x64
+  RenderTextControl {TEXTAREA} at (0,0) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x45
-      RenderText {#text} at (381,0) size 415x30
-        text run at (381,0) width 0 RTL: " "
-        text run at (381,0) width 34 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
+      RenderText {#text} at (375,0) size 415x30
+        text run at (375,0) width 0 RTL: " "
+        text run at (375,0) width 40 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
         text run at (0,15) width 48: "hello!"
         text run at (48,15) width 0: " "
       RenderBR {BR} at (415,30) size 0x15
-layer at (10,120) size 421x66 clip at (11,121) size 419x64
-  RenderTextControl {TEXTAREA} at (2,76) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,114) size 421x66 clip at (9,115) size 419x64
+  RenderTextControl {TEXTAREA} at (0,70) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x45
-      RenderText {#text} at (381,0) size 415x30
-        text run at (381,0) width 0 RTL: " "
-        text run at (381,0) width 34 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
+      RenderText {#text} at (375,0) size 415x30
+        text run at (375,0) width 0 RTL: " "
+        text run at (375,0) width 40 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
         text run at (0,15) width 48: "hello!"
         text run at (48,15) width 0: " "
       RenderBR {BR} at (0,30) size 0x15
-layer at (10,194) size 421x66 clip at (11,195) size 419x64
-  RenderTextControl {TEXTAREA} at (2,150) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,184) size 421x66 clip at (9,185) size 419x64
+  RenderTextControl {TEXTAREA} at (0,140) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x45
-      RenderText {#text} at (381,0) size 415x30
-        text run at (381,0) width 0 RTL: " "
-        text run at (381,0) width 34 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
+      RenderText {#text} at (375,0) size 415x30
+        text run at (375,0) width 0 RTL: " "
+        text run at (375,0) width 40 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
         text run at (0,15) width 48: "hello!"
         text run at (48,15) width 0: " "
       RenderBR {BR} at (0,30) size 0x15
-layer at (10,268) size 421x66 clip at (11,269) size 419x64
-  RenderTextControl {TEXTAREA} at (2,224) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,254) size 421x66 clip at (9,255) size 419x64
+  RenderTextControl {TEXTAREA} at (0,210) size 421x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 415x45
-      RenderText {#text} at (381,0) size 415x30
-        text run at (381,0) width 0 RTL: " "
-        text run at (381,0) width 34 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
+      RenderText {#text} at (375,0) size 415x30
+        text run at (375,0) width 0 RTL: " "
+        text run at (375,0) width 40 RTL: "\x{5E9}\x{5DC}\x{5D5}\x{5DD}!"
         text run at (0,15) width 48: "hello!"
         text run at (48,15) width 0: " "
       RenderBR {BR} at (415,30) size 0x15

--- a/LayoutTests/platform/win/tables/mozilla/bugs/45621-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/45621-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x146
-  RenderBlock {HTML} at (0,0) size 800x146
-    RenderBody {BODY} at (8,13) size 784x125
+layer at (0,0) size 800x142
+  RenderBlock {HTML} at (0,0) size 800x142
+    RenderBody {BODY} at (8,13) size 784x121
       RenderBlock {PRE} at (0,0) size 784x45
         RenderText {#text} at (0,0) size 168x45
           text run at (0,0) width 120: "table width=50%"
@@ -11,13 +11,13 @@ layer at (0,0) size 800x146
           text run at (96,15) width 0: " "
           text run at (0,30) width 168: "    input width=100% "
           text run at (168,30) width 0: " "
-      RenderTable {TABLE} at (0,58) size 392x49 [bgcolor=#C0C0C0] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 390x47
-          RenderTableRow {TR} at (0,2) size 390x43
-            RenderTableCell {TD} at (2,2) size 386x43 [bgcolor=#AABBFF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTextControl {INPUT} at (9,11) size 372x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+      RenderTable {TABLE} at (0,58) size 392x45 [bgcolor=#C0C0C0] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 390x43
+          RenderTableRow {TR} at (0,2) size 390x39
+            RenderTableCell {TD} at (2,2) size 386x39 [bgcolor=#AABBFF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTextControl {INPUT} at (9,9) size 372x21 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,107) size 784x18
+      RenderBlock (anonymous) at (0,103) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-layer at (22,88) size 368x15
+layer at (22,86) size 368x15
   RenderBlock {DIV} at (2,3) size 368x15

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug1318-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 784x137
-        RenderTableSection {TBODY} at (0,0) size 784x137
+      RenderTable {TABLE} at (0,0) size 784x133
+        RenderTableSection {TBODY} at (0,0) size 784x133
           RenderTableRow {TR} at (0,0) size 784x74
             RenderTableCell {TD} at (0,0) size 785x74 [r=0 c=0 rs=1 cs=4]
               RenderBR {BR} at (392,1) size 1x18
@@ -18,31 +18,31 @@ layer at (0,0) size 800x600
                 RenderBR {BR} at (392,55) size 1x17
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,74) size 784x18
-            RenderTableCell {TD} at (0,74) size 541x18 [r=1 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,74) size 550x18 [r=1 c=0 rs=1 cs=1]
               RenderInline {FONT} at (0,0) size 141x15
-                RenderText {#text} at (399,0) size 141x17
-                  text run at (399,1) width 141: "I agree with the program"
+                RenderText {#text} at (408,0) size 141x17
+                  text run at (408,1) width 141: "I agree with the program"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (540,74) size 81x18 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (549,74) size 83x18 [r=1 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (6,4) size 13x13
           RenderTableRow {TR} at (0,92) size 784x18
-            RenderTableCell {TD} at (0,92) size 541x18 [r=2 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (0,92) size 550x18 [r=2 c=0 rs=1 cs=1]
               RenderInline {FONT} at (0,0) size 154x15
-                RenderText {#text} at (386,0) size 154x17
-                  text run at (386,1) width 154: "I think vouchers are wrong"
+                RenderText {#text} at (395,0) size 154x17
+                  text run at (395,1) width 154: "I think vouchers are wrong"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (540,92) size 81x18 [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (549,92) size 83x18 [r=2 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (6,4) size 13x13
-          RenderTableRow {TR} at (0,110) size 784x27
-            RenderTableCell {TD} at (0,115) size 621x17 [r=3 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,110) size 784x23
+            RenderTableCell {TD} at (0,113) size 632x17 [r=3 c=0 rs=1 cs=2]
               RenderInline {A} at (0,0) size 77x18 [color=#0000EE]
                 RenderInline {FONT} at (0,0) size 77x15
-                  RenderText {#text} at (272,1) size 77x15
-                    text run at (272,1) width 77: "View Results"
+                  RenderText {#text} at (277,1) size 77x15
+                    text run at (277,1) width 77: "View Results"
               RenderInline {FONT} at (0,0) size 1x15
                 RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (620,110) size 165x27 [r=3 c=2 rs=1 cs=2]
-              RenderButton {INPUT} at (61,3) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (631,110) size 154x23 [r=3 c=2 rs=1 cs=2]
+              RenderButton {INPUT} at (55,1) size 42x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                 RenderBlock (anonymous) at (8,3) size 25x15
                   RenderText at (0,0) size 25x15
                     text run at (0,0) width 25: "vote"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug138725-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 162x59
-        RenderTableSection {TBODY} at (0,0) size 162x59
-          RenderTableRow {TR} at (0,2) size 162x55
-            RenderTableCell {TD} at (2,2) size 158x55 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (1,1) size 156x0
+      RenderTable {TABLE} at (0,0) size 158x55
+        RenderTableSection {TBODY} at (0,0) size 158x55
+          RenderTableRow {TR} at (0,2) size 158x51
+            RenderTableCell {TD} at (2,2) size 154x51 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (1,1) size 152x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,1) size 156x53
-                RenderTable {TABLE} at (0,0) size 156x53
-                  RenderTableSection {TBODY} at (0,0) size 156x53
-                    RenderTableRow {TR} at (0,2) size 156x49
-                      RenderTableCell {TD} at (2,2) size 152x49 [r=0 c=0 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 150x47
-                          RenderTableSection {TBODY} at (0,0) size 150x47
-                            RenderTableRow {TR} at (0,2) size 150x43
-                              RenderTableCell {TD} at (2,2) size 146x43 [r=0 c=0 rs=1 cs=1]
-                                RenderBlock {FORM} at (1,1) size 144x25
-                                  RenderButton {INPUT} at (2,2) size 140x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+              RenderBlock (anonymous) at (1,1) size 152x49
+                RenderTable {TABLE} at (0,0) size 152x49
+                  RenderTableSection {TBODY} at (0,0) size 152x49
+                    RenderTableRow {TR} at (0,2) size 152x45
+                      RenderTableCell {TD} at (2,2) size 148x45 [r=0 c=0 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 146x43
+                          RenderTableSection {TBODY} at (0,0) size 146x43
+                            RenderTableRow {TR} at (0,2) size 146x39
+                              RenderTableCell {TD} at (2,2) size 142x39 [r=0 c=0 rs=1 cs=1]
+                                RenderBlock {FORM} at (1,1) size 140x21
+                                  RenderButton {INPUT} at (0,0) size 140x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                                     RenderBlock (anonymous) at (8,3) size 124x15
                                       RenderText at (0,0) size 124x15
                                         text run at (0,0) width 124: "ApplyForThisPosition"
                                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,54) size 156x0
+              RenderBlock (anonymous) at (1,50) size 152x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug194024-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug194024-expected.txt
@@ -6,141 +6,141 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 285x18
           text run at (0,0) width 285: "border=\"0\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,18) size 784x38 [bgcolor=#DDDD33]
-        RenderTableSection {TBODY} at (0,0) size 784x38
-          RenderTableRow {TR} at (0,0) size 784x38
-            RenderTableCell {TD} at (0,19) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 760x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (772,19) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,56) size 784x18
+      RenderTable {TABLE} at (0,18) size 784x34 [bgcolor=#DDDD33]
+        RenderTableSection {TBODY} at (0,0) size 784x34
+          RenderTableRow {TR} at (0,0) size 784x34
+            RenderTableCell {TD} at (0,17) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,17) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,52) size 784x18
         RenderText {#text} at (0,0) size 209x18
           text run at (0,0) width 209: "cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,74) size 784x38 [bgcolor=#CCCCFF]
-        RenderTableSection {TBODY} at (0,0) size 784x38
-          RenderTableRow {TR} at (0,0) size 784x38
-            RenderTableCell {TD} at (0,19) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (12,0) size 760x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (772,19) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,112) size 784x18
+      RenderTable {TABLE} at (0,70) size 784x34 [bgcolor=#CCCCFF]
+        RenderTableSection {TBODY} at (0,0) size 784x34
+          RenderTableRow {TR} at (0,0) size 784x34
+            RenderTableCell {TD} at (0,17) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (12,0) size 760x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (772,17) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,104) size 784x18
         RenderText {#text} at (0,0) size 104x18
           text run at (0,0) width 104: "cellpadding=\"0\""
-      RenderTable {TABLE} at (0,130) size 784x42 [bgcolor=#FF9999]
-        RenderTableSection {TBODY} at (0,0) size 784x42
-          RenderTableRow {TR} at (0,2) size 784x38
-            RenderTableCell {TD} at (2,21) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 752x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (770,21) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,172) size 784x18
+      RenderTable {TABLE} at (0,122) size 784x38 [bgcolor=#FF9999]
+        RenderTableSection {TBODY} at (0,0) size 784x38
+          RenderTableRow {TR} at (0,2) size 784x34
+            RenderTableCell {TD} at (2,19) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,19) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,160) size 784x18
         RenderText {#text} at (0,0) size 180x18
           text run at (0,0) width 180: "border=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,190) size 784x42 [bgcolor=#AAEEBB]
-        RenderTableSection {TBODY} at (0,0) size 784x42
-          RenderTableRow {TR} at (0,2) size 784x38
-            RenderTableCell {TD} at (2,21) size 12x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,2) size 752x38 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (770,21) size 12x0 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,232) size 784x18
+      RenderTable {TABLE} at (0,178) size 784x38 [bgcolor=#AAEEBB]
+        RenderTableSection {TBODY} at (0,0) size 784x38
+          RenderTableRow {TR} at (0,2) size 784x34
+            RenderTableCell {TD} at (2,19) size 12x0 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,2) size 752x34 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (770,19) size 12x0 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,216) size 784x18
         RenderInline {FONT} at (0,0) size 29x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 76x18
           text run at (29,0) width 76: " border=\"0\""
-      RenderTable {TABLE} at (0,250) size 784x44 [bgcolor=#FFCCEE]
-        RenderTableSection {TBODY} at (0,0) size 784x44
-          RenderTableRow {TR} at (0,2) size 784x40
-            RenderTableCell {TD} at (2,21) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 748x40 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,21) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,294) size 784x18
+      RenderTable {TABLE} at (0,234) size 784x40 [bgcolor=#FFCCEE]
+        RenderTableSection {TBODY} at (0,0) size 784x40
+          RenderTableRow {TR} at (0,2) size 784x36
+            RenderTableCell {TD} at (2,19) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x36 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,19) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,274) size 784x18
         RenderInline {FONT} at (0,0) size 29x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 108x18
           text run at (29,0) width 108: " cellpadding=\"1\""
-      RenderTable {TABLE} at (0,312) size 784x44 [bgcolor=#66DDFF]
-        RenderTableSection {TBODY} at (0,0) size 784x44
-          RenderTableRow {TR} at (0,2) size 784x40
-            RenderTableCell {TD} at (2,21) size 14x2 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (18,2) size 748x40 [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,21) size 14x2 [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,356) size 784x18
+      RenderTable {TABLE} at (0,292) size 784x40 [bgcolor=#66DDFF]
+        RenderTableSection {TBODY} at (0,0) size 784x40
+          RenderTableRow {TR} at (0,2) size 784x36
+            RenderTableCell {TD} at (2,19) size 14x2 [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (18,2) size 748x36 [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,19) size 14x2 [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,332) size 784x18
         RenderInline {FONT} at (0,0) size 29x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 289x18
           text run at (29,0) width 289: " border=\"1\" cellspacing=\"0\" cellpadding=\"0\""
-      RenderTable {TABLE} at (0,374) size 784x42 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x40
-          RenderTableRow {TR} at (0,0) size 782x40
-            RenderTableCell {TD} at (0,19) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (14,0) size 754x40 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (768,19) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,416) size 784x18
+      RenderTable {TABLE} at (0,350) size 784x38 [bgcolor=#EEEEEE] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x36
+          RenderTableRow {TR} at (0,0) size 782x36
+            RenderTableCell {TD} at (0,17) size 14x2 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (14,0) size 754x36 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (768,17) size 14x2 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,388) size 784x18
         RenderInline {FONT} at (0,0) size 29x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 181x18
           text run at (29,0) width 181: " border=\"1\" cellspacing=\"0\""
-      RenderTable {TABLE} at (0,434) size 784x44 [bgcolor=#FFCC66] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x42
-          RenderTableRow {TR} at (0,0) size 782x42
-            RenderTableCell {TD} at (0,19) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (16,0) size 750x42 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (766,19) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-      RenderBlock (anonymous) at (0,478) size 784x18
+      RenderTable {TABLE} at (0,406) size 784x40 [bgcolor=#FFCC66] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x38
+          RenderTableRow {TR} at (0,0) size 782x38
+            RenderTableCell {TD} at (0,17) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (16,0) size 750x38 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (766,17) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,446) size 784x18
         RenderInline {FONT} at (0,0) size 29x18 [color=#0000FF]
           RenderText {#text} at (0,0) size 29x18
             text run at (0,0) width 29: "right"
         RenderText {#text} at (29,0) size 76x18
           text run at (29,0) width 76: " border=\"1\""
-      RenderTable {TABLE} at (0,496) size 784x48 [bgcolor=#CCFF33] [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 782x46
-          RenderTableRow {TR} at (0,2) size 782x42
-            RenderTableCell {TD} at (2,21) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (20,2) size 742x42 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-            RenderTableCell {TD} at (764,21) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
-layer at (20,28) size 760x34 clip at (21,29) size 758x32
-  RenderTextControl {TEXTAREA} at (0,2) size 760x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+      RenderTable {TABLE} at (0,464) size 784x44 [bgcolor=#CCFF33] [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 782x42
+          RenderTableRow {TR} at (0,2) size 782x38
+            RenderTableCell {TD} at (2,19) size 16x4 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (20,2) size 742x38 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (764,19) size 16x4 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+layer at (20,26) size 760x34 clip at (21,27) size 758x32
+  RenderTextControl {TEXTAREA} at (0,0) size 760x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 756x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (20,84) size 760x34 clip at (21,85) size 758x32
-  RenderTextControl {TEXTAREA} at (0,2) size 760x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (20,78) size 760x34 clip at (21,79) size 758x32
+  RenderTextControl {TEXTAREA} at (0,0) size 760x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 756x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (24,142) size 752x34 clip at (25,143) size 750x32
-  RenderTextControl {TEXTAREA} at (0,2) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,132) size 752x34 clip at (25,133) size 750x32
+  RenderTextControl {TEXTAREA} at (0,0) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 748x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (24,202) size 752x34 clip at (25,203) size 750x32
-  RenderTextControl {TEXTAREA} at (0,2) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,188) size 752x34 clip at (25,189) size 750x32
+  RenderTextControl {TEXTAREA} at (0,0) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 748x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (27,263) size 746x34 clip at (28,264) size 744x32
-  RenderTextControl {TEXTAREA} at (1,3) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,245) size 746x34 clip at (28,246) size 744x32
+  RenderTextControl {TEXTAREA} at (1,1) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 742x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (27,325) size 746x34 clip at (28,326) size 744x32
-  RenderTextControl {TEXTAREA} at (1,3) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,303) size 746x34 clip at (28,304) size 744x32
+  RenderTextControl {TEXTAREA} at (1,1) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 742x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (24,386) size 752x34 clip at (25,387) size 750x32
-  RenderTextControl {TEXTAREA} at (1,3) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (24,360) size 752x34 clip at (25,361) size 750x32
+  RenderTextControl {TEXTAREA} at (1,1) size 752x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 748x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (27,447) size 746x34 clip at (28,448) size 744x32
-  RenderTextControl {TEXTAREA} at (2,4) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (27,417) size 746x34 clip at (28,418) size 744x32
+  RenderTextControl {TEXTAREA} at (2,2) size 746x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 742x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"
-layer at (31,511) size 738x34 clip at (32,512) size 736x32
-  RenderTextControl {TEXTAREA} at (2,4) size 738x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (31,477) size 738x34 clip at (32,478) size 736x32
+  RenderTextControl {TEXTAREA} at (2,2) size 738x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 734x15
       RenderText {#text} at (0,0) size 32x15
         text run at (0,0) width 32: "test"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x690
+layer at (0,0) size 785x682
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x690
-  RenderBlock {HTML} at (0,0) size 785x690
-    RenderBody {BODY} at (8,21) size 769x653
+layer at (0,0) size 785x682
+  RenderBlock {HTML} at (0,0) size 785x682
+    RenderBody {BODY} at (8,21) size 769x645
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 315x37
           text run at (0,0) width 315: "Generic Table Tests - 1"
@@ -91,7 +91,7 @@ layer at (0,0) size 785x690
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (136,0) size 4x18
           text run at (136,0) width 4: "."
-      RenderBlock {P} at (0,566) size 769x19
+      RenderBlock {P} at (0,558) size 769x19
         RenderText {#text} at (0,0) size 63x18
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 98x18 [color=#0000EE]
@@ -99,7 +99,7 @@ layer at (0,0) size 785x690
             text run at (63,0) width 98: "Evil Tests Page"
         RenderText {#text} at (161,0) size 4x18
           text run at (161,0) width 4: "."
-      RenderBlock {P} at (0,600) size 769x19
+      RenderBlock {P} at (0,592) size 769x19
         RenderText {#text} at (0,0) size 173x18
           text run at (0,0) width 173: "This page is maintained by "
         RenderInline {A} at (0,0) size 77x18 [color=#0000EE]

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2592
+layer at (0,0) size 785x2714
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2592
-  RenderBlock {HTML} at (0,0) size 785x2593
-    RenderBody {BODY} at (8,21) size 769x2556 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x2714
+  RenderBlock {HTML} at (0,0) size 785x2715
+    RenderBody {BODY} at (8,21) size 769x2678 [bgcolor=#FFFFFF]
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 365x37
           text run at (0,0) width 365: "Table Inheritance Tests - 1"
@@ -209,7 +209,7 @@ layer at (0,0) size 785x2592
             text run at (63,0) width 73: "Table Tests"
         RenderText {#text} at (136,0) size 4x18
           text run at (136,0) width 4: "."
-      RenderBlock {P} at (0,2434) size 769x19
+      RenderBlock {P} at (0,2556) size 769x19
         RenderText {#text} at (0,0) size 63x18
           text run at (0,0) width 63: "Up to the "
         RenderInline {A} at (0,0) size 98x18 [color=#0000EE]
@@ -217,13 +217,13 @@ layer at (0,0) size 785x2592
             text run at (63,0) width 98: "Evil Tests Page"
         RenderText {#text} at (161,0) size 4x18
           text run at (161,0) width 4: "."
-      RenderBlock {P} at (0,2468) size 769x19
+      RenderBlock {P} at (0,2590) size 769x19
         RenderText {#text} at (0,0) size 61x18
           text run at (0,0) width 61: "Bugzilla: "
         RenderInline {A} at (0,0) size 63x18 [color=#0000EE]
           RenderText {#text} at (61,0) size 63x18
             text run at (61,0) width 63: "Bug 1044"
-      RenderBlock {P} at (0,2502) size 769x19
+      RenderBlock {P} at (0,2624) size 769x19
         RenderText {#text} at (0,0) size 173x18
           text run at (0,0) width 173: "This page is maintained by "
         RenderInline {A} at (0,0) size 77x18 [color=#0000EE]

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug26178-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug26178-expected.txt
@@ -14,8 +14,8 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,0) size 61x20 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 57x18
                 text run at (1,1) width 57: "First row"
-      RenderBlock {FORM} at (0,46) size 784x25
-        RenderButton {INPUT} at (2,2) size 48x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {FORM} at (0,46) size 784x21
+        RenderButton {INPUT} at (0,0) size 48x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 32x15
             RenderText at (0,0) size 32x15
               text run at (0,0) width 32: "insert"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug29326-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug29326-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (192,0) size 400x49 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x47
-          RenderTableRow {TR} at (0,2) size 398x43
-            RenderTableCell {TD} at (2,2) size 394x43 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x23
-                RenderMenuList {SELECT} at (2,2) size 51x19 [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (192,0) size 400x45 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x43
+          RenderTableRow {TR} at (0,2) size 398x39
+            RenderTableCell {TD} at (2,2) size 394x39 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x19
+                RenderMenuList {SELECT} at (0,0) size 51x19 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (4,2) size 26x15
                     RenderText at (0,0) size 26x15
                       text run at (0,0) width 26: "Test"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug30559-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug30559-expected.txt
@@ -7,17 +7,17 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 716x18
           text run at (0,0) width 716: "The bug causes the nested table containing the textarea to be positioned away from the left edge of the outer table "
         RenderBR {BR} at (716,14) size 0x0
-      RenderTable {TABLE} at (242,18) size 300x58 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x56
-          RenderTableRow {TR} at (0,2) size 298x52
-            RenderTableCell {TD} at (2,2) size 294x52 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 73x48 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 71x46
-                  RenderTableRow {TR} at (0,2) size 71x42
-                    RenderTableCell {TD} at (2,2) size 67x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (242,18) size 300x54 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x52
+          RenderTableRow {TR} at (0,2) size 298x48
+            RenderTableCell {TD} at (2,2) size 294x48 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 69x44 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 67x42
+                  RenderTableRow {TR} at (0,2) size 67x38
+                    RenderTableCell {TD} at (2,2) size 63x38 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (0,0) size 0x0
-layer at (262,38) size 59x34 clip at (263,39) size 57x32
-  RenderTextControl {TEXTAREA} at (4,4) size 59x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (260,36) size 59x34 clip at (261,37) size 57x32
+  RenderTextControl {TEXTAREA} at (2,2) size 59x34 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 55x15
       RenderText {#text} at (0,0) size 24x15
         text run at (0,0) width 24: "bar"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug33855-expected.txt
@@ -3,35 +3,35 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576 [bgcolor=#FFFFFF]
-      RenderBlock {FORM} at (0,0) size 784x31
-        RenderTable {TABLE} at (0,0) size 784x31
-          RenderTableSection {TBODY} at (0,0) size 784x31
-            RenderTableRow {TR} at (0,2) size 784x27 [bgcolor=#FFFFFF]
-              RenderTableCell {TD} at (2,2) size 75x27 [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 69x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {FORM} at (0,0) size 784x27
+        RenderTable {TABLE} at (0,0) size 784x27
+          RenderTableSection {TBODY} at (0,0) size 784x27
+            RenderTableRow {TR} at (0,2) size 784x23 [bgcolor=#FFFFFF]
+              RenderTableCell {TD} at (2,2) size 71x23 [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 69x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 53x15
                     RenderText at (0,0) size 53x15
                       text run at (0,0) width 53: "Select all"
-              RenderTableCell {TD} at (79,2) size 59x27 [r=0 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 53x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+              RenderTableCell {TD} at (75,2) size 55x23 [r=0 c=1 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 53x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 37x15
                     RenderText at (0,0) size 37x15
                       text run at (0,0) width 37: "Delete"
-              RenderTableCell {TD} at (140,2) size 92x27 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 86x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+              RenderTableCell {TD} at (132,2) size 88x23 [r=0 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 86x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 70x15
                     RenderText at (0,0) size 70x15
                       text run at (0,0) width 70: "Empty trash"
-              RenderTableCell {TD} at (234,9) size 359x20 [r=0 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (222,5) size 379x20 [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (1,1) size 4x18
                   text run at (1,1) width 4: " "
-              RenderTableCell {TD} at (595,2) size 72x27 [r=0 c=4 rs=1 cs=1]
-                RenderButton {INPUT} at (3,3) size 66x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+              RenderTableCell {TD} at (603,2) size 68x23 [r=0 c=4 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 66x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                   RenderBlock (anonymous) at (8,3) size 50x15
                     RenderText at (0,0) size 50x15
                       text run at (0,0) width 50: "Move to:"
-              RenderTableCell {TD} at (669,4) size 113x25 [r=0 c=5 rs=1 cs=1]
-                RenderMenuList {SELECT} at (3,3) size 107x19 [bgcolor=#FFFFFF]
+              RenderTableCell {TD} at (673,4) size 109x21 [r=0 c=5 rs=1 cs=1]
+                RenderMenuList {SELECT} at (1,1) size 107x19 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (4,2) size 82x15
                     RenderText at (0,0) size 82x15
                       text run at (0,0) width 82: "Choose folder "

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug39209-expected.txt
@@ -3,24 +3,24 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 431x85 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 429x83
-          RenderTableRow {TR} at (0,2) size 429x55
-            RenderTableCell {TD} at (2,18) size 132x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 431x81 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 429x79
+          RenderTableRow {TR} at (0,2) size 429x51
+            RenderTableCell {TD} at (2,16) size 137x23 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 30x19
                 text run at (2,3) width 30: "Blah"
-            RenderTableCell {TD} at (135,2) size 293x55 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (110,2) size 72x51 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 69x49
-                  RenderTableRow {TR} at (0,2) size 69x45
-                    RenderTableCell {TD} at (2,2) size 65x45 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                      RenderBlock {FORM} at (2,2) size 61x25
-                        RenderButton {INPUT} at (2,2) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderTableCell {TD} at (140,2) size 288x51 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (109,2) size 68x47 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 65x45
+                  RenderTableRow {TR} at (0,2) size 65x41
+                    RenderTableCell {TD} at (2,2) size 61x41 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                      RenderBlock {FORM} at (2,2) size 57x21
+                        RenderButton {INPUT} at (0,0) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                           RenderBlock (anonymous) at (8,3) size 41x15
                             RenderText at (0,0) size 41x15
                               text run at (0,0) width 41: "Submit"
                         RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,59) size 429x22
-            RenderTableCell {TD} at (2,59) size 426x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
+          RenderTableRow {TR} at (0,55) size 429x22
+            RenderTableCell {TD} at (2,55) size 426x22 [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=2]
               RenderText {#text} at (2,2) size 421x18
                 text run at (2,2) width 421: "This line is only here to separate the two columns in the row above"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug4429-expected.txt
@@ -3,15 +3,15 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {FORM} at (0,0) size 784x53
+      RenderBlock {FORM} at (0,0) size 784x49
         RenderTable {TABLE} at (0,0) size 31x28 [border: (1px outset #808080)]
           RenderTableSection {TBODY} at (1,1) size 29x26
             RenderTableRow {TR} at (0,2) size 29x22
               RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 21x18
                   text run at (2,2) width 21: "foo"
-        RenderBlock (anonymous) at (0,28) size 784x25
-          RenderButton {INPUT} at (2,2) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock (anonymous) at (0,28) size 784x21
+          RenderButton {INPUT} at (0,0) size 57x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 41x15
               RenderText at (0,0) size 41x15
                 text run at (0,0) width 41: "Submit"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug44505-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug44505-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x616
+layer at (0,0) size 785x608
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x616
-  RenderBlock {HTML} at (0,0) size 785x616
-    RenderBody {BODY} at (8,8) size 769x600 [bgcolor=#FFFFFF]
+layer at (0,0) size 785x608
+  RenderBlock {HTML} at (0,0) size 785x608
+    RenderBody {BODY} at (8,8) size 769x592 [bgcolor=#FFFFFF]
       RenderTable {TABLE} at (0,0) size 308x52 [border: (1px outset #808080)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
@@ -25,19 +25,19 @@ layer at (0,0) size 785x616
         RenderTableSection {TBODY} at (1,1) size 298x50
           RenderTableRow {TR} at (0,2) size 298x22
           RenderTableRow {TR} at (0,26) size 298x22
-      RenderTable {TABLE} at (0,208) size 300x59 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x57
-          RenderTableRow {TR} at (0,2) size 298x29
-          RenderTableRow {TR} at (0,33) size 298x22
-      RenderTable {TABLE} at (0,267) size 300x59 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 298x57
-          RenderTableRow {TR} at (0,2) size 298x29
-          RenderTableRow {TR} at (0,33) size 298x22
-      RenderTable {TABLE} at (0,326) size 300x94 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,208) size 300x55 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x53
+          RenderTableRow {TR} at (0,2) size 298x25
+          RenderTableRow {TR} at (0,29) size 298x22
+      RenderTable {TABLE} at (0,263) size 300x55 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 298x53
+          RenderTableRow {TR} at (0,2) size 298x25
+          RenderTableRow {TR} at (0,29) size 298x22
+      RenderTable {TABLE} at (0,318) size 300x94 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x92
           RenderTableRow {TR} at (0,2) size 298x46
           RenderTableRow {TR} at (0,50) size 298x40
-      RenderTable {TABLE} at (0,510) size 300x90 [border: (1px outset #808080)]
+      RenderTable {TABLE} at (0,502) size 300x90 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 298x88
           RenderTableRow {TR} at (0,2) size 298x60
           RenderTableRow {TR} at (0,64) size 298x22
@@ -105,97 +105,97 @@ layer at (167,191) size 138x22 clip at (168,192) size 136x20
   RenderTableCell {TD} at (158,26) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,219) size 154x29 clip at (12,220) size 152x27 scrollWidth 201
-  RenderTableCell {TD} at (2,2) size 154x29 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 150x25
-      RenderButton {BUTTON} at (0,2) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (11,219) size 154x25 clip at (12,220) size 152x23 scrollWidth 201
+  RenderTableCell {TD} at (2,2) size 154x25 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 150x21
+      RenderButton {BUTTON} at (0,0) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 184x15
           RenderText {#text} at (74,0) size 36x15
             text run at (74,0) width 36: "button"
-layer at (167,219) size 138x29 clip at (168,220) size 136x27
-  RenderTableCell {TD} at (158,5) size 138x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (167,219) size 138x25 clip at (168,220) size 136x23
+  RenderTableCell {TD} at (158,3) size 138x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x19
       text run at (2,3) width 4: " "
-layer at (11,250) size 154x22 clip at (12,251) size 152x20
-  RenderTableCell {TD} at (2,33) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (11,246) size 154x22 clip at (12,247) size 152x20
+  RenderTableCell {TD} at (2,29) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (167,250) size 138x22 clip at (168,251) size 136x20
-  RenderTableCell {TD} at (158,33) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+layer at (167,246) size 138x22 clip at (168,247) size 136x20
+  RenderTableCell {TD} at (158,29) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,278) size 281x29 clip at (12,279) size 279x27
-  RenderTableCell {TD} at (2,2) size 281x29 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-    RenderBlock {FORM} at (2,2) size 277x25
-      RenderButton {BUTTON} at (0,2) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (11,274) size 281x25 clip at (12,275) size 279x23
+  RenderTableCell {TD} at (2,2) size 281x25 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+    RenderBlock {FORM} at (2,2) size 277x21
+      RenderButton {BUTTON} at (0,0) size 200x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
         RenderBlock (anonymous) at (8,3) size 184x15
           RenderText {#text} at (74,0) size 36x15
             text run at (74,0) width 36: "button"
-layer at (294,278) size 11x29 clip at (295,279) size 9x27
-  RenderTableCell {TD} at (284,5) size 13x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+layer at (294,274) size 11x25 clip at (295,275) size 9x23
+  RenderTableCell {TD} at (284,3) size 13x23 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x19
       text run at (2,3) width 4: " "
-layer at (11,309) size 281x22 clip at (12,310) size 279x20
-  RenderTableCell {TD} at (2,33) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+layer at (11,301) size 281x22 clip at (12,302) size 279x20
+  RenderTableCell {TD} at (2,29) size 281x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (294,309) size 11x22 clip at (295,310) size 9x20
-  RenderTableCell {TD} at (284,33) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+layer at (294,301) size 11x22 clip at (295,302) size 9x20
+  RenderTableCell {TD} at (284,29) size 13x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,337) size 172x46 clip at (12,338) size 170x44 scrollWidth 216
+layer at (11,329) size 172x46 clip at (12,330) size 170x44 scrollWidth 216
   RenderTableCell {TD} at (2,2) size 172x46 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {DIV} at (11,11) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 20x18
         text run at (3,3) width 20: "div"
-layer at (185,337) size 120x46 clip at (186,338) size 118x44
+layer at (185,329) size 120x46 clip at (186,330) size 118x44
   RenderTableCell {TD} at (176,5) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (11,385) size 172x40 clip at (12,386) size 170x38
+layer at (11,377) size 172x40 clip at (12,378) size 170x38
   RenderTableCell {TD} at (2,50) size 172x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (185,385) size 120x40 clip at (186,386) size 118x38
+layer at (185,377) size 120x40 clip at (186,378) size 118x38
   RenderTableCell {TD} at (176,50) size 120x40 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (11,11) size 4x18
       text run at (11,11) width 4: " "
-layer at (8,428) size 300x90 clip at (9,429) size 298x88
-  RenderTable {TABLE} at (0,420) size 300x90 [border: (1px outset #808080)]
+layer at (8,420) size 300x90 clip at (9,421) size 298x88
+  RenderTable {TABLE} at (0,412) size 300x90 [border: (1px outset #808080)]
     RenderTableSection {TBODY} at (1,1) size 298x88
       RenderTableRow {TR} at (0,2) size 298x60
       RenderTableRow {TR} at (0,64) size 298x22
-layer at (11,431) size 154x60 clip at (12,432) size 152x58 scrollWidth 207
+layer at (11,423) size 154x60 clip at (12,424) size 152x58 scrollWidth 207
   RenderTableCell {TD} at (2,2) size 154x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 27x18
         text run at (3,3) width 27: "para"
-layer at (167,431) size 138x60 clip at (168,432) size 136x58
+layer at (167,423) size 138x60 clip at (168,424) size 136x58
   RenderTableCell {TD} at (158,21) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,493) size 154x22 clip at (12,494) size 152x20
+layer at (11,485) size 154x22 clip at (12,486) size 152x20
   RenderTableCell {TD} at (2,64) size 154x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (167,493) size 138x22 clip at (168,494) size 136x20
+layer at (167,485) size 138x22 clip at (168,486) size 136x20
   RenderTableCell {TD} at (158,64) size 138x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,521) size 254x60 clip at (12,522) size 252x58
+layer at (11,513) size 254x60 clip at (12,514) size 252x58
   RenderTableCell {TD} at (2,2) size 254x60 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
     RenderBlock {P} at (2,18) size 206x24 [border: (3px solid #000000)]
       RenderText {#text} at (3,3) size 27x18
         text run at (3,3) width 27: "para"
-layer at (267,521) size 38x60 clip at (268,522) size 36x58
+layer at (267,513) size 38x60 clip at (268,514) size 36x58
   RenderTableCell {TD} at (258,21) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (11,583) size 254x22 clip at (12,584) size 252x20
+layer at (11,575) size 254x22 clip at (12,576) size 252x20
   RenderTableCell {TD} at (2,64) size 254x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "
-layer at (267,583) size 38x22 clip at (268,584) size 36x20
+layer at (267,575) size 38x22 clip at (268,576) size 36x20
   RenderTableCell {TD} at (258,64) size 38x22 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
     RenderText {#text} at (2,2) size 4x18
       text run at (2,2) width 4: " "

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug51727-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug51727-expected.txt
@@ -1,20 +1,20 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x92
-  RenderBlock {HTML} at (0,0) size 800x92
-    RenderBody {BODY} at (8,8) size 784x76
-      RenderBlock {FORM} at (0,0) size 784x50
-        RenderButton {INPUT} at (2,2) size 162x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (0,0) size 800x84
+  RenderBlock {HTML} at (0,0) size 800x84
+    RenderBody {BODY} at (8,8) size 784x68
+      RenderBlock {FORM} at (0,0) size 784x42
+        RenderButton {INPUT} at (0,0) size 162x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 146x15
             RenderText at (0,0) size 146x15
               text run at (0,0) width 146: "(1) Fill cell with long string"
-        RenderBR {BR} at (166,3) size 0x18
-        RenderButton {INPUT} at (2,27) size 167x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBR {BR} at (162,1) size 0x18
+        RenderButton {INPUT} at (0,21) size 167x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 151x15
             RenderText at (0,0) size 151x15
               text run at (0,0) width 151: "(2) Fill cell with short string"
-        RenderBR {BR} at (171,28) size 0x18
-      RenderTable {TABLE} at (0,50) size 83x26
+        RenderBR {BR} at (167,22) size 0x18
+      RenderTable {TABLE} at (0,42) size 83x26
         RenderTableSection {TBODY} at (0,0) size 83x26
           RenderTableRow {TR} at (0,2) size 83x22
             RenderTableCell {TD} at (2,2) size 79x22 [border: (1px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug52505-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug52505-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x116
-  RenderBlock {HTML} at (0,0) size 800x116
-    RenderBody {BODY} at (8,8) size 784x100
-      RenderBlock {FORM} at (0,0) size 784x44
-        RenderButton {INPUT} at (2,0) size 269x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (0,0) size 800x112
+  RenderBlock {HTML} at (0,0) size 800x112
+    RenderBody {BODY} at (8,8) size 784x96
+      RenderBlock {FORM} at (0,0) size 784x42
+        RenderButton {INPUT} at (0,0) size 269x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 253x15
             RenderText at (0,0) size 253x15
               text run at (0,0) width 253: "[Step 1] Set cell width to 60px (nothing seen)"
-        RenderButton {INPUT} at (2,23) size 273x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (0,21) size 273x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 257x15
             RenderText at (0,0) size 257x15
               text run at (0,0) width 257: "[Step 2] Set cell width to 20px (garbage seen)"
-      RenderTable {TABLE} at (0,46) size 34x54
+      RenderTable {TABLE} at (0,42) size 34x54
         RenderTableSection {TBODY} at (0,0) size 34x54
           RenderTableRow {TR} at (0,2) size 34x24
             RenderTableCell {TD} at (2,2) size 14x24 [border: (2px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug52506-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug52506-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x124
-  RenderBlock {HTML} at (0,0) size 800x124
-    RenderBody {BODY} at (8,8) size 784x108
-      RenderBlock {FORM} at (0,0) size 784x44
-        RenderButton {INPUT} at (2,0) size 190x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+layer at (0,0) size 800x120
+  RenderBlock {HTML} at (0,0) size 800x120
+    RenderBody {BODY} at (8,8) size 784x104
+      RenderBlock {FORM} at (0,0) size 784x42
+        RenderButton {INPUT} at (0,0) size 190x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 174x15
             RenderText at (0,0) size 174x15
               text run at (0,0) width 174: "[Step 1] Set cell height to 60px"
-        RenderButton {INPUT} at (2,23) size 190x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderButton {INPUT} at (0,21) size 190x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 174x15
             RenderText at (0,0) size 174x15
               text run at (0,0) width 174: "[Step 2] Set cell height to 20px"
-      RenderTable {TABLE} at (0,46) size 42x62
+      RenderTable {TABLE} at (0,42) size 42x62
         RenderTableSection {TBODY} at (0,0) size 42x62
           RenderTableRow {TR} at (0,2) size 42x28
             RenderTableCell {TD} at (2,2) size 18x28 [border: (4px solid #000000)] [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug59354-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug59354-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 462x148 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 460x146
-          RenderTableRow {TR} at (0,0) size 460x146
-            RenderTableCell {TD} at (0,0) size 460x146 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (1,1) size 458x144 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 456x142
+      RenderTable {TABLE} at (0,0) size 462x144 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 460x142
+          RenderTableRow {TR} at (0,0) size 460x142
+            RenderTableCell {TD} at (0,0) size 460x142 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (1,1) size 458x140 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 456x138
                   RenderTableRow {TR} at (0,1) size 456x28
                     RenderTableCell {TD} at (1,1) size 137x28 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (5,5) size 127x18

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug60749-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug60749-expected.txt
@@ -12,14 +12,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (68,0) size 304x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 106x18
                 text run at (2,2) width 106: "   InspectionText"
-      RenderBlock {FORM} at (0,28) size 784x25
-        RenderButton {INPUT} at (2,2) size 91x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {FORM} at (0,28) size 784x21
+        RenderButton {INPUT} at (0,0) size 91x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 75x15
             RenderText at (0,0) size 75x15
               text run at (0,0) width 75: "change width"
-        RenderText {#text} at (95,3) size 4x18
-          text run at (95,3) width 4: " "
-        RenderButton {INPUT} at (101,2) size 185x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (91,1) size 4x18
+          text run at (91,1) width 4: " "
+        RenderButton {INPUT} at (95,0) size 185x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 169x15
             RenderText at (0,0) size 169x15
               text run at (0,0) width 169: "change width with table reflow"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug68912-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug68912-expected.txt
@@ -6,10 +6,10 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 468x18
           text run at (0,0) width 468: "This test case creates a TR element then tries to assign to the cells property"
-      RenderBlock {P} at (0,34) size 784x25
-        RenderText {#text} at (0,3) size 41x18
-          text run at (0,3) width 41: "Crash "
-        RenderButton {BUTTON} at (43,2) size 98x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock {P} at (0,34) size 784x21
+        RenderText {#text} at (0,1) size 41x18
+          text run at (0,1) width 41: "Crash "
+        RenderButton {BUTTON} at (41,0) size 98x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 82x15
             RenderText {#text} at (0,0) size 82x15
               text run at (0,0) width 82: "TR.cells = null"

--- a/LayoutTests/platform/win/tables/mozilla/bugs/bug92647-2-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/bugs/bug92647-2-expected.txt
@@ -3,14 +3,14 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 52x45 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 50x43
-          RenderTableRow {TR} at (0,2) size 50x39
-            RenderTableCell {TD} at (2,2) size 46x39 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderTable {TABLE} at (2,2) size 42x35 [border: (1px outset #808080)]
-                RenderTableSection {TBODY} at (1,1) size 40x33
-                  RenderTableRow {TR} at (0,2) size 40x29
-                    RenderTableCell {TD} at (2,14) size 4x5 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-                    RenderTableCell {TD} at (8,2) size 24x29 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
-                      RenderButton {INPUT} at (4,4) size 16x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
-                    RenderTableCell {TD} at (34,14) size 4x5 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
+      RenderTable {TABLE} at (0,0) size 48x41 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 46x39
+          RenderTableRow {TR} at (0,2) size 46x35
+            RenderTableCell {TD} at (2,2) size 42x35 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderTable {TABLE} at (2,2) size 38x31 [border: (1px outset #808080)]
+                RenderTableSection {TBODY} at (1,1) size 36x29
+                  RenderTableRow {TR} at (0,2) size 36x25
+                    RenderTableCell {TD} at (2,12) size 4x5 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+                    RenderTableCell {TD} at (8,2) size 20x25 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
+                      RenderButton {INPUT} at (2,2) size 16x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+                    RenderTableCell {TD} at (30,12) size 4x5 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/win/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/collapsing_borders/bug41262-4-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {BLOCKQUOTE} at (40,0) size 704x121
-        RenderBlock {CENTER} at (0,0) size 704x121
+      RenderBlock {BLOCKQUOTE} at (40,0) size 704x117
+        RenderBlock {CENTER} at (0,0) size 704x117
           RenderTable {TABLE} at (298,0) size 108x80 [border: (2px none #808080)]
             RenderTableSection {TBODY} at (2,2) size 103x75
               RenderTableRow {TR} at (0,0) size 103x25
@@ -28,14 +28,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (37,50) size 66x25 [border: (3px groove #0000FF)] [r=2 c=1 rs=1 cs=1]
                   RenderText {#text} at (4,4) size 59x18
                     text run at (4,4) width 59: "6:00 a.m."
-          RenderBlock {P} at (0,96) size 704x25
-            RenderButton {INPUT} at (283,2) size 66x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderBlock {P} at (0,96) size 704x21
+            RenderButton {INPUT} at (285,0) size 66x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
               RenderBlock (anonymous) at (8,3) size 50x15
                 RenderText at (0,0) size 50x15
                   text run at (0,0) width 50: "separate"
-            RenderText {#text} at (351,3) size 4x18
-              text run at (351,3) width 4: " "
-            RenderButton {INPUT} at (357,2) size 64x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+            RenderText {#text} at (351,1) size 4x18
+              text run at (351,1) width 4: " "
+            RenderButton {INPUT} at (355,0) size 64x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
               RenderBlock (anonymous) at (8,3) size 48x15
                 RenderText at (0,0) size 48x15
                   text run at (0,0) width 48: "collapse"

--- a/LayoutTests/platform/win/tables/mozilla/core/margins-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla/core/margins-expected.txt
@@ -6,20 +6,20 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 187x18
           text run at (0,0) width 187: "outer width=400 align=center"
-      RenderTable {TABLE} at (192,18) size 400x49 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 398x47
-          RenderTableRow {TR} at (0,2) size 398x43
-            RenderTableCell {TD} at (2,2) size 394x43 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderBlock {FORM} at (2,2) size 390x23
-                RenderMenuList {SELECT} at (2,2) size 51x19 [bgcolor=#FFFFFF]
+      RenderTable {TABLE} at (192,18) size 400x45 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 398x43
+          RenderTableRow {TR} at (0,2) size 398x39
+            RenderTableCell {TD} at (2,2) size 394x39 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
+              RenderBlock {FORM} at (2,2) size 390x19
+                RenderMenuList {SELECT} at (0,0) size 51x19 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (4,2) size 26x15
                     RenderText at (0,0) size 26x15
                       text run at (0,0) width 26: "Test"
                 RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,67) size 784x18
+      RenderBlock (anonymous) at (0,63) size 784x18
         RenderText {#text} at (0,0) size 296x18
           text run at (0,0) width 296: "outer width=400 inner width=200 align=center"
-      RenderTable {TABLE} at (0,85) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,81) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 392x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -29,10 +29,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 194x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x18
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,125) size 784x18
+      RenderBlock (anonymous) at (0,121) size 784x18
         RenderText {#text} at (0,0) size 181x18
           text run at (0,0) width 181: "outer auto inner align=center"
-      RenderTable {TABLE} at (0,143) size 43x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,139) size 43x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 39x36
           RenderTableRow {TR} at (0,2) size 39x32
             RenderTableCell {TD} at (2,2) size 35x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -42,10 +42,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x18
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,183) size 784x18
+      RenderBlock (anonymous) at (0,179) size 784x18
         RenderText {#text} at (0,0) size 215x18
           text run at (0,0) width 215: "outer width=50 inner align=center"
-      RenderTable {TABLE} at (0,201) size 43x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,197) size 43x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 39x36
           RenderTableRow {TR} at (0,2) size 39x32
             RenderTableCell {TD} at (2,2) size 35x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -55,10 +55,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x18
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,241) size 784x18
+      RenderBlock (anonymous) at (0,237) size 784x18
         RenderText {#text} at (0,0) size 226x18
           text run at (0,0) width 226: "outer width=50 inner margin-left:50"
-      RenderTable {TABLE} at (0,259) size 93x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,255) size 93x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 89x36
           RenderTableRow {TR} at (0,2) size 89x32
             RenderTableCell {TD} at (2,2) size 85x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -68,10 +68,10 @@ layer at (0,0) size 800x600
                     RenderTableCell {TD} at (2,2) size 25x22 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
                       RenderText {#text} at (2,2) size 21x18
                         text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,299) size 784x18
+      RenderBlock (anonymous) at (0,295) size 784x18
         RenderText {#text} at (0,0) size 223x18
           text run at (0,0) width 223: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,317) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,313) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 115x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (118,7) size 277x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x18
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,357) size 784x18
+      RenderBlock (anonymous) at (0,353) size 784x18
         RenderText {#text} at (0,0) size 223x18
           text run at (0,0) width 223: "outer width=400 inner align=center"
-      RenderTable {TABLE} at (0,375) size 400x40 [border: (2px outset #808080)]
+      RenderTable {TABLE} at (0,371) size 400x40 [border: (2px outset #808080)]
         RenderTableSection {TBODY} at (2,2) size 396x36
           RenderTableRow {TR} at (0,2) size 396x32
             RenderTableCell {TD} at (2,2) size 169x32 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
@@ -100,6 +100,6 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (172,7) size 223x22 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 80x18
                 text run at (2,2) width 80: "x x x x x x x"
-      RenderBlock (anonymous) at (0,415) size 784x18
+      RenderBlock (anonymous) at (0,411) size 784x18
         RenderText {#text} at (0,0) size 19x18
           text run at (0,0) width 19: "-->"

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 600x283 [bgcolor=#FFC0CB]
-        RenderTableSection {TBODY} at (0,0) size 600x283
+      RenderTable {TABLE} at (0,0) size 600x279 [bgcolor=#FFC0CB]
+        RenderTableSection {TBODY} at (0,0) size 600x279
           RenderTableRow {TR} at (0,0) size 600x18
             RenderTableCell {TD} at (0,0) size 601x18 [bgcolor=#FFFF00] [r=0 c=0 rs=1 cs=3]
               RenderText {#text} at (0,0) size 8x18
@@ -17,35 +17,35 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (0,36) size 156x18 [bgcolor=#00FFFF] [r=2 c=0 rs=40 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "3"
-          RenderTableRow {TR} at (0,36) size 600x31
-            RenderTableCell {TD} at (155,36) size 446x31 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (0,0) size 440x31
-                RenderTableSection {TBODY} at (0,0) size 440x31
-                  RenderTableRow {TR} at (0,2) size 440x27
-                    RenderTableCell {TD} at (2,2) size 217x27 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (3,3) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderTableRow {TR} at (0,36) size 600x27
+            RenderTableCell {TD} at (155,36) size 446x27 [bgcolor=#FFA500] [r=3 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (0,0) size 440x27
+                RenderTableSection {TBODY} at (0,0) size 440x27
+                  RenderTableRow {TR} at (0,2) size 440x23
+                    RenderTableCell {TD} at (2,2) size 217x23 [r=0 c=0 rs=1 cs=1]
+                      RenderButton {INPUT} at (1,1) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
                         RenderBlock (anonymous) at (8,3) size 85x15
                           RenderText at (0,0) size 85x15
                             text run at (0,0) width 85: "Submit Criteria"
-                    RenderTableCell {TD} at (221,5) size 217x21 [r=0 c=1 rs=1 cs=1]
+                    RenderTableCell {TD} at (221,3) size 217x21 [r=0 c=1 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 8x19
                         text run at (1,2) width 8: "4"
-          RenderTableRow {TR} at (0,67) size 600x18
-            RenderTableCell {TD} at (155,67) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,63) size 600x18
+            RenderTableCell {TD} at (155,63) size 446x18 [bgcolor=#FF0000] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "5"
-          RenderTableRow {TR} at (0,85) size 600x36
-            RenderTableCell {TD} at (155,85) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,81) size 600x36
+            RenderTableCell {TD} at (155,81) size 446x36 [bgcolor=#FFFF00] [r=5 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 426x36
                 text run at (0,0) width 257: "If you have entered your feature criteria, "
                 text run at (257,0) width 169: "press the \"Submit Criteria\""
                 text run at (0,18) width 86: "button above."
-          RenderTableRow {TR} at (0,121) size 600x18
-            RenderTableCell {TD} at (155,121) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,117) size 600x18
+            RenderTableCell {TD} at (155,117) size 446x18 [bgcolor=#D3D3D3] [r=6 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 8x18
                 text run at (0,0) width 8: "6"
-          RenderTableRow {TR} at (0,139) size 600x54
-            RenderTableCell {TD} at (155,139) size 446x54 [r=7 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,135) size 600x54
+            RenderTableCell {TD} at (155,135) size 446x54 [r=7 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 438x54
                 text run at (0,0) width 262: "If you want to do a radius search instead, "
                 text run at (262,0) width 164: "press the \"Radius Search\""
@@ -53,12 +53,12 @@ layer at (0,0) size 800x600
                 text run at (48,18) width 279: "This will allow you to select a starting point "
                 text run at (327,18) width 111: "and enter a radius"
                 text run at (0,36) width 157: "with new feature criteria."
-          RenderTableRow {TR} at (0,193) size 600x18
-            RenderTableCell {TD} at (155,193) size 446x18 [r=8 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,189) size 600x18
+            RenderTableCell {TD} at (155,189) size 446x18 [r=8 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 4x18
                 text run at (0,0) width 4: " "
-          RenderTableRow {TR} at (0,211) size 600x72
-            RenderTableCell {TD} at (155,211) size 446x72 [r=9 c=1 rs=1 cs=1]
+          RenderTableRow {TR} at (0,207) size 600x72
+            RenderTableCell {TD} at (155,207) size 446x72 [r=9 c=1 rs=1 cs=1]
               RenderText {#text} at (0,0) size 436x72
                 text run at (0,0) width 436: "All information provided is deemed reliable but is not guaranteed and"
                 text run at (0,18) width 65: "should be "

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -1,21 +1,21 @@
-layer at (0,0) size 785x1392
+layer at (0,0) size 785x1384
   RenderView at (0,0) size 785x600
-layer at (8,8) size 769x1384
-  RenderBlock {HTML} at (8,8) size 769x1384 [bgcolor=#008000] [border: (16px solid #00FF00)]
-    RenderTable at (16,16) size 737x1352
-      RenderTableSection (anonymous) at (0,0) size 737x1352
-        RenderTableRow (anonymous) at (0,0) size 737x1352
-          RenderTableCell {HEAD} at (0,0) size 209x508 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
-            RenderBlock {META} at (21,37) size 167x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,55) size 167x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,73) size 167x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {META} at (21,91) size 167x2 [border: (1px dotted #FFFFFF)]
-            RenderBlock {TITLE} at (21,109) size 167x56 [border: (1px dotted #FFFFFF)]
+layer at (8,8) size 769x1376
+  RenderBlock {HTML} at (8,8) size 769x1376 [bgcolor=#008000] [border: (16px solid #00FF00)]
+    RenderTable at (16,16) size 737x1344
+      RenderTableSection (anonymous) at (0,0) size 737x1344
+        RenderTableRow (anonymous) at (0,0) size 737x1344
+          RenderTableCell {HEAD} at (0,0) size 213x508 [color=#FFFFFF] [bgcolor=#FF0000] [border: (5px solid #FFFFFF)] [r=0 c=0 rs=1 cs=1]
+            RenderBlock {META} at (21,37) size 171x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,55) size 171x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,73) size 171x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {META} at (21,91) size 171x2 [border: (1px dotted #FFFFFF)]
+            RenderBlock {TITLE} at (21,109) size 171x56 [border: (1px dotted #FFFFFF)]
               RenderText {#text} at (1,1) size 141x54
                 text run at (1,1) width 137: "Evil Tests: Rendering"
                 text run at (1,19) width 141: "BODY and HEAD as"
                 text run at (1,37) width 139: "children of HTML - 2"
-            RenderBlock {STYLE} at (21,181) size 167x290 [border: (1px dotted #FFFFFF)]
+            RenderBlock {STYLE} at (21,181) size 171x290 [border: (1px dotted #FFFFFF)]
               RenderText {#text} at (1,1) size 163x288
                 text run at (1,1) width 81: "/* Layout */ "
                 text run at (82,1) width 58: "HTML {"
@@ -40,27 +40,27 @@ layer at (8,8) size 769x1384
                 text run at (1,235) width 162: "white; background: red; }"
                 text run at (1,253) width 150: "BODY { color: yellow;"
                 text run at (1,271) width 121: "background: teal; }"
-          RenderTableCell {BODY} at (209,41) size 528x1311 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
-            RenderBlock {H1} at (21,53) size 486x76 [border: (1px dotted #FFFF00)]
+          RenderTableCell {BODY} at (213,41) size 524x1303 [color=#FFFF00] [bgcolor=#008080] [border: (5px solid #FFFF00)] [r=0 c=1 rs=1 cs=1]
+            RenderBlock {H1} at (21,53) size 482x76 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 152x37
                 text run at (1,1) width 152: "Rendering "
               RenderInline {CODE} at (0,0) size 64x30
-                RenderText {#text} at (153,6) size 64x30
-                  text run at (153,6) width 64: "BODY"
+                RenderText {#text} at (153,8) size 64x30
+                  text run at (153,8) width 64: "BODY"
               RenderText {#text} at (217,1) size 68x37
                 text run at (217,1) width 68: " and "
               RenderInline {CODE} at (0,0) size 64x30
-                RenderText {#text} at (285,6) size 64x30
-                  text run at (285,6) width 64: "HEAD"
+                RenderText {#text} at (285,8) size 64x30
+                  text run at (285,8) width 64: "HEAD"
               RenderText {#text} at (349,1) size 384x74
                 text run at (349,1) width 36: " as"
                 text run at (1,38) width 157: "children of "
               RenderInline {CODE} at (0,0) size 64x30
-                RenderText {#text} at (158,43) size 64x30
-                  text run at (158,43) width 64: "HTML"
+                RenderText {#text} at (158,45) size 64x30
+                  text run at (158,45) width 64: "HTML"
               RenderText {#text} at (222,38) size 43x37
                 text run at (222,38) width 43: " - 2"
-            RenderBlock {P} at (21,161) size 486x38 [border: (1px dotted #FFFF00)]
+            RenderBlock {P} at (21,161) size 482x38 [border: (1px dotted #FFFF00)]
               RenderText {#text} at (1,1) size 383x18
                 text run at (1,1) width 383: "If you have any comments to make regarding this test, e-mail"
               RenderInline {A} at (0,0) size 182x18 [color=#0000EE]

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug45621-expected.txt
@@ -1,17 +1,17 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x77
-  RenderBlock {HTML} at (0,0) size 800x77
-    RenderBody {BODY} at (8,8) size 784x61
-      RenderTable {TABLE} at (0,0) size 392x61 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 392x61
-          RenderTableRow {TR} at (0,0) size 392x21
-            RenderTableCell {TD} at (0,0) size 392x21 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
-              RenderTextControl {INPUT} at (0,2) size 392x17 [bgcolor=#FFC0CB]
+layer at (0,0) size 800x73
+  RenderBlock {HTML} at (0,0) size 800x73
+    RenderBody {BODY} at (8,8) size 784x57
+      RenderTable {TABLE} at (0,0) size 392x57 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 392x57
+          RenderTableRow {TR} at (0,0) size 392x17
+            RenderTableCell {TD} at (0,0) size 392x17 [bgcolor=#808080] [r=0 c=0 rs=1 cs=1]
+              RenderTextControl {INPUT} at (0,0) size 392x17 [bgcolor=#FFC0CB]
               RenderText {#text} at (0,0) size 0x0
-          RenderTableRow {TR} at (0,21) size 392x40
-            RenderTableCell {TD} at (0,21) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,17) size 392x40
+            RenderTableCell {TD} at (0,17) size 392x40 [bgcolor=#808080] [r=1 c=0 rs=1 cs=1]
               RenderImage {IMG} at (0,0) size 392x40 [bgcolor=#00FFFF]
               RenderText {#text} at (0,0) size 0x0
-layer at (8,11) size 392x15
+layer at (8,9) size 392x15
   RenderBlock {DIV} at (0,1) size 392x15

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt
@@ -32,14 +32,14 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (2,158) size 42x22 [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 37x18
                 text run at (2,2) width 37: "row 3"
-      RenderBlock (anonymous) at (0,240) size 784x25
-        RenderButton {INPUT} at (2,2) size 58x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+      RenderBlock (anonymous) at (0,240) size 784x21
+        RenderButton {INPUT} at (0,0) size 58x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 42x15
             RenderText at (0,0) size 42x15
               text run at (0,0) width 42: "expand"
-        RenderText {#text} at (62,3) size 4x18
-          text run at (62,3) width 4: " "
-        RenderButton {INPUT} at (68,2) size 47x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderText {#text} at (58,1) size 4x18
+          text run at (58,1) width 4: " "
+        RenderButton {INPUT} at (62,0) size 47x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
           RenderBlock (anonymous) at (8,3) size 31x15
             RenderText at (0,0) size 31x15
               text run at (0,0) width 31: "sizes"

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x146
+      RenderBlock {CENTER} at (0,0) size 784x138
         RenderTable {TABLE} at (340,0) size 104x80
           RenderTableSection {THEAD} at (0,0) size 104x20
             RenderTableRow {TR} at (0,0) size 104x20
@@ -48,34 +48,34 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (65,0) size 39x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,1) size 36x18
                   text run at (2,1) width 36: "11pm"
-        RenderBlock {P} at (0,96) size 784x50
-          RenderButton {BUTTON} at (260,2) size 79x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock {P} at (0,96) size 784x42
+          RenderButton {BUTTON} at (264,0) size 79x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 62x15
               RenderText {#text} at (0,0) size 62x15
                 text run at (0,0) width 19: "No "
                 text run at (19,0) width 43: "borders"
-          RenderButton {BUTTON} at (342,2) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (342,0) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 84x15
               RenderText {#text} at (0,0) size 84x15
                 text run at (0,0) width 48: "Exterior "
                 text run at (48,0) width 36: "border"
-          RenderButton {BUTTON} at (446,2) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (442,0) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 61x15
               RenderText {#text} at (0,0) size 61x15
                 text run at (0,0) width 18: "All "
                 text run at (18,0) width 43: "borders"
-          RenderBR {BR} at (525,17) size 1x0
-          RenderButton {BUTTON} at (224,27) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderBR {BR} at (519,15) size 1x0
+          RenderButton {BUTTON} at (228,21) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 90x15
               RenderText {#text} at (0,0) size 90x15
                 text run at (0,0) width 47: "Column "
                 text run at (47,0) width 43: "borders"
-          RenderButton {BUTTON} at (334,27) size 105x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (334,21) size 105x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 88x15
               RenderText {#text} at (0,0) size 88x15
                 text run at (0,0) width 45: "Groups "
                 text run at (45,0) width 43: "borders"
-          RenderButton {BUTTON} at (442,27) size 118x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (438,21) size 118x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 101x15
               RenderText {#text} at (0,0) size 101x15
                 text run at (0,0) width 35: "Table "

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {CENTER} at (0,0) size 784x148
+      RenderBlock {CENTER} at (0,0) size 784x140
         RenderTable {TABLE} at (339,0) size 106x82 [border: none]
           RenderTableSection {THEAD} at (0,0) size 105x21
             RenderTableRow {TR} at (0,0) size 105x21
@@ -48,34 +48,34 @@ layer at (0,0) size 800x600
               RenderTableCell {TD} at (66,0) size 39x20 [border: none none none (1px solid #808080)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,1) size 36x18
                   text run at (2,1) width 36: "11pm"
-        RenderBlock {P} at (0,98) size 784x50
-          RenderButton {BUTTON} at (260,2) size 79x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+        RenderBlock {P} at (0,98) size 784x42
+          RenderButton {BUTTON} at (264,0) size 79x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 62x15
               RenderText {#text} at (0,0) size 62x15
                 text run at (0,0) width 19: "No "
                 text run at (19,0) width 43: "borders"
-          RenderButton {BUTTON} at (342,2) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (342,0) size 101x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 84x15
               RenderText {#text} at (0,0) size 84x15
                 text run at (0,0) width 48: "Exterior "
                 text run at (48,0) width 36: "border"
-          RenderButton {BUTTON} at (446,2) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (442,0) size 78x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 61x15
               RenderText {#text} at (0,0) size 61x15
                 text run at (0,0) width 18: "All "
                 text run at (18,0) width 43: "borders"
-          RenderBR {BR} at (525,17) size 1x0
-          RenderButton {BUTTON} at (224,27) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderBR {BR} at (519,15) size 1x0
+          RenderButton {BUTTON} at (228,21) size 107x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 90x15
               RenderText {#text} at (0,0) size 90x15
                 text run at (0,0) width 47: "Column "
                 text run at (47,0) width 43: "borders"
-          RenderButton {BUTTON} at (334,27) size 105x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (334,21) size 105x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 88x15
               RenderText {#text} at (0,0) size 88x15
                 text run at (0,0) width 45: "Groups "
                 text run at (45,0) width 43: "borders"
-          RenderButton {BUTTON} at (442,27) size 118x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
+          RenderButton {BUTTON} at (438,21) size 118x21 [bgcolor=#F0F0F0] [border: (2px outset #F0F0F0)]
             RenderBlock (anonymous) at (8,3) size 101x15
               RenderText {#text} at (0,0) size 101x15
                 text run at (0,0) width 35: "Table "

--- a/LayoutTests/platform/win/transforms/2d/zoom-menulist-expected.txt
+++ b/LayoutTests/platform/win/transforms/2d/zoom-menulist-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderBlock {H1} at (0,0) size 784x37
         RenderText {#text} at (0,0) size 272x37
           text run at (0,0) width 272: "Zooming Menu List"
-      RenderBlock (anonymous) at (0,58) size 784x67
-        RenderMenuList {SELECT} at (6,6) size 134x54 [bgcolor=#FFFFFF] [border: (3px solid #000000)]
+      RenderBlock (anonymous) at (0,58) size 784x55
+        RenderMenuList {SELECT} at (0,0) size 134x54 [bgcolor=#FFFFFF] [border: (3px solid #000000)]
           RenderBlock (anonymous) at (7,5) size 103x44
             RenderText at (0,0) size 74x44
               text run at (0,0) width 74: "One"

--- a/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-expected.txt
@@ -11,7 +11,7 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 div display height = 111
-Mouse moved to (30, 238)
+Mouse moved to (28, 236)
 PASS Page did not receive wheel events.
 (GraphicsLayer
   (anchor 0.00 0.00)

--- a/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-with-handler-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-with-handler-expected.txt
@@ -11,7 +11,7 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 div display height = 111
-Mouse moved to (30, 238)
+Mouse moved to (28, 236)
 PASS Page did not receive wheel events.
 (GraphicsLayer
   (anchor 0.00 0.00)

--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -56,6 +56,17 @@ AcceleratedCompositingForFixedPositionEnabled:
       PLATFORM(IOS_FAMILY): true
       default: false
 
+AddMarginsToFormControlElement:
+  type: bool
+  condition: ENABLE(ADD_MARGINS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AggressiveTileRetentionEnabled:
   type: bool
   defaultValue:

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -76,6 +76,7 @@ Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, con
 {
 }
 
+#if ENABLE(ADD_MARGINS)
 static void addIntrinsicMargins(RenderStyle& style)
 {
     // Intrinsic margin value.
@@ -97,6 +98,7 @@ static void addIntrinsicMargins(RenderStyle& style)
             style.setMarginBottom(Length(intrinsicMargin, LengthType::Fixed));
     }
 }
+#endif
 
 static DisplayType equivalentBlockDisplay(const RenderStyle& style, const Document& document)
 {
@@ -504,6 +506,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     style.adjustAnimations();
     style.adjustTransitions();
 
+#if ENABLE(ADD_MARGINS)
     // Important: Intrinsic margins get added to controls before the theme has adjusted the style, since the theme will
     // alter fonts and heights/widths.
     if (is<HTMLFormControlElement>(m_element) && style.computedFontPixelSize() >= 11) {
@@ -512,6 +515,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
         if (!is<HTMLInputElement>(*m_element) || !downcast<HTMLInputElement>(*m_element).isImageButton())
             addIntrinsicMargins(style);
     }
+#endif
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -434,11 +434,11 @@ TEST(DocumentEditingContext, RequestMarkedTextRectsAndTextOnly)
     EXPECT_EQ(CGRectMake(240, 8, 26, 26), [rectValues[3] CGRectValue]);
     EXPECT_EQ(CGRectMake(265, 8, 26, 26), [rectValues[4] CGRectValue]);
 #else
-    EXPECT_EQ(CGRectMake(165, 8, 26, 25), [rectValues[0] CGRectValue]);
-    EXPECT_EQ(CGRectMake(190, 8, 26, 25), [rectValues[1] CGRectValue]);
-    EXPECT_EQ(CGRectMake(215, 8, 26, 25), [rectValues[2] CGRectValue]);
-    EXPECT_EQ(CGRectMake(240, 8, 26, 25), [rectValues[3] CGRectValue]);
-    EXPECT_EQ(CGRectMake(265, 8, 26, 25), [rectValues[4] CGRectValue]);
+    EXPECT_EQ(CGRectMake(163, 6, 26, 25), [rectValues[0] CGRectValue]);
+    EXPECT_EQ(CGRectMake(188, 6, 26, 25), [rectValues[1] CGRectValue]);
+    EXPECT_EQ(CGRectMake(213, 6, 26, 25), [rectValues[2] CGRectValue]);
+    EXPECT_EQ(CGRectMake(238, 6, 26, 25), [rectValues[3] CGRectValue]);
+    EXPECT_EQ(CGRectMake(263, 6, 26, 25), [rectValues[4] CGRectValue]);
 #endif
 }
 
@@ -454,16 +454,16 @@ TEST(DocumentEditingContext, SpatialRequestInTextField)
     auto *textRects = [context textRects];
     EXPECT_EQ(10U, textRects.count);
     if (textRects.count >= 10) {
-        EXPECT_EQ(CGRectMake(8, 9, 12, 19), textRects[0].CGRectValue);
-        EXPECT_EQ(CGRectMake(19, 9, 8, 19), textRects[1].CGRectValue);
-        EXPECT_EQ(CGRectMake(26, 9, 6, 19), textRects[2].CGRectValue);
-        EXPECT_EQ(CGRectMake(31, 9, 5, 19), textRects[3].CGRectValue);
-        EXPECT_EQ(CGRectMake(35, 9, 9, 19), textRects[4].CGRectValue);
-        EXPECT_EQ(CGRectMake(202, 9, 12, 19), textRects[5].CGRectValue);
-        EXPECT_EQ(CGRectMake(213, 9, 9, 19), textRects[6].CGRectValue);
-        EXPECT_EQ(CGRectMake(221, 9, 7, 19), textRects[7].CGRectValue);
-        EXPECT_EQ(CGRectMake(227, 9, 5, 19), textRects[8].CGRectValue);
-        EXPECT_EQ(CGRectMake(231, 9, 9, 19), textRects[9].CGRectValue);
+        EXPECT_EQ(CGRectMake(8, 8, 12, 19), textRects[0].CGRectValue);
+        EXPECT_EQ(CGRectMake(19, 8, 8, 19), textRects[1].CGRectValue);
+        EXPECT_EQ(CGRectMake(26, 8, 6, 19), textRects[2].CGRectValue);
+        EXPECT_EQ(CGRectMake(31, 8, 5, 19), textRects[3].CGRectValue);
+        EXPECT_EQ(CGRectMake(35, 8, 9, 19), textRects[4].CGRectValue);
+        EXPECT_EQ(CGRectMake(178, 8, 13, 19), textRects[5].CGRectValue);
+        EXPECT_EQ(CGRectMake(190, 8, 9, 19), textRects[6].CGRectValue);
+        EXPECT_EQ(CGRectMake(198, 8, 6, 19), textRects[7].CGRectValue);
+        EXPECT_EQ(CGRectMake(203, 8, 6, 19), textRects[8].CGRectValue);
+        EXPECT_EQ(CGRectMake(208, 8, 9, 19), textRects[9].CGRectValue);
     }
 }
 
@@ -866,7 +866,7 @@ TEST(DocumentEditingContext, RequestRectsInTextAreaAcrossWordWrappedLine)
     const size_t yPos = 2;
     const size_t height = 26;
 #else
-    const size_t yPos = 3;
+    const size_t yPos = 1;
     const size_t height = 25;
 #endif
     
@@ -912,12 +912,12 @@ TEST(DocumentEditingContext, RequestRectsInTextAreaInsideIFrame)
     const size_t yPos = 27;
     const size_t height = 26;
 #else
-    const size_t yPos = 28;
+    const size_t yPos = 26;
     const size_t height = 25;
 #endif
 
     if (textRects.count >= 3) {
-        CGFloat x = 28;
+        CGFloat x = 26;
         EXPECT_EQ(CGRectMake(x + 0 * glyphWidth, yPos, 25, height), textRects[0].CGRectValue); // T
         EXPECT_EQ(CGRectMake(x + 1 * glyphWidth, yPos, 25, height), textRects[1].CGRectValue); // h
         EXPECT_EQ(CGRectMake(x + 2 * glyphWidth, yPos, 25, height), textRects[2].CGRectValue); // e

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -815,7 +815,7 @@ TEST(WebKit, ClickAutoFillButton)
     [webView setUIDelegate:delegate.get()];
     [webView evaluateJavaScript:@"" completionHandler: nil]; // Ensure the WebProcess and injected bundle are running.
     TestWebKitAPI::Util::run(&readyForClick);
-    NSPoint buttonLocation = NSMakePoint(130, 575);
+    NSPoint buttonLocation = NSMakePoint(132, 577);
     [webView mouseDownAtPoint:buttonLocation simulatePressure:NO];
     [webView mouseUpAtPoint:buttonLocation];
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -453,7 +453,7 @@ TEST(KeyboardInputTests, HandleKeyEventsWhileSwappingWebProcess)
 TEST(KeyboardInputTests, CaretSelectionRectAfterRestoringFirstResponderWithRetainActiveFocusedState)
 {
     // This difference in caret width is due to the fact that we don't zoom in to the input field on iPad, but do on iPhone.
-    auto expectedCaretRect = CGRectMake(16, 13, UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad ? 3 : 2, 15);
+    auto expectedCaretRect = CGRectMake(14, 11, UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad ? 3 : 2, 15);
     auto [webView, inputDelegate] = webViewAndInputDelegateWithAutofocusedInput();
     EXPECT_WK_STREQ("INPUT", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
     [webView waitForCaretViewFrameToBecome:expectedCaretRect];
@@ -672,8 +672,8 @@ TEST(KeyboardInputTests, SelectionClipRectsWhenPresentingInputView)
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><input>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.querySelector('input').focus()"];
 
-    EXPECT_EQ(11, selectionClipRect.origin.x);
-    EXPECT_EQ(11, selectionClipRect.origin.y);
+    EXPECT_EQ(9, selectionClipRect.origin.x);
+    EXPECT_EQ(9, selectionClipRect.origin.y);
     EXPECT_EQ(153, selectionClipRect.size.width);
     EXPECT_EQ(20, selectionClipRect.size.height);
 }


### PR DESCRIPTION
#### 42f2d1f4b0d4b9480dd5f4ac14bddc59819eb724
<pre>
Remove &apos;Intrinsic Margins&apos; feature from WebKit with flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=107380">https://bugs.webkit.org/show_bug.cgi?id=107380</a>

Reviewed by NOBODY (OOPS!).

The purpose of intrinsic margins was to try to prevent
adjacent controls from butting up against one another.
But this feature&apos;s behavior makes web developers confusing
and introduces some compat issues too.

Blink removed this feature at
<a href="http://code.google.com/p/chromium/issues/detail?id=128306">http://code.google.com/p/chromium/issues/detail?id=128306</a>

This patch is based on the hard work by Joonghun Park in 2020.
Instead of removing the code entirely, this patch
introduces a feature flag, with which we can turn this feature on/off.

* LayoutTests/TestExpectations:
* LayoutTests/accessibility/ios-simulator/unobscured-content-rect-expected.txt:
* LayoutTests/accessibility/ios-simulator/unobscured-content-rect.html:
* LayoutTests/editing/pasteboard/4944770-2.html:
* LayoutTests/fast/flexbox/clear-overflow-before-scroll-update-expected.txt:
* LayoutTests/fast/forms/auto-fill-button/input-credit-card-auto-fill-button-expected.txt:
* LayoutTests/fast/forms/button-with-float-expected.html:
* LayoutTests/fast/forms/listbox-clip-expected.txt:
* LayoutTests/fast/forms/option-mouseevents-expected.txt:
* LayoutTests/fast/forms/option-mouseevents.html:
* LayoutTests/fast/multicol/flexbox-rows-expected.html:
* LayoutTests/fast/multicol/flexbox-rows.html:
* LayoutTests/fast/scrolling/latching/scroll-select-bottom-test-expected.txt:
* LayoutTests/fast/scrolling/latching/scroll-select-latched-mainframe-expected.txt:
* LayoutTests/fast/scrolling/latching/scroll-select-latched-select-expected.txt:
* LayoutTests/fullscreen/full-screen-placeholder-expected.txt:
* LayoutTests/platform/ios-wk2/editing/pasteboard/pasting-tabs-expected.txt:
* LayoutTests/platform/ios-wk2/fast/block/margin-collapse/103-expected.txt:
* LayoutTests/platform/ios-wk2/fast/forms/textAreaLineHeight-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690703-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690719-expected.txt:
* LayoutTests/platform/ios/fast/block/float/float-avoidance-expected.txt:
* LayoutTests/platform/ios/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/ios/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/ios/fast/forms/button-generated-content-expected.txt:
* LayoutTests/platform/ios/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/ios/fast/forms/menulist-option-wrap-expected.txt:
* LayoutTests/platform/ios/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/ios/fast/table/text-field-baseline-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/45621-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug44505-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug59354-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/collapsing_borders/bug41262-4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/core/margins-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug45621-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt:
* LayoutTests/platform/mac/compositing/contents-opaque/control-layer-expected.txt:
* LayoutTests/platform/mac/css2.1/20110323/replaced-elements-001-expected.txt:
* LayoutTests/platform/mac/css3/flexbox/button-expected.txt:
* LayoutTests/platform/mac/editing/inserting/4960120-1-expected.txt:
* LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-1-expected.txt:
* LayoutTests/platform/mac/editing/mac/spelling/autocorrection-at-beginning-of-word-2-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/pasting-tabs-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690703-2-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690703-expected.txt:
* LayoutTests/platform/mac/editing/selection/3690719-expected.txt:
* LayoutTests/platform/mac/editing/selection/4397952-expected.txt:
* LayoutTests/platform/mac/editing/selection/5240265-expected.txt:
* LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-across-readonly-input-1-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-box-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt:
* LayoutTests/platform/mac/editing/selection/selection-button-text-expected.txt:
* LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt:
* LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt:
* LayoutTests/platform/mac/fast/block/positioning/inline-block-relposition-expected.txt:
* LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac/fast/css/margin-top-bottom-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt:
* LayoutTests/platform/mac/fast/dynamic/008-expected.txt:
* LayoutTests/platform/mac/fast/dynamic/positioned-movement-with-positioned-children-expected.txt:
* LayoutTests/platform/mac/fast/events/shadow-event-path-2-expected.txt:
* LayoutTests/platform/mac/fast/forms/001-expected.txt:
* LayoutTests/platform/mac/fast/forms/003-expected.txt:
* LayoutTests/platform/mac/fast/forms/004-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-cannot-be-nested-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-generated-content-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-inner-block-reuse-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-style-color-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-text-transform-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-white-space-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt:
* LayoutTests/platform/mac/fast/forms/file/file-input-direction-expected.txt:
* LayoutTests/platform/mac/fast/forms/floating-textfield-relayout-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/mac/fast/forms/formmove3-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-field-text-truncated-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-readonly-empty-expected.txt:
* LayoutTests/platform/mac/fast/forms/listbox-hit-test-zoomed-expected.txt:
* LayoutTests/platform/mac/fast/forms/listbox-scrollbar-incremental-load-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-clip-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-option-wrap-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-separator-painting-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt:
* LayoutTests/platform/mac/fast/forms/minWidthPercent-expected.txt:
* LayoutTests/platform/mac/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/mac/fast/forms/search-rtl-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-background-none-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-change-listbox-size-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-empty-option-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-item-background-clip-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-listbox-multiple-no-focusring-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-non-native-rendering-direction-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-overflow-scroll-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-overflow-scroll-inherited-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt:
* LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt:
* LayoutTests/platform/mac/fast/forms/targeted-frame-submission-expected.txt:
* LayoutTests/platform/mac/fast/forms/textAreaLineHeight-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-1-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-placeholder-visibility-2-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-scrollbar-expected.txt:
* LayoutTests/platform/mac/fast/forms/textarea-setinnerhtml-expected.txt:
* LayoutTests/platform/mac/fast/hidpi/resize-corner-hidpi-expected.txt:
* LayoutTests/platform/mac/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/mac/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/mac/fast/invalid/014-expected.txt:
* LayoutTests/platform/mac/fast/overflow/overflow-x-y-expected.txt:
* LayoutTests/platform/mac/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt:
* LayoutTests/platform/mac/fast/overflow/scrollRevealButton-expected.txt:
* LayoutTests/platform/mac/fast/parser/entity-comment-in-textarea-expected.txt:
* LayoutTests/platform/mac/fast/parser/open-comment-in-textarea-expected.txt:
* LayoutTests/platform/mac/fast/repaint/select-option-background-color-expected.txt:
* LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-button-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-textarea-expected.txt:
* LayoutTests/platform/mac/fast/selectors/064-expected.txt:
* LayoutTests/platform/mac/fast/table/003-expected.txt:
* LayoutTests/platform/mac/fast/table/append-cells2-expected.txt:
* LayoutTests/platform/mac/fast/table/remove-td-display-none-expected.txt:
* LayoutTests/platform/mac/fast/table/text-field-baseline-expected.txt:
* LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt:
* LayoutTests/platform/mac/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt:
* LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/mac/svg/custom/foreign-object-skew-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/45621-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug194024-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug44505-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug51727-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug52505-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug52506-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug59354-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug68912-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug92647-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/collapsing_borders/bug41262-4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug45621-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt:
* LayoutTests/platform/win/css2.1/20110323/replaced-elements-001-expected.txt:
* LayoutTests/platform/win/fast/block/float/float-avoidance-expected.txt:
* LayoutTests/platform/win/fast/block/float/overhanging-tall-block-expected.txt:
* LayoutTests/platform/win/fast/block/margin-collapse/103-expected.txt:
* LayoutTests/platform/win/fast/block/positioning/inline-block-relposition-expected.txt:
* LayoutTests/platform/win/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLTableColElement/resize-table-using-col-width-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLTextAreaElement/reset-textarea-expected.txt:
* LayoutTests/platform/win/fast/dynamic/008-expected.txt:
* LayoutTests/platform/win/fast/dynamic/positioned-movement-with-positioned-children-expected.txt:
* LayoutTests/platform/win/fast/flexbox/clear-overflow-before-scroll-update-expected.txt:
* LayoutTests/platform/win/fast/forms/001-expected.txt:
* LayoutTests/platform/win/fast/forms/003-expected.txt:
* LayoutTests/platform/win/fast/forms/004-expected.txt:
* LayoutTests/platform/win/fast/forms/basic-buttons-expected.txt:
* LayoutTests/platform/win/fast/forms/basic-inputs-expected.txt:
* LayoutTests/platform/win/fast/forms/basic-selects-expected.txt:
* LayoutTests/platform/win/fast/forms/basic-textareas-expected.txt:
* LayoutTests/platform/win/fast/forms/basic-textareas-quirks-expected.txt:
* LayoutTests/platform/win/fast/forms/blankbuttons-expected.txt:
* LayoutTests/platform/win/fast/forms/button-align-expected.txt:
* LayoutTests/platform/win/fast/forms/button-cannot-be-nested-expected.txt:
* LayoutTests/platform/win/fast/forms/button-generated-content-expected.txt:
* LayoutTests/platform/win/fast/forms/button-inner-block-reuse-expected.txt:
* LayoutTests/platform/win/fast/forms/button-positioned-expected.txt:
* LayoutTests/platform/win/fast/forms/button-sizes-expected.txt:
* LayoutTests/platform/win/fast/forms/button-style-color-expected.txt:
* LayoutTests/platform/win/fast/forms/button-table-styles-expected.txt:
* LayoutTests/platform/win/fast/forms/button-text-transform-expected.txt:
* LayoutTests/platform/win/fast/forms/button-white-space-expected.txt:
* LayoutTests/platform/win/fast/forms/control-clip-overflow-expected.txt:
* LayoutTests/platform/win/fast/forms/disabled-select-change-index-expected.txt:
* LayoutTests/platform/win/fast/forms/file/file-input-direction-expected.txt:
* LayoutTests/platform/win/fast/forms/file/file-input-disabled-expected.txt:
* LayoutTests/platform/win/fast/forms/floating-textfield-relayout-expected.txt:
* LayoutTests/platform/win/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/win/fast/forms/formmove3-expected.txt:
* LayoutTests/platform/win/fast/forms/hidden-listbox-expected.txt:
* LayoutTests/platform/win/fast/forms/input-appearance-disabled-expected.txt:
* LayoutTests/platform/win/fast/forms/input-appearance-readonly-expected.txt:
* LayoutTests/platform/win/fast/forms/input-button-sizes-expected.txt:
* LayoutTests/platform/win/fast/forms/input-field-text-truncated-expected.txt:
* LayoutTests/platform/win/fast/forms/input-first-letter-expected.txt:
* LayoutTests/platform/win/fast/forms/input-readonly-autoscroll-expected.txt:
* LayoutTests/platform/win/fast/forms/input-readonly-dimmed-expected.txt:
* LayoutTests/platform/win/fast/forms/input-readonly-empty-expected.txt:
* LayoutTests/platform/win/fast/forms/listbox-bidi-align-expected.txt:
* LayoutTests/platform/win/fast/forms/listbox-hit-test-zoomed-expected.txt:
* LayoutTests/platform/win/fast/forms/listbox-scrollbar-incremental-load-expected.txt:
* LayoutTests/platform/win/fast/forms/listbox-width-change-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-clip-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-deselect-update-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-option-wrap-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-restrict-line-height-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-separator-painting-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-style-color-expected.txt:
* LayoutTests/platform/win/fast/forms/menulist-width-change-expected.txt:
* LayoutTests/platform/win/fast/forms/minWidthPercent-expected.txt:
* LayoutTests/platform/win/fast/forms/onselect-textarea-expected.txt:
* LayoutTests/platform/win/fast/forms/option-script-expected.txt:
* LayoutTests/platform/win/fast/forms/option-strip-whitespace-expected.txt:
* LayoutTests/platform/win/fast/forms/option-text-clip-expected.txt:
* LayoutTests/platform/win/fast/forms/plaintext-mode-2-expected.txt:
* LayoutTests/platform/win/fast/forms/select-align-expected.txt:
* LayoutTests/platform/win/fast/forms/select-background-none-expected.txt:
* LayoutTests/platform/win/fast/forms/select-baseline-expected.txt:
* LayoutTests/platform/win/fast/forms/select-block-background-expected.txt:
* LayoutTests/platform/win/fast/forms/select-change-listbox-size-expected.txt:
* LayoutTests/platform/win/fast/forms/select-change-listbox-to-popup-expected.txt:
* LayoutTests/platform/win/fast/forms/select-change-popup-to-listbox-expected.txt:
* LayoutTests/platform/win/fast/forms/select-dirty-parent-pref-widths-expected.txt:
* LayoutTests/platform/win/fast/forms/select-disabled-appearance-expected.txt:
* LayoutTests/platform/win/fast/forms/select-element-focus-ring-expected.txt:
* LayoutTests/platform/win/fast/forms/select-empty-option-height-expected.txt:
* LayoutTests/platform/win/fast/forms/select-initial-position-expected.txt:
* LayoutTests/platform/win/fast/forms/select-item-background-clip-expected.txt:
* LayoutTests/platform/win/fast/forms/select-list-box-with-height-expected.txt:
* LayoutTests/platform/win/fast/forms/select-listbox-multiple-no-focusring-expected.txt:
* LayoutTests/platform/win/fast/forms/select-overflow-scroll-expected.txt:
* LayoutTests/platform/win/fast/forms/select-overflow-scroll-inherited-expected.txt:
* LayoutTests/platform/win/fast/forms/select-selected-expected.txt:
* LayoutTests/platform/win/fast/forms/select-style-expected.txt:
* LayoutTests/platform/win/fast/forms/select/optgroup-rendering-expected.txt:
* LayoutTests/platform/win/fast/forms/selectlist-minsize-expected.txt:
* LayoutTests/platform/win/fast/forms/stuff-on-my-optgroup-expected.txt:
* LayoutTests/platform/win/fast/forms/textAreaLineHeight-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-align-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-1-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-placeholder-visibility-2-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-scrollbar-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-scrolled-type-expected.txt:
* LayoutTests/platform/win/fast/forms/textarea-setinnerhtml-expected.txt:
* LayoutTests/platform/win/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/win/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/win/fast/invalid/014-expected.txt:
* LayoutTests/platform/win/fast/overflow/overflow-x-y-expected.txt:
* LayoutTests/platform/win/fast/overflow/scroll-nested-positioned-layer-in-overflow-expected.txt:
* LayoutTests/platform/win/fast/overflow/scrollRevealButton-expected.txt:
* LayoutTests/platform/win/fast/parser/document-write-option-expected.txt:
* LayoutTests/platform/win/fast/parser/entity-comment-in-textarea-expected.txt:
* LayoutTests/platform/win/fast/repaint/select-option-background-color-expected.txt:
* LayoutTests/platform/win/fast/replaced/three-selects-break-expected.txt:
* LayoutTests/platform/win/fast/replaced/width100percent-button-expected.txt:
* LayoutTests/platform/win/fast/replaced/width100percent-menulist-expected.txt:
* LayoutTests/platform/win/fast/selectors/064-expected.txt:
* LayoutTests/platform/win/fast/table/003-expected.txt:
* LayoutTests/platform/win/fast/table/append-cells2-expected.txt:
* LayoutTests/platform/win/fast/table/remove-td-display-none-expected.txt:
* LayoutTests/platform/win/fast/table/text-field-baseline-expected.txt:
* LayoutTests/platform/win/fast/text/international/bidi-listbox-atsui-expected.txt:
* LayoutTests/platform/win/fast/text/international/bidi-listbox-expected.txt:
* LayoutTests/platform/win/fast/text/international/bidi-menulist-expected.txt:
* LayoutTests/platform/win/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt:
* LayoutTests/platform/win/fast/text/international/unicode-bidi-plaintext-in-textarea-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/45621-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug194024-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug26178-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug29326-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug30559-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug44505-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug51727-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug52505-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug52506-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug59354-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug60749-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug68912-expected.txt:
* LayoutTests/platform/win/tables/mozilla/bugs/bug92647-2-expected.txt:
* LayoutTests/platform/win/tables/mozilla/collapsing_borders/bug41262-4-expected.txt:
* LayoutTests/platform/win/tables/mozilla/core/margins-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug45621-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug58402-2-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-5-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/collapsing_borders/bug41262-6-expected.txt:
* LayoutTests/platform/win/transforms/2d/zoom-menulist-expected.txt:
* LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-expected.txt:
* LayoutTests/tiled-drawing/scrolling/fast-scroll-select-latched-select-with-handler-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST):
</pre>