### PR TITLE
Build is broken: bitwise operation between different enumeration types in ShareableBitmapCG.cpp

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1852,3 +1852,5 @@ webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/w
 webkit.org/b/241266 compositing/video/video-border-radius.html [ Pass Timeout ]
 
 webkit.org/b/241376 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/241879 fast/replaced/encrypted-pdf-as-object-and-embed.html [ Pass Crash ]

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2315,7 +2315,7 @@ bool Element::isEventHandlerAttribute(const Attribute& attribute) const
     return attribute.name().namespaceURI().isNull() && attribute.name().localName().startsWith("on"_s);
 }
 
-bool Element::attributeContainsJavascriptURL(const Attribute& attribute) const
+bool Element::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
     return isURLAttribute(attribute) && WTF::protocolIsJavaScript(stripLeadingAndTrailingHTMLSpaces(attribute.value()));
 }
@@ -2324,7 +2324,7 @@ void Element::stripScriptingAttributes(Vector<Attribute>& attributeVector) const
 {
     attributeVector.removeAllMatching([this](auto& attribute) -> bool {
         return this->isEventHandlerAttribute(attribute)
-            || this->attributeContainsJavascriptURL(attribute)
+            || this->attributeContainsJavaScriptURL(attribute)
             || this->isHTMLContentAttribute(attribute);
     });
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -294,7 +294,7 @@ public:
     void parserSetAttributes(const Vector<Attribute>&);
 
     bool isEventHandlerAttribute(const Attribute&) const;
-    virtual bool attributeContainsJavascriptURL(const Attribute&) const;
+    virtual bool attributeContainsJavaScriptURL(const Attribute&) const;
 
     // Remove attributes that might introduce scripting from the vector leaving the element unchanged.
     void stripScriptingAttributes(Vector<Attribute>&) const;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -238,7 +238,7 @@ void ReplacementFragment::removeContentsWithSideEffects()
         }
         if (element->hasAttributes()) {
             for (auto& attribute : element->attributesIterator()) {
-                if (element->isEventHandlerAttribute(attribute) || element->attributeContainsJavascriptURL(attribute))
+                if (element->isEventHandlerAttribute(attribute) || element->attributeContainsJavaScriptURL(attribute))
                     attributesToRemove.append({ element.copyRef(), attribute.name() });
             }
         }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -556,7 +556,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
             // We'll handle the style attribute separately, below.
             if (attribute.name() == styleAttr && shouldOverrideStyleAttr)
                 continue;
-            if (element.isEventHandlerAttribute(attribute) || element.attributeContainsJavascriptURL(attribute))
+            if (element.isEventHandlerAttribute(attribute) || element.attributeContainsJavaScriptURL(attribute))
                 continue;
 #if ENABLE(DATA_DETECTION)
             if (replacementType == SpanReplacementType::DataDetector && DataDetection::isDataDetectorAttribute(attribute.name()))

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -148,7 +148,7 @@ bool SVGAnimationElement::isSupportedAttribute(const QualifiedName& attrName)
     return supportedAttributes.get().contains<SVGAttributeHashTranslator>(attrName);
 }
 
-bool SVGAnimationElement::attributeContainsJavascriptURL(const Attribute& attribute) const
+bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
     if (attribute.name() == SVGNames::fromAttr || attribute.name() == SVGNames::toAttr)
         return WTF::protocolIsJavaScript(stripLeadingAndTrailingHTMLSpaces(attribute.value()));
@@ -160,7 +160,7 @@ bool SVGAnimationElement::attributeContainsJavascriptURL(const Attribute& attrib
         }
         return false;
     }
-    return Element::attributeContainsJavascriptURL(attribute);
+    return Element::attributeContainsJavaScriptURL(attribute);
 }
 
 void SVGAnimationElement::parseAttribute(const QualifiedName& name, const AtomString& value)

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -88,7 +88,7 @@ protected:
     virtual void resetAnimation();
 
     static bool isSupportedAttribute(const QualifiedName&);
-    bool attributeContainsJavascriptURL(const Attribute&) const final;
+    bool attributeContainsJavaScriptURL(const Attribute&) const final;
     void parseAttribute(const QualifiedName&, const AtomString&) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
