### PR TITLE
Fix CodeSign error caused by Product Dependencies phase

### DIFF
--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
@@ -69,14 +69,14 @@ static CGBitmapInfo bitmapInfo(const ShareableBitmap::Configuration& configurati
 {
     CGBitmapInfo info = 0;
     if (wantsExtendedRange(configuration)) {
-        info |= kCGBitmapFloatComponents | kCGBitmapByteOrder16Host;
+        info |= kCGBitmapFloatComponents | static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host);
 
         if (configuration.isOpaque)
             info |= kCGImageAlphaNoneSkipLast;
         else
             info |= kCGImageAlphaPremultipliedLast;
     } else {
-        info |= kCGBitmapByteOrder32Host;
+        info |= static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
 
         if (configuration.isOpaque)
             info |= kCGImageAlphaNoneSkipFirst;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1721,7 +1721,7 @@
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 7;
+			dstSubfolderSpec = 16;
 			files = (
 				DD42949F284BE0B7004D49ED /* WebKit.framework in Product Dependencies */,
 			);


### PR DESCRIPTION
#### bf5a683664e9e54c97c8b06fd7262b951ea31b0e
<pre>
Fix CodeSign error caused by Product Dependencies phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=241713">https://bugs.webkit.org/show_bug.cgi?id=241713</a>

Unreviewed build fix.

Product Dependencies phases must be set to the &quot;Products Directory&quot;
destination. Otherwise, they unintentionally embed the dependencies into
their target&apos;s build product. This one must have been a default setting
that got overlooked.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/251760@main">https://commits.webkit.org/251760@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295755">https://svn.webkit.org/repository/webkit/trunk@295755</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
