### PR TITLE
Define post launch Mach bootstrap filter

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1325,6 +1325,9 @@
 (define-once (mach-bootstrap-message-numbers)
     (message-number 206 207 711 712 718 800 802 803 804 805 904))
 
+(define-once (mach-bootstrap-message-numbers-post-launch)
+    (message-number 206 207 711 712 800 804 904))
+
 (define (allow-mach-bootstrap-with-filter)
     (allow mach-bootstrap
         (apply-message-filter
@@ -1336,7 +1339,9 @@
 (if (require-ancestor-with-entitlement "com.apple.private.security.enable-state-flags")
     (allow mach-bootstrap
         (apply-message-filter
-            (allow mach-message-send (with telemetry-backtrace))))
+            (deny mach-message-send (with telemetry-backtrace))
+            (allow mach-message-send (with telemetry-backtrace)
+                (mach-bootstrap-message-numbers-post-launch))))
 ;; else
     (allow-mach-bootstrap-with-filter))
 

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -337,12 +337,13 @@ auto SandboxExtension::createHandleForMachLookup(ASCIILiteral service, std::opti
     // When launchd is blocked in the sandbox, we need to manually enable bootstrapping of new XPC connectons.
     // This is done by unblocking launchd, since launchd access is required when creating Mach connections.
     // Unblocking launchd is done by enabling a sandbox state variable.
-    // In the initial version of this change, Mach bootstrap'ing is enabled unconditionally.
-    if (auditToken) {
-        if (!sandbox_enable_state_flag(ENABLE_MACH_BOOTSTRAP, *auditToken))
-            RELEASE_LOG_FAULT(Sandbox, "Could not enable Mach bootstrap, errno = %d.", errno);
-    } else if (machBootstrapOptions == MachBootstrapOptions::EnableMachBootstrap)
-        RELEASE_LOG_FAULT(Sandbox, "Could not enable Mach bootstrap, no audit token provided.");
+    if (machBootstrapOptions == MachBootstrapOptions::EnableMachBootstrap) {
+        if (auditToken) {
+            if (!sandbox_enable_state_flag(ENABLE_MACH_BOOTSTRAP, *auditToken))
+                RELEASE_LOG_FAULT(Sandbox, "Could not enable Mach bootstrap, errno = %d.", errno);
+        } else
+            RELEASE_LOG_FAULT(Sandbox, "Could not enable Mach bootstrap, no audit token provided.");
+    }
 #endif
 
     return WTFMove(handle);

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2071,6 +2071,9 @@
 (define (mach-bootstrap-message-numbers)
     (message-number 204 207 301 711 800 804))
 
+(define (mach-bootstrap-message-numbers-post-launch)
+    (message-number 207 301 800 804))
+
 (define (allow-mach-bootstrap-with-filter)
     (allow mach-bootstrap
         (apply-message-filter
@@ -2085,7 +2088,9 @@
         (if (require-ancestor-with-entitlement "com.apple.private.security.enable-state-flags")
             (allow mach-bootstrap
                 (apply-message-filter
-                    (allow mach-message-send (with telemetry-backtrace))))
+                    (deny mach-message-send (with telemetry-backtrace))
+                    (allow mach-message-send (with telemetry-backtrace)
+                        (mach-bootstrap-message-numbers-post-launch))))
         ;; else
             (allow-mach-bootstrap-with-filter))
 


### PR DESCRIPTION
#### 8bc5eb48b7cdc9bb38c4dc1232a219fbdba4243d
<pre>
Define post launch Mach bootstrap filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=241970">https://bugs.webkit.org/show_bug.cgi?id=241970</a>

Reviewed by Geoffrey Garen.

Define the Mach bootstrap filter to be used after the WebContent process has finished launching.
This patch also enables Mach bootstrap&apos;ing only if the caller of createHandleForMachLookup is
requesting it, since it is not needed otherwise.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandleForMachLookup):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/251888@main">https://commits.webkit.org/251888@main</a>
</pre>
