### PR TITLE
Add custom handler for text-align: inherit.

### DIFF
--- a/LayoutTests/fast/table/center-th-when-parent-has-initial-text-align-expected.html
+++ b/LayoutTests/fast/table/center-th-when-parent-has-initial-text-align-expected.html
@@ -4,7 +4,7 @@
 <title>This tests that th is text-align centered when parent has initial value.</title>
 <style>
     table { 
-    width: 500px; border: 1px solid green; 
+    width: 500px; border: 1px solid green;
 }
 </style>
 <table><tbody>
@@ -12,10 +12,12 @@
     <tr><th style="text-align: left">th initial</th></tr>
     <tr><th style="text-align: left">th start</th></tr>
     <tr><th style="text-align: center">th center</th></tr>
+    <tr><th style="text-align: left">th initial</th></tr>
     <tr><th style="text-align: right">th end</th></tr>
     <tr><th style="text-align: center">tr initial</th></tr>
     <tr><th style="text-align: center">tr start</th></tr>
     <tr><th style="text-align: center">tr center</th></tr>
+    <tr><th style="text-align: right">tr end</th></tr>
     <tr><th style="text-align: right">tr end</th></tr>
     <tr><th style="text-align: left">tr initial, th initial</th></tr>
     <tr><th style="text-align: left">tr initial, th start</th></tr>

--- a/LayoutTests/fast/table/center-th-when-parent-has-initial-text-align.html
+++ b/LayoutTests/fast/table/center-th-when-parent-has-initial-text-align.html
@@ -4,7 +4,7 @@
 <title>This tests that th is text-align centered when parent has initial value.</title>
 <style>
     table { 
-    width: 500px; border: 1px solid green; 
+    width: 500px; border: 1px solid green;
 }
 </style>
 <table><tbody>
@@ -12,11 +12,13 @@
     <tr><th style="text-align: initial">th initial</th></tr>
     <tr><th style="text-align: start">th start</th></tr>
     <tr><th style="text-align: center">th center</th></tr>
+    <tr><th style="text-align: inherit">th initial</th></tr>
     <tr><th style="text-align: end">th end</th></tr>
     <tr style="text-align: initial"><th>tr initial</th></tr>
     <tr style="text-align: start"><th>tr start</th></tr>
     <tr style="text-align: center"><th>tr center</th></tr>
     <tr style="text-align: end"><th>tr end</th></tr>
+    <tr style="text-align: end"><th style="text-align: inherit">tr end</th></tr>
     <tr style="text-align: initial"><th style="text-align: initial">tr initial, th initial</th></tr>
     <tr style="text-align: initial"><th style="text-align: start">tr initial, th start</th></tr>
     <tr style="text-align: start"><th style="text-align: start">tr start, th start</th></tr>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4588,7 +4588,7 @@
             ],
             "codegen-properties": {
                 "converter": "TextAlign",
-                "custom": "Initial|Value"
+                "custom": "All"
             },
             "specification": {
                 "category": "css-22",

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -112,6 +112,7 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(OutlineStyle);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Size);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Stroke);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(TextAlign);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(TextEmphasisStyle);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(TextIndent);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(TextShadow);
@@ -137,8 +138,6 @@ public:
     static void applyValueVerticalAlign(BuilderState&, CSSValue&);
 
     // Custom handling of initial + value only.
-    static void applyInitialTextAlign(BuilderState&);
-    static void applyValueTextAlign(BuilderState&, CSSValue&);
     static void applyInitialTextAlignLast(BuilderState&);
     static void applyValueTextAlignLast(BuilderState&, CSSValue&);
 
@@ -203,6 +202,12 @@ inline void BuilderCustom::applyInitialTextAlign(BuilderState& builderState)
 inline void BuilderCustom::applyValueTextAlign(BuilderState& builderState, CSSValue& value)
 {
     builderState.style().setTextAlign(BuilderConverter::convertTextAlign(builderState, value));
+    builderState.style().setHasExplicitlySetTextAlign(true);
+}
+
+inline void BuilderCustom::applyInheritTextAlign(BuilderState& builderState)
+{
+    builderState.style().setTextAlign(builderState.parentStyle().textAlign());
     builderState.style().setHasExplicitlySetTextAlign(true);
 }
 


### PR DESCRIPTION
#### c113797a0376b301a5f2342652dc593a3595d612
<pre>
Add custom handler for text-align: inherit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=138577">https://bugs.webkit.org/show_bug.cgi?id=138577</a>

Reviewed by NOBODY (OOPS!).

&lt;th&gt; was being handled improperly due to an unset flag when the
text-align property was explicitly set to inherit. This adds a custom
handler that sets the flag when necessary.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInheritTextAlign):
* LayoutTests/fast/table/center-th-when-parent-has-initial-text-align-expected.html:
* LayoutTests/fast/table/center-th-when-parent-has-initial-text-align.html:
</pre>