### PR TITLE
Web Inspector: reference page links don't open externally when inspecting that reference page

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -36,6 +36,7 @@ extern NSString *NSTextCheckingSuppressInitialCapitalizationKey;
 
 @interface NSSpellChecker ()
 
+- (NSString *)languageForWordRange:(NSRange)range inString:(NSString *)string orthography:(NSOrthography *)orthography;
 - (BOOL)deletesAutospaceBeforeString:(NSString *)string language:(NSString *)language;
 - (void)_preflightChosenSpellServer;
 

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -1060,7 +1060,7 @@ WI.updateFindString = function(findString)
     return true;
 };
 
-WI.handlePossibleLinkClick = function(event, frame, options = {})
+WI.handlePossibleLinkClick = function(event, options = {})
 {
     let anchorElement = event.target.closest("a");
     if (!anchorElement || !anchorElement.href)
@@ -1075,7 +1075,7 @@ WI.handlePossibleLinkClick = function(event, frame, options = {})
     event.preventDefault();
     event.stopPropagation();
 
-    WI.openURL(anchorElement.href, frame, {
+    WI.openURL(anchorElement.href, {
         ...options,
         lineNumber: anchorElement.lineNumber,
         ignoreSearchTab: !WI.isShowingSearchTab(),
@@ -1084,19 +1084,17 @@ WI.handlePossibleLinkClick = function(event, frame, options = {})
     return true;
 };
 
-WI.openURL = function(url, frame, options = {})
+WI.openURL = function(url, {alwaysOpenExternally, frame, ...options} = {})
 {
     console.assert(url);
     if (!url)
         return;
 
-    console.assert(typeof options.lineNumber === "undefined" || typeof options.lineNumber === "number", "lineNumber should be a number.");
-
     // If alwaysOpenExternally is not defined, base it off the command/meta key for the current event.
-    if (options.alwaysOpenExternally === undefined || options.alwaysOpenExternally === null)
-        options.alwaysOpenExternally = window.event ? window.event.metaKey : false;
+    if (alwaysOpenExternally === undefined || alwaysOpenExternally === null)
+        alwaysOpenExternally = window.event?.metaKey ?? false;
 
-    if (options.alwaysOpenExternally) {
+    if (alwaysOpenExternally) {
         InspectorFrontendHost.openURLExternally(url);
         return;
     }
@@ -1119,6 +1117,8 @@ WI.openURL = function(url, frame, options = {})
         // Context menu selections may go through this code path; don't clobber the previously-set hint.
         if (!options.initiatorHint)
             options.initiatorHint = WI.TabBrowser.TabNavigationInitiator.LinkClick;
+
+        console.assert(typeof options.lineNumber === "undefined" || typeof options.lineNumber === "number");
         let positionToReveal = new WI.SourceCodePosition(options.lineNumber, 0);
         WI.showSourceCode(resource, {...options, positionToReveal});
         return;

--- a/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
+++ b/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
@@ -94,6 +94,7 @@ WI.ReferencePage.TimelinesTab.LayoutAndRenderingTimeline = new WI.ReferencePage(
 WI.ReferencePage.TimelinesTab.MediaAndAnimationsTimeline = new WI.ReferencePage(WI.ReferencePage.TimelinesTab, {topic: "media-animations-timeline"});
 WI.ReferencePage.TimelinesTab.MemoryTimeline = new WI.ReferencePage(WI.ReferencePage.TimelinesTab, {topic: "memory-timeline"});
 WI.ReferencePage.TimelinesTab.NetworkRequestsTimeline = new WI.ReferencePage(WI.ReferencePage.TimelinesTab, {topic: "network-timeline"});
+WI.ReferencePage.TimelinesTab.ScreenshotsTimeline = new WI.ReferencePage(WI.ReferencePage.TimelinesTab, {topic: "screenshots-timeline"});
 
 WI.ReferencePage.URLBreakpoints = new WI.ReferencePage("url-breakpoints");
 WI.ReferencePage.URLBreakpoints.Configuration = new WI.ReferencePage(WI.ReferencePage.URLBreakpoints, {topic: "configuration"});

--- a/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
+++ b/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
@@ -56,6 +56,12 @@ WI.ReferencePage = class ReferencePage {
         link.className = "reference-page-link";
         link.href = link.title = url;
         link.textContent = "?";
+        link.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            WI.openURL(link.href, {alwaysOpenExternally: true});
+        });
 
         return wrapper;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
@@ -233,13 +233,12 @@ WI.appendContextMenuItemsForURL = function(contextMenu, url, options = {})
         else if (options.sourceCode)
             WI.showSourceCode(options.sourceCode, options);
         else
-            WI.openURL(url, options.frame, options);
+            WI.openURL(url, options);
     }
 
     if (!url.startsWith("javascript:") && !url.startsWith("data:")) {
         contextMenu.appendItem(WI.UIString("Open in New Window", "Open in New Window @ Context Menu Item", "Context menu item for opening the target item in a new window."), () => {
-            const frame = null;
-            WI.openURL(url, frame, {alwaysOpenExternally: true});
+            WI.openURL(url, {alwaysOpenExternally: true});
         });
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMDetailsSidebarPanel.js
@@ -101,18 +101,17 @@ WI.DOMDetailsSidebarPanel = class DOMDetailsSidebarPanel extends WI.DetailsSideb
 
     _mouseWasClicked(event)
     {
-        let parentFrame = null;
+        let options = {
+            ignoreNetworkTab: true,
+            ignoreSearchTab: true,
+        };
 
         if (this._domNode && this._domNode.ownerDocument) {
             let mainResource = WI.networkManager.resourcesForURL(this._domNode.ownerDocument.documentURL).firstValue;
             if (mainResource)
-                parentFrame = mainResource.parentFrame;
+                options.frame = mainResource.parentFrame;
         }
 
-        const options = {
-            ignoreNetworkTab: true,
-            ignoreSearchTab: true,
-        };
-        WI.handlePossibleLinkClick(event, parentFrame, options);
+        WI.handlePossibleLinkClick(event, options);
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -583,12 +583,13 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
             // to see if the command key is down like it normally would. So we need to do that check
             // before calling WI.openURL.
             const options = {
-                alwaysOpenExternally: event ? event.metaKey : false,
+                alwaysOpenExternally: event?.metaKey ?? false,
+                frame: this._frame,
                 lineNumber: anchorElement.lineNumber,
                 ignoreNetworkTab: true,
                 ignoreSearchTab: true,
             };
-            WI.openURL(anchorElement.href, this._frame, options);
+            WI.openURL(anchorElement.href, options);
         }
 
         // Start a timeout since this is a single click, if the timeout is canceled before it fires,

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceContentView.js
@@ -436,7 +436,7 @@ WI.ResourceContentView = class ResourceContentView extends WI.ContentView
 
     _mouseWasClicked(event)
     {
-        WI.handlePossibleLinkClick(event, this._resource.parentFrame);
+        WI.handlePossibleLinkClick(event, {frame: this._resource.parentFrame});
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineView.css
@@ -23,19 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.timeline-view.screenshots {
+.timeline-view.screenshots > .content-view {
+    position: absolute;
+    inset: 0;
     text-align: center;
     white-space: nowrap; 
     overflow-x: auto;
     background-color: hsl(0, 0%, 90%);
 }
 
-.timeline-view.screenshots > .spacer {
+.timeline-view.screenshots > .content-view > .spacer {
     display: inline-block;
     height: 50%;
 }
 
-.timeline-view.screenshots > img {
+.timeline-view.screenshots > .content-view > img {
     max-width: calc(80% - (var(--margin) * 2));
     max-height: calc(100% - (var(--margin) * 2));
     margin: var(--margin);
@@ -46,16 +48,16 @@
     --shadow: 1px 2px 6px rgba(0, 0, 0, 0.58);
 }
 
-.timeline-view.screenshots > img + img {
+.timeline-view.screenshots > .content-view > img + img {
     margin-inline-start: 0;
 }
 
-.timeline-view.screenshots > img.selected {
+.timeline-view.screenshots > .content-view > img.selected {
     box-shadow: 0 0 0 2px var(--glyph-color-active), var(--shadow);
 }
 
 @media (prefers-color-scheme: dark) {
-    .timeline-view.screenshots {
+    .timeline-view.screenshots > .content-view {
         background-color: hsl(0, 0%, 14%);
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineView.js
@@ -55,6 +55,15 @@ WI.ScreenshotsTimelineView = class ScreenshotsTimelineView extends WI.TimelineVi
 
     get showsFilterBar() { return false; }
 
+    initialLayout()
+    {
+        super.initialLayout();
+
+        this._scrollView = new WI.ContentView;
+
+        this.addSubview(this._scrollView);
+    }
+
     layout()
     {
         if (this.layoutReason === WI.View.LayoutReason.Resize)
@@ -65,12 +74,12 @@ WI.ScreenshotsTimelineView = class ScreenshotsTimelineView extends WI.TimelineVi
         if (this.hidden)
             return;
 
-        this.element.removeChildren();
+        this._scrollView.element.removeChildren();
 
         let selectedElement = null;
 
         for (let record of this._visibleRecords()) {
-            this.element.appendChild(this._imageElementForRecord.getOrInitialize(record, () => {
+            this._scrollView.element.appendChild(this._imageElementForRecord.getOrInitialize(record, () => {
                 let imageElement = document.createElement("img");
 
                 imageElement.hidden = true;
@@ -96,11 +105,11 @@ WI.ScreenshotsTimelineView = class ScreenshotsTimelineView extends WI.TimelineVi
             selectedElement.scrollIntoView({inline: "center"});
         }
 
-        if (this.element.childNodes.length) {
-            let spacer = this.element.appendChild(document.createElement("div"));
+        if (this._scrollView.element.childNodes.length) {
+            let spacer = this._scrollView.element.appendChild(document.createElement("div"));
             spacer.className = "spacer";
         } else
-            this.element.appendChild(WI.createMessageTextView(WI.UIString("No screenshots", "No screenshots @ Screenshots Timeline", "Placeholder text shown when there are no images to display in the Screenshots timeline.")));
+            this._scrollView.element.appendChild(WI.createMessageTextView(WI.UIString("No screenshots", "No screenshots @ Screenshots Timeline", "Placeholder text shown when there are no images to display in the Screenshots timeline.")));
     }
 
     selectRecord(record)
@@ -151,3 +160,5 @@ WI.ScreenshotsTimelineView = class ScreenshotsTimelineView extends WI.TimelineVi
         return visibleRecords;
     }
 };
+
+WI.ScreenshotsTimelineView.ReferencePage = WI.ReferencePage.TimelinesTab.ScreenshotsTimeline;

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineView.css
@@ -48,5 +48,6 @@
 .timeline-view > .reference-page-link-container {
     position: absolute;
     bottom: 6px;
+    z-index: 1;
     inset-inline-end: 6px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineView.js
@@ -297,8 +297,7 @@ WI.TimelineView = class TimelineView extends WI.ContentView
     {
         super.initialLayout();
 
-        if (this.constructor.ReferencePage)
-            this.element.appendChild(this.constructor.ReferencePage.createLinkElement());
+        this.element.appendChild(this.constructor.ReferencePage.createLinkElement());
     }
 
     filterDidChange()

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -38,11 +38,6 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringView.h>
 
-@interface NSSpellChecker (WebNSSpellCheckerDetails)
-- (NSString *)languageForWordRange:(NSRange)range inString:(NSString *)string orthography:(NSOrthography *)orthography;
-@end
-
-
 static NSString* const WebAutomaticSpellingCorrectionEnabled = @"WebAutomaticSpellingCorrectionEnabled";
 static NSString* const WebContinuousSpellCheckingEnabled = @"WebContinuousSpellCheckingEnabled";
 static NSString* const WebGrammarCheckingEnabled = @"WebGrammarCheckingEnabled";

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -99,12 +99,6 @@ using namespace WebCore;
 
 using namespace HTMLNames;
 
-#if !PLATFORM(IOS_FAMILY)
-@interface NSSpellChecker (WebNSSpellCheckerDetails)
-- (NSString *)languageForWordRange:(NSRange)range inString:(NSString *)string orthography:(NSOrthography *)orthography;
-@end
-#endif
-
 // FIXME: Seems likely we can get rid of this legacy code for watchOS and tvOS.
 #if PLATFORM(WATCHOS) || PLATFORM(APPLETV)
 @interface NSAttributedString (WebNSAttributedStringDetails)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -386,10 +386,6 @@ SOFT_LINK_CLASS(AVKit, AVTouchBarScrubber)
 
 #if !PLATFORM(IOS_FAMILY)
 
-@interface NSSpellChecker (WebNSSpellCheckerDetails)
-- (void)_preflightChosenSpellServer;
-@end
-
 @interface NSView (WebNSViewDetails)
 - (NSView *)_hitTest:(NSPoint *)aPoint dragTypes:(NSSet *)types;
 - (void)_autoscrollForDraggingInfo:(id)dragInfo timeDelta:(NSTimeInterval)repeatDelta;


### PR DESCRIPTION
#### 2e79d84d40f3bee72306ac8ace6af5fd8b0a5d8b
<pre>
Web Inspector: reference page links don&apos;t open externally when inspecting that reference page
<a href="https://bugs.webkit.org/show_bug.cgi?id=241246">https://bugs.webkit.org/show_bug.cgi?id=241246</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Base/ReferencePage.js:
(WI.ReferencePage.prototype.createLinkElement):

* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.handlePossibleLinkClick):
(WI.openURL):
* Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js:
(WI.appendContextMenuItemsForURL):
* Source/WebInspectorUI/UserInterface/Views/DOMDetailsSidebarPanel.js:
(WI.DOMDetailsSidebarPanel.prototype._mouseWasClicked):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._mouseWasClicked.followLink):
* Source/WebInspectorUI/UserInterface/Views/ResourceContentView.js:
(WI.ResourceContentView.prototype._mouseWasClicked):
Drive-by: Refactor `WI.openURL` (and `WI.handlePossibleLinkClick`) to have `frame` be in `options`.

Canonical link: <a href="https://commits.webkit.org/251247@main">https://commits.webkit.org/251247@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295161">https://svn.webkit.org/repository/webkit/trunk@295161</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
