### PR TITLE
Replaced deprecated NSPasteboardNames with latest API constants

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -288,10 +288,8 @@ void Editor::takeFindStringFromSelection()
     Vector<String> types;
     types.append(String(legacyStringPasteboardType()));
     auto context = PagePasteboardContext::create(m_document.pageID());
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    platformStrategies()->pasteboardStrategy()->setTypes(types, NSFindPboard, context.get());
-    platformStrategies()->pasteboardStrategy()->setStringForType(WTFMove(stringFromSelection), legacyStringPasteboardType(), NSFindPboard, context.get());
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    platformStrategies()->pasteboardStrategy()->setTypes(types, NSPasteboardNameFind, context.get());
+    platformStrategies()->pasteboardStrategy()->setStringForType(WTFMove(stringFromSelection), legacyStringPasteboardType(), NSPasteboardNameFind, context.get());
 #else
     if (auto* client = this->client()) {
         // Since the find pasteboard doesn't exist on iOS, WebKit maintains its own notion of the latest find string,
@@ -361,12 +359,10 @@ void Editor::replaceNodeFromPasteboard(Node& node, const String& pasteboardName,
     }
 
 #if PLATFORM(MAC)
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // FIXME: How can this hard-coded pasteboard name be right, given that the passed-in pasteboard has a name?
     // FIXME: We can also remove `setInsertionPasteboard` altogether once Mail compose on macOS no longer uses WebKitLegacy,
     // since it's only implemented for WebKitLegacy on macOS, and the only known client is Mail compose.
-    client()->setInsertionPasteboard(NSGeneralPboard);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    client()->setInsertionPasteboard(NSPasteboardNameGeneral);
 #endif
 
     bool chosePlainText;

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -89,10 +89,8 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
 {
     auto range = selectedRange();
 
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // FIXME: How can this hard-coded pasteboard name be right, given that the passed-in pasteboard has a name?
-    client()->setInsertionPasteboard(NSGeneralPboard);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    client()->setInsertionPasteboard(NSPasteboardNameGeneral);
 
     bool chosePlainText;
     RefPtr<DocumentFragment> fragment = webContentFromPasteboard(*pasteboard, *range, options.contains(PasteOption::AllowPlainText), chosePlainText);

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -101,9 +101,7 @@ Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context, const Strin
 
 std::unique_ptr<Pasteboard> Pasteboard::createForCopyAndPaste(std::unique_ptr<PasteboardContext>&& context)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return makeUnique<Pasteboard>(WTFMove(context), NSGeneralPboard);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return makeUnique<Pasteboard>(WTFMove(context), NSPasteboardNameGeneral);
 }
 
 #if ENABLE(DRAG_SUPPORT)
@@ -114,9 +112,7 @@ String Pasteboard::nameOfDragPasteboard()
 
 std::unique_ptr<Pasteboard> Pasteboard::createForDragAndDrop(std::unique_ptr<PasteboardContext>&& context)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return makeUnique<Pasteboard>(WTFMove(context), NSDragPboard);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return makeUnique<Pasteboard>(WTFMove(context), NSPasteboardNameDrag);
 }
 
 std::unique_ptr<Pasteboard> Pasteboard::create(const DragData& dragData)

--- a/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
@@ -39,9 +39,7 @@ namespace WebKit {
 
 static NSPasteboard *findPasteboard()
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [NSPasteboard pasteboardWithName:NSFindPboard];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
 }
 
 #else

--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -4498,9 +4498,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, const ShareableBitmap
     // The call below could release the view.
     auto protector = m_view.get();
     auto clientDragLocation = item.dragLocationInWindowCoordinates;
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:NSDragPboard];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
 
     if (auto& info = item.promisedAttachmentInfo) {
         auto attachment = m_page->attachmentForIdentifier(info.attachmentIdentifier);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -453,9 +453,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)writeItemsToPasteboard:(NSArray *)items withTypes:(NSArray *)types
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    _pdfPlugin->writeItemsToPasteboard(NSGeneralPboard, items, types);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    _pdfPlugin->writeItemsToPasteboard(NSPasteboardNameGeneral, items, types);
 }
 
 - (void)showDefinitionForAttributedString:(NSAttributedString *)string atPoint:(CGPoint)point
