### PR TITLE
Add ongamepadconnected + ongamepaddisconnected

### DIFF
--- a/LayoutTests/gamepad/gamepad-event-handlers-expected.txt
+++ b/LayoutTests/gamepad/gamepad-event-handlers-expected.txt
@@ -1,0 +1,13 @@
+ongamepadconnected in [object Window]: true
+Connecting gamepad...
+Received gamepadconnected event on [object Window].
+ongamepaddisconnected in [object Window]: true
+Disconnecting gamepad...
+Received gamepaddisconnected event on [object Window].
+ongamepadconnected in [object HTMLBodyElement]: true
+Connecting gamepad...
+Received gamepadconnected event on [object HTMLBodyElement].
+ongamepaddisconnected in [object HTMLBodyElement]: true
+Disconnecting gamepad...
+Received gamepaddisconnected event on [object HTMLBodyElement].
+

--- a/LayoutTests/gamepad/gamepad-event-handlers.html
+++ b/LayoutTests/gamepad/gamepad-event-handlers.html
@@ -1,0 +1,52 @@
+<head>
+    <script>
+        testRunner?.dumpAsText();
+        testRunner?.waitUntilDone();
+        testRunner?.setMockGamepadDetails(0, "Test Joystick", "", 2, 2);
+
+        function log(msg) {
+            document.getElementById("logger").innerHTML += msg + "<br>";
+        }
+
+        async function runTest() {
+            await runHandlerTests(window);
+            await runHandlerTests(document.body);
+            testRunner.notifyDone();
+        }
+
+        async function runHandlerTests(target) {
+            log(
+                `ongamepadconnected in ${target}: ${
+                    "ongamepadconnected" in target
+                }`
+            );
+
+            log("Connecting gamepad...");
+            await new Promise((resolve) => {
+                target.ongamepadconnected = () => {
+                    log(`Received gamepadconnected event on ${target}.`);
+                    resolve();
+                };
+                testRunner.connectMockGamepad(0);
+            });
+
+            log(
+                `ongamepaddisconnected in ${target}: ${
+                    "ongamepaddisconnected" in target
+                }`
+            );
+
+            log("Disconnecting gamepad...");
+            await new Promise((resolve) => {
+                target.ongamepaddisconnected = () => {
+                    log(`Received gamepaddisconnected event on ${target}.`);
+                    resolve();
+                };
+                testRunner.disconnectMockGamepad(0);
+            });
+        }
+    </script>
+</head>
+<body onload="runTest();">
+    <div id="logger"></div>
+</body>

--- a/LayoutTests/gamepad/gamepad-polling-access-expected.txt
+++ b/LayoutTests/gamepad/gamepad-polling-access-expected.txt
@@ -7,6 +7,7 @@ Index: 0
 Mapping:
 Axes:
 Buttons:
+onconnectedgamepad event fired (1).
 Connecting gamepad:
 [object Gamepad],[object Gamepad]
 Name: 1
@@ -14,6 +15,7 @@ Index: 1
 Mapping:
 Axes: 0
 Buttons: false-0
+onconnectedgamepad event fired (2).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad]
 Name: 2
@@ -21,6 +23,7 @@ Index: 2
 Mapping:
 Axes: 0,0
 Buttons: false-0 false-0
+onconnectedgamepad event fired (3).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 3
@@ -28,6 +31,7 @@ Index: 3
 Mapping:
 Axes: 0,0,0
 Buttons: false-0 false-0 false-0
+onconnectedgamepad event fired (4).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 4
@@ -35,6 +39,7 @@ Index: 4
 Mapping:
 Axes: 0,0,0,0
 Buttons: false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (5).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 5
@@ -42,6 +47,7 @@ Index: 5
 Mapping:
 Axes: 0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (6).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 6
@@ -49,6 +55,7 @@ Index: 6
 Mapping:
 Axes: 0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (7).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 7
@@ -56,6 +63,7 @@ Index: 7
 Mapping:
 Axes: 0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (8).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 8
@@ -63,6 +71,7 @@ Index: 8
 Mapping:
 Axes: 0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (9).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 9
