### PR TITLE
REGRESSION (251356@main): TestWebKitAPI.IPCTestingAPI.CanSendSharedMemory is consistently timing out

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -689,6 +689,23 @@ std::optional<WebPasteboardProxy::PasteboardAccessType> WebPasteboardProxy::Past
     return processes[matchIndex].second;
 }
 
+#if ENABLE(IPC_TESTING_API)
+void WebPasteboardProxy::testIPCSharedMemory(IPC::Connection& connection, const String& pasteboardName, const String& pasteboardType, SharedMemory::IPCHandle&& handle, std::optional<PageIdentifier> pageID, CompletionHandler<void(int64_t, String)>&& completionHandler)
+{
+    MESSAGE_CHECK_COMPLETION(!pasteboardName.isEmpty(), completionHandler(-1, makeString("error")));
+    MESSAGE_CHECK_COMPLETION(!pasteboardType.isEmpty(), completionHandler(-1, makeString("error")));
+
+    auto sharedMemoryBuffer = SharedMemory::map(handle.handle, SharedMemory::Protection::ReadOnly);
+    if (!sharedMemoryBuffer) {
+        completionHandler(-1, makeString("error EOM"));
+        return;
+    }
+
+    String message = { static_cast<char*>(sharedMemoryBuffer->data()), unsigned(handle.dataSize) };
+    completionHandler(handle.dataSize, WTFMove(message));
+}
+#endif
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK_COMPLETION

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -106,6 +106,11 @@ private:
     void setPasteboardColor(IPC::Connection&, const String&, const WebCore::Color&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardStringForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, const String&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, RefPtr<WebCore::SharedBuffer>&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t)>&&);
+
+#if ENABLE(IPC_TESTING_API)
+    void testIPCSharedMemory(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, WebKit::SharedMemory::IPCHandle&&, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(int64_t, String)>&&);
+#endif
+
 #endif
 
     void readStringFromPasteboard(IPC::Connection&, size_t index, const String& pasteboardType, const String& pasteboardName, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -58,6 +58,11 @@ messages -> WebPasteboardProxy NotRefCounted {
     SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<WebCore::SharedBuffer> buffer, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount) Synchronous WantsConnection
     ContainsURLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (bool result) Synchronous WantsConnection
     URLStringSuitableForLoading(String pasteboardName, std::optional<WebCore::PageIdentifier> pageID) -> (String url, String title) Synchronous WantsConnection
+
+#if ENABLE(IPC_TESTING_API)
+    TestIPCSharedMemory(String pasteboardName, String pasteboardType, WebKit::SharedMemory::IPCHandle handle, std::optional<WebCore::PageIdentifier> pageID) -> (int64_t changeCount, String buffer) Synchronous WantsConnection
+#endif
+
 #endif
 
 #if PLATFORM(GTK)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -46,7 +46,7 @@ static RetainPtr<NSString> promptResult;
 @interface IPCTestingAPIDelegate : NSObject <WKUIDelegate, WKNavigationDelegate>
 - (BOOL)sayHelloWasCalled;
 @end
-    
+
 @implementation IPCTestingAPIDelegate {
     BOOL _didCallSayHello;
 }
@@ -320,10 +320,12 @@ TEST(IPCTestingAPI, CanSendSharedMemory)
 <script>
 const sharedMemory = IPC.createSharedMemory(8);
 sharedMemory.writeBytes(new Uint8Array(Array.from('hello').map((char) => char.charCodeAt(0))));
-const result = IPC.sendSyncMessage('UI', 0, IPC.messages.WebPasteboardProxy_SetPasteboardBufferForType.name, 100, [
-    {type: 'String', value: 'Apple CFPasteboard general'}, {type: 'String', value: 'text/plain'},
-    {type: 'SharedMemory', value: sharedMemory, protection: 'ReadOnly'}, {type: 'bool', value: 1}, {type: 'uint64_t', value: IPC.pageID}]);
-alert(result.arguments.length + ':' + JSON.stringify(result.arguments[0]));
+const result = IPC.sendSyncMessage('UI', 0, IPC.messages.WebPasteboardProxy_TestIPCSharedMemory.name, 100, [
+    {type: 'String', value: 'Apple CFPasteboard general'},
+    {type: 'String', value: 'text/plain'},
+    {type: 'SharedMemory', value: sharedMemory, protection: 'ReadOnly'},
+    {type: 'bool', value: 1}, {type: 'uint64_t', value: IPC.pageID}]);
+alert(result.arguments.length + ':' + JSON.stringify(result.arguments[0]) + ',' + JSON.stringify(result.arguments[1]));
 </script>
 </body>)HTML";
 
@@ -331,7 +333,7 @@ alert(result.arguments.length + ':' + JSON.stringify(result.arguments[0]));
     [webView synchronouslyLoadHTMLString:html];
     TestWebKitAPI::Util::run(&done);
 
-    EXPECT_STREQ([alertMessage UTF8String], "1:{\"type\":\"int64_t\",\"value\":0}");
+    EXPECT_STREQ([alertMessage UTF8String], "2:{\"type\":\"int64_t\",\"value\":8},{\"type\":\"String\",\"value\":\"hello\\u0000\\u0000\\u0000\"}");
 }
 #endif
 


### PR DESCRIPTION
#### 61f8d5ff24866b5ac11cfcb1ced31bca274f510b
<pre>
REGRESSION (251356@main): TestWebKitAPI.IPCTestingAPI.CanSendSharedMemory is consistently timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=241385">https://bugs.webkit.org/show_bug.cgi?id=241385</a>
rdar://problem/94566204

Reviewed by Jer Noble.

This test relied on an implementation detail to check that the SharedMemory was
sent without error to the remote process.
However, following bug 240902 this was no longer the case causing the test to
fail.

Add an API_TEST only API, specifically conceived to use SharedMemory and amend
the original test to check on the buffer received.

* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::testIPCSharedMemory):
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/251952@main">https://commits.webkit.org/251952@main</a>
</pre>
