### PR TITLE
Add the gradient space transform to SourceBrush logging

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -78,8 +78,10 @@ WTF::TextStream& operator<<(TextStream& ts, const SourceBrush& brush)
 {
     ts.dumpProperty("color", brush.color());
 
-    if (auto gradient = brush.gradient())
+    if (auto gradient = brush.gradient()) {
         ts.dumpProperty("gradient", *gradient);
+        ts.dumpProperty("gradient-space-transform", brush.gradientSpaceTransform());
+    }
 
     if (auto pattern = brush.pattern())
         ts.dumpProperty("pattern", pattern);


### PR DESCRIPTION
#### 1cebed97b64c27dcc84834319e4cf13d3424543f
<pre>
Add the gradient space transform to SourceBrush logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=241959">https://bugs.webkit.org/show_bug.cgi?id=241959</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/251849@main">https://commits.webkit.org/251849@main</a>
</pre>
