### PR TITLE
[GStreamer][WebRTC] Implement data-channel id retrieval

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -891,6 +891,9 @@ webkit.org/b/235885 http/wpt/webrtc/transfer-datachannel-service-worker.https.ht
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-datachannel.html [ Skip ]
 
+# Expected to pass since bug #242025 was fixed.
+webrtc/datachannel/creation.html [ Pass ]
+
 # The GstWebRTC backend doesn't support transforms yet.
 webkit.org/b/235885 http/wpt/webrtc/audiovideo-script-transform.html [ Skip ]
 webkit.org/b/235885 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Skip ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -167,6 +167,13 @@ void GStreamerDataChannelHandler::close()
     g_signal_emit_by_name(m_channel.get(), "close");
 }
 
+std::optional<unsigned short> GStreamerDataChannelHandler::id() const
+{
+    int id;
+    g_object_get(m_channel.get(), "id", &id, nullptr);
+    return id != -1 ? std::make_optional(id) : std::nullopt;
+}
+
 void GStreamerDataChannelHandler::checkState()
 {
     ASSERT(m_clientLock.isHeld());

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -52,6 +52,7 @@ private:
     void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) final;
     bool sendStringData(const CString&) final;
     bool sendRawData(const uint8_t*, size_t) final;
+    std::optional<unsigned short> id() const final;
     void close() final;
 
     void onMessageData(GBytes*);


### PR DESCRIPTION
#### 0398394bfe0f972ad8786f7c66970162bdde31a4
<pre>
[GStreamer][WebRTC] Implement data-channel id retrieval
<a href="https://bugs.webkit.org/show_bug.cgi?id=242025">https://bugs.webkit.org/show_bug.cgi?id=242025</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::id const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:

Canonical link: <a href="https://commits.webkit.org/251867@main">https://commits.webkit.org/251867@main</a>
</pre>
