### PR TITLE
clean-webkit should prevent extremely large local repositories

### DIFF
--- a/Tools/Scripts/clean-webkit
+++ b/Tools/Scripts/clean-webkit
@@ -59,6 +59,7 @@ def main(args):
     scm = SCMDetector(fs, host.executive).detect_scm_system(fs.getcwd())
 
     scm.discard_working_directory_changes()
+    scm.cleanup_and_optimize_local_repository()
 
     if args.keep_jhbuild_directory:
         # Clean everything inside WebKitBuild, except the JHBuild directories.

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -651,3 +651,6 @@ class Git(SCM, SVNRepository):
 
     def rev_parse(self, rev):
         return self._run_git(['rev-parse', rev]).rstrip()
+
+    def cleanup_and_optimize_local_repository(self):
+        return self._run_git(['gc', '--prune=3.days.ago'])

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm.py
@@ -244,6 +244,9 @@ class SCM:
     def discard_local_commits(self):
         return
 
+    def cleanup_and_optimize_local_repository(self):
+        return
+
     def remote_merge_base(self):
         SCM._subclass_must_implement()
 


### PR DESCRIPTION
#### bc31aac0bebf408f53939ffff05d426387813e53
<pre>
clean-webkit should prevent extremely large local repositories
<a href="https://bugs.webkit.org/show_bug.cgi?id=241925">https://bugs.webkit.org/show_bug.cgi?id=241925</a>
&lt;rdar://problem/95795503&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/clean-webkit:
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.cleanup_and_optimize_local_repository):
* Tools/Scripts/webkitpy/common/checkout/scm/scm.py:
(SCM.cleanup_and_optimize_local_repository):

Canonical link: <a href="https://commits.webkit.org/251804@main">https://commits.webkit.org/251804@main</a>
</pre>
