### PR TITLE
Web Inspector: include `referrerPolicy` in "Copy as fetch"

### DIFF
--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt
@@ -13,7 +13,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url?query=true", {
     "method": "GET",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.SpecialURL
@@ -27,7 +28,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url'with$special%7B1..2
     "method": "GET",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.SpecialHeaders
@@ -44,7 +46,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
     "method": "GET",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.URLUTF8
@@ -58,7 +61,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url?utf8=%F0%9F%91%8D",
     "method": "GET",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.POSTRequestURLEncodedData
@@ -74,7 +78,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
     "method": "POST",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.POSTRequestURLUTF8
@@ -90,7 +95,8 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url?utf8=%F0%9F%91%8D",
     "method": "POST",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
 })
 
 -- Running test case: WI.Resource.prototype.generateFetchCode.PUTRequestWithJSON
@@ -106,6 +112,36 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
     "method": "PUT",
     "mode": "cors",
     "redirect": "follow",
-    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html"
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
+})
+
+-- Running test case: WI.Resource.prototype.generateFetchCode.ReferrerPolicy.EmptyString
+fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
+    "cache": "default",
+    "credentials": "omit",
+    "headers": {
+        "Accept": "*/*",
+        "User-Agent": <filtered>
+    },
+    "method": "GET",
+    "mode": "cors",
+    "redirect": "follow",
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
+})
+
+-- Running test case: WI.Resource.prototype.generateFetchCode.ReferrerPolicy.NoReferrer
+fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
+    "cache": "default",
+    "credentials": "omit",
+    "headers": {
+        "Accept": "*/*",
+        "User-Agent": <filtered>
+    },
+    "method": "GET",
+    "mode": "cors",
+    "redirect": "follow",
+    "referrerPolicy": "no-referrer"
 })
 

--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
@@ -71,9 +71,12 @@ function test()
         {name: "POSTRequestURLEncodedData", expression: `createPOSTRequestWithURLEncodedData()`},
         {name: "POSTRequestURLUTF8", expression: `createPOSTRequestWithUTF8()`},
         {name: "PUTRequestWithJSON", expression: `createPUTRequestWithJSON()`},
