### PR TITLE
key is validated too late in RegistrationDatabase::importRecords()

### DIFF
--- a/Source/WebCore/workers/service/server/RegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/RegistrationDatabase.cpp
@@ -513,6 +513,10 @@ String RegistrationDatabase::importRecords()
     for (; result == SQLITE_ROW; result = sql->step()) {
         RELEASE_LOG(ServiceWorker, "RegistrationDatabase::importRecords: Importing a registration from the database");
         auto key = ServiceWorkerRegistrationKey::fromDatabaseKey(sql->columnText(0));
+        if (!key) {
+            RELEASE_LOG_ERROR(ServiceWorker, "RegistrationDatabase::importRecords: Failed to decode service worker registration key");
+            continue;
+        }
         auto originURL = URL { sql->columnText(1) };
         auto scopePath = sql->columnText(2);
         auto scopeURL = URL { originURL, scopePath };
@@ -582,7 +586,7 @@ String RegistrationDatabase::importRecords()
         // Validate the input for this registration.
         // If any part of this input is invalid, let's skip this registration.
         // FIXME: Should we return an error skipping *all* registrations?
-        if (!key || !originURL.isValid() || !topOrigin || !updateViaCache || !scriptURL.isValid() || !workerType || !scopeURL.isValid()) {
+        if (!originURL.isValid() || !topOrigin || !updateViaCache || !scriptURL.isValid() || !workerType || !scopeURL.isValid()) {
             RELEASE_LOG_ERROR(ServiceWorker, "RegistrationDatabase::importRecords: Failed to decode part of the registration");
             continue;
         }


### PR DESCRIPTION
#### 0d7255a3fd14f98db13d90322d8f22d734e2f3ac
<pre>
key is validated too late in RegistrationDatabase::importRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242036">https://bugs.webkit.org/show_bug.cgi?id=242036</a>
&lt;rdar://87056249&gt;

Reviewed by Alex Christensen.

ServiceWorkerRegistrationKey::fromDatabaseKey() may return std::nullopt if we cannot
convert the database string to a service worker registration key. We would validate
the returned key at line 585. However, the key could get dereferenced earlier at
line 559, which would lead to crashes under SWScriptStorage::retrieve() when using
the key.

To address the issue, we now validate the key much earlier, as soon as we&apos;ve
extracted it.

* Source/WebCore/workers/service/server/RegistrationDatabase.cpp:
(WebCore::RegistrationDatabase::importRecords):

Canonical link: <a href="https://commits.webkit.org/251893@main">https://commits.webkit.org/251893@main</a>
</pre>
