### PR TITLE
Add ability to mask URLs from DOM and JavaScript.

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1101,7 +1101,7 @@ sub GetterExpression
 
     my $functionName;
     if ($attribute->extendedAttributes->{"URL"}) {
-        $functionName = "getURLAttribute";
+        $functionName = "getURLAttributeForBindings";
     } elsif ($attributeType->name eq "boolean") {
         $functionName = "hasAttributeWithoutSynchronization";
     } elsif ($attributeType->name eq "long") {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -3991,7 +3991,7 @@ static inline JSValue jsTestObj_reflectedURLAttrGetter(JSGlobalObject& lexicalGl
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedurlattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttributeForBindings(WebCore::HTMLNames::reflectedurlattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4022,7 +4022,7 @@ static inline JSValue jsTestObj_reflectedUSVURLAttrGetter(JSGlobalObject& lexica
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::reflectedusvurlattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLUSVString>>(lexicalGlobalObject, throwScope, impl.getURLAttributeForBindings(WebCore::HTMLNames::reflectedusvurlattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4146,7 +4146,7 @@ static inline JSValue jsTestObj_reflectedCustomURLAttrGetter(JSGlobalObject& lex
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttribute(WebCore::HTMLNames::customContentURLAttrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttributeForBindings(WebCore::HTMLNames::customContentURLAttrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -122,10 +122,10 @@ CSSStyleDeclaration* Attr::style()
     return &m_style->ensureCSSStyleDeclaration();
 }
 
-const AtomString& Attr::value() const
+AtomString Attr::value() const
 {
     if (m_element)
-        return m_element->getAttribute(qualifiedName());
+        return m_element->getAttributeForBindings(qualifiedName());
     return m_standaloneValue;
 }
 

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -44,7 +44,7 @@ public:
     bool specified() const { return true; }
     Element* ownerElement() const { return m_element; }
 
-    WEBCORE_EXPORT const AtomString& value() const;
+    WEBCORE_EXPORT AtomString value() const;
     WEBCORE_EXPORT void setValue(const AtomString&);
 
     const QualifiedName& qualifiedName() const { return m_name; }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5645,6 +5645,41 @@ URL Document::completeURL(const String& url, ForceUTF8 forceUTF8) const
     return completeURL(url, m_baseURL, forceUTF8);
 }
 
+bool Document::shouldMaskURLForBindings(const URL& url) const
+{
+    auto* page = this->page();
+    if (UNLIKELY(!page))
+        return false;
+    return page->shouldMaskURLForBindings(url);
+}
+
+bool Document::hasURLsToMaskForBindings() const
+{
+    auto* page = this->page();
+    if (UNLIKELY(!page))
+        return false;
+    return page->hasURLsToMaskForBindings();
+}
+
+const URL& Document::maskedURLForBindingsIfNeeded(const URL& url) const
+{
+    if (UNLIKELY(shouldMaskURLForBindings(url)))
+        return maskedURLForBindings();
+    return url;
+}
+
+const AtomString& Document::maskedURLStringForBindings() const
+{
+    static MainThreadNeverDestroyed<const AtomString> url("webkit-masked-url://hidden/"_s);
+    return url;
+}
+
+const URL& Document::maskedURLForBindings() const
+{
+    static MainThreadNeverDestroyed<URL> url(maskedURLStringForBindings().string());
+    return url;
+}
+
 void Document::setBackForwardCacheState(BackForwardCacheState state)
 {
     if (m_backForwardCacheState == state)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -718,6 +718,12 @@ public:
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
     URL completeURL(const String&, const URL& baseURLOverride, ForceUTF8 = ForceUTF8::No) const;
 
+    bool shouldMaskURLForBindings(const URL&) const;
+    bool hasURLsToMaskForBindings() const;
+    const URL& maskedURLForBindingsIfNeeded(const URL&) const;
+    const AtomString& maskedURLStringForBindings() const;
+    const URL& maskedURLForBindings() const;
+
     String userAgent(const URL&) const final;
 
     void disableEval(const String& errorMessage) final;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -82,6 +82,7 @@ enum class AnimationImpact;
 enum class EventHandling : uint8_t;
 enum class EventProcessing : uint8_t;
 enum class IsSyntheticClick : bool { No, Yes };
+enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
 
 struct GetAnimationsOptions;
@@ -110,6 +111,7 @@ public:
 
     WEBCORE_EXPORT bool hasAttribute(const QualifiedName&) const;
     WEBCORE_EXPORT const AtomString& getAttribute(const QualifiedName&) const;
+    AtomString getAttributeForBindings(const QualifiedName&, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
     template<typename... QualifiedNames>
     inline const AtomString& getAttribute(const QualifiedName&, const QualifiedNames&...) const;
     WEBCORE_EXPORT void setAttribute(const QualifiedName&, const AtomString& value);
@@ -148,6 +150,8 @@ public:
 
     WEBCORE_EXPORT const AtomString& getAttribute(const AtomString& qualifiedName) const;
     WEBCORE_EXPORT const AtomString& getAttributeNS(const AtomString& namespaceURI, const AtomString& localName) const;
+    AtomString getAttributeForBindings(const AtomString& qualifiedName, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
+    inline AtomString getAttributeNSForBindings(const AtomString& namespaceURI, const AtomString& localName, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
 
     WEBCORE_EXPORT ExceptionOr<void> setAttribute(const AtomString& qualifiedName, const AtomString& value);
     static ExceptionOr<QualifiedName> parseAttributeName(const AtomString& namespaceURI, const AtomString& qualifiedName);
@@ -423,10 +427,12 @@ public:
 
     virtual bool isURLAttribute(const Attribute&) const { return false; }
     virtual bool attributeContainsURL(const Attribute& attribute) const { return isURLAttribute(attribute); }
-    virtual String completeURLsInAttributeValue(const URL& base, const Attribute&) const;
+    String resolveURLStringIfNeeded(const String& urlString, ResolveURLs = ResolveURLs::Yes, const URL& base = URL()) const;
+    virtual String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const;
     virtual bool isHTMLContentAttribute(const Attribute&) const { return false; }
 
     WEBCORE_EXPORT URL getURLAttribute(const QualifiedName&) const;
+    inline URL getURLAttributeForBindings(const QualifiedName&) const;
     URL getNonEmptyURLAttribute(const QualifiedName&) const;
 
     virtual const AtomString& imageSourceURL() const;
@@ -730,6 +736,9 @@ private:
 
     void synchronizeAttribute(const QualifiedName&) const;
     void synchronizeAttribute(const AtomString& localName) const;
+
+    inline const Attribute* getAttributeInternal(const QualifiedName&) const;
+    inline const Attribute* getAttributeInternal(const AtomString& qualifiedName) const;
 
     void updateName(const AtomString& oldName, const AtomString& newName);
     void updateNameForTreeScope(TreeScope&, const AtomString& oldName, const AtomString& newName);

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -40,8 +40,8 @@
     [DOMJIT=ReadDOM] boolean hasAttributes();
     [SameObject] readonly attribute NamedNodeMap attributes;
     sequence<DOMString> getAttributeNames();
-    [DOMJIT=ReadDOM] DOMString? getAttribute([AtomString] DOMString qualifiedName);
-    DOMString? getAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
+    [DOMJIT=ReadDOM, ImplementedAs=getAttributeForBindings] DOMString? getAttribute([AtomString] DOMString qualifiedName);
+    [ImplementedAs=getAttributeNSForBindings] DOMString? getAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
     [CEReactions] undefined setAttribute([AtomString] DOMString qualifiedName, [AtomString] DOMString value);
     [CEReactions] undefined setAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName, [AtomString] DOMString value);
     [CEReactions, ImplementedAs=removeAttributeForBindings] undefined removeAttribute([AtomString] DOMString qualifiedName);

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -90,6 +90,11 @@ inline const AtomString& Element::attributeWithoutSynchronization(const Qualifie
     return nullAtom();
 }
 
+inline URL Element::getURLAttributeForBindings(const QualifiedName& name) const
+{
+    return document().maskedURLForBindingsIfNeeded(getURLAttribute(name));
+}
+
 inline bool Element::hasAttributesWithoutUpdate() const
 {
     return elementData() && !elementData()->isEmpty();
@@ -169,6 +174,27 @@ inline UniqueElementData& Element::ensureUniqueElementData()
 inline bool shouldIgnoreAttributeCase(const Element& element)
 {
     return element.isHTMLElement() && element.document().isHTMLDocument();
+}
+
+inline const Attribute* Element::getAttributeInternal(const QualifiedName& name) const
+{
+    if (!elementData())
+        return nullptr;
+    synchronizeAttribute(name);
+    return findAttributeByName(name);
+}
+
+inline const Attribute* Element::getAttributeInternal(const AtomString& qualifiedName) const
+{
+    if (!elementData() || qualifiedName.isEmpty())
+        return nullptr;
+    synchronizeAttribute(qualifiedName);
+    return elementData()->findAttributeByName(qualifiedName, shouldIgnoreAttributeCase(*this));
+}
+
+inline AtomString Element::getAttributeNSForBindings(const AtomString& namespaceURI, const AtomString& localName, ResolveURLs resolveURLs) const
+{
+    return getAttributeForBindings(QualifiedName(nullAtom(), localName, namespaceURI), resolveURLs);
 }
 
 template<typename... QualifiedNames>

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -177,7 +177,7 @@ StyleSheetList& ShadowRoot::styleSheets()
 
 String ShadowRoot::innerHTML() const
 {
-    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren);
+    return serializeFragment(*this, SerializedNodes::SubtreesOfChildren, nullptr, ResolveURLs::NoExcludingURLsForPrivacy);
 }
 
 ExceptionOr<void> ShadowRoot::setInnerHTML(const String& markup)

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -233,19 +233,7 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
 
 String MarkupAccumulator::resolveURLIfNeeded(const Element& element, const String& urlString) const
 {
-    switch (m_resolveURLs) {
-    case ResolveURLs::Yes:
-        return element.document().completeURL(urlString).string();
-
-    case ResolveURLs::YesExcludingLocalFileURLsForPrivacy:
-        if (!element.document().url().isLocalFile())
-            return element.document().completeURL(urlString).string();
-        break;
-
-    case ResolveURLs::No:
-        break;
-    }
-    return urlString;
+    return element.resolveURLStringIfNeeded(urlString, m_resolveURLs);
 }
 
 void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespaces)

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -80,7 +80,7 @@ String Editor::selectionInHTMLFormat()
 {
     if (ImageOverlay::isInsideOverlay(m_document.selection().selection()))
         return { };
-    return serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingLocalFileURLsForPrivacy, SerializeComposedTree::Yes);
+    return serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/editing/gtk/EditorGtk.cpp
+++ b/Source/WebCore/editing/gtk/EditorGtk.cpp
@@ -117,7 +117,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     PasteboardWebContent pasteboardContent;
     pasteboardContent.canSmartCopyOrDelete = canSmartCopyOrDelete();
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingLocalFileURLsForPrivacy, SerializeComposedTree::Yes);
+    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
     pasteboardContent.contentOrigin = m_document.originIdentifierForPasteboard();
     pasteboard.write(pasteboardContent);
 }

--- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
+++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
@@ -66,7 +66,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
 {
     PasteboardWebContent pasteboardContent;
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingLocalFileURLsForPrivacy, SerializeComposedTree::Yes);
+    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
     pasteboard.write(pasteboardContent);
 }
 

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -269,7 +269,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
         pasteboardImage.dataInWebArchiveFormat = imageInWebArchiveFormat(imageElement);
 
     if (auto imageRange = makeRangeSelectingNode(imageElement))
-        pasteboardImage.dataInHTMLFormat = serializePreservingVisualAppearance(VisibleSelection { *imageRange }, ResolveURLs::YesExcludingLocalFileURLsForPrivacy, SerializeComposedTree::Yes);
+        pasteboardImage.dataInHTMLFormat = serializePreservingVisualAppearance(VisibleSelection { *imageRange }, ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes);
 
     pasteboardImage.url.url = url;
     pasteboardImage.url.title = title;

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1013,7 +1013,7 @@ String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Do
 
     // SerializeComposedTree::No because there can't be a shadow tree in the pasted fragment.
     auto result = serializePreservingVisualAppearanceInternal(firstPositionInNode(bodyElement.get()), lastPositionInNode(bodyElement.get()), nullptr,
-        ResolveURLs::YesExcludingLocalFileURLsForPrivacy, SerializeComposedTree::No, AnnotateForInterchange::Yes, ConvertBlocksToInlines::No,  StandardFontFamilySerializationMode::Strip, msoListMode);
+        ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::No, AnnotateForInterchange::Yes, ConvertBlocksToInlines::No, StandardFontFamilySerializationMode::Strip, msoListMode);
 
     if (msoListMode != MSOListMode::Preserve)
         return result;

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Element.h"
 #include "ExceptionOr.h"
 #include "FloatSize.h"
 #include "FragmentScriptingPermission.h"
@@ -70,7 +71,6 @@ bool isPlainTextMarkup(Node*);
 // These methods are used by HTMLElement & ShadowRoot to replace the children with respected fragment/text.
 ExceptionOr<void> replaceChildrenWithFragment(ContainerNode&, Ref<DocumentFragment>&&);
 
-enum class ResolveURLs : uint8_t { No, Yes, YesExcludingLocalFileURLsForPrivacy };
 enum class ConvertBlocksToInlines : uint8_t { No, Yes };
 enum class SerializeComposedTree : uint8_t { No, Yes };
 WEBCORE_EXPORT String serializePreservingVisualAppearance(const SimpleRange&, Vector<Node*>* = nullptr, AnnotateForInterchange = AnnotateForInterchange::No, ConvertBlocksToInlines = ConvertBlocksToInlines::No, ResolveURLs = ResolveURLs::No);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -578,7 +578,7 @@ bool HTMLImageElement::attributeContainsURL(const Attribute& attribute) const
         || HTMLElement::attributeContainsURL(attribute);
 }
 
-String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Attribute& attribute) const
+String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Attribute& attribute, ResolveURLs resolveURLs) const
 {
     if (attribute.name() == srcsetAttr) {
         Vector<ImageCandidate> imageCandidates = parseImageCandidatesFromSrcsetAttribute(StringView(attribute.value()));
@@ -586,7 +586,7 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
         for (const auto& candidate : imageCandidates) {
             if (&candidate != &imageCandidates[0])
                 result.append(", ");
-            result.append(URL(base, candidate.string.toString()).string());
+            result.append(resolveURLStringIfNeeded(candidate.string.toString(), resolveURLs, base));
             if (candidate.density != UninitializedDescriptor)
                 result.append(' ', candidate.density, 'x');
             if (candidate.resourceWidth != UninitializedDescriptor)
@@ -594,7 +594,8 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
         }
         return result.toString();
     }
-    return HTMLElement::completeURLsInAttributeValue(base, attribute);
+
+    return HTMLElement::completeURLsInAttributeValue(base, attribute, resolveURLs);
 }
 
 bool HTMLImageElement::matchesUsemap(const AtomStringImpl& name) const
@@ -847,6 +848,16 @@ bool HTMLImageElement::virtualHasPendingActivity() const
 size_t HTMLImageElement::pendingDecodePromisesCountForTesting() const
 {
     return m_imageLoader->pendingDecodePromisesCountForTesting();
+}
+
+AtomString HTMLImageElement::srcsetForBindings() const
+{
+    return getAttributeForBindings(srcsetAttr);
+}
+
+void HTMLImageElement::setSrcsetForBindings(const AtomString& value)
+{
+    setAttributeWithoutSynchronization(srcsetAttr, value);
 }
 
 const AtomString& HTMLImageElement::loadingForBindings() const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -130,6 +130,9 @@ public:
 
     void loadDeferredImage();
 
+    AtomString srcsetForBindings() const;
+    void setSrcsetForBindings(const AtomString&);
+
     const AtomString& loadingForBindings() const;
     void setLoadingForBindings(const AtomString&);
 
@@ -176,7 +179,7 @@ private:
 
     bool isURLAttribute(const Attribute&) const override;
     bool attributeContainsURL(const Attribute&) const override;
-    String completeURLsInAttributeValue(const URL& base, const Attribute&) const override;
+    String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const override;
 
     bool isDraggableIgnoringAttributes() const final { return true; }
 

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -29,7 +29,7 @@
 ] interface HTMLImageElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
-    [CEReactions=NotNeeded, Reflect] attribute USVString srcset;
+    [CEReactions=NotNeeded, ImplementedAs=srcsetForBindings] attribute [AtomString] USVString srcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString sizes;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
     [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -337,6 +337,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_deviceOrientationUpdateProvider(WTFMove(pageConfiguration.deviceOrientationUpdateProvider))
 #endif
     , m_corsDisablingPatterns(WTFMove(pageConfiguration.corsDisablingPatterns))
+    , m_maskedURLSchemes(WTFMove(pageConfiguration.maskedURLSchemes))
     , m_allowedNetworkHosts(WTFMove(pageConfiguration.allowedNetworkHosts))
     , m_loadsSubresources(pageConfiguration.loadsSubresources)
     , m_shouldRelaxThirdPartyCookieBlocking(pageConfiguration.shouldRelaxThirdPartyCookieBlocking)
@@ -3754,6 +3755,13 @@ bool Page::shouldDisableCorsForRequestTo(const URL& url) const
     return WTF::anyOf(m_corsDisablingPatterns, [&] (const auto& pattern) {
         return pattern.matches(url);
     });
+}
+
+bool Page::shouldMaskURLForBindings(const URL& url) const
+{
+    if (m_maskedURLSchemes.isEmpty())
+        return false;
+    return m_maskedURLSchemes.contains<StringViewHashTranslator>(url.protocol());
 }
 
 void Page::revealCurrentSelection()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -920,6 +920,8 @@ public:
     void forEachFrame(const Function<void(Frame&)>&);
 
     bool shouldDisableCorsForRequestTo(const URL&) const;
+    bool shouldMaskURLForBindings(const URL&) const;
+    bool hasURLsToMaskForBindings() const { return !m_maskedURLSchemes.isEmpty(); }
 
     WEBCORE_EXPORT void injectUserStyleSheet(UserStyleSheet&);
     WEBCORE_EXPORT void removeInjectedUserStyleSheet(UserStyleSheet&);
@@ -1294,6 +1296,7 @@ private:
 #endif
 
     Vector<UserContentURLPattern> m_corsDisablingPatterns;
+    HashSet<String> m_maskedURLSchemes;
     Vector<UserStyleSheet> m_userStyleSheetsPendingInjection;
     std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> m_allowedNetworkHosts;
     bool m_isTakingSnapshotsForApplicationSuspension { false };

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -139,6 +139,7 @@ public:
     RefPtr<DeviceOrientationUpdateProvider> deviceOrientationUpdateProvider;
 #endif
     Vector<UserContentURLPattern> corsDisablingPatterns;
+    HashSet<String> maskedURLSchemes;
     UniqueRef<SpeechRecognitionProvider> speechRecognitionProvider;
     UniqueRef<MediaRecorderProvider> mediaRecorderProvider;
 

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -509,7 +509,7 @@ void Pasteboard::writeSelection(const SimpleRange& selectedRange, bool canSmartC
     // Put CF_HTML format on the pasteboard 
     if (::OpenClipboard(m_owner)) {
         Vector<char> data;
-        // FIXME: Use ResolveURLs::YesExcludingLocalFileURLsForPrivacy.
+        // FIXME: Use ResolveURLs::YesExcludingURLsForPrivacy.
         markupToCFHTML(serializePreservingVisualAppearance(frame.selection().selection()),
             selectedRange.start.container->document().url().string(), data);
         HGLOBAL cbData = createGlobalData(data);

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -149,6 +149,7 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << oldPageID;
     encoder << overriddenMediaType;
     encoder << corsDisablingPatterns;
+    encoder << maskedURLSchemes;
     encoder << loadsSubresources;
     encoder << allowedNetworkHosts;
     encoder << userScriptsShouldWaitUntilNotification;
@@ -503,6 +504,12 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!corsDisablingPatterns)
         return std::nullopt;
     parameters.corsDisablingPatterns = WTFMove(*corsDisablingPatterns);
+
+    std::optional<HashSet<String>> maskedURLSchemes;
+    decoder >> maskedURLSchemes;
+    if (!maskedURLSchemes)
+        return std::nullopt;
+    parameters.maskedURLSchemes = WTFMove(*maskedURLSchemes);
 
     std::optional<bool> loadsSubresources;
     decoder >> loadsSubresources;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -222,6 +222,7 @@ struct WebPageCreationParameters {
 
     String overriddenMediaType;
     Vector<String> corsDisablingPatterns;
+    HashSet<String> maskedURLSchemes;
     bool userScriptsShouldWaitUntilNotification { true };
     bool loadsSubresources { true };
     std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> allowedNetworkHosts;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -83,6 +83,7 @@ Ref<PageConfiguration> PageConfiguration::copy() const
     for (auto& pair : this->m_urlSchemeHandlers)
         copy->m_urlSchemeHandlers.set(pair.key, pair.value.copyRef());
     copy->m_corsDisablingPatterns = this->m_corsDisablingPatterns;
+    copy->m_maskedURLSchemes = this->m_maskedURLSchemes;
     copy->m_crossOriginAccessControlCheckEnabled = this->m_crossOriginAccessControlCheckEnabled;
     copy->m_userScriptsShouldWaitUntilNotification = this->m_userScriptsShouldWaitUntilNotification;
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -144,7 +144,10 @@ public:
 
     const Vector<WTF::String>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
     void setCORSDisablingPatterns(Vector<WTF::String>&& patterns) { m_corsDisablingPatterns = WTFMove(patterns); }
-    
+
+    const HashSet<WTF::String>& maskedURLSchemes() const { return m_maskedURLSchemes; }
+    void setMaskedURLSchemes(HashSet<WTF::String>&& schemes) { m_maskedURLSchemes = WTFMove(schemes); }
+
     bool userScriptsShouldWaitUntilNotification() const { return m_userScriptsShouldWaitUntilNotification; }
     void setUserScriptsShouldWaitUntilNotification(bool value) { m_userScriptsShouldWaitUntilNotification = value; }
 
@@ -231,6 +234,7 @@ private:
 
     HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> m_urlSchemeHandlers;
     Vector<WTF::String> m_corsDisablingPatterns;
+    HashSet<WTF::String> m_maskedURLSchemes;
     bool m_userScriptsShouldWaitUntilNotification { true };
     bool m_crossOriginAccessControlCheckEnabled { true };
     WTF::String m_processDisplayName;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -962,6 +962,23 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     _pageConfiguration->setCORSDisablingPatterns(makeVector<String>(patterns));
 }
 
+- (NSSet<NSString *> *)_maskedURLSchemes
+{
+    const auto& schemes = _pageConfiguration->maskedURLSchemes();
+    NSMutableSet<NSString *> *set = [NSMutableSet setWithCapacity:schemes.size()];
+    for (const auto& scheme : schemes)
+        [set addObject:scheme];
+    return set;
+}
+
+- (void)_setMaskedURLSchemes:(NSSet<NSString *> *)schemes
+{
+    HashSet<String> set;
+    for (NSString *scheme in schemes)
+        set.add(scheme);
+    _pageConfiguration->setMaskedURLSchemes(WTFMove(set));
+}
+
 - (void)_setLoadsFromNetwork:(BOOL)loads
 {
     _pageConfiguration->setAllowedNetworkHosts(loads ? std::nullopt : std::optional { MemoryCompactLookupOnlyRobinHoodHashSet<String> { } });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, readonly) WKWebsiteDataStore *_websiteDataStoreIfExists WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, copy, setter=_setCORSDisablingPatterns:) NSArray<NSString *> *_corsDisablingPatterns WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
+@property (nonatomic, copy, setter=_setMaskedURLSchemes:) NSSet<NSString *> *_maskedURLSchemes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setDeferrableUserScriptsShouldWaitUntilNotification:) BOOL _deferrableUserScriptsShouldWaitUntilNotification WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, setter=_setCrossOriginAccessControlCheckEnabled:) BOOL _crossOriginAccessControlCheckEnabled WK_API_AVAILABLE(macos(11.0), ios(14.0));
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8505,6 +8505,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
     parameters.overriddenMediaType = m_overriddenMediaType;
     parameters.corsDisablingPatterns = corsDisablingPatterns();
