### PR TITLE
Update lldbWebKitTester's CLANG_DEBUG_INFORMATION_LEVEL workaround for workspace builds

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -323,8 +323,9 @@ class CompileWebKit(shell.Compile):
             # For build-only bots, the expectation is that tests will be run on separate machines,
             # so we need to package debug info as dSYMs. Only generating line tables makes
             # this much faster than full debug info, and crash logs still have line numbers.
+            # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
             self.setCommand(self.command + ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym'])
-            self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=line-tables-only'])
+            self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=$(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only)'])
         if platform == 'gtk':
             prefix = os.path.join("/app", "webkit", "WebKitBuild", self.getProperty("configuration").title(), "install")
             self.setCommand(self.command + [f'--prefix={prefix}'])

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2438,8 +2438,9 @@ class CompileWebKit(shell.Compile, AddToLogMixin):
             # For build-only bots, the expectation is that tests will be run on separate machines,
             # so we need to package debug info as dSYMs. Only generating line tables makes
             # this much faster than full debug info, and crash logs still have line numbers.
+            # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
             self.setCommand(self.command + ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym'])
-            self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=line-tables-only'])
+            self.setCommand(self.command + ['CLANG_DEBUG_INFORMATION_LEVEL=$(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only)'])
         if platform == 'gtk':
             prefix = os.path.join("/app", "webkit", "WebKitBuild", self.getProperty("configuration"), "install")
             self.setCommand(self.command + [f'--prefix={prefix}'])

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2108,17 +2108,6 @@ sub buildXCodeProject($$@)
 
     chomp($ENV{DSYMUTIL_NUM_THREADS} = `sysctl -n hw.activecpu`);
 
-    # lldbWebKitTester won't work with the wrong CLANG_DEBUG_INFORMATION_LEVEL, so always use the default for that project
-    if ($project eq "lldbWebKitTester") {
-        my $index = 0;
-        while ($index < scalar(@extraOptions)) {
-            if ($extraOptions[$index] =~ /CLANG_DEBUG_INFORMATION_LEVEL=/) {
-                splice @extraOptions, $index, 1;
-            } else {
-                $index += 1;
-            }
-        }
-    }
     return system "xcodebuild", "-project", "$project.xcodeproj", @extraOptions;
 }
 

--- a/Tools/lldb/lldbWebKitTester/Configurations/lldbWebKitTester.xcconfig
+++ b/Tools/lldb/lldbWebKitTester/Configurations/lldbWebKitTester.xcconfig
@@ -26,6 +26,10 @@ PRODUCT_NAME = $(TARGET_NAME);
 RELEASE_DEFINES = RELEASE_WITHOUT_OPTIMIZATIONS;
 RELEASE_DEFINES[config=Debug] = ;
 
+// Prevent WebKit CI from reducing debug info to line tables; full type
+// information is needed to test properly.
+WK_OVERRIDE_DEBUG_INFORMATION_LEVEL = default;
+
 SUPPORTED_PLATFORMS = macosx;
 
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(RELEASE_DEFINES);


### PR DESCRIPTION
#### 1b9d28989feaef9d3488cdfe4c40795944ac94b8
<pre>
Update lldbWebKitTester&apos;s CLANG_DEBUG_INFORMATION_LEVEL workaround for workspace builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=241863">https://bugs.webkit.org/show_bug.cgi?id=241863</a>

Reviewed by Alexey Proskuryakov.

When building lldbWebKitTester, we used to transparently filter out the
CLANG_DEBUG_INFORMATION_LEVEL setting that buildbot passes. Now that
builds are a single xcodebuild invocation, we cannot do that.

Introduce a WK_OVERRIDE_DEBUG_INFORMATION_LEVEL setting, which
lldbWebKitTester sets to its required debug info level. Change
buildbot&apos;s overrides to prefer this setting over `line-tables-only`.

* Tools/CISupport/build-webkit-org/steps.py:
(CompileWebKit.start):
* Tools/CISupport/ews-build/steps.py:
(CompileWebKit.start):
* Tools/Scripts/webkitdirs.pm:
(buildXCodeProject):
* Tools/lldb/lldbWebKitTester/Configurations/lldbWebKitTester.xcconfig:

Canonical link: <a href="https://commits.webkit.org/251808@main">https://commits.webkit.org/251808@main</a>
</pre>
