### PR TITLE
Add fred-wang github account to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2546,6 +2546,7 @@
          "fred.wang@free.fr",
          "fwang@igalia.com"
       ],
+      "github" : "fred-wang",
       "name" : "Fr\u00e9d\u00e9ric Wang",
       "nicks" : [
          "fredw"


### PR DESCRIPTION
#### df70de87f607080eaf97f8eaa90688c12ba904ea
<pre>
Add fred-wang github account to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=241219">https://bugs.webkit.org/show_bug.cgi?id=241219</a>

Reviewed by Tim Nguyen.

* metadata/contributors.json: Add my github account.

Canonical link: <a href="https://commits.webkit.org/251218@main">https://commits.webkit.org/251218@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295127">https://svn.webkit.org/repository/webkit/trunk@295127</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
