### PR TITLE
[Merge-Queue] Use contributor triggering commit as committer

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6016,6 +6016,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
 
     def setUp(self):
         self.longMessage = True
+        Contributors.load = mock_load_contributors
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -6024,6 +6025,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
     def test_patch(self):
         self.setupStep(Canonicalize())
         self.setProperty('patch_id', '1234')
+        self.setProperty('patch_committer', 'committer@webkit.org')
 
         gmtoffset = int(time.localtime().tm_gmtoff * 100 / (60 * 60))
         fixed_time = int(time.time())
@@ -6061,7 +6063,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 command=[
                     'git', 'filter-branch', '-f',
-                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(date=date),
+                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='WebKit Committer';GIT_COMMITTER_EMAIL='committer@webkit.org'".format(date=date),
                     'HEAD...HEAD~1',
                 ],
             ) + 0,
@@ -6074,6 +6076,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.number', '1234')
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('owners', ['webkit-commit-queue'])
 
         gmtoffset = int(time.localtime().tm_gmtoff * 100 / (60 * 60))
         fixed_time = int(time.time())
@@ -6117,7 +6120,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 command=[
                     'git', 'filter-branch', '-f',
-                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(date=date),
+                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='WebKit Committer';GIT_COMMITTER_EMAIL='committer@webkit.org'".format(date=date),
                     'HEAD...HEAD~1',
                 ],
             ) + 0,
@@ -6130,6 +6133,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.number', '1234')
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('owners', ['webkit-commit-queue'])
 
         gmtoffset = int(time.localtime().tm_gmtoff * 100 / (60 * 60))
         fixed_time = int(time.time())
@@ -6155,7 +6159,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 command=[
                     'git', 'filter-branch', '-f',
-                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}'".format(date=date),
+                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='WebKit Committer';GIT_COMMITTER_EMAIL='committer@webkit.org'".format(date=date),
                     'HEAD...HEAD~1',
                 ],
             ) + 0,
@@ -6168,6 +6172,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
         self.setProperty('github.number', '1234')
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('owners', ['webkit-commit-queue'])
 
         self.expectRemoteCommands(
             ExpectShell(


### PR DESCRIPTION
#### a43dac729e7e8d1cafa48e12575204305b964f54
<pre>
[Merge-Queue] Use contributor triggering commit as committer
<a href="https://bugs.webkit.org/show_bug.cgi?id=241923">https://bugs.webkit.org/show_bug.cgi?id=241923</a>
&lt;rdar://95793938&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(Contributors.load): Set emails for contributors.
(Canonicalize):
(Canonicalize.__init__): Cache contributors.
(Canonicalize.run): Set committer.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/251801@main">https://commits.webkit.org/251801@main</a>
</pre>
