### PR TITLE
[build.webkit.org] Add WebKitGTK and WPE bots for Ubuntu 22.04

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -47,7 +47,7 @@ const NumberOfWasmArguments = NumberOfWasmArgumentJSRs + NumberOfWasmArgumentFPR
 # All callee saves must match the definition in WasmCallee.cpp
 
 # These must match the definition in WasmMemoryInformation.cpp
-if X86_64 or ARM64 or ARM64E
+if X86_64 or ARM64 or ARM64E or RISCV64
     const wasmInstance = csr0
     const memoryBase = csr3
     const boundsCheckingSize = csr4

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -41,7 +41,7 @@ const PinnedRegisterInfo& PinnedRegisterInfo::get()
         unsigned numberOfPinnedRegisters = 2;
         if (!Context::useFastTLS())
             ++numberOfPinnedRegisters;
-#if CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
         GPRReg baseMemoryPointer = GPRInfo::regCS3;
         GPRReg boundsCheckingSizeRegister = GPRInfo::regCS4;
 #elif CPU(ARM)

--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -119,6 +119,7 @@
                     { "name": "gtk-linux-bot-18", "platform": "gtk" },
                     { "name": "gtk-linux-bot-19", "platform": "gtk" },
                     { "name": "gtk-linux-bot-20", "platform": "gtk" },
+                    { "name": "gtk-linux-bot-21", "platform": "gtk" },
 
                     { "name": "jsconly-linux-igalia-bot-1", "platform": "jsc-only" },
                     { "name": "jsconly-linux-igalia-bot-2", "platform": "jsc-only" },
@@ -135,7 +136,8 @@
                     { "name": "wpe-linux-bot-7", "platform": "wpe" },
                     { "name": "wpe-linux-bot-8", "platform": "wpe" },
                     { "name": "wpe-linux-bot-9", "platform": "wpe" },
-                    { "name": "wpe-linux-bot-10", "platform": "wpe" }
+                    { "name": "wpe-linux-bot-10", "platform": "wpe" },
+                    { "name": "wpe-linux-bot-11", "platform": "wpe" }
                   ],
 
     "builders":   [
@@ -467,10 +469,16 @@
                       "workernames": ["gtk-linux-bot-10"]
                     },
                     {
-                      "name": "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                      "name": "GTK-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "BuildFactory",
                       "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                       "additionalArguments": ["--no-experimental-features"],
                       "workernames": ["gtk-linux-bot-11"]
+                    },
+                    {
+                      "name": "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                      "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
+                      "additionalArguments": ["--no-experimental-features"],
+                      "workernames": ["gtk-linux-bot-21"]
                     },
                     {
                       "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
@@ -613,10 +621,16 @@
                       "workernames": ["wpe-linux-bot-9"]
                     },
                     {
-                      "name": "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                      "name": "WPE-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "BuildFactory",
                       "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                       "additionalArguments": ["--no-experimental-features"],
                       "workernames": ["wpe-linux-bot-10"]
+                    },
+                    {
+                      "name": "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                      "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
+                      "additionalArguments": ["--no-experimental-features"],
+                      "workernames": ["wpe-linux-bot-11"]
                     }
                   ],
 
@@ -624,7 +638,9 @@
                       "builderNames": ["GTK-Linux-64-bit-Release-Build", "GTK-Linux-64-bit-Debug-Build",
                                        "GTK-Linux-64-bit-Release-Clang",
                                        "GTK-Linux-64-bit-Release-Debian-Stable-Build",
+                                       "GTK-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build",
+                                       "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                        "JSCOnly-Linux-AArch64-Release",
                                        "JSCOnly-Linux-ARMv7-Thumb2-Release", "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release",

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1235,6 +1235,17 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
+        'GTK-Linux-64-bit-Release-Ubuntu-2004-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'compile-webkit'
+        ],
         'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804': [
             'configure-build',
             'configuration',
@@ -1633,7 +1644,19 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'jhbuild',
             'compile-webkit'
-        ]
+        ],
+        'WPE-Linux-64-bit-Release-Ubuntu-2004-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'compile-webkit'
+        ],
     }
 
     def setUp(self):

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import subprocess
+import shutil
 import sys
 import time
 
@@ -66,7 +67,9 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
                 self._server_port = connections[0].laddr[1]
         except ImportError:
             try:
