### PR TITLE
Fix encoding of std::optional<Ref<RefPtr>>

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -77,7 +77,7 @@ void ArtworkImageLoader::notifyFinished(CachedResource& resource, const NetworkL
         return;
     }
     // Sanitize the image by decoding it into a BitmapImage.
-    RefPtr<FragmentedSharedBuffer> bufferToSanitize = m_cachedImage->image()->data();
+    RefPtr bufferToSanitize = m_cachedImage->image()->data();
     auto bitmapImage = BitmapImage::create();
     bitmapImage->setData(WTFMove(bufferToSanitize), true);
     auto imageBuffer = ImageBuffer::create(bitmapImage->size(), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -87,7 +87,7 @@ private:
     }
 
     CachedResourceHandle<CachedScript> m_cachedScript;
-    RefPtr<FragmentedSharedBuffer> m_buffer;
+    RefPtr<const FragmentedSharedBuffer> m_buffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4239,7 +4239,7 @@ PromisedAttachmentInfo Editor::promisedAttachmentInfo(Element& element)
         return { };
 
     Vector<String> additionalTypes;
-    Vector<RefPtr<SharedBuffer>> additionalData;
+    Vector<RefPtr<const SharedBuffer>> additionalData;
 #if PLATFORM(COCOA)
     getPasteboardTypesAndDataForAttachment(element, additionalTypes, additionalData);
 #endif
@@ -4247,7 +4247,7 @@ PromisedAttachmentInfo Editor::promisedAttachmentInfo(Element& element)
     return { attachment->uniqueIdentifier(), WTFMove(additionalTypes), WTFMove(additionalData) };
 }
 
-void Editor::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& data)
+void Editor::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<const FragmentedSharedBuffer>&& data)
 {
     if (auto* client = this->client())
         client->registerAttachmentIdentifier(identifier, contentType, preferredFileName, WTFMove(data));
@@ -4271,7 +4271,7 @@ void Editor::registerAttachmentIdentifier(const String& identifier, const HTMLIm
     if (!client)
         return;
 
-    auto attachmentInfo = [&]() -> std::optional<std::tuple<String, String, Ref<FragmentedSharedBuffer>>> {
+    auto attachmentInfo = [&]() -> std::optional<std::tuple<String, String, Ref<const FragmentedSharedBuffer>>> {
         auto* renderer = dynamicDowncast<RenderImage>(imageElement.renderer());
         if (!renderer)
             return std::nullopt;

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -577,7 +577,7 @@ public:
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     WEBCORE_EXPORT void insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const AtomString& fileName, const AtomString& contentType);
-    void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& fileData);
+    void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<const FragmentedSharedBuffer>&& fileData);
     void registerAttachments(Vector<SerializedAttachmentData>&&);
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& filePath);
     void registerAttachmentIdentifier(const String&, const HTMLImageElement&);
@@ -587,7 +587,7 @@ public:
 
     WEBCORE_EXPORT PromisedAttachmentInfo promisedAttachmentInfo(Element&);
 #if PLATFORM(COCOA)
