### PR TITLE
REGRESSION (iOS 16): 2 finger click with trackpad does not select editable text if context menu is already shown

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -572,21 +572,20 @@ void EventHandler::selectClosestContextualWordOrLinkFromHitTestResult(const HitT
     if (!m_frame.selection().selection().isContentEditable() && !is<Text>(result.targetNode()))
         return;
 
+    if (!m_frame.settings().textInteractionEnabled())
+        return;
+
     RefPtr urlElement = result.URLElement();
     if (!urlElement || !isDraggableLink(*urlElement)) {
-        if (RefPtr targetNode = result.targetNode()) {
-            if (isEditableNode(*targetNode)) {
-                if (mouseDownMayStartSelect())
-                    return selectClosestWordFromHitTestResult(result, appendTrailingWhitespace);
-                return;
-            }
+        if (RefPtr targetNode = result.targetNode(); targetNode && isEditableNode(*targetNode)) {
+            selectClosestWordFromHitTestResult(result, appendTrailingWhitespace);
+            return;
         }
 
         return selectClosestContextualWordFromHitTestResult(result, appendTrailingWhitespace);
     }
 
-    RefPtr targetNode = result.targetNode();
-    if (targetNode && targetNode->renderer() && mouseDownMayStartSelect()) {
+    if (RefPtr targetNode = result.targetNode(); targetNode && targetNode->renderer()) {
         VisibleSelection newSelection;
         VisiblePosition pos(targetNode->renderer()->positionForPoint(result.localPoint(), nullptr));
         if (pos.isNotNull() && pos.deepEquivalent().deprecatedNode()->isDescendantOf(*urlElement))


### PR DESCRIPTION
#### 596af8195ab511187b2a70f1bc68923ec4809224
<pre>
REGRESSION (iOS 16): 2 finger click with trackpad does not select editable text if context menu is already shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=241993">https://bugs.webkit.org/show_bug.cgi?id=241993</a>
rdar://93638100

Reviewed by Tim Horton.

When performing a 2-finger click over editable content with a trackpad on iPad running iOS 16, we
no longer select text if the click happens if a context menu is already shown. This is because the
mouse gesture (`WKMouseGestureRecognizer`) temporarily transitions to Ended state while the context
menu is up, which prevents mouse events from firing during the subsequent click; this, in turn,
means `EventHandler::m_mouseDownMayStartSelect` will be `false`, causing us to avoid selecting the
closest word from the hit-tested node for editable content:

```
if (isEditableNode(*targetNode)) {
    if (mouseDownMayStartSelect())
        return selectClosestWordFromHitTestResult(result, appendTrailingWhitespace);
    return;
}
```

To address this bug, we can just simplify `selectClosestContextualWordOrLinkFromHitTestResult` so
that it doesn&apos;t check `mouseDownMayStartSelect()`, and instead simply returns early if the text
interaction preference is disabled. On macOS, this doesn&apos;t change any behavior, since the only
existing call site of `selectClosestContextualWordOrLinkFromHitTestResult` already unconditionally
sets `m_mouseDownMayStartSelect` to `true` beforehand. The only other caller is
`prepareSelectionForContextMenuWithLocationInView`, which handles 2-finger clicks on iPad.

In the future, we should consider refactoring this iOS-specific code to dispatch a &quot;contextmenu&quot;
event using `EventHandler::sendContextMenuEvent` (which would allow webpages to use
`preventDefault()` to prevent the native context menu from showing up).

Tests:  iOSMouseSupport.ShowingContextMenuSelectsEditableText
        iOSMouseSupport.DisablingTextIteractionPreventsSelectionWhenShowingContextMenu

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::selectClosestContextualWordOrLinkFromHitTestResult):

Additionally clean up some code to use modern C++ idioms, e.g. &quot;initializer if&quot;.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/251855@main">https://commits.webkit.org/251855@main</a>
</pre>
