### PR TITLE
Align WebGL draw call functions

### DIFF
--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
@@ -105,6 +105,14 @@ void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboo
     if (!m_context || m_context->isContextLost())
         return;
 
+    // Used in WebGLRenderingContextBase::clearIfComposited
+    if (!buf) {
+        m_context->m_colorMask[0] = red;
+        m_context->m_colorMask[1] = green;
+        m_context->m_colorMask[2] = blue;
+        m_context->m_colorMask[3] = alpha;
+    }
+
     m_context->graphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
 }
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1608,7 +1608,19 @@ void WebGL2RenderingContext::drawRangeElements(GCGLenum mode, GCGLuint start, GC
         return;
     if (!validateVertexArrayObject("drawRangeElements"))
         return;
-    m_context->drawRangeElements(mode, start, end, count, type, offset);
+
+    if (m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*this, *m_currentProgram))
+        return;
+
+    clearIfComposited(ClearCallerDrawOrClear);
+
+    {
+        InspectorScopedShaderProgramHighlight scopedHighlight(*this, m_currentProgram.get());
+
+        m_context->drawRangeElements(mode, start, end, count, type, offset);
+    }
+
+    markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -28,6 +28,8 @@
 #if ENABLE(WEBGL)
 #include "WebGLMultiDraw.h"
 
+#include "InspectorInstrumentation.h"
+
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -65,7 +67,21 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List firstsList, G
         return;
     }
 
-    m_context->graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.data() + firstsOffset, countsList.data() + countsOffset, static_cast<size_t>(drawcount) });
+    if (!m_context->validateVertexArrayObject("multiDrawArraysWEBGL"))
+        return;
+
+    if (m_context->m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*m_context, *m_context->m_currentProgram))
+        return;
+
+    m_context->clearIfComposited(WebGLRenderingContextBase::ClearCallerDrawOrClear);
+
+    {
+        InspectorScopedShaderProgramHighlight scopedHighlight(*m_context, m_context->m_currentProgram.get());
+
+        m_context->graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.data() + firstsOffset, countsList.data() + countsOffset, static_cast<size_t>(drawcount) });
+    }
+
+    m_context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List firstsList, GCGLuint firstsOffset, Int32List countsList, GCGLuint countsOffset, Int32List instanceCountsList, GCGLuint instanceCountsOffset, GCGLsizei drawcount)
@@ -80,7 +96,21 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List firs
         return;
     }
 
-    m_context->graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) });
+    if (!m_context->validateVertexArrayObject("multiDrawArraysInstancedWEBGL"))
+        return;
+
+    if (m_context->m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*m_context, *m_context->m_currentProgram))
+        return;
+
+    m_context->clearIfComposited(WebGLRenderingContextBase::ClearCallerDrawOrClear);
+
+    {
+        InspectorScopedShaderProgramHighlight scopedHighlight(*m_context, m_context->m_currentProgram.get());
+
+        m_context->graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) });
+    }
+
+    m_context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List countsList, GCGLuint countsOffset, GCGLenum type, Int32List offsetsList, GCGLuint offsetsOffset, GCGLsizei drawcount)
@@ -94,7 +124,21 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List countsList,
         return;
     }
 
-    m_context->graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, static_cast<size_t>(drawcount) }, type);
+    if (!m_context->validateVertexArrayObject("multiDrawElementsWEBGL"))
+        return;
+
+    if (m_context->m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*m_context, *m_context->m_currentProgram))
+        return;
+
+    m_context->clearIfComposited(WebGLRenderingContextBase::ClearCallerDrawOrClear);
+
+    {
+        InspectorScopedShaderProgramHighlight scopedHighlight(*m_context, m_context->m_currentProgram.get());
+
+        m_context->graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, static_cast<size_t>(drawcount) }, type);
+    }
+
+    m_context->markContextChangedAndNotifyCanvasObserver();
 }
 
 void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List countsList, GCGLuint countsOffset, GCGLenum type, Int32List offsetsList, GCGLuint offsetsOffset, Int32List instanceCountsList, GCGLuint instanceCountsOffset, GCGLsizei drawcount)
@@ -109,7 +153,21 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List co
         return;
     }
 
-    m_context->graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) }, type);
+    if (!m_context->validateVertexArrayObject("multiDrawElementsInstancedWEBGL"))
+        return;
+
+    if (m_context->m_currentProgram && InspectorInstrumentation::isWebGLProgramDisabled(*m_context, *m_context->m_currentProgram))
+        return;
+
+    m_context->clearIfComposited(WebGLRenderingContextBase::ClearCallerDrawOrClear);
+
+    {
+        InspectorScopedShaderProgramHighlight scopedHighlight(*m_context, m_context->m_currentProgram.get());
+
+        m_context->graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) }, type);
+    }
+
+    m_context->markContextChangedAndNotifyCanvasObserver();
 }
 
 bool WebGLMultiDraw::validateDrawcount(const char* functionName, GCGLsizei drawcount)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1361,7 +1361,10 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cle
                               m_colorMask[3] ? m_clearColor[3] : 0);
     } else
         m_context->clearColor(0, 0, 0, 0);
