### PR TITLE
[Modern Media Controls] [iOS] adjust appearance of time scrubber

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/slider-base.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider-base.css
@@ -38,16 +38,6 @@
     pointer-events: none;
 }
 
-.slider.allows-relative-scrubbing > .appearance {
-    transition-property: top, height;
-    transition-duration: 0.5s;
-}
-
-.slider.allows-relative-scrubbing > .appearance.changing {
-    top: 0.5px;
-    height: 15px;
-}
-
 .slider > input {
     top: 0;
     margin: 0;

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
@@ -44,7 +44,6 @@ class SliderBase extends LayoutNode
         this.value = 0;
         this.enabled = true;
         this.isActive = false;
-        this._secondaryValue = 0;
         this._disabled = false;
 
         this._allowsRelativeScrubbing = false;
@@ -89,20 +88,6 @@ class SliderBase extends LayoutNode
 
         this._value = value;
         this.markDirtyProperty("value");
-        this.needsLayout = true;
-    }
-
-    get secondaryValue()
-    {
-        return this._secondaryValue;
-    }
-
-    set secondaryValue(secondaryValue)
-    {
-        if (this._secondaryValue === secondaryValue)
-            return;
-
-        this._secondaryValue = secondaryValue;
         this.needsLayout = true;
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.css
@@ -28,19 +28,21 @@
     height: 5px;
 }
 
+.slider.default.allows-relative-scrubbing > .appearance {
+    transition-property: top, height;
+    transition-duration: 0.5s;
+}
+
 .slider.default.allows-relative-scrubbing > .appearance.changing {
     top: 0.5px;
     height: 15px;
 }
 
-.slider.default > .appearance > * {
-    position: absolute;
-}
-
 .slider.default > .appearance > .fill {
-    top: 0;
+    position: relative;
     height: 100%;
-    mix-blend-mode: plus-lighter;
+    border-radius: 4.5px;
+    overflow: hidden;
 }
 
 .slider.default.allows-relative-scrubbing > .appearance > .fill {
@@ -48,42 +50,49 @@
     transition-duration: 0.5s;
 }
 
