### PR TITLE
[JSC] Drop wasm stale assertion

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1182,7 +1182,6 @@ auto LLIntGenerator::addDelegateToUnreachable(ControlType& target, ControlType& 
 
     ControlTry& tryData = std::get<ControlTry>(data);
     m_codeBlock->addExceptionHandler({ HandlerType::Delegate, tryData.m_try->location(), delegateLabel->location(), 0, m_tryDepth, targetDepth });
-    checkConsistency();
     return { };
 }
 


### PR DESCRIPTION
#### a3dd7dc5f60b87a7cfd14c372e40ebd339076763
<pre>
[JSC] Drop wasm stale assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=242047">https://bugs.webkit.org/show_bug.cgi?id=242047</a>
rdar://95866655

Reviewed by Mark Lam.

This patch drops stale assertion in addDelegateToUnreachable.

* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addDelegateToUnreachable):

Canonical link: <a href="https://commits.webkit.org/251902@main">https://commits.webkit.org/251902@main</a>
</pre>
