### PR TITLE
[Gardening]: New test landed failing: [ macOS ] TestWebKitAPI.WebKit2.ConnectedToHardwareConsole is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -1127,7 +1127,8 @@ TEST(WebKit2, CapturePermissionWithSystemBlocking)
 #endif
 
 #if PLATFORM(MAC)
-TEST(WebKit2, ConnectedToHardwareConsole)
+// FIXME webkit.org/b/241984 
+TEST(WebKit2, DISABLED_ConnectedToHardwareConsole)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);


### PR DESCRIPTION
#### 93e1b6195535a624553addde9f8fa0bfe718d33d
<pre>
[Gardening]: New test landed failing: [ macOS ] TestWebKitAPI.WebKit2.ConnectedToHardwareConsole is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241984">https://bugs.webkit.org/show_bug.cgi?id=241984</a>
&lt;rdar://95878755&gt;

Unreviewed test gardening.

* Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation.js:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:

Canonical link: <a href="https://commits.webkit.org/251877@main">https://commits.webkit.org/251877@main</a>
</pre>
