### PR TITLE
WKCGDisplayListContents does not take effect

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -425,22 +425,7 @@ void RemoteLayerBackingStore::paintContents()
 
     if (m_includeDisplayList == IncludeDisplayList::Yes) {
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-        auto& displayListContext = m_frontBuffer.displayListImageBuffer->context();
-
-        // FIXME: Remove this when <rdar://problem/80487697> is fixed.
-        static std::optional<bool> needsMissingFlipWorkaround;
-        GraphicsContextStateSaver workaroundStateSaver(displayListContext, false);
-        if (!needsMissingFlipWorkaround) {
-            id defaultValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitNeedsWorkaroundFor80487697"];
-            needsMissingFlipWorkaround = defaultValue ? [defaultValue boolValue] : true;
-        }
-        if (needsMissingFlipWorkaround.value()) {
-            workaroundStateSaver.save();
-            displayListContext.scale(FloatSize(1, -1));
-            displayListContext.translate(0, -m_size.height());
-        }
-
-        BifurcatedGraphicsContext context(m_frontBuffer.imageBuffer->context(), displayListContext);
+        BifurcatedGraphicsContext context(m_frontBuffer.imageBuffer->context(), m_frontBuffer.displayListImageBuffer->context());
 #else
         GraphicsContext& context = m_frontBuffer.imageBuffer->context();
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -59,6 +59,7 @@
 
     self.contents = contents;
     [self setValue:(id)data forKeyPath:WKCGDisplayListContentsKey];    
+    [self setNeedsDisplay];
 }
 
 - (void)drawInContext:(CGContextRef)context


### PR DESCRIPTION
#### 24dd48e8bf0126da8e55193df7e67308bc9e5ebf
<pre>
WKCGDisplayListContents does not take effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=241967">https://bugs.webkit.org/show_bug.cgi?id=241967</a>
&lt;rdar://93674270&gt;

Reviewed by Wenson Hsieh.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::paintContents):
Remove a now-unnecessary workaround.

* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer _setWKContents:withDisplayList:replayForTesting:]):
Call setNeedsDisplay to make the set display list actually take effect.
It does not actually result in drawRect being called, in this case.

Canonical link: <a href="https://commits.webkit.org/251833@main">https://commits.webkit.org/251833@main</a>
</pre>
