### PR TITLE
Fix internal build break on iOS simulator after https://commits.webkit.org/251798@main

### DIFF
--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -113,7 +113,7 @@ void SharedMemory::Handle::takeOwnershipOfMemory(MemoryLedger memoryLedger) cons
 
 void SharedMemory::Handle::setOwnershipOfMemory(const ProcessIdentity& processIdentity, MemoryLedger memoryLedger) const
 {
-#if HAVE(MACH_MEMORY_ENTRY) && HAVE(MACH_MEMORY_ENTRY_OWNERSHIP_IDENTITY_TOKEN_SUPPORT)
+#if HAVE(TASK_IDENTITY_TOKEN) && HAVE(MACH_MEMORY_ENTRY_OWNERSHIP_IDENTITY_TOKEN_SUPPORT)
     if (!m_port)
         return;
 


### PR DESCRIPTION
#### 65fd594463eabac2aa1f722e544ed4f32246b891
<pre>
Fix internal build break on iOS simulator after <a href="https://commits.webkit.org/251798@main">https://commits.webkit.org/251798@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=241937">https://bugs.webkit.org/show_bug.cgi?id=241937</a>

Reviewed by Ryan Haddad.

SharedMemory::Handle::setOwnershipOfMemory() calls ProcessIdentity::taskIdToken()
which is defined only if HAVE(TASK_IDENTITY_TOKEN) is true. Ensure the new code
compiles only if HAVE(TASK_IDENTITY_TOKEN) is true.

* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemory::Handle::setOwnershipOfMemory const):

Canonical link: <a href="https://commits.webkit.org/251806@main">https://commits.webkit.org/251806@main</a>
</pre>
