### PR TITLE
git-webkit land should apply the merge-queue label (Follow-up)

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.0',
+    version='5.2.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 0)
+version = Version(5, 2, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -29,6 +29,7 @@ from .canonicalize import Canonicalize
 from .command import Command
 from .branch import Branch
 from .pull_request import PullRequest
+from .squash import Squash
 from argparse import Namespace
 from webkitbugspy import Tracker
 from webkitcorepy import arguments, run, string_utils, Terminal


### PR DESCRIPTION
#### e358612bebec3f27895c3f7c1048914fd9824113
<pre>
git-webkit land should apply the merge-queue label (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=240308">https://bugs.webkit.org/show_bug.cgi?id=240308</a>
&lt;rdar://problem/93501363&gt;

Unreviewed follow-up fix.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:

Canonical link: <a href="https://commits.webkit.org/251805@main">https://commits.webkit.org/251805@main</a>
</pre>
