### PR TITLE
Start Live Text image analysis when Find-in-Page is performed on MacOS Safari

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -381,6 +381,18 @@ IPCTestingAPIEnabled:
     WebKit:
       default: false
 
+ImageAnalysisDuringFindInPageEnabled:
+  type: bool
+  humanReadableName: "Image Analysis for Find-in-Page"
+  humanReadableDescription: "Trigger image analysis when performing Find-in-Page"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 InlineFormattingContextIntegrationEnabled:
   type: bool
   humanReadableName: "Next-generation inline layout integration (IFC)"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -808,6 +808,16 @@ bool Page::findString(const String& target, FindOptions options, DidWrap* didWra
     return false;
 }
 
+#if ENABLE(IMAGE_ANALYSIS)
+void Page::analyzeImagesForFindInPage()
+{
+    if (settings().imageAnalysisDuringFindInPageEnabled()) {
+        if (RefPtr mainDocument = m_mainFrame->document(); mainDocument && !m_imageAnalysisQueue)
+            imageAnalysisQueue().enqueueAllImages(*mainDocument, { }, { });
+    }
+}
+#endif
+
 auto Page::findTextMatches(const String& target, FindOptions options, unsigned limit, bool markMatches) -> MatchingRanges
 {
     MatchingRanges result;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -972,6 +972,9 @@ public:
 
     WEBCORE_EXPORT void forceRepaintAllFrames();
 
+#if ENABLE(IMAGE_ANALYSIS)
+    WEBCORE_EXPORT void analyzeImagesForFindInPage();
+#endif
 private:
     struct Navigation {
         RegistrableDomain domain;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/FrameView.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageAnalysisQueue.h>
 #include <WebCore/ImageOverlay.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>
@@ -236,6 +237,10 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 {
 #if ENABLE(PDFKIT_PLUGIN)
     auto* pluginView = mainFramePlugIn();
+#endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+    m_webPage->corePage()->analyzeImagesForFindInPage();
 #endif
 
     WebCore::FindOptions coreOptions = core(options);


### PR DESCRIPTION
#### 86cccca6075ebd2e357c6ab410881af35727d970
<pre>
Start Live Text image analysis when Find-in-Page is performed on MacOS Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=241877">https://bugs.webkit.org/show_bug.cgi?id=241877</a>
rdar://95726585

Reviewed by Wenson Hsieh.

Test:
FindInPAgeAPI.FindAPITextInImage

This patch makes it so that when Find-in-Page is performed, text within images
On the page is included in the results. This feature is placed behind a WebKit
internal feature flag.

Added a test that checks that an image analysis request is made after doing
Find-in-page.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:

Added internal feature flag &quot;ImageAnalysisDuringFindInPageEnabled&quot;.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::analyzeImagesForFindInPage):

Helper function that is called from FindController::FindString. If flag is
turned on, images are analyzed.

* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):

Now starts image analysis before beginning find-in-page.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
(FindInPageAPI::createWebViewWithImageAnalysisDuringFindInPageEnabled):
(FindInPageAPI::makeImageAnalysisRequestSwizzler):
(FindInPageAPI:makeFakeRequest):
(FindInPageAPI:processRequestWithResults):

Canonical link: <a href="https://commits.webkit.org/252515@main">https://commits.webkit.org/252515@main</a>
</pre>
