### PR TITLE
[GTK][WPE] Revamp focus rings

### DIFF
--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.cpp
@@ -36,13 +36,12 @@
 
 namespace WebCore {
 
-static const unsigned focusLineWidth = 1;
-static constexpr auto focusRingColorLight = SRGBA<uint8_t> { 46, 52, 54, 150 };
-static constexpr auto focusRingColorDark = SRGBA<uint8_t> { 238, 238, 236, 150 };
+static const double focusRingOpacity = 0.8; // Keep in sync with focusRingOpacity in RenderThemeAdwaita.
+static const unsigned focusLineWidth = 2;
 static const unsigned arrowSize = 16;
 static constexpr auto arrowColorLight = SRGBA<uint8_t> { 46, 52, 54 };
 static constexpr auto arrowColorDark = SRGBA<uint8_t> { 238, 238, 236 };
-static const int buttonFocusOffset = -3;
+static const int buttonFocusOffset = -2;
 static const unsigned buttonPadding = 5;
 static const int buttonBorderSize = 1; // Keep in sync with menuListButtonBorderSize in RenderThemeAdwaita.
 static const double disabledOpacity = 0.5;
@@ -63,7 +62,7 @@ static constexpr auto toggleBorderHoveredColorDark = SRGBA<uint8_t> { 255, 255, 
 
 static const double toggleSize = 14.;
 static const int toggleBorderSize = 2;
-static const int toggleFocusOffset = 2;
+static const int toggleFocusOffset = 1;
 
 static constexpr auto spinButtonBorderColorLight = SRGBA<uint8_t> { 0, 0, 0, 25 };
 static constexpr auto spinButtonBackgroundColorLight = Color::white;
@@ -81,18 +80,30 @@ Theme& Theme::singleton()
     return theme;
 }
 
-Color ThemeAdwaita::focusColor(bool useDarkAppearance)
+Color ThemeAdwaita::focusColor(const Color& accentColor)
 {
-    return useDarkAppearance ? focusRingColorDark : focusRingColorLight;
+    return accentColor.colorWithAlphaMultipliedBy(focusRingOpacity);
 }
 
-void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const FloatRect& rect, int offset, bool useDarkAppearance)
+static inline float getRectRadius(const FloatRect& rect, int offset)
+{
+    return (std::min(rect.width(), rect.height()) + offset) / 2;
+}
+
+void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const FloatRect& rect, int offset, const Color& color, bool round)
 {
     FloatRect focusRect = rect;
     focusRect.inflate(offset);
+
+    float radius;
+    if (round)
+        radius = getRectRadius(rect, offset);
+    else
+        radius = 2;
+
     Path path;
-    path.addRoundedRect(focusRect, { 2, 2 });
-    paintFocus(graphicsContext, path, focusColor(useDarkAppearance));
+    path.addRoundedRect(focusRect, { radius, radius });
+    paintFocus(graphicsContext, path, color);
 }
 
 void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Path& path, const Color& color)
@@ -100,8 +111,9 @@ void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Path& path
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     graphicsContext.beginTransparencyLayer(color.alphaAsFloat());
-    graphicsContext.setStrokeThickness(focusLineWidth);
-    graphicsContext.setLineDash({ focusLineWidth, 2 * focusLineWidth }, 0);
+    // Since we cut off a half of it by erasing the rect contents, and half
+    // of the stroke ends up inside that area, it needs to be twice as thick.
+    graphicsContext.setStrokeThickness(focusLineWidth * 2);
     graphicsContext.setLineCap(LineCap::Square);
     graphicsContext.setLineJoin(LineJoin::Miter);
     graphicsContext.setStrokeColor(color.opaqueColor());
@@ -113,12 +125,17 @@ void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Path& path
     graphicsContext.endTransparencyLayer();
 }
 
-void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Vector<FloatRect>& rects, const Color& color)
+void ThemeAdwaita::paintFocus(GraphicsContext& graphicsContext, const Vector<FloatRect>& rects, const Color& color, bool round)
 {
-    FloatSize corner(2, 2);
     Path path;
-    for (const auto& rect : rects)
-        path.addRoundedRect(rect, corner);
+    for (const auto& rect : rects) {
+        float radius;
+        if (round)
+            radius = getRectRadius(rect, 0);
+        else
+            radius = 2;
+        path.addRoundedRect(rect, { radius, radius });
+    }
     paintFocus(graphicsContext, path, color);
 }
 
