### PR TITLE
Add functionality for macOS smooth keyboard scrolling to scroll recursively on ancestor regions

### DIFF
--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame-expected.txt
@@ -1,0 +1,2 @@
+SUCCESSFUL: keyboard scroll propagated from iframe to main document.
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <style>
+        body {
+            height: 2000px;
+        }
+        #iframe {
+            width: 20%;
+            height: 20%;
+            border: 1px solid black;
+            padding: 10px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function documentScrolled()
+        {
+            debug("SUCCESSFUL: keyboard scroll propagated from iframe to main document.");
+            testRunner.notifyDone();
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            var iframe = document.getElementById("iframe");
+            document.addEventListener("scroll", documentScrolled);
+            iframe.contentWindow.scrollTo(0,10000);
+
+            // Click inside iframe
+            await UIHelper.activateAt(10,10);
+
+            await UIHelper.keyDown("downArrow");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <iframe id="iframe" srcdoc="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.">
+    </iframe>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow-expected.txt
@@ -1,0 +1,3 @@
+SUCCESSFUL: keyboard scroll propagated from iframe to parent overflow:scroll region.
+
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <style>
+        body {
+            height: 2000px;
+        }
+        .scroller {
+            width: 20%;
+            height: 20%;
+            overflow: scroll;
+            border: 1px solid black;
+            padding: 10px;
+        }
+
+        #innerDiv {
+            height: 600px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function documentScrolled()
+        {
+            debug("UNSUCCESSFUL: keyboard scroll skipped over overflow:scroll region to main document.");
+            testRunner.notifyDone();
+        }
+
+        function overflowScrolled()
+        {
+            debug("SUCCESSFUL: keyboard scroll propagated from iframe to parent overflow:scroll region.");
+            testRunner.notifyDone();
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            var innerFrame = document.getElementById("iframe");
+            var overflow = document.getElementById("overflow");
+
+            document.addEventListener("scroll", documentScrolled);
+            overflow.addEventListener("scroll", overflowScrolled);
+            innerFrame.contentWindow.scrollTo(0,10000);
+
+            // Click inside iframe
+            await UIHelper.activateAt(20,20);
+            await UIHelper.keyDown("downArrow");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="scroller" id="overflow">
+        <iframe class="scroller" id="iframe" srcdoc="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.">
+        </iframe>
+        <div id="innerDiv"></div>
+    </div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame-expected.txt
@@ -1,0 +1,2 @@
+SUCCESSFUL: keyboard scroll propagated from overflow:scroll region to main document.
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <style>
+        body {
+            height: 2000px;
+        }
+        #scroller {
+            width: 20%;
+            height: 20%;
+            overflow: scroll;
+            border: 1px solid black;
+            padding: 10px;
+        }
+        #innerDiv {
+            height: 500px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function documentScrolled()
+        {
+            debug("SUCCESSFUL: keyboard scroll propagated from overflow:scroll region to main document.");
+            testRunner.notifyDone();
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            var scroller = document.getElementById("scroller");
+            document.addEventListener("scroll", documentScrolled);
+            scroller.scrollTo(0,10000)
+
+            // Click inside scroller
+            await UIHelper.activateAt(30,30);
+            await UIHelper.keyDown("downArrow");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div id="scroller">
+        <div id="innerDiv"></div>
+    </div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow-expected.txt
@@ -1,0 +1,2 @@
+SUCCESSFUL: keyboard scroll propagated from overflow:scroll region to parent overflow:scroll region.
+

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <style>
+        body {
+            height: 2000px;
+        }
+        .scroller {
+            width: 20%;
+            height: 20%;
+            overflow: scroll;
+            border: 1px solid black;
+            padding: 10px;
+        }
+        #innerDiv1 {
+            height: 400px;
+        }
+        #innerDiv2 {
+            height: 120px;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function outerScrollerScrolled()
+        {
+            debug("SUCCESSFUL: keyboard scroll propagated from overflow:scroll region to parent overflow:scroll region.");
+            testRunner.notifyDone();
+        }
+
+        async function runTest()
+        {
+            if (!window.testRunner || !testRunner.runUIScript)
+                return;
+
+            var innerScroller = document.getElementById("innerScroller");
+            var outerScroller = document.getElementById("outerScroller");
+            outerScroller.addEventListener("scroll", outerScrollerScrolled);
+            innerScroller.scrollTo(0,10000);
+
+            // Click inside innerScroller
+            await UIHelper.activateAt(30,30);
+
+            await UIHelper.keyDown("downArrow");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="scroller" id="outerScroller">
+        <div class="scroller" id="innerScroller">
+            <div id="innerDiv2"></div>
+        </div>
+        <div id="innerDiv1"></div>
+    </div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1286,6 +1286,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/FileStreamClient.h
     platform/FloatConversion.h
     platform/HostWindow.h
+    platform/KeyboardScrollingAnimator.h
     platform/KeyboardScroll.h
     platform/KeyedCoding.h
     platform/KeypressCommand.h
@@ -1354,14 +1355,17 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SSLKeyGenerator.h
     platform/ScreenProperties.h
     platform/ScriptExecutionContextIdentifier.h
+    platform/ScrollAnimation.h
     platform/ScrollAnimationMomentum.h
     platform/ScrollAnimator.h
+    platform/ScrollSnapAnimatorState.h
     platform/ScrollTypes.h
     platform/ScrollView.h
     platform/ScrollableArea.h
     platform/Scrollbar.h
     platform/ScrollbarTheme.h
     platform/ScrollbarThemeComposite.h
+    platform/ScrollingEffectsController.h
     platform/SearchPopupMenu.h
     platform/SerializedPlatformDataCue.h
     platform/SerializedPlatformDataCueValue.h

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -383,9 +383,13 @@ private:
     bool handleMousePressEventDoubleClick(const MouseEventWithHitTestResults&);
     bool handleMousePressEventTripleClick(const MouseEventWithHitTestResults&);
 
-    KeyboardScrollingAnimator* keyboardScrollingAnimatorForFocusedNode();
-    bool startKeyboardScrolling(KeyboardEvent&);
+    bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, KeyboardEvent&);
     void stopKeyboardScrolling();
+    bool startKeyboardScrollAnimationOnDocument(KeyboardEvent&);
+    bool startKeyboardScrollAnimationOnRenderBoxLayer(KeyboardEvent&, RenderBox*);
+    bool startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(KeyboardEvent&, RenderBox*);
+    bool startKeyboardScrollAnimationOnEnclosingScrollableContainer(KeyboardEvent&, Node*);
+    bool keyboardScrollRecursively(KeyboardEvent&, Node*);
 
 #if ENABLE(DRAG_SUPPORT)
     bool handleMouseDraggedEvent(const MouseEventWithHitTestResults&, CheckDragHysteresis = ShouldCheckDragHysteresis);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2684,6 +2684,11 @@ void Page::whenUnnested(Function<void()>&& callback)
     m_unnestCallback = WTFMove(callback);
 }
 
