### PR TITLE
Canvas.toDataURL causes excessive GPUP memory use on Cocoa

### DIFF
--- a/Source/WebCore/platform/graphics/ConcreteImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ConcreteImageBuffer.h
@@ -230,24 +230,6 @@ protected:
         }
     }
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const override
-    {
-        if (auto* backend = ensureBackendCreated()) {
-            const_cast<ConcreteImageBuffer&>(*this).flushContext();
-            return backend->toDataURL(mimeType, quality, preserveResolution);
-        }
-        return String();
-    }
-
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const override
-    {
-        if (auto* backend = ensureBackendCreated()) {
-            const_cast<ConcreteImageBuffer&>(*this).flushContext();
-            return backend->toData(mimeType, quality);
-        }
-        return { };
-    }
-
     RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator) const override
     {
         if (auto* backend = ensureBackendCreated()) {

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -143,8 +143,12 @@ public:
     virtual void convertToLuminanceMask() = 0;
     virtual void transformToColorSpace(const DestinationColorSpace&) = 0;
 
-    virtual String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const = 0;
-    virtual Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const = 0;
+    WEBCORE_EXPORT String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+    WEBCORE_EXPORT Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+
+
+    WEBCORE_EXPORT static String toDataURL(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
+    WEBCORE_EXPORT static Vector<uint8_t> toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
 
     virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& = ImageBufferAllocator()) const = 0;
     virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint = { }, AlphaPremultiplication destFormat = AlphaPremultiplication::Premultiplied) = 0;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -119,9 +119,6 @@ public:
     WEBCORE_EXPORT void convertToLuminanceMask();
     virtual void transformToColorSpace(const DestinationColorSpace&) { }
 
-    virtual String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const = 0;
-    virtual Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const = 0;
-
     virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect&, const ImageBufferAllocator& = ImageBufferAllocator()) const = 0;
     virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) = 0;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
@@ -36,10 +36,7 @@
 #include "ColorTransferFunctions.h"
 #include "GraphicsContext.h"
 #include "GraphicsContextCairo.h"
-#include "ImageBufferUtilitiesCairo.h"
-#include "MIMETypeRegistry.h"
 #include <cairo.h>
-#include <wtf/text/Base64.h>
 
 #if USE(CAIRO)
 
