### PR TITLE
[Alternate WebM Player] Register SourceBufferParserWebM Logger

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -77,6 +77,7 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     , m_videoLayerManager(makeUnique<VideoLayerManagerObjC>(m_logger, m_logIdentifier))
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    m_parser->setLogger(m_logger, m_logIdentifier);
 }
 
 MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()


### PR DESCRIPTION
#### fb5a266378ffa6a304898120fe187569329d46fe
<pre>
[Alternate WebM Player] Register SourceBufferParserWebM Logger
<a href="https://bugs.webkit.org/show_bug.cgi?id=242093">https://bugs.webkit.org/show_bug.cgi?id=242093</a>

Reviewed by Jer Noble.

The SourceBufferParserWebM requires its logger to be set after it&apos;s instantiated.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):

Canonical link: <a href="https://commits.webkit.org/251937@main">https://commits.webkit.org/251937@main</a>
</pre>
