### PR TITLE
REGRESSION (iOS 15): http/tests/websocket/tests/hybi/close-code-and-reason.html is failing

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1236,8 +1236,6 @@ webkit.org/b/171830 [ Debug ] http/tests/websocket/tests/hybi/workers/close.html
 
 webkit.org/b/230522 http/tests/websocket/tests/hybi/alert-in-event-handler.html [ Pass Crash ]
 
-webkit.org/b/231329 http/tests/websocket/tests/hybi/close-code-and-reason.html [ Pass Failure ]
-
 webkit.org/b/169637 imported/w3c/web-platform-tests/xhr/timeout-multiple-fetches.html [ Pass Failure ]
 
 webkit.org/b/231337 [ Debug ] imported/w3c/web-platform-tests/xhr/send-timeout-events.htm [ Pass Failure ]

--- a/LayoutTests/platform/ios-wk2/http/tests/websocket/tests/hybi/close-code-and-reason-expected.txt
+++ b/LayoutTests/platform/ios-wk2/http/tests/websocket/tests/hybi/close-code-and-reason-expected.txt
@@ -1,0 +1,82 @@
+Test CloseEvent code and reason property.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+ws.onclose() was called.
+PASS closeEvent.wasClean is false
+PASS closeEvent.code is codeAbnormalClosure
+PASS closeEvent.reason is emptyString
+WebSocketTest.onopen() was called with testId = 0.
+WebSocketTest.onclose() was called with testId = 0.
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+PASS closeEvent.code is 1005
+PASS closeEvent.reason is ''
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+PASS closeEvent.code is 1005
+PASS closeEvent.reason is ''
+WebSocketTest.onopen() was called with testId = 1.
+WebSocketTest.onclose() was called with testId = 1.
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is false
+PASS closeEvent.code is 1006
+PASS closeEvent.reason is ''
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is false
+PASS closeEvent.code is 1006
+PASS closeEvent.reason is ''
+WebSocketTest.onopen() was called with testId = 2.
+WebSocketTest.onclose() was called with testId = 2.
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+PASS closeEvent.code is 1000
+PASS closeEvent.reason is 'ok'
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+PASS closeEvent.code is 1000
+PASS closeEvent.reason is 'ok'
+WebSocketTest.onopen() was called with testId = 3.
+WebSocketTest.onclose() was called with testId = 3.
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1005.
+PASS closeEvent.reason is ''
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1005.
+PASS closeEvent.reason is ''
+WebSocketTest.onopen() was called with testId = 4.
+WebSocketTest.onclose() was called with testId = 4.
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1005.
+PASS closeEvent.reason is ''
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1005.
+PASS closeEvent.reason is ''
+WebSocketTest.onopen() was called with testId = 5.
+WebSocketTest.onclose() was called with testId = 5.
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1015.
+FAIL closeEvent.reason should be . Was baz.
+PASS typeof closeEvent.wasClean is 'boolean'
+FAIL closeEvent.wasClean should be false. Was true.
+FAIL closeEvent.code should be 1006. Was 1015.
+FAIL closeEvent.reason should be . Was baz.
+WebSocketTest.onopen() was called with testId = 6.
+WebSocketTest.onclose() was called with testId = 6.
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+FAIL closeEvent.code should be 65535. Was 1005.
+FAIL closeEvent.reason should be good bye. Was .
+PASS typeof closeEvent.wasClean is 'boolean'
+PASS closeEvent.wasClean is true
+FAIL closeEvent.code should be 65535. Was 1005.
+FAIL closeEvent.reason should be good bye. Was .
+PASS successfullyParsed is true
+
+TEST COMPLETE
+


### PR DESCRIPTION
#### 19a3f253f03d31d43398f81dc5c64c48353b225d
<pre>
REGRESSION (iOS 15): http/tests/websocket/tests/hybi/close-code-and-reason.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=231329">https://bugs.webkit.org/show_bug.cgi?id=231329</a>

Unreviewed.

Rebasing test expectation to match NSURLSession WebSocket behavior.
Unflake test at the same time.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios-wk2/http/tests/websocket/tests/hybi/workers/close-code-and-reason-expected.txt:

Canonical link: <a href="https://commits.webkit.org/252017@main">https://commits.webkit.org/252017@main</a>
</pre>