@@ -92,22 +89,6 @@ void ImageBufferCairoBackend::transformToColorSpace(const DestinationColorSpace&
     ASSERT(m_parameters.colorSpace == DestinationColorSpace::SRGB());
     UNUSED_PARAM(newColorSpace);
 #endif
-}
-
-String ImageBufferCairoBackend::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const
-{
-    Vector<uint8_t> encodedImage = toData(mimeType, quality);
-    if (encodedImage.isEmpty())
-        return "data:,"_s;
-
-    return makeString("data:", mimeType, ";base64,", base64Encoded(encodedImage.data(), encodedImage.size()));
-}
-
-Vector<uint8_t> ImageBufferCairoBackend::toData(const String& mimeType, std::optional<double> quality) const
-{
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-    cairo_surface_t* image = cairo_get_target(context().platformContext()->cr());
-    return data(image, mimeType, quality);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
@@ -41,9 +41,6 @@ public:
 
     void transformToColorSpace(const DestinationColorSpace&) override;
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const override;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const override;
-
 protected:
     using ImageBufferBackend::ImageBufferBackend;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -50,6 +50,17 @@
 
 namespace WebCore {
 
+static String imageTypeFromMIMEType(const String& mimeType)
+{
+    return mimeType.substring(sizeof "image");
+}
+
+bool platformMIMETypeIsJPEG(const String& mimeType)
+{
+    return imageTypeFromMIMEType(mimeType) == "jpeg"_s;
+
+}
+
 #if !PLATFORM(GTK)
 static cairo_status_t writeFunction(void* output, const unsigned char* data, unsigned length)
 {
@@ -78,31 +89,11 @@ static bool encodeImage(cairo_surface_t* surface, const String& mimeType, std::o
     // List of supported image encoding types comes from the GdkPixbuf documentation.
     // http://developer.gnome.org/gdk-pixbuf/stable/gdk-pixbuf-File-saving.html#gdk-pixbuf-save-to-bufferv
 
-    String type = mimeType.substring(sizeof "image");
+    String type = imageTypeFromMIMEType(mimeType);
     if (type != "jpeg"_s && type != "png"_s && type != "tiff"_s && type != "ico"_s && type != "bmp"_s)
         return false;
 
-    GRefPtr<GdkPixbuf> pixbuf;
-    if (type == "jpeg"_s) {
-        // JPEG doesn't support alpha channel. The <canvas> spec states that toDataURL() must encode a Porter-Duff
-        // composite source-over black for image types that do not support alpha.
-        RefPtr<cairo_surface_t> newSurface;
-        if (cairo_surface_get_type(surface) == CAIRO_SURFACE_TYPE_IMAGE) {
-            newSurface = adoptRef(cairo_image_surface_create_for_data(cairo_image_surface_get_data(surface),
-                CAIRO_FORMAT_RGB24,
-                cairo_image_surface_get_width(surface),
-                cairo_image_surface_get_height(surface),
-                cairo_image_surface_get_stride(surface)));
-        } else {
-            IntSize size = cairoSurfaceSize(surface);
-            newSurface = adoptRef(cairo_image_surface_create(CAIRO_FORMAT_RGB24, size.width(), size.height()));
-            RefPtr<cairo_t> cr = adoptRef(cairo_create(newSurface.get()));
-            cairo_set_source_surface(cr.get(), surface, 0, 0);
-            cairo_paint(cr.get());
-        }
-        pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(newSurface.get()));
-    } else
-        pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(surface));
+    GRefPtr<GdkPixbuf> pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(surface));
     if (!pixbuf)
         return false;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+bool platformMIMETypeIsJPEG(const String& mimeType);
+
 Vector<uint8_t> data(cairo_surface_t*, const String& mimeType, std::optional<double> quality);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -32,7 +32,6 @@
 #include "GraphicsContextCG.h"
 #include "ImageBufferUtilitiesCG.h"
 #include "IntRect.h"
-#include "MIMETypeRegistry.h"
 #include "PixelBuffer.h"
 #include "RuntimeApplicationChecks.h"
 #include <CoreGraphics/CoreGraphics.h>
@@ -78,20 +77,6 @@ RetainPtr<CGColorSpaceRef> ImageBufferCGBackend::contextColorSpace(const Graphic
 #endif
 }
 
-static RetainPtr<CGImageRef> createCroppedImageIfNecessary(CGImageRef image, const IntSize& backendSize)
-{
-    if (image && (CGImageGetWidth(image) != static_cast<size_t>(backendSize.width()) || CGImageGetHeight(image) != static_cast<size_t>(backendSize.height())))
-        return adoptCF(CGImageCreateWithImageInRect(image, CGRectMake(0, 0, backendSize.width(), backendSize.height())));
-    return image;
-}
-
-static CGColorSpaceRef colorSpaceForBitmap(DestinationColorSpace imageBufferColorSpace)
-{
-    if (CGColorSpaceGetModel(imageBufferColorSpace.platformColorSpace()) != kCGColorSpaceModelRGB)
-        return sRGBColorSpaceRef();
-    return imageBufferColorSpace.platformColorSpace();
-}
-
 void ImageBufferCGBackend::clipToMask(GraphicsContext& destContext, const FloatRect& destRect)
 {
     auto nativeImage = copyNativeImage(DontCopyBackingStore);
@@ -107,79 +92,6 @@ void ImageBufferCGBackend::clipToMask(GraphicsContext& destContext, const FloatR
     CGContextClipToMask(cgContext, { { }, destRect.size() }, nativeImage->platformImage().get());
     CGContextScaleCTM(cgContext, 1, -1);
     CGContextTranslateCTM(cgContext, -destRect.x(), -destRect.maxY());
-}
-
-RetainPtr<CGImageRef> ImageBufferCGBackend::copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution preserveResolution) const
-{
-    if (CFEqual(destinationUTI, jpegUTI())) {
-        // FIXME: Should this be using the same logic as ImageBufferUtilitiesCG?
-
-        // JPEGs don't have an alpha channel, so we have to manually composite on top of black.
-        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, DestinationColorSpace(colorSpaceForBitmap(colorSpace())) };
-        auto pixelBuffer = getPixelBuffer(format, logicalRect());
-        if (!pixelBuffer)
-            return nullptr;
-
-        Ref protectedPixelBuffer = *pixelBuffer;
-        auto dataSize = pixelBuffer->sizeInBytes();
-        auto data = pixelBuffer->bytes();
-
-        verifyImageBufferIsBigEnough(data, dataSize);
-
-        auto dataProvider = adoptCF(CGDataProviderCreateWithData(&protectedPixelBuffer.leakRef(), data, dataSize, [] (void* context, const void*, size_t) {
-            static_cast<PixelBuffer*>(context)->deref();
-        }));
-        if (!dataProvider)
-            return nullptr;
-
-        auto imageSize = pixelBuffer->size();
-        return adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->format().colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(kCGImageAlphaNoneSkipLast), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
-    }
-
-    if (resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
-        auto nativeImage = copyNativeImage(CopyBackingStore);
-        if (!nativeImage)
-            return nullptr;
-        return createCroppedImageIfNecessary(nativeImage->platformImage().get(), backendSize());
-    }
-    
-    auto nativeImage = copyNativeImage(DontCopyBackingStore);
-    if (!nativeImage)
-        return nullptr;
-    auto image = nativeImage->platformImage();
-    auto context = adoptCF(CGBitmapContextCreate(0, backendSize().width(), backendSize().height(), 8, 4 * backendSize().width(), colorSpaceForBitmap(colorSpace()), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
-    CGContextSetBlendMode(context.get(), kCGBlendModeCopy);
-    CGContextClipToRect(context.get(), CGRectMake(0, 0, backendSize().width(), backendSize().height()));
-    CGContextDrawImage(context.get(), CGRectMake(0, 0, backendSize().width(), backendSize().height()), image.get());
-    return adoptCF(CGBitmapContextCreateImage(context.get()));
-}
-
-Vector<uint8_t> ImageBufferCGBackend::toData(const String& mimeType, std::optional<double> quality) const
-{
-#if ENABLE(GPU_PROCESS)
-    ASSERT_IMPLIES(!isInGPUProcess(), MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#else
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#endif
-
-    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
-    auto image = copyCGImageForEncoding(destinationUTI.get(), PreserveResolution::No);
-
-    return WebCore::data(image.get(), destinationUTI.get(), quality);
-}
-
-String ImageBufferCGBackend::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
-{
-#if ENABLE(GPU_PROCESS)
-    ASSERT_IMPLIES(!isInGPUProcess(), MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#else
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#endif
-
-    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
-    auto image = copyCGImageForEncoding(destinationUTI.get(), preserveResolution);
-
-    return WebCore::dataURL(image.get(), destinationUTI.get(), mimeType, quality);
 }
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlusher()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -45,16 +45,11 @@ protected:
 
     void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const override;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const override;
-
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     bool originAtBottomLeftCorner() const override;
 
     static RetainPtr<CGColorSpaceRef> contextColorSpace(const GraphicsContext&);
-
-    virtual RetainPtr<CGImageRef> copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -79,14 +79,11 @@ protected:
     static RetainPtr<CGColorSpaceRef> contextColorSpace(const GraphicsContext&);
     unsigned bytesPerRow() const override;
 
-    // ImageBufferCGBackend overrides.
-    RetainPtr<CGImageRef> copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution) const final;
-
     void finalizeDrawIntoContext(GraphicsContext& destinationContext) override;
     void invalidateCachedNativeImage() const;
 
     std::unique_ptr<IOSurface> m_surface;
-    mutable bool m_requiresDrawAfterPutPixelBuffer { false };
+    mutable bool m_hasCGImageRefs { false };
 
     mutable bool m_needsSetupContext { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
@@ -36,13 +36,12 @@ class PixelBuffer;
 
 WEBCORE_EXPORT uint8_t verifyImageBufferIsBigEnough(const void* buffer, size_t bufferSize);
 
-CFStringRef jpegUTI();
-WEBCORE_EXPORT RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String&);
+bool platformMIMETypeIsJPEG(const String& mimeType);
 
-Vector<uint8_t> data(CGImageRef, CFStringRef destinationUTI, std::optional<double> quality);
+Vector<uint8_t> data(CGImageRef, const String& mimeType, std::optional<double> quality);
 Vector<uint8_t> data(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
 
-WEBCORE_EXPORT String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
+WEBCORE_EXPORT String dataURL(CGImageRef, const String& mimeType, std::optional<double> quality);
 String dataURL(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -244,40 +244,6 @@ void RemoteRenderingBackend::putPixelBufferForImageBuffer(RenderingResourceIdent
     }
 }
 
-void RemoteRenderingBackend::getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(String&&)>&& completionHandler)
-{
-    // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
-    // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    getDataURLForImageBufferWithQualifiedIdentifier(mimeType, quality, preserveResolution, { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() }, WTFMove(completionHandler));
-}
-
-void RemoteRenderingBackend::getDataURLForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(String&&)>&& completionHandler)
-{
-    ASSERT(!RunLoop::isMain());
-
-    String urlString;
-    if (auto imageBuffer = m_remoteResourceCache.cachedImageBuffer(renderingResourceIdentifier))
-        urlString = imageBuffer->toDataURL(mimeType, quality, preserveResolution);
-    completionHandler(WTFMove(urlString));
-}
-
-void RemoteRenderingBackend::getDataForImageBuffer(const String& mimeType, std::optional<double> quality, RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler)
-{
-    // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
-    // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    getDataForImageBufferWithQualifiedIdentifier(mimeType, quality, { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() }, WTFMove(completionHandler));
-}
-
-void RemoteRenderingBackend::getDataForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler)
-{
-    ASSERT(!RunLoop::isMain());
-
-    Vector<uint8_t> data;
-    if (auto imageBuffer = m_remoteResourceCache.cachedImageBuffer(renderingResourceIdentifier))
-        data = imageBuffer->toData(mimeType, quality);
-    completionHandler(WTFMove(data));
-}
-
 void RemoteRenderingBackend::getShareableBitmapForImageBuffer(RenderingResourceIdentifier identifier, PreserveResolution preserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&& completionHandler)
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -114,8 +114,6 @@ private:
     void getPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier, SharedMemory::IPCHandle&&, WebCore::PixelBufferFormat&& destinationFormat, WebCore::IntRect&& srcRect, CompletionHandler<void()>&&);
     void destroyGetPixelBufferSharedMemory();
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, IPC::PixelBufferReference&&, WebCore::IntRect&& srcRect, WebCore::IntPoint&& destPoint, WebCore::AlphaPremultiplication destFormat);
-    void getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, WebCore::RenderingResourceIdentifier, CompletionHandler<void(String&&)>&&);
-    void getDataForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&&);
     void getShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void getFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier, IPC::FilterReference&&, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);