@@ -70,6 +79,7 @@ Index: 9
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (10).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 10
@@ -77,6 +87,7 @@ Index: 10
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (11).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 11
@@ -84,6 +95,7 @@ Index: 11
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (12).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 12
@@ -91,6 +103,7 @@ Index: 12
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (13).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 13
@@ -98,6 +111,7 @@ Index: 13
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (14).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 14
@@ -105,6 +119,7 @@ Index: 14
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (15).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 15
@@ -112,6 +127,7 @@ Index: 15
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (16).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 16
@@ -119,6 +135,7 @@ Index: 16
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (17).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 17
@@ -126,6 +143,7 @@ Index: 17
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (18).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 18
@@ -133,6 +151,7 @@ Index: 18
 Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
+onconnectedgamepad event fired (19).
 Connecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad]
 Name: 19
@@ -243,47 +262,68 @@ Mapping:
 Axes: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 Buttons: false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0 false-0
 Disconnecting gamepads in reverse order, making sure gamepads array remains as expected
+onconnectedgamepad event fired (20).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],
+ondisconnectedgamepad event fired (19).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,
+ondisconnectedgamepad event fired (18).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,
+ondisconnectedgamepad event fired (17).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,
+ondisconnectedgamepad event fired (16).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,
+ondisconnectedgamepad event fired (15).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,
+ondisconnectedgamepad event fired (14).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,
+ondisconnectedgamepad event fired (13).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,
+ondisconnectedgamepad event fired (12).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,
+ondisconnectedgamepad event fired (11).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,
+ondisconnectedgamepad event fired (10).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,
+ondisconnectedgamepad event fired (9).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,
+ondisconnectedgamepad event fired (8).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,
+ondisconnectedgamepad event fired (7).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (6).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (5).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (4).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (3).
 Disconnecting gamepad:
 [object Gamepad],[object Gamepad],,,,,,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (2).
 Disconnecting gamepad:
 [object Gamepad],,,,,,,,,,,,,,,,,,,
+ondisconnectedgamepad event fired (1).
 Disconnecting gamepad:
 ,,,,,,,,,,,,,,,,,,,
 Checking non-zero'ed details for a gamepad
+ondisconnectedgamepad event fired (0).
 Connecting gamepad:
 ,,,,,,,,,,[object Gamepad],,,,,,,,,
 Name: Awesome Joystick 5000

--- a/LayoutTests/gamepad/gamepad-polling-access.html
+++ b/LayoutTests/gamepad/gamepad-polling-access.html
@@ -17,6 +17,18 @@ function finishTest()
         testRunner.notifyDone();
 }
 
+function onconnectedEventHandler(evt)
+{
+    const {length} = navigator.getGamepads();
+    log(`onconnectedgamepad event fired (${length}).`);
+}
+
+function ondisconnectedEventHandler(evt)
+{
+    const {length} = navigator.getGamepads().filter(g => g);
+    log(`ondisconnectedgamepad event fired (${length}).`);
+}
+
 function handleGamepadConnect(evt)
 {
     log("Connecting gamepad:");
@@ -31,6 +43,7 @@ function handleGamepadDisconnect(evt)
     log(navigator.getGamepads());
     testGenerator.next();
 }
