### PR TITLE
Change my (Youssef Soliman) primary committer email

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -7082,8 +7082,8 @@
    },
    {
       "emails" : [
-         "y_soliman@apple.com",
-         "youssefdevelops@gmail.com"
+         "youssefdevelops@gmail.com",
+         "y_soliman@apple.com"
       ],
       "github" : "youssefsoli",
       "name" : "Youssef Soliman",


### PR DESCRIPTION
#### 6637f117b9a98d8489dc523b6d30cd3acdc4fa1c
<pre>
Change my (Youssef Soliman) primary committer email
<a href="https://bugs.webkit.org/show_bug.cgi?id=242062">https://bugs.webkit.org/show_bug.cgi?id=242062</a>

Reviewed by Jonathan Bedard.

Currently the primary committer email that the EWS bot uses to write
commits on my behalf is my apple email which is different than my primary
GitHub email.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/251912@main">https://commits.webkit.org/251912@main</a>
</pre>
