### PR TITLE
Fix clearIfComposited for indexed color write masks

### DIFF
--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
@@ -105,6 +105,14 @@ void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboo
     if (!m_context || m_context->isContextLost())
         return;
 
+    // Used in WebGLRenderingContextBase::clearIfComposited
+    if (!buf) {
+        m_context->m_colorMask[0] = red;
+        m_context->m_colorMask[1] = green;
+        m_context->m_colorMask[2] = blue;
+        m_context->m_colorMask[3] = alpha;
+    }
+
     m_context->graphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1361,7 +1361,10 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cle
                               m_colorMask[3] ? m_clearColor[3] : 0);
     } else
         m_context->clearColor(0, 0, 0, 0);
-    m_context->colorMask(true, true, true, true);
+    if (m_oesDrawBuffersIndexed)
+        m_context->colorMaskiOES(0, true, true, true, true);
+    else
+        m_context->colorMask(true, true, true, true);
     GCGLbitfield clearMask = GraphicsContextGL::COLOR_BUFFER_BIT;
     if (contextAttributes.depth) {
         if (!combinedClear || !m_depthMask || !(mask & GraphicsContextGL::DEPTH_BUFFER_BIT))
@@ -1405,8 +1408,10 @@ void WebGLRenderingContextBase::restoreStateAfterClear()
         m_context->enable(GraphicsContextGL::SCISSOR_TEST);
     m_context->clearColor(m_clearColor[0], m_clearColor[1],
                           m_clearColor[2], m_clearColor[3]);
-    m_context->colorMask(m_colorMask[0], m_colorMask[1],
-                         m_colorMask[2], m_colorMask[3]);
+    if (m_oesDrawBuffersIndexed)
+        m_context->colorMaskiOES(0, m_colorMask[0], m_colorMask[1], m_colorMask[2], m_colorMask[3]);
+    else
+        m_context->colorMask(m_colorMask[0], m_colorMask[1], m_colorMask[2], m_colorMask[3]);
     m_context->clearDepth(m_clearDepth);
     m_context->clearStencil(m_clearStencil);
     m_context->stencilMaskSeparate(GraphicsContextGL::FRONT, m_stencilMask);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -446,6 +446,7 @@ protected:
 
     friend class EXTTextureCompressionBPTC;
     friend class EXTTextureCompressionRGTC;
+    friend class OESDrawBuffersIndexed;
     friend class OESVertexArrayObject;
     friend class WebGLCompressedTextureASTC;
     friend class WebGLCompressedTextureATC;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -355,12 +355,7 @@ void GraphicsContextGLGBM::prepareTexture()
     if (contextAttributes().antialias)
         resolveMultisamplingIfNecessary();
 
-    GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-    GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
     GL_Flush();
-
-    if (m_state.boundDrawFBO != m_fbo)
-        GL_BindFramebuffer(GraphicsContextGL::FRAMEBUFFER, m_state.boundDrawFBO);
 }
 
 bool GraphicsContextGLGBM::reshapeDisplayBufferBacking()


### PR DESCRIPTION
#### d26dacdc2fc03f111cf24ad1e8fe116a4bdaf197
<pre>
Fix clearIfComposited for indexed color write masks
<a href="https://bugs.webkit.org/show_bug.cgi?id=241511">https://bugs.webkit.org/show_bug.cgi?id=241511</a>

Patch by Alexey Knyazev &lt;3479527+lexaknyazev@users.noreply.github.com &gt; on 2022-06-13
Reviewed by Kimmo Kinnunen.

Implicit clears must correctly restore color write mask state.

* Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp:
(WebCore::OESDrawBuffersIndexed::colorMaskiOES):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::restoreStateAfterClear):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/251490@main">https://commits.webkit.org/251490@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295485">https://svn.webkit.org/repository/webkit/trunk@295485</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
