### PR TITLE
Fix PlayStation build after r295294

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1,5 +1,5 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2022 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -5196,8 +5196,7 @@ bool CSSPropertyParser::consumeSystemFont(bool important)
     if (!m_range.atEnd())
         return false;
     
-    FontCascadeDescription fontDescription;
-    RenderTheme::singleton().systemFont(systemFontID, fontDescription);
+    auto fontDescription = RenderTheme::singleton().systemFont(systemFontID);
     if (!fontDescription.isAbsoluteSize())
         return false;
     

--- a/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp
@@ -75,8 +75,7 @@ public:
     ResourceUsageOverlayPainter(ResourceUsageOverlay& overlay)
         : m_overlay(overlay)
     {
-        FontCascadeDescription fontDescription;
-        RenderTheme::singleton().systemFont(CSSValueMessageBox, fontDescription);
+        auto fontDescription = RenderTheme::singleton().systemFont(CSSValueMessageBox);
         fontDescription.setComputedSize(gFontSize);
         m_textFont = FontCascade(WTFMove(fontDescription), 0, 0);
         m_textFont.update(nullptr);

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
  *           (C) 2000 Stefan Schimanski (1Stein@gmx.de)
- * Copyright (C) 2004, 2005, 2006, 2008, 2009, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -304,8 +304,7 @@ void RenderEmbeddedObject::getReplacementTextGeometry(const LayoutPoint& accumul
     contentRect = contentBoxRect();
     contentRect.moveBy(roundedIntPoint(accumulatedOffset));
 
-    FontCascadeDescription fontDescription;
-    RenderTheme::singleton().systemFont(CSSValueWebkitSmallControl, fontDescription);
+    auto fontDescription = RenderTheme::singleton().systemFont(CSSValueWebkitSmallControl);
     fontDescription.setWeight(boldWeightValue());
     fontDescription.setRenderingMode(settings().fontRenderingMode());
     fontDescription.setComputedSize(12);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -1322,45 +1322,6 @@ auto RenderTheme::colorCache(OptionSet<StyleColorOptions> options) const -> Colo
     return m_colorCacheMap.ensure(optionsIgnoringVisitedLink.toRaw(), [] {
         return ColorCache();
     }).iterator->value;
-}
-
-FontCascadeDescription& RenderTheme::cachedSystemFontDescription(CSSValueID systemFontID) const
-{
-    static NeverDestroyed<std::array<FontCascadeDescription, 10>> fontDescriptions;
-    switch (systemFontID) {
-    case CSSValueCaption:
-        return fontDescriptions.get()[0];
-    case CSSValueIcon:
-        return fontDescriptions.get()[1];
-    case CSSValueMenu:
-        return fontDescriptions.get()[2];
-    case CSSValueMessageBox:
-        return fontDescriptions.get()[3];
-    case CSSValueSmallCaption:
-        return fontDescriptions.get()[4];
-    case CSSValueStatusBar:
-        return fontDescriptions.get()[5];
-    case CSSValueWebkitMiniControl:
-        return fontDescriptions.get()[6];
-    case CSSValueWebkitSmallControl:
-        return fontDescriptions.get()[7];
-    case CSSValueWebkitControl:
-        return fontDescriptions.get()[8];
-    case CSSValueNone:
-        return fontDescriptions.get()[9];
-    default:
-        ASSERT_NOT_REACHED();
-        return fontDescriptions.get()[9];
-    }
-}
-
-void RenderTheme::systemFont(CSSValueID systemFontID, FontCascadeDescription& fontDescription) const
-{
-    fontDescription = cachedSystemFontDescription(systemFontID);
-    if (fontDescription.isAbsoluteSize())
-        return;
-
-    updateCachedSystemFontDescription(systemFontID, fontDescription);
 }
 
 Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOptions> options) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -187,7 +187,7 @@ public:
     virtual Seconds caretBlinkInterval() const { return 500_ms; }
 
     // System fonts and colors for CSS.
