### PR TITLE
[iOS] Simplify some EditorState update logic after r295626

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7733,12 +7733,10 @@ void WebPageProxy::didReceiveEvent(uint32_t opaqueType, bool handled)
     }
 }
 
-void WebPageProxy::editorStateChanged(const EditorState& editorState, CompletionHandler<void()>&& completionHandler)
+void WebPageProxy::editorStateChanged(const EditorState& editorState)
 {
     if (updateEditorState(editorState))
         dispatchDidUpdateEditorState();
-
-    completionHandler();
 }
 
 bool WebPageProxy::updateEditorState(const EditorState& newEditorState)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1735,7 +1735,7 @@ public:
 #if PLATFORM(COCOA)
     void createSandboxExtensionsIfNeeded(const Vector<String>& files, SandboxExtension::Handle& fileReadHandle, Vector<SandboxExtension::Handle>& fileUploadHandles);
 #endif
-    void editorStateChanged(const EditorState&, CompletionHandler<void()>&&);
+    void editorStateChanged(const EditorState&);
     bool updateEditorState(const EditorState& newEditorState);
     void scheduleFullEditorStateUpdate();
     void dispatchDidUpdateEditorState();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -212,7 +212,7 @@ messages -> WebPageProxy {
     LogScrollingEvent(uint32_t eventType, MonotonicTime timestamp, uint64_t data)
 
     # Editor notifications
-    EditorStateChanged(struct WebKit::EditorState editorState) -> ()
+    EditorStateChanged(struct WebKit::EditorState editorState)
     CompositionWasCanceled()
     SetHasHadSelectionChangesFromUserInteraction(bool hasHadUserSelectionChanges)
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6200,19 +6200,19 @@ void WebPage::deleteSurrounding(int64_t offset, unsigned characterCount)
     targetFrame->selection().setSelection(VisibleSelection(selectionRange));
     targetFrame->editor().deleteSelectionWithSmartDelete(false);
     targetFrame->editor().setIgnoreSelectionChanges(false);
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 #endif
 
 void WebPage::didApplyStyle()
 {
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::didChangeContents()
 {
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::didScrollSelection()
@@ -6409,26 +6409,26 @@ void WebPage::focusedElementDidChangeInputMode(WebCore::Element& element, WebCor
 
 void WebPage::didUpdateComposition()
 {
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::didEndUserTriggeredSelectionChanges()
 {
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
     if (!frame->editor().ignoreSelectionChanges())
-        sendEditorStateUpdate([] { });
+        sendEditorStateUpdate();
 }
 
 void WebPage::discardedComposition()
 {
     send(Messages::WebPageProxy::CompositionWasCanceled());
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::canceledComposition()
 {
     send(Messages::WebPageProxy::CompositionWasCanceled());
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::navigateServiceWorkerClient(ScriptExecutionContextIdentifier documentIdentifier, const URL& url, CompletionHandler<void(bool)>&& callback)
@@ -6825,13 +6825,11 @@ void WebPage::reportUsedFeatures()
     m_loaderClient->featuresUsedInPage(*this, namedFeatures);
 }
 
-void WebPage::sendEditorStateUpdate(CompletionHandler<void()>&& completionHandler)
+void WebPage::sendEditorStateUpdate()
 {
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    if (frame->editor().ignoreSelectionChanges() || !frame->document() || !frame->document()->hasLivingRenderTree()) {
-        completionHandler();
+    if (frame->editor().ignoreSelectionChanges() || !frame->document() || !frame->document()->hasLivingRenderTree())
         return;
-    }
 
     m_pendingEditorStateUpdateStatus = PendingEditorStateUpdateStatus::NotScheduled;
 
@@ -6839,7 +6837,7 @@ void WebPage::sendEditorStateUpdate(CompletionHandler<void()>&& completionHandle
     // If that is the case, just send what we have (i.e. don't include post-layout data) and wait until the
     // next layer tree commit to compute and send the complete EditorState over.
     auto state = editorState();
-    sendWithAsyncReply(Messages::WebPageProxy::EditorStateChanged(state), WTFMove(completionHandler));
+    send(Messages::WebPageProxy::EditorStateChanged(state));
     if (state.isMissingPostLayoutData && !shouldAvoidComputingPostLayoutDataForEditorState())
         scheduleFullEditorStateUpdate();
 }
@@ -6921,7 +6919,7 @@ void WebPage::flushPendingEditorStateUpdate()
     if (frame->editor().ignoreSelectionChanges())
         return;
 
-    sendEditorStateUpdate([] { });
+    sendEditorStateUpdate();
 }
 
 void WebPage::updateWebsitePolicies(WebsitePoliciesData&& websitePolicies)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1566,7 +1566,7 @@ private:
     void getPlatformEditorState(WebCore::Frame&, EditorState&) const;
     bool requiresPostLayoutDataForEditorState(const WebCore::Frame&) const;
     void platformWillPerformEditingCommand();
-    void sendEditorStateUpdate(CompletionHandler<void()>&&);
+    void sendEditorStateUpdate();
 
     void getPlatformEditorStateCommon(const WebCore::Frame&, EditorState&) const;
 


### PR DESCRIPTION
#### b50f7ed1e3d2ac79868f253592befb1017d87112
<pre>
[iOS] Simplify some EditorState update logic after r295626
<a href="https://bugs.webkit.org/show_bug.cgi?id=241985">https://bugs.webkit.org/show_bug.cgi?id=241985</a>
rdar://93638100

Reviewed by Tim Horton.

Simplify some logic that was added in r295626 to ensure that editor state is up-to-date in the UI
process. The completion handler for `sendEditorStateUpdate()` is actually not needed, since we can
propagate the editor state to the UI process before invoking the async IPC reply completion handler
in the web process. Due to IPC message ordering, this ensures that the editor state is updated in
the UI process right before the context menu is about to be shown.

No change in behavior.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::editorStateChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::deleteSurrounding):
(WebKit::WebPage::didApplyStyle):
(WebKit::WebPage::didChangeContents):
(WebKit::WebPage::didUpdateComposition):
(WebKit::WebPage::didEndUserTriggeredSelectionChanges):
(WebKit::WebPage::discardedComposition):
(WebKit::WebPage::canceledComposition):
(WebKit::WebPage::sendEditorStateUpdate):

Remove the completion handler argument from the IPC message handler, as well as this helper method
on `WebPage`.

(WebKit::WebPage::flushPendingEditorStateUpdate):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::prepareSelectionForContextMenuWithLocationInView):
(WebKit::WebPage::requestPositionInformation):

Canonical link: <a href="https://commits.webkit.org/251846@main">https://commits.webkit.org/251846@main</a>
</pre>
