### PR TITLE
Define _GNU_SOURCE

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -36,6 +36,8 @@
 #include "pas_local_allocator_result.h"
 #include "pas_segregated_page_config_kind_and_role.h"
 #include "pas_utils.h"
+
+#define _GNU_SOURCE
 #include <pthread.h>
 
 #if defined(__has_include) && __has_include(<pthread/private.h>)


### PR DESCRIPTION
Reviewed by NOBODY (OOPS!).

* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:

This is needed for using pthread_getname_np, since this function is a
nonstandard GNU extension.