-    void getPasteboardTypesAndDataForAttachment(Element&, Vector<String>& outTypes, Vector<RefPtr<SharedBuffer>>& outData);
+    void getPasteboardTypesAndDataForAttachment(Element&, Vector<String>& outTypes, Vector<RefPtr<const SharedBuffer>>& outData);
 #endif
 #endif
 

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -85,7 +85,7 @@ String Editor::selectionInHTMLFormat()
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-void Editor::getPasteboardTypesAndDataForAttachment(Element& element, Vector<String>& outTypes, Vector<RefPtr<SharedBuffer>>& outData)
+void Editor::getPasteboardTypesAndDataForAttachment(Element& element, Vector<String>& outTypes, Vector<RefPtr<const SharedBuffer>>& outData)
 {
     auto elementRange = makeRangeSelectingNode(element);
     client()->getClientPasteboardData(elementRange, outTypes, outData);

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2324,7 +2324,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForURL(DocumentLoader* dataSource, NS
 static RetainPtr<NSFileWrapper> fileWrapperForElement(HTMLImageElement& element)
 {
     if (CachedImage* cachedImage = element.cachedImage()) {
-        if (FragmentedSharedBuffer* sharedBuffer = cachedImage->resourceBuffer())
+        if (auto* sharedBuffer = cachedImage->resourceBuffer())
             return adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:sharedBuffer->makeContiguous()->createNSData().get()]);
     }
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -143,7 +143,7 @@ void ImageDocument::updateDuringParsing()
     if (!m_imageElement)
         createDocumentStructure();
 
-    if (RefPtr<FragmentedSharedBuffer> buffer = loader()->mainResourceData())
+    if (RefPtr<const FragmentedSharedBuffer> buffer = loader()->mainResourceData())
         m_imageElement->cachedImage()->updateBuffer(*buffer);
 
     imageUpdated();
@@ -153,7 +153,7 @@ void ImageDocument::finishedParsing()
 {
     if (!parser()->isStopped() && m_imageElement) {
         CachedImage& cachedImage = *m_imageElement->cachedImage();
-        RefPtr<FragmentedSharedBuffer> data = loader()->mainResourceData();
+        auto data = loader()->mainResourceData();
 
         // If this is a multipart image, make a copy of the current part, since the resource data
         // will be overwritten by the next part.

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -267,7 +267,7 @@ void NetworkResourcesData::addCachedResource(const String& requestId, CachedReso
     resourceData->setCachedResource(cachedResource);
 }
 
-void NetworkResourcesData::addResourceSharedBuffer(const String& requestId, RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName)
+void NetworkResourcesData::addResourceSharedBuffer(const String& requestId, RefPtr<const FragmentedSharedBuffer>&& buffer, const String& textEncodingName)
 {
     ResourceData* resourceData = resourceDataForRequestId(requestId);
     if (!resourceData)

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -88,8 +88,8 @@ public:
         RefPtr<TextResourceDecoder> decoder() const { return m_decoder.copyRef(); }
         void setDecoder(RefPtr<TextResourceDecoder>&& decoder) { m_decoder = WTFMove(decoder); }
 
-        RefPtr<FragmentedSharedBuffer> buffer() const { return m_buffer.copyRef(); }
-        void setBuffer(RefPtr<FragmentedSharedBuffer>&& buffer) { m_buffer = WTFMove(buffer); }
+        RefPtr<const FragmentedSharedBuffer> buffer() const { return m_buffer.copyRef(); }
+        void setBuffer(RefPtr<const FragmentedSharedBuffer>&& buffer) { m_buffer = WTFMove(buffer); }
 
         const std::optional<CertificateInfo>& certificateInfo() const { return m_certificateInfo; }
         void setCertificateInfo(const std::optional<CertificateInfo>& certificateInfo) { m_certificateInfo = certificateInfo; }
@@ -120,7 +120,7 @@ public:
         String m_mimeType;
         RefPtr<TextResourceDecoder> m_decoder;
         SharedBufferBuilder m_dataBuffer;
-        RefPtr<FragmentedSharedBuffer> m_buffer;
+        RefPtr<const FragmentedSharedBuffer> m_buffer;
         std::optional<CertificateInfo> m_certificateInfo;
         CachedResource* m_cachedResource { nullptr };
         InspectorPageAgent::ResourceType m_type { InspectorPageAgent::OtherResource };
@@ -144,7 +144,7 @@ public:
     ResourceData const* maybeAddResourceData(const String& requestId, const SharedBuffer&);
     void maybeDecodeDataToContent(const String& requestId);
     void addCachedResource(const String& requestId, CachedResource*);
-    void addResourceSharedBuffer(const String& requestId, RefPtr<FragmentedSharedBuffer>&&, const String& textEncodingName);
+    void addResourceSharedBuffer(const String& requestId, RefPtr<const FragmentedSharedBuffer>&&, const String& textEncodingName);
     ResourceData const* data(const String& requestId);
     ResourceData const* dataForURL(const String& url);
     Vector<String> removeCachedResource(CachedResource*);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -925,7 +925,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHeaders(Ref<JSO
 
 Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorNetworkAgent::getResponseBody(const Protocol::Network::RequestId& requestId)
 {
-    NetworkResourcesData::ResourceData const* resourceData = m_resourcesData->data(requestId);
+    const NetworkResourcesData::ResourceData* resourceData = m_resourcesData->data(requestId);
     if (!resourceData)
         return makeUnexpected("Missing resource for given requestId"_s);
 
@@ -935,16 +935,16 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorN
     if (resourceData->isContentEvicted())
         return makeUnexpected("Resource content was evicted from inspector cache"_s);
 
-    if (resourceData->buffer() && !resourceData->textEncodingName().isNull()) {
+    if (auto buffer = resourceData->buffer(); buffer && !resourceData->textEncodingName().isNull()) {
         String body;
-        if (InspectorPageAgent::sharedBufferContent(resourceData->buffer(), resourceData->textEncodingName(), false, &body))
+        if (InspectorPageAgent::sharedBufferContent(buffer.get(), resourceData->textEncodingName(), false, &body))
             return { { body, false } };
     }
 
-    if (resourceData->cachedResource()) {
+    if (auto cachedResource = resourceData->cachedResource()) {
         String body;
         bool base64Encoded;
-        if (InspectorNetworkAgent::cachedResourceContent(*resourceData->cachedResource(), &body, &base64Encoded))
+        if (InspectorNetworkAgent::cachedResourceContent(*cachedResource, &body, &base64Encoded))
             return { { body, base64Encoded } };
     }
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -100,13 +100,13 @@ static bool decodeBuffer(const uint8_t* buffer, unsigned size, const String& tex
 
 bool InspectorPageAgent::mainResourceContent(Frame* frame, bool withBase64Encode, String* result)
 {
-    RefPtr<FragmentedSharedBuffer> buffer = frame->loader().documentLoader()->mainResourceData();
+    auto buffer = frame->loader().documentLoader()->mainResourceData();
     if (!buffer)
         return false;
     return InspectorPageAgent::dataContent(buffer->makeContiguous()->data(), buffer->size(), frame->document()->encoding(), withBase64Encode, result);
 }
 
-bool InspectorPageAgent::sharedBufferContent(RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName, bool withBase64Encode, String* result)
+bool InspectorPageAgent::sharedBufferContent(const FragmentedSharedBuffer* buffer, const String& textEncodingName, bool withBase64Encode, String* result)
 {
     return dataContent(buffer ? buffer->makeContiguous()->data() : nullptr, buffer ? buffer->size() : 0, textEncodingName, withBase64Encode, result);
 }

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -76,7 +76,7 @@ public:
         OtherResource,
     };
 
-    static bool sharedBufferContent(RefPtr<FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
+    static bool sharedBufferContent(const FragmentedSharedBuffer*, const String& textEncodingName, bool withBase64Encode, String* result);
     static Vector<CachedResource*> cachedResourcesForFrame(Frame*);
     static void resourceContent(Inspector::Protocol::ErrorString&, Frame*, const URL&, String* result, bool* base64Encoded);
     static String sourceMapURLForResource(CachedResource*);

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -183,7 +183,7 @@ public:
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
     WEBCORE_EXPORT SubresourceLoader* mainResourceLoader() const;
-    WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> mainResourceData() const;
+    WEBCORE_EXPORT RefPtr<const FragmentedSharedBuffer> mainResourceData() const;
     
     DocumentWriter& writer() const { return m_writer; }
 
@@ -416,8 +416,8 @@ public:
 #endif
 
     void startIconLoading();
-    WEBCORE_EXPORT void didGetLoadDecisionForIcon(bool decision, uint64_t loadIdentifier, CompletionHandler<void(FragmentedSharedBuffer*)>&&);
-    void finishedLoadingIcon(IconLoader&, FragmentedSharedBuffer*);
+    WEBCORE_EXPORT void didGetLoadDecisionForIcon(bool decision, uint64_t loadIdentifier, CompletionHandler<void(const FragmentedSharedBuffer*)>&&);
+    void finishedLoadingIcon(IconLoader&, const FragmentedSharedBuffer*);
 
     const Vector<LinkIcon>& linkIcons() const { return m_linkIcons; }
 
@@ -655,7 +655,7 @@ private:
     bool m_waitingForNavigationPolicy { false };
 
     HashMap<uint64_t, LinkIcon> m_iconsPendingLoadDecision;
-    HashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(FragmentedSharedBuffer*)>> m_iconLoaders;
+    HashMap<std::unique_ptr<IconLoader>, CompletionHandler<void(const FragmentedSharedBuffer*)>> m_iconLoaders;
     Vector<LinkIcon> m_linkIcons;
 
 #if ENABLE(APPLICATION_MANIFEST)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -284,7 +284,7 @@ private:
     void didEndUserTriggeredSelectionChanges() final { }
     void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) final { }
     void didWriteSelectionToPasteboard() final { }
-    void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>&, Vector<RefPtr<SharedBuffer>>&) final { }
+    void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>&, Vector<RefPtr<const SharedBuffer>>&) final { }
     void requestCandidatesForSelection(const VisibleSelection&) final { }
     void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) final { }
 

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -194,7 +194,7 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
     });
 }
 
-void ResourceLoader::deliverResponseAndData(const ResourceResponse& response, RefPtr<FragmentedSharedBuffer>&& buffer)
+void ResourceLoader::deliverResponseAndData(const ResourceResponse& response, RefPtr<const FragmentedSharedBuffer>&& buffer)
 {
     didReceiveResponse(response, [this, protectedThis = Ref { *this }, buffer = WTFMove(buffer)]() mutable {
         if (reachedTerminalState())

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -67,7 +67,7 @@ public:
 
     virtual void init(ResourceRequest&&, CompletionHandler<void(bool)>&&);
 
-    void deliverResponseAndData(const ResourceResponse&, RefPtr<FragmentedSharedBuffer>&&);
+    void deliverResponseAndData(const ResourceResponse&, RefPtr<const FragmentedSharedBuffer>&&);
 
 #if PLATFORM(IOS_FAMILY)
     virtual void startLoading()

--- a/Source/WebCore/loader/SubstituteData.h
+++ b/Source/WebCore/loader/SubstituteData.h
@@ -43,7 +43,7 @@ namespace WebCore {
         {
         }
 
-        SubstituteData(RefPtr<FragmentedSharedBuffer>&& content, const URL& failingURL, const ResourceResponse& response, SessionHistoryVisibility shouldRevealToSessionHistory)
+        SubstituteData(RefPtr<const FragmentedSharedBuffer>&& content, const URL& failingURL, const ResourceResponse& response, SessionHistoryVisibility shouldRevealToSessionHistory)
             : m_content(WTFMove(content))
             , m_failingURL(failingURL)
             , m_response(response)
@@ -64,7 +64,7 @@ namespace WebCore {
         template<class Decoder> static std::optional<SubstituteData> decode(Decoder&);
 
     private:
-        RefPtr<FragmentedSharedBuffer> m_content;
+        RefPtr<const FragmentedSharedBuffer> m_content;
         URL m_failingURL;
         ResourceResponse m_response;
         SessionHistoryVisibility m_shouldRevealToSessionHistory { SessionHistoryVisibility::Hidden };

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -37,17 +37,17 @@ public:
 
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
-    FragmentedSharedBuffer& data() const { return static_reference_cast<FragmentedSharedBuffer>(Ref { *m_data.get() }); }
+    const FragmentedSharedBuffer& data() const { return static_reference_cast<const FragmentedSharedBuffer>(Ref { *m_data.get() }); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }
 
     virtual void deliver(ResourceLoader& loader) { loader.deliverResponseAndData(m_response, m_data.copy()); }
 
 protected:
-    SubstituteResource(URL&& url, ResourceResponse&& response, Ref<FragmentedSharedBuffer>&& data)
+    SubstituteResource(URL&& url, ResourceResponse&& response, Ref<const FragmentedSharedBuffer>&& data)
         : m_url(WTFMove(url))
         , m_response(WTFMove(response))
-        , m_data(WTFMove(data))
+        , m_data(std::in_place, WTFMove(data))
     {
     }
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheResource.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheResource.cpp
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-Ref<ApplicationCacheResource> ApplicationCacheResource::create(const URL& url, const ResourceResponse& response, unsigned type, RefPtr<FragmentedSharedBuffer>&& buffer, const String& path)
+Ref<ApplicationCacheResource> ApplicationCacheResource::create(const URL& url, const ResourceResponse& response, unsigned type, RefPtr<const FragmentedSharedBuffer>&& buffer, const String& path)
 {
     ASSERT(!url.hasFragmentIdentifier());
     if (!buffer)
@@ -40,7 +40,7 @@ Ref<ApplicationCacheResource> ApplicationCacheResource::create(const URL& url, c
     return adoptRef(*new ApplicationCacheResource(URL { url }, WTFMove(resourceResponse), type, buffer.releaseNonNull(), path));
 }
 
-ApplicationCacheResource::ApplicationCacheResource(URL&& url, ResourceResponse&& response, unsigned type, Ref<FragmentedSharedBuffer>&& data, const String& path)
+ApplicationCacheResource::ApplicationCacheResource(URL&& url, ResourceResponse&& response, unsigned type, Ref<const FragmentedSharedBuffer>&& data, const String& path)
     : SubstituteResource(WTFMove(url), WTFMove(response), WTFMove(data))
     , m_type(type)
     , m_storageID(0)

--- a/Source/WebCore/loader/appcache/ApplicationCacheResource.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheResource.h
@@ -40,7 +40,7 @@ public:
         Fallback = 1 << 4
     };
 
-    static Ref<ApplicationCacheResource> create(const URL&, const ResourceResponse&, unsigned type, RefPtr<FragmentedSharedBuffer>&& = SharedBuffer::create(), const String& path = String());
+    static Ref<ApplicationCacheResource> create(const URL&, const ResourceResponse&, unsigned type, RefPtr<const FragmentedSharedBuffer>&& = SharedBuffer::create(), const String& path = String());
 
     unsigned type() const { return m_type; }
     void addType(unsigned type);
@@ -58,7 +58,7 @@ public:
 #endif
     
 private:
-    ApplicationCacheResource(URL&&, ResourceResponse&&, unsigned type, Ref<FragmentedSharedBuffer>&&, const String& path);
+    ApplicationCacheResource(URL&&, ResourceResponse&&, unsigned type, Ref<const FragmentedSharedBuffer>&&, const String& path);
 
     void deliver(ResourceLoader&) override;
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1272,7 +1272,7 @@ bool ApplicationCacheStorage::shouldStoreResourceAsFlatFile(ApplicationCacheReso
     return startsWithLettersIgnoringASCIICase(type, "audio/"_s) || startsWithLettersIgnoringASCIICase(type, "video/"_s);
 }
     
-bool ApplicationCacheStorage::writeDataToUniqueFileInDirectory(FragmentedSharedBuffer& data, const String& directory, String& path, StringView fileExtension)
+bool ApplicationCacheStorage::writeDataToUniqueFileInDirectory(const FragmentedSharedBuffer& data, const String& directory, String& path, StringView fileExtension)
 {
     String fullPath;
     

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -122,7 +122,7 @@ private:
     bool ensureOriginRecord(const SecurityOrigin*);
     static bool shouldStoreResourceAsFlatFile(ApplicationCacheResource*);
     void deleteTables();
-    bool writeDataToUniqueFileInDirectory(FragmentedSharedBuffer&, const String& directory, String& outFilename, StringView fileExtension);
+    bool writeDataToUniqueFileInDirectory(const FragmentedSharedBuffer&, const String& directory, String& outFilename, StringView fileExtension);
 
     void loadManifestHostHashes();
     

--- a/Source/WebCore/loader/archive/ArchiveFactory.cpp
+++ b/Source/WebCore/loader/archive/ArchiveFactory.cpp
@@ -46,12 +46,12 @@
 
 namespace WebCore {
 
-typedef RefPtr<Archive> RawDataCreationFunction(const URL&, FragmentedSharedBuffer&);
+typedef RefPtr<Archive> RawDataCreationFunction(const URL&, const FragmentedSharedBuffer&);
 typedef HashMap<String, RawDataCreationFunction*, ASCIICaseInsensitiveHash> ArchiveMIMETypesMap;
 
 // The create functions in the archive classes return RefPtr to concrete subclasses
 // of Archive. This adaptor makes the functions have a uniform return type.
-template<typename ArchiveClass> static RefPtr<Archive> archiveFactoryCreate(const URL& url, FragmentedSharedBuffer& buffer)
+template<typename ArchiveClass> static RefPtr<Archive> archiveFactoryCreate(const URL& url, const FragmentedSharedBuffer& buffer)
 {
     return ArchiveClass::create(url, buffer);
 }
@@ -83,7 +83,7 @@ bool ArchiveFactory::isArchiveMIMEType(const String& mimeType)
     return !mimeType.isEmpty() && archiveMIMETypes().contains(mimeType);
 }
 
-RefPtr<Archive> ArchiveFactory::create(const URL& url, FragmentedSharedBuffer* data, const String& mimeType)
+RefPtr<Archive> ArchiveFactory::create(const URL& url, const FragmentedSharedBuffer* data, const String& mimeType)
 {
     if (!data)
         return nullptr;

--- a/Source/WebCore/loader/archive/ArchiveFactory.h
+++ b/Source/WebCore/loader/archive/ArchiveFactory.h
@@ -39,7 +39,7 @@ class FragmentedSharedBuffer;
 class ArchiveFactory {
 public:
     static bool isArchiveMIMEType(const String&);
-    static RefPtr<Archive> create(const URL&, FragmentedSharedBuffer* data, const String& mimeType);
+    static RefPtr<Archive> create(const URL&, const FragmentedSharedBuffer* data, const String& mimeType);
     static void registerKnownArchiveMIMETypes(HashSet<String, ASCIICaseInsensitiveHash>&);
 };
 

--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-inline ArchiveResource::ArchiveResource(Ref<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response)
+inline ArchiveResource::ArchiveResource(Ref<const FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response)
     : SubstituteResource(URL { url }, ResourceResponse { response }, WTFMove(data))
     , m_mimeType(mimeType)
     , m_textEncoding(textEncoding)
@@ -42,7 +42,7 @@ inline ArchiveResource::ArchiveResource(Ref<FragmentedSharedBuffer>&& data, cons
 {
 }
 
-RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response)
+RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<const FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response)
 {
     if (!data)
         return nullptr;
@@ -54,7 +54,7 @@ RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&&
     return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response));
 }
 
-RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const ResourceResponse& response)
+RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<const FragmentedSharedBuffer>&& data, const URL& url, const ResourceResponse& response)
 {
     return create(WTFMove(data), url, response.mimeType(), response.textEncodingName(), String(), response);
 }

--- a/Source/WebCore/loader/archive/ArchiveResource.h
+++ b/Source/WebCore/loader/archive/ArchiveResource.h
@@ -34,8 +34,8 @@ namespace WebCore {
 
 class ArchiveResource : public SubstituteResource {
 public:
-    static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&, const ResourceResponse&);
-    WEBCORE_EXPORT static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&,
+    static RefPtr<ArchiveResource> create(RefPtr<const FragmentedSharedBuffer>&&, const URL&, const ResourceResponse&);
+    WEBCORE_EXPORT static RefPtr<ArchiveResource> create(RefPtr<const FragmentedSharedBuffer>&&, const URL&,
         const String& mimeType, const String& textEncoding, const String& frameName,
         const ResourceResponse& = ResourceResponse());
 
@@ -47,7 +47,7 @@ public:
     bool shouldIgnoreWhenUnarchiving() const { return m_shouldIgnoreWhenUnarchiving; }
 
 private:
-    ArchiveResource(Ref<FragmentedSharedBuffer>&&, const URL&, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse&);
+    ArchiveResource(Ref<const FragmentedSharedBuffer>&&, const URL&, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse&);
 
     String m_mimeType;
     String m_textEncoding;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -248,12 +248,12 @@ Ref<LegacyWebArchive> LegacyWebArchive::create(Ref<ArchiveResource>&& mainResour
     return archive;
 }
 
-RefPtr<LegacyWebArchive> LegacyWebArchive::create(FragmentedSharedBuffer& data)
+RefPtr<LegacyWebArchive> LegacyWebArchive::create(const FragmentedSharedBuffer& data)
 {
     return create(URL(), data);
 }
 
-RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBuffer& data)
+RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, const FragmentedSharedBuffer& data)
 {
     LOG(Archives, "LegacyWebArchive - Creating from raw data");
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -41,8 +41,8 @@ struct SimpleRange;
 class LegacyWebArchive final : public Archive {
 public:
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create();
-    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(FragmentedSharedBuffer&);
-    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, const FragmentedSharedBuffer&);
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<Ref<LegacyWebArchive>>&& subframeArchives);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Node&, Function<bool(Frame&)>&& frameFilter = { });
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Frame&);

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -106,7 +106,7 @@ Ref<MHTMLArchive> MHTMLArchive::create()
     return adoptRef(*new MHTMLArchive);
 }
 
