### PR TITLE
Add ldp and stp support to ARM64 and ARM64E offlineasm.

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -851,8 +851,8 @@ macro preserveCalleeSavesUsedByLLInt()
         storep PB, -4[cfr]
         storep metadataTable, -8[cfr]
     elsif ARM64 or ARM64E
-        emit "stp x27, x28, [x29, #-16]"
-        emit "stp x25, x26, [x29, #-32]"
+        storepairq csr8, csr9, -16[cfr]
+        storepairq csr6, csr7, -32[cfr]
     elsif X86
     elsif X86_WIN
     elsif X86_64
@@ -880,8 +880,8 @@ macro restoreCalleeSavesUsedByLLInt()
         loadp -4[cfr], PB
         loadp -8[cfr], metadataTable
     elsif ARM64 or ARM64E
-        emit "ldp x25, x26, [x29, #-32]"
-        emit "ldp x27, x28, [x29, #-16]"
+        loadpairq -32[cfr], csr6, csr7
+        loadpairq -16[cfr], csr8, csr9
     elsif X86
     elsif X86_WIN
     elsif X86_64
@@ -907,24 +907,15 @@ macro copyCalleeSavesToEntryFrameCalleeSavesBuffer(entryFrame)
         vmEntryRecord(entryFrame, entryFrame)
         leap VMEntryRecord::calleeSaveRegistersBuffer[entryFrame], entryFrame
         if ARM64 or ARM64E
-            storeq csr0, [entryFrame]
-            storeq csr1, 8[entryFrame]
-            storeq csr2, 16[entryFrame]
-            storeq csr3, 24[entryFrame]
-            storeq csr4, 32[entryFrame]
-            storeq csr5, 40[entryFrame]
-            storeq csr6, 48[entryFrame]
-            storeq csr7, 56[entryFrame]
-            storeq csr8, 64[entryFrame]
-            storeq csr9, 72[entryFrame]
-            stored csfr0, 80[entryFrame]
-            stored csfr1, 88[entryFrame]
-            stored csfr2, 96[entryFrame]
-            stored csfr3, 104[entryFrame]
-            stored csfr4, 112[entryFrame]
-            stored csfr5, 120[entryFrame]
-            stored csfr6, 128[entryFrame]
-            stored csfr7, 136[entryFrame]
+            storepairq csr0, csr1, [entryFrame]
+            storepairq csr2, csr3, 16[entryFrame]
+            storepairq csr4, csr5, 32[entryFrame]
+            storepairq csr6, csr7, 48[entryFrame]
+            storepairq csr8, csr9, 64[entryFrame]
+            storepaird csfr0, csfr1, 80[entryFrame]
+            storepaird csfr2, csfr3, 96[entryFrame]
+            storepaird csfr4, csfr5, 112[entryFrame]
+            storepaird csfr6, csfr7, 128[entryFrame]
         elsif X86_64
             storeq csr0, [entryFrame]
             storeq csr1, 8[entryFrame]
@@ -993,24 +984,15 @@ macro restoreCalleeSavesFromVMEntryFrameCalleeSavesBuffer(vm, temp)
         vmEntryRecord(temp, temp)
         leap VMEntryRecord::calleeSaveRegistersBuffer[temp], temp
         if ARM64 or ARM64E
-            loadq [temp], csr0
-            loadq 8[temp], csr1
-            loadq 16[temp], csr2
-            loadq 24[temp], csr3
-            loadq 32[temp], csr4
-            loadq 40[temp], csr5
-            loadq 48[temp], csr6
-            loadq 56[temp], csr7
-            loadq 64[temp], csr8
-            loadq 72[temp], csr9
-            loadd 80[temp], csfr0
-            loadd 88[temp], csfr1
-            loadd 96[temp], csfr2
-            loadd 104[temp], csfr3
-            loadd 112[temp], csfr4
-            loadd 120[temp], csfr5
-            loadd 128[temp], csfr6
-            loadd 136[temp], csfr7
+            loadpairq [temp], csr0, csr1
+            loadpairq 16[temp], csr2, csr3
+            loadpairq 32[temp], csr4, csr5
+            loadpairq 48[temp], csr6, csr7
+            loadpairq 64[temp], csr8, csr9
+            loadpaird 80[temp], csfr0, csfr1
+            loadpaird 96[temp], csfr2, csfr3
+            loadpaird 112[temp], csfr4, csfr5
+            loadpaird 128[temp], csfr6, csfr7
         elsif X86_64
             loadq [temp], csr0
             loadq 8[temp], csr1

