### PR TITLE
Regression(247804@main): Network process is terminated while fetching website data

### DIFF
--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -132,17 +132,21 @@ Vector<Ref<NetworkProcessProxy>> NetworkProcessProxy::allNetworkProcesses()
     });
 }
 
-RefPtr<NetworkProcessProxy>& NetworkProcessProxy::defaultNetworkProcess()
+WeakPtr<NetworkProcessProxy>& NetworkProcessProxy::defaultNetworkProcess()
 {
-    static NeverDestroyed<RefPtr<NetworkProcessProxy>> process;
-    return process.get();
+    static NeverDestroyed<WeakPtr<NetworkProcessProxy>> networkProcess;
+    return networkProcess.get();
 }
 
 Ref<NetworkProcessProxy> NetworkProcessProxy::ensureDefaultNetworkProcess()
 {
-    if (!defaultNetworkProcess())
-        defaultNetworkProcess() = NetworkProcessProxy::create();
-    return *defaultNetworkProcess();
+    auto& networkProcess = defaultNetworkProcess();
+    if (networkProcess)
+        return Ref { *networkProcess };
+
+    auto newNetworkProcess = NetworkProcessProxy::create();
+    networkProcess = newNetworkProcess.get();
+    return newNetworkProcess;
 }
 
 void NetworkProcessProxy::terminate()

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -120,7 +120,7 @@ public:
     using OpenerDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkProcessProxy> ensureDefaultNetworkProcess();
-    static RefPtr<NetworkProcessProxy>& defaultNetworkProcess();
+    static WeakPtr<NetworkProcessProxy>& defaultNetworkProcess();
     static Ref<NetworkProcessProxy> create() { return adoptRef(*new NetworkProcessProxy); }
     ~NetworkProcessProxy();
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -313,16 +313,6 @@ WebProcessPool::~WebProcessPool()
 
         process->shutDown();
     }
-
-    if (processPools().isEmpty()) {
-        WebsiteDataStore::forEachWebsiteDataStore([](auto& websiteDataStore) {
-            websiteDataStore.removeNetworkProcessReference();
-        });
-        if (auto& networkProcess = NetworkProcessProxy::defaultNetworkProcess()) {
-            ASSERT(networkProcess->hasOneRef());
-            networkProcess = nullptr;
-        }
-    }
 }
 
 void WebProcessPool::initializeClient(const WKContextClientBase* client)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -124,7 +124,6 @@ public:
     NetworkProcessProxy& networkProcess() const;
     NetworkProcessProxy& networkProcess();
     NetworkProcessProxy* networkProcessIfExists() { return m_networkProcess.get(); }
-    void removeNetworkProcessReference();
     
     static WebsiteDataStore* existingDataStoreForSessionID(PAL::SessionID);
 


### PR DESCRIPTION
#### 5867c9a72edd6825d5ace624f462c9161f8ba673
<pre>
Regression(247804@main): Network process is terminated while fetching website data
<a href="https://bugs.webkit.org/show_bug.cgi?id=241830">https://bugs.webkit.org/show_bug.cgi?id=241830</a>

Reviewed by Chris Dumez.

229885@main moves the ownership of NetworkProcessProxy from WebProcessPool to WebsiteDataStore, and we started to have
an issue that network process never exits, because we have default WebsiteDataStore that is never destroyed.
236145@main tries to make network process exit by setting NetworkProcessProxy::defaultNetworkProcess() to null when last
WebProcessPool is gone. However, it didn&apos;t achieve the goal, because it failed to clear the strong reference in
WebsiteDataStore, which means network process can stay as long as default WebsiteDataStore.
247804@main fixes the issue above by clearing the reference in WebsiteDataStore and now network process will actually
be terminated when last WebProcessPool is destroyed. However, network process can be terminated when WebsiteDataStore is
using it (e.g. waiting for task reply as in new test).

We may fix this issue by protecting NetworkProcessProxy when WebsiteDataStore is using network process, but this is
non-intuitive and with this approach we may accidentally introduce the bug again (i.e. we fail to protect
NetworkProcessProxy in some case and network process gets terminated while in use). Also, network process can carry
some session states in memory, so it feels weird that the states are lost while WebsiteDataStore is still alive. The
correct solution may be let default WebsiteDataStore be destroyed when it&apos;s not in use.

Therefore, to fix existing bug, the patch restores the old behavior: network process is terminated when last
WebsiteDataStore using it is destroyed.

API test: NetworkProcess.TerminateWhenNoWebsiteDataStore
          NetworkProcess.TerminateWhenNoDefaultWebsiteDataStore
          WKWebsiteDataStore.FetchPersistentWebStorage

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::defaultNetworkProcess):
(WebKit::NetworkProcessProxy::ensureDefaultNetworkProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::~WebProcessPool):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::WebsiteDataStore):
(WebKit::WebsiteDataStore::~WebsiteDataStore):
(WebKit::protectedDefaultDataStore):
(WebKit::globalDefaultDataStore):
(WebKit::WebsiteDataStore::defaultDataStore):
(WebKit::WebsiteDataStore::deleteDefaultDataStoreForTesting):
(WebKit::WebsiteDataStore::removeNetworkProcessReference): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::networkProcessIfExists):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251983@main">https://commits.webkit.org/251983@main</a>
</pre>