-    m_context->colorMask(true, true, true, true);
+    if (m_oesDrawBuffersIndexed)
+        m_context->colorMaskiOES(0, true, true, true, true);
+    else
+        m_context->colorMask(true, true, true, true);
     GCGLbitfield clearMask = GraphicsContextGL::COLOR_BUFFER_BIT;
     if (contextAttributes.depth) {
         if (!combinedClear || !m_depthMask || !(mask & GraphicsContextGL::DEPTH_BUFFER_BIT))
@@ -1405,8 +1408,10 @@ void WebGLRenderingContextBase::restoreStateAfterClear()
         m_context->enable(GraphicsContextGL::SCISSOR_TEST);
     m_context->clearColor(m_clearColor[0], m_clearColor[1],
                           m_clearColor[2], m_clearColor[3]);
-    m_context->colorMask(m_colorMask[0], m_colorMask[1],
-                         m_colorMask[2], m_colorMask[3]);
+    if (m_oesDrawBuffersIndexed)
+        m_context->colorMaskiOES(0, m_colorMask[0], m_colorMask[1], m_colorMask[2], m_colorMask[3]);
+    else
+        m_context->colorMask(m_colorMask[0], m_colorMask[1], m_colorMask[2], m_colorMask[3]);
     m_context->clearDepth(m_clearDepth);
     m_context->clearStencil(m_clearStencil);
     m_context->stencilMaskSeparate(GraphicsContextGL::FRONT, m_stencilMask);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -138,6 +138,39 @@ using WebGLCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
 class VideoFrame;
 #endif
 
+class InspectorScopedShaderProgramHighlight {
+public:
+    InspectorScopedShaderProgramHighlight(WebGLRenderingContextBase&, WebGLProgram*);
+
+    ~InspectorScopedShaderProgramHighlight();
+
+private:
+    void showHighlight();
+    void hideHighlight();
+
+    template <typename T>
+    void saveBlendValue(GCGLenum attachment, T& destination);
+
+    bool hasBufferBinding(GCGLenum pname);
+
+    bool hasFramebufferParameterAttachment(GCGLenum attachment);
+
+    struct {
+        RefPtr<Float32Array> color;
+        unsigned equationRGB { 0 };
+        unsigned equationAlpha { 0 };
+        unsigned srcRGB { 0 };
+        unsigned srcAlpha { 0 };
+        unsigned dstRGB { 0 };
+        unsigned dstAlpha { 0 };
+        bool enabled { false };
+    } m_savedBlend;
+
+    WebGLRenderingContextBase& m_context;
+    WebGLProgram* m_program { nullptr };
+    bool m_didApply { false };
+};
+
 class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBasedCanvasRenderingContext, private ActivityStateChangeObserver {
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContextBase);
 public:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -446,6 +446,7 @@ protected:
 
     friend class EXTTextureCompressionBPTC;
     friend class EXTTextureCompressionRGTC;
+    friend class OESDrawBuffersIndexed;
     friend class OESVertexArrayObject;
     friend class WebGLCompressedTextureASTC;
     friend class WebGLCompressedTextureATC;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -355,12 +355,7 @@ void GraphicsContextGLGBM::prepareTexture()
     if (contextAttributes().antialias)
         resolveMultisamplingIfNecessary();
 
-    GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-    GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
     GL_Flush();
-
-    if (m_state.boundDrawFBO != m_fbo)
-        GL_BindFramebuffer(GraphicsContextGL::FRAMEBUFFER, m_state.boundDrawFBO);
 }
 
 bool GraphicsContextGLGBM::reshapeDisplayBufferBacking()


### PR DESCRIPTION
#### 4dbed460da50a50ad4b11944f9ed6452f9714d34
<pre>
Align WebGL draw call functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=241347">https://bugs.webkit.org/show_bug.cgi?id=241347</a>

Patch by Alexey Knyazev &lt;3479527+lexaknyazev@users.noreply.github.com &gt; on 2022-06-13
Reviewed by Kimmo Kinnunen.

Some draw commands did not have implicit clears,
inspector helpers, and post-draw notifications.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::drawRangeElements):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::multiDrawArraysWEBGL):
(WebCore::WebGLMultiDraw::multiDrawArraysInstancedWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsInstancedWEBGL):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::InspectorScopedShaderProgramHighlight::InspectorScopedShaderProgramHighlight):
(WebCore::InspectorScopedShaderProgramHighlight::~InspectorScopedShaderProgramHighlight):
(WebCore::InspectorScopedShaderProgramHighlight::showHighlight):
(WebCore::InspectorScopedShaderProgramHighlight::hideHighlight):
(WebCore::InspectorScopedShaderProgramHighlight::saveBlendValue):
(WebCore::InspectorScopedShaderProgramHighlight::hasBufferBinding):
(WebCore::InspectorScopedShaderProgramHighlight::hasFramebufferParameterAttachment):
(WebCore::WebGLRenderingContextBase::drawArraysInstanced):
(WebCore::WebGLRenderingContextBase::drawElementsInstanced):
(WebCore::InspectorScopedShaderProgramHighlight::showHightlight): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/251491@main">https://commits.webkit.org/251491@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295486">https://svn.webkit.org/repository/webkit/trunk@295486</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
