### PR TITLE
[JSC] JSON.stringify should collect property names in faster way even with getter / setter

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -30,6 +30,7 @@
 #include "ArrayConstructor.h"
 #include "BigIntObject.h"
 #include "BooleanObject.h"
+#include "GetterSetter.h"
 #include "JSArrayInlines.h"
 #include "JSCInlines.h"
 #include "LiteralParser.h"
@@ -93,20 +94,20 @@ private:
 
         JSObject* object() const { return m_object; }
         bool isArray() const { return m_isArray; }
-        bool hasFastObjectProperties() const { return m_hasFastObjectProperties; }
 
         bool appendNextProperty(Stringifier&, StringBuilder&);
 
     private:
+        using GenericPropertyNames = RefPtr<PropertyNameArrayData>;
+        using FastPropertyNamesAndOffsets = Vector<std::tuple<PropertyName, PropertyOffset>, 8>;
+
         JSObject* m_object { nullptr };
         Structure* m_structure { nullptr };
         const bool m_isJSArray { false };
         const bool m_isArray { false };
-        bool m_hasFastObjectProperties { false };
         unsigned m_index { 0 };
         unsigned m_size { 0 };
-        RefPtr<PropertyNameArrayData> m_propertyNames;
-        Vector<std::tuple<PropertyName, unsigned>, 8> m_propertiesAndOffsets;
+        std::variant<GenericPropertyNames, FastPropertyNamesAndOffsets> m_properties;
     };
 
     friend class Holder;
@@ -510,9 +511,10 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
             builder.append('[');
         } else {
             if (stringifier.m_usingArrayReplacer) {
-                m_propertyNames = stringifier.m_arrayReplacerPropertyNames.data();
-                m_size = m_propertyNames->propertyNameVector().size();
-            } else if (m_structure && m_object->structureID() == m_structure->id() && canPerformFastPropertyEnumerationForJSONStringify(m_structure)) {
+                m_properties = stringifier.m_arrayReplacerPropertyNames.data();
+                m_size = std::get<GenericPropertyNames>(m_properties)->propertyNameVector().size();
+            } else if (m_structure && m_object->structure() == m_structure && canPerformFastPropertyNameEnumerationForJSONStringifyWithSideEffect(m_structure)) {
+                m_properties.emplace<FastPropertyNamesAndOffsets>();
                 m_structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     if (entry.attributes() & PropertyAttribute::DontEnum)
                         return true;
@@ -520,18 +522,21 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
                     PropertyName propertyName(entry.key());
                     if (propertyName.isSymbol())
                         return true;
-                    m_propertiesAndOffsets.constructAndAppend(propertyName, entry.offset());
+                    PropertyOffset offset = entry.offset();
+                    if (!canPerformFastPropertyNameAndOffsetEnumerationForJSONStringifyWithSideEffect(m_structure))
+                        offset = invalidOffset;
+                    std::get<FastPropertyNamesAndOffsets>(m_properties).constructAndAppend(propertyName, offset);
                     return true;
                 });
-                m_hasFastObjectProperties = true;
-                m_size = m_propertiesAndOffsets.size();
+                m_size = std::get<FastPropertyNamesAndOffsets>(m_properties).size();
             } else {
                 PropertyNameArray objectPropertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
                 m_object->methodTable()->getOwnPropertyNames(m_object, globalObject, objectPropertyNames, DontEnumPropertiesMode::Exclude);
                 RETURN_IF_EXCEPTION(scope, false);
-                m_propertyNames = objectPropertyNames.releaseData();
-                m_size = m_propertyNames->propertyNameVector().size();
+                m_properties = objectPropertyNames.releaseData();
+                m_size = std::get<GenericPropertyNames>(m_properties)->propertyNameVector().size();
             }
+
             builder.append('{');
         }
         stringifier.indent();
@@ -573,20 +578,28 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
     } else {
         PropertyName propertyName { nullptr };
         JSValue value;
-        if (m_hasFastObjectProperties) {
-            propertyName = std::get<0>(m_propertiesAndOffsets[index]);
-            if (m_object->structureID() == m_structure->id()) {
-                unsigned offset = std::get<1>(m_propertiesAndOffsets[index]);
-                value = m_object->getDirect(offset);
-            } else {
+        std::visit(WTF::makeVisitor(
+            [&](GenericPropertyNames& propertyNames) {
+                propertyName = propertyNames->propertyNameVector()[index];
                 value = m_object->get(globalObject, propertyName);
-                RETURN_IF_EXCEPTION(scope, false);
-            }
-        } else {
-            propertyName = m_propertyNames->propertyNameVector()[index];
-            value = m_object->get(globalObject, propertyName);
-            RETURN_IF_EXCEPTION(scope, false);
-        }
+            },
+            [&](FastPropertyNamesAndOffsets& propertiesAndOffsets) {
+                propertyName = std::get<0>(propertiesAndOffsets[index]);
+                unsigned offset = std::get<1>(propertiesAndOffsets[index]);
+                if (m_object->structure() == m_structure && isValidOffset(offset)) {
+                    JSValue slotValue = m_object->getDirect(offset);
+                    // We can skip Structure lookup if we can invoke GetterSetter / CustomGetterSetter directly without going to JSObject::get.
+                    if (slotValue) {
+                        if (slotValue.inherits<GetterSetter>())
+                            value = jsCast<GetterSetter*>(slotValue)->callGetter(globalObject, m_object);
+                        else if (!slotValue.inherits<CustomGetterSetter>())
+                            value = slotValue;
+                    }
+                }
+                if (!value)
+                    value = m_object->get(globalObject, propertyName);
+            }), m_properties);
+        RETURN_IF_EXCEPTION(scope, false);
 
         rollBackPoint = builder.length();
 


### PR DESCRIPTION
#### 8db8b5d7fa16e85cba03d4d3c7019acd1a590bdd
<pre>
[JSC] JSON.stringify should collect property names in faster way even with getter / setter
<a href="https://bugs.webkit.org/show_bug.cgi?id=241898">https://bugs.webkit.org/show_bug.cgi?id=241898</a>

Reviewed by NOBODY (OOPS!).

EmberJS-Debug-TodoMVC has many JSON.stringify calls with objects having getter / setter. Since
invoking getter / setter is observable, it is possible that it changes Structure during iteration,
but just collecting names does not matter.
We first collect properties and offsets. And so long as structure is not changed, we continue using
it. If it is changed, then we just use the name. We also invoke GetterSetter / CustomGetterSetter
through `get` operation, but probably in the future, we can optimize it further.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::Holder::isArray const):
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::Stringifier::Holder::hasFastObjectProperties const): Deleted.
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::canPerformFastPropertyNameAndValueEnumerationForJSONStringify):
(JSC::canPerformFastPropertyNameEnumerationForJSONStringify):
(JSC::canPerformFastPropertyEnumerationForJSONStringify): Deleted.
</pre>