### PR TITLE
Regression(r290521): Network process is terminated while fetching website data

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -230,7 +230,7 @@ uint64_t AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHa
     uint64_t listenerID = IPC::nextAsyncReplyHandlerID();
     encoder.get() << listenerID;
     encoder.get() << message.arguments();
-    sendMessage(WTFMove(encoder), sendOptions, {{ [completionHandler = WTFMove(completionHandler)] (IPC::Decoder* decoder) mutable {
+    sendMessage(WTFMove(encoder), sendOptions, {{ [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (IPC::Decoder* decoder) mutable {
         if (decoder && decoder->isValid())
             T::callReply(*decoder, WTFMove(completionHandler));
         else

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -132,17 +132,20 @@ Vector<Ref<NetworkProcessProxy>> NetworkProcessProxy::allNetworkProcesses()
     });
 }
 
-RefPtr<NetworkProcessProxy>& NetworkProcessProxy::defaultNetworkProcess()
+WeakPtr<NetworkProcessProxy>& NetworkProcessProxy::defaultNetworkProcess()
 {
-    static NeverDestroyed<RefPtr<NetworkProcessProxy>> process;
+    static NeverDestroyed<WeakPtr<NetworkProcessProxy>> process;
     return process.get();
 }
 
 Ref<NetworkProcessProxy> NetworkProcessProxy::ensureDefaultNetworkProcess()
 {
-    if (!defaultNetworkProcess())
-        defaultNetworkProcess() = NetworkProcessProxy::create();
-    return *defaultNetworkProcess();
+    auto& networkProcess = defaultNetworkProcess();
+    if (networkProcess)
+        return *networkProcess;
+    auto process = NetworkProcessProxy::create();
+    networkProcess = process.get();
+    return process;
 }
 
 void NetworkProcessProxy::terminate()

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -120,7 +120,7 @@ public:
     using OpenerDomain = WebCore::RegistrableDomain;
 
     static Ref<NetworkProcessProxy> ensureDefaultNetworkProcess();
-    static RefPtr<NetworkProcessProxy>& defaultNetworkProcess();
+    static WeakPtr<NetworkProcessProxy>& defaultNetworkProcess();
     static Ref<NetworkProcessProxy> create() { return adoptRef(*new NetworkProcessProxy); }
     ~NetworkProcessProxy();
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -322,10 +322,6 @@ WebProcessPool::~WebProcessPool()
         WebsiteDataStore::forEachWebsiteDataStore([](auto& websiteDataStore) {
             websiteDataStore.removeNetworkProcessReference();
         });
-        if (auto& networkProcess = NetworkProcessProxy::defaultNetworkProcess()) {
-            ASSERT(networkProcess->hasOneRef());
-            networkProcess = nullptr;
-        }
     }
 }
 


### PR DESCRIPTION
#### 2d5652cce002862b1c87e35c91bb7b21cca46aec
<pre>
Regression(r290521): Network process is terminated while fetching website data
<a href="https://bugs.webkit.org/show_bug.cgi?id=241830">https://bugs.webkit.org/show_bug.cgi?id=241830</a>

Reviewed by NOBODY (OOPS!).

Make sure the network process keeps running while we are waiting for an IPC
response from it. Also make sure the NetworkProcess still exits when it is
no longer used.

This is based on a patch from Sihui.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::defaultNetworkProcess):
(WebKit::NetworkProcessProxy::ensureDefaultNetworkProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::~WebProcessPool):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):
</pre>