### PR TITLE
Switch Web Share Permissions Policy to *

### DIFF
--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt
@@ -1,9 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
-PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" MUST NOT be allowed to call canShare().
+PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call canShare().
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call canShare().
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call canShare().
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call canShare().

--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https.html
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https.html
@@ -48,7 +48,7 @@
   </head>
   <body>
     <iframe
-      data-enabled="false"
+      data-enabled="true"
       src="https://localhost:8443/webshare/resources/webshare-postmessage.html"
     ></iframe>
     <iframe

--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt
@@ -1,9 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
 CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
-PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" MUST NOT be allowed to call share(). NotAllowedError Third-party iframes are not allowed to call share() unless explicitly allowed via Feature-Policy (web-share)
+PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call share().
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call share().
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call share().
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call share().

--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https.html
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https.html
@@ -26,7 +26,7 @@
 
       const iframeDetails = [
         {
-          enabled: "false",
+          enabled: "true",
           src: "https://localhost:8443/webshare/resources/webshare-postmessage.html",
         },
         {

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -288,7 +288,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
     if (!isPaymentInitialized)
         policy.m_paymentRule.allowedList.add(document.securityOrigin().data());
     if (!isWebShareInitialized)
-        policy.m_webShareRule.allowedList.add(document.securityOrigin().data());
+        policy.m_webShareRule.type = FeaturePolicy::AllowRule::Type::All;
 #if ENABLE(DEVICE_ORIENTATION)
     if (!isGyroscopeInitialized)
         policy.m_gyroscopeRule.allowedList.add(document.securityOrigin().data());


### PR DESCRIPTION
#### 7de22008cc88d76fccc0d018ef1ffa95c35081d6
<pre>
Switch Web Share Permissions Policy to *
<a href="https://bugs.webkit.org/show_bug.cgi?id=241363">https://bugs.webkit.org/show_bug.cgi?id=241363</a>

Patch by Marcos Cáceres &lt;marcos@marcosc.com &gt; on 2022-06-12
Reviewed by Youenn Fablet and Tim Horton.

* LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt:
* LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https.html:
* LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt:
* LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https.html:
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::FeaturePolicy::parse):

Canonical link: <a href="https://commits.webkit.org/251487@main">https://commits.webkit.org/251487@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295482">https://svn.webkit.org/repository/webkit/trunk@295482</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
