### PR TITLE
Do not create origin directory or origin file for LocalStorage prewarming

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -67,6 +67,7 @@ namespace WebKit {
 
 class FileSystemStorageHandleRegistry;
 class IDBStorageRegistry;
+class StorageAreaBase;
 class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::Connection::WorkQueueMessageReceiver {
@@ -101,6 +102,7 @@ public:
 private:
     NetworkStorageManager(PAL::SessionID, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, bool shouldUseCustomPaths);
     ~NetworkStorageManager();
+    void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& localOriginStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -65,6 +65,8 @@ public:
     OptionSet<WebsiteDataType> fetchDataTypesInList(OptionSet<WebsiteDataType>);
     void deleteData(OptionSet<WebsiteDataType>, WallTime);
     void moveData(OptionSet<WebsiteDataType>, const String& localStoragePath, const String& idbStoragePath);
+    bool didWriteOriginToFile() const { return m_didWriteOriginToFile; }
+    void markDidWriteOriginToFile() { m_didWriteOriginToFile = true; }
 
 private:
     enum class StorageBucketMode : bool;
@@ -81,6 +83,7 @@ private:
     RefPtr<QuotaManager> m_quotaManager;
     bool m_persisted { false };
     bool m_shouldUseCustomPaths;
+    bool m_didWriteOriginToFile { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f0e6ad03798874ee0b2520dca4ec7c47f9c2e556
<pre>
Do not create origin directory or origin file for LocalStorage prewarming
<a href="https://bugs.webkit.org/show_bug.cgi?id=242064">https://bugs.webkit.org/show_bug.cgi?id=242064</a>

Reviewed by Chris Dumez.

We currently prewarm LocalStorage (try opening the LocalStorage database and fetch items before the API is called) for
performance, and we create origin directory and origin file when OriginStorageManager is created. This means we would
create the directory for each origin visited, but we should create the directory when it is needed, i.e. when there will
be content inside it; otherwise the origin file and directory are useless and will take up user&apos;s disk space.

API test: WebKit.CreateOriginFileWhenNeeded

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::writeOriginToFile):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::localOriginStorageManager):
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::setItem):
(WebKit::NetworkStorageManager::removeItem):
(WebKit::NetworkStorageManager::clear):
(WebKit::writeOriginToFileIfNecessary): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
(WebKit::OriginStorageManager::didWriteOriginToFile const):
(WebKit::OriginStorageManager::markDidWriteOriginToFile):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/251997@main">https://commits.webkit.org/251997@main</a>
</pre>
