### PR TITLE
Add validation for offset against size for multidraw calls.

### DIFF
--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -187,6 +187,11 @@ bool WebGLMultiDraw::validateOffset(const char* functionName, const char* outOfB
         return false;
     }
 
+    if (offset >= static_cast<GCGLuint>(size)) {
+        m_context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, outOfBoundsDescription);
+        return false;
+    }
+
     if (offset > static_cast<GCGLuint>(size - drawcount)) {
         m_context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, outOfBoundsDescription);
         return false;


### PR DESCRIPTION
#### 8b1a4038acb20bdb58e1617ae641365bff7a5970
<pre>
Add validation for offset against size for multidraw calls.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241841">https://bugs.webkit.org/show_bug.cgi?id=241841</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::validateOffset):
</pre>