### PR TITLE
Change contributor status of myself to committer

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -7090,7 +7090,8 @@
       "nicks" : [
          "ys",
          "youssefsoli"
-      ]
+      ],
+      "status" : "committer"
    },
    {
       "emails" : [


### PR DESCRIPTION
#### e3d255990ec6e7ef5b1dcb3a68aa5d3d808db293
<pre>
Change contributor status of myself to committer
<a href="https://bugs.webkit.org/show_bug.cgi?id=242042">https://bugs.webkit.org/show_bug.cgi?id=242042</a>

Reviewed by Jean-Yves Avenard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/251896@main">https://commits.webkit.org/251896@main</a>
</pre>
