### PR TITLE
LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html is flaky on bots

### DIFF
--- a/LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering-sharedworker.js
+++ b/LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering-sharedworker.js
@@ -1,3 +1,6 @@
+let ports = [];
 onconnect = (e) => {
-    e.ports[0].postMessage("got it");
+    const port = e.ports[0];
+    ports.push(port);
+    port.postMessage("worker" + ports.length);
 }

--- a/LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html
+++ b/LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html
@@ -8,22 +8,15 @@
 if (window.testRunner)
     testRunner.setUseSeparateServiceWorkerProcess(true);
 
-promise_test(async (test) => {
+promise_test(async (t) => {
     const worker1 = new SharedWorker('connect-event-ordering-sharedworker.js');
     const worker2 = new SharedWorker('connect-event-ordering-sharedworker.js');
 
-    let result = '';
-    await Promise.all([
-        new Promise(resolve => { worker1.port.onmessage = () => {
-            result += 'worker1';
-            resolve();
-        }}),
-        new Promise(resolve => { worker2.port.onmessage = () => {
-            result += 'worker2';
-            resolve();
-        }})
-    ]);
-    assert_equals(result, 'worker1worker2');
+    let promise1 = new Promise(resolve => { worker1.port.onmessage = (event) => resolve(event.data) });
+    let promise2 = new Promise(resolve => { worker2.port.onmessage = (event) => resolve(event.data) });
+
+    assert_equals(await promise1, "worker1");
+    assert_equals(await promise2, "worker2");
 }, "connect event should fire following SharedWorker creation order");
 </script>
 </body>


### PR DESCRIPTION
#### 5c2712ad8edd1ed6a68682d545a4bfe141bca962
<pre>
LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html is flaky on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=241957">https://bugs.webkit.org/show_bug.cgi?id=241957</a>

Reviewed by NOBODY (OOPS!).

Test was relying on sending messages to different ports would result in the same event ordering on receive side.
This does not seem guaranteed from bot results.
Instead, compute the order in the shared worker global scope itself and send the result in the message itself.
This removes the need to preserve MessageEvent ordering on the page itself.

* LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering-sharedworker.js:
(onconnect):
* LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html:
</pre>