### PR TITLE
[git-webkit] Prefer 'fork' over personal remote name when checking out PR

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.2',
+    version='5.2.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 2)
+version = Version(5, 2, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -874,7 +874,10 @@ class Git(Scm):
             name = match.group('name')
             username = name.split('/')[0]
             repo_name = rmt.name if '/' not in name else name.split('/', 1)[-1]
-            name = username + repo_name[len(rmt.name):]
+            if username == rmt.credentials(required=False)[0]:
+                name = 'fork' + repo_name[len(rmt.name):]
+            else:
+                name = username + repo_name[len(rmt.name):]
 
             if not self.url(name):
                 url = self.url()


### PR DESCRIPTION
#### 7be0170f99891c13dddb7829e10b8a2bb9d576d2
<pre>
[git-webkit] Prefer &apos;fork&apos; over personal remote name when checking out PR
<a href="https://bugs.webkit.org/show_bug.cgi?id=242070">https://bugs.webkit.org/show_bug.cgi?id=242070</a>
&lt;rdar://problem/96076687&gt;

Rubber-stamped by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.checkout): Use &apos;fork&apos; over &apos;&lt;username&gt;&apos; as remote if PR is authored by user.

Canonical link: <a href="https://commits.webkit.org/251949@main">https://commits.webkit.org/251949@main</a>
</pre>
