### PR TITLE
webpushd should protect incoming pushes with an os_transaction

### DIFF
--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -39,6 +39,7 @@
 #import <pal/spi/cf/CFUtilitiesSPI.h>
 #import <wtf/LogInitialization.h>
 #import <wtf/MainThread.h>
+#import <wtf/OSObjectPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 using WebKit::Daemon::EncodedMessage;
@@ -86,6 +87,8 @@ int WebPushDaemonMain(int argc, char** argv)
 {
     @autoreleasepool {
         WTF::initializeMainThread();
+        
+        auto transaction = adoptOSObject(os_transaction_create("com.apple.webkit.webpushd.push-service-main"));
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
         _CFPrefsSetDirectModeEnabled(YES);


### PR DESCRIPTION
#### f7b5d128dffff0d481dbb976e6c156f79b73e180
<pre>
webpushd should protect incoming pushes with an os_transaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=241740">https://bugs.webkit.org/show_bug.cgi?id=241740</a>

Reviewed by Youenn Fablet.

webpushd needs to acquire an os_transaction in its incoming push message path, or else it might get
jetsamed in the middle of processing a push.

* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::didReceivePushMessage): Create a transaction around fetching the decryption
key from the DB and decrypting the push.

* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::Daemon::Daemon):
(WebPushD::Daemon::startIncomingPushTransactionTimer):
(WebPushD::Daemon::cancelIncomingPushTransactionTimer):
(WebPushD::Daemon::incomingPushTransactionTimerFired):
(WebPushD::Daemon::handleIncomingPush):
(WebPushD::Daemon::getPendingPushMessages): Create a transaction around waking up the UIProcess to
handle the decrypted push and time it out after 10 seconds.

* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::WebPushDaemonMain): Create a transaction around the time from when we spawn to when we
start initializing PushService. (PushService initialization involves async steps and takes care of
acquiring its own transaction in its constructor.)

Canonical link: <a href="https://commits.webkit.org/251879@main">https://commits.webkit.org/251879@main</a>
</pre>