+    parameters.maskedURLSchemes = m_configuration->maskedURLSchemes();
     parameters.userScriptsShouldWaitUntilNotification = m_configuration->userScriptsShouldWaitUntilNotification();
     parameters.allowedNetworkHosts = m_configuration->allowedNetworkHosts();
     parameters.loadsSubresources = m_configuration->loadsSubresources();

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp
@@ -145,7 +145,7 @@ void WebEditorClient::updateGlobalSelection(Frame* frame)
     PasteboardWebContent pasteboardContent;
     pasteboardContent.canSmartCopyOrDelete = false;
     pasteboardContent.text = plainText(*range);
-    pasteboardContent.markup = serializePreservingVisualAppearance(frame->selection().selection(), ResolveURLs::YesExcludingLocalFileURLsForPrivacy);
+    pasteboardContent.markup = serializePreservingVisualAppearance(frame->selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy);
     Pasteboard::createForGlobalSelection(PagePasteboardContext::create(frame->pageID()))->write(pasteboardContent);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -657,6 +657,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         synchronizeCORSDisablingPatternsWithNetworkProcess();
     pageConfiguration.corsDisablingPatterns = parseAndAllowAccessToCORSDisablingPatterns(m_corsDisablingPatterns);
 
+    pageConfiguration.maskedURLSchemes = parameters.maskedURLSchemes;
     pageConfiguration.userScriptsShouldWaitUntilNotification = parameters.userScriptsShouldWaitUntilNotification;
     pageConfiguration.loadsSubresources = parameters.loadsSubresources;
     pageConfiguration.allowedNetworkHosts = parameters.allowedNetworkHosts;


