### PR TITLE
[Alternate WebM Player] Support non-zero start times

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -126,6 +126,7 @@ private:
 
     void setBufferedRanges(PlatformTimeRanges);
     void updateBufferedFromTrackBuffers(bool);
+    void updateDurationFromTrackBuffers();
 
     bool didLoadingProgress() const final;
 


### PR DESCRIPTION
#### fc8d527c41f642f21cb072a5cb71402a11246eeb
<pre>
[Alternate WebM Player] Support non-zero start times
<a href="https://bugs.webkit.org/show_bug.cgi?id=242074">https://bugs.webkit.org/show_bug.cgi?id=242074</a>

Reviewed by Jean-Yves Avenard.

Currently the player does not know how to deal with a non-zero timecode
for the initial cluster inside of the webm. The approach taken here is
to offset every sample in a track relative to the first sample&apos;s presentation
timestamp. The duration also needs to reflect this offset, so the approach
taken for that is to set the duration to the highest sample timestamp
across tracks.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::loadFinished):
(WebCore::MediaPlayerPrivateWebM::updateDurationFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):

Canonical link: <a href="https://commits.webkit.org/251973@main">https://commits.webkit.org/251973@main</a>
</pre>
