### PR TITLE
Make shouldApplyContainment methods more flexible

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2260,7 +2260,7 @@ void RenderBlock::offsetForContents(LayoutPoint& offset) const
 void RenderBlock::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
     ASSERT(!childrenInline());
-    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (!shouldIgnoreDescendantContentForLogicalWidth)
         computeBlockPreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -345,7 +345,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
 
 void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (!shouldIgnoreDescendantContentForLogicalWidth) {
         if (childrenInline())
             computeInlinePreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -89,11 +89,11 @@ public:
     bool shouldApplyLayoutContainment() const;
     bool shouldApplySizeContainment() const;
     bool shouldApplyInlineSizeContainment() const;
+    bool shouldApplySizeOrInlineSizeContainment() const;
     bool shouldApplyStyleContainment() const;
     bool shouldApplyPaintContainment() const;
+    bool shouldApplyLayoutOrPaintContainment() const;
     bool shouldApplyAnyContainment() const;
-    bool shouldApplyLayoutOrPaintContainment(OptionSet<Containment>) const;
-    bool shouldApplySizeOrStyleContainment(OptionSet<Containment>) const;
 
     Color selectionColor(CSSPropertyID) const;
     std::unique_ptr<RenderStyle> selectionPseudoStyle() const;
@@ -348,6 +348,9 @@ protected:
     bool createsNewFormattingContext() const;
     virtual bool establishesIndependentFormattingContext() const;
 
+    bool shouldApplyLayoutOrPaintContainment(bool) const;
+    bool shouldApplySizeOrStyleContainment(bool) const;
+
 private:
     RenderElement(ContainerNode&, RenderStyle&&, BaseTypeFlags);
     void node() const = delete;
@@ -475,7 +478,7 @@ inline bool RenderElement::canContainFixedPositionObjects() const
         || (canEstablishContainingBlockWithTransform() && hasTransform())
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForOutOfFlowPositioned()) // FIXME: will-change should create containing blocks on inline boxes (bug 225035)
         || isSVGForeignObject()
-        || shouldApplyLayoutOrPaintContainment({ Containment::Layout, Containment::Paint });
+        || shouldApplyLayoutOrPaintContainment();
 }
 
 inline bool RenderElement::canContainAbsolutelyPositionedObjects() const
@@ -485,7 +488,7 @@ inline bool RenderElement::canContainAbsolutelyPositionedObjects() const
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
         || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForAbsolutelyPositioned()) // FIXME: will-change should create containing blocks on inline boxes (bug 225035)
         || isSVGForeignObject()
-        || shouldApplyLayoutOrPaintContainment({ Containment::Layout, Containment::Paint });
+        || shouldApplyLayoutOrPaintContainment();
 }
 
 inline bool RenderElement::canEstablishContainingBlockWithTransform() const
@@ -493,45 +496,54 @@ inline bool RenderElement::canEstablishContainingBlockWithTransform() const
     return isRenderBlock() || (isTablePart() && !isRenderTableCol());
 }
 
-inline bool RenderElement::shouldApplyLayoutOrPaintContainment(OptionSet<Containment> options) const
+inline bool RenderElement::shouldApplyLayoutOrPaintContainment(bool containsAccordingToStyle) const
 {
-    return style().effectiveContainment().containsAny(options) && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isRenderBlockFlow());
+    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isRenderBlockFlow());
 }
 
-inline bool RenderElement::shouldApplySizeOrStyleContainment(OptionSet<Containment> options) const
+inline bool RenderElement::shouldApplySizeOrStyleContainment(bool containsAccordingToStyle) const
 {
-    return style().effectiveContainment().containsAny(options) && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isTableCaption()) && !isTable();
+    return containsAccordingToStyle && (!isInline() || isAtomicInlineLevelBox()) && !isRubyText() && (!isTablePart() || isTableCaption()) && !isTable();
 }
 
 inline bool RenderElement::shouldApplyLayoutContainment() const
 {
-    return shouldApplyLayoutOrPaintContainment(Containment::Layout);
+    return shouldApplyLayoutOrPaintContainment(style().containsLayout());
 }
 
 inline bool RenderElement::shouldApplyPaintContainment() const
 {
-    return shouldApplyLayoutOrPaintContainment(Containment::Paint);
+    return shouldApplyLayoutOrPaintContainment(style().containsPaint());
+}
+
+inline bool RenderElement::shouldApplyLayoutOrPaintContainment() const
+{
+    return shouldApplyLayoutOrPaintContainment(style().containsLayoutOrPaint());
 }
 
 inline bool RenderElement::shouldApplySizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(Containment::Size);
