### PR TITLE
REGRESSION (r286944?): web-platform-tests/html/semantics/text-level-semantics/the-a-element/a-download-click tests have become flaky failures

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1606,12 +1606,6 @@ webkit.org/b/232497 [ BigSur Debug ] media/media-source/media-source-istypesuppo
 webkit.org/b/235681 [ BigSur Release ]  imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html [ Pass Failure ]
 webkit.org/b/235681 [ BigSur Release ]  imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html [ Pass Failure ]
 
-# webkit.org/b/234410 Multiple semantics web-platform-tests have become flaky after r286944
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_allow_downloads.tentative.html [ DumpJSConsoleLogInStdErr Pass Failure ]
-imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a-download-click.html [ Pass Failure ]
-imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html [ Pass Failure ]
-http/wpt/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html [ Pass Failure ]
-
 # rdar://86037417 WindowServer returned not alive with context:,unresponsive work processor(s)
 [ Monterey+ ] http/tests/model/model-document.html [ Skip ]
 [ Monterey+ ] http/tests/model/model-document-interactive.html [ Skip ]

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1116,6 +1116,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     setBlockAllPlugins(false);
     setPluginSupportedMode({ });
 
+    m_shouldLogDownloadSize = false;
     m_shouldLogDownloadCallbacks = false;
     m_shouldLogHistoryClientCallbacks = false;
     m_shouldLogCanAuthenticateAgainstProtectionSpace = false;


### PR DESCRIPTION
#### 765fc0d0128371b11efc6ea51bce13d453402a98
<pre>
REGRESSION (r286944?): web-platform-tests/html/semantics/text-level-semantics/the-a-element/a-download-click tests have become flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=234410">https://bugs.webkit.org/show_bug.cgi?id=234410</a>

Reviewed by Chris Dumez.

Make sure to reset m_shouldLogDownloadSize when restarting a test.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/251789@main">https://commits.webkit.org/251789@main</a>
</pre>
