### PR TITLE
Web Inspector: include `integrity` in "Copy as fetch"

### DIFF
--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt
@@ -145,3 +145,35 @@ fetch("http://127.0.0.1:8000/inspector/network/resources/url", {
     "referrerPolicy": "no-referrer"
 })
 
+-- Running test case: WI.Resource.prototype.generateFetchCode.Integrity.Invalid
+fetch("http://127.0.0.1:8000/inspector/network/resources/data.txt?integrity=invalid", {
+    "cache": "default",
+    "credentials": "omit",
+    "headers": {
+        "Accept": "*/*",
+        "User-Agent": <filtered>
+    },
+    "integrity": "INVALID",
+    "method": "GET",
+    "mode": "cors",
+    "redirect": "follow",
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
+})
+
+-- Running test case: WI.Resource.prototype.generateFetchCode.Integrity.Valid
+fetch("http://127.0.0.1:8000/inspector/network/resources/data.txt?integrity=valid", {
+    "cache": "default",
+    "credentials": "omit",
+    "headers": {
+        "Accept": "*/*",
+        "User-Agent": <filtered>
+    },
+    "integrity": "sha256-qQCuhmp5o0z/of299BZBz6a+CBJGM2TPN53xY1PHXS8=",
+    "method": "GET",
+    "mode": "cors",
+    "redirect": "follow",
+    "referrer": "http://127.0.0.1:8000/inspector/network/copy-as-fetch.html",
+    "referrerPolicy": "strict-origin-when-cross-origin"
+})
+

--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
@@ -74,6 +74,9 @@ function test()
 
         {name: "ReferrerPolicy.EmptyString", expression: `fetch("resources/url", {referrerPolicy: ""})`},
         {name: "ReferrerPolicy.NoReferrer", expression: `fetch("resources/url", {referrerPolicy: "no-referrer"})`},
+
+        {name: "Integrity.Invalid", expression: `fetch("resources/data.txt?integrity=invalid", {integrity: "INVALID"})`},
+        {name: "Integrity.Valid", expression: `fetch("resources/data.txt?integrity=valid", {integrity: "sha256-qQCuhmp5o0z/of299BZBz6a+CBJGM2TPN53xY1PHXS8="})`},
     ].forEach(({name, expression}) => {
         suite.addTestCase({
             name: "WI.Resource.prototype.generateFetchCode." + name,

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -78,7 +78,8 @@
                 { "name": "method", "type": "string", "description": "HTTP request method." },
                 { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
                 { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." },
-                { "name": "referrerPolicy", "$ref": "ReferrerPolicy", "optional": true, "description": "The level of included referrer information." }
+                { "name": "referrerPolicy", "$ref": "ReferrerPolicy", "optional": true, "description": "The level of included referrer information." },
+                { "name": "integrity", "type": "string", "optional": true, "description": "The base64 cryptographic hash of the resource." }
             ]
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -339,8 +339,12 @@ static Ref<Protocol::Network::Request> buildObjectForResourceRequest(const Resou
         requestObject->setPostData(String::fromUTF8WithLatin1Fallback(bytes.data(), bytes.size()));
     }
 
-    if (resourceLoader)
+    if (resourceLoader) {
         requestObject->setReferrerPolicy(toProtocol(resourceLoader->options().referrerPolicy));
+
+        if (auto integrity = resourceLoader->options().integrity; !integrity.isEmpty())
+            requestObject->setIntegrity(integrity);
+    }
 
     return requestObject;
 }

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -684,6 +684,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             requestSentTimestamp: elapsedTime,
             requestSentWalltime: walltime,
             referrerPolicy: request.referrerPolicy,
+            integrity: request.integrity,
             initiatorCallFrames: this._initiatorCallFramesFromPayload(initiator),
             initiatorSourceCodeLocation: this._initiatorSourceCodeLocationFromPayload(initiator),
             initiatorNode: this._initiatorNodeFromPayload(initiator),

--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -26,7 +26,7 @@
 
 WI.Resource = class Resource extends WI.SourceCode
 {
-    constructor(url, {mimeType, type, loaderIdentifier, targetId, requestIdentifier, requestMethod, requestHeaders, requestData, requestSentTimestamp, requestSentWalltime, referrerPolicy, initiatorCallFrames, initiatorSourceCodeLocation, initiatorNode} = {})
+    constructor(url, {mimeType, type, loaderIdentifier, targetId, requestIdentifier, requestMethod, requestHeaders, requestData, requestSentTimestamp, requestSentWalltime, referrerPolicy, integrity, initiatorCallFrames, initiatorSourceCodeLocation, initiatorNode} = {})
     {
         console.assert(url);
 
@@ -83,6 +83,7 @@ WI.Resource = class Resource extends WI.SourceCode
         this._target = targetId ? WI.targetManager.targetForIdentifier(targetId) : WI.mainTarget;
         this._redirects = [];
         this._referrerPolicy = referrerPolicy ?? null;
+        this._integrity = integrity ?? null;
 
         // Exact sizes if loaded over the network or cache.
         this._requestHeadersTransferSize = NaN;
@@ -359,6 +360,7 @@ WI.Resource = class Resource extends WI.SourceCode
     get cachedResponseBodySize() { return this._cachedResponseBodySize; }
     get redirects() { return this._redirects; }
     get referrerPolicy() { return this._referrerPolicy; }
+    get integrity() { return this._integrity; }
 
     get loadedSecurely()
     {
@@ -701,6 +703,7 @@ WI.Resource = class Resource extends WI.SourceCode
         this._requestMethod = request.method || null;
         this._redirects.push(new WI.Redirect(oldURL, oldMethod, oldHeaders, response.status, response.statusText, response.headers, elapsedTime));
         this._referrerPolicy = request.referrerPolicy ?? null;
+        this._integrity = request.integrity ?? null;
 
         if (oldURL !== request.url) {
             // Delete the URL components so the URL is re-parsed the next time it is requested.
@@ -1191,7 +1194,8 @@ WI.Resource = class Resource extends WI.SourceCode
         if (!isEmptyObject(headers))
             options.headers = headers;
 
-        // FIXME: <https://webkit.org/b/241217> Web Inspector: include `integrity` in "Copy as fetch"
+        if (this._integrity)
+            options.integrity = this._integrity;
 
         if (this.requestMethod)
             options.method = this.requestMethod;


### PR DESCRIPTION
#### 16121838cc440eafe42d55a0b7f1d18f1cf5da8d
<pre>
Web Inspector: include `integrity` in &quot;Copy as fetch&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=241217">https://bugs.webkit.org/show_bug.cgi?id=241217</a>
&lt;rdar://problem/94698949&gt;

Reviewed by Patrick Angle.

* Source/JavaScriptCore/inspector/protocol/Network.json:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::buildObjectForResourceRequest):
Add an optional `integrity` string to `Network.Response` and pass it to the frontend.

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.resourceRequestWillBeSent):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.get integrity): Added.
(WI.Resource.prototype.updateForRedirectResponse):
(WI.Resource.prototype.generateFetchCode):
Pass along the `integrity` whenever updating a `WI.Resource` with a `Network.Request`.

* LayoutTests/http/tests/inspector/network/copy-as-fetch.html:
* LayoutTests/http/tests/inspector/network/copy-as-fetch-expected.txt:

Canonical link: <a href="https://commits.webkit.org/251819@main">https://commits.webkit.org/251819@main</a>
</pre>
