### PR TITLE
Add a way to create resources in webkitscmpy.GitHub

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.0',
+    version='5.2.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 0)
+version = Version(5, 2, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))


### PR DESCRIPTION
#### 1c7ed2344ae2d2adf9a781b853e726b5375bb52b
<pre>
Add a way to create resources in webkitscmpy.GitHub
<a href="https://bugs.webkit.org/show_bug.cgi?id=241618">https://bugs.webkit.org/show_bug.cgi?id=241618</a>
rdar://95153858

Reviewed by NOBODY (OOPS!).

Add a new create() method in webkitscmpy&apos;s GitHub SCM class for POST
manipulation of the GitHub API.
Add a new create_reference() method to create git references via API.
Add a new create_tag() method for creating tags in git.

* Tools/Scripts/libraries/webkitscmpy/setup.py: bump webkitscmpy version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: bump webkitscmpy version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py: add create() and create_tag().
(GitHub.PRGenerator.create): refactor to use the repository&apos;s create() method.
(GitHub.find):
(GitHub):
(GitHub.commits):
(GitHub.create): use for POST actions.
(GitHub.create_reference): leverages create to make an accessible git reference.
(GitHub.create_tag): leverages create and create_reference to make a git tag.
</pre>