### PR TITLE
[iOS] Add SPI to vend the find overlay layer

### DIFF
--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -46,17 +46,18 @@ static PageOverlay::PageOverlayID generatePageOverlayID()
     return ++pageOverlayID;
 }
 
-Ref<PageOverlay> PageOverlay::create(Client& client, OverlayType overlayType)
+Ref<PageOverlay> PageOverlay::create(Client& client, OverlayType overlayType, AlwaysTileOverlayLayer alwaysTileOverlayLayer)
 {
-    return adoptRef(*new PageOverlay(client, overlayType));
+    return adoptRef(*new PageOverlay(client, overlayType, alwaysTileOverlayLayer));
 }
 
-PageOverlay::PageOverlay(Client& client, OverlayType overlayType)
+PageOverlay::PageOverlay(Client& client, OverlayType overlayType, AlwaysTileOverlayLayer alwaysTileOverlayLayer)
     : m_client(client)
     , m_fadeAnimationTimer(*this, &PageOverlay::fadeAnimationTimerFired)
     , m_fadeAnimationDuration(fadeAnimationDuration)
     , m_needsSynchronousScrolling(overlayType == OverlayType::View)
     , m_overlayType(overlayType)
+    , m_alwaysTileOverlayLayer(alwaysTileOverlayLayer)
     , m_pageOverlayID(generatePageOverlayID())
 {
 }

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -67,7 +67,12 @@ public:
         Document, // Scales and scrolls with the document.
     };
 
-    WEBCORE_EXPORT static Ref<PageOverlay> create(Client&, OverlayType = OverlayType::View);
+    enum class AlwaysTileOverlayLayer : bool {
+        Yes,
+        No,
+    };
+
+    WEBCORE_EXPORT static Ref<PageOverlay> create(Client&, OverlayType = OverlayType::View, AlwaysTileOverlayLayer = AlwaysTileOverlayLayer::No);
     WEBCORE_EXPORT virtual ~PageOverlay();
 
     WEBCORE_EXPORT PageOverlayController* controller() const;
@@ -99,6 +104,7 @@ public:
     enum class FadeMode { DoNotFade, Fade };
 
     OverlayType overlayType() { return m_overlayType; }
+    AlwaysTileOverlayLayer alwaysTileOverlayLayer() { return m_alwaysTileOverlayLayer; }
 
     WEBCORE_EXPORT IntRect bounds() const;
     WEBCORE_EXPORT IntRect frame() const;
@@ -118,7 +124,7 @@ public:
     void setNeedsSynchronousScrolling(bool needsSynchronousScrolling) { m_needsSynchronousScrolling = needsSynchronousScrolling; }
 
 private:
-    explicit PageOverlay(Client&, OverlayType);
+    explicit PageOverlay(Client&, OverlayType, AlwaysTileOverlayLayer);
 
     void startFadeAnimation();
     void fadeAnimationTimerFired();
@@ -142,6 +148,7 @@ private:
     bool m_needsSynchronousScrolling;
 
     OverlayType m_overlayType;
