### PR TITLE
IPC stream send is slow due to semaphore signal if receiver is faster than sender

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -23,21 +23,21 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteDisplayListRecorder NotRefCounted Stream {
-    Save()
-    Restore()
-    Translate(float x, float y)
-    Rotate(float angle)
-    Scale(WebCore::FloatSize scale)
-    SetCTM(WebCore::AffineTransform ctm)
-    ConcatenateCTM(WebCore::AffineTransform ctm)
-    SetInlineFillColor(WebCore::DisplayList::SetInlineFillColor item)
-    SetInlineStrokeColor(WebCore::DisplayList::SetInlineStrokeColor item)
-    SetStrokeThickness(float thickness)
-    SetState(WebCore::DisplayList::SetState item)
-    SetLineCap(enum:uint8_t WebCore::LineCap lineCap)
-    SetLineDash(WebCore::DisplayList::SetLineDash item)
-    SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin)
-    SetMiterLimit(float limit)
+    Save() StreamBatched
+    Restore() StreamBatched
+    Translate(float x, float y) StreamBatched
+    Rotate(float angle) StreamBatched
+    Scale(WebCore::FloatSize scale) StreamBatched
+    SetCTM(WebCore::AffineTransform ctm) StreamBatched
+    ConcatenateCTM(WebCore::AffineTransform ctm) StreamBatched
+    SetInlineFillColor(WebCore::DisplayList::SetInlineFillColor item) StreamBatched
+    SetInlineStrokeColor(WebCore::DisplayList::SetInlineStrokeColor item) StreamBatched
+    SetStrokeThickness(float thickness) StreamBatched
+    SetState(WebCore::DisplayList::SetState item) StreamBatched
+    SetLineCap(enum:uint8_t WebCore::LineCap lineCap) StreamBatched
+    SetLineDash(WebCore::DisplayList::SetLineDash item) StreamBatched
+    SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin) StreamBatched
+    SetMiterLimit(float limit) StreamBatched
     ClearShadow()
     Clip(WebCore::FloatRect rect)
     ClipOut(WebCore::FloatRect rect)
@@ -80,13 +80,13 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     PaintFrameForMedia(WebCore::MediaPlayerIdentifier identifier, WebCore::FloatRect destination)
     StrokeRect(WebCore::FloatRect rect, float lineWidth)
 #if ENABLE(INLINE_PATH_DATA)
-    StrokeLine(struct WebCore::LineData data)
-    StrokeArc(struct WebCore::ArcData data)
-    StrokeQuadCurve(struct WebCore::QuadCurveData data)
-    StrokeBezierCurve(struct WebCore::BezierCurveData data)
+    StrokeLine(struct WebCore::LineData data) StreamBatched
+    StrokeArc(struct WebCore::ArcData data) StreamBatched
+    StrokeQuadCurve(struct WebCore::QuadCurveData data) StreamBatched
+    StrokeBezierCurve(struct WebCore::BezierCurveData data) StreamBatched
 #endif
-    StrokePath(WebCore::Path path)
-    StrokeEllipse(WebCore::FloatRect rect)
+    StrokePath(WebCore::Path path) StreamBatched
+    StrokeEllipse(WebCore::FloatRect rect) StreamBatched
     ClearRect(WebCore::FloatRect rect)
 #if USE(CG)
     ApplyStrokePattern()

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -47,6 +47,7 @@ _test_receiver_names = [
     'TestWithSemaphore',
     'TestWithImageData',
     'TestWithStream',
+    'TestWithStreamBatched',
     'TestWithStreamBuffer',
     'TestWithCVPixelBuffer',
 ]

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -7,6 +7,7 @@ TESTS = \
     TestWithSemaphore \
     TestWithImageData \
     TestWithStream \
+    TestWithStreamBatched \
     TestWithStreamBuffer \
     TestWithCVPixelBuffer \
 #

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -28,19 +28,20 @@
 #if ENABLE(IPC_TESTING_API) || !LOG_DISABLED
 
 #include "JSIPCBinding.h"
