### PR TITLE
OSAllocator::hintMemoryNotNeedsSoon() is used by CF.

### DIFF
--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -77,8 +77,10 @@ public:
     template<typename T>
     static T* reallocateCommitted(T*, size_t oldSize, size_t newSize, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false);
 
+#if USE(CF)
     // Hint to the OS that an address range is not expected to be accessed anytime soon.
     WTF_EXPORT_PRIVATE static void hintMemoryNotNeededSoon(void*, size_t);
+#endif
 };
 
 inline void* OSAllocator::reserveAndCommit(size_t reserveSize, size_t commitSize, Usage usage, bool writable, bool executable, bool jitCageEnabled)

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -269,16 +269,6 @@ void OSAllocator::decommit(void* address, size_t bytes)
 #endif
 }
 
-void OSAllocator::hintMemoryNotNeededSoon(void* address, size_t bytes)
-{
-#if HAVE(MADV_DONTNEED)
-    while (madvise(address, bytes, MADV_DONTNEED) == -1 && errno == EAGAIN) { }
-#else
-    UNUSED_PARAM(address);
-    UNUSED_PARAM(bytes);
-#endif
-}
-
 void OSAllocator::releaseDecommitted(void* address, size_t bytes)
 {
     int result = munmap(address, bytes);

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -643,8 +643,10 @@ bool CachedResource::deleteIfPossible()
         return true;
     }
 
+#if USE(CF)
     if (m_data)
         m_data->hintMemoryNotNeededSoon();
+#endif
 
     return false;
 }

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -380,12 +380,6 @@ bool FragmentedSharedBuffer::internallyConsistent() const
 }
 #endif // ASSERT_ENABLED
 
-#if !USE(CF)
-void FragmentedSharedBuffer::hintMemoryNotNeededSoon() const
-{
-}
-#endif
-
 bool FragmentedSharedBuffer::operator==(const FragmentedSharedBuffer& other) const
 {
     if (this == &other)

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -200,7 +200,9 @@ public:
 
     WEBCORE_EXPORT String toHexString() const;
 
+#if USE(CF)
     void hintMemoryNotNeededSoon() const;
+#endif
 
     WEBCORE_EXPORT bool operator==(const FragmentedSharedBuffer&) const;
     bool operator!=(const FragmentedSharedBuffer& other) const { return !operator==(other); }


### PR DESCRIPTION
<pre>
OSAllocator::hintMemoryNotNeedsSoon() is used by CF.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241439">https://bugs.webkit.org/show_bug.cgi?id=241439</a>

Reviewed by NOBODY (OOPS!).

OSAllocator::hintMemoryNotNeedsSoon() is used from WebCore::CachedResource and only
when USE(CF) is true. It is okay to delete it from other platform.
Also sending a hint to the pages CachedResource holds is also not right solution for
other platforms because usually we don't have way to recover the contents when system
actually decommits those pages. OSAllocator's header says pages should be managed
strictly by the owner of pages and the state which can be decommitted or not shouldn't
be allowed.

* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::deleteIfPossible):
* Source/WebCore/platform/SharedBuffer.cpp:
* Source/WebCore/platform/SharedBuffer.h:
</pre>