### PR TITLE
[iOS 16] LayoutTests that synthesize touches with keyboard modifiers fail or time out

### DIFF
--- a/LayoutTests/fast/events/touch/ios/pointer-events-with-modifiers.html
+++ b/LayoutTests/fast/events/touch/ios/pointer-events-with-modifiers.html
@@ -102,6 +102,7 @@ function runTest()
 function setUp()
 {
     let square = document.getElementById("square");
+    square.addEventListener("touchstart", event => event.preventDefault());
     square.addEventListener("pointerdown", handlePointerDown, true);
     square.addEventListener("pointerup", handlePointerUp, true);
 

--- a/LayoutTests/fast/events/touch/ios/touch-events-with-modifiers.html
+++ b/LayoutTests/fast/events/touch/ios/touch-events-with-modifiers.html
@@ -50,6 +50,7 @@ let tests = [];
 function handleTouchDown(event)
 {
     logTouchEvent(event);
+    event.preventDefault();
 }
 
 function handleTouchUp(event)

--- a/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
@@ -51,3 +51,22 @@
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+// Unfortunately, the following declarations need to be forward declared even when using the internal SDK,
+// since the headers that define these symbols (BKSHIDEventKeyCommand.h and BKSHIDEventAttributes.h) include
+// additional private headers that attempt to define macros, which conflict with other macros within WebKit
+// (in particular, `kB` being defined in BrightnessSystemKeys.h, and Sizes.h in bmalloc).
+
+typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
+    BKSKeyModifierShift = 1 << 17,
+    BKSKeyModifierControl = 1 << 18,
+    BKSKeyModifierAlternate = 1 << 19,
+    BKSKeyModifierCommand = 1 << 20,
+};
+
+@interface BKSHIDEventBaseAttributes : NSObject
+@end
+
+@interface BKSHIDEventDigitizerAttributes : BKSHIDEventBaseAttributes
+@property (nonatomic) BKSKeyModifierFlags activeModifiers;
+@end

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.h
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.h
@@ -75,6 +75,8 @@ RetainPtr<IOHIDEventRef> createHIDKeyEvent(NSString *, uint64_t timestamp, bool 
 
 + (HIDEventGenerator *)sharedHIDEventGenerator;
 
+- (void)resetActiveModifiers;
+
 // Touches
 - (void)touchDown:(CGPoint)location touchCount:(NSUInteger)count completionBlock:(void (^)(void))completionBlock;
 - (void)liftUp:(CGPoint)location touchCount:(NSUInteger)count completionBlock:(void (^)(void))completionBlock;

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -168,6 +168,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     [[UIApplication sharedApplication] _cancelAllTouches];
     [[UIDevice currentDevice] setOrientation:UIDeviceOrientationPortrait animated:NO];
     [[UIScreen mainScreen] _setScale:2.0];
+    [[HIDEventGenerator sharedHIDEventGenerator] resetActiveModifiers];
 
     // Ensures that only the UCB is on-screen when showing the keyboard, if the hardware keyboard is attached.
     TIPreferencesController *textInputPreferences = [getTIPreferencesControllerClass() sharedPreferencesController];


### PR DESCRIPTION
#### a7456fb062a794d9b7cc422597cf4baa37fdfa27
<pre>
[iOS 16] LayoutTests that synthesize touches with keyboard modifiers fail or time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=241938">https://bugs.webkit.org/show_bug.cgi?id=241938</a>
rdar://95418782

Reviewed by Tim Horton.

After the refactoring in rdar://90709069, the value of `-[UIGestureRecognizer modifierFlags]` is
derived from `BKSHIDEventDigitizerAttributes` on the inner `IOHIDEventRef`, via the
`-activeModifiers` property; normally, this is populated by logic in BackBoardServices, but in
WebKitTestRunner, nothing sets these flags. As a result, layout tests that attempt to synthesize
touches with modifier keys (with the expectation that resulting `UIEvent` and `UIGestureRecognizer`
state will reflect this modifier state) now fail.

To address these failures, we use BackBoardServices SPI to directly set the value of these modifier
flags before queueing them for event dispatch.

* LayoutTests/fast/events/touch/ios/pointer-events-with-modifiers.html:
* LayoutTests/fast/events/touch/ios/touch-events-with-modifiers.html:

Additionally make these tests `preventDefault()` on &quot;touchstart&quot;, to prevent the context menu from
showing up and intercepting subsequent touches, when performing a control-tap.

* Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h:

Add some SPI declarations; due to the inability to import the headers on internal builds, we
explicitly redeclare these methods when using both internal and non-internal iOS SDKs.

* Tools/WebKitTestRunner/ios/HIDEventGenerator.h:
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(ActiveModifierState::updateForUsageCode):
(ActiveModifierState::flags const):
(ActiveModifierState::update):

Add a helper class to track modifier state when dispatching synthetic key events. This is owned by
the shared `HIDEventGenerator`, and gets reset between layout tests.

(-[HIDEventGenerator _sendIOHIDKeyboardEvent:usage:isKeyDown:]):
(-[HIDEventGenerator resetActiveModifiers]):
(-[HIDEventGenerator _sendHIDEvent:]):

Set modifier flags on digitizer HID events, using the current `ActiveModifierState`.

* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/251820@main">https://commits.webkit.org/251820@main</a>
</pre>
