### PR TITLE
[Gardening]: [ iOS Release ]  TestWebKitAPI.RequestTextInputContext.TextInteraction_FocusingAssistedElementShouldNotScrollToReveal is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm
@@ -834,7 +834,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusDefocusFocusAgainShouldScroll
     EXPECT_TRUE(didScroll);
 }
 
-TEST(RequestTextInputContext, TextInteraction_FocusingAssistedElementShouldNotScrollToReveal)
+// FIXME: Re-enable after webkit.org/b/242085 is resolved
+TEST(RequestTextInputContext, DISABLED_TextInteraction_FocusingAssistedElementShouldNotScrollToReveal)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 


### PR DESCRIPTION
#### b3fa37c0102214ef4086eecc1e2346eb0af3e176
<pre>
[Gardening]: [ iOS Release ]  TestWebKitAPI.RequestTextInputContext.TextInteraction_FocusingAssistedElementShouldNotScrollToReveal is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242085">https://bugs.webkit.org/show_bug.cgi?id=242085</a>
&lt;rdar://96093478&gt;

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/RequestTextInputContext.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251931@main">https://commits.webkit.org/251931@main</a>
</pre>