@@ -69,14 +69,14 @@ static CGBitmapInfo bitmapInfo(const ShareableBitmap::Configuration& configurati
 {
     CGBitmapInfo info = 0;
     if (wantsExtendedRange(configuration)) {
-        info |= kCGBitmapFloatComponents | kCGBitmapByteOrder16Host;
+        info |= kCGBitmapFloatComponents | static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host);
 
         if (configuration.isOpaque)
             info |= kCGImageAlphaNoneSkipLast;
         else
             info |= kCGImageAlphaPremultipliedLast;
     } else {
-        info |= kCGBitmapByteOrder32Host;
+        info |= static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
 
         if (configuration.isOpaque)
             info |= kCGImageAlphaNoneSkipFirst;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2668,7 +2668,7 @@
 		1A07D2F71919B36500ECDA16 /* Copy Message Generation Scripts */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = PrivateHeaders/Scripts/webkit;
+			dstPath = "$(WK_FRAMEWORK_VERSION_PREFIX)PrivateHeaders/Scripts/webkit";
 			dstSubfolderSpec = 1;
 			files = (
 				1A07D2F81919B3A900ECDA16 /* __init__.py in Copy Message Generation Scripts */,

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -722,19 +722,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		535E08CB2254637200DF00CA /* Copy Mig Files into Private Framework Headers */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = PrivateHeaders;
-			dstSubfolderSpec = 1;
-			files = (
-			);
-			name = "Copy Mig Files into Private Framework Headers";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		065AD5A10B0C32C7005A2B1D /* WebContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebContextMenuClient.h; sourceTree = "<group>"; };
 		065AD5A20B0C32C7005A2B1D /* WebContextMenuClient.mm */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContextMenuClient.mm; sourceTree = "<group>"; };
@@ -3169,7 +3156,6 @@
 				7C02321B251B9A8A00BA7BB6 /* Generate Preferences */,
 				9398100D0824BF01008DF038 /* Headers */,
 				DDF74CA027EE3E990011F633 /* (Legacy) Install Headers */,
-				535E08CB2254637200DF00CA /* Copy Mig Files into Private Framework Headers */,
 				939810B20824BF01008DF038 /* Resources */,
 				1C395DE20C6BE8E0000D1E52 /* Generate Export Files */,
 				939810BB0824BF01008DF038 /* Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -376,7 +376,7 @@ static RetainPtr<CGImageRef> iconImage()
 static void simulateCalloutBarAppearance(TestWKWebView *webView)
 {
     __block bool done = false;
-    [webView.textInputContentView requestRectsToEvadeForSelectionCommandsWithCompletionHandler:^(NSArray<NSValue *> *) {
+    [webView.textInputContentView requestPreferredArrowDirectionForEditMenuWithCompletionHandler:^(UIEditMenuArrowDirection) {
         done = true;
     }];
     Util::run(&done);

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -34,7 +34,7 @@
 @protocol UITextInputInternal;
 @protocol UITextInputMultiDocument;
 @protocol UITextInputPrivate;
-@protocol UIWKInteractionViewProtocol_Staging_91919121;
+@protocol UIWKInteractionViewProtocol_Staging_95652872;
 #endif
 
 @interface WKWebView (AdditionalDeclarations)
@@ -50,7 +50,7 @@
 
 @interface WKWebView (TestWebKitAPI)
 #if PLATFORM(IOS_FAMILY)
-@property (nonatomic, readonly) UIView <UITextInputPrivate, UITextInputInternal, UITextInputMultiDocument, UIWKInteractionViewProtocol_Staging_91919121, UITextInputTokenizer> *textInputContentView;
+@property (nonatomic, readonly) UIView <UITextInputPrivate, UITextInputInternal, UITextInputMultiDocument, UIWKInteractionViewProtocol_Staging_95652872, UITextInputTokenizer> *textInputContentView;
 - (NSArray<_WKTextInputContext *> *)synchronouslyRequestTextInputContextsInRect:(CGRect)rect;
 #endif
 @property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -214,7 +214,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 
 @protocol UIWKInteractionViewProtocol
 - (void)pasteWithCompletionHandler:(void (^)(void))completionHandler;
-- (void)requestRectsToEvadeForSelectionCommandsWithCompletionHandler:(void(^)(NSArray<NSValue *> *rects))completionHandler;
 - (void)requestAutocorrectionRectsForString:(NSString *)input withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForInput))completionHandler;
 - (void)requestAutocorrectionContextWithCompletionHandler:(void (^)(UIWKAutocorrectionContext *autocorrectionContext))completionHandler;
 - (void)selectWordBackward;
@@ -356,6 +355,12 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 @optional
 - (void)willInsertFinalDictationResult;
 - (void)didInsertFinalDictationResult;
+@end
+
+@protocol UIWKInteractionViewProtocol_Staging_95652872 <UIWKInteractionViewProtocol_Staging_91919121>
+#if HAVE(UI_EDIT_MENU_INTERACTION)
+- (void)requestPreferredArrowDirectionForEditMenuWithCompletionHandler:(void (^)(UIEditMenuArrowDirection))completionHandler;
+#endif
 @end
 
 #if HAVE(UIFINDINTERACTION)


### PR DESCRIPTION
#### 3f4e9d1a399dc72c6bb0fb80f32ecd9f379d9868
<pre>
Build is broken: bitwise operation between different enumeration types in ShareableBitmapCG.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=241876">https://bugs.webkit.org/show_bug.cgi?id=241876</a>

Unreviewed build fix.

* Source/WebKit/Shared/cg/ShareableBitmapCG.cpp:
(WebKit::bitmapInfo):
Add some casts.

Canonical link: <a href="https://commits.webkit.org/251759@main">https://commits.webkit.org/251759@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295754">https://svn.webkit.org/repository/webkit/trunk@295754</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
