### PR TITLE
GPUConnectionToWebProcess::setCaptureAttributionString() should call setCurrentAttributionWebsiteString API when available

### DIFF
--- a/Source/WebKit/Platform/spi/ios/SystemStatusSPI.h
+++ b/Source/WebKit/Platform/spi/ios/SystemStatusSPI.h
@@ -28,6 +28,16 @@
 
 #import <SystemStatus/STDynamicActivityAttributionPublisher.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+@interface STDynamicActivityAttributionPublisher (SetCurrentAttributionWebsiteString)
+
++ (void)setCurrentAttributionWebsiteString:(NSString *)website auditToken:(audit_token_t)auditToken;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
 #else
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface STDynamicActivityAttributionPublisher : NSObject
 
 + (void)setCurrentAttributionStringWithFormat:(NSString *)format auditToken:(audit_token_t)auditToken;
++ (void)setCurrentAttributionWebsiteString:(NSString *)website auditToken:(audit_token_t)auditToken;
 
 @end
 


### PR DESCRIPTION
#### c35cd6f16cca66ee762d73495bc36069df08dadd
<pre>
GPUConnectionToWebProcess::setCaptureAttributionString() should call setCurrentAttributionWebsiteString API when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=241978">https://bugs.webkit.org/show_bug.cgi?id=241978</a>
&lt;rdar://95872119&gt;

Reviewed by Geoffrey Garen.

GPUConnectionToWebProcess::setCaptureAttributionString() should call setCurrentAttributionWebsiteString
API when available, instead of setCurrentAttributionStringWithFormat API.

* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setCaptureAttributionString):
* Source/WebKit/Platform/spi/ios/SystemStatusSPI.h:

Canonical link: <a href="https://commits.webkit.org/251842@main">https://commits.webkit.org/251842@main</a>
</pre>
