### PR TITLE
[Xcode] Stop passing build settings on the command line to avoid invalidating IDE builds

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -1,6 +1,7 @@
 SCRIPTS_PATH ?= ../Tools/Scripts
 
-XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(SDKROOT:%=--sdk %) $(BUILD_WEBKIT_OPTIONS)` $${COLOR_DIAGNOSTICS_ARG} $(ARGS)
+XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(SDKROOT:%=--sdk %) $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
+XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_DEFINITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_DEFINITIONS)')
 ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
 	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION
 endif
@@ -9,7 +10,10 @@ ifeq ($(USE_WORKSPACE),YES)
 SCHEME ?= $(notdir $(CURDIR))
 WORKSPACE_PATH ?= $(dir $(lastword $(MAKEFILE_LIST)))WebKit.xcworkspace
 XCODE_TARGET = -workspace $(WORKSPACE_PATH) -scheme "$(SCHEME)"
-XCODE_OPTIONS += WK_VALIDATE_DEPENDENCIES=YES_ERROR
+# FIXME: Move this setting to xcconfigs once all local Xcode builds of WebKit
+# happen in the workspace. When this is only passed on the command line, it
+# invalidates build results made in the IDE (rdar://88135402).
+#XCODE_OPTIONS += WK_VALIDATE_DEPENDENCIES=YES_ERROR
 else
 USE_WORKSPACE =
 endif
@@ -114,7 +118,6 @@ endef
 
 define invoke_xcode
 	( \
-		[[ -t 1 ]] && COLOR_DIAGNOSTICS_ARG="COLOR_DIAGNOSTICS=YES"; \
 		echo; \
 		echo "===== BUILDING $(if $(USE_WORKSPACE),$(SCHEME),$(notdir $(CURDIR))) ====="; \
 		echo; \
@@ -124,27 +127,28 @@ endef
 
 all:
 	@$(call set_webkit_configuration,)
-	@$(call invoke_xcode,,,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+	@$(call invoke_xcode,,,)
 
 debug d: force
 	@$(call set_webkit_configuration,--debug)
-	@$(call invoke_xcode,,,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+	@$(call invoke_xcode,,,)
 
 release r: force
 	@$(call set_webkit_configuration,--release)
-	@$(call invoke_xcode,,,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+	@$(call invoke_xcode,,,)
 
 release+assert ra: force
 	@$(call set_webkit_configuration,--release)
-	@$(call invoke_xcode,,,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) ASSERT_ENABLED=1 $$(inherited)')
+	@$(call invoke_xcode,,,)
+release+assert ra: override GCC_PREPROCESSOR_DEFINITIONS += ASSERT_ENABLED=1
 
 testing t: force
 	@$(call set_webkit_configuration,--debug --force-optimization-level=O3)
-	@$(call invoke_xcode,,,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+	@$(call invoke_xcode,,,)
 
 analyze:
 	@$(call set_webkit_configuration,--debug)
-	@$(call invoke_xcode,$(PATH_TO_SCAN_BUILD),build analyze,GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+	@$(call invoke_xcode,$(PATH_TO_SCAN_BUILD),build analyze,)
 
 clean:
 ifndef XCODE_TARGET

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2430,17 +2430,24 @@ class CompileWebKit(shell.Compile, AddToLogMixin):
 
         if additionalArguments:
             self.setCommand(self.command + additionalArguments)
-        if platform in ('mac', 'ios', 'tvos', 'watchos') and architecture:
-            self.setCommand(self.command + ['ARCHS=' + architecture])
-            if platform in ['ios', 'tvos', 'watchos']:
-                self.setCommand(self.command + ['ONLY_ACTIVE_ARCH=NO'])
-        if platform in ('mac', 'ios', 'tvos', 'watchos') and buildOnly:
-            # For build-only bots, the expectation is that tests will be run on separate machines,
-            # so we need to package debug info as dSYMs. Only generating line tables makes
-            # this much faster than full debug info, and crash logs still have line numbers.
-            # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
-            self.setCommand(self.command + ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym'])
-            self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=$(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only)'])
+        if platform in ('mac', 'ios', 'tvos', 'watchos'):
+            # FIXME: Once WK_VALIDATE_DEPENDENCIES is set via xcconfigs, it can
+            # be removed here. We can't have build-webkit pass this by default
+            # without invalidating local builds made by Xcode, and we set it
+            # via xcconfigs until all building of Xcode-based webkit is done in
+            # workspaces (rdar://88135402).
+            self.setCommand(self.command + ['WK_VALIDATE_DEPENDENCIES=YES'])
+            if architecture:
+                self.setCommand(self.command + ['ARCHS=' + architecture])
+                if platform in ['ios', 'tvos', 'watchos']:
+                    self.setCommand(self.command + ['ONLY_ACTIVE_ARCH=NO'])
+            if buildOnly:
+                # For build-only bots, the expectation is that tests will be run on separate machines,
+                # so we need to package debug info as dSYMs. Only generating line tables makes
+                # this much faster than full debug info, and crash logs still have line numbers.
+                # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
+                self.setCommand(self.command + ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym'])
+                self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=$(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only)'])
         if platform == 'gtk':
             prefix = os.path.join("/app", "webkit", "WebKitBuild", self.getProperty("configuration"), "install")
             self.setCommand(self.command + [f'--prefix={prefix}'])

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -347,11 +347,14 @@ if (isAppleWinWebKit() || isWinCairo() || isPlayStation() || isFTW()) {
     push @local_options, XcodeCoverageSupportOptions() if $coverageSupport;
     push @local_options, XcodeStaticAnalyzerOption() if $shouldRunStaticAnalyzer;
     push @local_options, "WK_LTO_MODE=$ltoMode" if ($ltoMode ne "default");
-    # When we know we're in a workspace (and not an individual project), turn
-    # on dependency validation errors. Other conditions (e.g. whether we're in
-    # a script phase or not) influence the actual VALIDATE_DEPENDENCIES setting
-    # recognized by the build system.
-    push @local_options, "WK_VALIDATE_DEPENDENCIES=YES_ERROR" if $useWorkspace;
+    # FIXME: Move this setting to xcconfigs once all local Xcode builds of WebKit
+    # happen in the workspace. When this is only passed on the command line, it
+    # invalidates build results made in the IDE (rdar://88135402).
+    ## When we know we're in a workspace (and not an individual project), turn
+    ## on dependency validation errors. Other conditions (e.g. whether we're in
+    ## a script phase or not) influence the actual VALIDATE_DEPENDENCIES setting
+    ## recognized by the build system.
+    #push @local_options, "WK_VALIDATE_DEPENDENCIES=YES_ERROR" if $useWorkspace;
  
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();
 


### PR DESCRIPTION
#### 05696d76ec9ef470c91faa8b2c90101cae225d0e
<pre>
[Xcode] Stop passing build settings on the command line to avoid invalidating IDE builds
rdar://88135402

Reviewed by Jonathan Bedard and Alexey Proskuryakov.

Xcode considers a shell script&apos;s environment part of its task
signature, so changing build settings will require scripts to re-run in
the next build. Since many of our upstream build tasks (e.g. headers,
generated sources) are produced by script executions, changing build
settings is effectively a full build, so we must avoid it whenever
possible.

In support of this goal, update Make and build-webkit to stop passing
some build settings overrides by default. Build settings overrides which
can be expected to match what Xcode is using (e.g. SYMROOT, OBJROOT,
ARCHS, SDKROOT) are fine to keep passing.

* Makefile.shared: Only pass GCC_PREPROCESSOR_DEFINITIONS if there are
  actual custom arguments specified. Avoid passing
  WK_VALIDATE_DEPENDENCIES and COLOR_DIAGNOSTICS.
* Tools/CISupport/build-webkit-org/steps.py:
(CompileWebKit.start): As WK_VALIDATE_DEPENDENCIES is no longer supplied
  by default, enable it explicitly for bots. We should revisit this
  after workspace builds have been deployed and we can reasonably expect
  all Xcode-based builds of WebKit to occur via the workspace.
* Tools/CISupport/ews-build/steps.py:
(CompileWebKit.start): Ditto above.
* Tools/Scripts/build-webkit: Avoid passing WK_VALIDATE_DEPENDENCIES.

Canonical link: <a href="https://commits.webkit.org/252143@main">https://commits.webkit.org/252143@main</a>
</pre>
