### PR TITLE
[WebAuthn] Include hybrid transport in IDL

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
@@ -30,5 +30,6 @@
     "nfc",
     "ble",
     "internal",
-    "cable"
+    "cable",
+    "hybrid"
 };


### PR DESCRIPTION
#### 3d9f5dd971292709f88591361419bc2256245e03
<pre>
[WebAuthn] Include hybrid transport in IDL
<a href="https://bugs.webkit.org/show_bug.cgi?id=242065">https://bugs.webkit.org/show_bug.cgi?id=242065</a>
rdar://problem/96072746

Unreviewed follow-up fix.

The hybrid transport enum value was added and handled in
<a href="https://commits.webkit.org/251621@main">https://commits.webkit.org/251621@main</a> but the idl change
didn&apos;t make it in the commit. Adding it here.

* Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl:

Canonical link: <a href="https://commits.webkit.org/251916@main">https://commits.webkit.org/251916@main</a>
</pre>
