### PR TITLE
Stripping whitespace in <animate> values attribute should use stripLeadingAndTrailingHTMLSpaces

### DIFF
--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -155,7 +155,7 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue.stripWhiteSpace()))
+            if (WTF::protocolIsJavaScript(stripLeadingAndTrailingHTMLSpaces(innerValue.toString())))
                 return true;
         }
         return false;
@@ -171,7 +171,7 @@ void SVGAnimationElement::parseAttribute(const QualifiedName& name, const AtomSt
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         value.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.stripWhiteSpace().toString());
+            m_values.append(stripLeadingAndTrailingHTMLSpaces(innerValue.toString()));
         });
 
         updateAnimationMode();


### PR DESCRIPTION
#### b1a443b54ece9b0e6c3beb8552faa21fbaa8d0af
<pre>
Stripping whitespace in &lt;animate&gt; values attribute should use stripLeadingAndTrailingHTMLSpaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=241867">https://bugs.webkit.org/show_bug.cgi?id=241867</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeContainsJavaScriptURL const):
(WebCore::SVGAnimationElement::parseAttribute):
</pre>