### PR TITLE
Crash UIProcess if taking a process assertion takes too much time

### DIFF
--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/Timer.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/ProcessID.h>
@@ -88,6 +89,7 @@ protected:
     void acquireSync();
 
 #if PLATFORM(IOS_FAMILY)
+    void acquireTimerFired();
     void processAssertionWillBeInvalidated();
     virtual void processAssertionWasInvalidated();
 #endif
@@ -100,6 +102,7 @@ private:
     RetainPtr<RBSAssertion> m_rbsAssertion;
     RetainPtr<WKRBSAssertionDelegate> m_delegate;
     bool m_wasInvalidated { false };
+    WebCore::Timer m_acquireTimer;
 #endif
     Function<void()> m_prepareForInvalidationHandler;
     Function<void()> m_invalidationHandler;


### PR DESCRIPTION
Crash UIProcess if taking a process assertion takes too much time
https://bugs.webkit.org/show_bug.cgi?id=241222
rdar://problem/94280886

Reviewed by NOBODY (OOPS!).

Crashing will help us diagnose whether we sometimes get stuck while taking a process assertion.
We only crash after a timer kicks in, current time out delay is set to 2 seconds.
This might for instance help rdar://92538915.

* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ios/ProcessAssertionIOS.mm: