### PR TITLE
[run-benchmark] Avoid race condition when killing the browser subprocess on Linux

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -79,10 +79,14 @@ class LinuxBrowserDriver(BrowserDriver):
                     main_browser_process.kill()
                     for browser_child in browser_children:
                         if browser_child.is_running():
-                            _log.info('Killing still alive {browser_name} child with pid {browser_pid} and cmd: {browser_cmd}'.format(
-                                       browser_name=self.browser_name, browser_pid=browser_child.pid,
-                                       browser_cmd=' '.join(browser_child.cmdline()).strip() or browser_child.name()))
-                            browser_child.kill()
+                            try:
+                                browser_child.kill()
+                                _log.info('Killed still alive {browser_name} child with pid {browser_pid} and cmd: {browser_cmd}'.format(
+                                          browser_name=self.browser_name, browser_pid=browser_child.pid,
+                                          browser_cmd=' '.join(browser_child.cmdline()).strip() or browser_child.name()))
+                            except psutil.NoSuchProcess:
+                                # There can be a race condition where the child ends in the interval between the is_running() and kill() calls.
+                                pass
                 else:
                     _log.info('Killing browser {browser_name} with pid {browser_pid}'.format(
                                browser_name=self.browser_name, browser_pid=self._browser_process.pid))


### PR DESCRIPTION
#### 7fd0981bb9da9eeb7c8625d578404d89ef171ae4
<pre>
[run-benchmark] Avoid race condition when killing the browser subprocess on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=242083">https://bugs.webkit.org/show_bug.cgi?id=242083</a>

Reviewed by Adrian Perez de Castro.

Fix a race condition that happens when the run-benchmark runner attempts to
close the browser (on Linux).

Sometimes the browser subprocess ends in the interval between the is_running()
check and the kill() call, causing an exception on the runner.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver.close_browsers):

Canonical link: <a href="https://commits.webkit.org/251936@main">https://commits.webkit.org/251936@main</a>
</pre>
