### PR TITLE
REGRESSION (251792@main?): [ macOS ][ iOS ] TestWebKitAPI.WKBackForwardList.BackForwardNavigationDoesNotSkipItemsWithUserGesture is a flaky failure and crash

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -37,7 +37,6 @@
 @property (nonatomic, copy) void (^didStartProvisionalNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didCommitNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
-@property (nonatomic, copy) void (^didSameDocumentNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^renderingProgressDidChange)(WKWebView *, _WKRenderingProgressEvents);
 @property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *);
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKWebView *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *));
@@ -45,7 +44,6 @@
 
 - (void)waitForDidStartProvisionalNavigation;
 - (void)waitForDidFinishNavigation;
-- (void)waitForDidFinishNavigationOrSameDocumentNavigation;
 - (void)waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (NSError *)waitForDidFailProvisionalNavigation;
 
@@ -54,7 +52,6 @@
 @interface WKWebView (TestWebKitAPIExtras)
 - (void)_test_waitForDidStartProvisionalNavigation;
 - (void)_test_waitForDidFinishNavigation;
-- (void)_test_waitForDidFinishNavigationOrSameDocumentNavigation;
 - (void)_test_waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (void)_test_waitForDidFinishNavigationWithoutPresentationUpdate;
 - (void)_test_waitForDidFailProvisionalNavigation;

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -98,12 +98,6 @@
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
 }
 
-- (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
-{
-    if (_didSameDocumentNavigation)
-        _didSameDocumentNavigation(webView, navigation);
-}
-
 - (void)waitForDidStartProvisionalNavigation
 {
     EXPECT_FALSE(self.didStartProvisionalNavigation);
@@ -130,25 +124,6 @@
     TestWebKitAPI::Util::run(&finished);
 
     self.didFinishNavigation = nil;
-}
-
-- (void)waitForDidFinishNavigationOrSameDocumentNavigation
-{
-    EXPECT_FALSE(self.didFinishNavigation);
-    EXPECT_FALSE(self.didSameDocumentNavigation);
-
-    __block bool finished = false;
-    self.didFinishNavigation = ^(WKWebView *, WKNavigation *) {
-        finished = true;
-    };
-    self.didSameDocumentNavigation = ^(WKWebView *, WKNavigation *) {
-        finished = true;
-    };
-
-    TestWebKitAPI::Util::run(&finished);
-
-    self.didFinishNavigation = nil;
-    self.didSameDocumentNavigation = nil;
 }
 
 - (void)waitForWebContentProcessDidTerminate
@@ -265,17 +240,6 @@
     }];
     TestWebKitAPI::Util::run(&presentationUpdateHappened);
 #endif
-}
-
-- (void)_test_waitForDidFinishNavigationOrSameDocumentNavigation
-{
-    EXPECT_FALSE(self.navigationDelegate);
-
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    self.navigationDelegate = navigationDelegate.get();
-    [navigationDelegate waitForDidFinishNavigationOrSameDocumentNavigation];
-
-    self.navigationDelegate = nil;
 }
 
 - (void)_test_waitForWebContentProcessDidTerminate


### PR DESCRIPTION
#### 2a7a51012dfcd5468c4e5ad6a41654ade58fe39e
<pre>
REGRESSION (251792@main?): [ macOS ][ iOS ] TestWebKitAPI.WKBackForwardList.BackForwardNavigationDoesNotSkipItemsWithUserGesture is a flaky failure and crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=241991">https://bugs.webkit.org/show_bug.cgi?id=241991</a>
&lt;rdar://95886849&gt;

Reviewed by Alex Christensen.

The API test relies on `[webView _test_waitForDidFinishNavigationOrSameDocumentNavigation]` to proceed
to the next steps instead of the usual `[webView _test_waitForDidFinishNavigation]` because
didFinishNavigation does not get called for same document navigations (e.g. back navigation after
history.pushState()).

However, what I didn&apos;t realize is that when doing a back navigation after a pushState(),
didSameDocumentNavigation would get called twice, once with _WKSameDocumentNavigationTypeAnchorNavigation
and then again with _WKSameDocumentNavigationTypeSessionStatePop. These duplicate calls would cause the
test to proceed further too eagerly.

To address the issue, these API tests now rely on their own custom navigation delegate which only marks
the navigation as complete if didSameDocumentNavigation gets called with either
_WKSameDocumentNavigationTypeSessionStatePush or _WKSameDocumentNavigationTypeSessionStatePop.

* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm:
(-[WKBackForwardNavigationDelegate init]):
(-[WKBackForwardNavigationDelegate webView:didFinishNavigation:]):
(-[WKBackForwardNavigationDelegate _webView:navigation:didSameDocumentNavigation:]):
(TEST):
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate _webView:navigation:didSameDocumentNavigation:]): Deleted.
(-[TestNavigationDelegate waitForDidFinishNavigationOrSameDocumentNavigation]): Deleted.
(-[WKWebView _test_waitForDidFinishNavigationOrSameDocumentNavigation]): Deleted.

Canonical link: <a href="https://commits.webkit.org/251894@main">https://commits.webkit.org/251894@main</a>
</pre>
