### PR TITLE
WebRTC DataChannel id of initiator not set

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-id-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-id-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL DTLS client uses odd data channel IDs assert_equals: Channel created by the DTLS server role must be odd (was null) expected 1 but got 0
-FAIL DTLS server uses even data channel IDs assert_true: Channel ID null should be unique expected true got false
-FAIL In-band negotiation with a specific ID should not work assert_equals: expected (object) null but got (number) 42
-FAIL Odd/even role should not be violated when mixing with negotiated channels assert_equals: Channel created by the DTLS server role must be odd (was null) expected 1 but got 0
+PASS DTLS client uses odd data channel IDs
+PASS DTLS server uses even data channel IDs
+PASS In-band negotiation with a specific ID should not work
+PASS Odd/even role should not be violated when mixing with negotiated channels
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt
@@ -17,10 +17,10 @@ PASS createDataChannel with protocol "foo" should succeed
 PASS createDataChannel with protocol null should succeed
 PASS createDataChannel with protocol undefined should succeed
 PASS createDataChannel with protocol lone surrogate should succeed
-FAIL createDataChannel with id 0 and negotiated not set should succeed, but not set the channel's id assert_equals: expected (object) null but got (number) 0
-FAIL createDataChannel with id 1 and negotiated not set should succeed, but not set the channel's id assert_equals: expected (object) null but got (number) 1
-FAIL createDataChannel with id 65534 and negotiated not set should succeed, but not set the channel's id assert_equals: expected (object) null but got (number) 65534
-FAIL createDataChannel with id 65535 and negotiated not set should succeed, but not set the channel's id Type error
+PASS createDataChannel with id 0 and negotiated not set should succeed, but not set the channel's id
+PASS createDataChannel with id 1 and negotiated not set should succeed, but not set the channel's id
+PASS createDataChannel with id 65534 and negotiated not set should succeed, but not set the channel's id
+PASS createDataChannel with id 65535 and negotiated not set should succeed, but not set the channel's id
 PASS createDataChannel with id 0 and negotiated true should succeed, and set the channel's id
 PASS createDataChannel with id 1 and negotiated true should succeed, and set the channel's id
 FAIL createDataChannel with id 65534 and negotiated true should succeed, and set the channel's id The operation is not supported.
@@ -29,33 +29,17 @@ PASS createDataChannel with id 65536 and negotiated not set should throw TypeErr
 PASS createDataChannel with id -1 should throw TypeError
 PASS createDataChannel with id 65535 should throw TypeError
 PASS createDataChannel with id 65536 should throw TypeError
-FAIL createDataChannel with too long label should throw TypeError assert_throws_js: function "() =>
-    pc.createDataChannel('l'.repeat(65536), {
-      negotiated: true,
-      id: 42
-    })" did not throw
-FAIL createDataChannel with too long label (2 byte unicode) should throw TypeError assert_throws_js: function "() =>
-    pc.createDataChannel('\u00b5'.repeat(32768))" did not throw
+PASS createDataChannel with too long label should throw TypeError
+PASS createDataChannel with too long label (2 byte unicode) should throw TypeError
 PASS createDataChannel with same label used twice should not throw
 PASS createDataChannel with negotiated true and id should succeed
-FAIL createDataChannel with too long protocol should throw TypeError assert_throws_js: function "() =>
-    pc.createDataChannel('', {
-      protocol: 'p'.repeat(65536),
-      negotiated: true,
-      id: 42
-    })" did not throw
-FAIL createDataChannel with too long protocol (2 byte unicode) should throw TypeError assert_throws_js: function "() =>
-    pc.createDataChannel('', {
-      protocol: '\u00b6'.repeat(32768)
-    })" did not throw
+PASS createDataChannel with too long protocol should throw TypeError
+PASS createDataChannel with too long protocol (2 byte unicode) should throw TypeError
 PASS createDataChannel with maximum length label and protocol should succeed
 PASS createDataChannel with negotiated false should succeed
