### PR TITLE
[Modern Media Controls] [iOS] controls should only be shown after a "full" tap, not just touchstart

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
@@ -91,7 +91,10 @@ class AutoHideController
 
         switch (event.type) {
         case "pointermove":
-            this._mediaControls.faded = false;
+            // If the pointer is a mouse (supports hover), immediately show the controls.
+            if (event.pointerType === "mouse")
+                this._mediaControls.faded = false;
+
             if (this._mediaControls.isPointInControls(new DOMPoint(event.clientX, event.clientY))) {
                 this._pointerIdentifiersPreventingAutoHideForHover.add(event.pointerId);
                 this._cancelAutoHideTimer();
@@ -118,7 +121,11 @@ class AutoHideController
             // if we recognize a tap, if it should fade the controls out.
             this._nextTapCanFadeControls = !this._mediaControls.faded;
             this._pointerIdentifiersPreventingAutoHide.add(event.pointerId);
-            this._mediaControls.faded = false;
+
+            // If the pointer is a mouse (supports hover), immediately show the controls.
+            if (event.pointerType === "mouse")
+                this._mediaControls.faded = false;
+
             this._cancelAutoHideTimer();
             return;
 


### PR DESCRIPTION
#### e358e1ccad2a1ce126e53013bfd684e761573fcc
<pre>
[Modern Media Controls] [iOS] controls should only be shown after a &quot;full&quot; tap, not just touchstart
<a href="https://bugs.webkit.org/show_bug.cgi?id=241875">https://bugs.webkit.org/show_bug.cgi?id=241875</a>
&lt;rdar://problem/95646138&gt;

Reviewed by Eric Carlson.

* Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js:
(AutoHideController.prototype.handleEvent):

Canonical link: <a href="https://commits.webkit.org/251786@main">https://commits.webkit.org/251786@main</a>
</pre>
