### PR TITLE
Speed up JSON serialization by not calling appendQuotedJSONString in the normal case

### DIFF
--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -17,49 +17,13 @@
 
 namespace WTF {
 
-// This table driven escaping is ported from SpiderMonkey.
-static const constexpr LChar escapedFormsForJSON[0x100] = {
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    'b', 't', 'n', 'u', 'f', 'r', 'u', 'u',
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    0,   0,  '\"', 0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,  '\\', 0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-};
-
 template<typename OutputCharacterType, typename InputCharacterType>
 ALWAYS_INLINE static void appendQuotedJSONStringInternal(OutputCharacterType*& output, const InputCharacterType* input, unsigned length)
 {
     for (auto* end = input + length; input != end; ++input) {
         auto character = *input;
         if (LIKELY(character <= 0xFF)) {
-            auto escaped = escapedFormsForJSON[character];
+            auto escaped = StringImpl::escapedFormsForJSON[character];
             if (LIKELY(!escaped)) {
                 *output++ = character;
                 continue;


### PR DESCRIPTION
#### 96254ba2d1c1428cb2730c63fc503d35971161e2
<pre>
Speed up JSON serialization by not calling appendQuotedJSONString in the normal case
<a href="https://bugs.webkit.org/show_bug.cgi?id=241306">https://bugs.webkit.org/show_bug.cgi?id=241306</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::startNewLine const): Tweak coding style, use a single call to
StringBuilder::append.
(JSC::Stringifier::Holder::appendNextProperty): Add a case that does not call
appendQuotedJSONString. Also eliminated a little reference count churn.

* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::appendQuotedJSONStringInternal): Update since the escapedFormsForJSON
table moved into StringImpl.h so it can be used in other code including constexpr.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::computeCharacterClassification): Added. Figures out if the
string has any characters that need escaping for JSON and stores the answer
in the string&apos;s flags.

* Source/WTF/wtf/text/StringImpl.h: Removed unused s_flagStringKindCount,
s_hashZeroValue, s_hashMaskStringKind, flagIsSymbol, and maskStringKind.
Added s_hashMaskCharactersClassification, CharactersClassification,
CharactersUnknown, CharactersNoEscapingNeededForJSONQuoting,
CharactersEscapingNeededForJSONQuoting, computeCharacterClassification,
needsEscapingForQuotedJSONString, classifyCharacters, and escapedFormsForJSON.
Changed StaticStringImpl constructors to compute the classification.
</pre>