### PR TITLE
Log a message when initializing the WebContent process

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -238,8 +238,21 @@ static void softlinkDataDetectorsFrameworks()
 #endif // ENABLE(DATA_DETECTION)
 }
 
+static void initializeXPCConnectionToLogd()
+{
+    // Log a long message to make sure the XPC connection to the log daemon for oversized messages is opened.
+    // This is needed to block launchd after the WebContent process has launched, since access to launchd is
+    // required when opening new XPC connections.
+    char stringWithSpaces[1024];
+    memset(stringWithSpaces, ' ', sizeof(stringWithSpaces));
+    stringWithSpaces[sizeof(stringWithSpaces) - 1] = 0;
+    RELEASE_LOG(Process, "WebProcess::platformInitializeWebProcess %s", stringWithSpaces);
+}
+
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
+    initializeXPCConnectionToLogd();
+    
     applyProcessCreationParameters(parameters.auxiliaryProcessParameters);
 
     setQOS(parameters.latencyQOS, parameters.throughputQOS);


### PR DESCRIPTION
#### c2a9f39f42b833b6c1640f954cfc06a712dd04cd
<pre>
Log a message when initializing the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=241829">https://bugs.webkit.org/show_bug.cgi?id=241829</a>

Reviewed by Geoffrey Garen.

Log a long message to make sure the XPC connection to the log daemon for oversized messages is opened.
This is needed to block launchd after the WebContent process has launched, since access to launchd is
required when opening new XPC connections.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::initializeXPCConnectionToLogd):
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/251892@main">https://commits.webkit.org/251892@main</a>
</pre>
