### PR TITLE
[JSC] Add writeFile function to JSC shell

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -196,7 +196,7 @@ public:
     inline std::optional<size_t> byteOffsetConcurrently();
 
     size_t length() const { return m_length; }
-    size_t byteLength() const;
+    JS_EXPORT_PRIVATE size_t byteLength() const;
 
     DECLARE_EXPORT_INFO;
     


### PR DESCRIPTION
#### df596416fde1d23b4767c4bb613bcebce18d163d
<pre>
[JSC] Add writeFile function to JSC shell
<a href="https://bugs.webkit.org/show_bug.cgi?id=241994">https://bugs.webkit.org/show_bug.cgi?id=241994</a>

Reviewed by Mark Lam.

JSC shell has readFile function, but it did not have writeFile function.
It is super useful in particular when debugging wasm, which needs binary blob, and reading and writing binaries
are critical to understand what the binary is.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:

Canonical link: <a href="https://commits.webkit.org/251847@main">https://commits.webkit.org/251847@main</a>
</pre>
