### PR TITLE
[libpas] pas_utils.c fails to build due to missing parameter names in pas_crash_with_info_impl()

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -147,7 +147,9 @@ PAS_NEVER_INLINE PAS_NO_RETURN static void pas_crash_with_info_impl(uint64_t rea
 
 #else
 
-PAS_NEVER_INLINE PAS_NO_RETURN static void pas_crash_with_info_impl(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { __builtin_trap(); }
+PAS_IGNORE_WARNINGS_BEGIN("unused-parameter")
+PAS_NEVER_INLINE PAS_NO_RETURN static void pas_crash_with_info_impl(uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6) { __builtin_trap(); }
+PAS_IGNORE_WARNINGS_END
 
 #endif
 


### PR DESCRIPTION
#### ff4150d0f6d4e30e8d7e9eb37ad1de15686ee018
<pre>
[libpas] pas_utils.c fails to build due to missing parameter names in pas_crash_with_info_impl()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242090">https://bugs.webkit.org/show_bug.cgi?id=242090</a>

Reviewed by Yusuke Suzuki.

* Source/bmalloc/libpas/src/libpas/pas_utils.c:
(pas_crash_with_info_impl): Add missing parameter names, and use
PAS_IGNORE_WARNINGS_{BEGIN,END} to avoid compiler warnings about
unused variables.

Canonical link: <a href="https://commits.webkit.org/251986@main">https://commits.webkit.org/251986@main</a>
</pre>
