### PR TITLE
Simplify non-scaling-stroke handling in (Legacy)RenderSVGShape

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -508,6 +508,9 @@ FloatRect Path::fastBoundingRectSlowCase() const
 
 void Path::transform(const AffineTransform& transform)
 {
+    if (transform.isIdentity())
+        return;
+
     cairo_matrix_t matrix = toCairoMatrix(transform);
     cairo_matrix_invert(&matrix);
     cairo_transform(ensureCairoPath(), &matrix);

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -31,6 +31,7 @@
 #include "FloatQuad.h"
 #include "FloatRect.h"
 #include "IntRect.h"
+#include "Path.h"
 #include "Region.h"
 #include "TransformationMatrix.h"
 #include <wtf/MathExtras.h>
@@ -325,6 +326,19 @@ Region AffineTransform::mapRegion(const Region& region) const
         mappedRegion.unite(mapRect(rect));
 
     return mappedRegion;
+}
+
+Path AffineTransform::mapPath(const Path& path) const
+{
+    if (isIdentityOrTranslation()) {
+        Path mappedPath(path);
+        mappedPath.translate(roundedIntSize(FloatSize(narrowPrecisionToFloat(m_transform[4]), narrowPrecisionToFloat(m_transform[5]))));
+        return mappedPath;
+    }
+
+    Path transformedPath = path;
+    transformedPath.transform(*this);
+    return transformedPath;
 }
 
 void AffineTransform::blend(const AffineTransform& from, double progress, CompositeOperation compositeOperation)

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -51,6 +51,7 @@ class FloatSize;
 class IntPoint;
 class IntSize;
 class IntRect;
+class Path;
 class Region;
 class TransformationMatrix;
 
@@ -85,6 +86,8 @@ public:
     WEBCORE_EXPORT FloatQuad mapQuad(const FloatQuad&) const;
 
     WEBCORE_EXPORT Region mapRegion(const Region&) const;
+
+    WEBCORE_EXPORT Path mapPath(const Path&) const;
 
     WEBCORE_EXPORT bool isIdentity() const;
 

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGPath.cpp
@@ -86,7 +86,6 @@ void LegacyRenderSVGPath::strokeShape(GraphicsContext& context) const
     if (m_zeroLengthLinecapLocations.isEmpty())
         return;
 
-    Path* usePath;
     AffineTransform nonScalingTransform;
 
     if (hasNonScalingStroke())
@@ -95,10 +94,11 @@ void LegacyRenderSVGPath::strokeShape(GraphicsContext& context) const
     GraphicsContextStateSaver stateSaver(context, true);
     useStrokeStyleToFill(context);
     for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
+        auto linecapPath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
         if (hasNonScalingStroke())
-            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
-        context.fillPath(*usePath);
+            context.fillPath(nonScalingTransform.mapPath(linecapPath));
+        else
+            context.fillPath(linecapPath);
     }
 }
 
@@ -130,17 +130,14 @@ bool LegacyRenderSVGPath::shouldStrokeZeroLengthSubpath() const
     return style().svgStyle().hasStroke() && style().capStyle() != LineCap::Butt;
 }
 
-Path* LegacyRenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
+Path LegacyRenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
 {
-    static NeverDestroyed<Path> tempPath;
-
-    tempPath.get().clear();
+    Path linecapPath;
     if (style().capStyle() == LineCap::Square)
-        tempPath.get().addRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
+        linecapPath.addRect(zeroLengthSubpathRect(linecapPosition, strokeWidth()));
     else
-        tempPath.get().addEllipse(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-
-    return &tempPath.get();
+        linecapPath.addEllipse(zeroLengthSubpathRect(linecapPosition, strokeWidth()));
+    return linecapPath;
 }
 
 FloatRect LegacyRenderSVGPath::zeroLengthSubpathRect(const FloatPoint& linecapPosition, float strokeWidth) const

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGPath.h
@@ -46,7 +46,7 @@ private:
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
 
     bool shouldStrokeZeroLengthSubpath() const;
-    Path* zeroLengthLinecapPath(const FloatPoint&) const;
+    Path zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
 

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
@@ -87,12 +87,11 @@ void LegacyRenderSVGShape::fillShape(GraphicsContext& context) const
 void LegacyRenderSVGShape::strokeShape(GraphicsContext& context) const
 {
     ASSERT(m_path);
-    Path* usePath = m_path.get();
 
     if (hasNonScalingStroke())
-        usePath = nonScalingStrokePath(usePath, nonScalingStrokeTransform());
-
-    context.strokePath(*usePath);
+        context.strokePath(nonScalingStrokeTransform().mapPath(path()));
+    else
+        context.strokePath(path());
 }
 
 bool LegacyRenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
@@ -100,16 +99,12 @@ bool LegacyRenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point,
     ASSERT(m_path);
 
     if (hasNonScalingStroke() && pointCoordinateSpace != LocalCoordinateSpace) {
-        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-        Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
-        return usePath->strokeContains(nonScalingTransform.mapPoint(point), [this] (GraphicsContext& context) {
-            SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-        });
+        auto nonScalingTransform = nonScalingStrokeTransform();
+        auto usePath = nonScalingTransform.mapPath(path());
+        return usePath.strokeContains(nonScalingTransform.mapPoint(point), strokeStyleApplier());
     }
 
-    return m_path->strokeContains(point, [this] (GraphicsContext& context) {
-        SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-    });
+    return m_path->strokeContains(point, strokeStyleApplier());
 }
 
 bool LegacyRenderSVGShape::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
