### PR TITLE
[Gardening]: [ Windows EWS ] webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html is a flaky image failure

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -5061,3 +5061,5 @@ fast/css3-text/css3-text-decoration/repaint/underline-outside-of-layout-rect-rem
 fast/css3-text/css3-text-decoration/repaint/underline-outside-of-layout-rect.html [ ImageOnlyFailure ]
 fast/css3-text/css3-text-decoration/text-decoration-offset-repaint.html [ ImageOnlyFailure ]
 fast/css3-text/css3-text-decoration/text-decoration-thickness-repaint.html [ ImageOnlyFailure ]
+
+webkit.org/b/241268 webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### ac4650a25a130ae4971c4e8c531937728406da65
<pre>
[Gardening]: [ Windows EWS ] webanimations/accelerated-transform-animation-from-scale-zero-and-implicit-to-kefyrame.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241268">https://bugs.webkit.org/show_bug.cgi?id=241268</a>
&lt;rdar://94347232 &gt;

Unreviewed test gardening.

* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251269@main">https://commits.webkit.org/251269@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295212">https://svn.webkit.org/repository/webkit/trunk@295212</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
