### PR TITLE
New test landed failing: [ macOS ] TestWebKitAPI.WebKit2.ConnectedToHardwareConsole is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -1127,8 +1127,7 @@ TEST(WebKit2, CapturePermissionWithSystemBlocking)
 #endif
 
 #if PLATFORM(MAC)
-// FIXME webkit.org/b/241984 
-TEST(WebKit2, DISABLED_ConnectedToHardwareConsole)
+TEST(WebKit2, ConnectedToHardwareConsole)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
@@ -1156,7 +1155,6 @@ TEST(WebKit2, DISABLED_ConnectedToHardwareConsole)
     int retryCount = 1000;
     while (--retryCount && cameraCaptureState == WKMediaCaptureStateMuted)
         TestWebKitAPI::Util::spinRunLoop(10);
-    EXPECT_TRUE(!!retryCount);
     EXPECT_TRUE(cameraCaptureState == WKMediaCaptureStateMuted);
 
     // Capture should be unmuted if it was active when the disconnect happened.


### PR DESCRIPTION
#### 60cb7b8237e7a9474c754e9d689eb9ca859900b9
<pre>
New test landed failing: [ macOS ] TestWebKitAPI.WebKit2.ConnectedToHardwareConsole is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241984">https://bugs.webkit.org/show_bug.cgi?id=241984</a>
rdar://95878755

Reviewed by Jer Noble.

* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm: Remove a typo.

Canonical link: <a href="https://commits.webkit.org/251890@main">https://commits.webkit.org/251890@main</a>
</pre>