-#include "TestWithSuperclassMessages.h"
+#include "TestWithSuperclassMessages.h" // NOLINT
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
-#include "TestWithLegacyReceiverMessages.h"
+#include "TestWithLegacyReceiverMessages.h" // NOLINT
 #endif
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
-#include "TestWithoutAttributesMessages.h"
+#include "TestWithoutAttributesMessages.h" // NOLINT
 #endif
-#include "TestWithIfMessageMessages.h"
-#include "TestWithSemaphoreMessages.h"
-#include "TestWithImageDataMessages.h"
-#include "TestWithStreamMessages.h"
-#include "TestWithStreamBufferMessages.h"
-#include "TestWithCVPixelBufferMessages.h"
+#include "TestWithIfMessageMessages.h" // NOLINT
+#include "TestWithSemaphoreMessages.h" // NOLINT
+#include "TestWithImageDataMessages.h" // NOLINT
+#include "TestWithStreamMessages.h" // NOLINT
+#include "TestWithStreamBatchedMessages.h" // NOLINT
+#include "TestWithStreamBufferMessages.h" // NOLINT
+#include "TestWithCVPixelBufferMessages.h" // NOLINT
 
 namespace IPC {
 
@@ -213,6 +214,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
         return jsValueForDecodedMessage<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, decoder);
 #endif
+    case MessageName::TestWithStreamBatched_SendString:
+        return jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(globalObject, decoder);
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(globalObject, decoder);
 #if USE(AVFOUNDATION)
@@ -592,6 +595,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
             { "a1", "MachSendRight", nullptr, false },
         };
 #endif