@@ -129,8 +127,6 @@ private:
 
     // Received messages translated to use QualifiedRenderingResourceIdentifier.
     void createImageBufferWithQualifiedIdentifier(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, QualifiedRenderingResourceIdentifier);
-    void getDataURLForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, QualifiedRenderingResourceIdentifier, CompletionHandler<void(String&&)>&&);
-    void getDataForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, QualifiedRenderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&&);
     void getShareableBitmapForImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImageWithQualifiedIdentifier(const ShareableBitmap::Handle&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -28,8 +28,6 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     GetPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier imageBuffer, WebKit::SharedMemory::IPCHandle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
     DestroyGetPixelBufferSharedMemory()
     PutPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, IPC::PixelBufferReference pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
-    GetDataURLForImageBuffer(String mimeType, std::optional<double> quality, enum:uint8_t WebCore::PreserveResolution preserveResolution, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (String urlString) Synchronous
-    GetDataForImageBuffer(String mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<uint8_t> data) Synchronous
     GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:uint8_t WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
     GetFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, IPC::FilterReference filter) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebKit::ShareableBitmap::Handle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable

--- a/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
+++ b/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
@@ -70,7 +70,6 @@ WKImageRef WKImageCreateFromCGImage(CGImageRef imageRef, WKImageOptions options)
 WKStringRef WKImageCreateDataURLFromImage(CGImageRef imageRef)
 {
     String mimeType { "image/png"_s };
-    auto destinationUTI = WebCore::utiFromImageBufferMIMEType(mimeType);
-    auto value = WebCore::dataURL(imageRef, destinationUTI.get(), mimeType, { });
+    auto value = WebCore::dataURL(imageRef, mimeType, { });
     return WKStringCreateWithUTF8CString(value.utf8().data());
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -162,24 +162,6 @@ protected:
         return m_backend.get();
     }
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution preserveResolution) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-
-        ASSERT(WebCore::MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-        return m_remoteRenderingBackendProxy->getDataURLForImageBuffer(mimeType, quality, preserveResolution, m_renderingResourceIdentifier);
-    }
-
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-
-        ASSERT(WebCore::MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-        return m_remoteRenderingBackendProxy->getDataForImageBuffer(mimeType, quality, m_renderingResourceIdentifier);
-    }
-
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy copyBehavior = WebCore::CopyBackingStore) const final
     {
         if (UNLIKELY(!m_remoteRenderingBackendProxy))

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -209,20 +209,6 @@ void RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory()
     sendToStream(Messages::RemoteRenderingBackend::DestroyGetPixelBufferSharedMemory());
 }
 
