### PR TITLE
[Gardening]: REGRESSION (r285418): Intl/numberformat-create-all-options.html performance test fails

### DIFF
--- a/PerformanceTests/Skipped
+++ b/PerformanceTests/Skipped
@@ -151,3 +151,6 @@ MediaTime/
 [Win] IndexedDB/stress/large-number-of-inserts-responsiveness.html
 [Win] IndexedDB/stress/large-number-of-inserts.html
 [Win] IndexedDB/stress/large-string-keys.html
+
+# https://bugs.webkit.org/show_bug.cgi?id=240767
+Intl/numberformat-create-all-options.html


### PR DESCRIPTION
#### 5e6fa1936157e1fe17fc27927afc56dbcc6d8fef
<pre>
[Gardening]: REGRESSION (r285418): Intl/numberformat-create-all-options.html performance test fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=240767">https://bugs.webkit.org/show_bug.cgi?id=240767</a>
&lt;rdar://93712843&gt;

Unreviewed test gardening.

* PerformanceTests/Skipped:

Canonical link: <a href="https://commits.webkit.org/251790@main">https://commits.webkit.org/251790@main</a>
</pre>