-FAIL createDataChannel with negotiated false and id 42 should ignore the id assert_equals: Expect dc.id to be ignored (null) expected (object) null but got (number) 42
-FAIL createDataChannel with negotiated true and id not defined should throw TypeError assert_throws_js: function "() =>
-    pc.createDataChannel('test', {
-      negotiated: true
-    })" did not throw
-FAIL Channels created (after setRemoteDescription) should have id assigned assert_not_equals: Expect dc1.id to be assigned after remote description has been set got disallowed value null
+PASS createDataChannel with negotiated false and id 42 should ignore the id
+PASS createDataChannel with negotiated true and id not defined should throw TypeError
+PASS Channels created (after setRemoteDescription) should have id assigned
 FAIL Reusing a data channel id that is in use should throw OperationError assert_throws_dom: function "() =>
     pc.createDataChannel('channel-3', {
       negotiated: true,
@@ -66,7 +50,11 @@ FAIL Reusing a data channel id that is in use (after setRemoteDescription) shoul
       negotiated: true,
       id: 42,
     })" threw object "NotSupportedError: The operation is not supported." that is not a DOMException OperationError: property "code" is equal to 9, expected 0
-FAIL Reusing a data channel id that is in use (after setRemoteDescription, negotiated via DCEP) should throw OperationError assert_not_equals: Expect dc1.id to be assigned after remote description has been set got disallowed value null
+FAIL Reusing a data channel id that is in use (after setRemoteDescription, negotiated via DCEP) should throw OperationError assert_throws_dom: function "() =>
+    pc1.createDataChannel('channel-2', {
+      negotiated: true,
+      id: dc1.id,
+    })" threw object "NotSupportedError: The operation is not supported." that is not a DOMException OperationError: property "code" is equal to 9, expected 0
 PASS New datachannel should be in the connecting state after creation (after connection establishment)
 PASS addTrack, then creating datachannel, should negotiate properly
 PASS addTrack, then creating datachannel, should negotiate properly when max-bundle is used

--- a/LayoutTests/webrtc/datachannel/creation-expected.txt
+++ b/LayoutTests/webrtc/datachannel/creation-expected.txt
@@ -4,9 +4,11 @@ PASS Creating data channel after closing the connection
 PASS Wrong data channel init: long protocol
 PASS Wrong data channel init: long id
 PASS Wrong data channel init: maxPacketLifeTime and maxRetransmits
+PASS Right data channel init: long id, but negotiated is false
 PASS Right data channel init: ordered init
 PASS Right data channel init: unordered init
-PASS Right data channel init: default ordered init with id
+PASS Right data channel init: default ordered init with id, not negotiated
+PASS Right data channel init: default ordered init with id, negotiated
 PASS Right data channel init: no init
 PASS Right data channel init: null
 

--- a/LayoutTests/webrtc/datachannel/creation.html
+++ b/LayoutTests/webrtc/datachannel/creation.html
@@ -58,17 +58,20 @@ function testRightDataChannelInit(init, title)
         assert_equals(channel.maxRetransmits, init.maxRetransmits, "maxRetransmits");
         assert_equals(channel.protocol, init.protocol, "protocol");
         assert_equals(channel.negotiated, init.negotiated, "negotiated");
-        assert_equals(channel.id, init.id, "id");
+        if (channel.negotiated)
+            assert_equals(channel.id, init.id, "id");
      }, "Right data channel init: " + title);
 }
 
 testWrongDataChannelInit({negotiated: false, protocol: longString}, "long protocol");
-testWrongDataChannelInit({id: 65535}, "long id");
+testWrongDataChannelInit({negotiated: true, id: 65535}, "long id");
 testWrongDataChannelInit({maxPacketLifeTime: 1, maxRetransmits: 1}, "maxPacketLifeTime and maxRetransmits");
 
