### PR TITLE
Set a flag on `LTUITranslationViewController` to indicate whether the text selection is in Live Text

### DIFF
--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -549,6 +549,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
                 view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())),
                 view->contentsToRootView(m_context.hitTestResult().roundedPointInInnerNodeFrame()),
                 m_context.hitTestResult().isContentEditable() ? TranslationContextMenuMode::Editable : TranslationContextMenuMode::NonEditable,
+                ImageOverlay::isInsideOverlay(frame->selection().selection()) ? TranslationContextMenuSource::Image : TranslationContextMenuSource::Unspecified,
             });
         }
 #endif

--- a/Source/WebCore/page/TranslationContextMenuInfo.h
+++ b/Source/WebCore/page/TranslationContextMenuInfo.h
@@ -35,12 +35,14 @@
 namespace WebCore {
 
 enum class TranslationContextMenuMode : bool { NonEditable, Editable };
+enum class TranslationContextMenuSource : bool { Unspecified, Image };
 
 struct TranslationContextMenuInfo {
     String text;
     IntRect selectionBoundsInRootView;
     IntPoint locationInRootView;
     TranslationContextMenuMode mode { TranslationContextMenuMode::NonEditable };
+    TranslationContextMenuSource source { TranslationContextMenuSource::Unspecified };
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<TranslationContextMenuInfo> decode(Decoder&);
@@ -52,6 +54,7 @@ template<class Encoder> void TranslationContextMenuInfo::encode(Encoder& encoder
     encoder << selectionBoundsInRootView;
     encoder << locationInRootView;
     encoder << mode;
+    encoder << source;
 }
 
 template<class Decoder> std::optional<TranslationContextMenuInfo> TranslationContextMenuInfo::decode(Decoder& decoder)
@@ -76,7 +79,12 @@ template<class Decoder> std::optional<TranslationContextMenuInfo> TranslationCon
     if (!mode)
         return std::nullopt;
 
-    return {{ WTFMove(*text), WTFMove(*selectionBoundsInRootView), WTFMove(*locationInRootView), *mode }};
+    std::optional<TranslationContextMenuSource> source;
+    decoder >> source;
+    if (!source)
+        return std::nullopt;
+
+    return { { WTFMove(*text), WTFMove(*selectionBoundsInRootView), WTFMove(*locationInRootView), *mode, *source } };
 }
 
 } // namespace WebCore
@@ -88,6 +96,14 @@ template<> struct EnumTraits<WebCore::TranslationContextMenuMode> {
         WebCore::TranslationContextMenuMode,
         WebCore::TranslationContextMenuMode::NonEditable,
         WebCore::TranslationContextMenuMode::Editable
+    >;
+};
+
+template<> struct EnumTraits<WebCore::TranslationContextMenuSource> {
+    using values = EnumValues<
+        WebCore::TranslationContextMenuSource,
+        WebCore::TranslationContextMenuSource::Unspecified,
+        WebCore::TranslationContextMenuSource::Image
     >;
 };
 

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -634,6 +634,10 @@ typedef enum {
 - (void)selectAll;
 @end
 
+@protocol _UITextInputTranslationSupport <UITextInput>
+@property (nonatomic, readonly, getter=isImageBacked) BOOL imageBacked;
+@end
+
 @interface UITextInputTraits : NSObject <UITextInputTraits, UITextInputTraits_Private, NSCopying>
 - (void)_setColorsToMatchTintColor:(UIColor *)tintColor;
 @end

--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -148,9 +148,11 @@
 #endif
 
 #if HAVE(TRANSLATION_UI_SERVICES)
+#import <TranslationUIServices/LTUISourceMeta.h>
 #import <TranslationUIServices/LTUITranslationViewController.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(TranslationUIServices)
+SOFT_LINK_CLASS_OPTIONAL(TranslationUIServices, LTUISourceMeta)
 SOFT_LINK_CLASS_OPTIONAL(TranslationUIServices, LTUITranslationViewController)
 #endif
 
@@ -5855,6 +5857,10 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
                 insertText(string.string);
         }];
     }
+
+    auto sourceMetadata = adoptNS([allocLTUISourceMetaInstance() init]);
+    [sourceMetadata setOrigin:info.source == WebCore::TranslationContextMenuSource::Image ? LTUISourceMetaOriginImage : LTUISourceMetaOriginUnspecified];
+    [translationViewController setSourceMeta:sourceMetadata.get()];
 
     if (NSEqualSizes([translationViewController preferredContentSize], NSZeroSize))
         [translationViewController setPreferredContentSize:NSMakeSize(400, 400)];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -549,7 +549,7 @@ using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIden
 
 @end
 
-@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextAutoscrolling, UITextInputMultiDocument, UITextInputPrivate, UIWebFormAccessoryDelegate, UIWebTouchEventsGestureRecognizerDelegate, UIWKInteractionViewProtocol, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
+@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextAutoscrolling, UITextInputMultiDocument, UITextInputPrivate, UIWebFormAccessoryDelegate, UIWebTouchEventsGestureRecognizerDelegate, UIWKInteractionViewProtocol, _UITextInputTranslationSupport, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
 #if HAVE(CONTACTSUI)
     , WKContactPickerDelegate
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11248,6 +11248,12 @@ constexpr auto analysisTypesForFullscreenVideo = VKAnalysisTypeAll & ~VKAnalysis
 #endif
 }
 
+#pragma mark - _UITextInputTranslationSupport
+
+- (BOOL)isImageBacked
+{
+    return _page && _page->editorState().selectionIsRangeInsideImageOverlay;
+}
 
 @end
 


### PR DESCRIPTION
#### 53038925c36f19a307ba993e45e75ae2ae8ba58d
<pre>
Set a flag on `LTUITranslationViewController` to indicate whether the text selection is in Live Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=242078">https://bugs.webkit.org/show_bug.cgi?id=242078</a>
rdar://94351954

Reviewed by Aditya Keerthi.

To improve telemetry around text translation, this patch adds plumbing to set some metadata on
`LTUITranslationViewController` when the selected text that&apos;s being translated is in Live Text,
inside of an image.

To achieve this on macOS, we add a bit to `TranslationContextMenuInfo` to indicate whether the
selection is inside Live Text (i.e. in an image overlay), plumb it through to the client layer, and
use it to create a new `LTUISourceMeta` object which we then set on the view controller.

On iOS, UIKit handles creating and presenting the `LTUITranslationViewController`; instead, we need
the text input to declare conformance to a protocol (`_UITextInputTranslationSupport`), which UIKit
then consults to determine whether or not the current selection range is in Live Text, when
presenting translation UI (i.e. `-isImageBacked`).

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebCore/page/TranslationContextMenuInfo.h:
(WebCore::TranslationContextMenuInfo::encode const):
(WebCore::TranslationContextMenuInfo::decode):

Propagate the new bit when translating selected text on macOS.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(WebKit::WebViewImpl::handleContextMenuTranslation):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Declare conformance to `_UITextInputTranslationSupport` on iOS.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView isImageBacked]):

Canonical link: <a href="https://commits.webkit.org/251927@main">https://commits.webkit.org/251927@main</a>
</pre>
