### PR TITLE
Right-click on links doesn't work in WebKit with Edit Menu enabled

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -801,8 +801,12 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 @interface UITextSelectionView : UIView
 @end
 
+@class UIContextMenuInteraction;
+@protocol UIContextMenuInteractionDelegate;
 @interface UITextInteractionAssistant (SPI)
 @property (nonatomic, readonly) UITextSelectionView *selectionView;
+@property (nonatomic, strong, readonly) UIContextMenuInteraction *contextMenuInteraction;
+@property (nonatomic, weak, readwrite) id<UIContextMenuInteractionDelegate> externalContextMenuInteractionDelegate;
 @end
 
 @interface UIWKTextInteractionAssistant : UITextInteractionAssistant <UIResponderStandardEditActions>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -855,6 +855,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #if HAVE(LINK_PREVIEW)
 #if USE(UICONTEXTMENU)
 @interface WKContentView (WKInteractionPreview) <UIContextMenuInteractionDelegate, UIPreviewItemDelegate>
+@property (nonatomic, readonly) UIContextMenuInteraction *contextMenuInteraction;
 #else
 @interface WKContentView (WKInteractionPreview) <UIPreviewItemDelegate>
 #endif


### PR DESCRIPTION
#### 5f6b3147994b8b806eaee6cf67f54e4f92ef2b48
<pre>
Right-click on links doesn&apos;t work in WebKit with Edit Menu enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=241395">https://bugs.webkit.org/show_bug.cgi?id=241395</a>

Reviewed by Wenson Hsieh.

UIKit is installing another UIContextMenuInteraction which was resulting in
two UIContextMenuInteraction instances installed on the view. Right-click on links
and some images showed an incorrect &apos;Select All&apos; menu only.

To avoid this, use the provided SPIs from UIKit which result in a single installed
UIContextMenuInteraction handler.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h
Stage changes for non-internal builds.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
Add convenience property for when USE(UICONTEXTMENU) is not defined.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textInteractionAssistantContextMenuInteraction]):
Helper for checking respondsToSelector before attempting to call SPI method.

(-[WKContentView setUpInteraction]):
The textSelectionAssistant needs to be created before registerPreview is called
in order to decided if we should use the SPI.

(-[WKContentView gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKContentView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKContentView imageAnalysisGestureDidTimeOut:]):
(-[WKContentView contextMenuInteraction]):
Use helper method which returns the current UIContextMenuInteraction handler.

(-[WKContentView _registerPreview]):
Use the UIKit provided UIContextMenuInteraction if it exists and set the delegate
to the same as what we would have passed to UIContextMenuInteraction&apos;s initializer.

Otherwise use the previous shipping behavior.

Canonical link: <a href="https://commits.webkit.org/251828@main">https://commits.webkit.org/251828@main</a>
</pre>
