### PR TITLE
Add a code owner for animation and model directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,3 +83,8 @@
 /Source/WebCore/Modules/mediacontrols @dcrousso
 /Source/WebCore/Modules/modern-media-controls @dcrousso
 /LayoutTests/media/modern-media-controls @dcrousso
+
+# ================================================================================
+
+Source/WebCore/animation @graouts
+Source/WebCore/Modules/model-element @graouts


### PR DESCRIPTION
#### bed478e13bd5a63e1edeaf6a1b2442391a9514a6
<pre>
Add a code owner for animation and model directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=241977">https://bugs.webkit.org/show_bug.cgi?id=241977</a>

Reviewed by Tim Nguyen.

Add myself as the code owner for work on animations and &lt;model&gt;.

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/251851@main">https://commits.webkit.org/251851@main</a>
</pre>
