### PR TITLE
Block unused syscall

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1202,8 +1202,7 @@
         SYS_necp_open
 #endif
         SYS_psynch_rw_wrlock
-        SYS_umask
-        SYS_work_interval_ctl))
+        SYS_umask))
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry) (with send-signal SIGKILL))


### PR DESCRIPTION
#### 19dadd1e5f72045589f1099660ef1691f9b32fa3
<pre>
Block unused syscall
<a href="https://bugs.webkit.org/show_bug.cgi?id=242011">https://bugs.webkit.org/show_bug.cgi?id=242011</a>

Reviewed by Chris Dumez.

Block unused syscall in the WebContent process on iOS. This is based on telemetry.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/251870@main">https://commits.webkit.org/251870@main</a>
</pre>
