### PR TITLE
[WebGPU] Parse literal integer/floats as AbstractInt/AbstractFloat

### DIFF
--- a/Source/WebGPU/WGSL/AST/Expression.h
+++ b/Source/WebGPU/WGSL/AST/Expression.h
@@ -38,6 +38,8 @@ public:
         Int32Literal,
         Uint32Literal,
         Float32Literal,
+        AbstractIntLiteral,
+        AbstractFloatLiteral,
         Identifier,
         StructureAccess,
         TypeConversion,
@@ -55,6 +57,8 @@ public:
     bool isInt32Literal() const { return kind() == Kind::Int32Literal; }
     bool isUInt32Literal() const { return kind() == Kind::Uint32Literal; }
     bool isFloat32Literal() const { return kind() == Kind::Float32Literal; }
+    bool isAbstractIntLiteral() const { return kind() == Kind::AbstractIntLiteral; }
+    bool isAbstractFloatLiteral() const { return kind() == Kind::AbstractFloatLiteral; }
     bool isIdentifier() const { return kind() == Kind::Identifier; }
     bool isStructureAccess() const { return kind() == Kind::StructureAccess; }
     bool isTypeConversion() const { return kind() == Kind::TypeConversion; }

--- a/Source/WebGPU/WGSL/AST/Expressions/LiteralExpressions.h
+++ b/Source/WebGPU/WGSL/AST/Expressions/LiteralExpressions.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "Expression.h"
+
 namespace WGSL::AST {
 
 class BoolLiteral final : public Expression {
@@ -36,7 +38,7 @@ public:
     {
     }
 
-    Kind kind() const override { return Kind::BoolLiteral; }
+    Kind kind() const final { return Kind::BoolLiteral; }
     bool value() const { return m_value; }
 
 private:
@@ -52,7 +54,7 @@ public:
     {
     }
 
-    Kind kind() const override { return Kind::Int32Literal; }
+    Kind kind() const final { return Kind::Int32Literal; }
     int32_t value() const { return m_value; }
 
 private:
@@ -68,7 +70,7 @@ public:
     {
     }
 
-    Kind kind() const override { return Kind::Uint32Literal; }
+    Kind kind() const final { return Kind::Uint32Literal; }
     uint32_t value() const { return m_value; }
 
 private:
@@ -84,11 +86,48 @@ public:
     {
     }
 
-    Kind kind() const override { return Kind::Float32Literal; }
+    Kind kind() const final { return Kind::Float32Literal; }
     float value() const { return m_value; }
 
 private:
     float m_value;
+};
+
+// Literal ints without size prefix; these ints are signed 64-bit numbers.
+// https://gpuweb.github.io/gpuweb/wgsl/#abstractint
+class AbstractIntLiteral final : public Expression {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    AbstractIntLiteral(SourceSpan span, int64_t value)
+        : Expression(span)
+        , m_value(value)
+    {
+    }
+
+    Kind kind() const final { return Kind::AbstractIntLiteral; }
+    int64_t value() const { return m_value; }
+
+private:
+    int64_t m_value;
+};
+
+// Literal floats without size prefix; these floats are double-precision
+// floating point numbers.
+// https://gpuweb.github.io/gpuweb/wgsl/#abstractfloat
+class AbstractFloatLiteral final : public Expression {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    AbstractFloatLiteral(SourceSpan span, double value)
+        : Expression(span)
+        , m_value(value)
+    {
+    }
+
+    Kind kind() const final { return Kind::AbstractFloatLiteral; }
+    double value() const { return m_value; }
+
+private:
+    double m_value;
 };
 
 } // namespace WGSL::AST
@@ -97,3 +136,5 @@ SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(BoolLiteral, isBoolLiteral())
 SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(Int32Literal, isInt32Literal())
 SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(Float32Literal, isFloat32Literal())
 SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(Uint32Literal, isUInt32Literal())
+SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(AbstractIntLiteral, isAbstractIntLiteral())
+SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(AbstractFloatLiteral, isAbstractFloatLiteral())