@@ -174,25 +169,15 @@ void LegacyRenderSVGShape::layout()
     clearNeedsLayout();
 }
 
-Path* LegacyRenderSVGShape::nonScalingStrokePath(const Path* path, const AffineTransform& strokeTransform) const
+bool LegacyRenderSVGShape::setupNonScalingStrokeContext(GraphicsContextStateSaver& stateSaver)
 {
-    static NeverDestroyed<Path> tempPath;
+    if (auto inverse = nonScalingStrokeTransform().inverse()) {
+        stateSaver.save();
+        stateSaver.context()->concatCTM(*inverse);
+        return true;
+    }
 
-    tempPath.get() = *path;
-    tempPath.get().transform(strokeTransform);
-
-    return &tempPath.get();
-}
-
-bool LegacyRenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeTransform, GraphicsContextStateSaver& stateSaver)
-{
-    std::optional<AffineTransform> inverse = strokeTransform.inverse();
-    if (!inverse)
-        return false;
-
-    stateSaver.save();
-    stateSaver.context()->concatCTM(inverse.value());
-    return true;
+    return false;
 }
 
 AffineTransform LegacyRenderSVGShape::nonScalingStrokeTransform() const
@@ -253,11 +238,8 @@ void LegacyRenderSVGShape::strokeShape(GraphicsContext& context)
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
-    if (hasNonScalingStroke()) {
-        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-        if (!setupNonScalingStrokeContext(nonScalingTransform, stateSaver))
-            return;
-    }
+    if (hasNonScalingStroke() && !setupNonScalingStrokeContext(stateSaver))
+        return;
     strokeShape(style(), context);
 }
 
@@ -420,20 +402,14 @@ FloatRect LegacyRenderSVGShape::calculateStrokeBoundingBox() const
 
     if (style().svgStyle().hasStroke()) {
         if (hasNonScalingStroke()) {
-            AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-            if (std::optional<AffineTransform> inverse = nonScalingTransform.inverse()) {
-                Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
-                FloatRect strokeBoundingRect = usePath->strokeBoundingRect(Function<void(GraphicsContext&)> { [this] (GraphicsContext& context) {
-                    SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-                } });
-                strokeBoundingRect = inverse.value().mapRect(strokeBoundingRect);
-                strokeBoundingBox.unite(strokeBoundingRect);
+            auto nonScalingTransform = nonScalingStrokeTransform();
+            if (auto inverse = nonScalingTransform.inverse()) {
+                auto usePath = nonScalingTransform.mapPath(path());
+                auto strokeBoundingRect = usePath.strokeBoundingRect(strokeStyleApplier());
+                strokeBoundingBox.unite(inverse->mapRect(strokeBoundingRect));
             }
-        } else {
-            strokeBoundingBox.unite(path().strokeBoundingRect(Function<void(GraphicsContext&)> { [this] (GraphicsContext& context) {
-                SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-            } }));
-        }
+        } else
+            strokeBoundingBox.unite(path().strokeBoundingRect(strokeStyleApplier()));
     }
 
     if (!m_markerPositions.isEmpty())

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGShape.h
@@ -85,7 +85,6 @@ protected:
 
     bool hasNonScalingStroke() const { return style().svgStyle().vectorEffect() == VectorEffect::NonScalingStroke; }
     AffineTransform nonScalingStrokeTransform() const;
-    Path* nonScalingStrokePath(const Path*, const AffineTransform&) const;
 
     FloatRect m_fillBoundingBox;
     FloatRect m_strokeBoundingBox;
@@ -115,7 +114,14 @@ private:
     FloatRect calculateStrokeBoundingBox() const;
     void updateRepaintBoundingBox();
 