-    void systemFont(CSSValueID, FontCascadeDescription&) const;
+    virtual FontCascadeDescription systemFont(CSSValueID) const = 0;
     virtual Color systemColor(CSSValueID, OptionSet<StyleColorOptions>) const;
 
     virtual int minimumMenuListSize(const RenderStyle&) const { return 0; }
@@ -256,8 +256,6 @@ public:
 
 protected:
     virtual bool canPaint(const PaintInfo&, const Settings&) const { return true; }
-    virtual FontCascadeDescription& cachedSystemFontDescription(CSSValueID systemFontID) const;
-    virtual void updateCachedSystemFontDescription(CSSValueID systemFontID, FontCascadeDescription&) const = 0;
 
     // The platform selection color.
     virtual Color platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;

--- a/Source/WebCore/rendering/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ private:
     bool supportsListBoxSelectionForegroundColors(OptionSet<StyleColorOptions>) const final { return true; }
     bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const final;
 
-    void updateCachedSystemFontDescription(CSSValueID, FontCascadeDescription&) const override { };
+    FontCascadeDescription systemFont(CSSValueID) const override { return FontCascadeDescription(); };
 
     Color platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const final;
     Color platformInactiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const final;

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,8 +48,7 @@ private:
     bool paintApplePayButton(const RenderObject&, const PaintInfo&, const IntRect&) override;
 #endif
 
-    FontCascadeDescription& cachedSystemFontDescription(CSSValueID systemFontID) const override;
-    void updateCachedSystemFontDescription(CSSValueID systemFontID, FontCascadeDescription&) const override;
+    FontCascadeDescription systemFont(CSSValueID systemFontID) const override;
 
 #if ENABLE(VIDEO) && ENABLE(MODERN_MEDIA_CONTROLS)
     String mediaControlsStyleSheet() override;

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -176,54 +176,6 @@ String RenderThemeCocoa::mediaControlsFormattedStringForDuration(const double du
 
 #endif // ENABLE(VIDEO) && ENABLE(MODERN_MEDIA_CONTROLS)
 
-FontCascadeDescription& RenderThemeCocoa::cachedSystemFontDescription(CSSValueID valueID) const
-{
-    static NeverDestroyed<std::array<FontCascadeDescription, 17>> fontDescriptions;
-
-    ASSERT(std::all_of(std::begin(fontDescriptions.get()), std::end(fontDescriptions.get()), [](auto& description) {
-        return !description.isAbsoluteSize();
-    }));
-
-    switch (valueID) {
-    case CSSValueAppleSystemHeadline:
-        return fontDescriptions.get()[0];
-    case CSSValueAppleSystemBody:
-        return fontDescriptions.get()[1];
-    case CSSValueAppleSystemTitle0:
-        return fontDescriptions.get()[2];
-    case CSSValueAppleSystemTitle1:
-        return fontDescriptions.get()[3];
-    case CSSValueAppleSystemTitle2:
-        return fontDescriptions.get()[4];
-    case CSSValueAppleSystemTitle3:
-        return fontDescriptions.get()[5];
-    case CSSValueAppleSystemTitle4:
-        return fontDescriptions.get()[6];
-    case CSSValueAppleSystemSubheadline:
-        return fontDescriptions.get()[7];
-    case CSSValueAppleSystemFootnote:
-        return fontDescriptions.get()[8];
-    case CSSValueAppleSystemCaption1:
-        return fontDescriptions.get()[9];
-    case CSSValueAppleSystemCaption2:
-        return fontDescriptions.get()[10];
-    case CSSValueAppleSystemShortHeadline:
-        return fontDescriptions.get()[11];
-    case CSSValueAppleSystemShortBody:
-        return fontDescriptions.get()[12];
-    case CSSValueAppleSystemShortSubheadline:
-        return fontDescriptions.get()[13];
-    case CSSValueAppleSystemShortFootnote:
-        return fontDescriptions.get()[14];
-    case CSSValueAppleSystemShortCaption1:
-        return fontDescriptions.get()[15];
-    case CSSValueAppleSystemTallBody:
-        return fontDescriptions.get()[16];
-    default:
-        return RenderTheme::cachedSystemFontDescription(valueID);
-    }
-}
-
 static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
 {
     auto resultRef = adoptCF(static_cast<CFNumberRef>(CTFontCopyAttribute(font, kCTFontCSSWeightAttribute)));
@@ -243,7 +195,7 @@ static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
     return FontSelectionValue(900);
 }
 
-void RenderThemeCocoa::updateCachedSystemFontDescription(CSSValueID valueID, FontCascadeDescription& fontDescription) const
+FontCascadeDescription RenderThemeCocoa::systemFont(CSSValueID valueID) const
 {
     auto cocoaFontClass = [] {
 #if PLATFORM(IOS_FAMILY)
@@ -380,11 +332,13 @@ void RenderThemeCocoa::updateCachedSystemFontDescription(CSSValueID valueID, Fon
 
     ASSERT(fontDescriptor);
     auto font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 0, nullptr));
+    FontCascadeDescription fontDescription;
     fontDescription.setIsAbsoluteSize(true);
     fontDescription.setOneFamily(style);
     fontDescription.setSpecifiedSize(CTFontGetSize(font.get()));
     fontDescription.setWeight(cssWeightOfSystemFont(font.get()));
     fontDescription.setItalic(normalItalicValue());
+    return fontDescription;
 }
 
 }