+void Page::setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator* animator)
+{
+    m_currentKeyboardScrollingAnimator = animator;
+}
+
 #if ENABLE(REMOTE_INSPECTOR)
 
 bool Page::remoteInspectionAllowed() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -30,6 +30,7 @@
 #include "FindOptions.h"
 #include "FrameLoaderTypes.h"
 #include "IntRectHash.h"
+#include "KeyboardScrollingAnimator.h"
 #include "LayoutMilestone.h"
 #include "LayoutRect.h"
 #include "LengthBox.h"
@@ -318,6 +319,10 @@ public:
     void decrementNestedRunLoopCount();
     bool insideNestedRunLoop() const { return m_nestedRunLoopCount > 0; }
     WEBCORE_EXPORT void whenUnnested(Function<void()>&&);
+
+    void setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator*);
+    KeyboardScrollingAnimator* currentKeyboardScrollingAnimator() const { return m_currentKeyboardScrollingAnimator.get(); }
+
 
 #if ENABLE(REMOTE_INSPECTOR)
     WEBCORE_EXPORT bool remoteInspectionAllowed() const;
@@ -1310,6 +1315,8 @@ private:
     Ref<PermissionController> m_permissionController;
     UniqueRef<StorageProvider> m_storageProvider;
     UniqueRef<ModelPlayerProvider> m_modelPlayerProvider;