+    AlwaysTileOverlayLayer m_alwaysTileOverlayLayer;
     IntRect m_overrideFrame;
 
     Color m_backgroundColor { Color::transparentBlack };

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -185,7 +185,8 @@ void PageOverlayController::installPageOverlay(PageOverlay& overlay, PageOverlay
 
     m_pageOverlays.append(&overlay);
 
-    auto layer = GraphicsLayer::create(m_page.chrome().client().graphicsLayerFactory(), *this);
+    auto layerType = (overlay.alwaysTileOverlayLayer() == PageOverlay::AlwaysTileOverlayLayer::Yes) ? GraphicsLayer::Type::TiledBacking : GraphicsLayer::Type::Normal;
+    auto layer = GraphicsLayer::create(m_page.chrome().client().graphicsLayerFactory(), *this, layerType);
     layer->setAnchorPoint({ });
     layer->setBackgroundColor(overlay.backgroundColor());
     layer->setName(MAKE_STATIC_STRING_IMPL("Overlay content"));

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -80,6 +80,7 @@ bool GraphicsLayer::supportsLayerType(Type type)
     case Type::PageTiledBacking:
     case Type::ScrollContainer:
     case Type::ScrolledContents:
+    case Type::TiledBacking:
         return true;
     case Type::Shape:
         return false;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -251,6 +251,7 @@ public:
     enum class Type : uint8_t {
         Normal,
         PageTiledBacking,
+        TiledBacking,
         ScrollContainer,
         ScrolledContents,
         Shape
@@ -424,7 +425,7 @@ public:
     virtual void setBackfaceVisibility(bool b) { m_backfaceVisibility = b; }
 
     float opacity() const { return m_opacity; }
-    virtual void setOpacity(float opacity) { m_opacity = opacity; }
+    WEBCORE_EXPORT virtual void setOpacity(float opacity) { m_opacity = opacity; }
 
     const FilterOperations& filters() const { return m_filters; }
     // Returns true if filter can be rendered by the compositor.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -323,6 +323,7 @@ bool GraphicsLayer::supportsLayerType(Type type)
     case Type::PageTiledBacking:
     case Type::ScrollContainer:
     case Type::ScrolledContents:
+    case Type::TiledBacking:
         return true;
     case Type::Shape:
 #if PLATFORM(COCOA)
@@ -442,6 +443,9 @@ void GraphicsLayerCA::initialize(Type layerType)
         break;
     case Type::Shape:
         platformLayerType = PlatformCALayer::LayerType::LayerTypeShapeLayer;
+        break;
+    case Type::TiledBacking:
+        platformLayerType = PlatformCALayer::LayerType::LayerTypeTiledBackingLayer;
         break;
     }
     m_layer = createPlatformCALayer(platformLayerType, this);
@@ -1619,6 +1623,7 @@ bool GraphicsLayerCA::adjustCoverageRect(VisibleAndCoverageRects& rects, const F
         }
         break;
     case Type::Normal:
+    case Type::TiledBacking:
         if (m_layer->usesTiledBackingLayer())
             coverageRect = tiledBacking()->adjustTileCoverageRect(coverageRect, oldVisibleRect, rects.visibleRect, size() != m_sizeAtLastCoverageRectUpdate);
         break;
@@ -4361,6 +4366,9 @@ void GraphicsLayerCA::setCustomAppearance(CustomAppearance customAppearance)
 
 bool GraphicsLayerCA::requiresTiledLayer(float pageScaleFactor) const
 {
+    if (isTiledBackingLayer())
+        return true;
+
     if (!m_drawsContent || isPageTiledBackingLayer() || !allowsTiling())
         return false;
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -342,7 +342,8 @@ private:
     void setVisibleAndCoverageRects(const VisibleAndCoverageRects&);
     
     bool recursiveVisibleRectChangeRequiresFlush(const CommitState&, const TransformState&) const;
-    
+
+    bool isTiledBackingLayer() const { return type() == Type::TiledBacking; }
     bool isPageTiledBackingLayer() const { return type() == Type::PageTiledBacking; }
 
     // Used to track the path down the tree for replica layers.

--- a/Source/WebKit/UIProcess/API/APIFindClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindClient.h
@@ -26,7 +26,10 @@
 #ifndef APIFindClient_h
 #define APIFindClient_h
 
+#include <WebCore/PlatformLayer.h>
 #include <wtf/text/WTFString.h>
+
+OBJC_CLASS CALayer;
 
 namespace WebCore {
 class IntRect;
@@ -46,6 +49,9 @@ public:
     virtual void didCountStringMatches(WebKit::WebPageProxy*, const WTF::String&, uint32_t) { }
     virtual void didFindString(WebKit::WebPageProxy*, const WTF::String&, const Vector<WebCore::IntRect>& matchRects, uint32_t, int32_t, bool didWrapAround) { }
     virtual void didFailToFindString(WebKit::WebPageProxy*, const WTF::String&) { }
+
+    virtual void didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer*) { }
+    virtual void didRemoveLayerForFindOverlay(WebKit::WebPageProxy*) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -370,6 +370,9 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     _allowsLinkPreview = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LinkPreviewEnabledByDefault);
     _findInteractionEnabled = NO;
 
+    _pendingFindLayerID = 0;
+    _committedFindLayerID = 0;
+
     auto fastClickingEnabled = []() {
         if (NSNumber *enabledValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitFastClickingDisabled"])
             return enabledValue.boolValue;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -167,6 +167,9 @@ class ViewGestureController;
     RetainPtr<UIFindInteraction> _findInteraction;
 #endif
 
+    WebCore::GraphicsLayer::PlatformLayerID _pendingFindLayerID;
+    WebCore::GraphicsLayer::PlatformLayerID _committedFindLayerID;
+
     RetainPtr<_WKRemoteObjectRegistry> _remoteObjectRegistry;
 
     std::optional<CGSize> _viewLayoutSizeOverride;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -509,7 +509,12 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 @property (nonatomic, readonly) _UIFindInteraction *_findInteraction WK_API_AVAILABLE(ios(16.0));
 @property (nonatomic, readwrite, setter=_setFindInteractionEnabled:) BOOL _findInteractionEnabled WK_API_AVAILABLE(ios(16.0));
 
+@property (nonatomic, readonly) CALayer *_layerForFindOverlay WK_API_AVAILABLE(ios(16.0));
+
 - (void)_requestRectForFoundTextRange:(UITextRange *)ranges completionHandler:(void (^)(CGRect))completionHandler WK_API_AVAILABLE(ios(16.0));
+
+- (void)_addLayerForFindOverlay WK_API_AVAILABLE(ios(16.0));
+- (void)_removeLayerForFindOverlay WK_API_AVAILABLE(ios(16.0));
 #endif
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFindDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFindDelegate.h
@@ -35,4 +35,7 @@
 - (void)_webView:(WKWebView *)webView didFindMatches:(NSUInteger)matches forString:(NSString *)string withMatchIndex:(NSInteger)matchIndex;
 - (void)_webView:(WKWebView *)webView didFailToFindString:(NSString *)string;
 
+- (void)_webView:(WKWebView *)webView didAddLayerForFindOverlay:(CALayer *)layer;
+- (void)_webViewDidRemoveLayerForFindOverlay:(WKWebView *)webView;
+
 @end

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.h
@@ -49,6 +49,9 @@ private:
     virtual void didCountStringMatches(WebPageProxy*, const String&, uint32_t matchCount);
     virtual void didFindString(WebPageProxy*, const String&, const Vector<WebCore::IntRect>&, uint32_t matchCount, int32_t matchIndex, bool didWrapAround);
     virtual void didFailToFindString(WebPageProxy*, const String&);
+
+    virtual void didAddLayerForFindOverlay(WebKit::WebPageProxy*, CALayer *);
+    virtual void didRemoveLayerForFindOverlay(WebKit::WebPageProxy*);
     
     WKWebView *m_webView;
     WeakObjCPtr<id <_WKFindDelegate>> m_delegate;
@@ -57,6 +60,8 @@ private:
         bool webviewDidCountStringMatches : 1;
         bool webviewDidFindString : 1;
         bool webviewDidFailToFindString : 1;
+        bool webviewDidAddLayerForFindOverlay : 1;
+        bool webviewDidRemoveLayerForFindOverlay : 1;
     } m_delegateMethods;
 };
     

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -47,6 +47,8 @@ void FindClient::setDelegate(id <_WKFindDelegate> delegate)
     m_delegateMethods.webviewDidCountStringMatches = [delegate respondsToSelector:@selector(_webView:didCountMatches:forString:)];
     m_delegateMethods.webviewDidFindString = [delegate respondsToSelector:@selector(_webView:didFindMatches:forString:withMatchIndex:)];
     m_delegateMethods.webviewDidFailToFindString = [delegate respondsToSelector:@selector(_webView:didFailToFindString:)];
+    m_delegateMethods.webviewDidAddLayerForFindOverlay = [delegate respondsToSelector:@selector(_webView:didAddLayerForFindOverlay:)];
+    m_delegateMethods.webviewDidRemoveLayerForFindOverlay = [delegate respondsToSelector:@selector(_webViewDidRemoveLayerForFindOverlay:)];
 }
     
 void FindClient::didCountStringMatches(WebPageProxy*, const String& string, uint32_t matchCount)
