### PR TITLE
Unreviewed, update .github/CODEOWNERS for TestWebKitAPI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 
 /Tools/Scripts/libraries @JonWBedard
 /Tools/Scripts/libraries/webkitscmpy @facetothefate @JonWBedard
+/Tools/TestWebKitAPI
 
 # ================================================================================
 
@@ -49,12 +50,14 @@
 # ================================================================================
 
 /Source/bmalloc @Constellation
+/Tools/TestWebKitAPI/Tests/WTF/bmalloc @Constellation
 
 # ================================================================================
 
 /Source/JavaScriptCore @WebKit/jsc-reviewers
 /JSTests @WebKit/jsc-reviewers
 /LayoutTests/js @WebKit/jsc-reviewers
+/Tools/TestWebKitAPI/Tests/JavaScriptCore @WebKit/jsc-reviewers
 
 # ================================================================================
 


### PR DESCRIPTION
#### 113f66dfe892275580d6af5601f7d7deab7da96c
<pre>
Unreviewed, update .github/CODEOWNERS for TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=241897">https://bugs.webkit.org/show_bug.cgi?id=241897</a>

Update .github/CODEOWNERS to more correctly add reviewer requests for TestWebKitAPI.

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/251768@main">https://commits.webkit.org/251768@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295763">https://svn.webkit.org/repository/webkit/trunk@295763</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
