### PR TITLE
Web Inspector: REGRESSION(251279@main): Uncaught Exception: ReferenceError: Can't find variable: sourceCode

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideWarningView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideWarningView.js
@@ -63,7 +63,7 @@ WI.LocalResourceOverrideWarningView = class LocalResourceOverrideWarningView ext
         this._revealButton.textContent = WI.UIString("Reveal");
         this._revealButton.addEventListener("click", (event) => {
             let localResourceOverride = WI.networkManager.localResourceOverridesForURL(this._resource.url)[0];
-            WI.showLocalResourceOverride(localResourceOverride, {overriddenResource: sourceCode});
+            WI.showLocalResourceOverride(localResourceOverride, {overriddenResource: this._resource});
         });
 
         let container = this.element.appendChild(document.createElement("div"));


### PR DESCRIPTION
#### d95aece0e847074ddd360dc1c40988bec7be8a31
<pre>
Web Inspector: REGRESSION(251279@main): Uncaught Exception: ReferenceError: Can&apos;t find variable: sourceCode
<a href="https://bugs.webkit.org/show_bug.cgi?id=241987">https://bugs.webkit.org/show_bug.cgi?id=241987</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverrideWarningView.js:
(WI.LocalResourceOverrideWarningView.prototype.initialLayout):

Canonical link: <a href="https://commits.webkit.org/251839@main">https://commits.webkit.org/251839@main</a>
</pre>