+
 
 function logGamepad(gp)
 {
@@ -50,6 +63,9 @@ function logGamepad(gp)
 function* testSteps() {
     addEventListener("gamepadconnected", handleGamepadConnect);
     addEventListener("gamepaddisconnected", handleGamepadDisconnect);
+
+    window.ongamepadconnected = onconnectedEventHandler;
+    window.ongamepaddisconnected = ondisconnectedEventHandler;
 
     log("Initial gamepads length: " + navigator.getGamepads().length);
     log("Connecting 20 different gamepads");

--- a/LayoutTests/gamepad/gamepad-visibility-1.html
+++ b/LayoutTests/gamepad/gamepad-visibility-1.html
@@ -38,6 +38,7 @@ function handleGamepadConnect()
 
 function runTest() {
     addEventListener("gamepadconnected", handleGamepadConnect);
+    window.ongamepadconnected = handleGamepadConnect;
 
     // Connecting the gamepad and changing axis values should *not* make it visible.
     // Only button presses should expose it.

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1113,6 +1113,7 @@ webkit.org/b/224105 compositing/video/video-clip-change-src.html [ ImageOnlyFail
 
 webkit.org/b/224106 fast/forms/textfield-onchange-without-focus.html [ ImageOnlyFailure Pass ]
 
+webkit.org/b/242370 gamepad/gamepad-event-handlers.html [ Failure ]
 webkit.org/b/224108 gamepad/gamepad-visibility-1.html [ Failure Pass ]
 
 webkit.org/b/224117 intersection-observer/intersection-observer-keeps-js-wrapper-of-target-alive.html [ Failure Pass ]

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1466,6 +1466,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/gamepad/GamepadButton.idl
     Modules/gamepad/GamepadEvent.idl
     Modules/gamepad/Navigator+Gamepad.idl
+    Modules/gamepad/WindowEventHandlers+Gamepad.idl
 )
 
 if (ENABLE_GAMEPAD)

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -294,6 +294,7 @@ $(PROJECT_DIR)/Modules/gamepad/Gamepad.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadButton.idl
 $(PROJECT_DIR)/Modules/gamepad/GamepadEvent.idl
 $(PROJECT_DIR)/Modules/gamepad/Navigator+Gamepad.idl
+$(PROJECT_DIR)/Modules/gamepad/WindowEventHandlers+Gamepad.idl
 $(PROJECT_DIR)/Modules/geolocation/Coordinates.idl
 $(PROJECT_DIR)/Modules/geolocation/Geolocation.idl
 $(PROJECT_DIR)/Modules/geolocation/GeolocationCoordinates.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2876,6 +2876,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWheelEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWheelEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowEventHandlers.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowEventHandlers.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowEventHandlers+Gamepad.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowEventHandlers+Gamepad.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowLocalStorage.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowLocalStorage.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowOrWorkerGlobalScope+Caches.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -316,6 +316,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/gamepad/GamepadButton.idl \
     $(WebCore)/Modules/gamepad/GamepadEvent.idl \
     $(WebCore)/Modules/gamepad/Navigator+Gamepad.idl \
+    $(WebCore)/Modules/gamepad/WindowEventHandlers+Gamepad.idl \
     $(WebCore)/Modules/geolocation/Geolocation.idl \
     $(WebCore)/Modules/geolocation/GeolocationCoordinates.idl \
     $(WebCore)/Modules/geolocation/GeolocationPosition.idl \

--- a/Source/WebCore/Modules/gamepad/WindowEventHandlers+Gamepad.idl
+++ b/Source/WebCore/Modules/gamepad/WindowEventHandlers+Gamepad.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/gamepad/#extensions-to-the-windoweventhandlers-interface-mixin
+partial interface mixin WindowEventHandlers {
+   [WindowEventHandler] attribute EventHandler ongamepadconnected;
+   [WindowEventHandler] attribute EventHandler ongamepaddisconnected;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4124,6 +4124,7 @@ JSWebXRViewport.cpp
 JSWebXRWebGLLayer.cpp
 JSWheelEvent.cpp
 JSWindowEventHandlers.cpp
+JSWindowEventHandlers+Gamepad.cpp
 JSWindowOrWorkerGlobalScope.cpp
 JSWorker.cpp
 JSWorkerGlobalScope.cpp

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -249,6 +249,8 @@ onfocus
 onfocusin
 onfocusout
 onformdata
+ongamepadconnected
+ongamepaddisconnected
 ongesturechange
 ongestureend
 ongesturestart


### PR DESCRIPTION
#### 57f8b6aa692023a6ee9e78c9d6fe73e9c571e75b
<pre>
Add ongamepadconnected + ongamepaddisconnected
<a href="https://bugs.webkit.org/show_bug.cgi?id=223860">https://bugs.webkit.org/show_bug.cgi?id=223860</a>

Reviewed by Brady Eidson.

* LayoutTests/gamepad/gamepad-event-handlers-expected.txt: Added.
* LayoutTests/gamepad/gamepad-event-handlers.html: Added.
* LayoutTests/gamepad/gamepad-polling-access-expected.txt:
* LayoutTests/gamepad/gamepad-polling-access.html:
* LayoutTests/gamepad/gamepad-visibility-1.html:
* LayoutTests/platform/gtk/TestExpectations
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/gamepad/WindowEventHandlers+Gamepad.idl: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLAttributeNames.in:

Canonical link: <a href="https://commits.webkit.org/252331@main">https://commits.webkit.org/252331@main</a>
</pre>