--- a/Source/WebGPU/WGSLUnitTests/Parser/ConstLiteralTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/Parser/ConstLiteralTests.mm
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "LiteralExpressions.h"
+#import "ParserPrivate.h"
+#import <XCTest/XCTest.h>
+
+static Expected<UniqueRef<WGSL::AST::Expression>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
+{
+    WGSL::Lexer<LChar> lexer(input);
+    WGSL::Parser parser(lexer);
+
+    return parser.parsePrimaryExpression();
+}
+
+template<class NumberType>
+struct ConstLiteralTestCase {
+    String input;
+    NumberType expectedValue;
+};
+
+@interface ConstLiteralTests : XCTestCase
+
+@end
+
+@implementation ConstLiteralTests
+
+- (void)setUp {
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)testBoolLiteralDecimal {
+    const ConstLiteralTestCase<bool> testCases[] = {
+        { "true"_s, true },
+        { "false"_s, false }
+    };
+
+    for (const auto& testCase : testCases) {
+        auto parseResult = parseLCharPrimaryExpression(testCase.input);
+        XCTAssert(parseResult);
+
+        auto expr = WTFMove(*parseResult);
+        XCTAssert(expr->isBoolLiteral());
+
+        const auto& intLiteral = downcast<WGSL::AST::BoolLiteral>(expr.get());
+        XCTAssert(intLiteral.value() == testCase.expectedValue);
+        auto inputLength = testCase.input.length();
+        XCTAssert(intLiteral.span() == WGSL::SourceSpan(0, inputLength, inputLength, 0));
+    }
+}
+
+- (void)testAbstractIntLiteralDecimal {
+    const ConstLiteralTestCase<int64_t> testCases[] = {
+        { "0"_s, 0LL },
+        { "1"_s, 1LL },
+        { "12345"_s, 12345LL },
+        { "9223372036854775807"_s, 9223372036854775807LL }
+    };
+
+    for (const auto& testCase : testCases) {
+        auto parseResult = parseLCharPrimaryExpression(testCase.input);
+        XCTAssert(parseResult);
+
+        auto expr = WTFMove(*parseResult);
+        XCTAssert(expr->isAbstractIntLiteral());
+
+        const auto& intLiteral = downcast<WGSL::AST::AbstractIntLiteral>(expr.get());
+        XCTAssert(intLiteral.value() == testCase.expectedValue);
+        auto inputLength = testCase.input.length();
+        XCTAssert(intLiteral.span() == WGSL::SourceSpan(0, inputLength, inputLength, 0));
+    }
+}
+
+- (void)testAbstractIntLiteralHex {
+    const ConstLiteralTestCase<int64_t> testCases[] = {
+        { "0x0"_s, 0x0LL },
+        { "0x1"_s, 0x1LL },
+        { "0x12345"_s, 0x12345LL },
+        { "0x8fffffffffffffff"_s, 9223372036854775807LL }
+    };
+
+    for (const auto& testCase : testCases) {
+        auto parseResult = parseLCharPrimaryExpression(testCase.input);
+        XCTAssert(parseResult);
+
+        auto expr = WTFMove(*parseResult);
+        XCTAssert(expr->isAbstractIntLiteral());
+
+        const auto& intLiteral = downcast<WGSL::AST::AbstractIntLiteral>(expr.get());
+        XCTAssert(intLiteral.value() == testCase.expectedValue);
+        auto inputLength = testCase.input.length();
+        XCTAssert(intLiteral.span() == WGSL::SourceSpan(0, inputLength, inputLength, 0));
+    }
+}
+
+- (void)testAbstractFloatLiteralDec {
+    const ConstLiteralTestCase<double> testCases[] = {
+        { "0.0"_s, 0.0 },
+        { "0.1"_s, 0.1 },
+        { "2612.0324"_s, 2612.0324 },
+        { "0.00000001"_s, 0.00000001 },
+        { "1234.5678e-3"_s, 1234.5678e-3 },
+        { "01."_s, 01. },
+        { ".01"_s, .01 },
+        { "1e-3"_s, 1e-3 }
+    };
+
+    for (const auto& testCase : testCases) {
+        auto parseResult = parseLCharPrimaryExpression(testCase.input);
+        XCTAssert(parseResult);
+
+        auto expr = WTFMove(*parseResult);
+        XCTAssert(expr->isAbstractFloatLiteral());
+
+        const auto& floatLiteral = downcast<WGSL::AST::AbstractFloatLiteral>(expr.get());
+        XCTAssert(floatLiteral.value() == testCase.expectedValue);
+        auto inputLength = testCase.input.length();
+        XCTAssert(floatLiteral.span() == WGSL::SourceSpan(0, inputLength, inputLength, 0));
+    }
+}
+
+- (void)testAbstractFloatLiteralHex {
+    XCTSkip(@"Hexadecimal floats not implemented yet");
+
+    const ConstLiteralTestCase<double> testCases[] = {
+        { "0xa.fp+2"_s, 0xa.fp+2 },
+        { "0X.3"_s, 0X.3p+0 },
+        { "0X1.fp-4"_s, 0X1.fp-4 }
+    };
+
+    for (const auto& testCase : testCases) {
+        auto parseResult = parseLCharPrimaryExpression(testCase.input);
+        XCTAssert(parseResult);
+
+        auto expr = WTFMove(*parseResult);
+        XCTAssert(expr->isAbstractFloatLiteral());
+
+        const auto& floatLiteral = downcast<WGSL::AST::AbstractFloatLiteral>(expr.get());
+        XCTAssert(floatLiteral.value() == testCase.expectedValue);
+        auto inputLength = testCase.input.length();
+        XCTAssert(floatLiteral.span() == WGSL::SourceSpan(0, inputLength, inputLength, 0));
+    }
+}
+
+@end

