### PR TITLE
LocalSampleBufferDisplayLayer::layerErrorDidChange should let know its client that a failure happened

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -109,7 +109,7 @@ private:
     PendingSampleQueue m_pendingVideoFrameQueue;
     
     bool m_paused { false };
-
+    bool m_didFail { false };
 #if !RELEASE_LOG_DISABLED
     String m_logIdentifier;
     FrameRateMonitor m_frameRateMonitor;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -208,14 +208,23 @@ LocalSampleBufferDisplayLayer::~LocalSampleBufferDisplayLayer()
 void LocalSampleBufferDisplayLayer::layerStatusDidChange()
 {
     ASSERT(isMainThread());
-    if (m_client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed)
-        m_client->sampleBufferDisplayLayerStatusDidFail();
+    if (m_client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed) {
+        RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerStatusDidChange going to failed status (%{public}s) ", m_logIdentifier.utf8().data());
+        if (!m_didFail) {
+            m_didFail = true;
+            m_client->sampleBufferDisplayLayerStatusDidFail();
+        }
+    }
 }
 
 void LocalSampleBufferDisplayLayer::layerErrorDidChange()
 {
     ASSERT(isMainThread());
-    // FIXME: Log error.
+    RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerErrorDidChange (%{public}s) ", m_logIdentifier.utf8().data());
+    if (!m_client || m_didFail)
+        return;
+    m_didFail = true;
+    m_client->sampleBufferDisplayLayerStatusDidFail();
 }
 
 PlatformLayer* LocalSampleBufferDisplayLayer::displayLayer()


### PR DESCRIPTION
#### 50ea1a168415122e704fde5a48e0f34d0ed9e28e
<pre>
LocalSampleBufferDisplayLayer::layerErrorDidChange should let know its client that a failure happened
<a href="https://bugs.webkit.org/show_bug.cgi?id=241909">https://bugs.webkit.org/show_bug.cgi?id=241909</a>

Reviewed by Eric Carlson.

Log both failure and error cases.
In case of error, call client sampleBufferDisplayLayerStatusDidFail.

* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::layerStatusDidChange):
(WebCore::LocalSampleBufferDisplayLayer::layerErrorDidChange):

Canonical link: <a href="https://commits.webkit.org/251792@main">https://commits.webkit.org/251792@main</a>
</pre>