-    bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
+    auto strokeStyleApplier() const
+    {
+        return [this] (GraphicsContext& context) {
+            SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
+        };
+    }
+
+    bool setupNonScalingStrokeContext(GraphicsContextStateSaver&);
 
     bool shouldGenerateMarkerPositions() const;
     FloatRect markerRect(float strokeWidth) const;

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -88,7 +88,6 @@ void RenderSVGPath::strokeShape(GraphicsContext& context) const
     if (m_zeroLengthLinecapLocations.isEmpty())
         return;
 
-    Path* usePath;
     AffineTransform nonScalingTransform;
 
     if (hasNonScalingStroke())
@@ -97,10 +96,11 @@ void RenderSVGPath::strokeShape(GraphicsContext& context) const
     GraphicsContextStateSaver stateSaver(context, true);
     useStrokeStyleToFill(context);
     for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
+        auto linecapPath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
         if (hasNonScalingStroke())
-            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
-        context.fillPath(*usePath);
+            context.fillPath(nonScalingTransform.mapPath(linecapPath));
+        else
+            context.fillPath(linecapPath);
     }
 }
 
@@ -132,17 +132,14 @@ bool RenderSVGPath::shouldStrokeZeroLengthSubpath() const
     return style().svgStyle().hasStroke() && style().capStyle() != LineCap::Butt;
 }
 
-Path* RenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
+Path RenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const
 {
-    static NeverDestroyed<Path> tempPath;
-
-    tempPath.get().clear();
+    Path linecapPath;
     if (style().capStyle() == LineCap::Square)
-        tempPath.get().addRect(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
+        linecapPath.addRect(zeroLengthSubpathRect(linecapPosition, strokeWidth()));
     else
-        tempPath.get().addEllipse(zeroLengthSubpathRect(linecapPosition, this->strokeWidth()));
-
-    return &tempPath.get();
+        linecapPath.addEllipse(zeroLengthSubpathRect(linecapPosition, strokeWidth()));
+    return linecapPath;
 }
 
 FloatRect RenderSVGPath::zeroLengthSubpathRect(const FloatPoint& linecapPosition, float strokeWidth) const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -48,7 +48,7 @@ private:
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
 
     bool shouldStrokeZeroLengthSubpath() const;
-    Path* zeroLengthLinecapPath(const FloatPoint&) const;
+    Path zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -86,12 +86,11 @@ void RenderSVGShape::fillShape(GraphicsContext& context) const
 void RenderSVGShape::strokeShape(GraphicsContext& context) const
 {
     ASSERT(m_path);
-    Path* usePath = m_path.get();
 
     if (hasNonScalingStroke())
-        usePath = nonScalingStrokePath(usePath, nonScalingStrokeTransform());
-
-    context.strokePath(*usePath);
+        context.strokePath(nonScalingStrokeTransform().mapPath(path()));
+    else
+        context.strokePath(path());
 }
 
 bool RenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
@@ -99,16 +98,12 @@ bool RenderSVGShape::shapeDependentStrokeContains(const FloatPoint& point, Point
     ASSERT(m_path);
 
     if (hasNonScalingStroke() && pointCoordinateSpace != LocalCoordinateSpace) {
-        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-        Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
-        return usePath->strokeContains(nonScalingTransform.mapPoint(point), [this] (GraphicsContext& context) {
-            SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-        });
+        auto nonScalingTransform = nonScalingStrokeTransform();
+        auto usePath = nonScalingTransform.mapPath(path());
+        return usePath.strokeContains(nonScalingTransform.mapPoint(point), strokeStyleApplier());
     }
 
-    return m_path->strokeContains(point, [this] (GraphicsContext& context) {
-        SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-    });
+    return m_path->strokeContains(point, strokeStyleApplier());
 }
 
 bool RenderSVGShape::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
@@ -164,25 +159,15 @@ void RenderSVGShape::layout()
     clearNeedsLayout();
 }
 
-Path* RenderSVGShape::nonScalingStrokePath(const Path* path, const AffineTransform& strokeTransform) const
+bool RenderSVGShape::setupNonScalingStrokeContext(GraphicsContextStateSaver& stateSaver)
 {
-    static NeverDestroyed<Path> tempPath;
+    if (auto inverse = nonScalingStrokeTransform().inverse()) {
+        stateSaver.save();
+        stateSaver.context()->concatCTM(*inverse);
+        return true;
+    }
 
-    tempPath.get() = *path;
-    tempPath.get().transform(strokeTransform);
-
-    return &tempPath.get();
-}
-
-bool RenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeTransform, GraphicsContextStateSaver& stateSaver)
-{
-    std::optional<AffineTransform> inverse = strokeTransform.inverse();
-    if (!inverse)
-        return false;
-
-    stateSaver.save();
-    stateSaver.context()->concatCTM(inverse.value());
-    return true;
+    return false;
 }
 
 AffineTransform RenderSVGShape::nonScalingStrokeTransform() const
