### PR TITLE
Improve MSE MediaSource handling

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2266,12 +2266,22 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
     else
         ASSERT_NOT_REACHED();
 
+    // 4 - If the media element's readyState attribute has a value equal to HAVE_NOTHING,
+    // set the element's networkState attribute to the NETWORK_EMPTY value and queue a task
+    // to fire a simple event named emptied at the element.
+    // Otherwise, set the element's networkState attribute to the NETWORK_IDLE value.
+    if (m_readyState == HAVE_NOTHING) {
 #if ENABLE(MEDIA_SOURCE)
-    detachMediaSource();
+        // MediaSource should be detached from HTML media element in any case where
+        // the media element is going to transition to NETWORK_EMPTY...
+        detachMediaSource();
 #endif
 
-    // 3 - Set the element's networkState attribute to the NETWORK_IDLE value.
-    m_networkState = NETWORK_IDLE;
+        m_networkState = NETWORK_EMPTY;
+        scheduleEvent(eventNames().emptiedEvent);
+    } else {
+        m_networkState = NETWORK_IDLE;
+    }
 
     // 4 - Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
     setShouldDelayLoadEvent(false);


### PR DESCRIPTION
#### 13c70ad2c66b079bb8ec331bb09551c0a8a57bc4
<pre>
Improve MSE MediaSource handling

1) Detach MediaSource when going to NETOWRK_EMPTY transition

This fixes a crash when appendBuffer triggeres &quot;Append Error&quot; algorithm
causing media souce detaching and the app tries to play the same
video object again (video.play()). MediaSource was reopened from
MSE player private but was crashing as not attached to media element.
</pre>
----------------------------------------------------------------------
#### e5f8c5735cb0ced013ea116a2e5a0400dc51090e
<pre>
Update network state on error condition.

Set the NETWORK_IDLE state on decode or network errors for high enough ready state
as specified in &apos;4.8.11.5 Loading the media resource&apos;:
<a href="https://html.spec.whatwg.org/multipage/media.html#location-of-the-media-resource">https://html.spec.whatwg.org/multipage/media.html#location-of-the-media-resource</a>

This change fixes orphant HTML video tag removal that is in error state.
removedFromAncestor() -&gt; pauseAfterDetachedTask() cycle
will trigger pause() switching m_playing to 0 so the object
won&apos;t report any pending activity from virtualHasPendingActivity()
and can be cleared by GC.

Signed-off-by: Xabier Rodriguez Calvar &lt;calvaris@igalia.com&gt;
</pre>