### PR TITLE
[GLIB] Fix overloaded-virtual warnings

### DIFF
--- a/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp
@@ -184,10 +184,10 @@ void LoadTrackingTest::loadURI(const char* uri)
     WebViewTest::loadURI(uri);
 }
 
-void LoadTrackingTest::loadHtml(const char* html, const char* baseURI)
+void LoadTrackingTest::loadHtml(const char* html, const char* baseURI, WebKitWebView* webView)
 {
     reset();
-    WebViewTest::loadHtml(html, baseURI);
+    WebViewTest::loadHtml(html, baseURI, webView);
 }
 
 void LoadTrackingTest::loadPlainText(const char* plainText)

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.h
@@ -39,7 +39,7 @@ public:
     virtual void estimatedProgressChanged();
 
     void loadURI(const char* uri);
-    void loadHtml(const char* html, const char* baseURI);
+    void loadHtml(const char* html, const char* baseURI, WebKitWebView* = nullptr);
     void loadPlainText(const char* plainText);
     void loadRequest(WebKitURIRequest*);
     void loadBytes(GBytes*, const char* mimeType, const char* encoding, const char* baseURI);


### PR DESCRIPTION
#### 65bee18661f8b934af1017478ce239c4b5e04583
<pre>
[GLIB] Fix overloaded-virtual warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=240221">https://bugs.webkit.org/show_bug.cgi?id=240221</a>

Fixes warnings introduced in 4db94c2b9e8bb6babecfdee47244250a0a8674c6.

Reviewed by Michael Catanzaro.

* Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp:
(LoadTrackingTest::loadHtml):
* Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.h:

Canonical link: <a href="https://commits.webkit.org/251825@main">https://commits.webkit.org/251825@main</a>
</pre>