+    case MessageName::TestWithStreamBatched_SendString:
+        return Vector<ArgumentDescription> {
+            { "url", "String", nullptr, false },
+        };
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return Vector<ArgumentDescription> {
             { "stream", "IPC::StreamConnectionBuffer", nullptr, false },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -84,6 +84,8 @@ const char* description(MessageName name)
         return "TestWithSemaphore_ReceiveSemaphore";
     case MessageName::TestWithSemaphore_SendSemaphore:
         return "TestWithSemaphore_SendSemaphore";
+    case MessageName::TestWithStreamBatched_SendString:
+        return "TestWithStreamBatched_SendString";
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return "TestWithStreamBuffer_SendStreamBuffer";
     case MessageName::TestWithStream_ReceiveMachSendRight:
@@ -248,6 +250,8 @@ ReceiverName receiverName(MessageName messageName)
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
     case MessageName::TestWithSemaphore_SendSemaphore:
         return ReceiverName::TestWithSemaphore;
+    case MessageName::TestWithStreamBatched_SendString:
+        return ReceiverName::TestWithStreamBatched;
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
         return ReceiverName::TestWithStreamBuffer;
     case MessageName::TestWithStream_ReceiveMachSendRight:
@@ -406,6 +410,8 @@ bool isValidMessageName(MessageName messageName)
     if (messageName == IPC::MessageName::TestWithSemaphore_ReceiveSemaphore)
         return true;
     if (messageName == IPC::MessageName::TestWithSemaphore_SendSemaphore)
+        return true;
+    if (messageName == IPC::MessageName::TestWithStreamBatched_SendString)
         return true;
     if (messageName == IPC::MessageName::TestWithStreamBuffer_SendStreamBuffer)
         return true;

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -35,12 +35,13 @@ enum class ReceiverName : uint8_t {
     , TestWithLegacyReceiver = 4
     , TestWithSemaphore = 5
     , TestWithStream = 6
-    , TestWithStreamBuffer = 7
-    , TestWithSuperclass = 8
-    , TestWithoutAttributes = 9
-    , IPC = 10
-    , AsyncReply = 11
-    , Invalid = 12
+    , TestWithStreamBatched = 7
+    , TestWithStreamBuffer = 8
+    , TestWithSuperclass = 9
+    , TestWithoutAttributes = 10
+    , IPC = 11
+    , AsyncReply = 12
+    , Invalid = 13
 };
 
 enum class MessageName : uint16_t {
@@ -71,6 +72,7 @@ enum class MessageName : uint16_t {
     , TestWithLegacyReceiver_TouchEvent
     , TestWithSemaphore_ReceiveSemaphore
     , TestWithSemaphore_SendSemaphore
+    , TestWithStreamBatched_SendString
     , TestWithStreamBuffer_SendStreamBuffer
     , TestWithStream_ReceiveMachSendRight
     , TestWithStream_SendAndReceiveMachSendRight

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -26,16 +26,16 @@
 #include "TestWithCVPixelBuffer.h"
 
 #if USE(AVFOUNDATION)
-#include "ArgumentCodersCF.h"
+#include "ArgumentCodersCF.h" // NOLINT
 #endif
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "TestWithCVPixelBufferMessages.h"
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithCVPixelBufferMessages.h" // NOLINT
 #if USE(AVFOUNDATION)
-#include <WebCore/CVUtilities.h>
+#include <WebCore/CVUtilities.h> // NOLINT
 #endif
 #if USE(AVFOUNDATION)
-#include <wtf/RetainPtr.h>
+#include <wtf/RetainPtr.h> // NOLINT
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in
@@ -1,0 +1,30 @@
+# Copyright (C) 2010 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This test should test the MessageArgumentReceivers.cpp include generation with
+// top-level #if, avoiding generic #include for ApplePayPaymentAuthorizationResult.
+
+#if ENABLE(APPLE_PAY)
+messages -> TestWithIfReceiver NotRefCounted {
+    CompletePaymentSession(struct WebCore::ApplePayPaymentAuthorizationResult result)
+}
+#endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessageReceiver.cpp
@@ -23,17 +23,14 @@
  */
 
 #include "config.h"
-#include "TestWithIfMessage.h"
+#if ENABLE(APPLE_PAY)
+#include "TestWithIfReceiver.h"
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
-#include "ArgumentCoders.h" // NOLINT
-#endif
-#include "Decoder.h" // NOLINT
-#include "HandleMessage.h" // NOLINT
-#include "TestWithIfMessageMessages.h" // NOLINT
-#if PLATFORM(COCOA) || PLATFORM(GTK)
-#include <wtf/text/WTFString.h> // NOLINT
-#endif
+#include "Decoder.h"
+#include "HandleMessage.h"
+#include "TestWithIfReceiverMessages.h"
+#include "WebCoreArgumentCoders.h"
+#include <WebCore/ApplePayPaymentAuthorizationResult.h>
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"
@@ -41,17 +38,10 @@
 
 namespace WebKit {
 
-void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithIfReceiver::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    Ref protectedThis { *this };
-#if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
-#endif
-#if PLATFORM(GTK)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
-#endif
+    if (decoder.messageName() == Messages::TestWithIfReceiver::CompletePaymentSession::name())
+        return IPC::handleMessage<Messages::TestWithIfReceiver::CompletePaymentSession>(connection, decoder, this, &TestWithIfReceiver::completePaymentSession);
     UNUSED_PARAM(connection);
     UNUSED_PARAM(decoder);
 #if ENABLE(IPC_TESTING_API)
@@ -67,20 +57,14 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 
 namespace IPC {
 
-#if PLATFORM(COCOA)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfReceiver_CompletePaymentSession>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithIfReceiver::CompletePaymentSession::Arguments>(globalObject, decoder);
 }
-#endif
-#if PLATFORM(GTK)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
-{
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
-}
-#endif
 
 }
 
 #endif
 
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessages.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(APPLE_PAY)
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include "TestWithIfReceiverMessagesReplies.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+struct ApplePayPaymentAuthorizationResult;
+}
+
+namespace Messages {
+namespace TestWithIfReceiver {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithIfReceiver;
+}
+
+class CompletePaymentSession {
+public:
+    using Arguments = std::tuple<const WebCore::ApplePayPaymentAuthorizationResult&>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithIfReceiver_CompletePaymentSession; }
+    static constexpr bool isSync = false;
+
+    explicit CompletePaymentSession(const WebCore::ApplePayPaymentAuthorizationResult& result)
+        : m_arguments(result)
+    {
+    }
+
+    const Arguments& arguments() const
+    {
+        return m_arguments;
+    }
+
+private:
+    Arguments m_arguments;
+};
+
+} // namespace TestWithIfReceiver
+} // namespace Messages
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessagesReplies.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessagesReplies.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(APPLE_PAY)
+
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+
+
+namespace Messages {
+namespace TestWithIfReceiver {
+
+
+} // namespace TestWithIfReceiver
+} // namespace Messages
+
+#endif // ENABLE(APPLE_PAY)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -25,13 +25,13 @@
 #include "config.h"
 #include "TestWithImageData.h"
 