### PR DESCRIPTION
#### c0c652e4bd3ca6542ebe26fcd55d36a47dca3c28
<pre>
Add ability to mask URLs from DOM and JavaScript.
<a href="https://bugs.webkit.org/show_bug.cgi?id=238576">https://bugs.webkit.org/show_bug.cgi?id=238576</a>
rdar://81991245

Reviewed by Chris Dumez.

* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(GetterExpression): Use getURLAttributeForBindings for URL types.
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::jsTestObj_reflectedURLAttrGetter): Updated to use getURLAttributeForBindings.
(WebCore::jsTestObj_reflectedUSVURLAttrGetter): Ditto.
(WebCore::jsTestObj_reflectedCustomURLAttrGetter): Ditto.
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::value const): Use getAttributeForBindings.
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::shouldMaskURLForBindings const): Added.
(WebCore::Document::hasURLsToMaskForBindings const): Added.
(WebCore::Document::maskedURLForBindingsIfNeeded const): Added.
(WebCore::Document::maskedURLStringForBindings const): Added.
(WebCore::Document::maskedURLForBindings const): Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getAttribute const): Use getAttributeInternal for the Attribute lookup.
(WebCore::Element::getAttributeForBindings const): Added.
(WebCore::Element::innerHTML const): Use new ResolveURLs::NoExcludingURLsForPrivacy when calling serializeFragment.
(WebCore::Element::outerHTML const): Ditto.
(WebCore::Element::resolveURLStringIfNeeded const): Added. Moved from MarkupAccumulator::resolveURLIfNeeded and added new NoExcludingURLsForPrivacy path.
Changed YesExcludingLocalFileURLsForPrivacy to YesExcludingURLsForPrivacy and included shouldMaskURLForBindings() check.
(WebCore::Element::completeURLsInAttributeValue const): Use resolveURLStringIfNeeded instead of making URL directly.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl: Use getAttributeForBindings for getAttribute, and getAttributeNSForBindings for getAttributeNS.
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::getURLAttributeForBindings const): Added.
(WebCore::Element::getAttributeInternal const): Added. Copied from getAttribute to share Attribute lookup code.
(WebCore::Element::getAttributeNSForBindings const): Added.
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::innerHTML const): Use new ResolveURLs::NoExcludingURLsForPrivacy when calling serializeFragment.
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::resolveURLIfNeeded const): Use Element::resolveURLStringIfNeeded.
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::selectionInHTMLFormat): Changed YesExcludingLocalFileURLsForPrivacy to YesExcludingURLsForPrivacy.
* Source/WebCore/editing/gtk/EditorGtk.cpp:
(WebCore::Editor::writeSelectionToPasteboard): Ditto.
* Source/WebCore/editing/libwpe/EditorLibWPE.cpp:
(WebCore::Editor::writeSelectionToPasteboard): Ditto.
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::writeImageToPasteboard): Ditto.
* Source/WebCore/editing/markup.cpp:
(WebCore::sanitizedMarkupForFragmentInDocument): Ditto.
* Source/WebCore/editing/markup.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::completeURLsInAttributeValue const): Use resolveURLStringIfNeeded instead of making URL directly.
(WebCore::HTMLImageElement::srcsetForBindings const):Added. Use getAttributeForBindings with ResolveURLs::YesExcludingURLsForPrivacy.
(WebCore::HTMLImageElement::setSrcsetForBindings): Added.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLImageElement.idl:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::shouldMaskURLForBindings const): Added.
* Source/WebCore/page/Page.h:
(WebCore::Page::hasURLsToMaskForBindings const):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::writeSelection): Changed YesExcludingLocalFileURLsForPrivacy to YesExcludingURLsForPrivacy.
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const): Added maskedURLSchemes.
(WebKit::WebPageCreationParameters::decode): Ditto.
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::copy const): Added maskedURLSchemes.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::maskedURLSchemes const): Added.
(API::PageConfiguration::setMaskedURLSchemes): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _maskedURLSchemes]): Added.
(-[WKWebViewConfiguration _setMaskedURLSchemes:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters): Added maskedURLSchemes.
* Source/WebKit/WebProcess/WebCoreSupport/gtk/WebEditorClientGtk.cpp:
(WebKit::WebEditorClient::updateGlobalSelection): Changed YesExcludingLocalFileURLsForPrivacy to YesExcludingURLsForPrivacy.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage): Added maskedURLSchemes.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:
(TEST(WebKit, ConfigurationMaskedURLSchemes)): Added.

Canonical link: <a href="https://commits.webkit.org/251962@main">https://commits.webkit.org/251962@main</a>
</pre>
