### PR TITLE
[JSC] remote function call thunk does not have tag registers

### DIFF
--- a/JSTests/stress/shadow-realm-tag-registers.js
+++ b/JSTests/stress/shadow-realm-tag-registers.js
@@ -1,0 +1,4 @@
+let foo = new ShadowRealm().evaluate(`()=>{}`);
+for (let i = 0; i < 1000000; i++) {
+    foo();
+}

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -1515,7 +1515,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
         jit.loadValue(CCallHelpers::addressFor(virtualRegisterForArgumentIncludingThis(0)).indexedBy(GPRInfo::regT1, CCallHelpers::TimesEight), valueRegs);
 
         CCallHelpers::JumpList valueIsPrimitive;
-        valueIsPrimitive.append(jit.branchIfNotCell(valueRegs));
+        valueIsPrimitive.append(jit.branchIfNotCell(valueRegs, DoNotHaveTagRegisters));
         valueIsPrimitive.append(jit.branchIfNotObject(valueRegs.payloadGPR()));
 
         jit.storePtr(GPRInfo::regT1, jit.addressFor(loopIndex));
@@ -1594,7 +1594,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
     constexpr JSValueRegs resultRegs = JSRInfo::returnValueJSR;
 
     CCallHelpers::JumpList resultIsPrimitive;
-    resultIsPrimitive.append(jit.branchIfNotCell(resultRegs));
+    resultIsPrimitive.append(jit.branchIfNotCell(resultRegs, DoNotHaveTagRegisters));
     resultIsPrimitive.append(jit.branchIfNotObject(resultRegs.payloadGPR()));
 
     jit.loadCell(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regT2);


### PR DESCRIPTION
#### fdb0f235b709c9d4099178be6ae7c865761882f8
<pre>
[JSC] remote function call thunk does not have tag registers
<a href="https://bugs.webkit.org/show_bug.cgi?id=241999">https://bugs.webkit.org/show_bug.cgi?id=241999</a>
rdar://95903837

Reviewed by Mark Lam and Saam Barati.

In remoteFunctionCallGenerator, we do not have tag registers.
So we should avoid relying on that.

* JSTests/stress/shadow-realm-tag-registers.js: Added.
(let.foo.new.ShadowRealm.evaluate):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::remoteFunctionCallGenerator):

Canonical link: <a href="https://commits.webkit.org/251854@main">https://commits.webkit.org/251854@main</a>
</pre>
