### PR TITLE
[JSC] Fix Temporal regulateTime's constraints for milliseconds, microseconds, and nanoseconds

### DIFF
--- a/JSTests/stress/temporal-plaintime-tostring-1000-millisecond.js
+++ b/JSTests/stress/temporal-plaintime-tostring-1000-millisecond.js
@@ -1,0 +1,43 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let data = Temporal.PlainTime.from({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 1000,
+      microsecond: 0,
+      nanosecond: 0,
+    }).toString();
+
+    shouldBe(data, `00:00:00.999`);
+}
+{
+    let data = Temporal.PlainTime.from({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 1000,
+      nanosecond: 0,
+    }).toString();
+
+    shouldBe(data, `00:00:00.000999`);
+}
+{
+    let data = Temporal.PlainTime.from({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+      microsecond: 0,
+      nanosecond: 1000,
+    }).toString();
+
+    shouldBe(data, `00:00:00.000000999`);
+}

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -375,9 +375,9 @@ static ISO8601::PlainTime constrainTime(ISO8601::Duration&& duration)
         constrainToRange(duration.hours(), 0, 23),
         constrainToRange(duration.minutes(), 0, 59),
         constrainToRange(duration.seconds(), 0, 59),
-        constrainToRange(duration.milliseconds(), 0, 1000),
-        constrainToRange(duration.microseconds(), 0, 1000),
-        constrainToRange(duration.nanoseconds(), 0, 1000));
+        constrainToRange(duration.milliseconds(), 0, 999),
+        constrainToRange(duration.microseconds(), 0, 999),
+        constrainToRange(duration.nanoseconds(), 0, 999));
 }
 
 static ISO8601::PlainTime regulateTime(JSGlobalObject* globalObject, ISO8601::Duration&& duration, TemporalOverflow overflow)

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -110,7 +110,11 @@ class CSSStyleValue : public RefCounted<CSSStyleValue>, public ScriptWrappable {
 public:
     String toString() const;
     virtual void serialize(StringBuilder&, OptionSet<SerializationArguments> = { }) const;
+
+IGNORE_GCC_WARNINGS_BEGIN("mismatched-new-delete")
+    // https://webkit.org/b/241516
     virtual ~CSSStyleValue() = default;
+IGNORE_GCC_WARNINGS_END
 
     virtual CSSStyleValueType getType() const { return CSSStyleValueType::CSSStyleValue; }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3191,5 +3191,5 @@ void WKPageDispatchActivityStateUpdateForTesting(WKPageRef pageRef)
 
 uint64_t WKPageGetIdentifier(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->identifier().toUInt64();
+    return toImpl(pageRef)->webPageID().toUInt64();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4141,6 +4141,9 @@ static void adjustSettingsForCaptivePortal(Settings& settings, const WebPreferen
 #if ENABLE(PDFJS)
     settings.setPdfJSViewerEnabled(true);
 #endif
+#if USE(SYSTEM_PREVIEW)
+    settings.setSystemPreviewEnabled(false);
+#endif
 
     settings.setAllowedMediaContainerTypes(store.getStringValueForKey(WebPreferencesKey::mediaContainerTypesAllowedInCaptivePortalModeKey()));
     settings.setAllowedMediaCodecTypes(store.getStringValueForKey(WebPreferencesKey::mediaCodecTypesAllowedInCaptivePortalModeKey()));


### PR DESCRIPTION
#### 9b4ed7838982af6ad2539c1a58012e9fe832be36
<pre>
[JSC] Fix Temporal regulateTime&apos;s constraints for milliseconds, microseconds, and nanoseconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=241818">https://bugs.webkit.org/show_bug.cgi?id=241818</a>
rdar://95534859

Reviewed by Ross Kirsling.

This patch fixes constraints for milliseconds, microseconds, and nanoseconds in constrainTime.
It should be from 0 to 999, not to 1000[1].

[1]: <a href="https://tc39.es/proposal-temporal/#sec-temporal-constraintime">https://tc39.es/proposal-temporal/#sec-temporal-constraintime</a>

* JSTests/stress/temporal-plaintime-tostring-1000-millisecond.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::constrainTime):

Canonical link: <a href="https://commits.webkit.org/251698@main">https://commits.webkit.org/251698@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295693">https://svn.webkit.org/repository/webkit/trunk@295693</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
