### PR TITLE
[WTF] Need specialization for DefaultHash<CompactPtr<StringImpl>> with StringHash

### DIFF
--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <wtf/CompactPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringHasher.h>
@@ -57,6 +58,7 @@ namespace WTF {
 
         static unsigned hash(const RefPtr<StringImpl>& key) { return key->hash(); }
         static unsigned hash(const PackedPtr<StringImpl>& key) { return key->hash(); }
+        static unsigned hash(const CompactPtr<StringImpl>& key) { return key->hash(); }
         static bool equal(const RefPtr<StringImpl>& a, const RefPtr<StringImpl>& b)
         {
             return equal(a.get(), b.get());
@@ -79,6 +81,19 @@ namespace WTF {
             return equal(a.get(), b);
         }
         static bool equal(const StringImpl* a, const PackedPtr<StringImpl>& b)
+        {
+            return equal(a, b.get());
+        }
+
+        static bool equal(const CompactPtr<StringImpl>& a, const CompactPtr<StringImpl>& b)
+        {
+            return equal(a.get(), b.get());
+        }
+        static bool equal(const CompactPtr<StringImpl>& a, const StringImpl* b)
+        {
+            return equal(a.get(), b);
+        }
+        static bool equal(const StringImpl* a, const CompactPtr<StringImpl>& b)
         {
             return equal(a, b.get());
         }
@@ -160,6 +175,16 @@ namespace WTF {
             return equal(a.get(), b.get());
         }
 
+        static unsigned hash(const CompactPtr<StringImpl>& key)
+        {
+            return hash(key.get());
+        }
+
+        static bool equal(const CompactPtr<StringImpl>& a, const CompactPtr<StringImpl>& b)
+        {
+            return equal(a.get(), b.get());
+        }
+
         static unsigned hash(const String& key)
         {
             return hash(key.impl());
@@ -233,6 +258,7 @@ namespace WTF {
     template<> struct DefaultHash<StringImpl*> : StringHash { };
     template<> struct DefaultHash<RefPtr<StringImpl>> : StringHash { };
     template<> struct DefaultHash<PackedPtr<StringImpl>> : StringHash { };
+    template<> struct DefaultHash<CompactPtr<StringImpl>> : StringHash { };
     template<> struct DefaultHash<String> : StringHash { };
 }
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -618,11 +618,12 @@ int codePointCompare(const StringImpl*, const StringImpl*);
 bool isSpaceOrNewline(UChar32);
 bool isNotSpaceOrNewline(UChar32);
 
-// StringHashd is the default hash for StringImpl* and RefPtr<StringImpl>
+// StringHash is the default hash for StringImpl* and RefPtr<StringImpl>
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<StringImpl*>;
 template<> struct DefaultHash<RefPtr<StringImpl>>;
 template<> struct DefaultHash<PackedPtr<StringImpl>>;
+template<> struct DefaultHash<CompactPtr<StringImpl>>;
 
 #define MAKE_STATIC_STRING_IMPL(characters) ([] { \
         static StaticStringImpl impl(characters); \

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
@@ -216,4 +216,61 @@ TEST(WTF_CompactPtr, HashMap)
     }
 }
 
+TEST(WTF_CompactPtr, HashMapRemoveAndAdd)
+{
+    Vector<AlignedPackingTarget> vector;
+    HashMap<PackedPtr<AlignedPackingTarget>, unsigned> map;
+    vector.reserveCapacity(10000);
+    for (unsigned i = 0; i < 10000; ++i)
+        vector.uncheckedAppend(AlignedPackingTarget { i });
+
+    for (auto& target : vector)
+        map.add(&target, target.m_value);
+
+    for (unsigned i = 0; i < 4000; ++i) {
+        auto& target = vector[i];
+        map.remove(&target);
+    }
+
+    for (unsigned i = 0; i < 4000; ++i) {
+        auto& target = vector[i];
+        map.add(&target, target.m_value);
+    }
+
+    for (auto& target : vector) {
+        EXPECT_TRUE(map.contains(&target));
+        EXPECT_EQ(map.get(&target), target.m_value);
+    }
+}
+
+TEST(WTF_CompactPtr, StringHashSet)
+{
+    Vector<String> vector;
+    HashSet<CompactPtr<StringImpl>> set;
+    vector.reserveCapacity(10000);
+    for (unsigned i = 0; i < 10000; ++i)
+        vector.uncheckedAppend(String::number(i));
+
+    for (auto& target : vector)
+        set.add(target.impl());
+
+    for (unsigned i = 0; i < 4000; ++i) {
+        auto& target = vector[i];
+        set.remove(target.impl());
+    }
+
+    for (unsigned i = 0; i < 4000; ++i) {
+        auto& target = vector[i];
+        set.add(target.impl());
+    }
+
+    for (auto& target : vector)
+        set.add(target.impl());
+
+    EXPECT_EQ(set.size(), vector.size());
+
+    for (auto& target : vector)
+        EXPECT_TRUE(set.contains(target.impl()));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 62275c8924c5e8a1865db324d3ce4f11e8787ad9
<pre>
[WTF] Need specialization for DefaultHash&lt;CompactPtr&lt;StringImpl&gt;&gt; with StringHash
<a href="https://bugs.webkit.org/show_bug.cgi?id=241955">https://bugs.webkit.org/show_bug.cgi?id=241955</a>

Reviewed by Tim Horton.

AtomStringTable uses CompactPtr only when it is more efficient than PackedPtr, which means, it is non-simulator iOS family.
And we lack the specialization of DefaultHash&lt;CompactPtr&lt;StringImpl&gt;&gt; with StringHash: usually, we can just use PtrHash.
But for StringImpl, we have specialization of this hash function, so we must make DefaultHash StringHash for CompactPtr&lt;StringImpl&gt;
case too. This patch also adds a test including HashMap&lt;CompactPtr&lt;StringImpl&gt;&gt; removal &amp; re-addition to hit deleted cases.

* Source/WTF/wtf/text/StringHash.h:
(WTF::StringHash::hash):
(WTF::StringHash::equal):
(WTF::ASCIICaseInsensitiveHash::hash):
(WTF::ASCIICaseInsensitiveHash::equal):
* Source/WTF/wtf/text/StringImpl.h:
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251824@main">https://commits.webkit.org/251824@main</a>
</pre>