+    return shouldApplySizeOrStyleContainment(style().containsSize());
 }
 
 inline bool RenderElement::shouldApplyInlineSizeContainment() const
 {
-    return shouldApplySizeOrStyleContainment(Containment::InlineSize);
+    return shouldApplySizeOrStyleContainment(style().containsInlineSize());
+}
+
+inline bool RenderElement::shouldApplySizeOrInlineSizeContainment() const
+{
+    return shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize());
 }
 
 inline bool RenderElement::shouldApplyStyleContainment() const
 {
-    return shouldApplySizeOrStyleContainment(Containment::Style);
+    return shouldApplySizeOrStyleContainment(style().containsStyle());
 }
 
 inline bool RenderElement::shouldApplyAnyContainment() const
 {
-    return shouldApplyLayoutOrPaintContainment({ Containment::Layout, Containment::Paint })
-        || shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize, Containment::Style });
+    return shouldApplyLayoutOrPaintContainment() || shouldApplySizeOrStyleContainment(style().containsSizeOrInlineSize() || style().containsStyle());
 }
 
 inline bool RenderElement::createsGroupForStyle(const RenderStyle& style)

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -103,7 +103,7 @@ void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
         minLogicalWidth += scrollbarWidth;
     };
 
-    auto shouldIgnoreFlexItemContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreFlexItemContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (shouldIgnoreFlexItemContentForLogicalWidth) {
         addScrollbarWidth();
         return;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -299,7 +299,7 @@ void RenderGrid::layoutBlock(bool relayoutChildren, LayoutUnit)
         // logical width is always definite as the above call to updateLogicalWidth() properly resolves intrinsic 
         // sizes. We cannot do the same for heights though because many code paths inside updateLogicalHeight() require 
         // a previous call to setLogicalHeight() to resolve heights properly (like for positioned items for example).
-        auto shouldIgnoreGridItemContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+        auto shouldIgnoreGridItemContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
         if (shouldIgnoreGridItemContentForLogicalWidth)
             computeTrackSizesForIndefiniteSize(m_trackSizingAlgorithm, ForColumns);
         else
@@ -643,7 +643,7 @@ std::unique_ptr<OrderedTrackIndexSet> RenderGrid::computeEmptyTracksForAutoRepea
     unsigned firstAutoRepeatTrack = insertionPoint + grid.explicitGridStart(direction);
     unsigned lastAutoRepeatTrack = firstAutoRepeatTrack + grid.autoRepeatTracks(direction);
 
-    if (!grid.hasGridItems() || shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize })) {
+    if (!grid.hasGridItems() || shouldApplySizeOrInlineSizeContainment()) {
         emptyTrackIndexes = makeUnique<OrderedTrackIndexSet>();
         for (unsigned trackIndex = firstAutoRepeatTrack; trackIndex < lastAutoRepeatTrack; ++trackIndex)
             emptyTrackIndexes->add(trackIndex);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -540,8 +540,11 @@ public:
     OptionSet<Containment> effectiveContainment() const { return m_rareNonInheritedData->effectiveContainment(); }
     bool containsLayout() const { return effectiveContainment().contains(Containment::Layout); }
     bool containsSize() const { return effectiveContainment().contains(Containment::Size); }
+    bool containsInlineSize() const { return effectiveContainment().contains(Containment::InlineSize); }
+    bool containsSizeOrInlineSize() const { return effectiveContainment().containsAny({ Containment::Size, Containment::InlineSize }); }
     bool containsStyle() const { return effectiveContainment().contains(Containment::Style); }
     bool containsPaint() const { return effectiveContainment().contains(Containment::Paint); }
+    bool containsLayoutOrPaint() const { return effectiveContainment().containsAny({ Containment::Layout, Containment::Paint }); }
     ContainerType containerType() const { return static_cast<ContainerType>(m_rareNonInheritedData->containerType); }
     const Vector<AtomString>& containerNames() const { return m_rareNonInheritedData->containerNames; }
 


### PR DESCRIPTION
#### 1b20a37406c70eeb2793c585c869d4de626cb3f7
<pre>
Make shouldApplyContainment methods more flexible
<a href="https://bugs.webkit.org/show_bug.cgi?id=240906">https://bugs.webkit.org/show_bug.cgi?id=240906</a>

Reviewed by NOBODY (OOPS!).

In r293943 some shouldApplyContainment methods were optimised, however
they are not flexible enough to deal with the content-visibility feature,
which in certain cases can influence containment. So to be flexible use
boolean parameters instead of relying on effectiveContainment() directly.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::canContainFixedPositionObjects const):
(WebCore::RenderElement::canContainAbsolutelyPositionedObjects const):
(WebCore::RenderElement::shouldApplyLayoutOrPaintContainment const):
(WebCore::RenderElement::shouldApplySizeOrStyleContainment const):
(WebCore::RenderElement::shouldApplyLayoutContainment const):
(WebCore::RenderElement::shouldApplyPaintContainment const):
(WebCore::RenderElement::shouldApplySizeContainment const):
(WebCore::RenderElement::shouldApplyInlineSizeContainment const):
(WebCore::RenderElement::shouldApplySizeOrInlineSizeContainment const):
(WebCore::RenderElement::shouldApplyStyleContainment const):
(WebCore::RenderElement::shouldApplyAnyContainment const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeIntrinsicLogicalWidths const):
(WebCore::RenderFlexibleBox::firstLineBaseline const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeEmptyTracksForAutoRepeat const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::containsInlineSize const):
(WebCore::RenderStyle::containsSizeOrInlineSize const):
(WebCore::RenderStyle::containsLayoutOrPaint const):
</pre>