### PR TITLE
[Make] Avoid passing default xcodebuild options to installsrc

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -154,10 +154,6 @@ else
 endif
 
 installsrc:
-ifndef XCODE_TARGET
-	@$(call invoke_xcode,,,-alltargets installsrc SRCROOT="$(SRCROOT)$(PATH_FROM_ROOT)")
-else
-	@$(call invoke_xcode,,,installsrc SRCROOT="$(SRCROOT)$(PATH_FROM_ROOT)")
-endif
+	xcodebuild installsrc SRCROOT="$(SRCROOT)$(PATH_FROM_ROOT)"
 
 force: ;


### PR DESCRIPTION
#### c68a647dbadb0275a7e3c30320c8a56b8e08afe1
<pre>
[Make] Avoid passing default xcodebuild options to installsrc
<a href="https://bugs.webkit.org/show_bug.cgi?id=242089">https://bugs.webkit.org/show_bug.cgi?id=242089</a>
rdar://95680722

Reviewed by Alexey Proskuryakov.

Our &quot;standard&quot; xcodebuild options, as computed by `XcodeOptionString()`
in webkitdirs, are not suitable for `xcodebuild installsrc`. In
particular, they can lead to PIFCache directories being created in
WebKitBuild that are created as a side effect of installsrc.

The -alltargets flag added in
<a href="https://bugs.webkit.org/show_bug.cgi?id=220370">https://bugs.webkit.org/show_bug.cgi?id=220370</a> should no longer be
needed, as installsrc is project (not target) based, and we no longer
pass an XCODE_TARGET selection flag.

* Makefile.shared:

Canonical link: <a href="https://commits.webkit.org/252050@main">https://commits.webkit.org/252050@main</a>
</pre>
