### PR TITLE
Canvas elements not garbage collected immediately in Safari on iOS 12

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,7 @@
 # WebKit
 
+Should we remove the limit on canvas memory use?
+
 WebKit is a cross-platform web browser engine. On iOS and macOS, it powers Safari, Mail, iBooks, and many other applications.
 
 ## Feature Status


### PR DESCRIPTION
#### a7d3049eaf1df79d88ad52331fa3739610ef62d5
<pre>
Canvas context allocation fails because &quot;Total canvas memory use exceeds the maximum limit&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=195325">https://bugs.webkit.org/show_bug.cgi?id=195325</a>
rdar://48609162

Reviewed by Geoff Garen.

Some pages that use a lot of transient canvas memory can hit our
artificial limits even when they are no longer referencing canvases.
This happens because we don&apos;t instantly reclaim memory when we
drop the reference, and instead have to wait for garbage collection.
This problem can also continue between page refreshes.

The limit was introduced many many releases ago when devices had
less memory, and it was more common to accidentally jetsam a page
if you used too much canvas memory. After some internal and external
discussion we&apos;ve decided to remove the canvas limit and just let the page
follow the same memory restrictions as all other Web features.

This might mean more pages crash (jetsam) than break.

* LayoutTests/fast/canvas/canvas-too-large-to-draw-expected.txt: Removed.
* LayoutTests/fast/canvas/canvas-too-large-to-draw.html: Removed.
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::allocateImageBuffer const):
(WebCore::CanvasBase::maxActivePixelMemory): Deleted.
(WebCore::CanvasBase::setMaxPixelMemoryForTesting): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContext2d):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::avoidIOSurfaceSizeCheckInWebProcess):
(WebCore::Internals::setMaxCanvasPixelMemory): Deleted.
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::getPixelBufferForImageBufferWithNewMemory):
</pre>