### PR TITLE
Find top privately controlled domain in the UI process

### DIFF
--- a/Source/WebCore/platform/PublicSuffix.h
+++ b/Source/WebCore/platform/PublicSuffix.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 WEBCORE_EXPORT bool isPublicSuffix(StringView domain);
 WEBCORE_EXPORT String topPrivatelyControlledDomain(const String& domain);
+WEBCORE_EXPORT void setTopPrivatelyControlledDomain(const String& domain, const String& topPrivatelyControlledDomain);
 String decodeHostName(const String& domain);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp
@@ -81,6 +81,10 @@ String topPrivatelyControlledDomain(const String& domain)
     return topPrivatelyControlledDomainInternal(psl, domainUTF8.data() + position);
 }
 
+void setTopPrivatelyControlledDomain(const String&, const String&)
+{
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)

--- a/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
@@ -77,6 +77,10 @@ String topPrivatelyControlledDomain(const String& domain)
     return String();
 }
 
+void setTopPrivatelyControlledDomain(const String&, const String&)
+{
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)

--- a/Source/WebKit/Shared/LoadParameters.cpp
+++ b/Source/WebKit/Shared/LoadParameters.cpp
@@ -61,7 +61,9 @@ void LoadParameters::encode(IPC::Encoder& encoder) const
     encoder << existingNetworkResourceLoadIdentifierToResume;
     encoder << isServiceWorkerLoad;
     encoder << sessionHistoryVisibility;
-
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    encoder << topPrivatelyControlledDomain;
+#endif
     platformEncode(encoder);
 }
 
@@ -155,7 +157,12 @@ bool LoadParameters::decode(IPC::Decoder& decoder, LoadParameters& data)
     
     if (!decoder.decode(data.sessionHistoryVisibility))
         return false;
-    
+
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    if (!decoder.decode(data.topPrivatelyControlledDomain))
+        return false;
+#endif
+
     if (!platformDecode(decoder, data))
         return false;
 

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -93,6 +93,9 @@ struct LoadParameters {
 #endif // PLATFORM(IOS)
 #endif // !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
 #endif
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    String topPrivatelyControlledDomain;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1446,6 +1446,9 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.effectiveSandboxFlags = navigation.effectiveSandboxFlags();
     loadParameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     loadParameters.existingNetworkResourceLoadIdentifierToResume = existingNetworkResourceLoadIdentifierToResume;
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    loadParameters.topPrivatelyControlledDomain = WebCore::topPrivatelyControlledDomain(loadParameters.request.url().host().toString());
+#endif
     maybeInitializeSandboxExtensionHandle(process, url, m_pageLoadState.resourceDirectoryURL(), loadParameters.sandboxExtensionHandle);
 
     addPlatformLoadParameters(process, loadParameters);
@@ -1518,6 +1521,9 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     loadParameters.request = WTFMove(request);
     loadParameters.shouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow;
     loadParameters.userData = UserData(process().transformObjectsToHandles(userData).get());
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    loadParameters.topPrivatelyControlledDomain = WebCore::topPrivatelyControlledDomain(loadParameters.request.url().host().toString());
+#endif
     const bool checkAssumedReadAccessToResourceURL = false;
     maybeInitializeSandboxExtensionHandle(m_process, fileURL, resourceDirectoryURL, loadParameters.sandboxExtensionHandle, checkAssumedReadAccessToResourceURL);
     addPlatformLoadParameters(m_process, loadParameters);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1734,6 +1734,10 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
     // to all the client to set up any needed state.
     m_loaderClient->willLoadURLRequest(*this, loadParameters.request, WebProcess::singleton().transformHandlesToObjects(loadParameters.userData.object()).get());
 
+#if ENABLE(PUBLIC_SUFFIX_LIST)
+    WebCore::setTopPrivatelyControlledDomain(loadParameters.request.url().host().toString(), loadParameters.topPrivatelyControlledDomain);
+#endif
+
     platformDidReceiveLoadParameters(loadParameters);
 
     // Initate the load in WebCore.


### PR DESCRIPTION
#### fed8a6b4c74b8962c252227e983c78c27a8b85c8
<pre>
Find top privately controlled domain in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=238216">https://bugs.webkit.org/show_bug.cgi?id=238216</a>
&lt;rdar://89108256&gt;

Reviewed by Brent Fulgham.

This operation sometimes requires access to the container manager service, which we block in the WebContent process.
To avoid these sandbox violations we can find the top privately controlled domain in the UI process and send to the
WebContent process.

* Source/WebCore/platform/PublicSuffix.h:
* Source/WebCore/platform/mac/PublicSuffixMac.mm:
(WebCore::cache):
(WebCore::topPrivatelyControlledDomain):
(WebCore::setTopPrivatelyControlledDomain):
* Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp:
(WebCore::setTopPrivatelyControlledDomain):
* Source/WebCore/platform/soup/PublicSuffixSoup.cpp:
(WebCore::setTopPrivatelyControlledDomain):
* Source/WebKit/Shared/LoadParameters.cpp:
(WebKit::LoadParameters::encode const):
(WebKit::LoadParameters::decode):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):

Canonical link: <a href="https://commits.webkit.org/251873@main">https://commits.webkit.org/251873@main</a>
</pre>
