### PR TITLE
[macOS] Unreviewed, fix unified source build error after r295757

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -273,7 +273,7 @@ void WebProcessProxy::hardwareConsoleStateChanged()
 {
     m_isConnectedToHardwareConsole = WindowServerConnection::singleton().hardwareConsoleState() == WindowServerConnection::HardwareConsoleState::Connected;
     for (const auto& page : m_pageMap.values())
-        page->activityStateDidChange(ActivityState::IsConnectedToHardwareConsole);
+        page->activityStateDidChange(WebCore::ActivityState::IsConnectedToHardwareConsole);
 }
 #endif
 


### PR DESCRIPTION
#### 7177e2715da5b49087012a9285c6200bb20af383
<pre>
[macOS] Unreviewed, fix unified source build error after r295757

* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::hardwareConsoleStateChanged):

Canonical link: <a href="https://commits.webkit.org/251822@main">https://commits.webkit.org/251822@main</a>
</pre>