--- a/Source/WebCore/rendering/RenderThemeGtk.cpp
+++ b/Source/WebCore/rendering/RenderThemeGtk.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,22 +37,23 @@ RenderTheme& RenderTheme::singleton()
     return theme;
 }
 
-void RenderThemeGtk::updateCachedSystemFontDescription(CSSValueID, FontCascadeDescription& fontDescription) const
+FontCascadeDescription RenderThemeGtk::systemFont(CSSValueID) const
 {
     GtkSettings* settings = gtk_settings_get_default();
     if (!settings)
-        return;
+        return FontCascadeDescription();
 
     // This will be a font selection string like "Sans 10" so we cannot use it as the family name.
     GUniqueOutPtr<gchar> fontName;
     g_object_get(settings, "gtk-font-name", &fontName.outPtr(), nullptr);
     if (!fontName || !fontName.get()[0])
-        return;
+        return FontCascadeDescription();
 
     PangoFontDescription* pangoDescription = pango_font_description_from_string(fontName.get());
     if (!pangoDescription)
-        return;
+        return FontCascadeDescription();
 
+    FontCascadeDescription fontDescription;
     fontDescription.setOneFamily(AtomString::fromLatin1(pango_font_description_get_family(pangoDescription)));
 
     int size = pango_font_description_get_size(pangoDescription) / PANGO_SCALE;
@@ -64,6 +66,7 @@ void RenderThemeGtk::updateCachedSystemFontDescription(CSSValueID, FontCascadeDe
     fontDescription.setWeight(normalWeightValue());
     fontDescription.setItalic(FontSelectionValue());
     pango_font_description_free(pangoDescription);
+    return fontDescription;
 }
 
 Seconds RenderThemeGtk::caretBlinkInterval() const

--- a/Source/WebCore/rendering/RenderThemeGtk.h
+++ b/Source/WebCore/rendering/RenderThemeGtk.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -28,7 +29,7 @@ class RenderThemeGtk final : public RenderThemeAdwaita {
 private:
     virtual ~RenderThemeGtk() = default;
 
-    void updateCachedSystemFontDescription(CSSValueID, FontCascadeDescription&) const override;
+    FontCascadeDescription systemFont(CSSValueID) const override;
     Seconds caretBlinkInterval() const override;
 };
 

--- a/Source/WebCore/rendering/RenderThemePlayStation.cpp
+++ b/Source/WebCore/rendering/RenderThemePlayStation.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,9 +37,10 @@ RenderTheme& RenderTheme::singleton()
     return theme;
 }
 
