### PR TITLE
Remove redundant text-align-last BuilderCustom functions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2216,8 +2216,6 @@ webkit.org/b/233543 imported/w3c/web-platform-tests/css/css-masking/mask-image/m
 
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-clip-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-clip-2.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1a.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1b.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1c.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-2c.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-1c.html [ ImageOnlyFailure ]
@@ -2230,7 +2228,6 @@ imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-to-mask-typ
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-opacity-1d.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-origin-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-origin-3.html [ ImageOnlyFailure ]
-
 
 # A support file for a test
 imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clipPath.svg [ Skip ]

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -411,11 +411,11 @@ CSSTextAlignLastEnabled:
   humanReadableDescription: "Enable the property text-align-last, defined in CSS Text 3"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSTextJustifyEnabled:
   type: bool

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4609,7 +4609,6 @@
             ],
             "codegen-properties": {
                 "converter": "TextAlignLast",
-                "custom": "Initial|Value",
                 "settings-flag": "cssTextAlignLastEnabled"
             },
             "specification": {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -235,6 +235,9 @@ public:
     bool hasShadowRootContainingSlots() const { return hasNodeFlag(NodeFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setNodeFlag(NodeFlag::HasShadowRootContainingSlots, flag); }
 
+    bool needsSVGRendererUpdate() const { return hasNodeFlag(NodeFlag::NeedsSVGRendererUpdate); }
+    void setNeedsSVGRendererUpdate(bool flag) { setNodeFlag(NodeFlag::NeedsSVGRendererUpdate, flag); }
+
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
     ShadowRoot* containingShadowRoot() const;
@@ -579,8 +582,9 @@ protected:
         IsComputedStyleInvalidFlag = 1 << 25,
         HasShadowRootContainingSlots = 1 << 26,
         IsInTopLayer = 1 << 27,
+        NeedsSVGRendererUpdate = 1 << 28
 
-        // Bits 28-31 are free.
+        // Bits 29-31 are free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -975,7 +975,7 @@ void RenderBoxModelObject::paintFillLayerExtended(const PaintInfo& paintInfo, co
                 downcast<BitmapImage>(*image).updateFromSettings(settings());
 
             ImagePaintingOptions options = {
-                op == CompositeOperator::SourceOver ? bgLayer.composite() : op,
+                op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,
                 bgLayer.blendMode(),
                 decodingModeForImageDraw(*image, paintInfo),
                 ImageOrientation::FromImage,

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -300,7 +300,7 @@ static ScrollingScope nextScrollingScope()
     return ++currentScope;
 }
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderLayer);
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderLayer);
 
 RenderLayer::RenderLayer(RenderLayerModelObject& renderer)
     : m_isRenderViewLayer(renderer.isRenderView())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -146,9 +146,8 @@ struct ScrollRectToVisibleOptions {
 
 using ScrollingScope = uint64_t;
 
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderLayer);
 class RenderLayer : public CanMakeWeakPtr<RenderLayer> {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(RenderLayer);
+    WTF_MAKE_ISO_ALLOCATED(RenderLayer);
 public:
     friend class RenderReplica;
     friend class RenderLayerFilters;

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -87,6 +87,15 @@ public:
     FillSize size() const { return FillSize(static_cast<FillSizeType>(m_sizeType), m_sizeLength); }
     MaskMode maskMode() const { return static_cast<MaskMode>(m_maskMode); }
 
+    // https://drafts.fxtf.org/css-masking/#the-mask-composite
+    // If there is no further mask layer, the compositing operator must be ignored.
+    CompositeOperator compositeForPainting() const
+    {
+        if (type() == FillLayerType::Mask && !next())
+            return CompositeOperator::SourceOver;
+        return composite();
+    }
+
     const FillLayer* next() const { return m_next.get(); }
     FillLayer* next() { return m_next.get(); }
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -59,6 +59,7 @@ private:
     void updateTextRenderer(Text&, const Style::TextUpdate*);
     void createTextRenderer(Text&, const Style::TextUpdate*);
     void updateElementRenderer(Element&, const Style::ElementUpdate&);
+    void updateSVGRenderer(Element&);
     void updateRendererStyle(RenderElement&, RenderStyle&&, StyleDifference);
     void createRenderer(Element&, RenderStyle&&);
     void updateBeforeDescendants(Element&, const Style::ElementUpdate*);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -139,8 +139,6 @@ public:
     // Custom handling of initial + value only.
     static void applyInitialTextAlign(BuilderState&);
     static void applyValueTextAlign(BuilderState&, CSSValue&);
-    static void applyInitialTextAlignLast(BuilderState&);
-    static void applyValueTextAlignLast(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
     static void applyValueBaselineShift(BuilderState&, CSSValue&);
@@ -204,16 +202,6 @@ inline void BuilderCustom::applyValueTextAlign(BuilderState& builderState, CSSVa
 {
     builderState.style().setTextAlign(BuilderConverter::convertTextAlign(builderState, value));
     builderState.style().setHasExplicitlySetTextAlign(true);
-}
-
-inline void BuilderCustom::applyInitialTextAlignLast(BuilderState& builderState)
-{
-    builderState.style().setTextAlignLast(RenderStyle::initialTextAlignLast());
-}
-
-inline void BuilderCustom::applyValueTextAlignLast(BuilderState& builderState, CSSValue& value)
-{
-    builderState.style().setTextAlignLast(BuilderConverter::convertTextAlignLast(builderState, value));
 }
 
 inline void BuilderCustom::resetEffectiveZoom(BuilderState& builderState)

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -46,7 +46,6 @@ struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     Change change { Change::None };
     bool recompositeLayer { false };
-    bool updateSVGRenderer { false };
 };
 
 struct TextUpdate {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
@@ -268,7 +268,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
         return nil;
 #endif
     case _WKElementActionTypeCopyCroppedImage:
-        return [UIImage systemImageNamed:@"person.fill.viewfinder"];
+        return [UIImage _systemImageNamed:@"circle.dashed.rectangle"];
     }
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10434,10 +10434,10 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
     // The limit matches the limit set on existing WKWebView find API.
     constexpr auto maxMatches = 1000;
-    _page->findTextRangesForStringMatches(string, findOptions, maxMatches, [string, aggregator = retainPtr(aggregator)](const Vector<WebKit::WebFoundTextRange> ranges) {
+    _page->findTextRangesForStringMatches(string, findOptions, maxMatches, [string = retainPtr(string), aggregator = retainPtr(aggregator)](const Vector<WebKit::WebFoundTextRange> ranges) {
         for (auto& range : ranges) {
             WKFoundTextRange *textRange = [WKFoundTextRange foundTextRangeWithWebFoundTextRange:range];
-            [aggregator foundRange:textRange forSearchString:string inDocument:nil];
+            [aggregator foundRange:textRange forSearchString:string.get() inDocument:nil];
         }
 
         [aggregator finishedSearching];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4694,7 +4694,7 @@ static void selectionChangedWithTouch(WKContentView *view, const WebCore::IntPoi
     if (_removeBackgroundData->element != _page->editorState().postLayoutData().selectedEditableImage)
         return nil;
 
-    return [self menuWithInlineAction:WebCore::contextMenuItemTitleRemoveBackground() identifier:@"WKActionRemoveBackground" handler:[](WKContentView *view) {
+    return [self menuWithInlineAction:WebCore::contextMenuItemTitleRemoveBackground() image:[UIImage _systemImageNamed:@"circle.rectangle.filled.pattern.diagonalline"] identifier:@"WKActionRemoveBackground" handler:[](WKContentView *view) {
         auto data = std::exchange(view->_removeBackgroundData, { });
         if (!data)
             return;
@@ -9875,9 +9875,9 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 #endif
 }
 
-- (UIMenu *)menuWithInlineAction:(NSString *)title identifier:(NSString *)identifier handler:(Function<void(WKContentView *)>&&)handler
+- (UIMenu *)menuWithInlineAction:(NSString *)title image:(UIImage *)image identifier:(NSString *)identifier handler:(Function<void(WKContentView *)>&&)handler
 {
-    auto action = [UIAction actionWithTitle:title image:nil identifier:identifier handler:makeBlockPtr([handler = WTFMove(handler), weakSelf = WeakObjCPtr<WKContentView>(self)](UIAction *) mutable {
+    auto action = [UIAction actionWithTitle:title image:image identifier:identifier handler:makeBlockPtr([handler = WTFMove(handler), weakSelf = WeakObjCPtr<WKContentView>(self)](UIAction *) mutable {
         if (auto strongSelf = weakSelf.get())
             handler(strongSelf.get());
     }).get()];
@@ -9893,7 +9893,7 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 
     bool isVisible = _page->appHighlightsVisibility();
     auto title = isVisible ? WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote() : WebCore::contextMenuItemTagAddHighlightToNewQuickNote();
-    return [self menuWithInlineAction:title identifier:@"WKActionCreateQuickNote" handler:[isVisible](WKContentView *view) mutable {
+    return [self menuWithInlineAction:title image:nil identifier:@"WKActionCreateQuickNote" handler:[isVisible](WKContentView *view) mutable {
         view->_page->createAppHighlightInSelectedRange(isVisible ? WebCore::CreateNewGroupForHighlight::No : WebCore::CreateNewGroupForHighlight::Yes, WebCore::HighlightRequestOriginatedInApp::No);
     }];
 }

--- a/Source/bmalloc/libpas/ReadMe.md
+++ b/Source/bmalloc/libpas/ReadMe.md
@@ -17,23 +17,23 @@ will seem to work. In production, libpas gets built as part of some other
 project (like bmalloc), which just pulls all of libpas' files into that
 project's build system.
 
-Build and test:
+Build and Test
 
     ./build_and_test.sh
 
-Just build:
+Build
 
     ./build.sh
 
-Just test:
+Test
 
     ./test.sh
 
-Clean:
+Clean
 
     ./clean.sh
 
-On my M1 machine, I usually do this:
+On my M1 machine, I usually do this
 
     ./build_and_test.sh -a arm64e
 
@@ -54,6 +54,13 @@ All of the tools (`build.sh`, `test.sh`, `build_and_test.sh`, and `clean.sh`)
 take the same options (`-h`, `-c <config>`, `-s <sdk>`, `-a <arch>`,
 `-v <variant>`, `-t <target>`, and `-p <port>`).
 
+Libpas creates multiple binaries (`test_pas` and `chaos`) during compilation, which are used by `test.sh`. Calling these binaries directly may be preferred if you would like to test or debug just one or a handful of test cases.
+
+`test_pas` allows you to filter which test cases will be run. These are a few examples
+
+	  ./test_pas 'JITHeapTests' # Run all JIT heap tests
+	  ./test_pas 'testPGMSingleAlloc()' # Run specific test
+	  ./test_pas '(1):' # Run test case 1
 
 # Synopsis
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -48,6 +48,7 @@ class Tracker(GenericTracker):
     REFRESH_TOKEN_PROMPT = "Is your API token out of date? Run 'git-webkit setup' to refresh credentials\n"
     DEFAULT_COMPONENT_COLOR = 'FFFFFF'
     DEFAULT_VERSION_COLOR = 'EEEEEE'
+    ACCEPT_HEADER = 'application/vnd.github.v3+json'
 
 
     class Encoder(GenericTracker.Encoder):
@@ -105,7 +106,7 @@ class Tracker(GenericTracker):
                 return False
             response = self.session.get(
                 '{}/user'.format(self.api_url),
-                headers=dict(Accept='application/vnd.github.v3+json'),
+                headers=dict(Accept=self.ACCEPT_HEADER),
                 auth=HTTPBasicAuth(username, access_token),
             )
             expiration = response.headers.get('github-authentication-token-expiration', None)
@@ -144,7 +145,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
     def request(self, path=None, params=None, method='GET', headers=None, authenticated=None, paginate=True, json=None, error_message=None):
         headers = {key: value for key, value in headers.items()} if headers else dict()
-        headers['Accept'] = headers.get('Accept', 'application/vnd.github.v3+json')
+        headers['Accept'] = headers.get('Accept', self.ACCEPT_HEADER)
 
         username, access_token = self.credentials(required=bool(authenticated))
         auth = HTTPBasicAuth(username, access_token) if username and access_token else None
@@ -196,7 +197,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         url = '{api_url}/users/{username}'.format(api_url=self.api_url, username=username)
         response = self.session.get(
             url, auth=HTTPBasicAuth(*self.credentials(required=True)),
-            headers=dict(Accept='application/vnd.github.v3+json'),
+            headers=dict(Accept=self.ACCEPT_HEADER),
         )
         if response.status_code // 100 != 2:
             sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -40,6 +40,7 @@ from xml.dom import minidom
 class GitHub(Scm):
     URL_RE = re.compile(r'\Ahttps?://github.(?P<domain>\S+)/(?P<owner>\S+)/(?P<repository>\S+)\Z')
     EMAIL_RE = re.compile(r'(?P<email>[^@]+@[^@]+)(@.*)?')
+    ACCEPT_HEADER = Tracker.ACCEPT_HEADER
 
     class PRGenerator(Scm.PRGenerator):
         SUPPORTS_DRAFTS = True
@@ -113,7 +114,7 @@ class GitHub(Scm):
             )
             response = self.repository.session.post(
                 url, auth=HTTPBasicAuth(*self.repository.credentials(required=True)),
-                headers=dict(Accept='application/vnd.github.v3+json'),
+                headers=dict(Accept=self.repository.ACCEPT_HEADER),
                 json=dict(
                     title=title,
                     body=PullRequest.create_body(body, commits),
@@ -167,7 +168,7 @@ class GitHub(Scm):
             )
             response = self.repository.session.post(
                 url, auth=HTTPBasicAuth(*self.repository.credentials(required=True)),
-                headers=dict(Accept='application/vnd.github.v3+json'),
+                headers=dict(Accept=self.repository.ACCEPT_HEADER),
                 json=updates,
             )
             if response.status_code == 422:
@@ -317,7 +318,7 @@ class GitHub(Scm):
 
     def request(self, path=None, params=None, headers=None, authenticated=None, paginate=True):
         headers = {key: value for key, value in headers.items()} if headers else dict()
-        headers['Accept'] = headers.get('Accept', 'application/vnd.github.v3+json')
+        headers['Accept'] = headers.get('Accept', self.ACCEPT_HEADER)
 
         username, access_token = self.credentials(required=bool(authenticated))
         auth = HTTPBasicAuth(username, access_token) if username and access_token else None

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -357,4 +357,11 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 - (void)didInsertFinalDictationResult;
 @end
 
+#if HAVE(UIFINDINTERACTION)
+@interface UITextSearchOptions ()
+@property (nonatomic, readwrite) UITextSearchMatchMethod wordMatchMethod;
+@property (nonatomic, readwrite) NSStringCompareOptions stringCompareOptions;
+@end
+#endif
+
 #endif // PLATFORM(IOS_FAMILY)

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -8,5 +8,7 @@
 [webkitscmpy "remotes"]
         origin = git@github.com:WebKit/WebKit.git
         apple = git@github.com:apple/WebKit.git
+[webkitscmpy "access"]
+        apple = apple/teams/WebKit
 [webkitscmpy "pre-pr"]
         style-checker = python3 Tools/Scripts/check-webkit-style


### PR DESCRIPTION
#### 36953c35092b8a0848798b5cb7252f1a888893b8
<pre>
Remove redundant text-align-last BuilderCustom functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=241607">https://bugs.webkit.org/show_bug.cgi?id=241607</a>
&lt;rdar://95131415 &gt;

Reviewed by Simon Fraser.

They might have been copy pasted from text-align, which needs them for the hasExplicitlySetTextAlign flag, which text-align-last does not have.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialTextAlignLast): Deleted.
(WebCore::Style::BuilderCustom::applyValueTextAlignLast): Deleted.

Canonical link: <a href="https://commits.webkit.org/251546@main">https://commits.webkit.org/251546@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295541">https://svn.webkit.org/repository/webkit/trunk@295541</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
