### PR TITLE
[media-controls] allow for ::before and ::after augmentation of the container

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -90,13 +90,17 @@
     display: none;
 }
 
-.media-controls > * {
+.media-controls > *,
+.media-controls::before,
+.media-controls::after {
     /* We always want to avoid showing the text selection magnifier on iOS. */
     user-select: none;
     transition: opacity 0.1s linear;
 }
 
-.media-controls.faded > *:not(.placard) {
+.media-controls.faded > *:not(.placard),
+.media-controls.faded::before,
+.media-controls.faded::after {
     opacity: 0;
     pointer-events: none;
     transition-duration: 0.25s;


### PR DESCRIPTION
#### 9fd7b9016b84101db831a8ae1650be72567ef5eb
<pre>
[media-controls] allow for ::before and ::after augmentation of the container
<a href="https://bugs.webkit.org/show_bug.cgi?id=241972">https://bugs.webkit.org/show_bug.cgi?id=241972</a>

Reviewed by Devin Rousso.

Since content under the container needs to fade, augmenting the container with ::before and ::after
needs to have the fade animations baked in for new media controls subclasses to be able to use
those pseudo-elements.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:

Canonical link: <a href="https://commits.webkit.org/251863@main">https://commits.webkit.org/251863@main</a>
</pre>
