### PR TITLE
IPC stream send is slow due to semaphore signal if receiver is faster than sender

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -238,11 +238,10 @@ std::optional<StreamClientConnection::SendSyncResult> StreamClientConnection::tr
         if (!(messageEncoder << syncRequestID << message.arguments()))
             return std::nullopt;
         auto wakeupResult = release(messageEncoder.size());
-
-        if (wakeupResult == StreamClientConnection::WakeUpServer::Yes)
-            wakeUpServer();
-        else
-            sendDeferredWakeUpMessageIfNeeded();
+        UNUSED_VARIABLE(wakeupResult);
+        // Always signal the receiver, since we do not want to buffer calls in case server is idle-waiting.
+        // Also, the kernel might be able to switch the thread to the server.
+        wakeUpServer();
         if constexpr(T::isReplyStreamEncodable) {
             auto replySpan = tryAcquireAll(timeout);
             if (!replySpan)

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -56,7 +56,7 @@ public:
     Semaphore& wakeUpSemaphore();
 private:
     void startProcessingThread() WTF_REQUIRES_LOCK(m_lock);
-    void processStreams();
+    void processStreams(Vector<Ref<StreamServerConnection>>&& connections);
 #if ASSERT_ENABLED
     void assertIsCurrent() const;
 #endif
@@ -64,7 +64,12 @@ private:
     const char* const m_name;
 
     Semaphore m_wakeUpSemaphore;
-    std::atomic<bool> m_shouldQuit { false };
+    enum class RunState : int {
+        Run,
+        ReloadState,
+        Quit
+    };
+    std::atomic<RunState> m_runState { RunState::Run };
 
     mutable Lock m_lock;
     RefPtr<Thread> m_processingThread WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -75,11 +75,16 @@ public:
 
     Connection& connection() { return m_connection; }
 
-    enum DispatchResult : bool {
-        HasNoMessages,
-        HasMoreMessages
+    enum class DispatchResult : int {
+        NoMessages,
+        DidDispatchMessages,
+        HasIncompleteMessages
     };
-    DispatchResult dispatchStreamMessages(size_t messageLimit);
+    enum class SleepIfNoMessages : bool {
+        No,
+        Yes
+    };
+    DispatchResult dispatchStreamMessages(size_t messageLimit, SleepIfNoMessages);
 
     void open();
     void invalidate();
@@ -100,7 +105,7 @@ private:
         uint8_t* data;
         size_t size;
     };
-    std::optional<Span> tryAcquire();
+    std::optional<Span> tryAcquire(SleepIfNoMessages);
     Span acquireAll();
 
     void release(size_t readSize);


### PR DESCRIPTION
#### 50a233c3a0fa44df32b6f45f71b52e94b4e8836c
<pre>
IPC stream send is slow due to semaphore signal if receiver is faster than sender
<a href="https://bugs.webkit.org/show_bug.cgi?id=239895">https://bugs.webkit.org/show_bug.cgi?id=239895</a>

Reviewed by NOBODY (OOPS!).
Avoid client signal() calls by marking the receiver as sleeping after a delay.
This should let the sender accrue more messages to the buffer without the signal.
WIP: no perf data yet, the numbers are just first guesses. Does not seem to
improve MM Canvas Lines on macOS AS Release.
No new tests, optimization.Need a short description (OOPS!).

* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::dispatch):
(IPC::StreamConnectionWorkQueue::addStreamConnection):
(IPC::StreamConnectionWorkQueue::removeStreamConnection):
(IPC::StreamConnectionWorkQueue::stopAndWaitForCompletion):
(IPC::StreamConnectionWorkQueue::startProcessingThread):
(IPC::StreamConnectionWorkQueue::processStreams):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::tryAcquire):
(IPC::StreamServerConnection::dispatchStreamMessages):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
</pre>