### PR TITLE
Implicit extension enabling should use WebGL frontend

### DIFF
--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
@@ -38,9 +38,11 @@ EXTColorBufferFloat::EXTColorBufferFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context)
 {
     context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_float"_s);
+
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
+    // Enable it both in the backend and in WebKit.
+    context.getExtension("EXT_float_blend"_s);
 }
 
 EXTColorBufferFloat::~EXTColorBufferFloat() = default;

--- a/Source/WebCore/html/canvas/OESTextureFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloat.cpp
@@ -38,11 +38,14 @@ OESTextureFloat::OESTextureFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context)
 {
     context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float"_s);
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgb"_s);
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgba"_s);
+
+    // Spec requires WEBGL_color_buffer_float to be turned on implicitly here.
+    // Enable it both in the backend and in WebKit.
+    context.getExtension("WEBGL_color_buffer_float"_s);
+
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
+    // It will be implicitly enabled by the WEBGL_color_buffer_float above.
 }
 
 OESTextureFloat::~OESTextureFloat() = default;

--- a/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
@@ -38,8 +38,10 @@ OESTextureHalfFloat::OESTextureHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context)
 {
     context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float"_s);
-    // Renderability is implicit when this extension is enabled.
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_half_float"_s);
+
+    // Spec requires EXT_color_buffer_half_float to be turned on implicitly here.
+    // Enable it both in the backend and in WebKit.
+    context.getExtension("EXT_color_buffer_half_float"_s);
 }
 
 OESTextureHalfFloat::~OESTextureHalfFloat() = default;

--- a/Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp
@@ -40,9 +40,11 @@ WebGLColorBufferFloat::WebGLColorBufferFloat(WebGLRenderingContextBase& context)
     context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgba"_s);
     // Optimistically enable RGB floating-point render targets also, if possible.
     context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgb"_s);
+
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
+    // Enable it both in the backend and in WebKit.
+    context.getExtension("EXT_float_blend"_s);
 }
 
 WebGLColorBufferFloat::~WebGLColorBufferFloat() = default;

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -40,7 +40,11 @@ WebGLMultiDraw::WebGLMultiDraw(WebGLRenderingContextBase& context)
     : WebGLExtension(context)
 {
     context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_multi_draw"_s);
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_instanced_arrays"_s);
+
+    // Spec requires ANGLE_instanced_arrays to be turned on implicitly here.
+    // Enable it both in the backend and in WebKit.
+    if (context.isWebGL1())
+        context.getExtension("ANGLE_instanced_arrays"_s);
 }
 
 WebGLMultiDraw::~WebGLMultiDraw() = default;


### PR DESCRIPTION
#### 51f1a6142c926416da78b4d9aea558c569fd97ab
<pre>
Implicit extension enabling should use WebGL frontend
<a href="https://bugs.webkit.org/show_bug.cgi?id=241918">https://bugs.webkit.org/show_bug.cgi?id=241918</a>

Reviewed by Kimmo Kinnunen.

Use WebGL frontend to implicitly enable extensions.
This makes them appear in canvas debugging tools and
enables any frontend side-effects that they may have.

* Source/WebCore/html/canvas/EXTColorBufferFloat.cpp:
(WebCore::EXTColorBufferFloat::EXTColorBufferFloat):
* Source/WebCore/html/canvas/OESTextureFloat.cpp:
(WebCore::OESTextureFloat::OESTextureFloat):
* Source/WebCore/html/canvas/OESTextureHalfFloat.cpp:
(WebCore::OESTextureHalfFloat::OESTextureHalfFloat):
* Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp:
(WebCore::WebGLColorBufferFloat::WebGLColorBufferFloat):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::WebGLMultiDraw):

Canonical link: <a href="https://commits.webkit.org/251904@main">https://commits.webkit.org/251904@main</a>
</pre>
