### PR TITLE
Expose Page identifier via WKBrowsingContextHandle SPI instead of WKPageRef

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm
@@ -48,7 +48,7 @@
         return nil;
 
     _pageProxyID = pageProxyID;
-    _webPageID = webPageID;
+    _webPageID = webPageID.toUInt64();
 
     return self;
 }
@@ -69,18 +69,12 @@
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeInt64:_pageProxyID.toUInt64() forKey:@"pageProxyID"];
-    [coder encodeInt64:_webPageID.toUInt64() forKey:@"webPageID"];
+    [coder encodeInt64:_webPageID forKey:@"webPageID"];
 }
 
 - (id)initWithCoder:(NSCoder *)coder
 {
-    if (!(self = [super init]))
-        return nil;
-
-    _pageProxyID = makeObjectIdentifier<WebKit::WebPageProxyIdentifierType>([coder decodeInt64ForKey:@"pageProxyID"]);
-    _webPageID = makeObjectIdentifier<WebCore::PageIdentifierType>([coder decodeInt64ForKey:@"webPageID"]);
-
-    return self;
+    return [self _initWithPageProxyID:makeObjectIdentifier<WebKit::WebPageProxyIdentifierType>([coder decodeInt64ForKey:@"pageProxyID"]) andWebPageID:makeObjectIdentifier<WebCore::PageIdentifierType>([coder decodeInt64ForKey:@"webPageID"])];
 }
 
 + (BOOL)supportsSecureCoding
@@ -90,12 +84,11 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [[WKBrowsingContextHandle allocWithZone:zone] _initWithPageProxyID:_pageProxyID andWebPageID:_webPageID];
+    return [[WKBrowsingContextHandle allocWithZone:zone] _initWithPageProxyID:_pageProxyID andWebPageID:makeObjectIdentifier<WebCore::PageIdentifierType>(_webPageID)];
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; pageProxyID = %llu; webPageID = %llu>", NSStringFromClass(self.class), self, _pageProxyID.toUInt64(), _webPageID.toUInt64()];
+    return [NSString stringWithFormat:@"<%@: %p; pageProxyID = %llu; webPageID = %llu>", NSStringFromClass(self.class), self, _pageProxyID.toUInt64(), _webPageID];
 }
-
 @end

--- a/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandlePrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandlePrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKBrowsingContextHandlePrivate.h"
-#import "WebPageProxyIdentifier.h"
-#import <WebCore/PageIdentifier.h>
-#import <wtf/NakedRef.h>
+#import <WebKit/WKBrowsingContextHandle.h>
 
-namespace WebKit {
-class WebPage;
-class WebPageProxy;
-}
-
-@interface WKBrowsingContextHandle ()
-
-@property (nonatomic, readonly, getter=_pageProxyID) WebKit::WebPageProxyIdentifier pageProxyID;
+@interface WKBrowsingContextHandle (WKPrivate)
 @property (nonatomic, readonly, getter=_webPageID) uint64_t webPageID;
-
-- (id)_initWithPageProxy:(NakedRef<WebKit::WebPageProxy>)page;
-- (id)_initWithPage:(NakedRef<WebKit::WebPage>)page;
-- (id)_initWithPageProxyID:(WebKit::WebPageProxyIdentifier)pageProxyID andWebPageID:(WebCore::PageIdentifier)webPageID;
 @end

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3188,8 +3188,3 @@ void WKPageDispatchActivityStateUpdateForTesting(WKPageRef pageRef)
     CRASH_IF_SUSPENDED;
     toImpl(pageRef)->dispatchActivityStateUpdateForTesting();
 }
-
-uint64_t WKPageGetIdentifier(WKPageRef pageRef)
-{
-    return toImpl(pageRef)->webPageID().toUInt64();
-}

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -117,7 +117,6 @@ WK_EXPORT WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef page) WK_C_API_DEPR
 WK_EXPORT double WKPageGetEstimatedProgress(WKPageRef page);
 
 WK_EXPORT uint64_t WKPageGetRenderTreeSize(WKPageRef page);
-WK_EXPORT uint64_t WKPageGetIdentifier(WKPageRef page);
 
 WK_EXPORT WKWebsiteDataStoreRef WKPageGetWebsiteDataStore(WKPageRef page);
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1070,6 +1070,7 @@
 		52688AB427D7CE40003577A2 /* _WKResidentKeyRequirement.h in Headers */ = {isa = PBXBuildFile; fileRef = 52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5272D4C91E735F0900EB4290 /* WKProtectionSpaceNS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5272D4C71E735F0900EB4290 /* WKProtectionSpaceNS.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		528C37C1195CBB1A00D8B9CC /* WKBackForwardListPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9F28101958F478008CAC72 /* WKBackForwardListPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		52C3C26528651F860005BE6E /* WKBrowsingContextHandlePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52CDC5C42731DA0D00A3E3EB /* VirtualAuthenticatorConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 52CDC5BD2731DA0C00A3E3EB /* VirtualAuthenticatorConfiguration.h */; };
 		52CDC5C52731DA0D00A3E3EB /* VirtualService.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52CDC5BE2731DA0C00A3E3EB /* VirtualService.mm */; };
 		52CDC5C62731DA0D00A3E3EB /* VirtualAuthenticatorManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52CDC5BF2731DA0C00A3E3EB /* VirtualAuthenticatorManager.cpp */; };
