### PR TITLE
[JSC] Typed array private name resolvable only after public name has been seen

### DIFF
--- a/JSTests/stress/typed-array-builtin-names.js
+++ b/JSTests/stress/typed-array-builtin-names.js
@@ -1,0 +1,29 @@
+var createBuiltin = $vm.createBuiltin;
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+let list = [
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "BigInt64Array",
+    "BigUint64Array",
+];
+
+for (let constructorName of list) {
+    let builtin = createBuiltin(`(function (a) {
+        return @${constructorName};
+    })`);
+    let constructor = builtin();
+    shouldBe(constructor.name, constructorName);
+    shouldBe(constructor, globalThis[constructorName]);
+}

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5322,3 +5322,10 @@ fast/text/bulgarian-system-language-shaping.html [ ImageOnlyFailure ]
 
 # Accessibility bold only exists on iOS.
 fast/text/accessibility-bold-system-font [ Skip ]
+
+# ReadableByteStream has a crash bug (ReadableByteStream is not enabled).
+imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.html [ Skip ]
+imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.serviceworker.html [ Skip ]
+imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.worker.html [ Skip ]
+streams/readable-byte-stream-controller.html [ Skip ]
+streams/readable-byte-stream-controller-worker.html [ Skip ]

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -123,6 +123,17 @@ class JSGlobalObject;
     v(jsonParse, nullptr) \
     v(jsonStringify, nullptr) \
     v(String, nullptr) \
+    v(Int8Array, nullptr) \
+    v(Uint8Array, nullptr) \
+    v(Uint8ClampedArray, nullptr) \
+    v(Int16Array, nullptr) \
+    v(Uint16Array, nullptr) \
+    v(Int32Array, nullptr) \
+    v(Uint32Array, nullptr) \
+    v(Float32Array, nullptr) \
+    v(Float64Array, nullptr) \
+    v(BigInt64Array, nullptr) \
+    v(BigUint64Array, nullptr) \
 
 
 #define DECLARE_LINK_TIME_CONSTANT(name, code) name,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -879,7 +879,9 @@ void JSGlobalObject::init(VM& vm)
             init.setPrototype(JS ## type ## ArrayPrototype::create(init.vm, init.global, JS ## type ## ArrayPrototype::createStructure(init.vm, init.global, init.global->m_typedArrayProto.get(init.global)))); \
             init.setStructure(JS ## type ## Array::createStructure(init.vm, init.global, init.prototype)); \
             init.setConstructor(JS ## type ## ArrayConstructor::create(init.vm, init.global, JS ## type ## ArrayConstructor::createStructure(init.vm, init.global, init.global->m_typedArraySuperConstructor.get(init.global)), init.prototype, #type "Array"_s)); \
-            init.global->putDirect(init.vm, init.vm.propertyNames->builtinNames().type ## ArrayPrivateName(), init.constructor, static_cast<unsigned>(PropertyAttribute::DontEnum)); \
+        }); \
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::type##Array)].initLater([](const Initializer<JSCell>& init) { \
+            init.set(jsCast<JSGlobalObject*>(init.owner)->typedArrayConstructor(TypedArrayType::Type##type)); \
         });
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(INIT_TYPED_ARRAY_LATER)
 #undef INIT_TYPED_ARRAY_LATER


### PR DESCRIPTION
#### 0363dc450d9678d87ba6972cea2a443bc2450717
<pre>
[JSC] Typed array private name resolvable only after public name has been seen
<a href="https://bugs.webkit.org/show_bug.cgi?id=167697">https://bugs.webkit.org/show_bug.cgi?id=167697</a>

Reviewed by Ross Kirsling.

Because @Uint8Array property of JSGlobalObject is defined in the lazy initializer of Uint8Array,
we cannot access this field until we access Uint8Array. This is causing a problem in ReadableByteStream
implementation.

This patch defines @Uint8Array as LinkTimeConstant, and use lazy initializer to materialize public Uint8Array.
In this way, we can access @Uint8Array before Uint8Array is accessed. Plus, we can avoid defining a new global
object private property.

For now, this patch turned out that our ReadableByteStream implementation is broken. If we use Uint8Array first
and touch ReadableByteStream, even without this patch, we crash. This patch skips these tests, since (1) it
was passing just because this @Uint8Array thing was broken, and now crashes since ReadableByteStream is
broken, (2) ReadableByteStream is not enabled yet, and (3) these tests crash without this patch if we materialize
Uint8Array in these tests before running the main function of these tests, so they are pre-existing crashes.

* JSTests/stress/typed-array-builtin-names.js: Added.
(shouldBe):
(let.constructorName.of.list.let.builtin.createBuiltin):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/251972@main">https://commits.webkit.org/251972@main</a>
</pre>
