### PR TITLE
[WPE] Mark /webkit/WebKitWebView/external-audio-rendering as slow after 251219@main

### DIFF
--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -126,6 +126,9 @@
             },
             "/webkit/WebKitWebView/fullscreen": {
                 "expected": {"wpe": {"status": ["TIMEOUT", "PASS"]}}
+            },
+            "/webkit/WebKitWebView/external-audio-rendering": {
+                "expected": {"wpe": {"status": ["PASS"], "slow": true}}
             }
         }
     },


### PR DESCRIPTION
#### f9cbbcaaf6dd7456972b10dc341aef6a6ce5047d
<pre>
[WPE] Mark /webkit/WebKitWebView/external-audio-rendering as slow after 251219@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242956">https://bugs.webkit.org/show_bug.cgi?id=242956</a>

Unreviewed test gardening.

This test became slower with the new media controls for WPE/GTK and is
frequently timing out with the default timeout of 5s for API tests.

* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/252659@main">https://commits.webkit.org/252659@main</a>
</pre>
