### PR TITLE
[Gardening]: [ macOS Debug wk2 EWS ]fast/animation/request-animation-frame-throttling-lowPowerMode.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1430,7 +1430,7 @@ webkit.org/b/227639 [ BigSur Release ] fast/history/visited-href-mutation.html [
 [ Monterey arm64 ] platform/mac/fast/overflow/overflow-scrollbar-hit-test.html [ Failure Crash ]
 
 # rdar://80333935 (REGRESSION: [ Monterey wk2 arm64 ] fast/animation/request-animation-frame-throttling-detached-iframe.html and request-animation-frame-throttling-lowPowerMode.html failing)
-[ Monterey arm64 ] fast/animation/request-animation-frame-throttling-lowPowerMode.html [ Failure ]
+[ arm64 ] fast/animation/request-animation-frame-throttling-lowPowerMode.html [ Failure ]
 [ Monterey arm64 ] fast/animation/css-animation-throttling-lowPowerMode.html [ Failure ]
 
 # Behavior of navigator-language-ru changed in Monterey


### PR DESCRIPTION
#### abcfa41ee0a7d8e8cf8a8283adea809a5cc4a8fe
<pre>
[Gardening]: [ macOS Debug wk2 EWS ]fast/animation/request-animation-frame-throttling-lowPowerMode.html is a flaky failure
rdar://80333935

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:
</pre>