### PR TITLE
Stripping whitespace in <animate> values attribute should use stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>)

### DIFF
--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -155,7 +155,7 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue.stripWhiteSpace()))
+            if (WTF::protocolIsJavaScript(innerValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>)))
                 return true;
         }
         return false;
@@ -171,7 +171,7 @@ void SVGAnimationElement::parseAttribute(const QualifiedName& name, const AtomSt
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         value.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.stripWhiteSpace().toString());
+            m_values.append(innerValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString());
         });
 
         updateAnimationMode();


### PR DESCRIPTION
#### e41bfba750f7297186d9401b7af414de5d1d1b58
<pre>
Stripping whitespace in &lt;animate&gt; values attribute should use stripLeadingAndTrailingMatchedCharacters(isHTMLSpace&lt;UChar&gt;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=241867">https://bugs.webkit.org/show_bug.cgi?id=241867</a>

Reviewed by Chris Dumez and Darin Adler.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeContainsJavaScriptURL const):
(WebCore::SVGAnimationElement::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/251835@main">https://commits.webkit.org/251835@main</a>
</pre>