@@ -243,11 +228,8 @@ void RenderSVGShape::strokeShape(GraphicsContext& context)
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
-    if (hasNonScalingStroke()) {
-        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-        if (!setupNonScalingStrokeContext(nonScalingTransform, stateSaver))
-            return;
-    }
+    if (hasNonScalingStroke() && !setupNonScalingStrokeContext(stateSaver))
+        return;
     strokeShape(style(), context);
 }
 
@@ -436,20 +418,14 @@ FloatRect RenderSVGShape::calculateStrokeBoundingBox() const
 
     if (style().svgStyle().hasStroke()) {
         if (hasNonScalingStroke()) {
-            AffineTransform nonScalingTransform = nonScalingStrokeTransform();
-            if (std::optional<AffineTransform> inverse = nonScalingTransform.inverse()) {
-                Path* usePath = nonScalingStrokePath(m_path.get(), nonScalingTransform);
-                FloatRect strokeBoundingRect = usePath->strokeBoundingRect(Function<void(GraphicsContext&)> { [this] (GraphicsContext& context) {
-                    SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-                } });
-                strokeBoundingRect = inverse.value().mapRect(strokeBoundingRect);
-                strokeBoundingBox.unite(strokeBoundingRect);
+            auto nonScalingTransform = nonScalingStrokeTransform();
+            if (auto inverse = nonScalingTransform.inverse()) {
+                auto usePath = nonScalingTransform.mapPath(path());
+                auto strokeBoundingRect = usePath.strokeBoundingRect(strokeStyleApplier());
+                strokeBoundingBox.unite(inverse->mapRect(strokeBoundingRect));
             }
-        } else {
-            strokeBoundingBox.unite(path().strokeBoundingRect(Function<void(GraphicsContext&)> { [this] (GraphicsContext& context) {
-                SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
-            } }));
-        }
+        } else
+            strokeBoundingBox.unite(path().strokeBoundingRect(strokeStyleApplier()));
     }
 
     return strokeBoundingBox;

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -95,7 +95,6 @@ protected:
 
     bool hasNonScalingStroke() const { return style().svgStyle().vectorEffect() == VectorEffect::NonScalingStroke; }
     AffineTransform nonScalingStrokeTransform() const;
-    Path* nonScalingStrokePath(const Path*, const AffineTransform&) const;
 
     FloatRect m_fillBoundingBox;
     FloatRect m_strokeBoundingBox;
@@ -117,7 +116,14 @@ private:
     FloatRect calculateObjectBoundingBox() const;
     FloatRect calculateStrokeBoundingBox() const;
 
-    bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
+    auto strokeStyleApplier() const
+    {
+        return [this] (GraphicsContext& context) {
+            SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
+        };
+    }
+
+    bool setupNonScalingStrokeContext(GraphicsContextStateSaver&);
 
     bool shouldGenerateMarkerPositions() const;
     


### PR DESCRIPTION
#### b8abd5adb45e7aa2f3c232740d232e3b29c594dc
<pre>
Simplify non-scaling-stroke handling in (Legacy)RenderSVGShape
<a href="https://bugs.webkit.org/show_bug.cgi?id=241754">https://bugs.webkit.org/show_bug.cgi?id=241754</a>

Reviewed by NOBODY (OOPS!).

(Legacy)RenderSVGShape::nonScalingStrokePath has a static variable that
stores the returned Path, presumably so that it can live long enough for
the caller to make use of it. We can simplify this by returning Path
object directly.

While we&apos;re here, we can also simplify some other functions dealing with
the non-scaling stroke transform and usage of the non-scaling stroke
path.

We add a new AffineTransform::mapPath function, which does what the
current nonScalingStrokePath function does.

* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::Path::transform):
* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(WebCore::AffineTransform::mapPath const):
* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeShape const):
(WebCore::LegacyRenderSVGShape::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGShape::setupNonScalingStrokeContext):
(WebCore::LegacyRenderSVGShape::strokeShape):
(WebCore::LegacyRenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::nonScalingStrokePath const): Deleted.
* Source/WebCore/rendering/svg/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::strokeStyleApplier const):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::strokeShape const):
(WebCore::RenderSVGPath::zeroLengthLinecapPath const):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeShape const):
(WebCore::RenderSVGShape::shapeDependentStrokeContains):
(WebCore::RenderSVGShape::setupNonScalingStrokeContext):
(WebCore::RenderSVGShape::strokeShape):
(WebCore::RenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::RenderSVGShape::nonScalingStrokePath const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGShape.h:
(WebCore::RenderSVGShape::strokeStyleApplier const):
</pre>