-String RemoteRenderingBackendProxy::getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, RenderingResourceIdentifier renderingResourceIdentifier)
-{
-    String urlString;
-    sendSyncToStream(Messages::RemoteRenderingBackend::GetDataURLForImageBuffer(mimeType, quality, preserveResolution, renderingResourceIdentifier), Messages::RemoteRenderingBackend::GetDataURLForImageBuffer::Reply(urlString));
-    return urlString;
-}
-
-Vector<uint8_t> RemoteRenderingBackendProxy::getDataForImageBuffer(const String& mimeType, std::optional<double> quality, RenderingResourceIdentifier renderingResourceIdentifier)
-{
-    Vector<uint8_t> data;
-    sendSyncToStream(Messages::RemoteRenderingBackend::GetDataForImageBuffer(mimeType, quality, renderingResourceIdentifier), Messages::RemoteRenderingBackend::GetDataForImageBuffer::Reply(data));
-    return data;
-}
-
 RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(RenderingResourceIdentifier imageBuffer, PreserveResolution preserveResolution)
 {
     ShareableBitmap::Handle handle;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -87,8 +87,6 @@ public:
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, Span<uint8_t> result);
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat);
-    String getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, WebCore::RenderingResourceIdentifier);
-    Vector<uint8_t> getDataForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier);
     RefPtr<ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
     RefPtr<WebCore::Image> getFilteredImage(WebCore::RenderingResourceIdentifier, WebCore::Filter&);
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -112,18 +112,6 @@ RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage(BackingSt
     return { };
 }
 
