### PR TITLE
[GPU Process] RemoteRenderingBackend has to explicitly stop IOSurfacePool::m_collectionTimer before destruction

### DIFF
--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -51,6 +51,13 @@ IOSurfacePool::IOSurfacePool()
 {
 }
 
+IOSurfacePool::~IOSurfacePool()
+{
+    callOnMainRunLoopAndWait([&] {
+        discardAllSurfaces();
+    });
+}
+
 IOSurfacePool& IOSurfacePool::sharedPool()
 {
     static LazyNeverDestroyed<IOSurfacePool> pool;

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -51,6 +51,8 @@ public:
     WEBCORE_EXPORT static IOSurfacePool& sharedPool();
     WEBCORE_EXPORT static Ref<IOSurfacePool> create();
 
+    WEBCORE_EXPORT ~IOSurfacePool();
+
     std::unique_ptr<IOSurface> takeSurface(IntSize, const DestinationColorSpace&, IOSurface::Format);
     WEBCORE_EXPORT void addSurface(std::unique_ptr<IOSurface>&&);
 


### PR DESCRIPTION
#### 0cabd082474b11fdd3a2197218356d15e5d1787a
<pre>
[GPU Process] RemoteRenderingBackend has to explicitly stop IOSurfacePool::m_collectionTimer before destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=242031">https://bugs.webkit.org/show_bug.cgi?id=242031</a>
rdar://94516877

Reviewed by Simon Fraser.

RemoteRenderingBackend can be deleted on the SteamConnection work queue while
handling the IOSurfacePool collection timer happens on the main thread. If the
destruction happens before the timer fires, the handler will enumerate null
IOSurfaces and this will lead to crash due to accessing null std::unique_ptr.

The fix is to explicitly stop to the collection timer in the IOSurfacePool
destructor. But it will be safer to call discardAllSurfaces(). This call has to
happen on the main thread, otherwise we may end up in this situation.

1. StreamConnection WorkQueue calls deletes the RemoteRenderingBackend and hence
   it will call IOSurfacePool destructor which calls discardAllSurfaces().
   discardAllSurfaces() is protected by m_lock and it acquires it.

2. Before discardAllSurfaces() stops the m_collectionTimer, the timer fires and
   the main thread calls IOSurfacePool::collectionTimerFired() which is also
   protected by m_lock. So it waits till it is released by IOSurfacePool
   destructor on the StreamConnection WorkQueue.

3. Once m_lock is released, collectionTimerFired() can access the IOSurfacePool
   members even they be completely destroyed.

Calling IOSurfacePool::discardAllSurfaces() on the main thread will ensure it
will not compete with IOSurfacePool::collectionTimerFired(). If discardAllSurfaces()
is executed first, collectionTimerFired() will not be called. If collectionTimerFired()
is called first it will access non destroyed IOSurfacePool members. And it will
no do anything to the timer since it will be inactive.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::~RemoteRenderingBackend):

Canonical link: <a href="https://commits.webkit.org/251907@main">https://commits.webkit.org/251907@main</a>
</pre>