-#include "ArgumentCoders.h"
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "TestWithImageDataMessages.h"
-#include "WebCoreArgumentCoders.h"
-#include <WebCore/ImageData.h>
-#include <wtf/RefCounted.h>
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithImageDataMessages.h" // NOLINT
+#include "WebCoreArgumentCoders.h" // NOLINT
+#include <WebCore/ImageData.h> // NOLINT
+#include <wtf/RefCounted.h> // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -26,38 +26,38 @@
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 #include "TestWithLegacyReceiver.h"
 
-#include "ArgumentCoders.h"
-#include "Connection.h"
-#include "Decoder.h"
+#include "ArgumentCoders.h" // NOLINT
+#include "Connection.h" // NOLINT
+#include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)
-#include "DummyType.h"
+#include "DummyType.h" // NOLINT
 #endif
 #if PLATFORM(MAC)
-#include "GestureTypes.h"
+#include "GestureTypes.h" // NOLINT
 #endif
-#include "HandleMessage.h"
-#include "Plugin.h"
-#include "TestWithLegacyReceiverMessages.h"
-#include "WebCoreArgumentCoders.h"
-#include "WebPreferencesStore.h"
+#include "HandleMessage.h" // NOLINT
+#include "Plugin.h" // NOLINT
+#include "TestWithLegacyReceiverMessages.h" // NOLINT
+#include "WebCoreArgumentCoders.h" // NOLINT
+#include "WebPreferencesStore.h" // NOLINT
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION)) || (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-#include "WebTouchEvent.h"
+#include "WebTouchEvent.h" // NOLINT
 #endif
-#include <WebCore/GraphicsLayer.h>
+#include <WebCore/GraphicsLayer.h> // NOLINT
 #if PLATFORM(MAC)
-#include <WebCore/KeyboardEvent.h>
+#include <WebCore/KeyboardEvent.h> // NOLINT
 #endif
-#include <WebCore/PluginData.h>
-#include <utility>
-#include <wtf/HashMap.h>
+#include <WebCore/PluginData.h> // NOLINT
+#include <utility> // NOLINT
+#include <wtf/HashMap.h> // NOLINT
 #if PLATFORM(MAC)
-#include <wtf/MachSendRight.h>
+#include <wtf/MachSendRight.h> // NOLINT
 #endif
 #if PLATFORM(MAC)
-#include <wtf/OptionSet.h>
+#include <wtf/OptionSet.h> // NOLINT
 #endif
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Vector.h> // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -25,10 +25,10 @@
 #include "config.h"
 #include "TestWithSemaphore.h"
 
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "IPCSemaphore.h"
-#include "TestWithSemaphoreMessages.h"
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "IPCSemaphore.h" // NOLINT
+#include "TestWithSemaphoreMessages.h" // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Tests StreamBatched message attribute.
+messages -> TestWithStreamBatched NotRefCounted Stream {
+    void SendString(String url) StreamBatched
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -23,17 +23,13 @@
  */
 
 #include "config.h"
-#include "TestWithIfMessage.h"
+#include "TestWithStreamBatched.h"
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
 #include "ArgumentCoders.h" // NOLINT
-#endif
 #include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
-#include "TestWithIfMessageMessages.h" // NOLINT
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#include "TestWithStreamBatchedMessages.h" // NOLINT
 #include <wtf/text/WTFString.h> // NOLINT
-#endif
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"
@@ -41,24 +37,17 @@
 
 namespace WebKit {
 
-void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
 {
-    Ref protectedThis { *this };
-#if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
-#endif
-#if PLATFORM(GTK)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
-#endif
-    UNUSED_PARAM(connection);
+    if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
+        return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection.connection(), decoder, this, &TestWithStreamBatched::sendString);
     UNUSED_PARAM(decoder);
+    UNUSED_PARAM(connection);
 #if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
+    if (connection.connection().ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 
 } // namespace WebKit
@@ -67,18 +56,10 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 
 namespace IPC {
 
-#if PLATFORM(COCOA)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
 {
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStreamBatched::SendString::Arguments>(globalObject, decoder);
 }
-#endif
-#if PLATFORM(GTK)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
-{
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
-}
-#endif
 
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include "TestWithStreamBatchedMessagesReplies.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithStreamBatched {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithStreamBatched;
+}
+
+class SendString {
+public:
+    using Arguments = std::tuple<const String&>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamBatched_SendString; }
+    static constexpr bool isSync = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = true;
+
+    explicit SendString(const String& url)
+        : m_arguments(url)
+    {
+    }
+
+    const Arguments& arguments() const
+    {
+        return m_arguments;
+    }
+
+private:
+    Arguments m_arguments;
+};
+
+} // namespace TestWithStreamBatched
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessagesReplies.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessagesReplies.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+
+
+namespace Messages {
+namespace TestWithStreamBatched {
+
+
+} // namespace TestWithStreamBatched
+} // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -25,10 +25,10 @@
 #include "config.h"
 #include "TestWithStreamBuffer.h"
 
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "StreamConnectionBuffer.h"
-#include "TestWithStreamBufferMessages.h"
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "StreamConnectionBuffer.h" // NOLINT
+#include "TestWithStreamBufferMessages.h" // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -25,14 +25,14 @@
 #include "config.h"
 #include "TestWithStream.h"
 
-#include "ArgumentCoders.h"
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "TestWithStreamMessages.h"
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithStreamMessages.h" // NOLINT
 #if PLATFORM(COCOA)
-#include <wtf/MachSendRight.h>
+#include <wtf/MachSendRight.h> // NOLINT
 #endif
-#include <wtf/text/WTFString.h>
+#include <wtf/text/WTFString.h> // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -49,6 +49,7 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendString; }
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
 
     explicit SendString(const String& url)
         : m_arguments(url)
@@ -72,6 +73,7 @@ public:
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
 
     static void callReply(IPC::Decoder&, CompletionHandler<void(int64_t&&)>&&);
     static void cancelReply(CompletionHandler<void(int64_t&&)>&&);
@@ -102,6 +104,7 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithStream_SendMachSendRight; }
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = false;
+    static constexpr bool isStreamBatched = false;
 
     explicit SendMachSendRight(const MachSendRight& a1)
         : m_arguments(a1)