-String ImageBufferRemoteIOSurfaceBackend::toDataURL(const String&, std::optional<double>, PreserveResolution) const
-{
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
-Vector<uint8_t> ImageBufferRemoteIOSurfaceBackend::toData(const String&, std::optional<double>) const
-{
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
 RefPtr<PixelBuffer> ImageBufferRemoteIOSurfaceBackend::getPixelBuffer(const PixelBufferFormat&, const IntRect&, const ImageBufferAllocator&) const
 {
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -60,8 +60,7 @@ public:
 private:
     WebCore::IntSize backendSize() const final;
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy) const final;
-    String toDataURL(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution) const final;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const final;
+
     RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& outputFormat, const WebCore::IntRect&, const WebCore::ImageBufferAllocator&) const final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 


### PR DESCRIPTION
#### 53bdf17e4498d6b6a00cc9bcc1845367c987ec46
<pre>
Canvas.toDataURL causes excessive GPUP memory use on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=240639">https://bugs.webkit.org/show_bug.cgi?id=240639</a>

Reviewed by NOBODY (OOPS!).

ImageBuffer::toData() and ImageBuffer::toDataURL() would construct a temporary
image-sized bitmap in the GPUP to act as the data encoding source image.
This intermediate bitmap is large for large source images, and will easily make GPUP
memory footprint exceed the limit.

Use the ImageBuffer drawing mechanism to composite the encoding source. This ensures
that the intermediate bitmaps are constructed similar to any other ImageBuffer, and as
such attributes the memory to WP.

Copy the ImageBuffer source to WP instead of GPUP and run the encoding in WP. This makes
the encoding cycles be spent in the correct process and reduces the code footprint of
GPUP.

ImageBuffer::toData() and ::toDataURL() were accessors that were propagated all the way
to the ImageBufferBackend and in GPUP case across processes. They are redundant, as
the data being used is available through copyNativeImage / copyImage.

WIP:
- add a test with subcase permutation:
  canvas various opaque and translucent colors, [png, jgeg], [2d, webgl]
- The patch removes passing of kCGImageAlphaNoneSkipLast for jpegs. Ensure
  with tests that this is ok.

* Source/WebCore/platform/graphics/ConcreteImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::copyImageBuffer):
(WebCore::copyNativeImageImpl):
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::copyImage const):
(WebCore::ImageBuffer::toDataURL const):
(WebCore::ImageBuffer::toData const):
(WebCore::ImageBuffer::toDataURL):
(WebCore::ImageBuffer::toData):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp:
(WebCore::ImageBufferCairoBackend::toDataURL const): Deleted.
(WebCore::ImageBufferCairoBackend::toData const): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp:
(WebCore::imageTypeFromMIMEType):
(WebCore::platformMIMETypeIsJPEG):
(WebCore::encodeImage):
* Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::createCroppedImageIfNecessary): Deleted.
(WebCore::colorSpaceForBitmap): Deleted.
(WebCore::ImageBufferCGBackend::copyCGImageForEncoding const): Deleted.
(WebCore::ImageBufferCGBackend::toData const): Deleted.
(WebCore::ImageBufferCGBackend::toDataURL const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage const):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImage const):
(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
(WebCore::ImageBufferIOSurfaceBackend::copyCGImageForEncoding const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::jpegUTI):
(WebCore::utiFromImageBufferMIMEType):
(WebCore::platformMIMETypeIsJPEG):
(WebCore::encode):
(WebCore::encodeToVector):
(WebCore::encodeToDataURL):
(WebCore::data):
(WebCore::dataURL):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::getDataURLForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::getDataURLForImageBufferWithQualifiedIdentifier): Deleted.
(WebKit::RemoteRenderingBackend::getDataForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::getDataForImageBufferWithQualifiedIdentifier): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/API/c/cg/WKImageCG.cpp:
(WKImageCreateDataURLFromImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getDataURLForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackendProxy::getDataForImageBuffer): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::toDataURL const): Deleted.
(WebKit::ImageBufferRemoteIOSurfaceBackend::toData const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
</pre>