### PR TITLE
[WebAuthn] Fix swapped page / frame ids

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -181,7 +181,7 @@ static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensi
 static inline void setGlobalFrameIDForContext(RetainPtr<ASCCredentialRequestContext> requestContext, std::optional<WebCore::GlobalFrameIdentifier> globalFrameID)
 {
     if (globalFrameID && [requestContext respondsToSelector:@selector(setGlobalFrameID:)]) {
-        auto asGlobalFrameID = adoptNS([allocASGlobalFrameIdentifierInstance() initWithPageID:[NSNumber numberWithUnsignedLong:globalFrameID->frameID.toUInt64()] frameID:[NSNumber numberWithUnsignedLong:globalFrameID->pageID.toUInt64()]]);
+        auto asGlobalFrameID = adoptNS([allocASGlobalFrameIdentifierInstance() initWithPageID:[NSNumber numberWithUnsignedLong:globalFrameID->pageID.toUInt64()] frameID:[NSNumber numberWithUnsignedLong:globalFrameID->frameID.toUInt64()]]);
         requestContext.get().globalFrameID = asGlobalFrameID.get();
     }
 }


### PR DESCRIPTION
#### e88ef9d569628e8e2f7699bcec7b29fa46b6c63c
<pre>
[WebAuthn] Fix swapped page / frame ids
<a href="https://bugs.webkit.org/show_bug.cgi?id=242030">https://bugs.webkit.org/show_bug.cgi?id=242030</a>
rdar://95987244

Reviewed by Brent Fulgham.

These ids got swapped during the refactor in <a href="https://bugs.webkit.org/show_bug.cgi?id=241941">https://bugs.webkit.org/show_bug.cgi?id=241941</a>

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::setGlobalFrameIDForContext):

Canonical link: <a href="https://commits.webkit.org/251880@main">https://commits.webkit.org/251880@main</a>
</pre>