@@ -65,6 +67,18 @@ void FindClient::didFailToFindString(WebPageProxy*, const String& string)
 {
     if (m_delegateMethods.webviewDidFailToFindString)
         [m_delegate.get() _webView:m_webView didFailToFindString:string];
+}
+
+void FindClient::didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer* layer)
+{
+    if (m_delegateMethods.webviewDidAddLayerForFindOverlay)
+        [m_delegate _webView:m_webView didAddLayerForFindOverlay:layer];
+}
+
+void FindClient::didRemoveLayerForFindOverlay(WebKit::WebPageProxy*)
+{
+    if (m_delegateMethods.webviewDidRemoveLayerForFindOverlay)
+        [m_delegate _webViewDidRemoveLayerForFindOverlay:m_webView];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4442,6 +4442,16 @@ void WebPageProxy::requestRectForFoundTextRange(const WebFoundTextRange& range, 
     sendWithAsyncReply(Messages::WebPage::RequestRectForFoundTextRange(range), WTFMove(callbackFunction));
 }
 
+void WebPageProxy::addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&& callbackFunction)
+{
+    sendWithAsyncReply(Messages::WebPage::AddLayerForFindOverlay(), WTFMove(callbackFunction));
+}
+
+void WebPageProxy::removeLayerForFindOverlay(CompletionHandler<void()>&& callbackFunction)
+{
+    sendWithAsyncReply(Messages::WebPage::RemoveLayerForFindOverlay(), WTFMove(callbackFunction));
+}
+
 void WebPageProxy::getImageForFindMatch(int32_t matchIndex)
 {
     send(Messages::WebPage::GetImageForFindMatch(matchIndex));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1247,6 +1247,8 @@ public:
     void didEndTextSearchOperation();
 
     void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
+    void addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&&);
+    void removeLayerForFindOverlay(CompletionHandler<void()>&&);
 
     void getContentsAsString(ContentAsStringIncludesChildFrames, CompletionHandler<void(const String&)>&&);
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -188,6 +188,25 @@ void WebFoundTextRangeController::didEndTextSearchOperation()
         m_webPage->corePage()->pageOverlayController().uninstallPageOverlay(*m_findPageOverlay, WebCore::PageOverlay::FadeMode::Fade);
 }
 
