### PR TITLE
Track SVG renderer updates using a NodeFlag instead of on Style::Update

### DIFF
--- a/LayoutTests/svg/custom/tref-update.svg
+++ b/LayoutTests/svg/custom/tref-update.svg
@@ -2,13 +2,14 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Basic//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-basic.dtd">
 <svg version="1.1" baseProfile="basic" id="svg-root" width="100%" height="100%" viewBox="0 0 480 360"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     xmlns="http://www.w3.org/2000/svg" onload="mytest()">
+     xmlns="http://www.w3.org/2000/svg" xonload="mytest()">
     <script>
      	function mytest() {
             var myTref = document.getElementById("tref");
             myTref.setAttributeNS("http://www.w3.org/1999/xlink", "href", "#tref-internal-reference-success");
      	}
     </script>
+    <rect width="10" height="10" onclick="mytest()"/>
     <defs>
        <text id="tref-internal-reference-failure">Failure</text>
        <text id="tref-internal-reference-success">Success</text>

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -235,6 +235,9 @@ public:
     bool hasShadowRootContainingSlots() const { return hasNodeFlag(NodeFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setNodeFlag(NodeFlag::HasShadowRootContainingSlots, flag); }
 
+    bool needsSVGRendererUpdate() const { return hasNodeFlag(NodeFlag::NeedsSVGRendererUpdate); }
+    void setNeedsSVGRendererUpdate(bool flag) { setNodeFlag(NodeFlag::NeedsSVGRendererUpdate, flag); }
+
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
     ShadowRoot* containingShadowRoot() const;
@@ -579,8 +582,9 @@ protected:
         IsComputedStyleInvalidFlag = 1 << 25,
         HasShadowRootContainingSlots = 1 << 26,
         IsInTopLayer = 1 << 27,
+        NeedsSVGRendererUpdate = 1 << 28
 
-        // Bits 28-31 are free.
+        // Bits 29-31 are free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -59,6 +59,7 @@ private:
     void updateTextRenderer(Text&, const Style::TextUpdate*);
     void createTextRenderer(Text&, const Style::TextUpdate*);
     void updateElementRenderer(Element&, const Style::ElementUpdate&);
+    void updateSVGRenderer(Element&);
     void updateRendererStyle(RenderElement&, RenderStyle&&, StyleDifference);
     void createRenderer(Element&, RenderStyle&&);
     void updateBeforeDescendants(Element&, const Style::ElementUpdate*);

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -46,7 +46,6 @@ struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     Change change { Change::None };
     bool recompositeLayer { false };
-    bool updateSVGRenderer { false };
 };
 
 struct TextUpdate {


### PR DESCRIPTION
#### 200209ca79afc706ec3f67199e17147cd5fe2408
<pre>
Track SVG renderer updates using a NodeFlag instead of on Style::Update
<a href="https://bugs.webkit.org/show_bug.cgi?id=241489">https://bugs.webkit.org/show_bug.cgi?id=241489</a>
&lt;rdar://problem/94756741&gt;

Reviewed by Antti Koivisto.

SVG renderer updates are currently tracked as a kind of Style::Update change.
When a page is updating attributes on many SVG elements, but is not making
changes that require a restyle on those elements, we can spend a lot of time
hashing to store and look up the Style::Update associated with an element.

This patch moves the &quot;SVG renderer update is needed&quot; state to a Node flag
instead, but continues to use the Style::Update mechanism for root tracking,
to reduce this overhead.

This is a 1% improvement on the MotionMark Suits sub-test.

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::updateSVGRendererIfNeeded):
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
* Source/WebCore/style/StyleUpdate.cpp:
(WebCore::Style::Update::addElement):
(WebCore::Style::Update::addSVGRendererUpdate):
* Source/WebCore/style/StyleUpdate.h:
</pre>