### PR TITLE
[WebGPU] Remove size member from GPUCanvasConfiguration

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
@@ -27,14 +27,10 @@
 
 #include "GPUCanvasCompositingAlphaMode.h"
 #include "GPUDevice.h"
-#include "GPUExtent3DDict.h"
 #include "GPUPredefinedColorSpace.h"
 #include "GPUTextureFormat.h"
 #include "GPUTextureUsage.h"
-#include <cstdint>
-#include <optional>
 #include <pal/graphics/WebGPU/WebGPUCanvasConfiguration.h>
-#include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -52,7 +48,6 @@ struct GPUCanvasConfiguration {
             }),
             WebCore::convertToBacking(colorSpace),
             WebCore::convertToBacking(compositingAlphaMode),
-            size ? std::optional { WebCore::convertToBacking(*size) } : std::nullopt,
         };
     }
 
@@ -62,7 +57,6 @@ struct GPUCanvasConfiguration {
     Vector<GPUTextureFormat> viewFormats;
     GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
     GPUCanvasCompositingAlphaMode compositingAlphaMode { GPUCanvasCompositingAlphaMode::Opaque };
-    std::optional<GPUExtent3D> size;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
@@ -27,8 +27,6 @@
 
 // https://bugs.webkit.org/show_bug.cgi?id=232548 These shouldn't need to be here.
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
-typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
-typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
     EnabledBySetting=WebGPU
@@ -40,5 +38,4 @@ dictionary GPUCanvasConfiguration {
     sequence<GPUTextureFormat> viewFormats = [];
     GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
-    GPUExtent3D size;
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCanvasConfiguration.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCanvasConfiguration.h
@@ -26,13 +26,10 @@
 #pragma once
 
 #include "WebGPUCanvasCompositingAlphaMode.h"
-#include "WebGPUExtent3D.h"
 #include "WebGPUPredefinedColorSpace.h"
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
-#include <cstdint>
-#include <optional>
-#include <wtf/Ref.h>
+#include <wtf/Vector.h>
 
 namespace PAL::WebGPU {
 
@@ -45,7 +42,6 @@ struct CanvasConfiguration {
     Vector<TextureFormat> viewFormats;
     PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
     CanvasCompositingAlphaMode compositingAlphaMode { CanvasCompositingAlphaMode::Opaque };
-    std::optional<Extent3D> size;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp
@@ -40,14 +40,7 @@ std::optional<CanvasConfiguration> ConvertToBackingContext::convertToBacking(con
     if (!device)
         return std::nullopt;
 
-    std::optional<Extent3D> size;
-    if (canvasConfiguration.size) {
-        size = convertToBacking(*canvasConfiguration.size);
-        if (!size)
-            return std::nullopt;
-    }
-
-    return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode, WTFMove(size) } };
+    return { { device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode } };
 }
 
 std::optional<PAL::WebGPU::CanvasConfiguration> ConvertFromBackingContext::convertFromBacking(const CanvasConfiguration& canvasConfiguration)
@@ -56,14 +49,7 @@ std::optional<PAL::WebGPU::CanvasConfiguration> ConvertFromBackingContext::conve
     if (!device)
         return std::nullopt;
 
-    std::optional<PAL::WebGPU::Extent3D> size;
-    if (canvasConfiguration.size) {
-        size = convertFromBacking(*canvasConfiguration.size);
-        if (!size)
-            return std::nullopt;
-    }
-
-    return { { *device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode, WTFMove(size) } };
+    return { { *device, canvasConfiguration.format, canvasConfiguration.usage, canvasConfiguration.viewFormats, canvasConfiguration.colorSpace, canvasConfiguration.compositingAlphaMode } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h
@@ -27,9 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "WebGPUExtent3D.h"
 #include "WebGPUIdentifier.h"
-#include <cstdint>
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUCanvasCompositingAlphaMode.h>
 #include <pal/graphics/WebGPU/WebGPUPredefinedColorSpace.h>
@@ -48,7 +46,6 @@ struct CanvasConfiguration {
     Vector<PAL::WebGPU::TextureFormat> viewFormats;
     PAL::WebGPU::PredefinedColorSpace colorSpace { PAL::WebGPU::PredefinedColorSpace::SRGB };
     PAL::WebGPU::CanvasCompositingAlphaMode compositingAlphaMode { PAL::WebGPU::CanvasCompositingAlphaMode::Opaque };
-    std::optional<Extent3D> size;
 
     template<class Encoder> void encode(Encoder& encoder) const
     {
@@ -58,7 +55,6 @@ struct CanvasConfiguration {
         encoder << viewFormats;
         encoder << colorSpace;
         encoder << compositingAlphaMode;
-        encoder << size;
     }
 
     template<class Decoder> static std::optional<CanvasConfiguration> decode(Decoder& decoder)
@@ -93,12 +89,7 @@ struct CanvasConfiguration {
         if (!compositingAlphaMode)
             return std::nullopt;
 
-        std::optional<std::optional<Extent3D>> size;
-        decoder >> size;
-        if (!size)
-            return std::nullopt;
-
-        return { { WTFMove(*device), WTFMove(*format), WTFMove(*usage), WTFMove(*viewFormats), WTFMove(*colorSpace), WTFMove(*compositingAlphaMode), WTFMove(*size) } };
+        return { { WTFMove(*device), WTFMove(*format), WTFMove(*usage), WTFMove(*viewFormats), WTFMove(*colorSpace), WTFMove(*compositingAlphaMode) } };
     }
 };
 


### PR DESCRIPTION
#### 68e829f4c00235e0f8e890783f5ec8ab6a14c7dc
<pre>
[WebGPU] Remove size member from GPUCanvasConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=242003">https://bugs.webkit.org/show_bug.cgi?id=242003</a>

Reviewed by Myles C. Maxfield.

GPUCanvasConfiguration::size was removed in
<a href="https://github.com/gpuweb/gpuweb/pull/2826">https://github.com/gpuweb/gpuweb/pull/2826</a> in favor of
using the canvas size directly.

* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h:
(WebCore::GPUCanvasConfiguration::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUCanvasConfiguration.h:
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUCanvasConfiguration.h:
(WebKit::WebGPU::CanvasConfiguration::encode const):
(WebKit::WebGPU::CanvasConfiguration::decode):

Canonical link: <a href="https://commits.webkit.org/251882@main">https://commits.webkit.org/251882@main</a>
</pre>