-void RenderThemePlayStation::updateCachedSystemFontDescription(CSSValueID, FontCascadeDescription&) const
+FontCascadeDescription RenderThemePlayStation::systemFont(CSSValueID) const
 {
     notImplemented();
+    return FontCascadeDescription();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderThemePlayStation.h
+++ b/Source/WebCore/rendering/RenderThemePlayStation.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,7 +35,7 @@ public:
     friend NeverDestroyed<RenderThemePlayStation>;
 
 private:
-    void updateCachedSystemFontDescription(CSSValueID systemFontID, FontCascadeDescription&) const final;
+    FontCascadeDescription systemFont(CSSValueID systemFontID) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderThemeWin.cpp
+++ b/Source/WebCore/rendering/RenderThemeWin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Kenneth Rohde Christiansen
  *
  * This library is free software; you can redistribute it and/or
@@ -308,16 +308,7 @@ Color RenderThemeWin::platformInactiveSelectionForegroundColor(OptionSet<StyleCo
     return platformActiveSelectionForegroundColor(options);
 }
 
-static void fillFontDescription(FontCascadeDescription& fontDescription, LOGFONT& logFont, float fontSize)
-{    
-    fontDescription.setIsAbsoluteSize(true);
-    fontDescription.setOneFamily(logFont.lfFaceName);
-    fontDescription.setSpecifiedSize(fontSize);
-    fontDescription.setWeight(logFont.lfWeight >= 700 ? boldWeightValue() : normalWeightValue()); // FIXME: Use real weight.
-    fontDescription.setIsItalic(logFont.lfItalic);
-}
-
-void RenderThemeWin::updateCachedSystemFontDescription(CSSValueID valueID, FontCascadeDescription& fontDescription) const
+FontCascadeDescription RenderThemeWin::systemFont(CSSValueID valueID) const
 {
     static bool initialized;
     static NONCLIENTMETRICS ncm;
@@ -357,12 +348,18 @@ void RenderThemeWin::updateCachedSystemFontDescription(CSSValueID valueID, FontC
     default: { // Everything else uses the stock GUI font.
         HGDIOBJ hGDI = ::GetStockObject(DEFAULT_GUI_FONT);
         if (!hGDI)
-            return;
+            return FontCascadeDescription();
         if (::GetObject(hGDI, sizeof(logFont), &logFont) <= 0)
-            return;
+            return FontCascadeDescription();
     }
     }
-    fillFontDescription(fontDescription, logFont, shouldUseDefaultControlFontPixelSize ? defaultControlFontPixelSize : abs(logFont.lfHeight));
+    FontCascadeDescription fontDescription;
+    fontDescription.setIsAbsoluteSize(true);
+    fontDescription.setOneFamily(logFont.lfFaceName);
+    fontDescription.setSpecifiedSize(shouldUseDefaultControlFontPixelSize ? defaultControlFontPixelSize : abs(logFont.lfHeight));
+    fontDescription.setWeight(logFont.lfWeight >= 700 ? boldWeightValue() : normalWeightValue()); // FIXME: Use real weight.
+    fontDescription.setIsItalic(logFont.lfItalic);
+    return fontDescription;
 }
 
 bool RenderThemeWin::supportsFocus(ControlPart appearance) const

--- a/Source/WebCore/rendering/RenderThemeWin.h
+++ b/Source/WebCore/rendering/RenderThemeWin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Kenneth Rohde Christiansen
  *
  * This library is free software; you can redistribute it and/or
@@ -140,7 +140,7 @@ private:
     virtual ~RenderThemeWin();
 
     // System fonts.
-    void updateCachedSystemFontDescription(CSSValueID, FontCascadeDescription&) const override;
+    FontCascadeDescription systemFont(CSSValueID) const override;
 
     void addIntrinsicMargins(RenderStyle&) const;
     void close();

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -90,7 +90,6 @@ if (ENABLE_WEBCORE)
         Fontconfig::Fontconfig
         Freetype::Freetype
         HarfBuzz::HarfBuzz
-        ICU::uc
         OpenSSL::SSL
         PNG::PNG
         WebKitRequirements::WebKitResources

--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.6.2',
+    version='0.6.3',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 6, 2)
+version = Version(0, 6, 3)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -65,10 +65,15 @@ class Tracker(GenericTracker):
                 raise TypeError('Cannot invoke parent class when classmethod')
             return super(Tracker.Encoder, context).default(obj)
 
