### PR TITLE
Canvas.toDataURL causes excessive GPUP memory use on Cocoa

### DIFF
--- a/LayoutTests/fast/canvas/toDataURL-alpha-permutation-expected.html
+++ b/LayoutTests/fast/canvas/toDataURL-alpha-permutation-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> 
+<html> 
+<head> 
+</head> 
+<body>
+    <style>
+        #test {
+            position: absolute;
+            width: 100px;
+            height: 400px;
+            background: rgba(255, 0, 0, 1);
+        }
+        #test2 {
+            position: relative;
+            left: 100px;
+            width: 100px;
+            height: 400px;
+            background: rgba(255, 0, 0, 0.5);
+        }
+    </style>
+    </div id="container">
+        <div id="test"></div>
+        <div id="test2"></div>
+    </div>
+</body> 
+</html> 

--- a/LayoutTests/fast/canvas/toDataURL-alpha-permutation.html
+++ b/LayoutTests/fast/canvas/toDataURL-alpha-permutation.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> 
+<html> 
+<head> 
+<script> 
+  function load() {
+      var canvas = document.createElement('canvas');
+      canvas.width = 300;
+      canvas.height = 100;
+      var context = canvas.getContext('2d');
+
+      context.fillStyle = "rgba(255, 0, 0, 1)";
+      context.fillRect(0, 0, context.canvas.width/3, context.canvas.height);
+
+      context.fillStyle = "rgba(255, 0, 0, 0.5)";
+      context.fillRect(context.canvas.width/3, 0, context.canvas.width/3, context.canvas.height);
+
+      context.fillStyle = "rgba(255, 0, 0, 0)";
+      context.fillRect(2*context.canvas.width/3, 0, context.canvas.width/3, context.canvas.height);
+
+      document.getElementById("jpg2dToDataUrl").style.imageRendering = "pixelated";
+      document.getElementById("jpg2dToDataUrl").style.backgroundImage = ["url(", context.canvas.toDataURL("image/jpg"), ")"].join("");
+      document.getElementById("png2dToDataUrl").style.imageRendering = "pixelated";
+      document.getElementById("png2dToDataUrl").style.backgroundImage = ["url(", context.canvas.toDataURL("image/png"), ")"].join("");
+      
+      var canvas = document.createElement('canvas');
+      canvas.width = 300;
+      canvas.height = 100;
+      var gl = canvas.getContext("webgl") 
+      || canvas.getContext("experimental-webgl");
+      
+      gl.enable(gl.SCISSOR_TEST);
+      gl.scissor(0, 0, canvas.width/3, canvas.height);
+      gl.clearColor(1.0, 0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      gl.scissor(canvas.width/3, 0, canvas.width/3, canvas.height);
+      gl.clearColor(1.0, 0, 0.0, 0.5);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      gl.scissor(2*canvas.width/3, 0, canvas.width/3, canvas.height);
+      gl.clearColor(1.0, 0.0, 0.0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      document.getElementById("pngwebglToDataUrl").style.imageRendering = "pixelated";
+      document.getElementById("jpgwebglToDataUrl").style.imageRendering = "pixelated";
+      document.getElementById("jpgwebglToDataUrl").style.backgroundImage = ["url(", gl.canvas.toDataURL("image/jpg"), ")"].join("");
+      document.getElementById("pngwebglToDataUrl").style.backgroundImage = ["url(", gl.canvas.toDataURL("image/png"), ")"].join("");
+}
+</script> 
+</head> 
+<body onload="load()">
+    <div id="jpg2dToDataUrl" style="width:300px;height:100px"></div>
+    <div id="png2dToDataUrl" style="width:300px;height:100px"></div>
+    <div id="jpgwebglToDataUrl" style="width:300px;height:100px"></div>
+    <div id="pngwebglToDataUrl" style="width:300px;height:100px"></div>
+</body> 
+</html> 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1820,6 +1820,9 @@ webkit.org/b/234782 imported/w3c/web-platform-tests/css/css-writing-modes/text-s
 imported/w3c/web-platform-tests/css/css-pseudo/selection-background-painting-order.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-007.html [ Failure ]
 
+# WebGL on GTK renders pixels with opacity slightly differently
+fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of non-crashing, non-flaky tests failing
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -985,6 +985,9 @@ fast/visual-viewport/zoomed-fixed-scroll-down-then-up.html [ Failure ]
 webkit.org/b/77568 fast/text/locale-shaping.html [ ImageOnlyFailure ]
 webkit.org/b/77568 fast/text/locale-shaping-complex.html [ ImageOnlyFailure ]
 
+# WebGL doesn't seem to work on windows
+fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
+
 ################################################################################
 ###########    End Missing Functionality Prevents Testing         ##############
 ################################################################################

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -728,7 +728,7 @@ ExceptionOr<void> HTMLCanvasElement::toBlob(Ref<BlobCallback>&& callback, const 
 #if USE(CG)
     if (auto imageData = getImageData()) {
         RefPtr<Blob> blob;
-        Vector<uint8_t> blobData = data(imageData->pixelBuffer(), encodingMIMEType, quality);
+        Vector<uint8_t> blobData = encodeData(imageData->pixelBuffer(), encodingMIMEType, quality);
         if (!blobData.isEmpty())
             blob = Blob::create(&document(), WTFMove(blobData), encodingMIMEType);
         callback->scheduleCallback(document(), WTFMove(blob));

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -39,6 +39,7 @@
 #include <wtf/Vector.h>
 
 #if USE(CG)
+#include "ImageBufferUtilitiesCG.h"
 #include "ImageSourceCG.h"
 #include "UTIRegistry.h"
 #include <ImageIO/ImageIO.h>
@@ -830,6 +831,20 @@ Vector<String> MIMETypeRegistry::allowedFileExtensions(const Vector<String>& mim
         allowedFileExtensions.appendIfNotContains(trimmedExtension(extension));
 
     return allowedFileExtensions;
+}
+
+bool MIMETypeRegistry::isJPEGMIMEType(const String& mimeType)
+{
+#if USE(CG)
+    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
+    if (!destinationUTI)
+        return false;
+    return CFEqual(destinationUTI.get(), jpegUTI());
+#else
+    return mimeType.substring(sizeof "image") == "jpeg"_s;
+#endif
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -146,7 +146,7 @@ public:
     WEBCORE_EXPORT static bool containsImageMIMETypeForEncoding(const Vector<String>& mimeTypes, const Vector<String>& extensions);
     WEBCORE_EXPORT static Vector<String> allowedMIMETypes(const Vector<String>& mimeTypes, const Vector<String>& extensions);
     WEBCORE_EXPORT static Vector<String> allowedFileExtensions(const Vector<String>& mimeTypes, const Vector<String>& extensions);
-    
+    WEBCORE_EXPORT static bool isJPEGMIMEType(const String& mimeType);
 private:
     // Check to see if the MIME type is not suitable for being loaded as a text
     // document in a frame. Only valid for MIME types begining with "text/".

--- a/Source/WebCore/platform/graphics/ConcreteImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ConcreteImageBuffer.h
@@ -230,24 +230,6 @@ protected:
         }
     }
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const override
-    {
-        if (auto* backend = ensureBackendCreated()) {
-            const_cast<ConcreteImageBuffer&>(*this).flushContext();
-            return backend->toDataURL(mimeType, quality, preserveResolution);
-        }
-        return String();
-    }
-
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const override
-    {
-        if (auto* backend = ensureBackendCreated()) {
-            const_cast<ConcreteImageBuffer&>(*this).flushContext();
-            return backend->toData(mimeType, quality);
-        }
-        return { };
-    }
-
     RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator) const override
     {
         if (auto* backend = ensureBackendCreated()) {

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -31,26 +31,77 @@
 #include "BitmapImage.h"
 #include "GraphicsContext.h"
 #include "HostWindow.h"
+#include "MIMETypeRegistry.h"
 #include "PlatformImageBuffer.h"
+#include <wtf/text/Base64.h>
+
+#if USE(CG)
+#include "ImageBufferUtilitiesCG.h"
+#endif
+#if USE(CAIRO)
+#include "ImageBufferUtilitiesCairo.h"
+#endif
 
 namespace WebCore {
 
 static const float MaxClampedLength = 4096;
 static const float MaxClampedArea = MaxClampedLength * MaxClampedLength;
 
+static RefPtr<ImageBuffer> copyImageBuffer(Ref<ImageBuffer> source, PreserveResolution preserveResolution)
+{
+    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
+        if (source->hasOneRef())
+            return source;
+    }
+    auto copySize = source->logicalSize();
+    auto copyScale = preserveResolution == PreserveResolution::Yes ? source->resolutionScale() : 1.f;
+    auto copyBuffer = source->context().createImageBuffer(copySize, copyScale, source->colorSpace());
+    if (!copyBuffer)
+        return nullptr;
+    if (source->hasOneRef())
+        ImageBuffer::drawConsuming(WTFMove(source), copyBuffer->context(), FloatRect { { }, copySize }, FloatRect { 0, 0, -1, -1 }, CompositeOperator::Copy);
+    else
+        copyBuffer->context().drawImageBuffer(source, FloatPoint { }, CompositeOperator::Copy);
+    return copyBuffer;
+}
+
+static RefPtr<NativeImage> copyImageBufferToNativeImage(Ref<ImageBuffer> source, BackingStoreCopy copyBehavior, PreserveResolution preserveResolution)
+{
+    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
+        if (source->hasOneRef())
+            return ImageBuffer::sinkIntoNativeImage(WTFMove(source));
+        return source->copyNativeImage(copyBehavior);
+    }
+    auto copyBuffer = copyImageBuffer(WTFMove(source), preserveResolution);
+    if (!copyBuffer)
+        return nullptr;
+    return ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
+}
+
+static RefPtr<NativeImage> copyImageBufferToOpaqueNativeImage(Ref<ImageBuffer> source, PreserveResolution preserveResolution)
+{
+    // Composite this ImageBuffer on top of opaque black, because JPEG does not have an alpha channel.
+    auto copyBuffer = copyImageBuffer(WTFMove(source), preserveResolution);
+    if (!copyBuffer)
+        return { };
+    // We composite the copy on top of black by drawing black under the copy.
+    copyBuffer->context().fillRect({ { }, copyBuffer->logicalSize() }, Color::black, CompositeOperator::DestinationOver);
+    return ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
+}
+
 RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, OptionSet<ImageBufferOptions> options, const CreationContext& creationContext)
 {
     RefPtr<ImageBuffer> imageBuffer;
-    
+
     // Give UseDisplayList a higher precedence since it is a debug option.
     if (options.contains(ImageBufferOptions::UseDisplayList)) {
         if (options.contains(ImageBufferOptions::Accelerated))
             imageBuffer = DisplayListAcceleratedImageBuffer::create(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
-        
+
         if (!imageBuffer)
             imageBuffer = DisplayListUnacceleratedImageBuffer::create(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
     }
-    
+
     if (creationContext.hostWindow && !imageBuffer) {
         auto renderingMode = options.contains(ImageBufferOptions::Accelerated) ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
         imageBuffer = creationContext.hostWindow->createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat);
@@ -61,7 +112,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
 
     if (options.contains(ImageBufferOptions::Accelerated))
         imageBuffer = AcceleratedImageBuffer::create(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
-    
+
     if (!imageBuffer)
         imageBuffer = UnacceleratedImageBuffer::create(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
 
@@ -70,12 +121,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
 
 RefPtr<ImageBuffer> ImageBuffer::clone() const
 {
-    auto clone = context().createAlignedImageBuffer(logicalSize(), colorSpace());
-    if (!clone)
-        return nullptr;
-
-    clone->context().drawImageBuffer(const_cast<ImageBuffer&>(*this), FloatPoint());
-    return clone;
+    return copyImageBuffer(const_cast<ImageBuffer&>(*this), PreserveResolution::Yes);
 }
 
 bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)
@@ -131,16 +177,7 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
 
 RefPtr<Image> ImageBuffer::copyImage(BackingStoreCopy copyBehavior, PreserveResolution preserveResolution) const
 {
-    RefPtr<NativeImage> image;
-    if (resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes)
-        image = copyNativeImage(copyBehavior);
-    else {
-        auto copyBuffer = context().createImageBuffer(logicalSize(), 1.f, colorSpace());
-        if (!copyBuffer)
-            return nullptr;
-        copyBuffer->context().drawImageBuffer(const_cast<ImageBuffer&>(*this), FloatPoint { }, CompositeOperator::Copy);
-        image = ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
-    }
+    auto image = copyImageBufferToNativeImage(const_cast<ImageBuffer&>(*this), copyBehavior, preserveResolution);
     if (!image)
         return nullptr;
     return BitmapImage::create(image.releaseNonNull());
@@ -169,6 +206,32 @@ RefPtr<Image> ImageBuffer::sinkIntoImage(RefPtr<ImageBuffer> source, PreserveRes
 void ImageBuffer::drawConsuming(RefPtr<ImageBuffer> imageBuffer, GraphicsContext& context, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& options)
 {
     imageBuffer->drawConsuming(context, destRect, srcRect, options);
+}
+
+String ImageBuffer::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
+{
+    return toDataURL(Ref { const_cast<ImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
+}
+
+Vector<uint8_t> ImageBuffer::toData(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
+{
+    return toData(Ref { const_cast<ImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
+}
+
+String ImageBuffer::toDataURL(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
+{
+    auto encodedData = toData(WTFMove(source), mimeType, quality, preserveResolution);
+    if (encodedData.isEmpty())
+        return "data:,"_s;
+    return makeString("data:", mimeType, ";base64,", base64Encoded(encodedData));
+}
+
+Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
+{
+    RefPtr<NativeImage> image = MIMETypeRegistry::isJPEGMIMEType(mimeType) ? copyImageBufferToOpaqueNativeImage(WTFMove(source), preserveResolution) : copyImageBufferToNativeImage(WTFMove(source), DontCopyBackingStore, preserveResolution);
+    if (!image)
+        return { };
+    return encodeData(image->platformImage().get(), mimeType, quality);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -143,8 +143,12 @@ public:
     virtual void convertToLuminanceMask() = 0;
     virtual void transformToColorSpace(const DestinationColorSpace&) = 0;
 
-    virtual String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const = 0;
-    virtual Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const = 0;
+    WEBCORE_EXPORT String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+    WEBCORE_EXPORT Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+
+
+    WEBCORE_EXPORT static String toDataURL(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
+    WEBCORE_EXPORT static Vector<uint8_t> toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
 
     virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& = ImageBufferAllocator()) const = 0;
     virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint = { }, AlphaPremultiplication destFormat = AlphaPremultiplication::Premultiplied) = 0;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -119,9 +119,6 @@ public:
     WEBCORE_EXPORT void convertToLuminanceMask();
     virtual void transformToColorSpace(const DestinationColorSpace&) { }
 
-    virtual String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const = 0;
-    virtual Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const = 0;
-
     virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect&, const ImageBufferAllocator& = ImageBufferAllocator()) const = 0;
     virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) = 0;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
@@ -36,10 +36,7 @@
 #include "ColorTransferFunctions.h"
 #include "GraphicsContext.h"
 #include "GraphicsContextCairo.h"
-#include "ImageBufferUtilitiesCairo.h"
-#include "MIMETypeRegistry.h"
 #include <cairo.h>
-#include <wtf/text/Base64.h>
 
 #if USE(CAIRO)
 
@@ -92,22 +89,6 @@ void ImageBufferCairoBackend::transformToColorSpace(const DestinationColorSpace&
     ASSERT(m_parameters.colorSpace == DestinationColorSpace::SRGB());
     UNUSED_PARAM(newColorSpace);
 #endif
-}
-
-String ImageBufferCairoBackend::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const
-{
-    Vector<uint8_t> encodedImage = toData(mimeType, quality);
-    if (encodedImage.isEmpty())
-        return "data:,"_s;
-
-    return makeString("data:", mimeType, ";base64,", base64Encoded(encodedImage.data(), encodedImage.size()));
-}
-
-Vector<uint8_t> ImageBufferCairoBackend::toData(const String& mimeType, std::optional<double> quality) const
-{
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-    cairo_surface_t* image = cairo_get_target(context().platformContext()->cr());
-    return data(image, mimeType, quality);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
@@ -41,9 +41,6 @@ public:
 
     void transformToColorSpace(const DestinationColorSpace&) override;
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const override;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const override;
-
 protected:
     using ImageBufferBackend::ImageBufferBackend;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -65,7 +65,7 @@ static bool encodeImage(cairo_surface_t* image, const String& mimeType, Vector<u
     return cairo_surface_write_to_png_stream(image, writeFunction, output) == CAIRO_STATUS_SUCCESS;
 }
 
-Vector<uint8_t> data(cairo_surface_t* image, const String& mimeType, std::optional<double>)
+Vector<uint8_t> encodeData(cairo_surface_t* image, const String& mimeType, std::optional<double>)
 {
     Vector<uint8_t> encodedImage;
     if (!image || !encodeImage(image, mimeType, &encodedImage))
@@ -78,31 +78,11 @@ static bool encodeImage(cairo_surface_t* surface, const String& mimeType, std::o
     // List of supported image encoding types comes from the GdkPixbuf documentation.
     // http://developer.gnome.org/gdk-pixbuf/stable/gdk-pixbuf-File-saving.html#gdk-pixbuf-save-to-bufferv
 
-    String type = mimeType.substring(sizeof "image");
+    String type = imageTypeFromMIMEType(mimeType);
     if (type != "jpeg"_s && type != "png"_s && type != "tiff"_s && type != "ico"_s && type != "bmp"_s)
         return false;
 
-    GRefPtr<GdkPixbuf> pixbuf;
-    if (type == "jpeg"_s) {
-        // JPEG doesn't support alpha channel. The <canvas> spec states that toDataURL() must encode a Porter-Duff
-        // composite source-over black for image types that do not support alpha.
-        RefPtr<cairo_surface_t> newSurface;
-        if (cairo_surface_get_type(surface) == CAIRO_SURFACE_TYPE_IMAGE) {
-            newSurface = adoptRef(cairo_image_surface_create_for_data(cairo_image_surface_get_data(surface),
-                CAIRO_FORMAT_RGB24,
-                cairo_image_surface_get_width(surface),
-                cairo_image_surface_get_height(surface),
-                cairo_image_surface_get_stride(surface)));
-        } else {
-            IntSize size = cairoSurfaceSize(surface);
-            newSurface = adoptRef(cairo_image_surface_create(CAIRO_FORMAT_RGB24, size.width(), size.height()));
-            RefPtr<cairo_t> cr = adoptRef(cairo_create(newSurface.get()));
-            cairo_set_source_surface(cr.get(), surface, 0, 0);
-            cairo_paint(cr.get());
-        }
-        pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(newSurface.get()));
-    } else
-        pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(surface));
+    GRefPtr<GdkPixbuf> pixbuf = adoptGRef(cairoSurfaceToGdkPixbuf(surface));
     if (!pixbuf)
         return false;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-Vector<uint8_t> data(cairo_surface_t*, const String& mimeType, std::optional<double> quality);
+Vector<uint8_t> encodeData(cairo_surface_t*, const String& mimeType, std::optional<double> quality);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -32,7 +32,6 @@
 #include "GraphicsContextCG.h"
 #include "ImageBufferUtilitiesCG.h"
 #include "IntRect.h"
-#include "MIMETypeRegistry.h"
 #include "PixelBuffer.h"
 #include "RuntimeApplicationChecks.h"
 #include <CoreGraphics/CoreGraphics.h>
@@ -78,20 +77,6 @@ RetainPtr<CGColorSpaceRef> ImageBufferCGBackend::contextColorSpace(const Graphic
 #endif
 }
 
-static RetainPtr<CGImageRef> createCroppedImageIfNecessary(CGImageRef image, const IntSize& backendSize)
-{
-    if (image && (CGImageGetWidth(image) != static_cast<size_t>(backendSize.width()) || CGImageGetHeight(image) != static_cast<size_t>(backendSize.height())))
-        return adoptCF(CGImageCreateWithImageInRect(image, CGRectMake(0, 0, backendSize.width(), backendSize.height())));
-    return image;
-}
-
-static CGColorSpaceRef colorSpaceForBitmap(DestinationColorSpace imageBufferColorSpace)
-{
-    if (CGColorSpaceGetModel(imageBufferColorSpace.platformColorSpace()) != kCGColorSpaceModelRGB)
-        return sRGBColorSpaceRef();
-    return imageBufferColorSpace.platformColorSpace();
-}
-
 void ImageBufferCGBackend::clipToMask(GraphicsContext& destContext, const FloatRect& destRect)
 {
     auto nativeImage = copyNativeImage(DontCopyBackingStore);
@@ -107,79 +92,6 @@ void ImageBufferCGBackend::clipToMask(GraphicsContext& destContext, const FloatR
     CGContextClipToMask(cgContext, { { }, destRect.size() }, nativeImage->platformImage().get());
     CGContextScaleCTM(cgContext, 1, -1);
     CGContextTranslateCTM(cgContext, -destRect.x(), -destRect.maxY());
-}
-
-RetainPtr<CGImageRef> ImageBufferCGBackend::copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution preserveResolution) const
-{
-    if (CFEqual(destinationUTI, jpegUTI())) {
-        // FIXME: Should this be using the same logic as ImageBufferUtilitiesCG?
-
-        // JPEGs don't have an alpha channel, so we have to manually composite on top of black.
-        PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, DestinationColorSpace(colorSpaceForBitmap(colorSpace())) };
-        auto pixelBuffer = getPixelBuffer(format, logicalRect());
-        if (!pixelBuffer)
-            return nullptr;
-
-        Ref protectedPixelBuffer = *pixelBuffer;
-        auto dataSize = pixelBuffer->sizeInBytes();
-        auto data = pixelBuffer->bytes();
-
-        verifyImageBufferIsBigEnough(data, dataSize);
-
-        auto dataProvider = adoptCF(CGDataProviderCreateWithData(&protectedPixelBuffer.leakRef(), data, dataSize, [] (void* context, const void*, size_t) {
-            static_cast<PixelBuffer*>(context)->deref();
-        }));
-        if (!dataProvider)
-            return nullptr;
-
-        auto imageSize = pixelBuffer->size();
-        return adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), pixelBuffer->format().colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(kCGImageAlphaNoneSkipLast), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
-    }
-
-    if (resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
-        auto nativeImage = copyNativeImage(CopyBackingStore);
-        if (!nativeImage)
-            return nullptr;
-        return createCroppedImageIfNecessary(nativeImage->platformImage().get(), backendSize());
-    }
-    
-    auto nativeImage = copyNativeImage(DontCopyBackingStore);
-    if (!nativeImage)
-        return nullptr;
-    auto image = nativeImage->platformImage();
-    auto context = adoptCF(CGBitmapContextCreate(0, backendSize().width(), backendSize().height(), 8, 4 * backendSize().width(), colorSpaceForBitmap(colorSpace()), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
-    CGContextSetBlendMode(context.get(), kCGBlendModeCopy);
-    CGContextClipToRect(context.get(), CGRectMake(0, 0, backendSize().width(), backendSize().height()));
-    CGContextDrawImage(context.get(), CGRectMake(0, 0, backendSize().width(), backendSize().height()), image.get());
-    return adoptCF(CGBitmapContextCreateImage(context.get()));
-}
-
-Vector<uint8_t> ImageBufferCGBackend::toData(const String& mimeType, std::optional<double> quality) const
-{
-#if ENABLE(GPU_PROCESS)
-    ASSERT_IMPLIES(!isInGPUProcess(), MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#else
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#endif
-
-    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
-    auto image = copyCGImageForEncoding(destinationUTI.get(), PreserveResolution::No);
-
-    return WebCore::data(image.get(), destinationUTI.get(), quality);
-}
-
-String ImageBufferCGBackend::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
-{
-#if ENABLE(GPU_PROCESS)
-    ASSERT_IMPLIES(!isInGPUProcess(), MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#else
-    ASSERT(MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-#endif
-
-    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
-    auto image = copyCGImageForEncoding(destinationUTI.get(), preserveResolution);
-
-    return WebCore::dataURL(image.get(), destinationUTI.get(), mimeType, quality);
 }
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlusher()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -45,16 +45,11 @@ protected:
 
     void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution) const override;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const override;
-
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     bool originAtBottomLeftCorner() const override;
 
     static RetainPtr<CGColorSpaceRef> contextColorSpace(const GraphicsContext&);
-
-    virtual RetainPtr<CGImageRef> copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -79,14 +79,10 @@ protected:
     static RetainPtr<CGColorSpaceRef> contextColorSpace(const GraphicsContext&);
     unsigned bytesPerRow() const override;
 
-    // ImageBufferCGBackend overrides.
-    RetainPtr<CGImageRef> copyCGImageForEncoding(CFStringRef destinationUTI, PreserveResolution) const final;
-
     void finalizeDrawIntoContext(GraphicsContext& destinationContext) override;
     void invalidateCachedNativeImage() const;
 
     std::unique_ptr<IOSurface> m_surface;
-    mutable bool m_requiresDrawAfterPutPixelBuffer { false };
     mutable bool m_mayHaveOutstandingBackingStoreReferences { false };
     mutable bool m_needsSetupContext { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -96,9 +96,13 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
-static bool encode(CGImageRef image, CFStringRef destinationUTI, std::optional<double> quality, const ScopedLambda<PutBytesCallback>& function)
+static bool encode(CGImageRef image, const String& mimeType, std::optional<double> quality, const ScopedLambda<PutBytesCallback>& function)
 {
-    if (!image || !destinationUTI)
+    if (!image)
+        return false;
+
+    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
+    if (!destinationUTI)
         return false;
 
     CGDataConsumerCallbacks callbacks {
@@ -110,11 +114,12 @@ static bool encode(CGImageRef image, CFStringRef destinationUTI, std::optional<d
     };
 
     auto consumer = adoptCF(CGDataConsumerCreate(const_cast<ScopedLambda<PutBytesCallback>*>(&function), &callbacks));
-    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer.get(), destinationUTI, 1, nullptr));
+    auto destination = adoptCF(CGImageDestinationCreateWithDataConsumer(consumer.get(), destinationUTI.get(), 1, nullptr));
     
     auto imageProperties = [&] () -> RetainPtr<CFDictionaryRef> {
-        if (CFEqual(destinationUTI, jpegUTI()) && quality && *quality >= 0.0 && *quality <= 1.0) {
+        if (CFEqual(destinationUTI.get(), jpegUTI()) && quality && *quality >= 0.0 && *quality <= 1.0) {
             // Apply the compression quality to the JPEG image destination.
+            quality = std::max(*quality, 0.0001); // FIXME: Remove once BigSur is unsupported (rdar://80446736)
             auto compressionQuality = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &*quality));
             const void* key = kCGImageDestinationLossyCompressionQuality;
             const void* value = compressionQuality.get();
@@ -179,14 +184,14 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
     auto imageSize = source.size();
     auto image = adoptCF(CGImageCreate(imageSize.width(), imageSize.height(), 8, 32, 4 * imageSize.width(), source.format().colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGBitmapByteOrderDefault) | static_cast<uint32_t>(dataAlphaInfo), dataProvider.get(), 0, false, kCGRenderingIntentDefault));
 
-    return encode(image.get(), destinationUTI.get(), quality, function);
+    return encode(image.get(), mimeType, quality, function);
 }
 
-template<typename Source, typename SourceDescription> static Vector<uint8_t> encodeToVector(Source&& source, SourceDescription&& sourceDescription, std::optional<double> quality)
+template<typename Source> static Vector<uint8_t> encodeToVector(Source&& source, const String& mimeType, std::optional<double> quality)
 {
     Vector<uint8_t> result;
 
-    bool success = encode(std::forward<Source>(source), std::forward<SourceDescription>(sourceDescription), quality, scopedLambdaRef<PutBytesCallback>([&] (const void* data, size_t length) {
+    bool success = encode(std::forward<Source>(source), mimeType, quality, scopedLambdaRef<PutBytesCallback>([&] (const void* data, size_t length) {
         result.append(static_cast<const uint8_t*>(data), length);
         return length;
     }));
@@ -196,35 +201,35 @@ template<typename Source, typename SourceDescription> static Vector<uint8_t> enc
     return result;
 }
 
-template<typename Source, typename SourceDescription> static String encodeToDataURL(Source&& source, SourceDescription&& sourceDescription, const String& mimeType, std::optional<double> quality)
+template<typename Source> static String encodeToDataURL(Source&& source, const String& mimeType, std::optional<double> quality)
 {
     // FIXME: This could be done more efficiently with a streaming base64 encoder.
 
-    auto encodedData = encodeToVector(std::forward<Source>(source), std::forward<SourceDescription>(sourceDescription), quality);
+    auto encodedData = encodeToVector(std::forward<Source>(source), mimeType, quality);
     if (encodedData.isEmpty())
         return "data:,"_s;
 
     return makeString("data:", mimeType, ";base64,", base64Encoded(encodedData));
 }
 
-Vector<uint8_t> data(CGImageRef image, CFStringRef destinationUTI, std::optional<double> quality)
+Vector<uint8_t> encodeData(CGImageRef image, const String& mimeType, std::optional<double> quality)
 {
-    return encodeToVector(image, destinationUTI, quality);
+    return encodeToVector(image, mimeType, quality);
 }
 
-Vector<uint8_t> data(const PixelBuffer& pixelBuffer, const String& mimeType, std::optional<double> quality)
+Vector<uint8_t> encodeData(const PixelBuffer& pixelBuffer, const String& mimeType, std::optional<double> quality)
 {
     return encodeToVector(pixelBuffer, mimeType, quality);
 }
 
-String dataURL(CGImageRef image, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality)
+String dataURL(CGImageRef image, const String& mimeType, std::optional<double> quality)
 {
-    return encodeToDataURL(image, destinationUTI, mimeType, quality);
+    return encodeToDataURL(image, mimeType, quality);
 }
 
 String dataURL(const PixelBuffer& pixelBuffer, const String& mimeType, std::optional<double> quality)
 {
-    return encodeToDataURL(pixelBuffer, mimeType, mimeType, quality);
+    return encodeToDataURL(pixelBuffer, mimeType, quality);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
@@ -36,13 +36,12 @@ class PixelBuffer;
 
 WEBCORE_EXPORT uint8_t verifyImageBufferIsBigEnough(const void* buffer, size_t bufferSize);
 
+RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String& mimeType);
 CFStringRef jpegUTI();
-WEBCORE_EXPORT RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String&);
+Vector<uint8_t> encodeData(CGImageRef, const String& mimeType, std::optional<double> quality);
+Vector<uint8_t> encodeData(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
 
-Vector<uint8_t> data(CGImageRef, CFStringRef destinationUTI, std::optional<double> quality);
-Vector<uint8_t> data(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
-
-WEBCORE_EXPORT String dataURL(CGImageRef, CFStringRef destinationUTI, const String& mimeType, std::optional<double> quality);
+WEBCORE_EXPORT String dataURL(CGImageRef, const String& mimeType, std::optional<double> quality);
 String dataURL(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -244,40 +244,6 @@ void RemoteRenderingBackend::putPixelBufferForImageBuffer(RenderingResourceIdent
     }
 }
 
-void RemoteRenderingBackend::getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(String&&)>&& completionHandler)
-{
-    // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
-    // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    getDataURLForImageBufferWithQualifiedIdentifier(mimeType, quality, preserveResolution, { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() }, WTFMove(completionHandler));
-}
-
-void RemoteRenderingBackend::getDataURLForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(String&&)>&& completionHandler)
-{
-    ASSERT(!RunLoop::isMain());
-
-    String urlString;
-    if (auto imageBuffer = m_remoteResourceCache.cachedImageBuffer(renderingResourceIdentifier))
-        urlString = imageBuffer->toDataURL(mimeType, quality, preserveResolution);
-    completionHandler(WTFMove(urlString));
-}
-
-void RemoteRenderingBackend::getDataForImageBuffer(const String& mimeType, std::optional<double> quality, RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler)
-{
-    // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
-    // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    getDataForImageBufferWithQualifiedIdentifier(mimeType, quality, { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() }, WTFMove(completionHandler));
-}
-
-void RemoteRenderingBackend::getDataForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&& completionHandler)
-{
-    ASSERT(!RunLoop::isMain());
-
-    Vector<uint8_t> data;
-    if (auto imageBuffer = m_remoteResourceCache.cachedImageBuffer(renderingResourceIdentifier))
-        data = imageBuffer->toData(mimeType, quality);
-    completionHandler(WTFMove(data));
-}
-
 void RemoteRenderingBackend::getShareableBitmapForImageBuffer(RenderingResourceIdentifier identifier, PreserveResolution preserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&& completionHandler)
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -116,8 +116,6 @@ private:
     void getPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier, SharedMemory::IPCHandle&&, WebCore::PixelBufferFormat&& destinationFormat, WebCore::IntRect&& srcRect, CompletionHandler<void()>&&);
     void destroyGetPixelBufferSharedMemory();
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, IPC::PixelBufferReference&&, WebCore::IntRect&& srcRect, WebCore::IntPoint&& destPoint, WebCore::AlphaPremultiplication destFormat);
-    void getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, WebCore::RenderingResourceIdentifier, CompletionHandler<void(String&&)>&&);
-    void getDataForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&&);
     void getShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void getFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier, IPC::FilterReference&&, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);
@@ -131,8 +129,6 @@ private:
 
     // Received messages translated to use QualifiedRenderingResourceIdentifier.
     void createImageBufferWithQualifiedIdentifier(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, QualifiedRenderingResourceIdentifier);
-    void getDataURLForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, QualifiedRenderingResourceIdentifier, CompletionHandler<void(String&&)>&&);
-    void getDataForImageBufferWithQualifiedIdentifier(const String& mimeType, std::optional<double> quality, QualifiedRenderingResourceIdentifier, CompletionHandler<void(Vector<uint8_t>&&)>&&);
     void getShareableBitmapForImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImageWithQualifiedIdentifier(const ShareableBitmap::Handle&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -28,8 +28,6 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     GetPixelBufferForImageBufferWithNewMemory(WebCore::RenderingResourceIdentifier imageBuffer, WebKit::SharedMemory::IPCHandle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
     DestroyGetPixelBufferSharedMemory()
     PutPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, IPC::PixelBufferReference pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
-    GetDataURLForImageBuffer(String mimeType, std::optional<double> quality, enum:uint8_t WebCore::PreserveResolution preserveResolution, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (String urlString) Synchronous
-    GetDataForImageBuffer(String mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<uint8_t> data) Synchronous
     GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:uint8_t WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
     GetFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, IPC::FilterReference filter) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebKit::ShareableBitmap::Handle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable

--- a/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
+++ b/Source/WebKit/Shared/API/c/cg/WKImageCG.cpp
@@ -70,7 +70,6 @@ WKImageRef WKImageCreateFromCGImage(CGImageRef imageRef, WKImageOptions options)
 WKStringRef WKImageCreateDataURLFromImage(CGImageRef imageRef)
 {
     String mimeType { "image/png"_s };
-    auto destinationUTI = WebCore::utiFromImageBufferMIMEType(mimeType);
-    auto value = WebCore::dataURL(imageRef, destinationUTI.get(), mimeType, { });
+    auto value = WebCore::dataURL(imageRef, mimeType, { });
     return WKStringCreateWithUTF8CString(value.utf8().data());
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -176,24 +176,6 @@ protected:
         return m_backend.get();
     }
 
-    String toDataURL(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution preserveResolution) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-
-        ASSERT(WebCore::MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-        return m_remoteRenderingBackendProxy->getDataURLForImageBuffer(mimeType, quality, preserveResolution, m_renderingResourceIdentifier);
-    }
-
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-
-        ASSERT(WebCore::MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(mimeType));
-        return m_remoteRenderingBackendProxy->getDataForImageBuffer(mimeType, quality, m_renderingResourceIdentifier);
-    }
-
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy copyBehavior = WebCore::CopyBackingStore) const final
     {
         if (UNLIKELY(!m_remoteRenderingBackendProxy))

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -209,20 +209,6 @@ void RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory()
     sendToStream(Messages::RemoteRenderingBackend::DestroyGetPixelBufferSharedMemory());
 }
 
-String RemoteRenderingBackendProxy::getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution, RenderingResourceIdentifier renderingResourceIdentifier)
-{
-    String urlString;
-    sendSyncToStream(Messages::RemoteRenderingBackend::GetDataURLForImageBuffer(mimeType, quality, preserveResolution, renderingResourceIdentifier), Messages::RemoteRenderingBackend::GetDataURLForImageBuffer::Reply(urlString));
-    return urlString;
-}
-
-Vector<uint8_t> RemoteRenderingBackendProxy::getDataForImageBuffer(const String& mimeType, std::optional<double> quality, RenderingResourceIdentifier renderingResourceIdentifier)
-{
-    Vector<uint8_t> data;
-    sendSyncToStream(Messages::RemoteRenderingBackend::GetDataForImageBuffer(mimeType, quality, renderingResourceIdentifier), Messages::RemoteRenderingBackend::GetDataForImageBuffer::Reply(data));
-    return data;
-}
-
 RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(RenderingResourceIdentifier imageBuffer, PreserveResolution preserveResolution)
 {
     ShareableBitmap::Handle handle;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -87,8 +87,6 @@ public:
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, Span<uint8_t> result);
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat);
-    String getDataURLForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution, WebCore::RenderingResourceIdentifier);
-    Vector<uint8_t> getDataForImageBuffer(const String& mimeType, std::optional<double> quality, WebCore::RenderingResourceIdentifier);
     RefPtr<ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
     RefPtr<WebCore::Image> getFilteredImage(WebCore::RenderingResourceIdentifier, WebCore::Filter&);
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -112,18 +112,6 @@ RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage(BackingSt
     return { };
 }
 
-String ImageBufferRemoteIOSurfaceBackend::toDataURL(const String&, std::optional<double>, PreserveResolution) const
-{
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
-Vector<uint8_t> ImageBufferRemoteIOSurfaceBackend::toData(const String&, std::optional<double>) const
-{
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
 RefPtr<PixelBuffer> ImageBufferRemoteIOSurfaceBackend::getPixelBuffer(const PixelBufferFormat&, const IntRect&, const ImageBufferAllocator&) const
 {
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -60,8 +60,7 @@ public:
 private:
     WebCore::IntSize backendSize() const final;
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy) const final;
-    String toDataURL(const String& mimeType, std::optional<double> quality, WebCore::PreserveResolution) const final;
-    Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality) const final;
+
     RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& outputFormat, const WebCore::IntRect&, const WebCore::ImageBufferAllocator&) const final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 


### PR DESCRIPTION
#### bc684eeb57fb0cb64b1a8d4f05e00dd1cb25bf02
<pre>
Canvas.toDataURL causes excessive GPUP memory use on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=240639">https://bugs.webkit.org/show_bug.cgi?id=240639</a>
&lt;rdar://93567863&gt;

Reviewed by Said Abou-Hallawa.

From Kimmo&apos;s WIP: #1407

ImageBuffer::toData() and ImageBuffer::toDataURL() would construct a temporary
image-sized bitmap in the GPUP to act as the data encoding source image.
This intermediate bitmap is large for large source images, and will easily make GPUP
memory footprint exceed the limit.

Use the ImageBuffer drawing mechanism to composite the encoding source. This ensures
that the intermediate bitmaps are constructed similar to any other ImageBuffer, and as
such attributes the memory to WP.

Copy the ImageBuffer source to WP instead of GPUP and run the encoding in WP. This makes
the encoding cycles be spent in the correct process and reduces the code footprint of
GPUP.

ImageBuffer::toData() and ::toDataURL() were accessors that were propagated all the way
to the ImageBufferBackend and in GPUP case across processes. They are redundant, as
the data being used is available through copyNativeImage / copyImage.

* LayoutTests/fast/canvas/toDataURL-alpha-permutation-expected.html: Added.
* LayoutTests/fast/canvas/toDataURL-alpha-permutation.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/platform/graphics/ConcreteImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::copyImageBuffer):
(WebCore::copyNativeImageImpl):
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::copyImage const):
(WebCore::ImageBuffer::toDataURL const):
(WebCore::ImageBuffer::toData const):
(WebCore::ImageBuffer::toDataURL):
(WebCore::ImageBuffer::toData):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp:
(WebCore::ImageBufferCairoBackend::toDataURL const): Deleted.
(WebCore::ImageBufferCairoBackend::toData const): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp:
(WebCore::imageTypeFromMIMEType):
(WebCore::platformMIMETypeIsJPEG):
(WebCore::encodeImage):
* Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::createCroppedImageIfNecessary): Deleted.
(WebCore::colorSpaceForBitmap): Deleted.
(WebCore::ImageBufferCGBackend::copyCGImageForEncoding const): Deleted.
(WebCore::ImageBufferCGBackend::toData const): Deleted.
(WebCore::ImageBufferCGBackend::toDataURL const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage const):
(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
(WebCore::ImageBufferIOSurfaceBackend::copyCGImageForEncoding const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::jpegUTI):
(WebCore::utiFromImageBufferMIMEType):
(WebCore::platformMIMETypeIsJPEG):
(WebCore::encode):
(WebCore::encodeToVector):
(WebCore::encodeToDataURL):
(WebCore::data):
(WebCore::dataURL):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::getDataURLForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::getDataURLForImageBufferWithQualifiedIdentifier): Deleted.
(WebKit::RemoteRenderingBackend::getDataForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::getDataForImageBufferWithQualifiedIdentifier): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/API/c/cg/WKImageCG.cpp:
(WKImageCreateDataURLFromImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getDataURLForImageBuffer): Deleted.
(WebKit::RemoteRenderingBackendProxy::getDataForImageBuffer): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::toDataURL const): Deleted.
(WebKit::ImageBufferRemoteIOSurfaceBackend::toData const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:

Canonical link: <a href="https://commits.webkit.org/251974@main">https://commits.webkit.org/251974@main</a>
</pre>