+
+    WeakPtr<KeyboardScrollingAnimator> m_currentKeyboardScrollingAnimator;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     std::unique_ptr<AttachmentElementClient> m_attachmentElementClient;

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -260,8 +260,17 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(const PlatformKeyboar
     if (!(event.type() == PlatformEvent::RawKeyDown || event.type() == PlatformEvent::Char))
         return false;
 
-    if (m_scrollTriggeringKeyIsPressed)
+    auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
+    auto direction = m_currentKeyboardScroll->direction;
+    if (!scrollableDirections.at(boxSideForDirection(direction))) {
+        m_scrollTriggeringKeyIsPressed = false;
+        m_scrollController.didStopKeyboardScrolling();
+        m_velocity = { };
         return false;
+    }
+
+    if (m_scrollTriggeringKeyIsPressed)
+        return true;
 
     if (m_currentKeyboardScroll->granularity == ScrollGranularity::Document) {
         m_velocity = { };

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class PlatformKeyboardEvent;
 
-class KeyboardScrollingAnimator {
+class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator> {
     WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
     WTF_MAKE_FAST_ALLOCATED;
 public:


### PR DESCRIPTION
#### 66e6a77ccc8ea5f8915860b3ae507dd9bba887ee
<pre>
Add functionality for macOS smooth keyboard scrolling to scroll recursively on ancestor regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=241562">https://bugs.webkit.org/show_bug.cgi?id=241562</a>
&lt;rdar://95045588&gt;

Reviewed by Simon Fraser.

Tests:
LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame.html
LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html
LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html
LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html

Currently, macOS smooth keyboard scrolling stops when it reaches
the edge of the region that the scroll was initiated on. This patch makes it so
that the KeyboardScrollingAnimator for the parent region is called once the animator
for the region current being scrolled is stopped.

* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-frame.html: Added.

Tests that when an iframe has run out of room to scroll, its parent frame scrolls.

* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html: Added.

Tests that when an iframe has run out of room to scroll, its parent overflow:scroll div scrolls.

* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html: Added.

Tests that when an overflow:scroll div has run out of room to scroll, its parent frame scrolls.

* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html: Added.

Tests that when an overflow:scroll div has run out of room to scroll, its parent overflow:scroll div scrolls.

* Source/WebCore/Headers.cmake:

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultKeyboardEventHandler):
(WebCore::EventHandler::defaultSpaceEventHandler):
(WebCore::EventHandler::DefaultArrowEventHandler):

Have these functions call KeyboardScrollRecursively instead of startKeyboardScrolling.

(WebCore::EventHandler::keyboardScrollingAnimatorForFocusedNode): Deleted.
(WebCore::EventHandler::stopKeyboardScrolling):

Retrieves from Page the KeyboardScrollingAnimator that is currently active and tells
it to stop scrolling.

(WebCore::EventHandler::startKeyboardScrolling): Deleted.
(WebCore::EventHandler::beginKeyboardScrollGesture):

Tells KeyboardScrollingAnimator to start scrolling.

(WebCore::EventHandler::startKeyboardScrollAnimationOnDocument):

Helper function for EventHandler::keyboardScrollRecursively. Handles scrolling the document.

(WebCore::EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer):

Helper function for EventHandler::startKeyboardScrollAnimationOnRenderBoxAndItsAncestors.

(WebCore::EventHandler::startKeyboardScrollAnimationOnRenderBoxAndItsAncestors):

Checks that a scrollable region is an overflow:scroll region, and if so, calls
EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer to scroll the region. If scrolling it fails,
Recurses on parent region.

(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):

Helper function for EventHandler::keyboardScrollRecursively. Handles scrolling overflow:scroll
regions within current frame. First determines if an overflow:scroll region is focused, and if so,
calls RenderBox::keyboardScroll to scroll that region and any of its ancestor overflow:scroll
regions within the frame.

(WebCore::EventHandler::keyboardScrollRecursively):

If an overflow:scroll region within the frame is focused, attempts to scroll it followed
by any containing overflow:scroll regions. Otherwise attempts to scroll the frame. If
that also returns false, recurses on the parent frame.

* Source/WebCore/page/EventHandler.h:

* Source/WebCore/page/Page.h:
(WebCore::Page::setCurrentKeyboardScrollingAnimator):
(WebCore::Page::currentKeyboardScrollingAnimator const):

Page now keeps a pointer to the KeyboardScrollingAnimator currently in use so that it
can be stopped when a keyup event occurs.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):

Now stops the animation and returns false if cannot scroll further in the direction given
by the event. Also now returns true if m_scrollTriggeringKeyIsPressed is true (indicating
a scroll is already in action) rather than returning false as before. This is needed because
when beginKeyboardScrollGesture returns false, the function that called it will try to
scroll on the parent region.

* Source/WebCore/platform/KeyboardScrollingAnimator.h:

Canonical link: <a href="https://commits.webkit.org/251914@main">https://commits.webkit.org/251914@main</a>
</pre>
