### PR TITLE
IntersectionObserver stops tracking when cmd+ is used to zoom in

### DIFF
--- a/LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom-expected.txt
+++ b/LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IntersectionObserver's root margin, with percentage units, accounts for zooming
+

--- a/LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom.html
+++ b/LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#intersection-observer-interface">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+#target {
+    position: absolute;
+    height: 20px;
+    width: 100px;
+    top: 41vh;
+    background-color: green;
+}
+</style>
+
+<div id="target"></div>
+<script>
+    if (window.internals)
+        window.internals.setPageZoomFactor(2);
+    async_test((t) =>  {
+        let options = {
+            rootMargin: '-40% 0px -40% 0px',
+            threshold: [1]
+        }
+        const target = document.getElementById("target");
+        let observer = new IntersectionObserver(t.step_func_done((entries) => {
+            assert_true(entries[0].isIntersecting, "isIntersecting");
+            target.remove();
+        }), options);
+        observer.observe(target);
+
+    }, "IntersectionObserver's root margin, with percentage units, accounts for zooming");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2048,6 +2048,8 @@ editing/pasteboard/paste-sanitize-crash-1.html [ Failure ]
 editing/pasteboard/paste-sanitize-crash-2.html [ Failure ]
 editing/pasteboard/paste-text-events.html [ Failure ]
 
+# setPageZoomFactor() is wrong/flaky on iOS
+webkit.org/b/241951 intersection-observer/root-margin-percentage-units-with-zoom.html [ Skip ]
 
 # Local pasteboard is not implemented on iOS, so pasteboard tests used to be all disabled.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8009,14 +8009,21 @@ void Document::removeIntersectionObserver(IntersectionObserver& observer)
 
 static void expandRootBoundsWithRootMargin(FloatRect& localRootBounds, const LengthBox& rootMargin, float zoomFactor)
 {
-    FloatBoxExtent rootMarginFloatBox(
-        floatValueForLength(rootMargin.top(), localRootBounds.height()) * zoomFactor,
-        floatValueForLength(rootMargin.right(), localRootBounds.width()) * zoomFactor,
-        floatValueForLength(rootMargin.bottom(), localRootBounds.height()) * zoomFactor,
-        floatValueForLength(rootMargin.left(), localRootBounds.width()) * zoomFactor
-    );
+    auto zoomAdjustedLength = [](const Length& length, float maximumValue, float zoomFactor) {
+        if (length.isPercent())
+            return floatValueForLength(length, maximumValue);
+    
+        return floatValueForLength(length, maximumValue) * zoomFactor;
+    };
 
-    localRootBounds.expand(rootMarginFloatBox);
+    auto rootMarginEdges = FloatBoxExtent {
+        zoomAdjustedLength(rootMargin.top(), localRootBounds.height(), zoomFactor),
+        zoomAdjustedLength(rootMargin.right(), localRootBounds.width(), zoomFactor),
+        zoomAdjustedLength(rootMargin.bottom(), localRootBounds.height(), zoomFactor),
+        zoomAdjustedLength(rootMargin.left(), localRootBounds.width(), zoomFactor)
+    };
+
+    localRootBounds.expand(rootMarginEdges);
 }
 
 static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const LayoutRect& rect, const RenderElement* renderer)


### PR DESCRIPTION
#### ee62d87260e875acf59f16a621658a93f93f61d7
<pre>
IntersectionObserver stops tracking when cmd+ is used to zoom in
<a href="https://bugs.webkit.org/show_bug.cgi?id=241730">https://bugs.webkit.org/show_bug.cgi?id=241730</a>
&lt;rdar://92272892&gt;

Reviewed by Alan Bujtas.

The root margin computation was broken when root margins used percentage values, and there was
effective zoom.

The existing code scaled the insets, computed via floatValueForLength(), by the zoom value. This
makes sense for fixed length insets; localRootBounds already has zoom applied, and will be compared
with element rectangles which have also taken zoom into account.

However, for percentage insets, multiplying the result of floatValueForLength() double-scales the
result (since the maximumValue is already scaled). So only multiply by zoomFactor for non-percentage
inset values.

* LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom-expected.txt: Added.
* LayoutTests/intersection-observer/root-margin-percentage-units-with-zoom.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::expandRootBoundsWithRootMargin):

Canonical link: <a href="https://commits.webkit.org/251829@main">https://commits.webkit.org/251829@main</a>
</pre>
