### PR TITLE
Regression (247017@main): correct an ASSERT in SQLiteIDBBackingStore

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -912,7 +912,7 @@ std::unique_ptr<IDBDatabaseInfo> SQLiteIDBBackingStore::extractExistingDatabaseI
 
 String SQLiteIDBBackingStore::encodeDatabaseName(const String& databaseName)
 {
-    ASSERT(!databaseName.isEmpty());
+    ASSERT(!databaseName.isNull());
     if (databaseName.isEmpty())
         return "%00"_s;
 


### PR DESCRIPTION
#### 016fd2a5046c8f06cb0a62fbee5fb8b66499cebe
<pre>
Regression (247017@main): correct an ASSERT in SQLiteIDBBackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=241939">https://bugs.webkit.org/show_bug.cgi?id=241939</a>

Reviewed by Geoffrey Garen.

<a href="https://commits.webkit.org/247017@main">https://commits.webkit.org/247017@main</a> changed the assert by mistake; let&apos;s revert the change. Empty string is valid for
database name per spec: <a href="https://www.w3.org/TR/IndexedDB/#name">https://www.w3.org/TR/IndexedDB/#name</a>

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::encodeDatabaseName):

Canonical link: <a href="https://commits.webkit.org/251807@main">https://commits.webkit.org/251807@main</a>
</pre>
