### PR TITLE
Remove ErrorEventInit's error default

### DIFF
--- a/LayoutTests/fast/events/constructors/error-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/error-event-constructor-expected.txt
@@ -64,7 +64,7 @@ PASS new ErrorEvent('eventType', { colno: 0 }).colno is 0
 PASS new ErrorEvent('eventType', { colno: 1 }).colno is 1
 PASS new ErrorEvent('eventType', { colno: 4294967294 }).colno is 4294967294
 PASS new ErrorEvent('eventType', { colno: 4294967295 }).colno is 4294967295
-PASS new ErrorEvent('eventType', { error: undefined }).error is null
+PASS new ErrorEvent('eventType', { error: undefined }).error is undefined
 PASS new ErrorEvent('eventType', { error: null }).error is null
 PASS new ErrorEvent('eventType', { error: '' }).error is ''
 PASS new ErrorEvent('eventType', { error: '12345' }).error is '12345'

--- a/LayoutTests/fast/events/constructors/error-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/error-event-constructor.html
@@ -82,7 +82,7 @@ shouldBe("new ErrorEvent('eventType', { colno: 4294967294 }).colno", "4294967294
 shouldBe("new ErrorEvent('eventType', { colno: 4294967295 }).colno", "4294967295");
 
 // error is passed.
-shouldBe("new ErrorEvent('eventType', { error: undefined }).error", "null");
+shouldBe("new ErrorEvent('eventType', { error: undefined }).error", "undefined");
 shouldBe("new ErrorEvent('eventType', { error: null }).error", "null");
 shouldBe("new ErrorEvent('eventType', { error: '' }).error", "''");
 shouldBe("new ErrorEvent('eventType', { error: '12345' }).error", "'12345'");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent-expected.txt
@@ -1,3 +1,4 @@
 
 PASS error event is normal (return true does not cancel; one arg) on Document, with a synthetic ErrorEvent
+PASS Initial values of ErrorEvent members
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent.html
@@ -21,10 +21,24 @@ promise_test(t => {
   const eventWatcher = new EventWatcher(t, document, "error");
   const promise = eventWatcher.wait_for("error").then(e => {
     assert_equals(e.defaultPrevented, false);
+    assert_equals(e.message, "");
+    assert_equals(e.filename, "");
+    assert_equals(e.lineno, 0);
+    assert_equals(e.colno, 0);
+    assert_equals(e.error, undefined);
   });
 
   document.dispatchEvent(new ErrorEvent("error", { cancelable: true }));
 
   return promise;
 }, "error event is normal (return true does not cancel; one arg) on Document, with a synthetic ErrorEvent");
+
+test(() => {
+  const e = new ErrorEvent("error");
+  assert_equals(e.message, "");
+  assert_equals(e.filename, "");
+  assert_equals(e.lineno, 0);
+  assert_equals(e.colno, 0);
+  assert_equals(e.error, undefined);
+}, "Initial values of ErrorEvent members")
 </script>

--- a/Source/WebCore/dom/ErrorEvent.h
+++ b/Source/WebCore/dom/ErrorEvent.h
@@ -57,7 +57,7 @@ public:
         String filename;
         unsigned lineno { 0 };
         unsigned colno { 0 };
-        JSC::JSValue error;
+        JSC::JSValue error { JSC::jsUndefined() };
     };
 
     static Ref<ErrorEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)

--- a/Source/WebCore/dom/ErrorEvent.idl
+++ b/Source/WebCore/dom/ErrorEvent.idl
@@ -47,5 +47,5 @@ dictionary ErrorEventInit : EventInit {
     USVString filename = "";
     unsigned long lineno = 0;
     unsigned long colno = 0;
-    any error = null;
+    any error;
 };


### PR DESCRIPTION
#### c649008d0fd5c0f083c8a13e867b5f8042f2ecde
<pre>
Remove ErrorEventInit&apos;s error default
<a href="https://bugs.webkit.org/show_bug.cgi?id=241259">https://bugs.webkit.org/show_bug.cgi?id=241259</a>
&lt;rdar://94793559&gt;

Reviewed by Darin Adler.

Update ErrorEventInit&apos;s error default to be undefined instead of null, as per:
- <a href="https://github.com/whatwg/html/pull/7983">https://github.com/whatwg/html/pull/7983</a>

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent.html:
* Source/WebCore/dom/ErrorEvent.cpp:
(WebCore::ErrorEvent::error):
* Source/WebCore/dom/ErrorEvent.idl:

Canonical link: <a href="https://commits.webkit.org/251797@main">https://commits.webkit.org/251797@main</a>
</pre>