-
-    def __init__(self, url, users=None, res=None, component_color=DEFAULT_COMPONENT_COLOR, version_color=DEFAULT_VERSION_COLOR):
+    def __init__(
+            self, url, users=None, res=None,
+            component_color=DEFAULT_COMPONENT_COLOR,
+            version_color=DEFAULT_VERSION_COLOR,
+            session=None
+    ):
         super(Tracker, self).__init__(users=users)
 
+        self.session = session or requests.Session()
         self.component_color = component_color
         self.version_color = version_color
 
@@ -98,7 +103,7 @@ class Tracker(GenericTracker):
             if '@' in username:
                 sys.stderr.write("Provided username contains an '@' symbol. Please make sure to enter your GitHub username, not an email associated with the account\n")
                 return False
-            response = requests.get(
+            response = self.session.get(
                 '{}/user'.format(self.api_url),
                 headers=dict(Accept='application/vnd.github.v3+json'),
                 auth=HTTPBasicAuth(username, access_token),
@@ -158,7 +163,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             name=self.name,
             path='{}'.format(path) if path else '',
         )
-        response = requests.request(method, url, params=params, headers=headers, auth=auth, json=json)
+        response = self.session.request(method, url, params=params, headers=headers, auth=auth, json=json)
         if authenticated is None and not auth and response.status_code // 100 == 4:
             return self.request(path=path, params=params, method=method, headers=headers, authenticated=True, paginate=paginate, json=json, error_message=error_message)
         if response.status_code // 100 != 2:
@@ -175,7 +180,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
         while paginate and isinstance(response.json(), list) and len(response.json()) == params['per_page']:
             params['page'] += 1
-            response = requests.get(url, params=params, headers=headers, auth=auth)
+            response = self.session.get(url, params=params, headers=headers, auth=auth)
             if response.status_code != 200:
                 raise OSError("Failed to assemble pagination requests for '{}', failed on page {}".format(url, params['page']))
             result += response.json()
@@ -189,7 +194,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             raise RuntimeError("Failed to find username for '{}'".format(name or email))
 
         url = '{api_url}/users/{username}'.format(api_url=self.api_url, username=username)
-        response = requests.get(
+        response = self.session.get(
             url, auth=HTTPBasicAuth(*self.credentials(required=True)),
             headers=dict(Accept='application/vnd.github.v3+json'),
         )

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='4.15.3',
+    version='4.15.4',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(4, 15, 3)
+version = Version(4, 15, 4)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))


### PR DESCRIPTION
#### 960a98cd9a3a5beed377b79685665cf5b109f8e7
<pre>
Fix PlayStation build after r295294
<a href="https://bugs.webkit.org/show_bug.cgi?id=241359">https://bugs.webkit.org/show_bug.cgi?id=241359</a>

Reviewed by Ross Kirsling.

The ICU::uc target was added twice to a list of modules causing it to be multiply defined.

* Source/cmake/OptionsPlayStation.cmake:

Canonical link: <a href="https://commits.webkit.org/251351@main">https://commits.webkit.org/251351@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295327">https://svn.webkit.org/repository/webkit/trunk@295327</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
