### PR TITLE
Remove 'Intrinsic Margins' feature from WebKit with flag.

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -545,6 +545,19 @@ DisallowSyncXHRDuringPageDismissalEnabled:
     WebCore:
       default: true
 
+ExludeMarginsFromFormControlElement:
+  type: bool
+  humanReadableName: "Exclude margins from control element"
+  humanReadableDescription: "Exclude margins from control element"
+  condition: ENABLE(EXCLUDE_MARGINS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 ExposeSpeakersEnabled:
   type: bool

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -116,6 +116,10 @@
 #define ENABLE_CURSOR_VISIBILITY 0
 #endif
 
+#if !defined(ENABLE_EXCLUDE_MARGINS)
+#define ENABLE_EXCLUDE_MARGINS 0
+#endif
+
 #if !defined(ENABLE_AIRPLAY_PICKER)
 #define ENABLE_AIRPLAY_PICKER 0
 #endif

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -76,6 +76,8 @@ Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, con
 {
 }
 
+#if ENABLE(EXCLUDE_MARGINS)
+#else
 static void addIntrinsicMargins(RenderStyle& style)
 {
     // Intrinsic margin value.
@@ -97,6 +99,7 @@ static void addIntrinsicMargins(RenderStyle& style)
             style.setMarginBottom(Length(intrinsicMargin, LengthType::Fixed));
     }
 }
+#endif
 
 static DisplayType equivalentBlockDisplay(const RenderStyle& style, const Document& document)
 {
@@ -504,6 +507,8 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     style.adjustAnimations();
     style.adjustTransitions();
 
+#if ENABLE(EXCLUDE_MARGINS)
+#else
     // Important: Intrinsic margins get added to controls before the theme has adjusted the style, since the theme will
     // alter fonts and heights/widths.
     if (is<HTMLFormControlElement>(m_element) && style.computedFontPixelSize() >= 11) {
@@ -512,6 +517,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
         if (!is<HTMLInputElement>(*m_element) || !downcast<HTMLInputElement>(*m_element).isImageButton())
             addIntrinsicMargins(style);
     }
+#endif
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())


### PR DESCRIPTION
#### b002ff59c5a6fa0c9edf1d32314a60c39999dc5e
<pre>
Remove &apos;Intrinsic Margins&apos; feature from WebKit with flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=107380">https://bugs.webkit.org/show_bug.cgi?id=107380</a>

The purpose of intrinsic margins was to try to prevent
adjacent controls from butting up against one another.
But this feature&apos;s behavior makes web developers confusing
and introduces some compat issues too.

Blink removed this feature at
<a href="http://code.google.com/p/chromium/issues/detail?id=128306">http://code.google.com/p/chromium/issues/detail?id=128306</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
</pre>