### PR TITLE
Enable OFFLINE_ASM_USE_ALT_ENTRY on Mac and Apple platforms using newer SDKs.

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -478,8 +478,17 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 // Define the opcode dispatch mechanism when using an ASM loop:
 //
 
-// We're disabling this for now because of a suspected linker issue.
+#if PLATFORM(MAC) \
+    || (PLATFORM(MACCATALYST) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) \
+    || (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) \
+    || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 160000) \
+    || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 90000)
+// Except for Mac, this requires a newer linker in order to work. Linkers from
+// older SDKs would hang. ref: rdar://93876735
+#define OFFLINE_ASM_USE_ALT_ENTRY 1
+#else
 #define OFFLINE_ASM_USE_ALT_ENTRY 0
+#endif
 
 #if COMPILER(CLANG)
 


### PR DESCRIPTION
#### f7192d6a16a3295122f2ba1cad167a2dcc0bcdf7
<pre>
Enable OFFLINE_ASM_USE_ALT_ENTRY on Mac and Apple platforms using newer SDKs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242088">https://bugs.webkit.org/show_bug.cgi?id=242088</a>
&lt;rdar://problem/94232529&gt;

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:

Canonical link: <a href="https://commits.webkit.org/251953@main">https://commits.webkit.org/251953@main</a>
</pre>