-                output = subprocess.check_output(['/usr/sbin/lsof', '-a', '-P', '-iTCP', '-sTCP:LISTEN', '-p', str(self._server_process.pid)])
+                # lsof on Linux is shipped on /usr/bin typically, but on Mac on /usr/sbin
+                lsof_path = shutil.which('lsof') or '/usr/sbin/lsof'
+                output = subprocess.check_output([lsof_path, '-a', '-P', '-iTCP', '-sTCP:LISTEN', '-p', str(self._server_process.pid)])
                 self._server_port = int(re.search(r'TCP .*:(\d+) \(LISTEN\)', str(output)).group(1))
             except Exception as error:
                 _log.info('Error: %s' % error)

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -2,12 +2,23 @@
 
 # If the package $1 is available, prints it. Otherwise prints $2.
 # Useful for handling when a package is renamed on new versions of Debian/Ubuntu.
-function aptIfElse {
+aptIfElse() {
     if apt-cache show $1 &>/dev/null; then
         echo $1
     else
         echo $2
     fi
+}
+
+aptIfExists() {
+    local ret=$(apt show "$1" 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+        return
+    fi
+    if [[ "$ret" =~ "(virtual)" ]]; then
+        return
+    fi
+    echo "$1"
 }
 
 PACKAGES=(
@@ -58,9 +69,9 @@ PACKAGES=(
     libcgi-pm-perl
     psmisc
     pulseaudio-utils
-    python-gi
     ruby-highline
     ruby-json
+    $(aptIfExists python-gi)
 
     # These are dependencies necessary for building with the Flatpak SDK.
     flatpak

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -7,7 +7,6 @@ PACKAGES+=(
     geoclue-2.0
     gnome-common
     libedit-dev
-    libenchant-dev
     libfaad-dev
     libffi-dev
     libgirepository1.0-dev
@@ -35,6 +34,7 @@ PACKAGES+=(
     libxtst-dev
     nasm
     xfonts-utils
+    $(aptIfExists libenchant-dev)
 
     # These are dependencies necessary for running tests.
     cups-daemon
@@ -42,17 +42,16 @@ PACKAGES+=(
     hunspell
     hunspell-en-gb
     hunspell-en-us
-    python-psutil
-    python-yaml
     weston
     xvfb
+    $(aptIfExists python-psutil)
+    $(aptIfExists python-yaml)
 
     # These are dependencies necessary for building the jhbuild.
     bison
     flex
     gobject-introspection
     icon-naming-utils
-    libcroco3-dev
     libcups2-dev
     libdrm-dev
     libevdev-dev
@@ -75,18 +74,19 @@ PACKAGES+=(
     libxfont-dev
     libxkbcommon-x11-dev
     libxkbfile-dev
-    python-dev
     ragel
-    x11proto-bigreqs-dev
-    x11proto-composite-dev
     x11proto-gl-dev
     x11proto-input-dev
     x11proto-randr-dev
-    x11proto-resource-dev
     x11proto-scrnsaver-dev
     x11proto-video-dev
-    x11proto-xcmisc-dev
     x11proto-xf86dri-dev
     xtrans-dev
     xutils-dev
+    $(aptIfExists libcroco3-dev)
+    $(aptIfExists python-dev)
+    $(aptIfExists x11proto-bigreqs-dev)
+    $(aptIfExists x11proto-composite-dev)
+    $(aptIfExists x11proto-resource-dev)
+    $(aptIfExists x11proto-xcmisc-dev)
 )


### PR DESCRIPTION
#### c28c6a1fa20a0d8f073a88642cf15b39af54590e
<pre>
[build.webkit.org] Add WebKitGTK and WPE bots for Ubuntu 22.04
<a href="https://bugs.webkit.org/show_bug.cgi?id=241335">https://bugs.webkit.org/show_bug.cgi?id=241335</a>

Reviewed by Adrian Perez de Castro and Aakash Jain.

* Tools/CISupport/build-webkit-org/config.json: Add two new entries for
  building WebKitGTK and WPE on Ubuntu 20.04. The current Ubuntu LTS
  bots are now building WebKitGTK and WPE on Ubuntu 22.04.
* Tools/CISupport/build-webkit-org/factories_unittest.py: Add two new
  entries for testing WebKitGTK and WPE on Ubuntu 20.04.
* Tools/glib/dependencies/apt: Install package &apos;python-gi&apos; only if available.
* Tools/gtk/dependencies/apt: Install packages only if available.

Canonical link: <a href="https://commits.webkit.org/251526@main">https://commits.webkit.org/251526@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295521">https://svn.webkit.org/repository/webkit/trunk@295521</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
