### PR TITLE
[Flatpak SDK] Bump to GStreamer 1.20.3

### DIFF
--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -43,6 +43,7 @@ depends:
 - sdk/libkate.bst
 - sdk/libmanette.bst
 - sdk/libnotify.bst
+- sdk/libsecret.bst
 - sdk/libsoup3.bst
 - sdk/libusrsctp.bst
 - sdk/libwpe.bst

--- a/Tools/buildstream/elements/sdk/gst-libav.bst
+++ b/Tools/buildstream/elements/sdk/gst-libav.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gst-libav/gst-libav-1.20.2.tar.xz
-  ref: b5c531dd8413bf771c79dab66b8e389f20b3991f745115133f0fa0b8e32809f9
+  url: gst_downloads:gst-libav/gst-libav-1.20.3.tar.xz
+  ref: 3fedd10560fcdfaa1b6462cbf79a38c4e7b57d7f390359393fc0cef6dbf27dfe
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 - freedesktop-sdk.bst:components/nasm.bst

--- a/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gst-plugins-bad/gst-plugins-bad-1.20.2.tar.xz
-  ref: 4adc4c05f41051f8136b80cda99b0d049a34e777832f9fea7c5a70347658745b
+  url: gst_downloads:gst-plugins-bad/gst-plugins-bad-1.20.3.tar.xz
+  ref: 7a11c13b55dd1d2386dd902219e41cbfcdda8e1e0aa3e738186c95074b35da4f
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:

--- a/Tools/buildstream/elements/sdk/gst-plugins-base.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-base.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gst-plugins-base/gst-plugins-base-1.20.2.tar.xz
-  ref: ab0656f2ad4d38292a803e0cb4ca090943a9b43c8063f650b4d3e3606c317f17
+  url: gst_downloads:gst-plugins-base/gst-plugins-base-1.20.3.tar.xz
+  ref: 7e30b3dd81a70380ff7554f998471d6996ff76bbe6fc5447096f851e24473c9f
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:

--- a/Tools/buildstream/elements/sdk/gst-plugins-good.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-good.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gst-plugins-good/gst-plugins-good-1.20.2.tar.xz
-  ref: 83589007bf002b8f9ef627718f308c16d83351905f0db8e85c3060f304143aae
+  url: gst_downloads:gst-plugins-good/gst-plugins-good-1.20.3.tar.xz
+  ref: f8f3c206bf5cdabc00953920b47b3575af0ef15e9f871c0b6966f6d0aa5868b7
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:
@@ -33,6 +33,7 @@ variables:
     -Dpackage-origin="webkit-sdk"
     -Daalib=disabled
     -Ddoc=disabled
+    -Dexamples=disabled
     -Djack=disabled
     -Dlibcaca=disabled
     -Ddv=disabled

--- a/Tools/buildstream/elements/sdk/gst-plugins-ugly.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-ugly.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gst-plugins-ugly/gst-plugins-ugly-1.20.2.tar.xz
-  ref: b43fb4df94459afbf67ec22003ca58ffadcd19e763f276dca25b64c848adb7bf
+  url: gst_downloads:gst-plugins-ugly/gst-plugins-ugly-1.20.3.tar.xz
+  ref: 8caa20789a09c304b49cf563d33cca9421b1875b84fcc187e4a385fa01d6aefd
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:

--- a/Tools/buildstream/elements/sdk/gstreamer.bst
+++ b/Tools/buildstream/elements/sdk/gstreamer.bst
@@ -1,8 +1,8 @@
 kind: meson
 sources:
 - kind: tar
-  url: gst_downloads:gstreamer/gstreamer-1.20.2.tar.xz
-  ref: df24e8792691a02dfe003b3833a51f1dbc6c3331ae625d143b17da939ceb5e0a
+  url: gst_downloads:gstreamer/gstreamer-1.20.3.tar.xz
+  ref: 607daf64bbbd5fb18af9d17e21c0d22c4d702fffe83b23cb22d1b1af2ca23a2a
 build-depends:
 - freedesktop-sdk.bst:components/gobject-introspection.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/Tools/buildstream/elements/sdk/libsecret.bst
+++ b/Tools/buildstream/elements/sdk/libsecret.bst
@@ -1,0 +1,25 @@
+kind: meson
+sources:
+- kind: tar
+  url: gnome_downloads:libsecret/0.20/libsecret-0.20.3.tar.xz
+  ref: 4fcb3c56f8ac4ab9c75b66901fb0104ec7f22aa9a012315a14c0d6dffa5290e4
+build-depends:
+- freedesktop-sdk.bst:components/valgrind.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/libxslt.bst
+depends:
+- sdk/glib.bst
+- freedesktop-sdk.bst:components/gobject-introspection.bst
+- freedesktop-sdk.bst:components/libgcrypt.bst
+- freedesktop-sdk.bst:bootstrap-import.bst
+variables:
+  meson-local: >-
+    -Dgtk_doc=false
+    -Dvapi=false
+    -Dmanpage=false
+public:
+  bst:
+    split-rules:
+      devel:
+        (>):
+        - '%{libdir}/libsecret-1.so'


### PR DESCRIPTION
#### 9fd37734bc14e7c88b148a61f9fe047bc59e1de6
<pre>
[Flatpak SDK] Bump to GStreamer 1.20.3
<a href="https://bugs.webkit.org/show_bug.cgi?id=242024">https://bugs.webkit.org/show_bug.cgi?id=242024</a>

Reviewed by Adrian Perez de Castro.

This patch updates the GStreamer version from 1.20.2 to 1.20.3. It also reverts the libsecret
removal that was done when Subversion was removed. That removal was not deployed yet. libsecret is
still a direct WebKit build dependency, so we need it in the SDK.

* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/gst-libav.bst:
* Tools/buildstream/elements/sdk/gst-plugins-bad.bst:
* Tools/buildstream/elements/sdk/gst-plugins-base.bst:
* Tools/buildstream/elements/sdk/gst-plugins-good.bst:
* Tools/buildstream/elements/sdk/gst-plugins-ugly.bst:
* Tools/buildstream/elements/sdk/gstreamer.bst:
* Tools/buildstream/elements/sdk/libsecret.bst: Added.

Canonical link: <a href="https://commits.webkit.org/251868@main">https://commits.webkit.org/251868@main</a>
</pre>
