### PR TITLE
Make sure to close connections in webrtc/datachannel/mdns-ice-candidates.html

### DIFF
--- a/LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt
+++ b/LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt
@@ -1,3 +1,7 @@
+CONSOLE MESSAGE: receiving one
+CONSOLE MESSAGE: receiving two
+CONSOLE MESSAGE: receiving three
+CONSOLE MESSAGE: receiving four
 
 PASS Getting some MDNS candidates
 PASS Basic data channel exchange from offerer to receiver

--- a/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
+++ b/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
@@ -22,6 +22,9 @@ function closeDataChannels() {
 }
 
 function receiveMessages(event) {
+if (window.logReceivedMessage)
+    console.log("receiving " + event.data);
+
 try {
     if (++counter === 1)
         assert_equals(event.data, "one");
@@ -72,9 +75,9 @@ promise_test(async (test) => {
 }, "Getting some MDNS candidates");
 
 var finishTest;
-promise_test((test) => {
+promise_test(async (test) => {
     counter = 0;
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
         finishTest = resolve;
         createConnections((localConnection) => {
             localChannel = localConnection.createDataChannel('sendDataChannel');
@@ -90,9 +93,9 @@ promise_test((test) => {
     closeConnections();
 }, "Basic data channel exchange from offerer to receiver");
 
-promise_test((test) => {
+promise_test(async (test) => {
     counter = 0;
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
         finishTest = resolve;
         createConnections((localConnection) => {
             localChannel = localConnection.createDataChannel('sendDataChannel');
@@ -109,9 +112,9 @@ promise_test((test) => {
 }, "Basic data channel exchange from receiver to offerer");
 
 
-promise_test((test) => {
+promise_test(async (test) => {
     counter = 0;
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
         finishTest = resolve;
         createConnections((localConnection) => {
             localChannel = localConnection.createDataChannel('sendDataChannel');
@@ -127,19 +130,11 @@ promise_test((test) => {
     closeConnections();
 }, "Basic data channel exchange from offerer to receiver using UDP only");
 
-promise_test((test) => {
-    counter = 0;
-    return new Promise((resolve, reject) => {
-        var checkDataChannelOptions = (channel, init) => {
-            assert_equals(channel.ordered, init.ordered, "ordered");
-            assert_equals(channel.maxPacketLifeTime, init.maxPacketLifeTime, "maxPacketLifeTime");
-            assert_equals(channel.maxRetransmitTime, init.maxRetransmitTime, "maxRetransmitTime");
-            assert_equals(channel.maxRetransmits, init.maxRetransmits, "maxRetransmits");
-            assert_equals(channel.protocol, init.protocol, "protocol");
-            assert_equals(channel.negotiated, init.negotiated, "negotiated");
-            assert_equals(channel.id, init.id, "id");
-        };
+promise_test(async (test) => {
+    window.logReceivedMessage = true;
 
+    counter = 0;
+    await new Promise((resolve, reject) => {
         finishTest = resolve;
         createConnections((localConnection) => {
             var init = { ordered: true, maxPacketLifeTime: 10, maxRetransmitTime: 11, protocol: "whatever", negotiated: false, id: 1 };
@@ -154,6 +149,8 @@ promise_test((test) => {
         setTimeout(() => { reject("Test timed out"); }, 5000);
     });
     closeConnections();
+
+    window.logReceivedMessage = false;
 }, "Basic data channel exchange from offerer to receiver 2");
 
 promise_test(async (test) => {


### PR DESCRIPTION
#### 5fe6b7111edcce81c35607715861996b50f5de5c
<pre>
Make sure to close connections in webrtc/datachannel/mdns-ice-candidates.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=241846">https://bugs.webkit.org/show_bug.cgi?id=241846</a>

Patch by Youenn Fablet &lt;youennf@gmail.com&gt; on 2022-06-22
Reviewed by Eric Carlson.

Make sure to close connections by using await instead of return.
Add some logging to further check the failing test in bots.
Remove some unnecessary code.

* LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt:
* LayoutTests/webrtc/datachannel/mdns-ice-candidates.html:

Canonical link: <a href="https://commits.webkit.org/251774@main">https://commits.webkit.org/251774@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295769">https://svn.webkit.org/repository/webkit/trunk@295769</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
