### PR TITLE
Regression(r291141) Flashing when hovering photos on nytimes.com

### DIFF
--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -89,7 +89,6 @@ public:
 protected:
     explicit ImageLoader(Element&);
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) override;
-    void didStartLoading() override;
 
 private:
     void resetLazyImageLoading(Document&);
@@ -132,7 +131,6 @@ private:
     bool m_imageComplete : 1;
     bool m_loadManually : 1;
     bool m_elementIsProtected : 1;
-    bool m_inUpdateFromElement : 1;
     LazyImageLoadState m_lazyImageLoadState { LazyImageLoadState::None };
 };
 

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -99,12 +99,9 @@ CachedImage::~CachedImage()
 void CachedImage::load(CachedResourceLoader& loader)
 {
     m_skippingRevalidationDocument = loader.document();
-    if (loader.shouldPerformImageLoad(url())) {
+    if (loader.shouldPerformImageLoad(url()))
         CachedResource::load(loader);
-        CachedResourceClientWalker<CachedImageClient> walker(*this);
-        while (auto* client = walker.next())
-            client->didStartLoading();
-    } else
+    else
         setLoading(false);
 }
 

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -49,7 +49,6 @@ public:
     virtual VisibleInViewportState imageFrameAvailable(CachedImage& image, ImageAnimatingState, const IntRect* changeRect) { imageChanged(&image, changeRect); return VisibleInViewportState::No; }
     virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
 
-    virtual void didStartLoading() { }
     virtual void didRemoveCachedImageClient(CachedImage&) { }
 
     virtual void scheduleRenderingUpdateForImage(CachedImage&) { }


### PR DESCRIPTION
#### 04e2b883c9aefdbe1b533b9bf256bde9cb1ddf29
<pre>
Regression(r291141) Flashing when hovering photos on nytimes.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=241921">https://bugs.webkit.org/show_bug.cgi?id=241921</a>
&lt;rdar://95098539&gt;

Reviewed by Geoffrey Garen.

Revert r291141 since it introduced the flashing of photos on nytimes.com and we suspect
it caused some crashes as well.

Instead, do a much more minimal fix in ImageLoader::updatedHasPendingEvent() to fix the
memory leak that r291141 was trying to fix. In updatedHasPendingEvent() we no longer
protect the element if the load is deferred indefinitely (which is the case for lazy
image loading). In the lazy image loading case, when the load actually starts,
ImageLoader::updateFromElement() gets called again, which calls updatedHasPendingEvent()
which will protect the element then.

No new tests, covered by fast/dom/lazy-image-loading-document-leak.html that is still
passing.

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::ImageLoader):
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::updatedHasPendingEvent):
(WebCore::ImageLoader::didStartLoading): Deleted.
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::load):
* Source/WebCore/loader/cache/CachedImageClient.h:
(WebCore::CachedImageClient::didStartLoading): Deleted.

Canonical link: <a href="https://commits.webkit.org/251802@main">https://commits.webkit.org/251802@main</a>
</pre>