+void WebFoundTextRangeController::addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&& completionHandler)
+{
+    if (!m_findPageOverlay) {
+        m_findPageOverlay = WebCore::PageOverlay::create(*this, WebCore::PageOverlay::OverlayType::Document, WebCore::PageOverlay::AlwaysTileOverlayLayer::Yes);
+        m_webPage->corePage()->pageOverlayController().installPageOverlay(*m_findPageOverlay, WebCore::PageOverlay::FadeMode::DoNotFade);
+        m_findPageOverlay->layer().setOpacity(0);
+    }
+
+    completionHandler(m_findPageOverlay->layer().primaryLayerID());
+
+    m_findPageOverlay->setNeedsDisplay();
+}
+
+void WebFoundTextRangeController::removeLayerForFindOverlay()
+{
+    if (m_findPageOverlay)
+        m_webPage->corePage()->pageOverlayController().uninstallPageOverlay(*m_findPageOverlay, WebCore::PageOverlay::FadeMode::DoNotFade);
+}
+
 void WebFoundTextRangeController::requestRectForFoundTextRange(const WebFoundTextRange& range, CompletionHandler<void(WebCore::FloatRect)>&& completionHandler)
 {
     auto simpleRange = simpleRangeFromFoundTextRange(range);

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -28,6 +28,7 @@
 #include "WebFindOptions.h"
 #include "WebFoundTextRange.h"
 #include <WebCore/FindOptions.h>
+#include <WebCore/GraphicsLayer.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SimpleRange.h>
@@ -63,6 +64,9 @@ public:
 
     void didBeginTextSearchOperation();
     void didEndTextSearchOperation();
+
+    void addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&&);
+    void removeLayerForFindOverlay();
 
     void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4914,6 +4914,17 @@ void WebPage::requestRectForFoundTextRange(const WebFoundTextRange& range, Compl
     foundTextRangeController().requestRectForFoundTextRange(range, WTFMove(completionHandler));
 }
 
