### PR TITLE
[GPU Process] Introduce RenderingResource and make it the base of DecomposedGlyphs and NativeImage

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1776,6 +1776,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PlatformVideoTransferCharacteristics.h
     platform/graphics/PositionedGlyphs.h
     platform/graphics/Region.h
+    platform/graphics/RenderingResource.h
     platform/graphics/RenderingResourceIdentifier.h
     platform/graphics/RenderingMode.h
     platform/graphics/RoundedRect.h

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,22 +39,16 @@ Ref<DecomposedGlyphs> DecomposedGlyphs::create(PositionedGlyphs&& positionedGlyp
 }
 
 DecomposedGlyphs::DecomposedGlyphs(const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
-    : m_positionedGlyphs({ glyphs, count }, { advances, count }, localAnchor, mode)
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_positionedGlyphs({ glyphs, count }, { advances, count }, localAnchor, mode)
 {
 }
 
 DecomposedGlyphs::DecomposedGlyphs(PositionedGlyphs&& positionedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)
-    : m_positionedGlyphs(WTFMove(positionedGlyphs))
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_positionedGlyphs(WTFMove(positionedGlyphs))
 {
     ASSERT(m_positionedGlyphs.glyphs.size() == m_positionedGlyphs.advances.size());
-}
-
-DecomposedGlyphs::~DecomposedGlyphs()
-{
-    for (auto observer : m_observers)
-        observer->releaseDecomposedGlyphs(m_renderingResourceIdentifier);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -27,42 +27,23 @@
 
 #include "FloatRect.h"
 #include "PositionedGlyphs.h"
-#include "RenderingResourceIdentifier.h"
-#include <wtf/HashSet.h>
-#include <wtf/ThreadSafeWeakPtr.h>
+#include "RenderingResource.h"
 
 namespace WebCore {
 
-class DecomposedGlyphs final
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DecomposedGlyphs, WTF::DestructionThread::Main> {
+class DecomposedGlyphs final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    class Observer {
-    public:
-        virtual ~Observer() = default;
-        virtual void releaseDecomposedGlyphs(RenderingResourceIdentifier) = 0;
-    protected:
-        Observer() = default;
-    };
-
     static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
     static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(PositionedGlyphs&&, RenderingResourceIdentifier);
-    WEBCORE_EXPORT ~DecomposedGlyphs();
 
     const PositionedGlyphs& positionedGlyphs() const { return m_positionedGlyphs; }
-
-    void addObserver(Observer& observer) { m_observers.add(&observer); }
-    void removeObserver(Observer& observer) { m_observers.remove(&observer); }
-
-    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
 
 private:
     DecomposedGlyphs(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier);
     DecomposedGlyphs(PositionedGlyphs&&, RenderingResourceIdentifier);
 
     PositionedGlyphs m_positionedGlyphs;
-    HashSet<Observer*> m_observers;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include "NativeImage.h"
 
-#include <wtf/NeverDestroyed.h>
-
 namespace WebCore {
 
 RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, RenderingResourceIdentifier renderingResourceIdentifier)
@@ -38,16 +36,10 @@ RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, Render
 }
 
 NativeImage::NativeImage(PlatformImagePtr&& platformImage, RenderingResourceIdentifier renderingResourceIdentifier)
-    : m_platformImage(WTFMove(platformImage))
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_platformImage(WTFMove(platformImage))
 {
     ASSERT(m_platformImage);
-}
-
-NativeImage::~NativeImage()
-{
-    for (auto observer : m_observers)
-        observer->releaseNativeImage(m_renderingResourceIdentifier);
 }
 
 void NativeImage::setPlatformImage(PlatformImagePtr&& platformImage)

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -31,31 +31,16 @@
 #include "ImagePaintingOptions.h"
 #include "IntSize.h"
 #include "PlatformImage.h"
-#include "RenderingResourceIdentifier.h"
-#include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
-#include <wtf/RefCounted.h>
-#include <wtf/ThreadSafeWeakPtr.h>
+#include "RenderingResource.h"
 
 namespace WebCore {
 
 class GraphicsContext;
 
-class NativeImage final
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<NativeImage> {
+class NativeImage final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    class Observer {
-    public:
-        virtual ~Observer() = default;
-        virtual void releaseNativeImage(RenderingResourceIdentifier) = 0;
-    protected:
-        Observer() = default;
-    };
-
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
-
-    WEBCORE_EXPORT ~NativeImage();
 
     WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }
@@ -69,18 +54,12 @@ public:
 
     void draw(GraphicsContext&, const FloatSize& imageSize, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions&);
 
-    void addObserver(Observer& observer) { m_observers.add(&observer); }
-    void removeObserver(Observer& observer) { m_observers.remove(&observer); }
-    
     void clearSubimages();
 
 private:
-    NativeImage(PlatformImagePtr&&);
     NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
 
     PlatformImagePtr m_platformImage;
-    HashSet<Observer*> m_observers;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderingResourceIdentifier.h"
+#include <wtf/HashSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+
+class RenderingResource
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RenderingResource> {
+public:
+    class Observer {
+    public:
+        virtual ~Observer() = default;
+        virtual void releaseRenderingResource(RenderingResourceIdentifier) = 0;
+    protected:
+        Observer() = default;
+    };
+
+    virtual ~RenderingResource()
+    {
+        for (auto observer : m_observers)
+            observer->releaseRenderingResource(m_renderingResourceIdentifier);
+    }
+
+    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
+
+    void addObserver(Observer& observer) { m_observers.add(&observer); }
+    void removeObserver(Observer& observer) { m_observers.remove(&observer); }
+
+protected:
+    RenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
+        : m_renderingResourceIdentifier(renderingResourceIdentifier)
+    {
+    }
+
+    HashSet<Observer*> m_observers;
+    RenderingResourceIdentifier m_renderingResourceIdentifier;
+};
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -379,14 +379,14 @@ void RemoteRenderingBackend::releaseAllResources()
     m_remoteResourceCache.releaseAllResources();
 }
 
-void RemoteRenderingBackend::releaseResource(RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackend::releaseRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
     // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    releaseResourceWithQualifiedIdentifier({ renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
+    releaseRenderingResourceWithQualifiedIdentifier({ renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
 }
 
-void RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackend::releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     ASSERT(!RunLoop::isMain());
     {
@@ -394,7 +394,7 @@ void RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier(QualifiedRen
         if (auto remoteDisplayList = m_remoteDisplayLists.take(renderingResourceIdentifier))
             remoteDisplayList->clearImageBufferReference();
     }
-    auto success = m_remoteResourceCache.releaseResource(renderingResourceIdentifier);
+    auto success = m_remoteResourceCache.releaseRenderingResource(renderingResourceIdentifier);
     MESSAGE_CHECK(success, "Resource is being released before being cached.");
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -100,8 +100,6 @@ public:
 
     const WebCore::ProcessIdentity& resourceOwner() const { return m_resourceOwner; }
 
-    void releaseResource(WebCore::RenderingResourceIdentifier);
-
     GPUConnectionToWebProcess& gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
 
 private:
@@ -126,6 +124,7 @@ private:
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheFont(Ref<WebCore::Font>&&);
     void releaseAllResources();
+    void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>&);
 #if PLATFORM(COCOA)
@@ -137,7 +136,7 @@ private:
     void getShareableBitmapForImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmapHandle&&)>&&);
     void cacheNativeImageWithQualifiedIdentifier(const ShareableBitmapHandle&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
-    void releaseResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
+    void releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,7 +34,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheFont(Ref<WebCore::Font> font) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     ReleaseAllResources()
-    ReleaseResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 
 #if PLATFORM(COCOA)
     PrepareBuffersForDisplay(Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodable NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,7 +101,7 @@ void RemoteResourceCache::releaseAllResources()
     m_resourceHeap.releaseAllResources();
 }
 
-bool RemoteResourceCache::releaseResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (m_resourceHeap.removeImageBuffer(renderingResourceIdentifier)
         || m_resourceHeap.removeNativeImage(renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ public:
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;
 
     void releaseAllResources();
-    bool releaseResource(QualifiedRenderingResourceIdentifier);
+    bool releaseRenderingResource(QualifiedRenderingResourceIdentifier);
 
 private:
     QualifiedResourceHeap m_resourceHeap;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -267,9 +267,9 @@ void RemoteRenderingBackendProxy::releaseAllRemoteResources()
     send(Messages::RemoteRenderingBackend::ReleaseAllResources());
 }
 
-void RemoteRenderingBackendProxy::releaseRemoteResource(RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackendProxy::releaseRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    send(Messages::RemoteRenderingBackend::ReleaseResource(renderingResourceIdentifier));
+    send(Messages::RemoteRenderingBackend::ReleaseRenderingResource(renderingResourceIdentifier));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,7 +99,7 @@ public:
     void cacheFont(Ref<WebCore::Font>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void releaseAllRemoteResources();
-    void releaseRemoteResource(WebCore::RenderingResourceIdentifier);
+    void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void markSurfacesVolatile(Vector<WebCore::RenderingResourceIdentifier>&&, CompletionHandler<void(bool madeAllVolatile)>&&);
 
     struct BufferSet {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -30,7 +30,7 @@
 #include "RenderingUpdateID.h"
 #include <WebCore/DecomposedGlyphs.h>
 #include <WebCore/NativeImage.h>
-#include <WebCore/RenderingResourceIdentifier.h>
+#include <WebCore/RenderingResource.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -43,7 +43,7 @@ namespace WebKit {
 class RemoteImageBufferProxy;
 class RemoteRenderingBackendProxy;
 
-class RemoteResourceCacheProxy : public WebCore::NativeImage::Observer, public WebCore::DecomposedGlyphs::Observer {
+class RemoteResourceCacheProxy : public WebCore::RenderingResource::Observer {
 public:
     RemoteResourceCacheProxy(RemoteRenderingBackendProxy&);
     ~RemoteResourceCacheProxy();
@@ -73,8 +73,7 @@ private:
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
     using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::DecomposedGlyphs>>;
     
-    void releaseNativeImage(WebCore::RenderingResourceIdentifier) override;
-    void releaseDecomposedGlyphs(WebCore::RenderingResourceIdentifier) override;
+    void releaseRenderingResource(WebCore::RenderingResourceIdentifier) override;
     void clearNativeImageMap();
     void clearDecomposedGlyphsMap();
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -62,7 +62,7 @@ struct MockStreamTestMessageWithAsyncReply1 {
     static constexpr bool isSync = false;
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
-    static constexpr IPC::MessageName name()  { return IPC::MessageName::RemoteRenderingBackend_ReleaseResource; }
+    static constexpr IPC::MessageName name()  { return IPC::MessageName::RemoteRenderingBackend_ReleaseRenderingResource; }
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }


### PR DESCRIPTION
#### 11e07c42d4bfe42c167bdf3ec290d1db6e54694d
<pre>
[GPU Process] Introduce RenderingResource and make it the base of DecomposedGlyphs and NativeImage
 <a href="https://bugs.webkit.org/show_bug.cgi?id=220943">https://bugs.webkit.org/show_bug.cgi?id=220943</a>
 &lt;rdar://problem/73843739&gt;

Reviewed by Darin Adler.

Move smart pointer support and RenderingResourceIdentifier and observers&apos;
management to the new class RenderingResource.

Make DecomposedGlyphs and NativeImage inherit RenderingResource so they can
share this code instead of duplicating it.

Rename releaseRemoteResource() to releaseRenderingResource().

Make DecomposedGlyphs be destructible on any thread and not necessarily on
the main thread. I do not think there was a reason for making it
WTF::DestructionThread::Main from the beginning.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/DecomposedGlyphs.cpp:
(WebCore::DecomposedGlyphs::DecomposedGlyphs):
(WebCore::m_renderingResourceIdentifier): Deleted.
(WebCore::DecomposedGlyphs::~DecomposedGlyphs): Deleted.
* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::~NativeImage): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/RenderingResource.h: Added.
(WebCore::RenderingResource::~RenderingResource):
(WebCore::RenderingResource::renderingResourceIdentifier const):
(WebCore::RenderingResource::addObserver):
(WebCore::RenderingResource::removeObserver):
(WebCore::RenderingResource::RenderingResource):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::releaseRenderingResource):
(WebKit::RemoteRenderingBackend::releaseRenderingResourceWithQualifiedIdentifier):
(WebKit::RemoteRenderingBackend::releaseResource): Deleted.
(WebKit::RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::releaseRenderingResource):
(WebKit::RemoteResourceCache::releaseResource): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::releaseRenderingResource):
(WebKit::RemoteRenderingBackendProxy::releaseRemoteResource): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::releaseImageBuffer):
(WebKit::RemoteResourceCacheProxy::releaseRenderingResource):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
(WebKit::RemoteResourceCacheProxy::releaseNativeImage): Deleted.
(WebKit::RemoteResourceCacheProxy::releaseDecomposedGlyphs): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/262021@main">https://commits.webkit.org/262021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28194f8a0f2ea915e2540e437ec393cca153bdef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/193 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/211 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/187 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; 39 api tests failed or timed out; 39 api tests failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/184 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/283 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/166 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/193 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/71 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/187 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->