### PR TITLE
[Gardening]: New test: [macOS/iOS arm64] TestWebKitAPI.WKContentRuleListStoreTest.CrossOriginCookieBlocking is crashing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -211,7 +211,8 @@ TEST_F(WKContentRuleListStoreTest, Removal)
     TestWebKitAPI::Util::run(&doneRemoving);
 }
 
-TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
+// FIXME: webkit.org/b/241653
+TEST_F(WKContentRuleListStoreTest, DISABLED_CrossOriginCookieBlocking)
 {
     using namespace TestWebKitAPI;
 


### PR DESCRIPTION
#### 469551ebd9f7c2248de3c0e78cacbe5e640e994c
<pre>
[Gardening]: New test: [macOS/iOS arm64] TestWebKitAPI.WKContentRuleListStoreTest.CrossOriginCookieBlocking is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=241653">https://bugs.webkit.org/show_bug.cgi?id=241653</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/251889@main">https://commits.webkit.org/251889@main</a>
</pre>
