### PR TITLE
Add further logging to webrtc/datachannel/mdns-ice-candidates.html

### DIFF
--- a/LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt
+++ b/LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: sending messages
+CONSOLE MESSAGE: ondatachannel event handler
 CONSOLE MESSAGE: receiving one
 CONSOLE MESSAGE: receiving two
 CONSOLE MESSAGE: receiving three

--- a/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
+++ b/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
@@ -137,11 +137,15 @@ promise_test(async (test) => {
     await new Promise((resolve, reject) => {
         finishTest = resolve;
         createConnections((localConnection) => {
-            var init = { ordered: true, maxPacketLifeTime: 10, maxRetransmitTime: 11, protocol: "whatever", negotiated: false, id: 1 };
+            var init = { ordered: true };
             localChannel = localConnection.createDataChannel('sendDataChannel', init);
-            localChannel.onopen = () => { sendMessages(localChannel) };
+            localChannel.onopen = () => {
+                console.log("sending messages");
+                sendMessages(localChannel);
+            };
         }, (remoteConnection) => {
             remoteConnection.ondatachannel = (event) => {
+                console.log("ondatachannel event handler");
                 remoteChannel = event.channel;
                 remoteChannel.onmessage = receiveMessages;
             };


### PR DESCRIPTION
#### 1414fa659ce05d9cf6a1cc0c019404137bee395b
<pre>
Add further logging to webrtc/datachannel/mdns-ice-candidates.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=241913">https://bugs.webkit.org/show_bug.cgi?id=241913</a>

Reviewed by Eric Carlson.

Add more logging and remove max retransmit options.

* LayoutTests/webrtc/datachannel/mdns-ice-candidates-expected.txt:
* LayoutTests/webrtc/datachannel/mdns-ice-candidates.html:

Canonical link: <a href="https://commits.webkit.org/251793@main">https://commits.webkit.org/251793@main</a>
</pre>
