### PR TITLE
[git-webkit] WebKit is no longer canonically subversion

### DIFF
--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -71,6 +71,5 @@ if '__main__' == __name__:
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
         additional_setup=is_webkit_filter(additional_setup),
         hooks=os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'hooks'),
-        canonical_svn=is_webkit_filter(True),
     ))
 


### PR DESCRIPTION
#### 7bb116361f4d1625a6e4b9b4d29b20a3406315c0
<pre>
[git-webkit] WebKit is no longer canonically subversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=241917">https://bugs.webkit.org/show_bug.cgi?id=241917</a>
&lt;rdar://problem/95781547&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/git-webkit:

Canonical link: <a href="https://commits.webkit.org/251785@main">https://commits.webkit.org/251785@main</a>
</pre>