+void WebPage::addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&& completionHandler)
+{
+    foundTextRangeController().addLayerForFindOverlay(WTFMove(completionHandler));
+}
+
+void WebPage::removeLayerForFindOverlay(CompletionHandler<void()>&& completionHandler)
+{
+    foundTextRangeController().removeLayerForFindOverlay();
+    completionHandler();
+}
+
 void WebPage::getImageForFindMatch(uint32_t matchIndex)
 {
     findController().getImageForFindMatch(matchIndex);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1835,6 +1835,8 @@ private:
     void didEndTextSearchOperation();
 
     void requestRectForFoundTextRange(const WebFoundTextRange&, CompletionHandler<void(WebCore::FloatRect)>&&);
+    void addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&&);
+    void removeLayerForFindOverlay(CompletionHandler<void()>&&);
 
 #if USE(COORDINATED_GRAPHICS)
     void sendViewportAttributesChanged(const WebCore::ViewportArguments&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -339,6 +339,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidEndTextSearchOperation();
 
     RequestRectForFoundTextRange(struct WebKit::WebFoundTextRange range) -> (WebCore::FloatRect rect)
+    AddLayerForFindOverlay() -> (WebCore::GraphicsLayer::PlatformLayerID findLayerID)
+    RemoveLayerForFindOverlay() -> ()
     
     AddMIMETypeWithCustomContentProvider(String mimeType)
 


### PR DESCRIPTION
#### 90483815379d97337a85f9424fad5d4e64ceb1ae
<pre>
[iOS] Add SPI to vend the find overlay layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=241357">https://bugs.webkit.org/show_bug.cgi?id=241357</a>
rdar://90466280

Reviewed by Simon Fraser, Tim Horton and Wenson Hsieh.

Currently, when searching a conversation in Mail, find overlays for multiple
messages do not animate in at the same time. This issue occurs due to the fact
that each message is in its own web view, backed by its own web process, and
showing the find overlay involves communication across UI and web processes.

In order to ensure the overlays are animated in/out at the same time, give
Mail access to the find overlay layer. The overlays can then be displayed
alongside other Mail content. The overlay layer is exposed through WKWebView
SPI, and _WKFindDelegate methods to inform the client when the overlay is
added/removed.

Alternatives considered:

1. Mail owns the overlay layer and paints highlights themselves. This approach
was not chosen, as WebKit would still need to provide SPI to vend the rects, and
the complexity of implementation increases as the highlight rects could change
position relative to the web view (for example, in subscrollable regions).
In general, this approach would involve significant work in both Mail and WebKit.

2. Mail owns the overlay layer and gives it to WebKit. This approach was not
chosen, as it is incompatible with the existing remote layer tree.

* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::create):
(WebCore::PageOverlay::PageOverlay):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::installPageOverlay):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::supportsLayerType):
* Source/WebCore/platform/graphics/GraphicsLayer.h:

Introduce a new layer type that ensures the layer is always tile-backed. This
is necessary for client-added overlays, since the layer type could otherwise
change, leaving the client with the incorrect layer.

(WebCore::GraphicsLayer::setOpacity):

Export this method, so that the find overlay can begin at zero opacity. The
client is responsible for changing the opacity.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayer::supportsLayerType):
(WebCore::GraphicsLayerCA::initialize):
(WebCore::GraphicsLayerCA::adjustCoverageRect const):
(WebCore::GraphicsLayerCA::requiresTiledLayer const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::isTiledBackingLayer const):
* Source/WebKit/UIProcess/API/APIFindClient.h:
(API::FindClient::didAddLayerForFindOverlay):
(API::FindClient::didRemoveLayerForFindOverlay):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFindDelegate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _processWillSwapOrDidExit]):
(-[WKWebView _didCommitLayerTree:]):

Inform the client that the find overlay is available, once it has been created
and parented. Note that the layer properties arrive in a separate transaction,
since the overlay container is created lazily. Consequently, we wait until the
layer is parented. This ensures that the opacity of the layer is actually zero
once the client is notified.

(-[WKWebView _addLayerForFindOverlay]):

Mark the find overlay as pending once we have a layer ID. At this point, the
layer is not yet in the tree.

(-[WKWebView _removeLayerForFindOverlay]):

Do not send a message to the web process if there is no overlay.

(-[WKWebView _layerForFindOverlay]):

Return the find overlay layer using the `_committedFindLayerID`.

* Source/WebKit/UIProcess/Cocoa/FindClient.h:
* Source/WebKit/UIProcess/Cocoa/FindClient.mm:
(WebKit::FindClient::setDelegate):
(WebKit::FindClient::didAddLayerForFindOverlay):
(WebKit::FindClient::didRemoveLayerForFindOverlay):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addLayerForFindOverlay):
(WebKit::WebPageProxy::removeLayerForFindOverlay):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::addLayerForFindOverlay):

Ensure the overlay is always tile-backed. Without this change, the layer ID can
change depending on the size of the web view, and could leave the client with
the incorrect layer.

(WebKit::WebFoundTextRangeController::removeLayerForFindOverlay):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addFindOverlayLayer):
(WebKit::WebPage::removeFindOverlayLayer):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(-[TestFindDelegate setDidAddLayerForFindOverlayHandler:]):
(-[TestFindDelegate didAddLayerForFindOverlayHandler]):
(-[TestFindDelegate setDidRemoveLayerForFindOverlayHandler:]):
(-[TestFindDelegate didRemoveLayerForFindOverlayHandler]):
(-[TestFindDelegate _webView:didAddLayerForFindOverlay:]):
(-[TestFindDelegate _webViewDidRemoveLayerForFindOverlay:]):
(TEST):

Added a test to exercise the new SPI.

Canonical link: <a href="https://commits.webkit.org/252181@main">https://commits.webkit.org/252181@main</a>
</pre>