+
+        {name: "ReferrerPolicy.EmptyString", expression: `fetch("resources/url", {referrerPolicy: ""})`},
+        {name: "ReferrerPolicy.NoReferrer", expression: `fetch("resources/url", {referrerPolicy: "no-referrer"})`},
     ].forEach(({name, expression}) => {
         suite.addTestCase({
-            name: suite.name + "." + name,
+            name: "WI.Resource.prototype.generateFetchCode." + name,
             async test() {
                 let [resourceWasAddedEvent] = await Promise.all([
                     WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -30,6 +30,22 @@
             "description": "Number of seconds since epoch."
         },
         {
+            "id": "ReferrerPolicy",
+            "type": "string",
+            "description": "Controls how much referrer information is sent with the request",
+            "enum": [
+                "empty-string",
+                "no-referrer",
+                "no-referrer-when-downgrade",
+                "same-origin",
+                "origin",
+                "strict-origin",
+                "origin-when-cross-origin",
+                "strict-origin-when-cross-origin",
+                "unsafe-url"
+            ]
+        },
+        {
             "id": "Headers",
             "type": "object",
             "description": "Request / response headers as keys / values of JSON object."
@@ -61,7 +77,8 @@
                 { "name": "url", "type": "string", "description": "Request URL." },
                 { "name": "method", "type": "string", "description": "HTTP request method." },
                 { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
-                { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+                { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." },
+                { "name": "referrerPolicy", "$ref": "ReferrerPolicy", "optional": true, "description": "The level of included referrer information." }
             ]
         },
         {

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -590,10 +590,10 @@ void InspectorInstrumentation::flexibleBoxRendererWrappedToNextLineImpl(Instrume
         domAgent->flexibleBoxRendererWrappedToNextLine(renderer, lineStartItemIndex);
 }
 
-void InspectorInstrumentation::willSendRequestImpl(InstrumentingAgents& instrumentingAgents, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource)
+void InspectorInstrumentation::willSendRequestImpl(InstrumentingAgents& instrumentingAgents, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
 {
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
-        networkAgent->willSendRequest(identifier, loader, request, redirectResponse, cachedResource);
+        networkAgent->willSendRequest(identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
 }
 
 void InspectorInstrumentation::willSendRequestOfTypeImpl(InstrumentingAgents& instrumentingAgents, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, LoadType loadType)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -194,7 +194,7 @@ public:
     static void flexibleBoxRendererBeganLayout(const RenderObject&);
     static void flexibleBoxRendererWrappedToNextLine(const RenderObject&, size_t lineStartItemIndex);
 
-    static void willSendRequest(Frame*, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
+    static void willSendRequest(Frame*, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*, ResourceLoader*);
     static void didLoadResourceFromMemoryCache(Page&, DocumentLoader*, CachedResource*);
     static void didReceiveResourceResponse(Frame&, ResourceLoaderIdentifier, DocumentLoader*, const ResourceResponse&, ResourceLoader*);
     static void didReceiveThreadableLoaderResponse(DocumentThreadableLoader&, ResourceLoaderIdentifier);
@@ -416,7 +416,7 @@ private:
     static void flexibleBoxRendererBeganLayoutImpl(InstrumentingAgents&, const RenderObject&);
     static void flexibleBoxRendererWrappedToNextLineImpl(InstrumentingAgents&, const RenderObject&, size_t lineStartItemIndex);
 
-    static void willSendRequestImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
+    static void willSendRequestImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*, ResourceLoader*);
     static void willSendRequestOfTypeImpl(InstrumentingAgents&, ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, LoadType);
     static void markResourceAsCachedImpl(InstrumentingAgents&, ResourceLoaderIdentifier);
     static void didLoadResourceFromMemoryCacheImpl(InstrumentingAgents&, DocumentLoader*, CachedResource*);
@@ -1060,17 +1060,17 @@ inline void InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(const
         flexibleBoxRendererWrappedToNextLineImpl(*agents, renderer, lineStartItemIndex);
 }
 
-inline void InspectorInstrumentation::willSendRequest(Frame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource)
+inline void InspectorInstrumentation::willSendRequest(Frame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        willSendRequestImpl(*agents, identifier, loader, request, redirectResponse, cachedResource);
+        willSendRequestImpl(*agents, identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
 }
 
 inline void InspectorInstrumentation::willSendRequest(WorkerOrWorkletGlobalScope& globalScope, ResourceLoaderIdentifier identifier, ResourceRequest& request)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    willSendRequestImpl(instrumentingAgents(globalScope), identifier, nullptr, request, ResourceResponse { }, nullptr);
+    willSendRequestImpl(instrumentingAgents(globalScope), identifier, nullptr, request, ResourceResponse { }, nullptr, nullptr);
 }
 
 inline void InspectorInstrumentation::willSendRequestOfType(Frame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, LoadType loadType)

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -102,7 +102,7 @@ public:
     // InspectorInstrumentation
     void willRecalculateStyle();
     void didRecalculateStyle();
-    void willSendRequest(ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
+    void willSendRequest(ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*, ResourceLoader*);
     void willSendRequestOfType(ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, InspectorInstrumentation::LoadType);
     void didReceiveResponse(ResourceLoaderIdentifier, DocumentLoader*, const ResourceResponse&, ResourceLoader*);
     void didReceiveData(ResourceLoaderIdentifier, const SharedBuffer*, int expectedDataLength, int encodedDataLength);
@@ -145,7 +145,7 @@ protected:
     virtual bool shouldForceBufferingNetworkResourceData() const = 0;
 
 private:
-    void willSendRequest(ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, InspectorPageAgent::ResourceType);
+    void willSendRequest(ResourceLoaderIdentifier, DocumentLoader*, ResourceRequest&, const ResourceResponse& redirectResponse, InspectorPageAgent::ResourceType, ResourceLoader*);
 
     bool shouldIntercept(URL, Inspector::Protocol::Network::NetworkStage);
     void continuePendingRequests();

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -197,7 +197,7 @@ String InspectorPageAgent::sourceMapURLForResource(CachedResource* cachedResourc
     return String();
 }
 
-CachedResource* InspectorPageAgent::cachedResource(Frame* frame, const URL& url)
+CachedResource* InspectorPageAgent::cachedResource(const Frame* frame, const URL& url)
 {
     if (url.isNull())
         return nullptr;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -80,7 +80,7 @@ public:
     static Vector<CachedResource*> cachedResourcesForFrame(Frame*);
     static void resourceContent(Inspector::Protocol::ErrorString&, Frame*, const URL&, String* result, bool* base64Encoded);
     static String sourceMapURLForResource(CachedResource*);
-    static CachedResource* cachedResource(Frame*, const URL&);
+    static CachedResource* cachedResource(const Frame*, const URL&);
     static Inspector::Protocol::Page::ResourceType resourceTypeJSON(ResourceType);
     static ResourceType inspectorResourceType(CachedResource::Type);
     static ResourceType inspectorResourceType(const CachedResource&);

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -66,7 +66,7 @@ void ResourceLoadNotifier::willSendRequest(ResourceLoader* loader, ResourceReque
 {
     m_frame.loader().applyUserAgentIfNeeded(clientRequest);
 
-    dispatchWillSendRequest(loader->documentLoader(), loader->identifier(), clientRequest, redirectResponse, loader->cachedResource());
+    dispatchWillSendRequest(loader->documentLoader(), loader->identifier(), clientRequest, redirectResponse, loader->cachedResource(), loader);
 }
 
 void ResourceLoadNotifier::didReceiveResponse(ResourceLoader* loader, const ResourceResponse& r)
@@ -120,7 +120,7 @@ void ResourceLoadNotifier::assignIdentifierToInitialRequest(ResourceLoaderIdenti
     m_frame.loader().client().assignIdentifierToInitialRequest(identifier, loader, request);
 }
 
-void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource)
+void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
 {
 #if USE(QUICK_LOOK)
     // Always allow QuickLook-generated URLs based on the protocol scheme.
@@ -142,7 +142,7 @@ void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, Resou
     if (!request.isNull() && oldRequestURL != request.url().string() && m_frame.loader().documentLoader())
         m_frame.loader().documentLoader()->didTellClientAboutLoad(request.url().string());
 
-    InspectorInstrumentation::willSendRequest(&m_frame, identifier, loader, request, redirectResponse, cachedResource);
+    InspectorInstrumentation::willSendRequest(&m_frame, identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
 }
 
 void ResourceLoadNotifier::dispatchDidReceiveResponse(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceResponse& r, ResourceLoader* resourceLoader)

--- a/Source/WebCore/loader/ResourceLoadNotifier.h
+++ b/Source/WebCore/loader/ResourceLoadNotifier.h
@@ -61,7 +61,7 @@ public:
     void didFailToLoad(ResourceLoader*, const ResourceError&);
 
     void assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&);
-    void dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*);
+    void dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse& redirectResponse, const CachedResource*, ResourceLoader* = nullptr);
     void dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&, ResourceLoader* = nullptr);
     void dispatchDidReceiveData(DocumentLoader*, ResourceLoaderIdentifier, const SharedBuffer*, int expectedDataLength, int encodedDataLength);
     void dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier, const NetworkLoadMetrics&, ResourceLoader*);

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -426,7 +426,7 @@ void ResourceLoader::willSendRequestInternal(ResourceRequest&& request, const Re
         frameLoader()->notifier().willSendRequest(this, request, redirectResponse);
     }
     else
-        InspectorInstrumentation::willSendRequest(m_frame.get(), m_identifier, m_frame->loader().documentLoader(), request, redirectResponse, cachedResource());
+        InspectorInstrumentation::willSendRequest(m_frame.get(), m_identifier, m_frame->loader().documentLoader(), request, redirectResponse, cachedResource(), this);
 
 #if USE(QUICK_LOOK)
     if (m_documentLoader) {

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -438,7 +438,7 @@ void ApplicationCacheGroup::update(Frame& frame, ApplicationCacheUpdateOption up
     auto request = createRequest(URL { m_manifestURL }, m_newestCache ? m_newestCache->manifestResource() : nullptr);
 
     m_currentResourceIdentifier = ResourceLoaderIdentifier::generate();
-    InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr);
+    InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr, nullptr);
 
     m_manifestLoader = ApplicationCacheResourceLoader::create(ApplicationCacheResource::Type::Manifest, documentLoader.cachedResourceLoader(), WTFMove(request), [this] (auto&& resourceOrError) {
         // 'this' is only valid if returned value is not Error::Abort.
@@ -899,7 +899,7 @@ void ApplicationCacheGroup::startLoadingEntry()
     auto request = createRequest(URL { firstPendingEntryURL }, m_newestCache ? m_newestCache->resourceForURL(firstPendingEntryURL) : nullptr);
 
     m_currentResourceIdentifier = ResourceLoaderIdentifier::generate();
-    InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr);
+    InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr, nullptr);
 
     auto& documentLoader = *m_frame->loader().documentLoader();
     auto requestURL = request.url();

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -683,6 +683,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             requestData: request.postData,
             requestSentTimestamp: elapsedTime,
             requestSentWalltime: walltime,
+            referrerPolicy: request.referrerPolicy,
             initiatorCallFrames: this._initiatorCallFramesFromPayload(initiator),
             initiatorSourceCodeLocation: this._initiatorSourceCodeLocationFromPayload(initiator),
             initiatorNode: this._initiatorNodeFromPayload(initiator),

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -26,7 +26,7 @@
 
 WI.Resource = class Resource extends WI.SourceCode
 {
-    constructor(url, {mimeType, type, loaderIdentifier, targetId, requestIdentifier, requestMethod, requestHeaders, requestData, requestSentTimestamp, requestSentWalltime, initiatorCallFrames, initiatorSourceCodeLocation, initiatorNode} = {})
+    constructor(url, {mimeType, type, loaderIdentifier, targetId, requestIdentifier, requestMethod, requestHeaders, requestData, requestSentTimestamp, requestSentWalltime, referrerPolicy, initiatorCallFrames, initiatorSourceCodeLocation, initiatorNode} = {})
     {
         console.assert(url);
 
@@ -82,6 +82,7 @@ WI.Resource = class Resource extends WI.SourceCode
         this._isProxyConnection = false;
         this._target = targetId ? WI.targetManager.targetForIdentifier(targetId) : WI.mainTarget;
         this._redirects = [];
+        this._referrerPolicy = referrerPolicy ?? null;
 
         // Exact sizes if loaded over the network or cache.
         this._requestHeadersTransferSize = NaN;
@@ -357,6 +358,7 @@ WI.Resource = class Resource extends WI.SourceCode
     get responseBodyTransferSize() { return this._responseBodyTransferSize; }
     get cachedResponseBodySize() { return this._cachedResponseBodySize; }
     get redirects() { return this._redirects; }
+    get referrerPolicy() { return this._referrerPolicy; }
 
     get loadedSecurely()
     {
@@ -698,6 +700,7 @@ WI.Resource = class Resource extends WI.SourceCode
         this._requestCookies = null;
         this._requestMethod = request.method || null;
         this._redirects.push(new WI.Redirect(oldURL, oldMethod, oldHeaders, response.status, response.statusText, response.headers, elapsedTime));
+        this._referrerPolicy = request.referrerPolicy ?? null;
 
         if (oldURL !== request.url) {
             // Delete the URL components so the URL is re-parsed the next time it is requested.
@@ -1200,7 +1203,8 @@ WI.Resource = class Resource extends WI.SourceCode
         if (referrer)
             options.referrer = referrer;
 
-        // FIXME: <https://webkit.org/b/241218> Web Inspector: include `referrerPolicy` in "Copy as fetch"
+        if (this._referrerPolicy)
+            options.referrerPolicy = this._referrerPolicy;
 
         return `fetch(${JSON.stringify(this.url)}, ${JSON.stringify(options, null, WI.indentString())})`;
     }


### PR DESCRIPTION
#### 531afa8f61ee4bb09cc15dea91bd0dc280ef0fd1
<pre>
Web Inspector: include `referrerPolicy` in &quot;Copy as fetch&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=241218">https://bugs.webkit.org/show_bug.cgi?id=241218</a>
&lt;rdar://problem/94698964&gt;

Reviewed by Patrick Angle.

* Source/JavaScriptCore/inspector/protocol/Network.json:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::toProtocol):
(WebCore::buildObjectForResourceRequest):
(WebCore::InspectorNetworkAgent::willSendRequest):
(WebCore::InspectorNetworkAgent::willSendRequestOfType):
(WebCore::InspectorNetworkAgent::interceptRequest):
Add a `Network.ReferrerPolicy` protocol enum (corresponding to `WebCore::ReferrerPolicy`) and pass it to the frontend.

* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::willSendRequest):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::willSendRequestImpl):
* Source/WebCore/loader/ResourceLoadNotifier.h:
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::willSendRequest):
(WebCore::ResourceLoadNotifier::dispatchWillSendRequest):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::willSendRequestInternal):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::update):
(WebCore::ApplicationCacheGroup::startLoadingEntry):
Pass along a `ResourceLoader*` when `willSendRequest` so that the `InspectorNetworkAgent` can look
at it to get the `FetchOptions` for that request.

* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.get referrerPolicy): Added.
(WI.Resource.prototype.updateForRedirectResponse):
(WI.Resource.prototype.generateFetchCode):
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.resourceRequestWillBeSent):
Pass along the `Network.ReferrerPolicy` whenever creating/updating a `WI.Resource` with a `Network.Request`.

* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::cachedResource):
Drive-by: Change to `const Frame*`.

* LayoutTests/http/tests/inspector/network/copy-as-fetch.html:
* LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt:

Canonical link: <a href="https://commits.webkit.org/251818@main">https://commits.webkit.org/251818@main</a>
</pre>
