### PR TITLE
Web Inspector: provide an option for controlling whether local overrides entirely replace or have some passthrough

### DIFF
--- a/LayoutTests/http/tests/inspector/network/intercept-request-properties-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/intercept-request-properties-expected.txt
@@ -79,7 +79,17 @@ Request details:
   Request Headers:
     X-Value: overridden
 
--- Running test case: Network.interceptRequest.Headers.Passthrough
+-- Running test case: Network.interceptRequest.Headers.Empty
+Triggering load...
+Request details:
+  URI: /inspector/network/resources/intercept-echo.py
+  Response URL: http://127.0.0.1:8000/inspector/network/resources/intercept-echo.py
+  Method: POST
+  Request Headers:
+  Post:
+    value: overridden
+
+-- Running test case: Network.interceptRequest.Headers.Passthrough.Add
 Triggering load...
 Request details:
   URI: /inspector/network/resources/intercept-echo.py
@@ -87,6 +97,19 @@ Request details:
   Method: POST
   Request Headers:
     Content-Type: application/x-www-form-urlencoded
+    X-Expected: PASS
+  Post:
+    value: overridden
+
+-- Running test case: Network.interceptRequest.Headers.Passthrough.Replace
+Triggering load...
+Request details:
+  URI: /inspector/network/resources/intercept-echo.py
+  Response URL: http://127.0.0.1:8000/inspector/network/resources/intercept-echo.py
+  Method: POST
+  Request Headers:
+    Content-Type: application/x-www-form-urlencoded
+    X-Expected: PASS
   Post:
     value: overridden
 

--- a/LayoutTests/http/tests/inspector/network/intercept-request-properties.html
+++ b/LayoutTests/http/tests/inspector/network/intercept-request-properties.html
@@ -17,13 +17,13 @@ async function fetchData(url)
     }
 }
 
-async function postData(url)
+async function postData(url, headers = {})
 {
+    headers["Content-Type"] = "application/x-www-form-urlencoded"
+
     let response = await fetch(url, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-        },
+        headers,
         body: "value=original",
     });
     // Eval to accept trailing coma JSON.
@@ -164,12 +164,37 @@ function test()
     });
 
     addTestCase({
-        name: "Network.interceptRequest.Headers.Passthrough",
-        description: "Tests request headers passthrough",
+        name: "Network.interceptRequest.Headers.Empty",
+        description: "Tests request headers interception removing all headers",
         expression: "postData('resources/intercept-echo.py')",
         override: {
             requestMethod: "POST",
             requestData: "value=overridden",
+            requestHeaders: {},
+        },
+    });
+
+    addTestCase({
+        name: "Network.interceptRequest.Headers.Passthrough.Add",
+        description: "Tests request headers passthrough with a new header",
+        expression: "postData('resources/intercept-echo.py')",
+        override: {
+            requestMethod: "POST",
+            requestData: "value=overridden",
+            requestHeaders: { "X-Expected": "PASS" },
+            isPassthrough: true,
+        },
+    });
+
+    addTestCase({
+        name: "Network.interceptRequest.Headers.Passthrough.Replace",
+        description: "Tests request headers passthrough with an overridden header",
+        expression: "postData('resources/intercept-echo.py', {'X-Expected': 'FAIL'})",
+        override: {
+            requestMethod: "POST",
+            requestData: "value=overridden",
+            requestHeaders: { "X-Expected": "PASS" },
+            isPassthrough: true,
         },
     });
 

--- a/LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt
@@ -127,7 +127,19 @@ Response Headers:
   X-Expected: PASS
 Content: PASS
 
--- Running test case: LocalResourceOverride.Headers.Passthrough
+-- Running test case: LocalResourceOverride.Headers.Empty
+Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
+Triggering load...
+Resource Loaded:
+URL: http://127.0.0.1:8000/inspector/network/resources/override.txt
+MIME Type: text/plain
+Status: 200 OK
+Response Source: Symbol(inspector-override)
+Response Headers:
+  Content-Type: text/plain
+Content: PASS
+
+-- Running test case: LocalResourceOverride.Headers.Passthrough.Add
 Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
 Triggering load...
 Resource Loaded:
