### PR TITLE
REGRESSION (248034@main): Safari crashes when focusing text field on srsre.com

### DIFF
--- a/LayoutTests/fast/events/ios/blur-and-prompt-after-focus-expected.txt
+++ b/LayoutTests/fast/events/ios/blur-and-prompt-after-focus-expected.txt
@@ -1,0 +1,6 @@
+ALERT: Hello world
+PASS didAlert became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html
+++ b/LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    font-size: 16px;
+}
+</style>
+</head>
+<body>
+<input value="Tap here">
+<script>
+jsTestIsAsync = true;
+if (window.testRunner)
+    testRunner.setShouldDismissJavaScriptAlertsAsynchronously(true);
+
+let didAlert = false;
+let input = document.querySelector("input");
+input.addEventListener("focus", () => {
+    input.select();
+    input.blur();
+    setTimeout(() => {
+        alert("Hello world");
+        didAlert = true;
+    }, 1);
+});
+
+(async function () {
+    await UIHelper.activateElement(input);
+    await shouldBecomeEqual("didAlert", "true");
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -443,7 +443,8 @@ using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIden
     BOOL _showDebugTapHighlightsForFastClicking;
     BOOL _textInteractionDidChangeFocusedElement;
     BOOL _treatAsContentEditableUntilNextEditorStateUpdate;
-    bool _isWaitingOnPositionInformation;
+    BOOL _isWaitingOnPositionInformation;
+    BOOL _isRequestingAutocorrectionContext;
     BOOL _autocorrectionContextNeedsUpdate;
 
     WebCore::PointerID _commitPotentialTapPointerId;


### PR DESCRIPTION
#### adc281052919e95d1c976efcef757aefefa8375f
<pre>
REGRESSION (248034@main): Safari crashes when focusing text field on srsre.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=242018">https://bugs.webkit.org/show_bug.cgi?id=242018</a>
rdar://95149057

Reviewed by Devin Rousso.

When focusing a particular search field on srsre.com, the page immediately sets a selection in the
newly focused element, blurs it, and then installs a zero-delay timer, after which it runs a modal
prompt. Prior to the changes in `248034@main`, focusing this text field would trigger a 1-second IPC
deadlock between the web and UI processes, as the UI process attempted to request an autocorrection
context from the web process at the same time as the web process was stuck on an unbounded sync IPC
call to the UI process, due to the modal prompt. After hanging until the IPC timeout and failing the
autocorrection context request, we&apos;d then proceed to show the modal prompt as intended by the page.
The timeline of relevant method calls prior to `248034@main` was:

```
-_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:
-requestAutocorrectionContextWithCompletionHandler:
-_elementDidBlur
-_elementDidBlur (done)
// 1 second timeout
WebPageProxy::runModalJavaScriptDialog
-_invokePendingAutocorrectionContextHandler: (calling completion handler)
-requestAutocorrectionContextWithCompletionHandler: (done)
-_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject: (done)
```

Note that `ElementDidBlur` is handled in the UI process in `SyncMessageState::dispatchMessages`
before the call to `-[WKContentView requestAutocorrectionContextWithCompletionHandler:]` even
returns, due to the fact that it&apos;s dispatched while waiting for a sync IPC response during the
autocorrection context request.

After the changes in `248034@main`, the autocorrection context is now preemptively computed and sent
to the UI process after the selection changes during element focus. This (correctly) causes us to
avoid deadlocking, since the sync autocorrection context request no longer requires a round trip to
the web process to complete; however, this instead results in UIKit throwing an exception due to the
fact that the autocorrection context request completion handler gets invoked before the call to
`-_elementDidBlur` triggers a nested call to `-reloadInputViews`.

```
-_elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:
-requestAutocorrectionContextWithCompletionHandler:
-_invokePendingAutocorrectionContextHandler: (calling completion handler)
-_elementDidBlur
// crash!
```

To address this, we add a scoped boolean flag to detect when a sync autocorrection context request
is in progress, and defer any calls to `-_elementDidBlur` and `-_elementDidFocus:` that occur while
this flag is set until the next runloop.

Test: fast/events/ios/blur-and-prompt-after-focus.html

* LayoutTests/fast/events/ios/blur-and-prompt-after-focus-expected.txt: Added.
* LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html: Added.

Add a test case to exercise this bug; the test passes if tapping the text field doesn&apos;t cause the UI
process to crash.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Drive-by fix: change a flag type from `bool` to `BOOL`, for consistency with nearby flags.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):

Add a flag, `_isRequestingAutocorrectionContext`, that is set when UIKit requests autocorrection
context from WebKit; use this below to defer calls to handle element focus or blur in the content
view.

(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _elementDidBlur]):

Canonical link: <a href="https://commits.webkit.org/251885@main">https://commits.webkit.org/251885@main</a>
</pre>
