### PR TITLE
Allow keyboard smooth scrolling to take place in overflow:scroll regions

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll-expected.txt
@@ -1,0 +1,2 @@
+Successful.
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+
+<html>
+
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+    <style>
+        body {
+            height: 2000px;
+        }
+        #scroller {
+            width: 20%;
+            height: 20%;
+            overflow: scroll;
+            border: 1px solid black;
+            padding: 10px;
+        }
+        #innerDiv {
+            height: 1000px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function scrollerScrolled()
+        {
+            debug("Successful.")
+            testRunner.notifyDone();
+        }
+
+        function documentScrolled()
+        {
+            debug("Unsuccessful.");
+            testRunner.notifyDone();
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            let scroller = document.getElementById("scroller");
+
+            scroller.addEventListener("scroll", scrollerScrolled);
+            document.addEventListener("scroll", documentScrolled);
+
+            await UIHelper.activateAt(10, 10);
+            await UIHelper.keyDown("downArrow");
+        }
+    </script>
+</head>
+
+<body onload="runTest()">
+    <div id="scroller">
+        <div id="innerDiv"></div>
+    </div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4337,30 +4337,37 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
         event.setDefaultHandled();
 }
 
+KeyboardScrollingAnimator* EventHandler::keyboardScrollingAnimatorForFocusedNode()
+{
+    Node* node = m_frame.document()->focusedElement();
+
+    if (!node)
+        node = m_mousePressNode.get();
+
+    auto* scrollableArea = enclosingScrollableArea(node);
+    if (!scrollableArea)
+        return nullptr;
+
+    return scrollableArea->scrollAnimator().keyboardScrollingAnimator();
+}
+
 void EventHandler::stopKeyboardScrolling()
 {
-    Ref protectedFrame = m_frame;
-    auto* view = m_frame.view();
-    if (!view)
-        return;
-
-    auto* animator = view->scrollAnimator().keyboardScrollingAnimator();
+    auto* animator = keyboardScrollingAnimatorForFocusedNode();
     if (animator)
         animator->handleKeyUpEvent();
 }
 
 bool EventHandler::startKeyboardScrolling(KeyboardEvent& event)
 {
+    Ref protectedFrame = m_frame;
+
     if (!m_frame.settings().eventHandlerDrivenSmoothKeyboardScrollingEnabled())
         return false;
 
-    Ref protectedFrame = m_frame;
-    auto* view = m_frame.view();
-    if (!view)
-        return false;
-
-    auto* animator = view->scrollAnimator().keyboardScrollingAnimator();
+    auto* animator = keyboardScrollingAnimatorForFocusedNode();
     auto* platformEvent = event.underlyingPlatformEvent();
+
     if (animator && platformEvent)
         return animator->beginKeyboardScrollGesture(*platformEvent);
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -74,6 +74,7 @@ class FrameView;
 class HTMLFrameSetElement;
 class HitTestResult;
 class KeyboardEvent;
+class KeyboardScrollingAnimator;
 class MouseEventWithHitTestResults;
 class Node;
 class Pasteboard;
@@ -382,6 +383,7 @@ private:
     bool handleMousePressEventDoubleClick(const MouseEventWithHitTestResults&);
     bool handleMousePressEventTripleClick(const MouseEventWithHitTestResults&);
 
+    KeyboardScrollingAnimator* keyboardScrollingAnimatorForFocusedNode();
     bool startKeyboardScrolling(KeyboardEvent&);
     void stopKeyboardScrolling();
 


### PR DESCRIPTION
#### 52d75c8bf2198e556c133825f52f3c181d2c45ed
<pre>
Allow keyboard smooth scrolling to take place in overflow:scroll regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=228158">https://bugs.webkit.org/show_bug.cgi?id=228158</a>
rdar://80911829

Reviewed by Tim Horton.

Test: LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html

Right now, keyboard smooth scrolling can only scroll the entire page and
cannot scroll overflow:scroll regions. To fix this, rather than always
obtaining ScrollingAnimator from m_frame-&gt;view(), which will only ever
scroll the whole page, the code should get ScrollingAnimator from
m_frame.document()-&gt;focusedElement() or m_mousePressNode if either one
of them is non-null, which indicates that a sub-scrollable region is
focused.

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(Webcore::EventHandler::keyboardScrollingAnimatorForFocusedNode):
(WebCore::EventHandler::stopKeyboardScrolling):
(WebCore::EventHandler::startKeyboardScrolling):
* Source/WebCore/page/EventHandler.h:
</pre>