-.slider.default > .appearance > .fill.primary {
+.slider.default.allows-relative-scrubbing > .appearance.changing > .fill {
+    border-radius: 7.5px;
+}
+
+.slider.default > .appearance > .fill > * {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    mix-blend-mode: plus-lighter;
+}
+
+.slider.default.allows-relative-scrubbing > .appearance > .fill > * {
+    mix-blend-mode: initial;
+}
+
+.slider.default > .appearance > .fill > .primary {
     left: 0;
     background-color: rgba(255, 255, 255, 0.45);
-    border-top-left-radius: 4.5px;
-    border-bottom-left-radius: 4.5px;
 }
 
-.slider.default.allows-relative-scrubbing > .appearance.changing > .fill.primary {
-    border-top-left-radius: 7.5px;
-    border-bottom-left-radius: 7.5px;
+.slider.default.allows-relative-scrubbing > .appearance > .fill > .primary {
+    background-color: rgb(236, 236, 236);
 }
 
-.slider.default > .appearance > .fill.track {
+.slider.default > .appearance > .fill > .track {
     right: 0;
     background-color: rgba(255, 255, 255, 0.1);
-    border-top-right-radius: 4.5px;
-    border-bottom-right-radius: 4.5px;
 }
 
-.slider.default.allows-relative-scrubbing > .appearance.changing > .fill.track {
-    border-top-right-radius: 7.5px;
-    border-bottom-right-radius: 7.5px;
+.slider.default.allows-relative-scrubbing > .appearance > .fill > .track {
+    background-color: rgb(102, 102, 102);
 }
 
-.slider.default > .appearance > .fill.secondary {
+.slider.default > .appearance > .fill > .secondary {
     background-color: rgba(255, 255, 255, 0.08);
-    border-top-right-radius: 4.5px;
-    border-bottom-right-radius: 4.5px;
 }
 
-.slider.default.allows-relative-scrubbing > .appearance.changing > .fill.secondary {
-    border-top-right-radius: 7.5px;
-    border-bottom-right-radius: 7.5px;
+.slider.default.allows-relative-scrubbing > .appearance > .fill > .secondary {
+    background-color: rgb(128, 128, 128);
 }
 
 .slider.default > .appearance > .knob {
+    position: absolute;
     background-color: white;
     transform: translateX(-50%);
 }
@@ -112,8 +121,7 @@
 
 /* When disabled, we only want to show the track and turn off interaction. */
 
-.slider.default.disabled > .appearance > .primary,
-.slider.default.disabled > .appearance > .secondary,
+.slider.default.disabled > .appearance > .fill > :is(.primary, .secondary),
 .slider.default.disabled > .appearance > .knob {
     display: none;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.js
@@ -29,17 +29,37 @@ class Slider extends SliderBase
     {
         super(layoutDelegate, `default ${cssClassName}`);
 
-        this._primaryFill = new LayoutNode(`<div class="primary fill"></div>`);
-        this._trackFill = new LayoutNode(`<div class="track fill"></div>`);
-        this._secondaryFill = new LayoutNode(`<div class="secondary fill"></div>`);
+        this._primaryFill = new LayoutNode(`<div class="primary"></div>`);
+        this._trackFill = new LayoutNode(`<div class="track"></div>`);
+        this._secondaryFill = new LayoutNode(`<div class="secondary"></div>`);
+
+        let fillContainer = new LayoutNode(`<div class="fill"></div>`);
+        fillContainer.children = [this._primaryFill, this._trackFill, this._secondaryFill];
+
         this._knob = new LayoutNode(`<div class="knob ${knobStyle}"></div>`);
-        this.appearanceContainer.children = [this._primaryFill, this._trackFill, this._secondaryFill, this._knob];
+
+        this.appearanceContainer.children = [fillContainer, this._knob];
 
         this.height = 16;
+        this._secondaryValue = 0;
         this._knobStyle = knobStyle;
     }
 
     // Public
+
+    get secondaryValue()
+    {
+        return this._secondaryValue;
+    }
+
+    set secondaryValue(secondaryValue)
+    {
+        if (this._secondaryValue === secondaryValue)
+            return;
+
+        this._secondaryValue = secondaryValue;
+        this.needsLayout = true;
+    }
 
     get knobStyle()
     {


### PR DESCRIPTION
#### 64b7f65dbae32bbd03126eff5cd207a32ad8be74
<pre>
[Modern Media Controls] [iOS] adjust appearance of time scrubber
<a href="https://bugs.webkit.org/show_bug.cgi?id=242075">https://bugs.webkit.org/show_bug.cgi?id=242075</a>
&lt;rdar://problem/95642930&gt;

Reviewed by Eric Carlson.

* Source/WebCore/Modules/modern-media-controls/controls/slider.css:
(.slider.default &gt; .appearance):
(.slider.default.allows-relative-scrubbing &gt; .appearance): Added.
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing):
(.slider.default &gt; .appearance &gt; .fill): Added.
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing &gt; .fill): Added.
(.slider.default &gt; .appearance &gt; .fill &gt; *): Added.
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; *): Added.
(.slider.default &gt; .appearance &gt; .fill &gt; .primary): Renamed from `.slider.default &gt; .appearance &gt; .fill.primary`.
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; .primary): Added.
(.slider.default &gt; .appearance &gt; .fill &gt; .track): Renamed from `.slider.default &gt; .appearance &gt; .fill.track`.
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; .track): Added.
(.slider.default &gt; .appearance &gt; .fill &gt; .secondary): Renamed from `.slider.default &gt; .appearance &gt; .fill.secondary`.
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; .secondary): Added.
(.slider.default &gt; .appearance &gt; .knob):
(.slider.default.disabled &gt; .appearance &gt; .fill &gt; :is(.primary, .secondary), .slider.default.disabled &gt; .appearance &gt; .knob): Renamed from `.slider.default.disabled &gt; .appearance &gt; .primary, .slider.default.disabled &gt; .appearance &gt; .secondary, .slider.default.disabled &gt; .appearance &gt; .knob`.
(.slider.default &gt; .appearance &gt; *): Deleted.
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing &gt; .fill.primary): Deleted.
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing &gt; .fill.track): Deleted.
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing &gt; .fill.secondary): Deleted.
- Adjust the `background-color` of each component of the time scrubber.
- Move the `border-radius` to a new `.fill` container so that the if the `.track` is not the full
  width then it won&apos;t also have a `border-*-right-radius` (i.e. only the corners of the
  entire `.fill` container should have any `border-radius`).

* Source/WebCore/Modules/modern-media-controls/controls/slider-base.js:
(SliderBase):
(SliderBase.prototype.get secondaryValue): Deleted.
(SliderBase.prototype.set secondaryValue): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/slider-base.css:
(.slider.allows-relative-scrubbing &gt; .appearance): Deleted.
(.slider.allows-relative-scrubbing &gt; .appearance.changing): Deleted.
Move these things since they specific to the concrete `Slider`, not the more abstract `SliderBase`.

Canonical link: <a href="https://commits.webkit.org/251935@main">https://commits.webkit.org/251935@main</a>
</pre>
