### PR TITLE
[Cocoa] Add SPI for implementing accessibility bold

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -155,6 +155,7 @@ CFArrayRef CTFontManagerCreateFontDescriptorsFromData(CFDataRef);
 bool CTFontManagerEnableAllUserFonts(bool postFontChangeNotification);
 
 void CTParagraphStyleSetCompositionLanguage(CTParagraphStyleRef, CTCompositionLanguage);
+CGFloat CTFontGetAccessibilityBoldWeightOfWeight(CGFloat);
 
 extern const CFStringRef kCTFontCSSWeightAttribute;
 extern const CFStringRef kCTFontCSSWidthAttribute;

--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h
@@ -47,4 +47,7 @@ WTF_EXTERN_C_BEGIN
 AXSIsolatedTreeMode _AXSIsolatedTreeMode(void);
 void _AXSSetIsolatedTreeMode(AXSIsolatedTreeMode);
 
+extern CFStringRef kAXSEnhanceTextLegibilityChangedNotification;
+Boolean _AXSEnhanceTextLegibilityEnabled();
+
 WTF_EXTERN_C_END

--- a/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
@@ -61,6 +61,7 @@ AXValueState _AXSIncreaseButtonLegibilityApp(CFStringRef appID);
 AXValueState _AXSEnhanceTextLegibilityEnabledApp(CFStringRef appID);
 AXValueState _AXDarkenSystemColorsApp(CFStringRef appID);
 AXValueState _AXSInvertColorsEnabledApp(CFStringRef appID);
+Boolean _AXSEnhanceTextLegibilityEnabled();
 
 void _AXSSetReduceMotionEnabledApp(AXValueState enabled, CFStringRef appID);
 void _AXSSetIncreaseButtonLegibilityApp(AXValueState enabled, CFStringRef appID);


### PR DESCRIPTION
#### 72b59ad50e079037073722bbdf469c0952e399fa
<pre>
[Cocoa] Add SPI for implementing accessibility bold
<a href="https://bugs.webkit.org/show_bug.cgi?id=242021">https://bugs.webkit.org/show_bug.cgi?id=242021</a>

Reviewed by Alan Bujtas.
This was reviewed previously as a part of 52162fce399265e2bef87f7314d7e58e0014dc17.

This patch adds the necessary SPI for implementing the accessibility bold setting.

* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSPI.h:
* Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h:

Canonical link: <a href="https://commits.webkit.org/251861@main">https://commits.webkit.org/251861@main</a>
</pre>
