### PR TITLE
[media-controls] allow customization of the class used for the scrubber slider

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
@@ -107,6 +107,11 @@ class LayoutTraits
     {
         return 1;
     }
+
+    scrubberSliderClass()
+    {
+        return Slider;
+    }
 }
 
 LayoutTraits.Mode = {

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -42,7 +42,7 @@ class TimeControl extends LayoutItem
         this._shouldShowDurationTimeLabel = this.layoutTraits.supportsDurationTimeLabel();
 
         this.elapsedTimeLabel = new TimeLabel(TimeLabel.Type.Elapsed);
-        this.scrubber = new Slider(this.layoutDelegate, "scrubber");
+        this.scrubber = new (this.layoutTraits.scrubberSliderClass())(this.layoutDelegate, "scrubber");
         if (this._shouldShowDurationTimeLabel)
             this.durationTimeLabel = new TimeLabel(TimeLabel.Type.Duration);
         this.remainingTimeLabel = new TimeLabel(TimeLabel.Type.Remaining);


### PR DESCRIPTION
#### 5f067f4eacd93e28ebe56d6f91a63ff9da02059f
<pre>
[media-controls] allow customization of the class used for the scrubber slider
<a href="https://bugs.webkit.org/show_bug.cgi?id=241975">https://bugs.webkit.org/show_bug.cgi?id=241975</a>

Reviewed by NOBODY (OOPS!).

Add a new LayoutTraits method to define the class used to instantiate the scrubber slider.

* Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js:
(LayoutTraits.prototype.scrubberSliderClass):
(LayoutTraits):
* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
</pre>