### PR TITLE
IOSurfacePool has to stop its collection timer when it is being deleted

### DIFF
--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -51,6 +51,11 @@ IOSurfacePool::IOSurfacePool()
 {
 }
 
+IOSurfacePool::~IOSurfacePool()
+{
+    stopCollectionTimer();
+}
+
 IOSurfacePool& IOSurfacePool::sharedPool()
 {
     static LazyNeverDestroyed<IOSurfacePool> pool;
@@ -328,6 +333,12 @@ void IOSurfacePool::scheduleCollectionTimer()
 {
     if (!m_collectionTimer.isActive())
         m_collectionTimer.startRepeating(collectionInterval);
+}
+
+void IOSurfacePool::stopCollectionTimer()
+{
+    if (m_collectionTimer.isActive())
+        m_collectionTimer.stop();
 }
 
 void IOSurfacePool::discardAllSurfaces()

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -51,6 +51,8 @@ public:
     WEBCORE_EXPORT static IOSurfacePool& sharedPool();
     WEBCORE_EXPORT static Ref<IOSurfacePool> create();
 
+    WEBCORE_EXPORT ~IOSurfacePool();
+
     std::unique_ptr<IOSurface> takeSurface(IntSize, const DestinationColorSpace&, IOSurface::Format);
     WEBCORE_EXPORT void addSurface(std::unique_ptr<IOSurface>&&);
 
@@ -96,6 +98,7 @@ private:
 
     void scheduleCollectionTimer() WTF_REQUIRES_LOCK(m_lock);
     void collectionTimerFired();
+    void stopCollectionTimer() WTF_REQUIRES_LOCK(m_lock);
     void collectInUseSurfaces() WTF_REQUIRES_LOCK(m_lock);
     bool markOlderSurfacesPurgeable() WTF_REQUIRES_LOCK(m_lock);
 


### PR DESCRIPTION
#### 875f8256e130abbe24d03e2f04c907e9dee346d1
<pre>
IOSurfacePool has to stop its collection timer when it is being deleted
<a href="https://bugs.webkit.org/show_bug.cgi?id=242013">https://bugs.webkit.org/show_bug.cgi?id=242013</a>
rdar://94516877

Reviewed by NOBODY (OOPS!).

The timer is a kernel object and if it is active it can fire even after its
container RunLoop::Timer object is destroyed. So the destructor of IOSurfacePool
needs to stop the collection timer if it is active.

* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::~IOSurfacePool):
(WebCore::IOSurfacePool::stopCollectionTimer):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
</pre>