### PR TITLE
If an <object> is removed from the page while its fallback content is being used, Safari will automatically use fallback content when the object is re-inserted.

### DIFF
--- a/LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update-expected.txt
+++ b/LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update-expected.txt
@@ -1,0 +1,10 @@
+This tests updating an object element which was showing fallback content while it's disconnected from the document.
+WebKit should update the object element when it gets reinserted back into the document.
+Test passes if you see "PASS" below:
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+PASS

--- a/LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update.html
+++ b/LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests updating an object element which was showing fallback content while it's disconnected from the document.<br>
+WebKit should update the object element when it gets reinserted back into the document.<br>
+Test passes if you see "PASS" below:</p>
+<object width="100" height="100">FAIL</object>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpChildFramesAsText();
+}
+
+onload = () => {
+    let object = document.querySelector('object');
+    object.remove();
+    object.setAttribute('type', 'text/html');
+    object.setAttribute('data', 'data:text/html,PASS');
+    document.body.appendChild(object);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -102,28 +102,33 @@ void HTMLObjectElement::collectPresentationalHintsForAttribute(const QualifiedNa
 void HTMLObjectElement::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
     bool invalidateRenderer = false;
+    bool needsWidgetUpdate = false;
 
     if (name == formAttr)
         formAttributeChanged();
     else if (name == typeAttr) {
         m_serviceType = value.string().left(value.find(';')).convertToASCIILowercase();
         invalidateRenderer = !hasAttributeWithoutSynchronization(classidAttr);
-        setNeedsWidgetUpdate(true);
+        needsWidgetUpdate = true;
     } else if (name == dataAttr) {
         m_url = stripLeadingAndTrailingHTMLSpaces(value);
         invalidateRenderer = !hasAttributeWithoutSynchronization(classidAttr);
-        setNeedsWidgetUpdate(true);
+        needsWidgetUpdate = true;
         updateImageLoaderWithNewURLSoon();
     } else if (name == classidAttr) {
         invalidateRenderer = true;
-        setNeedsWidgetUpdate(true);
+        needsWidgetUpdate = true;
     } else
         HTMLPlugInImageElement::parseAttribute(name, value);
+
+    if (needsWidgetUpdate) {
+        setNeedsWidgetUpdate(true);
+        m_useFallbackContent = false;
+    }
 
     if (!invalidateRenderer || !isConnected() || !renderer())
         return;
 
-    m_useFallbackContent = false;
     scheduleUpdateForAfterStyleResolution();
     invalidateStyleAndRenderersForSubtree();
 }


### PR DESCRIPTION
#### fdae8b382e051d3ca6521d2c5a90bc3169ffe098
<pre>
If an &lt;object&gt; is removed from the page while its fallback content is being used, Safari will automatically use fallback content when the object is re-inserted.
<a href="https://bugs.webkit.org/show_bug.cgi?id=44827">https://bugs.webkit.org/show_bug.cgi?id=44827</a>

Reviewed by Alexey Proskuryakov.

The bug was caused by HTMLObjectElement::parseAttribute not resetting m_useFallbackContent
when the object element is disconnected. This patch addresses it and adds a test.

* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::parseAttribute):

* LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update-expected.txt: Added.
* LayoutTests/fast/dom/HTMLObjectElement/object-element-fallback-content-update.html: Added.

Canonical link: <a href="https://commits.webkit.org/251903@main">https://commits.webkit.org/251903@main</a>
</pre>
