### PR TITLE
[iOS] Selection highlight is not visible after right clicking non-editable text for the first time

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -7700,6 +7700,9 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
         if (!strongSelf)
             return completionHandler(false, nil);
 
+        if (shouldPresentMenu && ![strongSelf _shouldSuppressSelectionCommands])
+            [strongSelf->_textInteractionAssistant activateSelection];
+
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
         [strongSelf doAfterComputingImageAnalysisResultsForBackgroundRemoval:[completionHandler, shouldPresentMenu, item = RetainPtr { item.item() }]() mutable {
             completionHandler(shouldPresentMenu, item.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -437,6 +437,22 @@ TEST(iOSMouseSupport, ShowingContextMenuSelectsEditableText)
 
     TestWebKitAPI::Util::run(&done);
     EXPECT_WK_STREQ("Hello", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
+    EXPECT_FALSE(CGRectIsEmpty([webView _uiTextSelectionRects].firstObject.CGRectValue));
+}
+
+TEST(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@(largeResponsiveHelloMarkup)];
+
+    __block bool done = false;
+    [[webView wkContentView] prepareSelectionForContextMenuWithLocationInView:CGPointMake(100, 100) completionHandler:^(BOOL, RVItem *) {
+        done = true;
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_WK_STREQ("Hello", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
+    EXPECT_FALSE(CGRectIsEmpty([webView _uiTextSelectionRects].firstObject.CGRectValue));
 }
 
 #if ENABLE(IOS_TOUCH_EVENTS)


### PR DESCRIPTION
#### b90ad693d459cfdffd59421254a60f43a1e8afbe
<pre>
[iOS] Selection highlight is not visible after right clicking non-editable text for the first time
<a href="https://bugs.webkit.org/show_bug.cgi?id=242041">https://bugs.webkit.org/show_bug.cgi?id=242041</a>
rdar://95810910

Reviewed by Aditya Keerthi.

When right clicking non-editable text in a web view where we&apos;ve never selected text before, UIKit&apos;s
selection highlight views will be hidden, despite the UI-side selection geometry (i.e.
`EditorState`&apos;s post-layout data) being up-to-date. This is because the text interaction assistant
(`UIWKTextInteractionAssistant`) may not have been activated yet in this scenario.

In editable content, this bug doesn&apos;t reproduce, since the process of selecting editable content
also focuses the web view, which causes the selection assistant to activate in the process of
showing the keyboard. To make this work for non-editable content, we add an explicit call to
activate the text interaction assistant after we&apos;ve set the text selection range, and we&apos;re
proceeding with showing the context menu.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView prepareSelectionForContextMenuWithLocationInView:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:

Adjust an existing API test to verify that the selection view rects are present when showing the
context menu on iOS; also, add a new API test to exercise the case where we&apos;re right-clicking in
non-editable content.

Canonical link: <a href="https://commits.webkit.org/251901@main">https://commits.webkit.org/251901@main</a>
</pre>