@@ -145,6 +157,28 @@ Response Headers:
   Keep-Alive: <filtered>
   Last-Modified: <filtered>
   Server: <filtered>
+  X-Expected: PASS
+Content: PASS
+
+-- Running test case: LocalResourceOverride.Headers.Passthrough.Replace
+Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
+Triggering load...
+Resource Loaded:
+URL: http://127.0.0.1:8000/inspector/network/resources/override.txt
+MIME Type: text/plain
+Status: 200 OK
+Response Source: Symbol(inspector-override)
+Response Headers:
+  Accept-Ranges: <filtered>
+  Connection: <filtered>
+  Content-Length: 29
+  Content-Type: text/plain
+  Date: <filtered>
+  ETag: <filtered>
+  Keep-Alive: <filtered>
+  Last-Modified: <filtered>
+  Server: <filtered>
+  X-Expected: PASS
 Content: PASS
 
 -- Running test case: LocalResourceOverride.404

--- a/LayoutTests/http/tests/inspector/network/local-resource-override-basic.html
+++ b/LayoutTests/http/tests/inspector/network/local-resource-override-basic.html
@@ -4,11 +4,11 @@
 <meta charset="utf-8">
 <script src="../resources/inspector-test.js"></script>
 <script>
-function triggerOverrideLoad(urlSuffix) {
+function triggerOverrideLoad(urlSuffix, headers = {}) {
     let url = "http://127.0.0.1:8000/inspector/network/resources/override.txt";
     if (urlSuffix)
         url += urlSuffix;
-    fetch(url).then(() => {
+    fetch(url, {headers}).then(() => {
         TestPage.dispatchEventToFrontend("LoadComplete");
     });
 }
@@ -214,8 +214,8 @@ function test()
     });
 
     addTestCase({
-        name: "LocalResourceOverride.Headers.Passthrough",
-        description: "Load an override without modifying headers.",
+        name: "LocalResourceOverride.Headers.Empty",
+        description: "Tests request headers interception removing all headers.",
         expression: `triggerOverrideLoad()`,
         overrides: [{
             url: "http://127.0.0.1:8000/inspector/network/resources/override.txt",
@@ -225,6 +225,38 @@ function test()
             responseStatusCode: 200,
             responseStatusText: "OK",
             responseHeaders: {},
+        }]
+    });
+
+    addTestCase({
+        name: "LocalResourceOverride.Headers.Passthrough.Add",
+        description: "Tests request headers passthrough with a new header.",
+        expression: `triggerOverrideLoad()`,
+        overrides: [{
+            url: "http://127.0.0.1:8000/inspector/network/resources/override.txt",
+            responseMIMEType: "text/plain",
+            responseContent: "PASS",
+            responseBase64Encoded: false,
+            responseStatusCode: 200,
+            responseStatusText: "OK",
+            responseHeaders: {"X-Expected": "PASS"},
+            isPassthrough: true,
+        }]
+    });
+
+    addTestCase({
+        name: "LocalResourceOverride.Headers.Passthrough.Replace",
+        description: "Tests request headers passthrough with an overridden header.",
+        expression: `triggerOverrideLoad("", {"X-Expected": "FAIL"})`,
+        overrides: [{
+            url: "http://127.0.0.1:8000/inspector/network/resources/override.txt",
+            responseMIMEType: "text/plain",
+            responseContent: "PASS",
+            responseBase64Encoded: false,
+            responseStatusCode: 200,
+            responseStatusText: "OK",
+            responseHeaders: {"X-Expected": "PASS"},
+            isPassthrough: true,
         }]
     });
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -66,7 +66,6 @@ localizedStrings["%s Fired"] = "%s Fired";
 localizedStrings["%s Prototype"] = "%s Prototype";
 /* Format string for the suggested filename when saving the content for a request local override. */
 localizedStrings["%s Request Data @ Local Override Request Content View"] = "%s Request Data";
-localizedStrings["%s Result"] = "%s Result";
 localizedStrings["%s \u2013 %s"] = "%s \u2013 %s";
 localizedStrings["%s \u2013 %s (%s)"] = "%s \u2013 %s (%s)";
 localizedStrings["%s \u2014 %s"] = "%s \u2014 %s";
@@ -821,6 +820,8 @@ localizedStrings["Import audit or result"] = "Import audit or result";
 localizedStrings["Imported"] = "Imported";
 localizedStrings["Imported - %s"] = "Imported - %s";
 localizedStrings["Imported \u2014 %s"] = "Imported \u2014 %s";
+localizedStrings["Include original repsonse data"] = "Include original repsonse data";
+localizedStrings["Include original request data"] = "Include original request data";
 localizedStrings["Incomplete"] = "Incomplete";
 localizedStrings["Indent width:"] = "Indent width:";
 localizedStrings["Index"] = "Index";

--- a/Source/WebInspectorUI/UserInterface/Models/LocalResourceOverride.js
+++ b/Source/WebInspectorUI/UserInterface/Models/LocalResourceOverride.js
@@ -25,7 +25,7 @@
 
 WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
 {
-    constructor(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, disabled} = {})
+    constructor(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, isPassthrough, disabled} = {})
     {
         console.assert(url && typeof url === "string", url);
         console.assert(Object.values(WI.LocalResourceOverride.InterceptType).includes(type), type);
@@ -34,6 +34,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
         console.assert(!resourceErrorType || Object.values(WI.LocalResourceOverride.ResourceErrorType).includes(resourceErrorType), resourceErrorType);
         console.assert(isCaseSensitive === undefined || typeof isCaseSensitive === "boolean", isCaseSensitive);
         console.assert(isRegex === undefined || typeof isRegex === "boolean", isRegex);
+        console.assert(isPassthrough === undefined || typeof isPassthrough === "boolean", isPassthrough);
         console.assert(disabled === undefined || typeof disabled === "boolean", disabled);
 
         super();
@@ -45,6 +46,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
         this._resourceErrorType = resourceErrorType || WI.LocalResourceOverride.ResourceErrorType.General;
         this._isCaseSensitive = isCaseSensitive !== undefined ? isCaseSensitive : true;
         this._isRegex = isRegex !== undefined ? isRegex : false;
+        this._isPassthrough = isPassthrough !== undefined ? isPassthrough : false;
         this._disabled = disabled !== undefined ? disabled : false;
 
         this._localResource._localResourceOverride = this;
@@ -52,7 +54,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
 
     // Static
 
-    static create(url, type, {requestURL, requestMethod, requestHeaders, requestData, responseMIMEType, responseContent, responseBase64Encoded, responseStatusCode, responseStatusText, responseHeaders, resourceErrorType, isCaseSensitive, isRegex, disabled} = {})
+    static create(url, type, {requestURL, requestMethod, requestHeaders, requestData, responseMIMEType, responseContent, responseBase64Encoded, responseStatusCode, responseStatusText, responseHeaders, resourceErrorType, isCaseSensitive, isRegex, isPassthrough, disabled} = {})
     {
         let localResource = new WI.LocalResource({
             request: {
@@ -70,7 +72,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
                 base64Encoded: responseBase64Encoded,
             },
         });
-        return new WI.LocalResourceOverride(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, disabled});
+        return new WI.LocalResourceOverride(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, isPassthrough, disabled});
     }
 
     static displayNameForNetworkStageOfType(type)
