### PR TITLE
[Linux] Fix and improve format handling in DMABufFormat, TextureMapperPlatformLayerProxyDMABuf

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
@@ -271,7 +271,7 @@ inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::UYVY>()
 template<>
 inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::VYUY>()
 {
-    return DMABufFormat::instantiate<FourCC::YVYU,
+    return DMABufFormat::instantiate<FourCC::VYUY,
         PlaneDefinition<FourCC::GR88, 0, 0>>();
 }
 
@@ -285,7 +285,7 @@ inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::VUYA>()
 template<>
 inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::AYUV>()
 {
-    return DMABufFormat::instantiate<FourCC::VUYA,
+    return DMABufFormat::instantiate<FourCC::AYUV,
         PlaneDefinition<FourCC::ABGR8888, 0, 0>>();
 }
 
@@ -318,54 +318,38 @@ inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::Y42B>()
 
 inline DMABufFormat DMABufFormat::create(uint32_t fourccValue)
 {
+#define CREATE_FORMAT_FOR_FOURCC(FourCCValue) \
+    case uint32_t(FourCC::FourCCValue): \
+        return create<FourCC::FourCCValue>();
+
     switch (fourccValue) {
-    case uint32_t(FourCC::XRGB8888):
-        return create<FourCC::XRGB8888>();
-    case uint32_t(FourCC::XBGR8888):
-        return create<FourCC::XBGR8888>();
-    case uint32_t(FourCC::RGBX8888):
-        return create<FourCC::RGBX8888>();
-    case uint32_t(FourCC::BGRX8888):
-        return create<FourCC::BGRX8888>();
-    case uint32_t(FourCC::ARGB8888):
-        return create<FourCC::ARGB8888>();
-    case uint32_t(FourCC::ABGR8888):
-        return create<FourCC::ABGR8888>();
-    case uint32_t(FourCC::RGBA8888):
-        return create<FourCC::RGBA8888>();
-    case uint32_t(FourCC::BGRA8888):
-        return create<FourCC::BGRA8888>();
-    case uint32_t(FourCC::I420):
-        return create<FourCC::I420>();
-    case uint32_t(FourCC::YV12):
-        return create<FourCC::YV12>();
-    case uint32_t(FourCC::A420):
-        return create<FourCC::A420>();
-    case uint32_t(FourCC::NV12):
-        return create<FourCC::NV12>();
-    case uint32_t(FourCC::NV21):
-        return create<FourCC::NV21>();
-    case uint32_t(FourCC::YUY2):
-        return create<FourCC::YUY2>();
-    case uint32_t(FourCC::YVYU):
-        return create<FourCC::YVYU>();
-    case uint32_t(FourCC::UYVY):
-        return create<FourCC::UYVY>();
-    case uint32_t(FourCC::VYUY):
-        return create<FourCC::UYVY>();
-    case uint32_t(FourCC::VUYA):
-        return create<FourCC::VUYA>();
-    case uint32_t(FourCC::AYUV):
-        return create<FourCC::AYUV>();
-    case uint32_t(FourCC::Y444):
-        return create<FourCC::Y444>();
-    case uint32_t(FourCC::Y41B):
-        return create<FourCC::Y41B>();
-    case uint32_t(FourCC::Y42B):
-        return create<FourCC::Y42B>();
+    CREATE_FORMAT_FOR_FOURCC(XRGB8888);
+    CREATE_FORMAT_FOR_FOURCC(XBGR8888);
+    CREATE_FORMAT_FOR_FOURCC(RGBX8888);
+    CREATE_FORMAT_FOR_FOURCC(BGRX8888);
+    CREATE_FORMAT_FOR_FOURCC(ARGB8888);
+    CREATE_FORMAT_FOR_FOURCC(ABGR8888);
+    CREATE_FORMAT_FOR_FOURCC(RGBA8888);
+    CREATE_FORMAT_FOR_FOURCC(BGRA8888);
+    CREATE_FORMAT_FOR_FOURCC(I420);
+    CREATE_FORMAT_FOR_FOURCC(YV12);
+    CREATE_FORMAT_FOR_FOURCC(A420);
+    CREATE_FORMAT_FOR_FOURCC(NV12);
+    CREATE_FORMAT_FOR_FOURCC(NV21);
+    CREATE_FORMAT_FOR_FOURCC(YUY2);
+    CREATE_FORMAT_FOR_FOURCC(YVYU);
+    CREATE_FORMAT_FOR_FOURCC(UYVY);
+    CREATE_FORMAT_FOR_FOURCC(VYUY);
+    CREATE_FORMAT_FOR_FOURCC(VUYA);
+    CREATE_FORMAT_FOR_FOURCC(AYUV);
+    CREATE_FORMAT_FOR_FOURCC(Y444);
+    CREATE_FORMAT_FOR_FOURCC(Y41B);
+    CREATE_FORMAT_FOR_FOURCC(Y42B);
     default:
         break;
     }
+
+#undef CREATE_FORMAT_FOR_FOURCC
 
     return { };
 }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -279,9 +279,11 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
             yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::YUY2:
-    case DMABufFormat::FourCC::UYVY:
-    case DMABufFormat::FourCC::VUYA:
     case DMABufFormat::FourCC::YVYU:
+    case DMABufFormat::FourCC::UYVY:
+    case DMABufFormat::FourCC::VYUY:
+    case DMABufFormat::FourCC::VUYA:
+    case DMABufFormat::FourCC::AYUV:
         texmapGL.drawTexturePackedYUV(data.texture[0],
             yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;


### PR DESCRIPTION
#### f497a2f081105840e363b473cda009358a95e3db
<pre>
[Linux] Fix and improve format handling in DMABufFormat, TextureMapperPlatformLayerProxyDMABuf
<a href="https://bugs.webkit.org/show_bug.cgi?id=241326">https://bugs.webkit.org/show_bug.cgi?id=241326</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-06-06
Reviewed by Miguel Gomez.

In the DMABufFormat header, VYUY and AYUV format definitions are fixed to use
the correct FourCC values. In DMABufFormat::create(), a macro is used to map
FourCC values to corresponding DMABufFormat definitions.

In TextureMapperPlatformLayerProxyDMABuf, missing packed-YUV formats are
added to the switch statement, and properly ordered.

* Source/WebCore/platform/graphics/gbm/DMABufFormat.h:
(WebCore::DMABufFormat::create&lt;DMABufFormat::FourCC::VYUY &gt;):
(WebCore::DMABufFormat::create&lt;DMABufFormat::FourCC::AYUV &gt;):
(WebCore::DMABufFormat::create):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/251326@main">https://commits.webkit.org/251326@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295280">https://svn.webkit.org/repository/webkit/trunk@295280</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
