### PR TITLE
Create a way to reflect process-wide state in WebCore

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1342,6 +1342,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/PopupMenu.h
     platform/PopupMenuClient.h
     platform/PopupMenuStyle.h
+    platform/ProcessCapabilities.h
     platform/ProcessIdentifier.h
     platform/ProcessIdentity.h
     platform/ProcessQualified.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1917,6 +1917,7 @@ platform/PlatformSpeechSynthesizer.cpp
 platform/PlatformStrategies.cpp
 platform/PlatformWheelEvent.cpp
 platform/PreviewConverter.cpp
+platform/ProcessCapabilities.cpp
 platform/ProcessIdentifier.cpp
 platform/ProcessIdentity.cpp
 platform/ReferrerPolicy.cpp

--- a/Source/WebCore/platform/ProcessCapabilities.cpp
+++ b/Source/WebCore/platform/ProcessCapabilities.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ProcessCapabilities.h"
+
+namespace WebCore {
+
+#if USE(CG)
+static bool s_HEICDecodingEnabled = false;
+static bool s_AVIFDecodingEnabled = false;
+static bool s_hardwareAcceleratedDecodingDisabled = false;
+#endif
+
+#if USE(CG)
+void ProcessCapabilities::setHEICDecodingEnabled(bool value)
+{
+    s_HEICDecodingEnabled = value;
+}
+
+bool ProcessCapabilities::isHEICDecodingEnabled()
+{
+    return s_HEICDecodingEnabled;
+}
+
+void ProcessCapabilities::setAVIFDecodingEnabled(bool value)
+{
+    s_AVIFDecodingEnabled = value;
+}
+
+bool ProcessCapabilities::isAVIFDecodingEnabled()
+{
+    return s_AVIFDecodingEnabled;
+}
+
+void ProcessCapabilities::setHardwareAcceleratedDecodingDisabled(bool value)
+{
+    s_hardwareAcceleratedDecodingDisabled = value;
+}
+
+bool ProcessCapabilities::isHardwareAcceleratedDecodingDisabled()
+{
+    return s_hardwareAcceleratedDecodingDisabled;
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ProcessCapabilities.h
+++ b/Source/WebCore/platform/ProcessCapabilities.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer. 
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+// This class exposes process-wide options (e.g. those imposed by sandboxing).
+class ProcessCapabilities {
+public:
+#if USE(CG)
+    WEBCORE_EXPORT static void setHEICDecodingEnabled(bool);
+    static bool isHEICDecodingEnabled();
+
+    WEBCORE_EXPORT static void setAVIFDecodingEnabled(bool);
+    static bool isAVIFDecodingEnabled();
+
+    WEBCORE_EXPORT static void setHardwareAcceleratedDecodingDisabled(bool);
+    static bool isHardwareAcceleratedDecodingDisabled();
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -70,22 +70,10 @@ public:
     bool isAllDataReceived() const final { return m_isAllDataReceived; }
     void clearFrameBufferCache(size_t) final { }
 
-    WEBCORE_EXPORT static void enableDecodingHEIC();
-    static bool decodingHEICEnabled();
-
-    WEBCORE_EXPORT static void enableDecodingAVIF();
-    static bool decodingAVIFEnabled();
-
-    WEBCORE_EXPORT static void disableHardwareAcceleratedDecoding();
-    static bool hardwareAcceleratedDecodingDisabled();
-
 private:
     bool m_isAllDataReceived { false };
     mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
     RetainPtr<CGImageSourceRef> m_nativeDecoder;
-    static bool s_enableDecodingHEIC;
-    static bool s_enableDecodingAVIF;
-    static bool s_hardwareAcceleratedDecodingDisabled;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -930,8 +930,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         && m_shouldRenderDOMInGPUProcess
         && m_shouldPlayMediaInGPUProcess;
 
-    if (blockIOKit)
+    if (blockIOKit) {
         CFPreferencesGetAppIntegerValue(CFSTR("key"), CFSTR("com.apple.WebKit.WebContent.BlockIOKitInWebContentSandbox"), nullptr);
+        ProcessCapabilities::setHardwareAcceleratedDecodingDisabled(true);
+    }
 #endif
 
     updateThrottleState();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2032,14 +2032,7 @@ void WebProcess::setUseGPUProcessForCanvasRendering(bool useGPUProcessForCanvasR
 
 void WebProcess::setUseGPUProcessForDOMRendering(bool useGPUProcessForDOMRendering)
 {
-    if (useGPUProcessForDOMRendering == m_useGPUProcessForDOMRendering)
-        return;
-
     m_useGPUProcessForDOMRendering = useGPUProcessForDOMRendering;
-#if USE(CG)
-    if (m_useGPUProcessForDOMRendering)
-        ImageDecoderCG::disableHardwareAcceleratedDecoding();
-#endif
 }
 
 void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -79,6 +79,7 @@
 #import <WebCore/PictureInPictureSupport.h>
 #import <WebCore/PlatformMediaSessionManager.h>
 #import <WebCore/PlatformScreen.h>
+#import <WebCore/ProcessCapabilities.h>
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/RuntimeEnabledFeatures.h>
 #import <WebCore/SWContextManager.h>
@@ -286,12 +287,12 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     OptionSet<VideoDecoderBehavior> videoDecoderBehavior;
     
     if (parameters.enableDecodingHEIC) {
-        ImageDecoderCG::enableDecodingHEIC();
+        ProcessCapabilities::setHEICDecodingEnabled(true);
         videoDecoderBehavior.add(VideoDecoderBehavior::EnableHEIC);
     }
 
     if (parameters.enableDecodingAVIF) {
-        ImageDecoderCG::enableDecodingAVIF();
+        ProcessCapabilities::setAVIFDecodingEnabled(true);
         videoDecoderBehavior.add(VideoDecoderBehavior::EnableAVIF);
     }
 


### PR DESCRIPTION
#### 91926a7cd5a5025ce6241dbabd2dedab15fd67e8
<pre>
Create a way to reflect process-wide state in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=242049">https://bugs.webkit.org/show_bug.cgi?id=242049</a>

Reviewed by Per Arne Vollan.

Sandboxing can affect capabilities that WebCore has, such as certain types of image decoding.
Move static functions from ImageDecoderCG into a class that can hold more options in future.

Also fix the call site for disableHardwareAcceleratedDecoding(); previously this assumed that
&quot;DOM Rendering in GPU Process&quot; would be enabled last; but there&apos;s no ordering here; we should
just call setHardwareAcceleratedDecodingDisabled(true) at the same place where we enable
IOKit sandboxing.

This is a precursor to fixing rdar://95618211.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ProcessCapabilities.cpp: Added.
(WebCore::ProcessCapabilities::setHEICDecodingEnabled):
(WebCore::ProcessCapabilities::isHEICDecodingEnabled):
(WebCore::ProcessCapabilities::setHardwareAcceleratedDecodingDisabled):
(WebCore::ProcessCapabilities::isHardwareAcceleratedDecodingDisabled):
* Source/WebCore/platform/ProcessCapabilities.h: Added.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::createImageSourceOptions):
(WebCore::ImageDecoderCG::enableDecodingHEIC): Deleted.
(WebCore::ImageDecoderCG::decodingHEICEnabled): Deleted.
(WebCore::ImageDecoderCG::disableHardwareAcceleratedDecoding): Deleted.
(WebCore::ImageDecoderCG::hardwareAcceleratedDecodingDisabled): Deleted.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setUseGPUProcessForDOMRendering):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/251918@main">https://commits.webkit.org/251918@main</a>
</pre>
