### PR TITLE
Ignore history items added by JS without user interaction via fragment navigation when navigation back/forward via the WKWebView API

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3238,6 +3238,11 @@ void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequ
         setProvisionalDocumentLoader(nullptr);
     }
 
+    if (!UserGestureIndicator::processingUserGesture(m_frame.document())) {
+        if (auto* currentItem = history().currentItem())
+            currentItem->setWasCreatedByJSWithoutUserInteraction(true);
+    }
+
     bool isRedirect = m_quickRedirectComing || policyChecker().loadType() == FrameLoadType::RedirectWithLockedBackForwardList;
     loadInSameDocument(request.url(), nullptr, !isRedirect);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm
@@ -489,6 +489,67 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesture)
     EXPECT_WK_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
 }
 
+TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesture2)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Add back/forward list items without user gestures.
+    [webView _evaluateJavaScriptWithoutUserGesture:@"location.href = location.pathname + '#a';" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"location.href = location.pathname + '#b';" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"location.href = location.pathname + '#c';" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    auto* lastURL = [webView URL];
+
+    // Going back should skip the back/forward list items without user gestures.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, url1.absoluteString.UTF8String);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 4U);
+
+    // Going forward should skip the back/forward list items without user gestures.
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, lastURL.absoluteString.UTF8String);
+
+    EXPECT_EQ([webView backForwardList].backList.count, 4U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+
+    NSString *currentURLString = [webView URL].absoluteString;
+    NSString *expectedURLString = makeString(String(url2.absoluteString), "#c");
+    EXPECT_WK_STREQ(currentURLString, expectedURLString);
+
+    // Navigating via the JS API shouldn't skip those back/forward list items.
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    expectedURLString = makeString(String([[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"].absoluteString), "#b");
+    EXPECT_WK_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.UTF8String);
+}
+
 TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesture)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
@@ -511,6 +572,51 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesture)
 
     auto* lastURL = [webView URL];
     EXPECT_FALSE([lastURL isEqual:url2]);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, url2.absoluteString.UTF8String);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, url1.absoluteString.UTF8String);
+
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, url2.absoluteString.UTF8String);
+
+    [webView goForward];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, lastURL.absoluteString.UTF8String);
+}
+
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesture2)
+{
+    auto webView = adoptNS([[WKWebView alloc] init]);
+
+    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    NSURL *url1 = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+    NSURL *url2 = [[NSBundle mainBundle] URLForResource:@"simple2" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // Add back/forward list items without user gestures.
+    [webView evaluateJavaScript:@"location.href = location.pathname + '#a';" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    NSString *expectedURLString = makeString(String(url2.absoluteString), "#a");
+    auto* lastURL = [webView URL];
+    EXPECT_WK_STREQ(lastURL.absoluteString.UTF8String, expectedURLString.UTF8String);
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];


### PR DESCRIPTION
#### 2c5890a4f8362e655340baad7130dccd37f50a86
<pre>
Ignore history items added by JS without user interaction via fragment navigation when navigation back/forward via the WKWebView API
<a href="https://bugs.webkit.org/show_bug.cgi?id=241924">https://bugs.webkit.org/show_bug.cgi?id=241924</a>
&lt;rdar://95790598&gt;

Reviewed by Geoffrey Garen.

This is a follow-up to 251783@main to set the wasCreatedByJSWithoutUserInteraction
flag on the HistoryItem when doing a fragment navigation without user gesture.
251783@main only did so for HistoryItems added via history.pushState() in JS. It is
however easy to achieve the same thing using fragment navigations.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/251900@main">https://commits.webkit.org/251900@main</a>
</pre>