-RefPtr<MHTMLArchive> MHTMLArchive::create(const URL& url, FragmentedSharedBuffer& data)
+RefPtr<MHTMLArchive> MHTMLArchive::create(const URL& url, const FragmentedSharedBuffer& data)
 {
     // For security reasons we only load MHTML pages from local URLs.
     if (!LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(url.protocol()))

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.h
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.h
@@ -43,7 +43,7 @@ class FragmentedSharedBuffer;
 class MHTMLArchive final : public Archive {
 public:
     static Ref<MHTMLArchive> create();
-    static RefPtr<MHTMLArchive> create(const URL&, FragmentedSharedBuffer&);
+    static RefPtr<MHTMLArchive> create(const URL&, const FragmentedSharedBuffer&);
 
     static Ref<FragmentedSharedBuffer> generateMHTMLData(Page*);
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -91,7 +91,7 @@ bool CachedFont::ensureCustomFontData(const AtomString&)
         return ensureCustomFontData(nullptr);
     if (!m_data->isContiguous())
         m_data = m_data->makeContiguous();
-    return ensureCustomFontData(downcast<SharedBuffer>(m_data.get()));
+    return ensureCustomFontData(downcast<const SharedBuffer>(m_data.get()));
 }
 
 String CachedFont::calculateItemInCollection() const
@@ -99,7 +99,7 @@ String CachedFont::calculateItemInCollection() const
     return url().fragmentIdentifier().toString();
 }
 
