### PR TITLE
[Gardening]: REGRESSION (r293829): [ iOS ] TestWebKitAPI.GPUProcess.WebProcessTerminationAfterTooManyGPUProcessCrashes is a flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest-expected.txt
@@ -1,5 +1,0 @@
-
-PASS Element Source tests completed
-PASS Channel 0 processed some data
-FAIL All data processed correctly assert_array_approx_equals: comparing expected and rendered buffers (channel 0) lengths differ, expected 44098 got 40447
-

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -53,7 +53,7 @@ PredefinedColorSpace ImageData::computeColorSpace(std::optional<ImageDataSetting
 Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer)
 {
     auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
-    return adoptRef(*new ImageData(pixelBuffer->size(), ByteArrayPixelBuffer::data(WTFMove(pixelBuffer)), *colorSpace));
+    return adoptRef(*new ImageData(pixelBuffer->size(), pixelBuffer->takeData(), *colorSpace));
 }
 
 RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer)

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -87,13 +87,6 @@ ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, cons
 {
 }
 
-Ref<JSC::Uint8ClampedArray> ByteArrayPixelBuffer::data(Ref<ByteArrayPixelBuffer> pixelBuffer)
-{
-    if (pixelBuffer->hasOneRef())
-        return WTFMove(pixelBuffer->m_data);
-    return pixelBuffer->m_data;
-}
-
 RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
     return ByteArrayPixelBuffer::tryCreate(m_format, size);

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -38,7 +38,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ByteArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
 
     JSC::Uint8ClampedArray& data() const { return m_data.get(); }
-    static Ref<JSC::Uint8ClampedArray> data(Ref<ByteArrayPixelBuffer>);
+    Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
 
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.13.7',
+    version='0.13.8',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -44,7 +44,7 @@ from webkitcorepy.call_by_need import CallByNeed
 from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 
-version = Version(0, 13, 7)
+version = Version(0, 13, 8)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -115,7 +115,12 @@ TEST(GPUProcess, RelaunchOnCrash)
     EXPECT_TRUE([webView _isPlayingAudio]);
 }
 
+// FIXME: Re-enable after webkit.org/b/240692 is resolved
+#if (PLATFORM(IOS))
+TEST(GPUProcess, DISABLED_WebProcessTerminationAfterTooManyGPUProcessCrashes)
+#else
 TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));


### PR DESCRIPTION
#### 0ec524a4538b0e5ff80a199e6e1d77391b3e7072
<pre>
[Gardening]: REGRESSION (r293829): [ iOS ] TestWebKitAPI.GPUProcess.WebProcessTerminationAfterTooManyGPUProcessCrashes is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=240692">https://bugs.webkit.org/show_bug.cgi?id=240692</a>
&lt;rdar://93611089 &gt;

Unreviewed test gardening.
I disabled API test while the issue is being investigated.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/251410@main">https://commits.webkit.org/251410@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295404">https://svn.webkit.org/repository/webkit/trunk@295404</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
