### PR TITLE
[web-animations] support custom properties in Animation.commitStyles()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -6,7 +6,7 @@ PASS Commits logical properties
 PASS Commits logical properties as physical properties
 PASS Commits values calculated mid-interval
 PASS Commits variable references as their computed values
-FAIL Commits custom variables assert_approx_equals: expected 0.8 +/- 0.0001 but got 0.5
+PASS Commits custom variables
 FAIL Commits em units as pixel values assert_approx_equals: expected 100 +/- 0.0001 but got 0
 FAIL Commits relative line-height assert_equals: line-height is committed as a relative value expected "1.5" but got "15px"
 PASS Commits transforms

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -904,6 +904,21 @@ const HashSet<CSSPropertyID>& KeyframeEffect::animatedProperties()
     return m_animatedProperties;
 }
 
+const HashSet<AtomString>& KeyframeEffect::animatedCustomProperties()
+{
+    if (!m_blendingKeyframes.isEmpty())
+        return m_blendingKeyframes.customProperties();
+
+    if (m_animatedCustomProperties.isEmpty()) {
+        for (auto& keyframe : m_parsedKeyframes) {
+            for (auto keyframeCustomProperty : keyframe.customStyleStrings.keys())
+                m_animatedCustomProperties.add(keyframeCustomProperty);
+        }
+    }
+
+    return m_animatedCustomProperties;
+}
+
 bool KeyframeEffect::animatesProperty(CSSPropertyID property) const
 {
     if (!m_blendingKeyframes.isEmpty())
@@ -949,6 +964,7 @@ void KeyframeEffect::setBlendingKeyframes(KeyframeList& blendingKeyframes)
 
     m_blendingKeyframes = WTFMove(blendingKeyframes);
     m_animatedProperties.clear();
+    m_animatedCustomProperties.clear();
 
     computedNeedsForcedLayout();
     computeStackingContextImpact();

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -160,6 +160,7 @@ public:
     void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<CSSPropertyID>& animatedProperties();
+    const HashSet<AtomString>& animatedCustomProperties();
     const HashSet<CSSPropertyID>& inheritedProperties() const { return m_inheritedProperties; }
     bool animatesProperty(CSSPropertyID) const;
 
@@ -254,6 +255,7 @@ private:
     AtomString m_keyframesName;
     KeyframeList m_blendingKeyframes { emptyAtom() };
     HashSet<CSSPropertyID> m_animatedProperties;
+    HashSet<AtomString> m_animatedCustomProperties;
     HashSet<CSSPropertyID> m_inheritedProperties;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;


### PR DESCRIPTION
#### 8161c9767ffb3605893aed55edd55e82b2deb387
<pre>
[web-animations] support custom properties in Animation.commitStyles()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242007">https://bugs.webkit.org/show_bug.cgi?id=242007</a>

Reviewed by Dean Jackson.

We add a new KeyframeEffect::animatedCustomProperties() method to access the list of custom properties
affected by this effect. Then, in WebAnimation::commitStyles(), we account for those properties to commit
them onto the target element&apos;s inline style.

This yields an additional WPT PASS result in web-animations/interfaces/Animation/commitStyles.html.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animatedCustomProperties):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):

Canonical link: <a href="https://commits.webkit.org/251858@main">https://commits.webkit.org/251858@main</a>
</pre>