@@ -4914,6 +4915,7 @@
 		52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = _WKResidentKeyRequirement.h; path = UIProcess/API/Cocoa/_WKResidentKeyRequirement.h; sourceTree = "<group>"; };
 		5272D4C71E735F0900EB4290 /* WKProtectionSpaceNS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKProtectionSpaceNS.h; path = mac/WKProtectionSpaceNS.h; sourceTree = "<group>"; };
 		5272D4C81E735F0900EB4290 /* WKProtectionSpaceNS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKProtectionSpaceNS.mm; path = mac/WKProtectionSpaceNS.mm; sourceTree = "<group>"; };
+		52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextHandlePrivate.h; sourceTree = "<group>"; };
 		52CDC5BD2731DA0C00A3E3EB /* VirtualAuthenticatorConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualAuthenticatorConfiguration.h; sourceTree = "<group>"; };
 		52CDC5BE2731DA0C00A3E3EB /* VirtualService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualService.mm; sourceTree = "<group>"; };
 		52CDC5BF2731DA0C00A3E3EB /* VirtualAuthenticatorManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VirtualAuthenticatorManager.cpp; sourceTree = "<group>"; };
@@ -9812,6 +9814,7 @@
 				1AE00D4A182D6EB000087DD7 /* WKBrowsingContextHandle.mm */,
 				1AE00D4E182D6F5000087DD7 /* WKBrowsingContextHandleInternal.h */,
 				373D122418A473B30066D9CC /* WKBrowsingContextHandleInternal.h */,
+				52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */,
 				37A709A61E3EA0FD00CA5969 /* WKDataDetectorTypes.h */,
 				37A709A81E3EA40C00CA5969 /* WKDataDetectorTypesInternal.h */,
 				F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */,
@@ -14965,6 +14968,7 @@
 				BCBAACF61452324F0053F82F /* WKBrowsingContextGroupPrivate.h in Headers */,
 				1AE00D4D182D6EB000087DD7 /* WKBrowsingContextHandle.h in Headers */,
 				1AE00D4F182D6F5000087DD7 /* WKBrowsingContextHandleInternal.h in Headers */,
+				52C3C26528651F860005BE6E /* WKBrowsingContextHandlePrivate.h in Headers */,
 				370F34A71829CFF3009027C8 /* WKBrowsingContextHistoryDelegate.h in Headers */,
 				BCBAAD0B14560A430053F82F /* WKBrowsingContextLoadDelegate.h in Headers */,
 				37FC19471850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h in Headers */,

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -438,7 +438,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 + (instancetype)lookUpBrowsingContextFromHandle:(WKBrowsingContextHandle *)handle
 {
-    return wrapper(WebKit::WebProcess::singleton().webPage(handle.webPageID));
+    return wrapper(WebKit::WebProcess::singleton().webPage(makeObjectIdentifier<WebCore::PageIdentifierType>(handle.webPageID)));
 }
 
 - (_WKRemoteObjectRegistry *)_remoteObjectRegistry

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -857,7 +857,7 @@ RefPtr<ObjCObjectGraph> WebProcess::transformHandlesToObjects(ObjCObjectGraph& o
         RetainPtr<id> transformObject(id object) const override
         {
             if (auto* handle = dynamic_objc_cast<WKBrowsingContextHandle>(object)) {
-                if (auto* webPage = m_webProcess.webPage(handle._webPageID))
+                if (auto* webPage = m_webProcess.webPage(makeObjectIdentifier<WebCore::PageIdentifierType>(handle._webPageID)))
                     return wrapper(*webPage);
 
                 return [NSNull null];


### PR DESCRIPTION
#### b791516ec89988ea1a2768a76a803091e0465382
<pre>
Expose Page identifier via WKBrowsingContextHandle SPI instead of WKPageRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=241941">https://bugs.webkit.org/show_bug.cgi?id=241941</a>
rdar://problem/95814743

Reviewed by Chris Dumez.

* Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm:
(-[WKBrowsingContextHandle _initWithPageProxyID:andWebPageID:]):
(-[WKBrowsingContextHandle encodeWithCoder:]):
(-[WKBrowsingContextHandle initWithCoder:]):
(-[WKBrowsingContextHandle copyWithZone:]):
(-[WKBrowsingContextHandle description]):
* Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandleInternal.h:
* Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandlePrivate.h: Copied from Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandleInternal.h.
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageDispatchActivityStateUpdateForTesting):
(WKPageGetIdentifier): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(+[WKWebProcessPlugInBrowserContextController lookUpBrowsingContextFromHandle:]):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::transformHandlesToObjects):

Canonical link: <a href="https://commits.webkit.org/251840@main">https://commits.webkit.org/251840@main</a>
</pre>