@@ -303,7 +320,7 @@ void ThemeAdwaita::paintCheckbox(ControlStates& states, GraphicsContext& graphic
     }
 
     if (states.states().contains(ControlStates::States::Focused))
-        paintFocus(graphicsContext, zoomedRect, toggleFocusOffset, useDarkAppearance);
+        paintFocus(graphicsContext, zoomedRect, toggleFocusOffset, focusColor(accentColor));
 
     if (!states.states().contains(ControlStates::States::Enabled))
         graphicsContext.endTransparencyLayer();
@@ -370,7 +387,7 @@ void ThemeAdwaita::paintRadio(ControlStates& states, GraphicsContext& graphicsCo
     }
 
     if (states.states().contains(ControlStates::States::Focused))
-        paintFocus(graphicsContext, zoomedRect, toggleFocusOffset, useDarkAppearance);
+        paintFocus(graphicsContext, zoomedRect, toggleFocusOffset, focusColor(accentColor), true);
 
     if (!states.states().contains(ControlStates::States::Enabled))
         graphicsContext.endTransparencyLayer();
@@ -424,7 +441,7 @@ void ThemeAdwaita::paintButton(ControlStates& states, GraphicsContext& graphicsC
     graphicsContext.fillPath(path);
 
     if (states.states().contains(ControlStates::States::Focused))
-        paintFocus(graphicsContext, zoomedRect, buttonFocusOffset, useDarkAppearance);
+        paintFocus(graphicsContext, zoomedRect, buttonFocusOffset, focusColor(m_accentColor));
 
     if (!states.states().contains(ControlStates::States::Enabled))
         graphicsContext.endTransparencyLayer();

--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -35,10 +35,9 @@ class Path;
 
 class ThemeAdwaita : public Theme {
 public:
-    static Color focusColor(bool focusColor);
-    static void paintFocus(GraphicsContext&, const FloatRect&, int offset, bool useDarkAppearance);
+    static void paintFocus(GraphicsContext&, const FloatRect&, int offset, const Color&, bool round = false);
     static void paintFocus(GraphicsContext&, const Path&, const Color&);
-    static void paintFocus(GraphicsContext&, const Vector<FloatRect>&, const Color&);
+    static void paintFocus(GraphicsContext&, const Vector<FloatRect>&, const Color&, bool round = false);
     enum class ArrowDirection { Up, Down };
     static void paintArrow(GraphicsContext&, ArrowDirection, bool);
 
@@ -56,6 +55,8 @@ private:
     void paintRadio(ControlStates&, GraphicsContext&, const FloatRect&, bool, const Color&);
     void paintButton(ControlStates&, GraphicsContext&, const FloatRect&, bool);
     void paintSpinButton(ControlStates&, GraphicsContext&, const FloatRect&, bool);
+
+    static Color focusColor(const Color&);
 
     Color m_accentColor;
 };

--- a/Source/WebCore/rendering/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/RenderThemeAdwaita.cpp
@@ -50,6 +50,7 @@
 
 namespace WebCore {
 
+static const double focusRingOpacity = 0.8; // Keep in sync with focusRingOpacity in ThemeAdwaita.
 static const double disabledOpacity = 0.5; // Keep in sync with disabledOpacity in ThemeAdwaita.
 static const int textFieldBorderSize = 1;
 static constexpr auto textFieldBorderColorLight = SRGBA<uint8_t> { 0, 0, 0, 50 };
@@ -59,7 +60,7 @@ static constexpr auto textFieldBorderColorDark = SRGBA<uint8_t> { 255, 255, 255,
 static constexpr auto textFieldBackgroundColorDark = SRGBA<uint8_t> { 45, 45, 45 };
 
 static const unsigned menuListButtonArrowSize = 16;
-static const int menuListButtonFocusOffset = -3;
+static const int menuListButtonFocusOffset = -2;
 static const unsigned menuListButtonPadding = 5;
 static const int menuListButtonBorderSize = 1; // Keep in sync with buttonBorderSize in ThemeAdwaita.
 static const unsigned progressActivityBlocks = 5;
@@ -186,9 +187,9 @@ Color RenderThemeAdwaita::platformInactiveListBoxSelectionForegroundColor(Option
     return platformActiveListBoxSelectionForegroundColor(options);
 }
 
-Color RenderThemeAdwaita::platformFocusRingColor(OptionSet<StyleColorOptions> options) const
+Color RenderThemeAdwaita::platformFocusRingColor(OptionSet<StyleColorOptions>) const
 {
-    return ThemeAdwaita::focusColor(options.contains(StyleColorOptions::UseDarkAppearance));
+    return getSystemAccentColor().colorWithAlphaMultipliedBy(focusRingOpacity);
 }
 
 void RenderThemeAdwaita::platformColorsDidChange()
@@ -279,6 +280,9 @@ Color RenderThemeAdwaita::systemColor(CSSValueID cssValueID, OptionSet<StyleColo
 
     case CSSValueWebkitFocusRingColor:
     case CSSValueActiveborder:
+        // Hardcoded to avoid exposing a user appearance preference to the web for fingerprinting.
+        return SRGBA<uint8_t> { 52, 132, 228, static_cast<unsigned char>(255 * focusRingOpacity) };
+
     case CSSValueHighlight:
         // Hardcoded to avoid exposing a user appearance preference to the web for fingerprinting.
         return SRGBA<uint8_t> { 52, 132, 228 };
@@ -324,7 +328,7 @@ bool RenderThemeAdwaita::paintTextField(const RenderObject& renderObject, const 
     path.addRoundedRect(fieldRect, corner);
     graphicsContext.setFillRule(WindRule::EvenOdd);
     if (enabled && isFocused(renderObject))
-        graphicsContext.setFillColor(getAccentColor(renderObject));
+        graphicsContext.setFillColor(platformFocusRingColor({ }));
     else
         graphicsContext.setFillColor(textFieldBorderColor);
     graphicsContext.fillPath(path);
@@ -436,7 +440,7 @@ bool RenderThemeAdwaita::paintMenuList(const RenderObject& renderObject, const P
     }
 
     if (isFocused(renderObject))
-        ThemeAdwaita::paintFocus(graphicsContext, rect, menuListButtonFocusOffset, renderObject.useDarkAppearance());
+        ThemeAdwaita::paintFocus(graphicsContext, rect, menuListButtonFocusOffset, platformFocusRingColor({ }));
 
     return false;
 }
@@ -589,8 +593,11 @@ bool RenderThemeAdwaita::paintSliderTrack(const RenderObject& renderObject, cons
     paintSliderTicks(renderObject, paintInfo, rect);
 #endif
 
-    if (isFocused(renderObject))
-        ThemeAdwaita::paintFocus(graphicsContext, fieldRect, sliderTrackFocusOffset, renderObject.useDarkAppearance());
+    if (isFocused(renderObject)) {
+        // Sliders support accent-color, so we want to color their focus rings too
+        Color focusRingColor = getAccentColor(renderObject).colorWithAlphaMultipliedBy(focusRingOpacity);
+        ThemeAdwaita::paintFocus(graphicsContext, fieldRect, sliderTrackFocusOffset, focusRingColor, true);
+    }
 
     if (!isEnabled(renderObject))
         graphicsContext.endTransparencyLayer();


### PR DESCRIPTION
#### 145e9284f7fd84b9fa5b737428e3f2f3563ceefc
<pre>
[GTK][WPE] Revamp focus rings
<a href="https://bugs.webkit.org/show_bug.cgi?id=241228">https://bugs.webkit.org/show_bug.cgi?id=241228</a>

Reviewed by NOBODY (OOPS!).

Use semi-transparent accent-colored focus rings, like macOS or GTK4.
Round them for radios and scales. Make sure to support CSS accent-color
for checks, radios and scales.

Use the same opacity as the libadwaita high contrast style and not the
regular one - the regular one doesn&apos;t work well on colorful backgrounds
like most webpages. This is also closer to the macOS style.

Make ThemeAdwaita::focusColor() private as it&apos;s both unused and doesn&apos;t
make much sense to be called from outside anymore.

This should fix the issue with modern media controls turning black
when focused.

* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::focusColor):
(WebCore::getRectRadius):
(WebCore::ThemeAdwaita::paintFocus):
(WebCore::ThemeAdwaita::paintCheckbox):
(WebCore::ThemeAdwaita::paintRadio):
(WebCore::ThemeAdwaita::paintButton):
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::platformFocusRingColor const):
(WebCore::RenderThemeAdwaita::systemColor const):
(WebCore::RenderThemeAdwaita::paintTextField):
(WebCore::RenderThemeAdwaita::paintMenuList):
(WebCore::RenderThemeAdwaita::paintSliderTrack):
</pre>