### PR TITLE
[RISC-V] Build fixes after 251455@main

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -47,7 +47,7 @@ const NumberOfWasmArguments = NumberOfWasmArgumentJSRs + NumberOfWasmArgumentFPR
 # All callee saves must match the definition in WasmCallee.cpp
 
 # These must match the definition in WasmMemoryInformation.cpp
-if X86_64 or ARM64 or ARM64E
+if X86_64 or ARM64 or ARM64E or RISCV64
     const wasmInstance = csr0
     const memoryBase = csr3
     const boundsCheckingSize = csr4

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp
@@ -41,7 +41,7 @@ const PinnedRegisterInfo& PinnedRegisterInfo::get()
         unsigned numberOfPinnedRegisters = 2;
         if (!Context::useFastTLS())
             ++numberOfPinnedRegisters;
-#if CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
         GPRReg baseMemoryPointer = GPRInfo::regCS3;
         GPRReg boundsCheckingSizeRegister = GPRInfo::regCS4;
 #elif CPU(ARM)


### PR DESCRIPTION
#### 91022fcd667b8c76f8308387197da4470f83d1c2
<pre>
[RISC-V] Build fixes after 251455@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=241591">https://bugs.webkit.org/show_bug.cgi?id=241591</a>

Patch by Žan Doberšek &lt;zdobersek@igalia.com &gt; on 2022-06-14
Unreviewed, adding missing RISCV64 build guards alongside guards for other
64-bit platforms to get the build back up and running.

* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmMemoryInformation.cpp:
(JSC::Wasm::PinnedRegisterInfo::get):

Canonical link: <a href="https://commits.webkit.org/251524@main">https://commits.webkit.org/251524@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295519">https://svn.webkit.org/repository/webkit/trunk@295519</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