--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -45,8 +45,8 @@ require "risc"
 #  x5  => t5, a5, wa5
 #  x6  => t6, a6, wa6
 #  x7  => t7, a7, wa7
-#  x8  => ws0
-#  x9  => ws1
+#  x9  => ws0
+# x10  => ws1
 # x13  =>                  (scratch)
 # x16  =>                  (scratch)
 # x17  =>                  (scratch)
@@ -249,6 +249,11 @@ class Address
         "[#{base.arm64Operand(:quad)}]"
     end
     
+    def arm64PairAddressOperand(kind)
+        raise "Invalid offset #{offset.value} at #{codeOriginString}" if offset.value < -512 or offset.value > 504
+        "[#{base.arm64Operand(:quad)}, \##{offset.value}]"
+    end
+
     def arm64EmitLea(destination, kind)
         offset.value.zero? \
             ? ($asm.puts "mov #{destination.arm64Operand(kind)}, #{base.arm64Operand(kind)}")
@@ -269,10 +274,17 @@ class BaseIndex
             ? ($asm.puts "add #{destination.arm64Operand(kind)}, #{base.arm64Operand(kind)}, #{index.arm64Operand(kind)}")
             : ($asm.puts "add #{destination.arm64Operand(kind)}, #{base.arm64Operand(kind)}, #{index.arm64Operand(kind)}, lsl \##{scaleShift}")
     end
+
+    def arm64PairAddressOperand(kind)
+        raise "Unconverted base index address #{address.value} at #{codeOriginString}"
+    end
 end
 
 class AbsoluteAddress
     def arm64Operand(kind)
+        raise "Unconverted absolute address #{address.value} at #{codeOriginString}"
+    end
+    def arm64PairAddressOperand(kind)
         raise "Unconverted absolute address #{address.value} at #{codeOriginString}"
     end
 end
@@ -283,7 +295,7 @@ end
 # Actual lowering code follows.
 #
 
-def isMalformedArm64LoadAStoreAddress(opcode, operand)
+def isMalformedArm64LoadStoreAddress(opcode, operand)
     malformed = false
     if operand.is_a? Address
         case opcode
@@ -307,18 +319,45 @@ def isMalformedArm64LoadAStoreAddress(opcode, operand)
     malformed
 end
 
