### PR TITLE
[Gardening]: [ macOS Debug wk2 EWS ] fast/animation/request-animation-frame-throttling-detached-iframe.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1430,7 +1430,6 @@ webkit.org/b/227639 [ BigSur Release ] fast/history/visited-href-mutation.html [
 [ Monterey arm64 ] platform/mac/fast/overflow/overflow-scrollbar-hit-test.html [ Failure Crash ]
 
 # rdar://80333935 (REGRESSION: [ Monterey wk2 arm64 ] fast/animation/request-animation-frame-throttling-detached-iframe.html and request-animation-frame-throttling-lowPowerMode.html failing)
-[ Monterey arm64 ] fast/animation/request-animation-frame-throttling-detached-iframe.html [ Failure ]
 [ Monterey arm64 ] fast/animation/request-animation-frame-throttling-lowPowerMode.html [ Failure ]
 [ Monterey arm64 ] fast/animation/css-animation-throttling-lowPowerMode.html [ Failure ]
 
@@ -1720,3 +1719,5 @@ webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/w
 webkit.org/b/241191 [ Monterey Debug ] webgl/1.0.3/conformance/attribs/gl-vertexattribpointer-offsets.html [ Pass Timeout ]
 
 webkit.org/b/241265 [ Debug ] imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html [ Pass Crash ]
+
+webkit.org/b/241283 fast/animation/request-animation-frame-throttling-detached-iframe.html [ Pass Failure ]


### PR DESCRIPTION
#### 248a7910c2ce80ba07881867681d82e3f408747f
<pre>
[Gardening]: [ macOS Debug wk2 EWS ] fast/animation/request-animation-frame-throttling-detached-iframe.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241283">https://bugs.webkit.org/show_bug.cgi?id=241283</a>
&lt;rdar://94364006 &gt;

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251283@main">https://commits.webkit.org/251283@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295228">https://svn.webkit.org/repository/webkit/trunk@295228</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
