### PR TITLE
Web Inspector: Network panel: Disable context menu items for incomplete resources

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Resource.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Resource.js
@@ -435,6 +435,13 @@ WI.Resource = class Resource extends WI.SourceCode
         return this._mimeType;
     }
 
+    get hasMetadata()
+    {
+        // Some metadata is only collected when Web Inspector is open (e.g. resource timing data, HTTP method, request headers, etc.).
+        // Use `_requestIdentifier` as a general signal since it is always included when metadata is collected.
+        return !!this._requestIdentifier;
+    }
+
     createObjectURL()
     {
         let revision = this.currentRevision;

--- a/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
@@ -176,7 +176,7 @@ WI.appendContextMenuItemsForSourceCode = function(contextMenu, sourceCodeOrLocat
 
     WI.appendContextMenuItemsForURL(contextMenu, sourceCode.url, {sourceCode, location});
 
-    if (sourceCode instanceof WI.Resource && !sourceCode.localResourceOverride) {
+    if (sourceCode instanceof WI.Resource && !sourceCode.localResourceOverride && sourceCode.hasMetadata) {
         if (sourceCode.urlComponents.scheme !== "data") {
             contextMenu.appendItem(WI.UIString("Copy as fetch", "Copy the URL, method, headers, etc. of the given network request in the format of a JS fetch expression."), () => {
                 InspectorFrontendHost.copyText(sourceCode.generateFetchCode());


### PR DESCRIPTION
#### b23b8d5f212a59acaa618428d9e613f5757451fb
<pre>
Web Inspector: Network panel: Disable context menu items for incomplete resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=242035">https://bugs.webkit.org/show_bug.cgi?id=242035</a>

Reviewed by Devin Rousso.

Information collected about resources loaded before Web Inspector was opened is missing most metadata,
like resource timing data, HTTP method, request headers, etc.

* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.get hasMetadata):

Add a new member to quickly check if the resource has metadata.

* Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js:

In absence of metadata, context menu items to copy as cURL, copy as fetch, copy HTTP request
and copy HTTP response should not be shown to avoid getting useless output.

Canonical link: <a href="https://commits.webkit.org/251987@main">https://commits.webkit.org/251987@main</a>
</pre>