@@ -133,7 +135,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
 
     static fromJSON(json)
     {
-        let {url, type, localResource: localResourceJSON, resourceErrorType, isCaseSensitive, isRegex, disabled} = json;
+        let {url, type, localResource: localResourceJSON, resourceErrorType, isCaseSensitive, isRegex, isPassthrough, disabled} = json;
 
         let localResource = WI.LocalResource.fromJSON(localResourceJSON);
 
@@ -141,7 +143,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
         url ??= localResource.url;
         type ??= WI.LocalResourceOverride.InterceptType.Response;
 
-        return new WI.LocalResourceOverride(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, disabled});
+        return new WI.LocalResourceOverride(url, type, localResource, {resourceErrorType, isCaseSensitive, isRegex, isPassthrough, disabled});
     }
 
     toJSON(key)
@@ -152,6 +154,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
             localResource: this._localResource.toJSON(key),
             isCaseSensitive: this._isCaseSensitive,
             isRegex: this._isRegex,
+            isPassthrough: this._isPassthrough,
             disabled: this._disabled,
         };
 
@@ -171,6 +174,7 @@ WI.LocalResourceOverride = class LocalResourceOverride extends WI.Object
     get localResource() { return this._localResource; }
     get isCaseSensitive() { return this._isCaseSensitive; }
     get isRegex() { return this._isRegex; }