@@ -2340,10 +2338,8 @@ bool PDFPlugin::handleEditingCommand(StringView commandName)
         [m_pdfLayerController selectAll];
     else if (commandName == "takeFindStringFromSelection"_s) {
         NSString *string = [m_pdfLayerController currentSelection].string;
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (string.length)
-            writeItemsToPasteboard(NSFindPboard, @[ [string dataUsingEncoding:NSUTF8StringEncoding] ], @[ NSPasteboardTypeString ]);
-        ALLOW_DEPRECATED_DECLARATIONS_END
+            writeItemsToPasteboard(NSPasteboardNameFind, @[ [string dataUsingEncoding:NSUTF8StringEncoding] ], @[ NSPasteboardTypeString ]);
     }
 
     return true;

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -126,9 +126,7 @@ static WebCore::CachedImage* cachedImage(Element& element)
 
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& label, Frame*)
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    ASSERT(pasteboardName == String(NSDragPboard));
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    ASSERT(pasteboardName == String(NSPasteboardNameDrag));
 
     WebCore::CachedImage* image = cachedImage(element);
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.h
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.h
@@ -58,7 +58,7 @@ extern NSString *WebURLNamePboardType;
 // Writes the URL to the pasteboard with the passed types.
 - (void)_web_writeURL:(NSURL *)URL andTitle:(NSString *)title types:(NSArray *)types;
 
-// Sets the text on the NSFindPboard. Returns the new changeCount for the NSFindPboard.
+// Sets the text on the find pasteboard (NSPasteboardNameFind). Returns the new changeCount for the find pasteboard.
 + (int)_web_setFindPasteboardString:(NSString *)string withOwner:(id)owner;
 
 // Writes a file wrapper to the pasteboard as an RTFD attachment.

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
@@ -175,9 +175,7 @@ static NSArray *writableTypesForImageWithArchive()
 
 + (int)_web_setFindPasteboardString:(NSString *)string withOwner:(id)owner
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSPasteboard *findPasteboard = [NSPasteboard pasteboardWithName:NSFindPboard];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSPasteboard *findPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
     [findPasteboard declareTypes:@[legacyStringPasteboardType()] owner:owner];
     [findPasteboard setString:string forType:legacyStringPasteboardType()];
     return [findPasteboard changeCount];
@@ -267,9 +265,7 @@ static CachedImage* imageFromElement(DOMElement *domElement)
                                    archive:(WebArchive *)archive
                                     source:(WebHTMLView *)source
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    ASSERT(self == [NSPasteboard pasteboardWithName:NSDragPboard]);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    ASSERT(self == [NSPasteboard pasteboardWithName:NSPasteboardNameDrag]);
 
     NSString *extension = @"";
     RetainPtr<NSMutableArray> types = adoptNS([[NSMutableArray alloc] initWithObjects:legacyFilesPromisePasteboardType(), nil]);

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -5045,9 +5045,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSDictionary *)_fontAttributesFromFontPasteboard
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSFontPboard];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFont];
     if (fontPasteboard == nil)
         return nil;
     NSData *data = [fontPasteboard dataForType:WebCore::legacyFontPasteboardType()];
@@ -5252,9 +5250,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     // Put RTF with font attributes on the pasteboard.
     // Maybe later we should add a pasteboard type that contains CSS text for "native" copy and paste font.
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSFontPboard];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFont];
     [fontPasteboard declareTypes:@[WebCore::legacyFontPasteboardType()] owner:nil];
     [fontPasteboard setData:[self _selectionStartFontAttributesAsRTF] forType:WebCore::legacyFontPasteboardType()];
 }


### PR DESCRIPTION
#### c28bb7beb9af15b2b8f8ab858c71d892023cb7fa
<pre>
Replaced deprecated NSPasteboardNames with latest API constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=241884">https://bugs.webkit.org/show_bug.cgi?id=241884</a>
rdar://95716307

Reviewed by Wenson Hsieh and Tim Horton.

NSGeneralPboard, NSFontPboard, NSRulerPboard, NSFindPboard and NSDragPboard were all deprecated in macOS 10.13.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::takeFindStringFromSelection):
(WebCore::Editor::replaceNodeFromPasteboard):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::pasteWithPasteboard):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::createForCopyAndPaste):
(WebCore::Pasteboard::createForDragAndDrop):
* Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm:
(WebKit::findPasteboard):
* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFLayerControllerDelegate writeItemsToPasteboard:withTypes:]):
(WebKit::PDFPlugin::handleEditingCommand):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.h:
* Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm:
(+[NSPasteboard _web_setFindPasteboardString:withOwner:]):
(-[NSPasteboard _web_declareAndWriteDragImageForElement:URL:title:archive:source:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _fontAttributesFromFontPasteboard]):
(-[WebHTMLView copyFont:]):

Canonical link: <a href="https://commits.webkit.org/251834@main">https://commits.webkit.org/251834@main</a>
</pre>
