### PR TITLE
Fix race condition in pas_local_view_cache_stop.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
@@ -119,6 +119,40 @@ bool pas_local_view_cache_stop(pas_local_view_cache* cache,
     cache->scavenger_data.is_in_use = true;
     pas_compiler_fence();
 
+    /* The scavenger thread may race with the client thread on calling pas_local_view_cache_stop.
+       The scavenger will first suspend the client thread before checking the is_in_use flag.
+       If is_in_use is set, the scavenger will not call pas_local_view_cache_stop, and move on.
+       If is_in_use is not set, the scavenger will call pas_local_allocator_scavenger_data_stop,
+       which in turn calls pas_local_view_cache_stop to stop the local_view_cache.
+
+       Normally, if the scavenger has already completed its call to pas_local_view_cache_stop
+       before the client calls it, pas_local_view_cache_stop will just return early for the client.
+       This is because pas_local_view_cache_stop first check pas_local_allocator_scavenger_data_is_stopped
+       before doing the work to stop the local_view_cache.
+
+       However, if the client thread is already in the process of executing pas_local_view_cache_stop,
+       gets passed the pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
+       the scavenger before setting the is_in_use flag, the scavenger can stop the local_view_cache
+       after the client already checked and thinks it is not stopped yet. When the client thread
+       resumes from suspension, it will be unhappy to find that the local_view_cache is already
+       stopped, and fails an assertion.
+
+       The fix is to re-check pas_local_allocator_scavenger_data_is_stopped after setting the
+       is_in_use flag.
+
+       If the re-check shows that the local_view_cache is already stopped, then pas_local_view_cache_stop
+       can return early like first pas_local_allocator_scavenger_data_is_stopped check. This is
+       fine to do because the caller expects this as a possible outcome.
+
+       Before returning early due to the re-check, we also need to clear the is_in_use flag.
+       The is_in_use flag is meant to be set like with an RAII scope. Hence, it is correct and
+       required that we also clear it here before we return.
+    */
+    if (pas_local_allocator_scavenger_data_is_stopped(&cache->scavenger_data)) {
+        cache->scavenger_data.is_in_use = false;
+        return true;
+    }
+
     result = stop_impl(cache, page_lock_mode);
 
     if (result) {


### PR DESCRIPTION
#### 484126cfed9edfd1e9e0a937fbbddad27dbfe0e5
<pre>
Fix race condition in pas_local_view_cache_stop.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242034">https://bugs.webkit.org/show_bug.cgi?id=242034</a>
&lt;rdar://problem/89619762&gt;

Reviewed by Saam Barati.

The scavenger thread may race with the client thread on calling pas_local_view_cache_stop.
The scavenger will first suspend the client thread before checking the is_in_use flag.
If is_in_use is set, the scavenger will not call pas_local_view_cache_stop, and move on.
If is_in_use is not set, the scavenger will call pas_local_allocator_scavenger_data_stop,
which in turn calls pas_local_view_cache_stop to stop the local_view_cache.

Normally, if the scavenger has already completed its call to pas_local_view_cache_stop
before the client calls it, pas_local_view_cache_stop will just return early for the client.
This is because pas_local_view_cache_stop first check pas_local_allocator_scavenger_data_is_stopped
before doing the work to stop the local_view_cache.

However, if the client thread is already in the process of executing pas_local_view_cache_stop,
gets passed the pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
the scavenger before setting the is_in_use flag, the scavenger can stop the local_view_cache
after the client already checked and thinks it is not stopped yet.  When the client thread
resumes from suspension, it will be unhappy to find that the local_view_cache is already
stopped, and fails an assertion.

The fix is to re-check pas_local_allocator_scavenger_data_is_stopped after setting the
is_in_use flag.

If the re-check shows that the local_view_cache is already stopped, then pas_local_view_cache_stop
can return early like first pas_local_allocator_scavenger_data_is_stopped check.  This is
fine to do because the caller expects this as a possible outcome.

Before returning early due to the re-check, we also need to clear the is_in_use flag.
The is_in_use flag is meant to be set like with an RAII scope.  Hence, it is correct and
required that we also clear it here before we return.

* Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c:
(pas_local_view_cache_stop):

Canonical link: <a href="https://commits.webkit.org/251886@main">https://commits.webkit.org/251886@main</a>
</pre>