@@ -127,6 +130,7 @@ public:
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isReplyStreamEncodable = false;
+    static constexpr bool isStreamBatched = false;
 
     static void callReply(IPC::Decoder&, CompletionHandler<void(MachSendRight&&)>&&);
     static void cancelReply(CompletionHandler<void(MachSendRight&&)>&&);
@@ -154,6 +158,7 @@ public:
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = false;
     static constexpr bool isReplyStreamEncodable = false;
+    static constexpr bool isStreamBatched = false;
 
     static void callReply(IPC::Decoder&, CompletionHandler<void(MachSendRight&&)>&&);
     static void cancelReply(CompletionHandler<void(MachSendRight&&)>&&);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -25,16 +25,16 @@
 #include "config.h"
 #include "TestWithSuperclass.h"
 
-#include "ArgumentCoders.h"
-#include "Decoder.h"
-#include "HandleMessage.h"
-#include "TestClassName.h"
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestClassName.h" // NOLINT
 #if ENABLE(TEST_FEATURE)
-#include "TestTwoStateEnum.h"
+#include "TestTwoStateEnum.h" // NOLINT
 #endif
-#include "TestWithSuperclassMessages.h"
-#include <optional>
-#include <wtf/text/WTFString.h>
+#include "TestWithSuperclassMessages.h" // NOLINT
+#include <optional> // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -26,38 +26,38 @@
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 #include "TestWithoutAttributes.h"
 
-#include "ArgumentCoders.h"
-#include "Connection.h"
-#include "Decoder.h"
+#include "ArgumentCoders.h" // NOLINT
+#include "Connection.h" // NOLINT
+#include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)
-#include "DummyType.h"
+#include "DummyType.h" // NOLINT
 #endif
 #if PLATFORM(MAC)
