### PR TITLE
Add some release logging for WebPageProxy::m_suppressVisibilityUpdates

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2151,6 +2151,8 @@ void WebPageProxy::setSuppressVisibilityUpdates(bool flag)
 {
     if (m_suppressVisibilityUpdates == flag)
         return;
+
+    WEBPAGEPROXY_RELEASE_LOG(ViewState, "setSuppressVisibilityUpdates: %d", flag);
     m_suppressVisibilityUpdates = flag;
 
     if (!m_suppressVisibilityUpdates) {
@@ -2209,8 +2211,10 @@ void WebPageProxy::activityStateDidChange(OptionSet<ActivityState::Flag> mayHave
         });
     }
 
-    if (m_suppressVisibilityUpdates && dispatchMode != ActivityStateChangeDispatchMode::Immediate)
+    if (m_suppressVisibilityUpdates && dispatchMode != ActivityStateChangeDispatchMode::Immediate) {
+        WEBPAGEPROXY_RELEASE_LOG(ViewState, "activityStateDidChange: Returning early due to m_suppressVisibilityUpdates");
         return;
+    }
 
 #if PLATFORM(COCOA)
     bool isNewlyInWindow = !isInWindow() && (mayHaveChanged & ActivityState::IsInWindow) && pageClient().isViewInWindow();


### PR DESCRIPTION
#### d54006245634584ccadcfc09a0d53c23fcf2b71b
<pre>
Add some release logging for WebPageProxy::m_suppressVisibilityUpdates
<a href="https://bugs.webkit.org/show_bug.cgi?id=241942">https://bugs.webkit.org/show_bug.cgi?id=241942</a>

Reviewed by Simon Fraser.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setSuppressVisibilityUpdates):
(WebKit::WebPageProxy::activityStateDidChange):

Canonical link: <a href="https://commits.webkit.org/251827@main">https://commits.webkit.org/251827@main</a>
</pre>
