### PR TITLE
Navigations via swipe gestures should also skip back/forward list items without a user gesture

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -521,7 +521,7 @@ void ViewGestureController::startSwipeGesture(PlatformScrollEvent event, SwipeDi
 
     m_webPageProxy.recordAutomaticNavigationSnapshot();
 
-    RefPtr<WebBackForwardListItem> targetItem = (direction == SwipeDirection::Back) ? m_webPageProxy.backForwardList().backItem() : m_webPageProxy.backForwardList().forwardItem();
+    RefPtr<WebBackForwardListItem> targetItem = (direction == SwipeDirection::Back) ? m_webPageProxy.backForwardList().goBackItemSkippingItemsWithoutUserGesture() : m_webPageProxy.backForwardList().goForwardItemSkippingItemsWithoutUserGesture();
     if (!targetItem)
         return;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -59,6 +59,9 @@ public:
     WebBackForwardListItem* forwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;
 
+    WebBackForwardListItem* goBackItemSkippingItemsWithoutUserGesture() const;
+    WebBackForwardListItem* goForwardItemSkippingItemsWithoutUserGesture() const;
+
     const BackForwardListItemVector& entries() const { return m_entries; }
 
     unsigned backListCount() const;

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -184,7 +184,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     m_webPageProxyForBackForwardListForCurrentSwipe = alternateBackForwardListSourcePage ? alternateBackForwardListSourcePage.get() : &m_webPageProxy;
 
     auto& backForwardList = m_webPageProxyForBackForwardListForCurrentSwipe->backForwardList();
-    RefPtr targetItem = direction == SwipeDirection::Back ? backForwardList.backItem() : backForwardList.forwardItem();
+    RefPtr targetItem = direction == SwipeDirection::Back ? backForwardList.goBackItemSkippingItemsWithoutUserGesture() : backForwardList.goForwardItemSkippingItemsWithoutUserGesture();
     if (!targetItem) {
         RELEASE_LOG_ERROR(ViewGestures, "Failed to find %s item when beginning swipe.", direction == SwipeDirection::Back ? "back" : "forward");
         didEndGesture();

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -135,6 +135,7 @@
 - (void)waitForDidFinishNavigationOrSameDocumentNavigation
 {
     EXPECT_FALSE(self.didFinishNavigation);
+    EXPECT_FALSE(self.didSameDocumentNavigation);
 
     __block bool finished = false;
     self.didFinishNavigation = ^(WKWebView *, WKNavigation *) {
@@ -147,6 +148,7 @@
     TestWebKitAPI::Util::run(&finished);
 
     self.didFinishNavigation = nil;
+    self.didSameDocumentNavigation = nil;
 }
 
 - (void)waitForWebContentProcessDidTerminate


### PR DESCRIPTION
#### 639644f93e26f1389ab3b6fb58b0a2a0017b1a50
<pre>
Navigations via swipe gestures should also skip back/forward list items without a user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=241932">https://bugs.webkit.org/show_bug.cgi?id=241932</a>

Reviewed by Geoffrey Garen.

Navigations via swipe gestures should also skip back/forward list items without a user gesture.
Previously, with Bug 241885, it only impacted navigations via the back/forward buttons.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::startSwipeGesture):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::itemSkippingBackForwardItemsAddedByJSWithoutUserGesture):
(WebKit::WebBackForwardList::goBackItemSkippingItemsWithoutUserGesture const):
(WebKit::WebBackForwardList::goForwardItemSkippingItemsWithoutUserGesture const):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):
(WebKit::itemSkippingBackForwardItemsAddedByJSWithoutUserGesture): Deleted.

Canonical link: <a href="https://commits.webkit.org/251837@main">https://commits.webkit.org/251837@main</a>
</pre>
