### PR TITLE
Clean up AccessibilitySupportSPI.h

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,17 +25,14 @@
 
 #pragma once
 
+#include <CoreFoundation/CoreFoundation.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #include <AccessibilitySupport.h>
 
 #else
 
-#include <CoreFoundation/CoreFoundation.h>
-
-WTF_EXTERN_C_BEGIN
-
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 typedef CF_ENUM(int32_t, AXSIsolatedTreeMode)
 {
     AXSIsolatedTreeModeOff = 0,
@@ -43,10 +40,11 @@ typedef CF_ENUM(int32_t, AXSIsolatedTreeMode)
     AXSIsolatedTreeModeSecondaryThread,
 };
 
+#endif
+
+WTF_EXTERN_C_BEGIN
+
 AXSIsolatedTreeMode _AXSIsolatedTreeMode(void);
 void _AXSSetIsolatedTreeMode(AXSIsolatedTreeMode);
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 WTF_EXTERN_C_END
-
-#endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,15 +31,23 @@
 
 #else
 
+typedef enum {
+    AXValueStateInvalid = -2,
+    AXValueStateEmpty = -1,
+    AXValueStateOff,
+    AXValueStateOn
+} AXValueState;
+
+#endif
+
 WTF_EXTERN_C_BEGIN
 
-extern void _AXSSetReduceMotionEnabled(Boolean enabled);
-extern void _AXSSetDarkenSystemColors(Boolean enabled);
-extern Boolean _AXSKeyRepeatEnabled();
-extern Boolean _AXSApplicationAccessibilityEnabled();
+void _AXSSetReduceMotionEnabled(Boolean enabled);
+void _AXSSetDarkenSystemColors(Boolean enabled);
+Boolean _AXSKeyRepeatEnabled();
+Boolean _AXSApplicationAccessibilityEnabled();
 extern CFStringRef kAXSApplicationAccessibilityEnabledNotification;
 
-#if PLATFORM(IOS_FAMILY)
 extern CFStringRef kAXSReduceMotionPreference;
 
 extern CFStringRef kAXSReduceMotionChangedNotification;
@@ -48,33 +56,23 @@ extern CFStringRef kAXSEnhanceTextLegibilityChangedNotification;
 extern CFStringRef kAXSDarkenSystemColorsEnabledNotification;
 extern CFStringRef kAXSInvertColorsEnabledNotification;
 
-typedef enum {
-    AXValueStateInvalid = -2,
-    AXValueStateEmpty = -1,
-    AXValueStateOff,
-    AXValueStateOn
-} AXValueState;
+AXValueState _AXSReduceMotionEnabledApp(CFStringRef appID);
+AXValueState _AXSIncreaseButtonLegibilityApp(CFStringRef appID);
+AXValueState _AXSEnhanceTextLegibilityEnabledApp(CFStringRef appID);
+AXValueState _AXDarkenSystemColorsApp(CFStringRef appID);
+AXValueState _AXSInvertColorsEnabledApp(CFStringRef appID);
 
-extern AXValueState _AXSReduceMotionEnabledApp(CFStringRef appID);
-extern AXValueState _AXSIncreaseButtonLegibilityApp(CFStringRef appID);
-extern AXValueState _AXSEnhanceTextLegibilityEnabledApp(CFStringRef appID);
-extern AXValueState _AXDarkenSystemColorsApp(CFStringRef appID);
-extern AXValueState _AXSInvertColorsEnabledApp(CFStringRef appID);
-
-extern void _AXSSetReduceMotionEnabledApp(AXValueState enabled, CFStringRef appID);
-extern void _AXSSetIncreaseButtonLegibilityApp(AXValueState enabled, CFStringRef appID);
-extern void _AXSSetEnhanceTextLegibilityEnabledApp(AXValueState enabled, CFStringRef appID);
-extern void _AXSSetDarkenSystemColorsApp(AXValueState enabled, CFStringRef appID);
-extern void _AXSInvertColorsSetEnabledApp(AXValueState enabled, CFStringRef appID);
-#endif
+void _AXSSetReduceMotionEnabledApp(AXValueState enabled, CFStringRef appID);
+void _AXSSetIncreaseButtonLegibilityApp(AXValueState enabled, CFStringRef appID);
+void _AXSSetEnhanceTextLegibilityEnabledApp(AXValueState enabled, CFStringRef appID);
+void _AXSSetDarkenSystemColorsApp(AXValueState enabled, CFStringRef appID);
+void _AXSInvertColorsSetEnabledApp(AXValueState enabled, CFStringRef appID);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(FULL_KEYBOARD_ACCESS)
 extern CFStringRef kAXSFullKeyboardAccessEnabledNotification;
-extern Boolean _AXSFullKeyboardAccessEnabled();
+Boolean _AXSFullKeyboardAccessEnabled();
 #endif
 
 extern CFStringRef kAXSAccessibilityPreferenceDomain;
 
 WTF_EXTERN_C_END
-
-#endif

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4196,6 +4196,7 @@ def check_identifier_name_in_declaration(filename, line_number, line, file_state
                 and not modified_identifier == "LOG_CHANNEL"
                 and not modified_identifier == "WTF_GUARDED_BY_LOCK"
                 and not modified_identifier == "WTF_GUARDED_BY_CAPABILITY"
+                and not modified_identifier.startswith("_AX")
                 and not modified_identifier.find('chrono_literals') >= 0):
                 error(line_number, 'readability/naming/underscores', 4, identifier + " is incorrectly named. Don't use underscores in your identifier names.")
 


### PR DESCRIPTION
#### a713d4c4e774133040e273ce5c2ec5e8ebf85e02
<pre>
Clean up AccessibilitySupportSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=241995">https://bugs.webkit.org/show_bug.cgi?id=241995</a>

Reviewed by Cameron McCormack.

A few various cleanups. No behavior change.

1. Update copyright messages
2. Our general practice is to put function declarations ouside of #if USE(APPLE_INTERNAL_SDK).
       This is so that if the SPI changes, there will be a compile error. It also reduces the
       amount of conditional LOC. Some things, however, like enum definitions, can&apos;t be duplicated
       this way, and therefore need to be in !USE(APPLE_INTERNAL_SDK) blocks.
4. Similarly, we often don&apos;t guard the declarations for symbols which aren&apos;t present on some
       configurations/OSes. This also reduces the amount of conditional LOC, and reduces visual
       noise.
3. Function declarations don&apos;t need to be marked extern.

* Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h:
* Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:

Canonical link: <a href="https://commits.webkit.org/251860@main">https://commits.webkit.org/251860@main</a>
</pre>
