### PR TITLE
Add regression test for access to audio service in the GPU process

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2601,6 +2601,13 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
         _page->disableURLSchemeCheckInDataDetectors();
 }
 
+- (BOOL)_gpuProcessHasAccessToMachService:(NSString *)service
+{
+    if (!_page)
+        return FALSE;
+    return _page->gpuProcessHasAccessToMachService(service);
+}
+
 - (void)_switchFromStaticFontRegistryToUserFontRegistry
 {
     THROW_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -409,6 +409,8 @@ for this property.
 
 - (void)_disableURLSchemeCheckInDataDetectors WK_API_AVAILABLE(ios(16.0));
 
+- (BOOL)_gpuProcessHasAccessToMachService:(NSString *)service WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
 /*! @abstract If the WKWebView was created with _shouldAllowUserInstalledFonts = NO,
  the web process will automatically use an in-process font registry, and its sandbox
  will be restricted to forbid access to fontd. Otherwise, the web process will use

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -881,6 +881,11 @@ void WebPageProxy::disableURLSchemeCheckInDataDetectors() const
     process().send(Messages::WebProcess::DisableURLSchemeCheckInDataDetectors(), 0);
 }
 
+bool WebPageProxy::gpuProcessHasAccessToMachService(const String& service) const
+{
+    return false;
+}
+
 void WebPageProxy::switchFromStaticFontRegistryToUserFontRegistry()
 {
     process().send(Messages::WebProcess::SwitchFromStaticFontRegistryToUserFontRegistry(process().fontdMachExtensionHandle(SandboxExtension::MachBootstrapOptions::EnableMachBootstrap)), 0);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1923,6 +1923,8 @@ public:
 
     void disableURLSchemeCheckInDataDetectors() const;
 
+    bool gpuProcessHasAccessToMachService(const String& service) const;
+        
     void setIsTakingSnapshotsForApplicationSuspension(bool);
     void setNeedsDOMWindowResizeEvent();
 


### PR DESCRIPTION
#### 8d4dc26a7c800b0e3a858e042d3c0978aea29f6f
<pre>
Add regression test for access to audio service in the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=241612">https://bugs.webkit.org/show_bug.cgi?id=241612</a>

Reviewed by NOBODY (OOPS!).

This is the &quot;com.apple.audio.AudioComponentRegistrar&quot; service.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _gpuProcessHasAccessToMachService:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
(-[WKWebView _dataTaskWithRequest:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::gpuProcessHasAccessToMachService const):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre>