### PR TITLE
Text selection menu keeps dismissing when selecting text in BitBucket (Stash)

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -901,7 +901,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     bool scrollingEnabled = _page->scrollingCoordinatorProxy()->hasScrollableOrZoomedMainFrame() || hasDockedInputView || isZoomed || scrollingNeededToRevealUI;
     [_scrollView _setScrollEnabledInternal:scrollingEnabled];
 
-    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && [_scrollView zoomScale] != layerTreeTransaction.pageScaleFactor()) {
+    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && !WTF::areEssentiallyEqual<float>([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
         LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << layerTreeTransaction.pageScaleFactor());
         [_scrollView setZoomScale:layerTreeTransaction.pageScaleFactor()];
     }


### PR DESCRIPTION
#### 9458033af410a278f2b20d03d979a0583cc658b3
<pre>
Text selection menu keeps dismissing when selecting text in BitBucket (Stash)
<a href="https://bugs.webkit.org/show_bug.cgi?id=241980">https://bugs.webkit.org/show_bug.cgi?id=241980</a>
rdar://92488700

Reviewed by Aditya Keerthi.

In iOS 16, when viewing a page at a specific zoom level, the setScale function was called indefinitely due to an erroneous floating point equality check, which caused the menu to close immediately upon opening. We can mitigate this by using WTF::areEssentiallyEqual to be robust against floating point equality errors.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):

Canonical link: <a href="https://commits.webkit.org/251919@main">https://commits.webkit.org/251919@main</a>
</pre>
