### PR TITLE
[GTK][WPE] Unreviewed GPUProcess build fixes

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -287,7 +287,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 
 void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences)
 {
-#if ENABLE(MEDIA_SOURCE)
+#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
     if (updatePreference(m_preferences.webMParserEnabled, preferences.webMParserEnabled))
         WebCore::RuntimeEnabledFeatures::sharedFeatures().setWebMParserEnabled(*m_preferences.webMParserEnabled);
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -33,6 +33,7 @@
 #include "RemoteGraphicsContextGLMessages.h"
 #include "RemoteGraphicsContextGLProxyMessages.h"
 #include "StreamConnectionWorkQueue.h"
+#include <WebCore/GraphicsContext.h>
 #include <WebCore/GraphicsContextGLOpenGL.h>
 #include <WebCore/NotImplemented.h>
 #include <wtf/MainThread.h>


### PR DESCRIPTION
#### b9288e3b242cb8a8830c2ba860e210310047a747
<pre>
[GTK][WPE] Unreviewed GPUProcess build fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=241961">https://bugs.webkit.org/show_bug.cgi?id=241961</a>

Unreviewed build fixes for ENABLE(GPU_PROCESS) on GTK and WPE ports.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences): Add the ENABLE(VP9) guard to
match the guards around GPUProcessPreferences::webMParserEnabled declaration.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
Add a missing GraphicsContext header include.

Canonical link: <a href="https://commits.webkit.org/251826@main">https://commits.webkit.org/251826@main</a>
</pre>
