### PR TITLE
Revert [251654@main] video.currentSrc should not be reset when a new load errors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-currentSrc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-currentSrc-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Test currentSrc behaviour in various playback scenarios
+FAIL Test currentSrc behaviour in various playback scenarios assert_true: Not reset when a new load errors expected true got false
 

--- a/LayoutTests/media/video-currentsrc-cleared-expected.txt
+++ b/LayoutTests/media/video-currentsrc-cleared-expected.txt
@@ -1,0 +1,12 @@
+
+Check that 'currentsrc' is cleared when there is no media resource.
+
+EVENT(canplaythrough)
+EXPECTED (video.currentSrc.indexOf("content/test") > '-1') OK
+RUN(video.src = "")
+
+EVENT(error)
+EXPECTED (video.currentSrc == '') OK
+
+END OF TEST
+

--- a/LayoutTests/media/video-currentsrc-cleared.html
+++ b/LayoutTests/media/video-currentsrc-cleared.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=media-file.js></script>
+        <script src=video-test.js></script>
+        <script>
+            function error()
+            {
+                testExpected('video.currentSrc', '');
+                consoleWrite('');
+                endTest();
+            }
+
+            function canplaythrough()
+            {
+                testExpected('video.currentSrc.indexOf("content/test")', -1, '>');
+                run('video.src = ""');
+                consoleWrite('');
+            }
+
+            function start()
+            {
+                findMediaElement();
+                waitForEvent('error', error);
+                waitForEvent('canplaythrough', canplaythrough);
+                video.src = findMediaFile("video", "content/test");
+            }
+        </script>
+    </head>
+    <body onload="start()">
+        <video ></video>
+        <p>Check that 'currentsrc' is cleared when there is no media resource.</p>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1183,6 +1183,7 @@ void HTMLMediaElement::prepareForLoad()
     m_haveFiredLoadedData = false;
     m_completelyLoaded = false;
     m_havePreparedToPlay = false;
+    setCurrentSrc(URL());
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     m_failedToPlayToWirelessTarget = false;


### PR DESCRIPTION
#### dbb1064e05e5ecddb00d487d51bbd3e6b4569bf6
<pre>
Revert [251654@main] video.currentSrc should not be reset when a new load errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=225451">https://bugs.webkit.org/show_bug.cgi?id=225451</a>

Unreviewed.

This change caused two API tests to frequently time out on macOS release bots (see webkit.org/b/241982)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-currentSrc-expected.txt:
* LayoutTests/media/video-currentsrc-cleared-expected.txt: Added.
* LayoutTests/media/video-currentsrc-cleared.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::prepareForLoad):

Canonical link: <a href="https://commits.webkit.org/251841@main">https://commits.webkit.org/251841@main</a>
</pre>
