### PR TITLE
[WTF] Remove MSVC hack for alignof

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1184,12 +1184,7 @@ inline size_t StringImpl::maxInternalLength()
 
 template<typename T> inline size_t StringImpl::tailOffset()
 {
-#if COMPILER(MSVC)
-    // MSVC doesn't support alignof yet.
-    return roundUpToMultipleOf<sizeof(T)>(sizeof(StringImpl));
-#else
     return roundUpToMultipleOf<alignof(T)>(offsetof(StringImpl, m_hashAndFlags) + sizeof(StringImpl::m_hashAndFlags));
-#endif
 }
 
 inline bool StringImpl::requiresCopy() const


### PR DESCRIPTION
#### 86ba15678de045286b0da971339300a65552539b
<pre>
[WTF] Remove MSVC hack for alignof
<a href="https://bugs.webkit.org/show_bug.cgi?id=242032">https://bugs.webkit.org/show_bug.cgi?id=242032</a>

Reviewed by Don Olmstead and Darin Adler.

alignof is supported in MSVC now. We should remove this hack.

* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tailOffset):

Canonical link: <a href="https://commits.webkit.org/251887@main">https://commits.webkit.org/251887@main</a>
</pre>