--- a/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
@@ -200,10 +200,10 @@
         WGSL::AST::TypeConversion& expr = downcast<WGSL::AST::TypeConversion>(*stmt.maybeExpression());
         XCTAssert(expr.typeDecl()->isParameterized());
         XCTAssert(expr.arguments().size() == 4);
-        XCTAssert(expr.arguments()[0]->isFloat32Literal());
-        XCTAssert(expr.arguments()[1]->isFloat32Literal());
-        XCTAssert(expr.arguments()[2]->isFloat32Literal());
-        XCTAssert(expr.arguments()[3]->isFloat32Literal());
+        XCTAssert(expr.arguments()[0]->isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[1]->isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[2]->isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[3]->isAbstractFloatLiteral());
     }
 }
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* StructureAccess.h */; };
 		33EA188627BC26DF00A1DD52 /* TypeConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* TypeConversion.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
+		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
@@ -334,6 +335,7 @@
 		33EA188327BC268600A1DD52 /* StructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructureAccess.h; sourceTree = "<group>"; };
 		33EA188527BC26DF00A1DD52 /* TypeConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TypeConversion.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
+		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -378,6 +380,7 @@
 		1C023D3D27449070001DB734 /* WGSLUnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				6664847F28596A3E008FB60E /* Parser */,
 				1C023D3E27449070001DB734 /* WGSLLexerTests.mm */,
 				339B7B1C27D80A1C0072BF9A /* WGSLParserTests.mm */,
 			);
@@ -730,6 +733,14 @@
 			path = Expressions;
 			sourceTree = "<group>";
 		};
+		6664847F28596A3E008FB60E /* Parser */ = {
+			isa = PBXGroup;
+			children = (
+				6634666A285F0140002ABE8E /* ConstLiteralTests.mm */,
+			);
+			path = Parser;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -985,6 +996,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */,
 				1C023D3F27449070001DB734 /* WGSLLexerTests.mm in Sources */,
 				339B7B1D27D80A1C0072BF9A /* WGSLParserTests.mm in Sources */,
 			);


### PR DESCRIPTION
#### 6559f40a2d93a6f9d8fb8f06f66dca5f3b49d642
<pre>
[WebGPU] Parse literal integer/floats as AbstractInt/AbstractFloat
<a href="https://bugs.webkit.org/show_bug.cgi?id=241755">https://bugs.webkit.org/show_bug.cgi?id=241755</a>
&lt;rdar://95925953&gt;

Reviewed by Geoffrey Garen and Myles C. Maxfield.

Literal integers and floats should be parsed as AbstractInt (int64_t)
and AbstractFloat (double). Current code parses them as int32_t and
float instead.

Tests: Source/WebGPU/WGSLUnitTests/Parser/ConstLiteralTests.mm

* Source/WebGPU/WGSL/AST/Expression.h:
(WGSL::AST::Expression::isAbstractIntLiteral const):
(WGSL::AST::Expression::isAbstractFloatLiteral const):
* Source/WebGPU/WGSL/AST/Expressions/LiteralExpressions.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
* Source/WebGPU/WGSLUnitTests/Parser/ConstLiteralTests.mm: Added.
(parseLCharPrimaryExpression):
(-[ConstLiteralTests setUp]):
(-[ConstLiteralTests testBoolLiteralDecimal]):
(-[ConstLiteralTests testAbstractIntLiteralDecimal]):
(-[ConstLiteralTests testAbstractIntLiteralHex]):
(-[ConstLiteralTests testAbstractFloatLiteralDec]):
(-[ConstLiteralTests testAbstractFloatLiteralHex]):
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
(-[WGSLParserTests testTrivialGraphicsShader]):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/252060@main">https://commits.webkit.org/252060@main</a>
</pre>