+testRightDataChannelInit({id: 65535}, "long id, but negotiated is false");
 testRightDataChannelInit({ordered: true, maxRetransmit: 11, protocol: "whatever", negotiated: false, id: 1 }, "ordered init");
 testRightDataChannelInit({ordered: false, maxPacketLifeTime: 10, protocol: "whatever", negotiated: false, id: 2 }, "unordered init");
-testRightDataChannelInit({protocol: "whatever", negotiated: false, id: 123 }, "default ordered init with id");
+testRightDataChannelInit({protocol: "whatever", negotiated: false, id: 123 }, "default ordered init with id, not negotiated");
+testRightDataChannelInit({protocol: "whatever", negotiated: true, id: 123 }, "default ordered init with id, negotiated");
 testRightDataChannelInit(undefined, "no init");
 testRightDataChannelInit(null, "null");
     </script>

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -104,6 +104,14 @@ RTCDataChannel::RTCDataChannel(ScriptExecutionContext& context, std::unique_ptr<
 {
 }
 
+std::optional<unsigned short> RTCDataChannel::id() const
+{
+    if (!m_options.id && m_handler)
+        const_cast<RTCDataChannel*>(this)->m_options.id = m_handler->id();
+
+    return m_options.id;
+}
+
 const AtomString& RTCDataChannel::binaryType() const
 {
     switch (m_binaryType) {
@@ -259,6 +267,7 @@ void RTCDataChannel::stop()
 {
     removeFromDataChannelLocalMapIfNeeded();
 
+    id();
     close();
     m_stopped = true;
     m_handler = nullptr;

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -61,7 +61,7 @@ public:
     std::optional<unsigned short> maxRetransmits() const { return m_options.maxRetransmits; }
     String protocol() const { return m_options.protocol; }
     bool negotiated() const { return *m_options.negotiated; };
-    std::optional<unsigned short> id() const { return m_options.id; };
+    std::optional<unsigned short> id() const;
     RTCPriorityType priority() const { return m_options.priority; };
     const RTCDataChannelInit& options() const { return m_options; }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -127,6 +127,12 @@ void LibWebRTCDataChannelHandler::close()
     m_channel->Close();
 }
 
+std::optional<unsigned short> LibWebRTCDataChannelHandler::id() const
+{
+    auto id = m_channel->id();
+    return id != -1 ? std::make_optional(id) : std::nullopt;
+}
+
 void LibWebRTCDataChannelHandler::OnStateChange()
 {
     checkState();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
@@ -70,6 +70,7 @@ private:
     bool sendStringData(const CString&) final;
     bool sendRawData(const uint8_t*, size_t) final;
     void close() final;
+    std::optional<unsigned short> id() const final;
 
     // webrtc::DataChannelObserver API
     void OnStateChange();

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
@@ -118,6 +118,8 @@ public:
     virtual bool sendStringData(const CString&) = 0;
     virtual bool sendRawData(const uint8_t*, size_t) = 0;
     virtual void close() = 0;
+
+    virtual std::optional<unsigned short> id() const { return { }; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4bb2fa75278ddaed7b362e161196de2bc9e4757c
<pre>
WebRTC DataChannel id of initiator not set
<a href="https://bugs.webkit.org/show_bug.cgi?id=184688">https://bugs.webkit.org/show_bug.cgi?id=184688</a>
rdar://problem/95636476

Reviewed by Eric Carlson.

Compute channel ID based on backend channel.
We store the ID before stopping as ID should not be mutated when stopping the channel.
Tightening of createDataChannel options validation to better align with the spec.
A follow-up patch should further improve error reporting when creating the data channel backend.

Covered by updated and rebased tests.

* LayoutTests/webrtc/datachannel/creation-expected.txt:
* LayoutTests/webrtc/datachannel/creation.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-id-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::id const):
(WebCore::RTCDataChannel::stop):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::createDataChannel):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::id const):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h:
* Source/WebCore/platform/mediastream/RTCDataChannelHandler.h:
(WebCore::RTCDataChannelHandler::id const):

Canonical link: <a href="https://commits.webkit.org/251795@main">https://commits.webkit.org/251795@main</a>
</pre>
