### PR TITLE
Turn macOS smooth keyboard scrolling on by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -265,7 +265,7 @@ EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   WebKitLegacy:
    default: false
   WebKit:
-   default: false
+   default: true
   WebCore:
    default: false
 


### PR DESCRIPTION
#### c5376ec632ec47ab192ec842fdef36892dcd6dc8
<pre>
Turn macOS smooth keyboard scrolling on by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=228159">https://bugs.webkit.org/show_bug.cgi?id=228159</a>
rdar://80912063

Reviewed by NOBODY (OOPS!).

No tests.

Set the default value for EventHandlerDrivenSmoothKeyboardScrollingEnabled to true in WebKit.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
</pre>