+    get isPassthrough() { return this._isPassthrough; }
 
     get urlComponents()
     {

--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
@@ -47,8 +47,16 @@
     color: hsl(0, 0%, 34%);
 }
 
+.popover .local-resource-override-popover-content > table > tr.options > th {
+    line-height: 17px;
+}
+
 .popover .local-resource-override-popover-content > table > tr > td {
     padding-left: 4px;
+}
+
+.popover .local-resource-override-popover-content > table > tr.options > td > label:not([hidden]) {
+    display: block;
 }
 
 .popover .local-resource-override-popover-content .editor {
@@ -100,10 +108,6 @@
 
 .popover .local-resource-override-popover-content .data-grid tr.header-content-type > :matches(.name-column, .value-column) {
     opacity: 0.5;
-}
-
-.popover .local-resource-override-popover-content .options td {
-    vertical-align: bottom;
 }
 
 .popover .local-resource-override-popover-content .reference-page-link-container {


### PR DESCRIPTION
#### 716557a92a13730d3648c09b0bf8d18cc691a735
<pre>
Web Inspector: provide an option for controlling whether local overrides entirely replace or have some passthrough
<a href="https://bugs.webkit.org/show_bug.cgi?id=241990">https://bugs.webkit.org/show_bug.cgi?id=241990</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Models/LocalResourceOverride.js:
(WI.LocalResourceOverride.prototype.create):
(WI.LocalResourceOverride.fromJSON):
(WI.LocalResourceOverride.prototype.toJSON):
(WI.LocalResourceOverride.prototype.get isPassthrough): Added.
Add a `isPassthrough` member that indicates whether to include original request/response data (where
applicable/possible, e.g. headers).

* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.async requestIntercepted):
(WI.NetworkManager.prototype.async responseIntercepted):
Use `isPassthrough` to decide whether to return the original `request`/`response` data (or `undefined`
if the argument is optional) or the data from the `WI.LocalResourceOverride` (or `WI.LocalResource`).

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js:
(WI.LocalResourceOverridePopover):
(WI.LocalResourceOverridePopover.prototype.get serializedData):
(WI.LocalResourceOverridePopover.prototype.show):
* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css:
(.popover .local-resource-override-popover-content &gt; table &gt; tr.options &gt; th): Added.
(.popover .local-resource-override-popover-content &gt; table &gt; tr.options &gt; td &gt; label:not([hidden])): Added.
(.popover .local-resource-override-popover-content .options td): Deleted.
Add UI at the bottom of the local override popover for controlling `isPassthrough`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/http/tests/inspector/network/intercept-request-properties.html:
* LayoutTests/http/tests/inspector/network/intercept-request-properties-expected.txt:
* LayoutTests/http/tests/inspector/network/local-resource-override-basic.html:
* LayoutTests/http/tests/inspector/network/local-resource-override-basic-expected.txt:

Canonical link: <a href="https://commits.webkit.org/251884@main">https://commits.webkit.org/251884@main</a>
</pre>