+def isMalformedArm64LoadStorePairAddress(opcode, operand)
+    malformed = false
+    if operand.is_a? Address
+        malformed ||= (not (-512..504).include? operand.offset.value)
+        malformed ||= (not (operand.offset.value % 8).zero?)
+    end
+    malformed
+end
+
 def arm64LowerMalformedLoadStoreAddresses(list)
     newList = []
 
     list.each {
         | node |
         if node.is_a? Instruction
-            if node.opcode =~ /^store/ and isMalformedArm64LoadAStoreAddress(node.opcode, node.operands[1])
+            if node.opcode =~ /^storepair/
+                if isMalformedArm64LoadStorePairAddress(node.opcode, node.operands[2])
+                    address = node.operands[2]
+                    tmp = Tmp.new(codeOrigin, :gpr)
+                    newList << Instruction.new(node.codeOrigin, "move", [address.offset, tmp])
+                    newList << Instruction.new(node.codeOrigin, node.opcode, [node.operands[0], node.operands[1], BaseIndex.new(node.codeOrigin, address.base, tmp, Immediate.new(codeOrigin, 1), Immediate.new(codeOrigin, 0))], node.annotation)
+                else
+                    newList << node
+                end
+            elsif node.opcode =~ /^loadpair/
+                if isMalformedArm64LoadStorePairAddress(node.opcode, node.operands[0])
+                    address = node.operands[0]
+                    tmp = Tmp.new(codeOrigin, :gpr)
+                    newList << Instruction.new(node.codeOrigin, "move", [address.offset, tmp])
+                    newList << Instruction.new(node.codeOrigin, node.opcode, [BaseIndex.new(node.codeOrigin, address.base, tmp, Immediate.new(codeOrigin, 1), Immediate.new(codeOrigin, 0)), node.operands[1], node.operands[2]], node.annotation)
+                else
+                    newList << node
+                end
+            elsif node.opcode =~ /^store/ and isMalformedArm64LoadStoreAddress(node.opcode, node.operands[1])
                 address = node.operands[1]
                 tmp = Tmp.new(codeOrigin, :gpr)
                 newList << Instruction.new(node.codeOrigin, "move", [address.offset, tmp])
                 newList << Instruction.new(node.codeOrigin, node.opcode, [node.operands[0], BaseIndex.new(node.codeOrigin, address.base, tmp, Immediate.new(codeOrigin, 1), Immediate.new(codeOrigin, 0))], node.annotation)
-            elsif node.opcode =~ /^load/ and isMalformedArm64LoadAStoreAddress(node.opcode, node.operands[0])
+            elsif node.opcode =~ /^load/ and isMalformedArm64LoadStoreAddress(node.opcode, node.operands[0])
                 address = node.operands[0]
                 tmp = Tmp.new(codeOrigin, :gpr)
                 newList << Instruction.new(node.codeOrigin, "move", [address.offset, tmp])
@@ -408,6 +447,7 @@ class Sequence
         result = arm64LowerLabelReferences(result)
         result = riscLowerMalformedAddresses(result) {
             | node, address |
+            isLoadStorePairOp = false
             case node.opcode
             when "loadb", "loadbsi", "loadbsq", "storeb", /^bb/, /^btb/, /^cb/, /^tb/, "loadlinkacqb", "storecondrelb", /^atomic[a-z]+b$/
                 size = 1
@@ -423,6 +463,9 @@ class Sequence
                 "divd", "subd", "muld", "sqrtd", /^bp/, /^bq/, /^btp/, /^btq/, /^cp/, /^cq/, /^tp/, /^tq/, /^bd/,
                 "jmp", "call", "leap", "leaq", "loadlinkacqq", "storecondrelq", /^atomic[a-z]+q$/
                 size = $currentSettings["ADDRESS64"] ? 8 : 4
+            when "loadpairq", "storepairq", "loadpaird", "storepaird"
+                size = 16
+                isLoadStorePairOp = true
             else
                 raise "Bad instruction #{node.opcode} for heap access at #{node.codeOriginString}: #{node.dump}"
             end
@@ -431,7 +474,11 @@ class Sequence
                 address.offset.value == 0 and
                     (node.opcode =~ /^lea/ or address.scale == 1 or address.scale == size)
             elsif address.is_a? Address
-                not isMalformedArm64LoadAStoreAddress(node.opcode, address)
+                if isLoadStorePairOp
+                    not isMalformedArm64LoadStorePairAddress(node.opcode, address)
+                else
+                    not isMalformedArm64LoadStoreAddress(node.opcode, address)
+                end
             else
                 false
             end
@@ -475,8 +522,11 @@ class Sequence
         result = riscLowerMalformedAddresses(result) {
             | node, address |
             case node.opcode
+            when /^loadpair/, /^storepair/
+#                not (address.is_a? Address and not (-512..504).include? address.offset.value)
+                not address.is_a? Address or not isMalformedArm64LoadStorePairAddress(node.opcode, address)
             when /^load/, /^store/
-                not address.is_a? Address or not isMalformedArm64LoadAStoreAddress(node.opcode, address)
+                not address.is_a? Address or not isMalformedArm64LoadStoreAddress(node.opcode, address)
             when /^lea/
                 true
             when /^atomic/
@@ -1451,6 +1501,14 @@ class Instruction
             $asm.puts "ldar #{operands[1].arm64Operand(:word)}, #{operands[0].arm64SimpleAddressOperand(:word)}"
         when "atomicloadq"
             $asm.puts "ldar #{operands[1].arm64Operand(:quad)}, #{operands[0].arm64SimpleAddressOperand(:quad)}"
+        when "loadpairq"
+            $asm.puts "ldp #{operands[1].arm64Operand(:quad)}, #{operands[2].arm64Operand(:quad)}, #{operands[0].arm64PairAddressOperand(:quad)}"
+        when "storepairq"
+            $asm.puts "stp #{operands[0].arm64Operand(:quad)}, #{operands[1].arm64Operand(:quad)}, #{operands[2].arm64PairAddressOperand(:quad)}"
+        when "loadpaird"
+            $asm.puts "ldp #{operands[1].arm64Operand(:double)}, #{operands[2].arm64Operand(:double)}, #{operands[0].arm64PairAddressOperand(:double)}"
+        when "storepaird"
+            $asm.puts "stp #{operands[0].arm64Operand(:double)}, #{operands[1].arm64Operand(:double)}, #{operands[2].arm64PairAddressOperand(:double)}"
         else
             lowerDefault
         end

--- a/Source/JavaScriptCore/offlineasm/instructions.rb
+++ b/Source/JavaScriptCore/offlineasm/instructions.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -440,6 +440,10 @@ ARM64_INSTRUCTIONS =
      "atomicloadh",
      "atomicloadi",
      "atomicloadq",
+     "loadpairq",
+     "storepairq",
+     "loadpaird",
+     "storepaird",
     ]
 
 RISC_INSTRUCTIONS =


### PR DESCRIPTION
#### 79eb5e92d4fcc21e1c2674d0e39da1081cccc5b5
<pre>
Add ldp and stp support to ARM64 and ARM64E offlineasm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241905">https://bugs.webkit.org/show_bug.cgi?id=241905</a>

Reviewed by Yusuke Suzuki.

offlineasm used to emit this LLInt code:
    &quot;.loc 1 996\n&quot;        &quot;ldr x19, [x0] \n&quot;                   // LowLevelInterpreter.asm:996
    &quot;.loc 1 997\n&quot;        &quot;ldr x20, [x0, #8] \n&quot;               // LowLevelInterpreter.asm:997
    &quot;.loc 1 998\n&quot;        &quot;ldr x21, [x0, #16] \n&quot;              // LowLevelInterpreter.asm:998
    &quot;.loc 1 999\n&quot;        &quot;ldr x22, [x0, #24] \n&quot;              // LowLevelInterpreter.asm:999
    ...
    &quot;.loc 1 1006\n&quot;       &quot;ldr d8, [x0, #80] \n&quot;               // LowLevelInterpreter.asm:1006
    &quot;.loc 1 1007\n&quot;       &quot;ldr d9, [x0, #88] \n&quot;               // LowLevelInterpreter.asm:1007
    &quot;.loc 1 1008\n&quot;       &quot;ldr d10, [x0, #96] \n&quot;              // LowLevelInterpreter.asm:1008
    &quot;.loc 1 1009\n&quot;       &quot;ldr d11, [x0, #104] \n&quot;             // LowLevelInterpreter.asm:1009
    ...

Now, it can emit this instead:
    &quot;.loc 1 996\n&quot;        &quot;ldp x19, x20, [x0, #0] \n&quot;          // LowLevelInterpreter.asm:996
    &quot;.loc 1 997\n&quot;        &quot;ldp x21, x22, [x0, #16] \n&quot;         // LowLevelInterpreter.asm:997
    ...
    &quot;.loc 1 1001\n&quot;       &quot;ldp d8, d9, [x0, #80] \n&quot;           // LowLevelInterpreter.asm:1001
    &quot;.loc 1 1002\n&quot;       &quot;ldp d10, d11, [x0, #96] \n&quot;         // LowLevelInterpreter.asm:1002
    ...

Also, there was some code that kept recomputing the base address of a sequence of load/store
instructions.  For example,
    &quot;.loc 6 902\n&quot;        &quot;add x13, sp, x10, lsl #3 \n&quot;        // WebAssembly.asm:902
                          &quot;ldr x0, [x13, #48] \n&quot;
                          &quot;add x13, sp, x10, lsl #3 \n&quot;
                          &quot;ldr x1, [x13, #56] \n&quot;
                          &quot;add x13, sp, x10, lsl #3 \n&quot;
                          &quot;ldr x2, [x13, #64] \n&quot;
                          &quot;add x13, sp, x10, lsl #3 \n&quot;
                          &quot;ldr x3, [x13, #72] \n&quot;
    ...

For such places, we observe that the base address is the same for every load/store instruction
in the sequence, and precompute it in the LLInt asm code to help out the offline asm.  This
allows the offlineasm to now emit this more efficient code instead:
    &quot;.loc 6 896\n&quot;        &quot;add x10, sp, x10, lsl #3 \n&quot;        // WebAssembly.asm:896
    &quot;.loc 6 898\n&quot;        &quot;ldp x0, x1, [x10, #48] \n&quot;          // WebAssembly.asm:898
                          &quot;ldp x2, x3, [x10, #64] \n&quot;
    ...

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/offlineasm/instructions.rb:

Canonical link: <a href="https://commits.webkit.org/251799@main">https://commits.webkit.org/251799@main</a>
</pre>
