### PR TITLE
Combine leaf layer transforms into the content scale

### DIFF
--- a/LayoutTests/compositing/canvas/hidpi-canvas-backing-store.html
+++ b/LayoutTests/compositing/canvas/hidpi-canvas-backing-store.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script>
+
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.waitUntilDone();
+}
+
+function doTest() {
+  let canvasElement = document.getElementById("canvas");
+  let dpr = window.devicePixelRatio || 1;
+
+  canvas.width *= dpr;
+  canvas.height *= dpr;
+
+  canvas.style.transform = "scale(" + 1/dpr + ", " + 1/dpr + ")";
+
+  let ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+
+  ctx.fillStyle = 'green';
+  ctx.fillRect(0, 0, 500, 500);
+        
+  if (window.testRunner) {
+    document.getElementById('layers').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED | internals.LAYER_TREE_INCLUDES_TILE_CACHES);
+    testRunner.notifyDone();
+  }
+}
+    
+window.addEventListener('load', doTest, false);
+</script>
+</head>
+
+<body onload="setup()">
+<div style="opacity:0.5">
+<canvas id="canvas" width="500" height="500" style="transform-origin:top left"></canvas>
+<pre id="layers">Layer tree goes here in DRT</pre>
+</div>
+</body>
+
+</html>

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -658,6 +658,7 @@ private:
     std::unique_ptr<DisplayList::InMemoryDisplayList> m_displayList;
 
     ContentsLayerPurpose m_contentsLayerPurpose { ContentsLayerPurpose::None };
+    float m_transformScale { 1.f };
     bool m_isCommittingChanges { false };
 
     bool m_needsFullRepaint : 1;


### PR DESCRIPTION
#### ffe20ae18abed8d6a6f4590e02dc250b02bf58a9
<pre>
Combine leaf layer transforms into the content scale
<a href="https://bugs.webkit.org/show_bug.cgi?id=241443">https://bugs.webkit.org/show_bug.cgi?id=241443</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/compositing/canvas/hidpi-canvas-backing-store.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::scaleFromTransform):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
</pre>
----------------------------------------------------------------------
#### 82a311d28ea7af00a7d64760b08f9ef8dbd6b883
<pre>
Rename MAC_CATALYST_GRAMMAR_CHECKING to ENABLE_POST_EDITING_GRAMMAR_CHECKING for clarity.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241434">https://bugs.webkit.org/show_bug.cgi?id=241434</a>

Reviewed by Tim Horton.

After upstreaming, change the name of this flag, and also have it in open source for clarity.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::markAndReplaceFor):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::grammarColor):
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::mutableState):
(WebKit::TextChecker::setGrammarCheckingEnabled):
(WebKit::TextChecker::checkTextOfParagraph):

Canonical link: <a href="https://commits.webkit.org/251414@main">https://commits.webkit.org/251414@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295408">https://svn.webkit.org/repository/webkit/trunk@295408</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>