### PR TITLE
[GTK][WPE] Media control buttons become almost black when clicked

### DIFF
--- a/LayoutTests/media/modern-media-controls/button/button-focus-state.html
+++ b/LayoutTests/media/modern-media-controls/button/button-focus-state.html
@@ -7,7 +7,7 @@ description("Testing an <code>IconButton</code> has a blue background-color when
 
 window.jsTestIsAsync = true;
 
-const button = new Button({ layoutDelegate: { layoutTraits: new MacOSLayoutTraits(LayoutTraits.Mode.Inline) }, iconName: Icons.Pause });
+const button = new Button({ layoutDelegate: { layoutTraits: new MacOSLayoutTraits(LayoutTraits.Mode.Inline) }, cssClassName: "mac", iconName: Icons.Pause });
 document.body.appendChild(button.element);
 
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/button.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.css
@@ -55,8 +55,14 @@ button:focus {
 }
 
 button:focus > picture {
-    background-color: -webkit-focus-ring-color !important;
     mix-blend-mode: normal !important;
+}
+
+/* In GTK/WPE clicking a button brings focus to it, so in that case we want to avoid setting the
+   background color to focus-ring-color. That's why this CSS rule applies only to non-adwaita
+   layouts. */
+button:is(.mac, .ios, .watchos):focus > picture {
+    background-color: -webkit-focus-ring-color !important;
 }
 
 button.skip-back > picture,


### PR DESCRIPTION
#### 1190d600f424d490827db13c5c12ba6d9025339f
<pre>
[GTK][WPE] Media control buttons become almost black when clicked
<a href="https://bugs.webkit.org/show_bug.cgi?id=241468">https://bugs.webkit.org/show_bug.cgi?id=241468</a>

Reviewed by NOBODY (OOPS!).

Make an adwaita-specific button focus CSS rule where the background color is not overriden from the
default value. Using the focus-ring color would turn clicked buttons to blue (when bug #241228 is
fixed) or almost black (current main branch), which looks awkward and confusing.

* Source/WebCore/Modules/modern-media-controls/controls/button.css:
(.ios button:focus &gt; picture):
(.mac button:focus &gt; picture):
(.watchos button:focus &gt; picture):
(.adwaita button:focus &gt; picture):
(button:focus &gt; picture): Deleted.
</pre>