-bool CachedFont::ensureCustomFontData(SharedBuffer* data)
+bool CachedFont::ensureCustomFontData(const SharedBuffer* data)
 {
     if (!m_fontCustomPlatformData && !errorOccurred() && !isLoading() && data) {
         bool wrapping;
@@ -112,7 +112,7 @@ bool CachedFont::ensureCustomFontData(SharedBuffer* data)
     return m_fontCustomPlatformData.get();
 }
 
-std::unique_ptr<FontCustomPlatformData> CachedFont::createCustomFontData(SharedBuffer& bytes, const String& itemInCollection, bool& wrapping)
+std::unique_ptr<FontCustomPlatformData> CachedFont::createCustomFontData(const SharedBuffer& bytes, const String& itemInCollection, bool& wrapping)
 {
     RefPtr buffer = { &bytes };
     wrapping = !convertWOFFToSfntIfNecessary(buffer);

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -54,7 +54,7 @@ public:
     bool stillNeedsLoad() const override { return !m_loadInitiated; }
 
     virtual bool ensureCustomFontData(const AtomString& remoteURI);
-    static std::unique_ptr<FontCustomPlatformData> createCustomFontData(SharedBuffer&, const String& itemInCollection, bool& wrapping);
+    static std::unique_ptr<FontCustomPlatformData> createCustomFontData(const SharedBuffer&, const String& itemInCollection, bool& wrapping);
     static FontPlatformData platformDataFromCustomData(FontCustomPlatformData&, const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
     virtual RefPtr<Font> createFont(const FontDescription&, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
@@ -62,7 +62,7 @@ public:
 protected:
     FontPlatformData platformDataFromCustomData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
-    bool ensureCustomFontData(SharedBuffer* data);
+    bool ensureCustomFontData(const SharedBuffer* data);
 
 private:
     String calculateItemInCollection() const;

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -473,7 +473,7 @@ inline void CachedImage::clearImage()
 
 void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 {
-    m_data = const_cast<FragmentedSharedBuffer*>(&data);
+    m_data = &data;
     setEncodedSize(m_data->size());
     createImage();
 

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -930,7 +930,7 @@ void CachedResource::Callback::timerFired()
 
 #if ENABLE(SHAREABLE_RESOURCE)
 
-void CachedResource::tryReplaceEncodedData(SharedBuffer& newBuffer)
+void CachedResource::tryReplaceEncodedData(const SharedBuffer& newBuffer)
 {
     if (!m_data)
         return;
@@ -944,7 +944,7 @@ void CachedResource::tryReplaceEncodedData(SharedBuffer& newBuffer)
     if (*m_data != newBuffer)
         return;
 
-    m_data = Ref { newBuffer };
+    m_data = &newBuffer;
     didReplaceSharedBufferContents();
 }
 

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -216,7 +216,7 @@ public:
 
     void clearLoader();
 
-    FragmentedSharedBuffer* resourceBuffer() const { return m_data.get(); }
+    const FragmentedSharedBuffer* resourceBuffer() const { return m_data.get(); }
 
     virtual void redirectReceived(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     virtual void responseReceived(const ResourceResponse&);
@@ -288,7 +288,7 @@ public:
     virtual void didSendData(unsigned long long /* bytesSent */, unsigned long long /* totalBytesToBeSent */) { }
 
 #if ENABLE(SHAREABLE_RESOURCE)
-    WEBCORE_EXPORT void tryReplaceEncodedData(SharedBuffer&);
+    WEBCORE_EXPORT void tryReplaceEncodedData(const SharedBuffer&);
 #endif
 
     ResourceLoaderIdentifier identifierForLoadWithoutResourceLoader() const { return m_identifierForLoadWithoutResourceLoader; }
@@ -341,7 +341,7 @@ protected:
     WeakHashCountedSet<CachedResourceClient> m_clients;
     std::unique_ptr<ResourceRequest> m_originalRequest; // Needed by Ping loads.
     RefPtr<SubresourceLoader> m_loader;
-    RefPtr<FragmentedSharedBuffer> m_data;
+    RefPtr<const FragmentedSharedBuffer> m_data;
 
 private:
     MonotonicTime m_lastDecodedAccessTime; // Used as a "thrash guard" in the cache

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
@@ -42,7 +42,7 @@ public:
 private:
     DiskCacheMonitor(const ResourceRequest&, PAL::SessionID, CFCachedURLResponseRef);
 
-    void resourceBecameFileBacked(SharedBuffer&);
+    void resourceBecameFileBacked(const SharedBuffer&);
 
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }
     PAL::SessionID sessionID() const { return m_sessionID; }

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
@@ -113,7 +113,7 @@ DiskCacheMonitor::DiskCacheMonitor(const ResourceRequest& request, PAL::SessionI
     _CFCachedURLResponseSetBecameFileBackedCallBackBlock(cachedResponse, blockToRun, dispatch_get_main_queue());
 }
 
-void DiskCacheMonitor::resourceBecameFileBacked(SharedBuffer& fileBackedBuffer)
+void DiskCacheMonitor::resourceBecameFileBacked(const SharedBuffer& fileBackedBuffer)
 {
     auto* resource = MemoryCache::singleton().resourceForRequest(m_resourceRequest, m_sessionID);
     if (!resource)

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -110,7 +110,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // If we got a status code indicating an invalid response, then lets
     // ignore the data and not try to decode the error page as an icon.
-    auto* data = m_resource->resourceBuffer();
+    const auto* data = m_resource->resourceBuffer();
     int status = m_resource->response().httpStatusCode();
     if (status && (status < 200 || status > 299))
         data = nullptr;

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -80,7 +80,7 @@ public:
     virtual bool shouldMoveRangeAfterDelete(const SimpleRange&, const SimpleRange&) = 0;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    virtual void registerAttachmentIdentifier(const String& /* identifier */, const String& /* contentType */, const String& /* preferredFileName */, Ref<FragmentedSharedBuffer>&&) { }
+    virtual void registerAttachmentIdentifier(const String& /* identifier */, const String& /* contentType */, const String& /* preferredFileName */, Ref<const FragmentedSharedBuffer>&&) { }
     virtual void registerAttachmentIdentifier(const String& /* identifier */, const String& /* contentType */, const String& /* filePath */) { }
     virtual void registerAttachments(Vector<SerializedAttachmentData>&&) { }
     virtual void registerAttachmentIdentifier(const String& /* identifier */) { }
@@ -99,7 +99,7 @@ public:
     virtual void didEndEditing() = 0;
     virtual void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) = 0;
     virtual void didWriteSelectionToPasteboard() = 0;
-    virtual void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<SharedBuffer>>& pasteboardData) = 0;
+    virtual void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const SharedBuffer>>& pasteboardData) = 0;
     virtual void requestCandidatesForSelection(const VisibleSelection&) { }
     virtual void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) { }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -274,7 +274,7 @@ void PageSerializer::addImageToResources(CachedImage* image, RenderElement* imag
     if (!image || image->image() == &Image::nullImage())
         return;
 
-    RefPtr<FragmentedSharedBuffer> data = imageRenderer ? image->imageForRenderer(imageRenderer)->data() : 0;
+    RefPtr<const FragmentedSharedBuffer> data = imageRenderer ? image->imageForRenderer(imageRenderer)->data() : nullptr;
     if (!data)
         data = image->image()->data();
 

--- a/Source/WebCore/platform/NowPlayingManager.h
+++ b/Source/WebCore/platform/NowPlayingManager.h
@@ -70,7 +70,7 @@ private:
     std::optional<NowPlayingInfo> m_nowPlayingInfo;
     struct ArtworkCache {
         String src;
-        RefPtr<FragmentedSharedBuffer> imageData;
+        RefPtr<const FragmentedSharedBuffer> imageData;
     };
     std::optional<ArtworkCache> m_nowPlayingInfoArtwork;
     bool m_setAsNowPlayingApplication { false };

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -90,7 +90,7 @@ struct PasteboardWebContent {
     String dataInHTMLFormat;
     String dataInStringFormat;
     Vector<String> clientTypes;
-    Vector<RefPtr<SharedBuffer>> clientData;
+    Vector<RefPtr<const SharedBuffer>> clientData;
 #endif
 #if PLATFORM(GTK)
     String contentOrigin;
@@ -130,7 +130,7 @@ struct PasteboardImage {
     RefPtr<SharedBuffer> resourceData;
     String resourceMIMEType;
     Vector<String> clientTypes;
-    Vector<RefPtr<SharedBuffer>> clientData;
+    Vector<RefPtr<const SharedBuffer>> clientData;
 #endif
     String suggestedName;
     FloatSize imageSize;

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -63,7 +63,7 @@ public:
 
     virtual int64_t addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext*) = 0;
-    virtual int64_t setBufferForType(SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*) = 0;
+    virtual int64_t setBufferForType(const SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setURL(const PasteboardURL&, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setColor(const Color&, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*) = 0;

--- a/Source/WebCore/platform/PasteboardWriterData.h
+++ b/Source/WebCore/platform/PasteboardWriterData.h
@@ -58,7 +58,7 @@ public:
         String dataInHTMLFormat;
         String dataInStringFormat;
         Vector<String> clientTypes;
-        Vector<RefPtr<SharedBuffer>> clientData;
+        Vector<RefPtr<const SharedBuffer>> clientData;
 #endif
     };
 

--- a/Source/WebCore/platform/PlatformPasteboard.h
+++ b/Source/WebCore/platform/PlatformPasteboard.h
@@ -86,7 +86,7 @@ public:
 
     // These methods will return 0 if pasteboard ownership has been taken from us.
     WEBCORE_EXPORT int64_t copy(const String& fromPasteboard);
-    WEBCORE_EXPORT int64_t setBufferForType(SharedBuffer*, const String& pasteboardType);
+    WEBCORE_EXPORT int64_t setBufferForType(const SharedBuffer*, const String& pasteboardType);
     WEBCORE_EXPORT int64_t setURL(const PasteboardURL&);
     WEBCORE_EXPORT int64_t setColor(const Color&);
     WEBCORE_EXPORT int64_t setStringForType(const String&, const String& pasteboardType);

--- a/Source/WebCore/platform/PromisedAttachmentInfo.h
+++ b/Source/WebCore/platform/PromisedAttachmentInfo.h
@@ -38,7 +38,7 @@ struct PromisedAttachmentInfo {
 #endif
 
     Vector<String> additionalTypes;
-    Vector<RefPtr<SharedBuffer>> additionalData;
+    Vector<RefPtr<const SharedBuffer>> additionalData;
 
     operator bool() const
     {

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -21,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -143,7 +143,7 @@ public:
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(const uint8_t*, size_t);
     static Ref<FragmentedSharedBuffer> create(const char* data, size_t size) { return create(reinterpret_cast<const uint8_t*>(data), size); }
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(FileSystem::MappedFileData&&);
-    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(Ref<SharedBuffer>&&);
+    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(Ref<const FragmentedSharedBuffer>&&);
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(Vector<uint8_t>&&);
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(DataSegment::Provider&&);
 
@@ -181,7 +181,7 @@ public:
 
     WEBCORE_EXPORT void forEachSegment(const Function<void(const Span<const uint8_t>&)>&) const;
     WEBCORE_EXPORT bool startsWith(const Span<const uint8_t>& prefix) const;
-    WEBCORE_EXPORT void forEachSegmentAsSharedBuffer(const Function<void(Ref<SharedBuffer>&&)>&) const;
+    WEBCORE_EXPORT void forEachSegmentAsSharedBuffer(const Function<void(Ref<const SharedBuffer>&&)>&) const;
 
     using DataSegment = WebCore::DataSegment; // To keep backward compatibility when using FragmentedSharedBuffer::DataSegment
 
@@ -219,7 +219,7 @@ protected:
     explicit FragmentedSharedBuffer(Vector<uint8_t>&& data) { append(WTFMove(data)); }
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(FileSystem::MappedFileData&&);
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(DataSegment::Provider&&);
-    WEBCORE_EXPORT explicit FragmentedSharedBuffer(Ref<SharedBuffer>&&);
+    WEBCORE_EXPORT explicit FragmentedSharedBuffer(Ref<const FragmentedSharedBuffer>&&);
 #if USE(CF)
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(CFDataRef);
 #endif

--- a/Source/WebCore/platform/audio/NowPlayingInfo.h
+++ b/Source/WebCore/platform/audio/NowPlayingInfo.h
@@ -36,7 +36,7 @@ namespace WebCore {
 struct NowPlayingInfoArtwork {
     String src;
     String mimeType;
-    RefPtr<FragmentedSharedBuffer> imageData;
+    RefPtr<const FragmentedSharedBuffer> imageData;
 
     bool operator==(const NowPlayingInfoArtwork& other) const
     {

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -217,7 +217,7 @@ public:
     String description() const;
 
     struct CreationData {
-        Ref<SharedBuffer> fontFaceData;
+        Ref<const SharedBuffer> fontFaceData;
         String itemInCollection;
 #if PLATFORM(WIN)
         Ref<FontMemoryResource> m_fontResource;

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -107,7 +107,7 @@ bool Image::isPostScriptResource(const String& mimeType, const URL& url)
 }
 
 
-EncodedDataStatus Image::setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived)
+EncodedDataStatus Image::setData(RefPtr<const FragmentedSharedBuffer>&& data, bool allDataReceived)
 {
     m_encodedImageData = WTFMove(data);
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -124,7 +124,7 @@ public:
     virtual std::optional<IntPoint> hotSpot() const { return std::nullopt; }
     virtual ImageOrientation orientation() const { return ImageOrientation::FromImage; }
 
-    WEBCORE_EXPORT EncodedDataStatus setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived);
+    WEBCORE_EXPORT EncodedDataStatus setData(RefPtr<const FragmentedSharedBuffer>&& data, bool allDataReceived);
     virtual EncodedDataStatus dataChanged(bool /*allDataReceived*/) { return EncodedDataStatus::Unknown; }
 
     virtual String uti() const { return String(); } // null string if unknown
@@ -133,7 +133,6 @@ public:
 
     virtual void destroyDecodedData(bool destroyAll = true) = 0;
 
-    FragmentedSharedBuffer* data() { return m_encodedImageData.get(); }
     const FragmentedSharedBuffer* data() const { return m_encodedImageData.get(); }
 
     virtual DestinationColorSpace colorSpace();
@@ -208,7 +207,7 @@ protected:
     virtual Color singlePixelSolidColor() const { return Color(); }
 
 private:
-    RefPtr<FragmentedSharedBuffer> m_encodedImageData;
+    RefPtr<const FragmentedSharedBuffer> m_encodedImageData;
     ImageObserver* m_imageObserver;
     std::unique_ptr<Timer> m_animationStartTimer;
 };

--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -80,7 +80,7 @@ void ImageDecoder::clearFactories()
 }
 #endif
 
-RefPtr<ImageDecoder> ImageDecoder::create(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
+RefPtr<ImageDecoder> ImageDecoder::create(const FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
     UNUSED_PARAM(mimeType);
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -42,7 +42,7 @@ class FragmentedSharedBuffer;
 class ImageDecoder : public ThreadSafeRefCounted<ImageDecoder> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static RefPtr<ImageDecoder> create(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
+    static RefPtr<ImageDecoder> create(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
     virtual ~ImageDecoder() = default;
 
     enum class MediaType {
@@ -91,7 +91,7 @@ public:
 #if ENABLE(GPU_PROCESS)
     using SupportsMediaTypeFunc = Function<bool(MediaType)>;
     using CanDecodeTypeFunc = Function<bool(const String&)>;
-    using CreateImageDecoderFunc = Function<RefPtr<ImageDecoder>(FragmentedSharedBuffer&, const String&, AlphaOption, GammaAndColorProfileOption)>;
+    using CreateImageDecoderFunc = Function<RefPtr<ImageDecoder>(const FragmentedSharedBuffer&, const String&, AlphaOption, GammaAndColorProfileOption)>;
 
     struct ImageDecoderFactory {
         SupportsMediaTypeFunc supportsMediaType;

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -67,7 +67,7 @@ ImageSource::~ImageSource()
     ASSERT(&m_runLoop == &RunLoop::current());
 }
 
-bool ImageSource::ensureDecoderAvailable(FragmentedSharedBuffer* data)
+bool ImageSource::ensureDecoderAvailable(const FragmentedSharedBuffer* data)
 {
     if (!data || isDecoderAvailable())
         return true;
@@ -91,7 +91,7 @@ bool ImageSource::ensureDecoderAvailable(FragmentedSharedBuffer* data)
     return true;
 }
 
-void ImageSource::setData(FragmentedSharedBuffer* data, bool allDataReceived)
+void ImageSource::setData(const FragmentedSharedBuffer* data, bool allDataReceived)
 {
     if (!data || !ensureDecoderAvailable(data))
         return;
@@ -99,13 +99,13 @@ void ImageSource::setData(FragmentedSharedBuffer* data, bool allDataReceived)
     m_decoder->setData(*data, allDataReceived);
 }
 
-void ImageSource::resetData(FragmentedSharedBuffer* data)
+void ImageSource::resetData(const FragmentedSharedBuffer* data)
 {
     m_decoder = nullptr;
     setData(data, isAllDataReceived());
 }
 
-EncodedDataStatus ImageSource::dataChanged(FragmentedSharedBuffer* data, bool allDataReceived)
+EncodedDataStatus ImageSource::dataChanged(const FragmentedSharedBuffer* data, bool allDataReceived)
 {
     setData(data, allDataReceived);
     clearMetadata();

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -56,9 +56,9 @@ public:
         return adoptRef(*new ImageSource(WTFMove(nativeImage)));
     }
 
-    void setData(FragmentedSharedBuffer* data, bool allDataReceived);
-    void resetData(FragmentedSharedBuffer* data);
-    EncodedDataStatus dataChanged(FragmentedSharedBuffer* data, bool allDataReceived);
+    void setData(const FragmentedSharedBuffer* data, bool allDataReceived);
+    void resetData(const FragmentedSharedBuffer* data);
+    EncodedDataStatus dataChanged(const FragmentedSharedBuffer* data, bool allDataReceived);
     bool isAllDataReceived();
 
     unsigned decodedSize() const { return m_decodedSize; }
@@ -149,7 +149,7 @@ private:
     template<typename T>
     T firstFrameMetadataCacheIfNeeded(T& cachedValue, MetadataType, T (ImageFrame::*functor)() const, ImageFrame::Caching, const std::optional<SubsamplingLevel>& = { });
 
-    bool ensureDecoderAvailable(FragmentedSharedBuffer* data);
+    bool ensureDecoderAvailable(const FragmentedSharedBuffer* data);
     bool isDecoderAvailable() const { return m_decoder; }
     void decodedSizeChanged(long long decodedSize);
     void didDecodeProperties(unsigned decodedPropertiesSize);

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -37,7 +37,7 @@ static const uint32_t kWoff2Signature = 0x774f4632; // "wOF2"
 
 namespace WebCore {
 
-static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
+static bool readUInt32(const SharedBuffer& buffer, size_t& offset, uint32_t& value)
 {
     ASSERT_ARG(offset, offset <= buffer.size());
     if (buffer.size() - offset < sizeof(value))
@@ -49,7 +49,7 @@ static bool readUInt32(SharedBuffer& buffer, size_t& offset, uint32_t& value)
     return true;
 }
 
-static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
+static bool readUInt16(const SharedBuffer& buffer, size_t& offset, uint16_t& value)
 {
     ASSERT_ARG(offset, offset <= buffer.size());
     if (buffer.size() - offset < sizeof(value))
@@ -75,7 +75,7 @@ static bool writeUInt16(Vector<uint8_t>& vector, uint16_t value)
 
 static const uint32_t woffSignature = 0x774f4646; /* 'wOFF' */
 
-bool isWOFF(SharedBuffer& buffer)
+bool isWOFF(const SharedBuffer& buffer)
 {
     size_t offset = 0;
     uint32_t signature;
@@ -126,7 +126,7 @@ private:
 };
 #endif
 
-bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
+bool convertWOFFToSfnt(const SharedBuffer& woff, Vector<uint8_t>& sfnt)
 {
     ASSERT_ARG(sfnt, sfnt.isEmpty());
 
@@ -283,7 +283,7 @@ bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
     return sfnt.size() == totalSfntSize;
 }
 
-bool convertWOFFToSfntIfNecessary(RefPtr<SharedBuffer>& buffer)
+bool convertWOFFToSfntIfNecessary(RefPtr<const SharedBuffer>& buffer)
 {
 #if PLATFORM(COCOA)
     UNUSED_PARAM(buffer);

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.h
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.h
@@ -33,16 +33,16 @@ namespace WebCore {
 class SharedBuffer;
 
 // Returns whether the buffer is a WOFF file.
-bool isWOFF(SharedBuffer&);
+bool isWOFF(const SharedBuffer&);
 
 // Returns false if the WOFF file woff is invalid or could not be converted to sfnt (for example,
 // if conversion ran out of memory). Otherwise returns true and writes the sfnt payload into sfnt.
-bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt);
+bool convertWOFFToSfnt(const SharedBuffer& woff, Vector<uint8_t>& sfnt);
 
 // If the given buffer is a WOFF file and the current platform has no native support for WOFF
 // fonts, convert it to sfnt. Returns true if the given buffer was converted. If conversion fails,
 // the buffer will be set to nullptr.
-bool convertWOFFToSfntIfNecessary(RefPtr<SharedBuffer>&);
+bool convertWOFFToSfntIfNecessary(RefPtr<const SharedBuffer>&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -271,7 +271,7 @@ void sharedBufferRelease(void* info)
 bool ImageDecoderCG::s_enableDecodingHEIC = false;
 bool ImageDecoderCG::s_hardwareAcceleratedDecodingDisabled = false;
 
-ImageDecoderCG::ImageDecoderCG(FragmentedSharedBuffer& data, AlphaOption, GammaAndColorProfileOption)
+ImageDecoderCG::ImageDecoderCG(const FragmentedSharedBuffer& data, AlphaOption, GammaAndColorProfileOption)
 {
     RetainPtr<CFStringRef> utiHint;
     if (data.size() >= 32)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -34,9 +34,9 @@ namespace WebCore {
 class ImageDecoderCG final : public ImageDecoder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ImageDecoderCG(FragmentedSharedBuffer& data, AlphaOption, GammaAndColorProfileOption);
+    ImageDecoderCG(const FragmentedSharedBuffer& data, AlphaOption, GammaAndColorProfileOption);
 
-    static Ref<ImageDecoderCG> create(FragmentedSharedBuffer& data, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
+    static Ref<ImageDecoderCG> create(const FragmentedSharedBuffer& data, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
     {
         return adoptRef(*new ImageDecoderCG(data, alphaOption, gammaAndColorProfileOption));
     }

--- a/Source/WebCore/platform/graphics/mac/FontCustomPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/mac/FontCustomPlatformData.cpp
@@ -52,7 +52,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     return FontPlatformData(font.get(), size, bold, italic, orientation, widthVariant, fontDescription.textRenderingMode(), &creationData);
 }
 
-std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
+std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(const SharedBuffer& buffer, const String& itemInCollection)
 {
     RetainPtr<CFDataRef> bufferData = buffer.createCFData();
 

--- a/Source/WebCore/platform/graphics/mac/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/mac/FontCustomPlatformData.h
@@ -60,7 +60,7 @@ public:
     FontPlatformData::CreationData creationData;
 };
 
-WEBCORE_EXPORT std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer&, const String&);
+WEBCORE_EXPORT std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(const SharedBuffer&, const String&);
 
 }
 

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h
@@ -133,7 +133,7 @@ private:
     explicit OpenTypeMathData(const FontPlatformData&);
 
 #if ENABLE(OPENTYPE_MATH)
-    RefPtr<SharedBuffer> m_mathBuffer;
+    RefPtr<const SharedBuffer> m_mathBuffer;
 #elif USE(HARFBUZZ)
     HbUniquePtr<hb_font_t> m_mathFont;
 #endif

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -73,7 +73,7 @@ typedef UInt16 GlyphID;
 typedef uint32_t Tag;
 #define OT_MAKE_TAG(ch1, ch2, ch3, ch4) ((((uint32_t)(ch4)) << 24) | (((uint32_t)(ch3)) << 16) | (((uint32_t)(ch2)) << 8) | ((uint32_t)(ch1)))
 
-template <typename T> static const T* validateTable(const RefPtr<SharedBuffer>& buffer, size_t count = 1)
+template <typename T> static const T* validateTable(const RefPtr<const SharedBuffer>& buffer, size_t count = 1)
 {
     if (!buffer || buffer->size() < sizeof(T) * count)
         return 0;

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -338,7 +338,7 @@ int64_t PlatformPasteboard::setTypes(const Vector<String>&)
     return 0;
 }
 
-int64_t PlatformPasteboard::setBufferForType(SharedBuffer*, const String&)
+int64_t PlatformPasteboard::setBufferForType(const SharedBuffer*, const String&)
 {
     return 0;
 }

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -341,7 +341,7 @@ int64_t PlatformPasteboard::setTypes(const Vector<String>& pasteboardTypes)
     return [m_pasteboard declareTypes:createNSArray(pasteboardTypes).get() owner:nil];
 }
 
-int64_t PlatformPasteboard::setBufferForType(SharedBuffer* buffer, const String& pasteboardType)
+int64_t PlatformPasteboard::setBufferForType(const SharedBuffer* buffer, const String& pasteboardType)
 {
     if (!canWritePasteboardType(pasteboardType))
         return 0;

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -77,13 +77,13 @@ void WorkerFontLoadRequest::load(WorkerGlobalScope& workerGlobalScope)
 bool WorkerFontLoadRequest::ensureCustomFontData(const AtomString&)
 {
     if (!m_fontCustomPlatformData && !m_errorOccurred && !m_isLoading) {
-        RefPtr<SharedBuffer> contiguousData;
+        RefPtr<const SharedBuffer> contiguousData;
         if (m_data)
             contiguousData = m_data.takeAsContiguous();
         convertWOFFToSfntIfNecessary(contiguousData);
         if (contiguousData) {
             m_fontCustomPlatformData = createFontCustomPlatformData(*contiguousData, m_url.fragmentIdentifier().toString());
-            m_data = WTFMove(contiguousData);
+            m_data = SharedBufferBuilder(std::in_place, contiguousData.releaseNonNull());
             if (!m_fontCustomPlatformData)
                 m_errorOccurred = true;
         }

--- a/Source/WebKit/Platform/IPC/ArgumentCoder.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoder.h
@@ -57,15 +57,15 @@ template<typename T, typename = void> struct ArgumentCoder {
     }
 
     template<typename Decoder>
-    static std::optional<T> decode(Decoder& decoder)
+    static auto decode(Decoder& decoder)
     {
         if constexpr(HasModernDecoderV<T>)
             return T::decode(decoder);
         else {
             T t;
             if (T::decode(decoder, t))
-                return t;
-            return std::nullopt;
+                return std::optional<T> { WTFMove(t) };
+            return std::optional<T> { };
         }
     }
 

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.h
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.h
@@ -45,18 +45,30 @@ public:
     explicit SharedBufferReference(RefPtr<WebCore::FragmentedSharedBuffer>&& buffer)
         : m_size(buffer ? buffer->size() : 0)
         , m_buffer(WTFMove(buffer)) { }
-    explicit SharedBufferReference(Ref<WebCore::FragmentedSharedBuffer>&& buffer)
-        : m_size(buffer->size())
-        , m_buffer(WTFMove(buffer)) { }
     explicit SharedBufferReference(RefPtr<WebCore::SharedBuffer>&& buffer)
         : m_size(buffer ? buffer->size() : 0)
+        , m_buffer(WTFMove(buffer)) { }
+    explicit SharedBufferReference(RefPtr<const WebCore::FragmentedSharedBuffer>&& buffer)
+        : m_size(buffer ? buffer->size() : 0)
+        , m_buffer(WTFMove(buffer)) { }
+    explicit SharedBufferReference(RefPtr<const WebCore::SharedBuffer>&& buffer)
+        : m_size(buffer ? buffer->size() : 0)
+        , m_buffer(WTFMove(buffer)) { }
+    explicit SharedBufferReference(Ref<WebCore::FragmentedSharedBuffer>&& buffer)
+        : m_size(buffer->size())
         , m_buffer(WTFMove(buffer)) { }
     explicit SharedBufferReference(Ref<WebCore::SharedBuffer>&& buffer)
         : m_size(buffer->size())
         , m_buffer(WTFMove(buffer)) { }
+    explicit SharedBufferReference(Ref<const WebCore::FragmentedSharedBuffer>&& buffer)
+        : m_size(buffer->size())
+        , m_buffer(WTFMove(buffer)) { }
+    explicit SharedBufferReference(Ref<const WebCore::SharedBuffer>&& buffer)
+        : m_size(buffer->size())
+        , m_buffer(WTFMove(buffer)) { }
     explicit SharedBufferReference(const WebCore::FragmentedSharedBuffer& buffer)
         : m_size(buffer.size())
-        , m_buffer(const_cast<WebCore::FragmentedSharedBuffer*>(&buffer)) { }
+        , m_buffer(&buffer) { }
 
     SharedBufferReference(const SharedBufferReference&) = default;
     SharedBufferReference(SharedBufferReference&&) = default;
@@ -83,7 +95,7 @@ private:
         , m_memory(WTFMove(memory)) { }
 
     size_t m_size { 0 };
-    RefPtr<WebCore::FragmentedSharedBuffer> m_buffer;
+    RefPtr<const WebCore::FragmentedSharedBuffer> m_buffer;
     RefPtr<WebKit::SharedMemory> m_memory; // Only set on the receiver side and if m_size isn't 0.
 };
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -967,12 +967,9 @@ def headers_for_type(type):
         'WebKit::WebGPU::VertexAttribute': ['"WebGPUVertexAttribute.h"'],
         'WebKit::WebGPU::VertexBufferLayout': ['"WebGPUVertexBufferLayout.h"'],
         'WebKit::WebGPU::VertexState': ['"WebGPUVertexState.h"'],
-        'struct WebCore::Cookie': ['<WebCore/Cookie.h>'],
-        'struct WebCore::ElementContext': ['<WebCore/ElementContext.h>'],
-        'struct WebCore::VideoPlaybackQualityMetrics': ['<WebCore/VideoPlaybackQualityMetrics.h>'],
-        'struct WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
-        'struct WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
-        'struct WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
+        'WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
+        'WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
+        'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
         'webrtc::WebKitEncodedFrameInfo': ['<webrtc/sdk/WebKit/WebKitEncoder.h>', '<WebCore/LibWebRTCEnumTraits.h>'],
     }
 
@@ -981,6 +978,8 @@ def headers_for_type(type):
         headers += header_info['headers']
 
     for type in header_infos_and_types['types']:
+        # Remove const or struct qualifier from type.
+        type = re.sub("^(const|struct) +", "", type)
         if type in special_cases:
             headers += special_cases[type]
             continue

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -85,8 +85,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
         return;
 
     if (Image* image = hitTestResult.image()) {
-        RefPtr<FragmentedSharedBuffer> buffer = image->data();
-        if (buffer) {
+        if (auto buffer = image->data()) {
             imageSharedMemory = WebKit::SharedMemory::copyBuffer(*buffer);
             imageSize = buffer->size();
         }

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -388,7 +388,7 @@ void WebPasteboardProxy::urlStringSuitableForLoading(IPC::Connection& connection
     });
 }
 
-void WebPasteboardProxy::setPasteboardBufferForType(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, RefPtr<SharedBuffer>&& buffer, std::optional<PageIdentifier> pageID, CompletionHandler<void(int64_t)>&& completionHandler)
+void WebPasteboardProxy::setPasteboardBufferForType(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, RefPtr<const SharedBuffer>&& buffer, std::optional<PageIdentifier> pageID, CompletionHandler<void(int64_t)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(!pasteboardName.isEmpty(), completionHandler(0));
     MESSAGE_CHECK_COMPLETION(!pasteboardType.isEmpty(), completionHandler(0));

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -105,7 +105,7 @@ private:
     void setPasteboardURL(IPC::Connection&, const WebCore::PasteboardURL&, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardColor(IPC::Connection&, const String&, const WebCore::Color&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardStringForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, const String&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
-    void setPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, RefPtr<WebCore::SharedBuffer>&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
+    void setPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, RefPtr<const WebCore::SharedBuffer>&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
 #endif
 
     void readStringFromPasteboard(IPC::Connection&, size_t index, const String& pasteboardType, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -55,7 +55,7 @@ messages -> WebPasteboardProxy NotRefCounted {
     SetPasteboardURL(struct WebCore::PasteboardURL pasteboardURL, String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
     SetPasteboardColor(String pasteboardName, WebCore::Color color, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
     SetPasteboardStringForType(String pasteboardName, String pasteboardType, String string, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
-    SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<WebCore::SharedBuffer> buffer, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
+    SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<const WebCore::SharedBuffer> buffer, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
     ContainsURLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous WantsConnection
     URLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
@@ -45,7 +45,7 @@ class RemoteImageDecoderAVF final
     : public WebCore::ImageDecoder
     , public CanMakeWeakPtr<RemoteImageDecoderAVF> {
 public:
-    static Ref<RemoteImageDecoderAVF> create(RemoteImageDecoderAVFManager& manager, const WebCore::ImageDecoderIdentifier& identifier, WebCore::FragmentedSharedBuffer&, const String& mimeType)
+    static Ref<RemoteImageDecoderAVF> create(RemoteImageDecoderAVFManager& manager, const WebCore::ImageDecoderIdentifier& identifier, const WebCore::FragmentedSharedBuffer&, const String& mimeType)
     {
         return adoptRef(*new RemoteImageDecoderAVF(manager, identifier, mimeType));
     }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -39,7 +39,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
+RefPtr<RemoteImageDecoderAVF> RemoteImageDecoderAVFManager::createImageDecoder(const FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption)
 {
     std::optional<ImageDecoderIdentifier> imageDecoderIdentifier;
     if (!ensureGPUProcessConnection().connection().sendSync(Messages::RemoteImageDecoderAVFProxy::CreateDecoder(IPC::SharedBufferReference(data), mimeType), Messages::RemoteImageDecoderAVFProxy::CreateDecoder::Reply(imageDecoderIdentifier), 0))
@@ -107,7 +107,7 @@ void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)
     ImageDecoder::installFactory({
         RemoteImageDecoderAVF::supportsMediaType,
         RemoteImageDecoderAVF::canDecodeType,
-        [this](FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption) {
+        [this](const FragmentedSharedBuffer& data, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaAndColorProfileOption) {
             return createImageDecoder(data, mimeType, alphaOption, gammaAndColorProfileOption);
         }
     });

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -59,7 +59,7 @@ public:
     GPUProcessConnection& ensureGPUProcessConnection();
 
 private:
-    RefPtr<RemoteImageDecoderAVF> createImageDecoder(WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption);
+    RefPtr<RemoteImageDecoderAVF> createImageDecoder(const WebCore::FragmentedSharedBuffer& data, const String& mimeType, WebCore::AlphaOption, WebCore::GammaAndColorProfileOption);
 
     // GPUProcessConnection::Client.
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h
@@ -63,7 +63,7 @@ public:
     virtual void didChange(WebKit::WebPage&, const WTF::String&) { }
     virtual void didChangeSelection(WebKit::WebPage&, const WTF::String&) { }
     virtual void willWriteToPasteboard(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>&) { }
-    virtual void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>&, Vector<WTF::String>&, Vector<RefPtr<WebCore::SharedBuffer>>&) { }
+    virtual void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>&, Vector<WTF::String>&, Vector<RefPtr<const WebCore::SharedBuffer>>&) { }
     virtual void didWriteToPasteboard(WebKit::WebPage&) { }
     virtual bool performTwoStepDrop(WebKit::WebPage&, WebCore::DocumentFragment&, const WebCore::SimpleRange&, bool) { return false; }
 };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -629,7 +629,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
             [m_controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:m_controller willWriteRangeToPasteboard:wrapper(WebKit::createHandle(range).get())];
         }
 
-        void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final
+        void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData) final
         {
             if (!m_delegateMethods.getPasteboardDataForRange)
                 return;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
@@ -135,7 +135,7 @@ void InjectedBundlePageEditorClient::willWriteToPasteboard(WebPage& page, const 
         m_client.willWriteToPasteboard(toAPI(&page), toAPI(createHandle(range).get()), m_client.base.clientInfo);
 }
 
-void InjectedBundlePageEditorClient::getPasteboardDataForRange(WebPage& page, const std::optional<SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<SharedBuffer>>& pasteboardData)
+void InjectedBundlePageEditorClient::getPasteboardDataForRange(WebPage& page, const std::optional<SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<const SharedBuffer>>& pasteboardData)
 {
     if (m_client.getPasteboardDataForRange) {
         WKArrayRef types = nullptr;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.h
@@ -64,7 +64,7 @@ private:
     void didChange(WebPage&, const String& notificationName) final;
     void didChangeSelection(WebPage&, const String& notificationName) final;
     void willWriteToPasteboard(WebPage&, const std::optional<WebCore::SimpleRange>&) final;
-    void getPasteboardDataForRange(WebPage&, const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getPasteboardDataForRange(WebPage&, const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData) final;
     void didWriteToPasteboard(WebPage&) final;
     bool performTwoStepDrop(WebPage&, WebCore::DocumentFragment&, const WebCore::SimpleRange& destination, bool isMove) final;
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -142,7 +142,7 @@ bool WebEditorClient::shouldApplyStyle(const StyleProperties& style, const std::
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-void WebEditorClient::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& data)
+void WebEditorClient::registerAttachmentIdentifier(const String& identifier, const String& contentType, const String& preferredFileName, Ref<const FragmentedSharedBuffer>&& data)
 {
     m_page->send(Messages::WebPageProxy::RegisterAttachmentIdentifierFromData(identifier, contentType, preferredFileName, IPC::SharedBufferReference(WTFMove(data))));
 }
@@ -265,7 +265,7 @@ void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleR
     m_page->injectedBundleEditorClient().willWriteToPasteboard(*m_page, range);
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<SharedBuffer>>& pasteboardData)
+void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<const SharedBuffer>>& pasteboardData)
 {
     m_page->injectedBundleEditorClient().getPasteboardDataForRange(*m_page, range, pasteboardTypes, pasteboardData);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -66,7 +66,7 @@ private:
     bool shouldMoveRangeAfterDelete(const WebCore::SimpleRange&, const WebCore::SimpleRange&) final;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<WebCore::FragmentedSharedBuffer>&&) final;
+    void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<const WebCore::FragmentedSharedBuffer>&&) final;
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& filePath) final;
     void registerAttachmentIdentifier(const String&) final;
     void registerAttachments(Vector<WebCore::SerializedAttachmentData>&&) final;
@@ -88,7 +88,7 @@ private:
     void didEndEditing() final;
     void willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&) final;
     void didWriteSelectionToPasteboard() final;
-    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData) final;
     
     void registerUndoStep(WebCore::UndoStep&) final;
     void registerRedoStep(WebCore::UndoStep&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -204,7 +204,7 @@ int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, c
     return newChangeCount;
 }
 
-int64_t WebPlatformStrategies::setBufferForType(SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
+int64_t WebPlatformStrategies::setBufferForType(const SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
     SharedMemory::Handle handle;
     // FIXME: Null check prevents crashing, but it is not great that we will have empty pasteboard content for this type,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -210,7 +210,8 @@ int64_t WebPlatformStrategies::setBufferForType(const SharedBuffer* buffer, cons
     // FIXME: Null check prevents crashing, but it is not great that we will have empty pasteboard content for this type,
     // because we've already set the types.
     int64_t newChangeCount { 0 };
-    WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardBufferForType(pasteboardName, pasteboardType, buffer ? RefPtr { buffer } : SharedBuffer::create(), pageIdentifier(context)), Messages::WebPasteboardProxy::SetPasteboardBufferForType::Reply(newChangeCount), 0);
+    auto bufferToSend = buffer ? RefPtr { buffer } : SharedBuffer::create();
+    WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardBufferForType(pasteboardName, pasteboardType, bufferToSend, pageIdentifier(context)), Messages::WebPasteboardProxy::SetPasteboardBufferForType::Reply(newChangeCount), 0);
     return newChangeCount;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -66,7 +66,7 @@ private:
 
     int64_t addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*) override;
-    int64_t setBufferForType(WebCore::SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
+    int64_t setBufferForType(const WebCore::SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setURL(const WebCore::PasteboardURL&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setColor(const WebCore::Color&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -342,7 +342,7 @@ String WebFrame::source() const
     DocumentLoader* documentLoader = m_coreFrame->loader().activeDocumentLoader();
     if (!documentLoader)
         return String();
-    RefPtr<FragmentedSharedBuffer> mainResourceData = documentLoader->mainResourceData();
+    auto mainResourceData = documentLoader->mainResourceData();
     if (!mainResourceData)
         return String();
     return decoder->encoding().decode(mainResourceData->makeContiguous()->data(), mainResourceData->size());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3986,7 +3986,7 @@ void WebPage::getSourceForFrame(FrameIdentifier frameID, CompletionHandler<void(
 
 void WebPage::getMainResourceDataOfFrame(FrameIdentifier frameID, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&& callback)
 {
-    RefPtr<FragmentedSharedBuffer> buffer;
+    RefPtr<const FragmentedSharedBuffer> buffer;
     if (WebFrame* frame = WebProcess::singleton().webFrame(frameID)) {
 #if ENABLE(PDFKIT_PLUGIN)
         if (PluginView* pluginView = pluginViewForFrame(frame->coreFrame()))
@@ -4002,7 +4002,7 @@ void WebPage::getMainResourceDataOfFrame(FrameIdentifier frameID, CompletionHand
     callback(IPC::SharedBufferReference(WTFMove(buffer)));
 }
 
-static RefPtr<FragmentedSharedBuffer> resourceDataForFrame(Frame* frame, const URL& resourceURL)
+static RefPtr<const FragmentedSharedBuffer> resourceDataForFrame(Frame* frame, const URL& resourceURL)
 {
     DocumentLoader* loader = frame->loader().documentLoader();
     if (!loader)
@@ -4017,7 +4017,7 @@ static RefPtr<FragmentedSharedBuffer> resourceDataForFrame(Frame* frame, const U
 
 void WebPage::getResourceDataFromFrame(FrameIdentifier frameID, const String& resourceURLString, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&& callback)
 {
-    RefPtr<FragmentedSharedBuffer> buffer;
+    RefPtr<const FragmentedSharedBuffer> buffer;
     if (auto* frame = WebProcess::singleton().webFrame(frameID)) {
         URL resourceURL { resourceURLString };
         buffer = resourceDataForFrame(frame->coreFrame(), resourceURL);
@@ -7203,7 +7203,7 @@ void WebPage::didGetLoadDecisionForIcon(bool decision, CallbackID loadIdentifier
     if (!documentLoader)
         return completionHandler({ });
 
-    documentLoader->didGetLoadDecisionForIcon(decision, loadIdentifier.toInteger(), [completionHandler = WTFMove(completionHandler)] (WebCore::FragmentedSharedBuffer* iconData) mutable {
+    documentLoader->didGetLoadDecisionForIcon(decision, loadIdentifier.toInteger(), [completionHandler = WTFMove(completionHandler)] (const WebCore::FragmentedSharedBuffer* iconData) mutable {
         completionHandler(IPC::SharedBufferReference(RefPtr { iconData }));
     });
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -80,7 +80,7 @@ private:
     void didEndEditing() final;
     void willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&) final;
     void didWriteSelectionToPasteboard() final;
-    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData) final;
 
     void setInsertionPasteboard(const String&) final;
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String&) final { return WebCore::DOMPasteAccessResponse::DeniedForGesture; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -407,7 +407,7 @@ void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleR
     // Not implemented WebKit, only WebKit2.
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData)
+void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData)
 {
     // Not implemented WebKit, only WebKit2.
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -250,7 +250,7 @@ private:
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, WebCore::ResourceError>&&)>&&) final;
 
     void getLoadDecisionForIcons(const Vector<std::pair<WebCore::LinkIcon&, uint64_t>>&) final;
-    void finishedLoadingIcon(WebCore::FragmentedSharedBuffer*);
+    void finishedLoadingIcon(const WebCore::FragmentedSharedBuffer*);
 
 #if !PLATFORM(IOS_FAMILY)
     bool m_loadingIcon { false };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -2093,7 +2093,7 @@ void WebFrameLoaderClient::getLoadDecisionForIcons(const Vector<std::pair<WebCor
         }
 
         m_loadingIcon = true;
-        documentLoader->didGetLoadDecisionForIcon(true, icon->second, [this, weakThis = WeakPtr { *this }] (WebCore::FragmentedSharedBuffer* buffer) {
+        documentLoader->didGetLoadDecisionForIcon(true, icon->second, [this, weakThis = WeakPtr { *this }] (const WebCore::FragmentedSharedBuffer* buffer) {
             if (!weakThis)
                 return;
             finishedLoadingIcon(buffer);
@@ -2130,7 +2130,7 @@ static NSImage *webGetNSImage(WebCore::Image* image, NSSize size)
 }
 #endif // !PLATFORM(IOS_FAMILY)
 
-void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* iconData)
+void WebFrameLoaderClient::finishedLoadingIcon(const WebCore::FragmentedSharedBuffer* iconData)
 {
 #if !PLATFORM(IOS_FAMILY)
     ASSERT(m_loadingIcon);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
@@ -75,7 +75,7 @@ private:
 
     int64_t addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*) override;
-    int64_t setBufferForType(WebCore::SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
+    int64_t setBufferForType(const WebCore::SharedBuffer*, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setURL(const WebCore::PasteboardURL&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setColor(const WebCore::Color&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -154,7 +154,7 @@ int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, c
     return PlatformPasteboard(pasteboardName).setTypes(pasteboardTypes);
 }
 
-int64_t WebPlatformStrategies::setBufferForType(SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setBufferForType(const SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
 {
     return PlatformPasteboard(pasteboardName).setBufferForType(buffer, pasteboardType);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -460,7 +460,7 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 
 - (NSData *)data
 {
-    RefPtr<WebCore::FragmentedSharedBuffer> mainResourceData = toPrivate(_private)->loader->mainResourceData();
+    auto mainResourceData = toPrivate(_private)->loader->mainResourceData();
     if (!mainResourceData)
         return nil;
     return mainResourceData->makeContiguous()->createNSData().autorelease();

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -367,7 +367,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     if (!encoding.isValid())
         encoding = PAL::WindowsLatin1Encoding();
     
-    FragmentedSharedBuffer* coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
+    const FragmentedSharedBuffer* coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
     return encoding.decode(reinterpret_cast<const char*>(coreData ? coreData->makeContiguous()->data() : nullptr), coreData ? coreData->size() : 0);
 }
 

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp
@@ -262,7 +262,7 @@ void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<WebCore
 {
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>&, Vector<RefPtr<WebCore::SharedBuffer> >&)
+void WebEditorClient::getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>&, Vector<RefPtr<const WebCore::SharedBuffer> >&)
 {
     notImplemented();
 }

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.h
@@ -55,7 +55,7 @@ private:
     void didEndEditing() final;
     void willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&) final;
     void didWriteSelectionToPasteboard() final;
-    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final;
+    void getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<String>& pasteboardTypes, Vector<RefPtr<const WebCore::SharedBuffer>>& pasteboardData) final;
 
     void didEndUserTriggeredSelectionChanges() final { }
     void respondToChangedContents() final;


### PR DESCRIPTION
#### b1ebf5d62be0861ab89a021171c51cc2866d8f2a
<pre>
Fix encoding of std::optional&lt;Ref&lt;RefPtr&gt;&gt;
</pre>
----------------------------------------------------------------------
#### 5588c056a3632c592ef22817d305b6b235c7368e
<pre>
fix for SetPasteboardBufferForType
</pre>
----------------------------------------------------------------------
#### a233d45facdf550f05ab4a7c405b847e0adc1b7f
<pre>
Make SharedBuffer passed via CachedResource const.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241251">https://bugs.webkit.org/show_bug.cgi?id=241251</a>
rdar://problem/94324781

Reviewed by NOBODY (OOPS!).

This change allows to avoid using const_cast whenever we need to take
a strong reference to a SharedBuffer sent over the networking stack as
those are passed as a const reference.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::notifyFinished):
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::promisedAttachmentInfo):
(WebCore::Editor::registerAttachmentIdentifier):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::getPasteboardTypesAndDataForAttachment):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(fileWrapperForElement):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::updateDuringParsing):
(WebCore::ImageDocument::finishedParsing):
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::addResourceSharedBuffer):
* Source/WebCore/inspector/NetworkResourcesData.h:
(WebCore::NetworkResourcesData::ResourceData::buffer const):
(WebCore::NetworkResourcesData::ResourceData::setBuffer):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::getResponseBody):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::mainResourceContent):
(WebCore::InspectorPageAgent::sharedBufferContent):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::mainResourceData const):
(WebCore::DocumentLoader::maybeCreateArchive):
(WebCore::DocumentLoader::mainResource const):
(WebCore::DocumentLoader::didGetLoadDecisionForIcon):
(WebCore::DocumentLoader::finishedLoadingIcon):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::deliverResponseAndData):
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/SubstituteData.h:
(WebCore::SubstituteData::SubstituteData):
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::data const):
(WebCore::SubstituteResource::SubstituteResource):
* Source/WebCore/loader/appcache/ApplicationCacheResource.cpp:
(WebCore::ApplicationCacheResource::create):
(WebCore::ApplicationCacheResource::ApplicationCacheResource):
* Source/WebCore/loader/appcache/ApplicationCacheResource.h:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::writeDataToUniqueFileInDirectory):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/loader/archive/ArchiveFactory.cpp:
(WebCore::archiveFactoryCreate):
(WebCore::ArchiveFactory::create):
* Source/WebCore/loader/archive/ArchiveFactory.h:
* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::ArchiveResource):
(WebCore::ArchiveResource::create):
* Source/WebCore/loader/archive/ArchiveResource.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::create):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.h:
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::ensureCustomFontData):
(WebCore::CachedFont::createCustomFontData):
* Source/WebCore/loader/cache/CachedFont.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::updateBufferInternal):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::tryReplaceEncodedData):
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::resourceBuffer const):
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h:
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm:
(WebCore::DiskCacheMonitor::resourceBecameFileBacked):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::notifyFinished):
* Source/WebCore/page/EditorClient.h:
(WebCore::EditorClient::registerAttachmentIdentifier):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::addImageToResources):
* Source/WebCore/platform/NowPlayingManager.h:
* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/PasteboardStrategy.h:
* Source/WebCore/platform/PasteboardWriterData.h:
* Source/WebCore/platform/PlatformPasteboard.h:
* Source/WebCore/platform/PromisedAttachmentInfo.h:
* Source/WebCore/platform/audio/NowPlayingInfo.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::setData):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::data): Deleted.
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::create):
* Source/WebCore/platform/graphics/ImageDecoder.h:
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::ensureDecoderAvailable):
(WebCore::ImageSource::setData):
(WebCore::ImageSource::resetData):
(WebCore::ImageSource::dataChanged):
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/WOFFFileFormat.cpp:
(WebCore::readUInt32):
(WebCore::readUInt16):
(WebCore::isWOFF):
(WebCore::convertWOFFToSfnt):
(WebCore::convertWOFFToSfntIfNecessary):
* Source/WebCore/platform/graphics/WOFFFileFormat.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::ImageDecoderCG):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/graphics/mac/FontCustomPlatformData.cpp:
(WebCore::createFontCustomPlatformData):
* Source/WebCore/platform/graphics/mac/FontCustomPlatformData.h:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.h:
* Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h:
(WebCore::OpenType::validateTable):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::setBufferForType):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::setBufferForType):
* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::ensureCustomFontData):
* Source/WebKit/Platform/IPC/SharedBufferReference.h:
(IPC::SharedBufferReference::SharedBufferReference):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::createImageDecoder):
(WebKit::RemoteImageDecoderAVFManager::setUseGPUProcess):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleEditorClient.h:
(API::InjectedBundle::EditorClient::getPasteboardDataForRange):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController _setEditingDelegate:]):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp:
(WebKit::InjectedBundlePageEditorClient::getPasteboardDataForRange):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::registerAttachmentIdentifier):
(WebKit::WebEditorClient::getClientPasteboardData):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::setBufferForType):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::source const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getMainResourceDataOfFrame):
(WebKit::resourceDataForFrame):
(WebKit::WebPage::getResourceDataFromFrame):
(WebKit::WebPage::didGetLoadDecisionForIcon):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::getClientPasteboardData):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::getLoadDecisionForIcons):
(WebFrameLoaderClient::finishedLoadingIcon):
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:
(WebPlatformStrategies::setBufferForType):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(-[WebDataSource data]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(-[WebResource _stringValue]):
* Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.cpp:
(WebEditorClient::getClientPasteboardData):
* Source/WebKitLegacy/win/WebCoreSupport/WebEditorClient.h:
</pre>
----------------------------------------------------------------------
#### 5eb9d9ec1e4b1daa3e712c95123ea834235a4ac4
<pre>
Have SharedBuffer constructors take a Ref&lt;const SharedBuffer&gt;
Move SharedBuffer::m_element in constructor, save on unnecessary copy and addRef.
</pre>