### PR TITLE
Check weak linked symbol before use

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -716,10 +716,12 @@ void WebProcessPool::registerNotificationObservers()
     addCFNotificationObserver(mediaAccessibilityPreferencesChangedCallback, kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    m_powerLogObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kPLTaskingStartNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
-        if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated())
-            gpuProcess->enablePowerLogging();
-    }];
+    if (kPLTaskingStartNotification) {
+        m_powerLogObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kPLTaskingStartNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
+            if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated())
+                gpuProcess->enablePowerLogging();
+        }];
+    }
 #endif // HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
 }
 
@@ -772,7 +774,8 @@ void WebProcessPool::unregisterNotificationObservers()
     removeCFNotificationObserver(kMAXCaptionAppearanceSettingsChangedNotification);
 #endif
 #if HAVE(POWERLOG_TASK_MODE_QUERY) && ENABLE(GPU_PROCESS)
-    [[NSNotificationCenter defaultCenter] removeObserver:m_powerLogObserver.get()];
+    if (m_powerLogObserver)
+        [[NSNotificationCenter defaultCenter] removeObserver:m_powerLogObserver.get()];
 #endif
     m_weakObserver = nil;
 }


### PR DESCRIPTION
#### 2c38428816cc65f16488d1c5d2f64cf517f311b8
<pre>
Check weak linked symbol before use
<a href="https://bugs.webkit.org/show_bug.cgi?id=241933">https://bugs.webkit.org/show_bug.cgi?id=241933</a>
&lt;rdar://95797334&gt;

Reviewed by Chris Dumez.

Check weak linked symbol from the Power log framework before use.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):

Canonical link: <a href="https://commits.webkit.org/251812@main">https://commits.webkit.org/251812@main</a>
</pre>
