### PR TITLE
[WebAuthn] Reject too long or too short user id

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -14,8 +14,12 @@ CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'na
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
+CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
+CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with minimum options in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with user handle of length=1 in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with user handle of length=64 in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with empty pubKeyCredParams in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform' } in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with requireResidentKey { false } in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -39,6 +39,50 @@
                 },
                 user: {
                     name: "John Appleseed",
+                    id: asciiToUint8Array("1"),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 100
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with user handle of length=1 in a mock hid authenticator.");
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: asciiToUint8Array("1234567812345678123456781234567812345678123456781234567812345678"),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 100
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with user handle of length=64 in a mock hid authenticator.");
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
                     id: Base64URL.parse(testUserhandleBase64),
                     displayName: "Appleseed",
                 },

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https-expected.txt
@@ -54,4 +54,6 @@ PASS PublicKeyCredential's [[create]] with with invalid parameters. 52
 PASS PublicKeyCredential's [[create]] with with invalid parameters. 53
 PASS PublicKeyCredential's [[create]] with with invalid parameters. 54
 PASS PublicKeyCredential's [[create]] with with invalid parameters. 55
+PASS PublicKeyCredential's [[create]] with with invalid parameters. 56
+PASS PublicKeyCredential's [[create]] with with invalid parameters. 57
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https.html
@@ -43,6 +43,8 @@
         [{ name: rp.name, id: Symbol() }, user, challenge, [pubKeyCredParam]],
         // wrong user attribute type
         [rp, { name: Symbol(), id: user.id, displayName: user.displayName}, challenge, [pubKeyCredParam]],
+        [rp, { name: user.name, id: asciiToUint8Array(""), displayName: user.displayName}, challenge, [pubKeyCredParam]],
+        [rp, { name: user.name, id: asciiToUint8Array("12345678123456781234567812345678123456781234567812345678123456781"), displayName: user.displayName}, challenge, [pubKeyCredParam]],
         [rp, { name: user.name, id: 1, displayName: user.displayName}, challenge, [pubKeyCredParam]],
         [rp, { name: user.name, id: true, displayName: user.displayName}, challenge, [pubKeyCredParam]],
         [rp, { name: user.name, id: null, displayName: user.displayName}, challenge, [pubKeyCredParam]],


### PR DESCRIPTION
#### 8f49569a327273a80904ab7d3cf11b31f5fcb4cc
<pre>
[WebAuthn] Reject too long or too short user id
<a href="https://bugs.webkit.org/show_bug.cgi?id=242073">https://bugs.webkit.org/show_bug.cgi?id=242073</a>
rdar://90281685

Reviewed by Brent Fulgham.

The creation option&apos;s user.id should be between 1-64 bytes inclusive
per the spec: <a href="https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-id">https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-id</a>

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-with-invalid-parameters.https.html:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create const):

Canonical link: <a href="https://commits.webkit.org/251938@main">https://commits.webkit.org/251938@main</a>
</pre>