-#include "GestureTypes.h"
+#include "GestureTypes.h" // NOLINT
 #endif
-#include "HandleMessage.h"
-#include "Plugin.h"
-#include "TestWithoutAttributesMessages.h"
-#include "WebCoreArgumentCoders.h"
-#include "WebPreferencesStore.h"
+#include "HandleMessage.h" // NOLINT
+#include "Plugin.h" // NOLINT
+#include "TestWithoutAttributesMessages.h" // NOLINT
+#include "WebCoreArgumentCoders.h" // NOLINT
+#include "WebPreferencesStore.h" // NOLINT
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION)) || (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-#include "WebTouchEvent.h"
+#include "WebTouchEvent.h" // NOLINT
 #endif
-#include <WebCore/GraphicsLayer.h>
+#include <WebCore/GraphicsLayer.h> // NOLINT
 #if PLATFORM(MAC)
-#include <WebCore/KeyboardEvent.h>
+#include <WebCore/KeyboardEvent.h> // NOLINT
 #endif
-#include <WebCore/PluginData.h>
-#include <utility>
-#include <wtf/HashMap.h>
+#include <WebCore/PluginData.h> // NOLINT
+#include <utility> // NOLINT
+#include <wtf/HashMap.h> // NOLINT
 #if PLATFORM(MAC)
-#include <wtf/MachSendRight.h>
+#include <wtf/MachSendRight.h> // NOLINT
 #endif
 #if PLATFORM(MAC)
-#include <wtf/OptionSet.h>
+#include <wtf/OptionSet.h> // NOLINT
 #endif
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Vector.h> // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
 #include "JSIPCBinding.h"


### PR DESCRIPTION
#### 05cb01bde6d067ee099500456f25a378abec4fd1
<pre>
IPC stream send is slow due to semaphore signal if receiver is faster than sender
<a href="https://bugs.webkit.org/show_bug.cgi?id=239895">https://bugs.webkit.org/show_bug.cgi?id=239895</a>

Reviewed by Wenson Hsieh.

Add a message property `StreamBatched`. Consecutive messages marked as such
will not wake up the sleeping receiver. This skips the semaphore signal call
in cases that the receiver is faster than the sender.

Conservatively add batched property only to cases that are invoked by MotionMark
Canvas test case.
Conservatively use maximum batch size of 40, this seems to skip most signal
invocations.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::setSemaphores):
(IPC::StreamClientConnection::wakeUpServer):
(IPC::StreamClientConnection::wakeUpServerBatched):
(IPC::StreamClientConnection::deferredWakeUpServer): Deleted.
(IPC::StreamClientConnection::decrementRemainingMessageCountBeforeSendingWakeUp): Deleted.
(IPC::StreamClientConnection::sendDeferredWakeUpMessageIfNeeded): Deleted.
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
(IPC::StreamClientConnection::sendProcessOutOfStreamMessage):
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
(generate_header_includes_from_conditions):
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::messageArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
(IPC::description):
(IPC::receiverName):
(IPC::isValidMessageName):
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiver.messages.in: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessageReceiver.cpp: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
(WebKit::TestWithIfReceiver::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithIfReceiver_CompletePaymentSession&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessages.h: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
(Messages::TestWithIfReceiver::messageReceiverName):
(Messages::TestWithIfReceiver::CompletePaymentSession::name):
(Messages::TestWithIfReceiver::CompletePaymentSession::CompletePaymentSession):
(Messages::TestWithIfReceiver::CompletePaymentSession::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithIfReceiverMessagesReplies.h: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatched.messages.in: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStreamBatched_SendString&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
(Messages::TestWithStreamBatched::messageReceiverName):
(Messages::TestWithStreamBatched::SendString::name):
(Messages::TestWithStreamBatched::SendString::SendString):
(Messages::TestWithStreamBatched::SendString::arguments const):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessagesReplies.h: Copied from Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:

Canonical link: <a href="https://commits.webkit.org/251815@main">https://commits.webkit.org/251815@main</a>
</pre>
