### PR TITLE
[Gardening]: [ macOS Release ] TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosScrollPlayingMutedVideoOutOfView is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
@@ -188,7 +188,8 @@ TEST(VideoControlsManager, VideoControlsManagerMultipleVideosScrollPlayingVideoW
     [webView expectControlsManager:YES afterReceivingMessage:@"scrolled"];
 }
 
-TEST(VideoControlsManager, VideoControlsManagerMultipleVideosScrollPlayingMutedVideoOutOfView)
+// FIXME: Re-enable after webkit.org/b/242043- is resolved 
+TEST(VideoControlsManager, DISABLED_VideoControlsManagerMultipleVideosScrollPlayingMutedVideoOutOfView)
 {
     RetainPtr<VideoControlsManagerTestWebView> webView = setUpWebViewForTestingVideoControlsManager(NSMakeRect(0, 0, 500, 500));
 


### PR DESCRIPTION
#### d64759548f1b99c234c7aaec255ee9f7762dc343
<pre>
[Gardening]: [ macOS Release ] TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosScrollPlayingMutedVideoOutOfView is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242043">https://bugs.webkit.org/show_bug.cgi?id=242043</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251929@main">https://commits.webkit.org/251929@main</a>
</pre>
