### PR TITLE
Have DumpRenderTree use legacy scrolling

### DIFF
--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -939,6 +939,7 @@ static void setDefaultsToConsistentValuesForTesting()
 #if !PLATFORM(IOS_FAMILY)
         @"NSScrollAnimationEnabled": @NO,
 #endif
+        @"NSScrollViewUseLegacyScrolling": @YES,
         @"NSOverlayScrollersEnabled": @NO,
         @"AppleShowScrollBars": @"Always",
         @"NSButtonAnimationsEnabled": @NO, // Ideally, we should find a way to test animations, but for now, make sure that the dumped snapshot matches actual state.


### PR DESCRIPTION
#### bf8293a1d8a78758c2b2461497cc16cd071cf07e
<pre>
Have DumpRenderTree use legacy scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=242038">https://bugs.webkit.org/show_bug.cgi?id=242038</a>
&lt;rdar://92772409&gt;

Reviewed by Simon Fraser.

After the AppKit changes in rdar://83912214, tests in WK1 stopped scrolling
properly (WebDynamicScrollBarsView::scrollClipView was not being triggered from
the AppKit side). This is due to the new behavior, where
NSScrollingBehaviorSingleThreadedVBL::advanceTimeWithDisplayLink was being called
asynchronously to eventually pass down the coordinates for the clip view to scroll
to. As we currently don&apos;t have a mechanism to wait for this callback to fire, we
will use the legacy scrolling behavior, which is functionally the same as the new
scrolling behavior.

* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(setDefaultsToConsistentValuesForTesting):

Canonical link: <a href="https://commits.webkit.org/251898@main">https://commits.webkit.org/251898@main</a>
</pre>
