### PR TITLE
[GPUProcess] [CG] Create ShareableBitmap with sRGB color-space when sending NativeImages to GPUProcess

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -196,7 +196,10 @@ void Recorder::drawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRe
 void Recorder::drawNativeImage(NativeImage& image, const FloatSize& imageSize, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& options)
 {
     appendStateChangeItemIfNecessary();
-    recordResourceUse(image);
+    if (!recordResourceUse(image)) {
+        LOG_WITH_STREAM(DisplayLists, stream << "\nRecorder::drawNativeImage(): Failed to record use of NativeImage " << image.size());
+        return;
+    }
     recordDrawNativeImage(image.renderingResourceIdentifier(), imageSize, destRect, srcRect, options);
 }
 
@@ -208,7 +211,10 @@ void Recorder::drawSystemImage(SystemImage& systemImage, const FloatRect& destin
             auto nativeImage = image->nativeImage();
             if (!nativeImage)
                 return;
-            recordResourceUse(*nativeImage);
+            if (!recordResourceUse(*nativeImage)) {
+                LOG_WITH_STREAM(DisplayLists, stream << "\nRecorder::drawSystemImage(): Failed to record use of NativeImage " << nativeImage->size());
+                return;
+            }
         }
     }
 #endif
@@ -218,7 +224,10 @@ void Recorder::drawSystemImage(SystemImage& systemImage, const FloatRect& destin
 void Recorder::drawPattern(NativeImage& image, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& options)
 {
     appendStateChangeItemIfNecessary();
-    recordResourceUse(image);
+    if (!recordResourceUse(image)) {
+        LOG_WITH_STREAM(DisplayLists, stream << "\nRecorder::drawPattern(): Failed to record use of NativeImage " << image.size());
+        return;
+    }
     recordDrawPattern(image.renderingResourceIdentifier(), destRect, tileRect, patternTransform, phase, spacing, options);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -394,8 +394,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
         return false;
     }
 
-    m_renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image);
-    return true;
+    return m_renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image);
 }
 
 bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -304,24 +304,6 @@ protected:
         return true;
     }
 
-    void recordNativeImageUse(WebCore::NativeImage& image)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordNativeImageUse(image);
-    }
-
-    void recordFontUse(WebCore::Font& font)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordFontUse(font);
-    }
-
-    void recordImageBufferUse(WebCore::ImageBuffer& imageBuffer)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
-    }
-
     std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> createFlusher() final
     {
         return WTF::makeUnique<ThreadSafeRemoteImageBufferFlusher<BackendType>>(*this);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -50,7 +50,7 @@ public:
     WebCore::ImageBuffer* cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
     void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
 
-    void recordNativeImageUse(WebCore::NativeImage&);
+    bool recordNativeImageUse(WebCore::NativeImage&);
     void recordFontUse(WebCore::Font&);
     void recordImageBufferUse(WebCore::ImageBuffer&);
 


### PR DESCRIPTION
#### d8680248c9630d96dcbc548401c6d86a63e65823
<pre>
[GPUProcess] [CG] Create ShareableBitmap with sRGB color-space when sending NativeImages to GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=241674">https://bugs.webkit.org/show_bug.cgi?id=241674</a>
rdar://95048318

Reviewed by NOBODY (OOPS!).

Sometimes CG fails to create GraphicsContext for some color-spaces. The conversion
to sRGB will happen anyway when drawing the image to the destination GraphicsContext.
So let&apos;s create ShareableBitmap with sRGB color-space when sending NativeImages
to GPUProcess.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawNativeImage):
(WebCore::DisplayList::Recorder::drawSystemImage):
(WebCore::DisplayList::Recorder::drawPattern):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteImageBufferProxy::recordNativeImageUse): Deleted.
(WebKit::RemoteImageBufferProxy::recordFontUse): Deleted.
(WebKit::RemoteImageBufferProxy::recordImageBufferUse): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapFromNativeImage):
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
</pre>