### PR TITLE
Add NSWindowCollectionBehaviorStationary to the fullscreen video NSWindow to make Stage Manager transitions nicer

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -98,7 +98,7 @@ static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSRe
     if (!self)
         return nil;
     [window setDelegate:self];
-    [window setCollectionBehavior:([window collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary)];
+    [window setCollectionBehavior:([window collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary | NSWindowCollectionBehaviorStationary)];
 
     // Hide the titlebar during the animation to full screen so that only the WKWebView content is visible.
     window.titlebarAlphaValue = 0;


### PR DESCRIPTION
#### 420b34ffb7a00ca237173823ffeca5e61e48d352
<pre>
Add NSWindowCollectionBehaviorStationary to the fullscreen video NSWindow to make Stage Manager transitions nicer
<a href="https://bugs.webkit.org/show_bug.cgi?id=242082">https://bugs.webkit.org/show_bug.cgi?id=242082</a>

Reviewed by Jer Noble.

When closing a fullscreen video when using Stage Manager on macOS, the main Safari
window was moving to the side strip and back quickly during the transition. By
adding NSWindowCollectionBehaviorStationary to the NSWindow used for the fullscreen
video, we can avoid this movement.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController initWithWindow:webView:page:]):

Canonical link: <a href="https://commits.webkit.org/251928@main">https://commits.webkit.org/251928@main</a>
</pre>
