### PR TITLE
Test gardening PR workflow is too noisy

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -98,7 +98,7 @@ class Land(Command):
 
             labels = pr_issue.labels
             if PullRequest.BLOCKED_LABEL in labels and merge_type == 'unsafe':
-                log.info("Removing '{}' from PR {}...".format(cls.BLOCKED_LABEL, existing_pr.number))
+                log.info("Removing '{}' from PR {}...".format(PullRequest.BLOCKED_LABEL, pr.number))
                 labels.remove(PullRequest.BLOCKED_LABEL)
             log.info("Adding '{}' to '{}'".format(merge_label, pr))
             labels.append(merge_label)
@@ -114,6 +114,7 @@ class Land(Command):
             repository, args, branch_point,
             callback=callback,
             unblock=True if merge_type == 'unsafe' else False,
+            update_issue=False,  # If we're immediately landing, no reason to track the code change as a WIP
         )
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -262,7 +262,7 @@ class PullRequest(Command):
         return 0
 
     @classmethod
-    def create_pull_request(cls, repository, args, branch_point, callback=None, unblock=True):
+    def create_pull_request(cls, repository, args, branch_point, callback=None, unblock=True, update_issue=True):
         # FIXME: We can do better by inferring the remote from the branch point, if it's not specified
         source_remote = args.remote or 'origin'
         if not repository.config().get('remote.{}.url'.format(source_remote)):
@@ -401,7 +401,7 @@ class PullRequest(Command):
             if cls.is_revert_commit(commits[0]):
                 cls.add_comment_to_reverted_commit_bug_tracker(repository, args, pr, commits[0])
 
-        if issue:
+        if issue and update_issue:
             log.info('Checking issue assignee...')
             if issue.assignee != issue.tracker.me():
                 issue.assign(issue.tracker.me())


### PR DESCRIPTION
#### 5b9ecabb854622be96d379ab1f5077e6096207be
<pre>
Test gardening PR workflow is too noisy
<a href="https://bugs.webkit.org/show_bug.cgi?id=239697">https://bugs.webkit.org/show_bug.cgi?id=239697</a>
&lt;rdar://92572308&gt;

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.merge_queue): Fix syntax errors, do not update issue when creating pull requests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Allow caller to opt-out of updating the associated issue.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLandGitHub):

Canonical link: <a href="https://commits.webkit.org/251830@main">https://commits.webkit.org/251830@main</a>
</pre>
