### PR TITLE
[git-webkit] Check expiration in token (Follow-up)

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -111,7 +111,8 @@ class Tracker(GenericTracker):
             expiration = response.headers.get('github-authentication-token-expiration', None)
             if expiration:
                 expiration = int(calendar.timegm(datetime.strptime(expiration, '%Y-%m-%d %H:%M:%S UTC').timetuple()))
-            if (expiration is None or expiration > time.time()) and response.status_code == 200 and response.json().get('login') == username:
+                expiring_soon = expiration - 12 * 60 * 60  # Consider a token expiring in the next 12 hours to be expired
+            if (expiration is None or expiring_soon > int(time.time())) and response.status_code == 200 and response.json().get('login') == username:
                 return True
             sys.stderr.write('Login to {} for {} failed\n'.format(self.api_url, username))
             return False


### PR DESCRIPTION
#### 852c6efbe0594eecccd53dabf48395441b894f39
<pre>
[git-webkit] Check expiration in token (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=240883">https://bugs.webkit.org/show_bug.cgi?id=240883</a>
&lt;rdar://93859778&gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.credentials.validater): Treat token as expired if it will expire in the next 12 hours.
</pre>