### PR TITLE
Don't allow Flush/PhantomLocal to be the head variable in a block in ThreadedCPS

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
@@ -273,8 +273,9 @@ private:
         }
         
         variable->setIsLoadedFrom(true);
-        node->children.setChild1(Edge(addPhi<operandKind>(node->origin, variable, idx)));
-        m_block->variablesAtHead.atFor<operandKind>(idx) = node;
+        Node* phi = addPhi<operandKind>(node->origin, variable, idx);
+        node->children.setChild1(Edge(phi));
+        m_block->variablesAtHead.atFor<operandKind>(idx) = phi;
         m_block->variablesAtTail.atFor<operandKind>(idx) = node;
     }
 
@@ -325,7 +326,7 @@ private:
             // The rules for threaded CPS form:
             // 
             // Head variable: describes what is live at the head of the basic block.
-            // Head variable links may refer to Flush, PhantomLocal, Phi, or SetArgumentDefinitely/SetArgumentMaybe.
+            // Head variable links may refer to Phi or SetArgumentDefinitely/SetArgumentMaybe.
             // SetArgumentDefinitely/SetArgumentMaybe may only appear in the root block.
             //
             // Tail variable: the last thing that happened to the variable in the block.

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -530,7 +530,11 @@ void Graph::dumpBlockHeader(PrintStream& out, const char* prefixStr, BasicBlock*
             ASSERT(phiNode->op() == Phi);
             if (!phiNode->shouldGenerate() && phiNodeDumpMode == DumpLivePhisOnly)
                 continue;
-            out.print(" D@", phiNode->index(), "<", phiNode->operand(), ",", phiNode->refCount(), ">->(");
+
+            out.print(" D@", phiNode->index(), "<", phiNode->operand(), ",", phiNode->refCount());
+            if (toCString(NodeFlagsDump(phiNode->flags())) != "<empty>")
+                out.print(", ", NodeFlagsDump(phiNode->flags()));
+            out.print(">->(");
             if (phiNode->child1()) {
                 out.print("D@", phiNode->child1()->index());
                 if (phiNode->child2()) {


### PR DESCRIPTION
#### 8b320548f9227eebbffd777122c377f56f9f7daa
<pre>
Don&apos;t allow Flush/PhantomLocal to be the head variable in a block in ThreadedCPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=242096">https://bugs.webkit.org/show_bug.cgi?id=242096</a>

Reviewed by Yusuke Suzuki.

Before this patch, we would allow Flush/PhantomLocal to be the node inside the variableAtHead Operands
in a basic block. However, this causes some issues inside of our CFG simplifcations phase.
CFG simplification will look at the variables at the head of the basic blocks that it&apos;s going to
remove to indicate how we should preserve liveness in its predecessor. We would then preserve
liveness using a Flush if the variableAtHead was Flushed, otherwise, we would use a PhantomLocal.

However, the variable at the head might be a PhantomLocal, and it might be a PhantomLocal
over a variable that&apos;s Flushed. However, in our IsFlushed analysis, we never mark
PhantomLocals as IsFlushed, we only mark value producing nodes, Flush, or Phis.
We do this by traversing the Phi data flow graph to propagate IsFlushed. And a Phi
can never transitively point to a PhantomLocal, so it will never indicate if a
variable is flushed.

To fix this, we just make the variableAtHead contain a Phi instead of
a Flush/PhantomLocal in the situation where it used to be a Flush/PhantomLocal.
This Phi is what the Flush/PhantomLocal used to point to. And the compiler is
already prepared for variableAtHead to point to a Phi since that&apos;s
what happens for GetLocal. GetLocal will point to a Phi that&apos;s inside
variableAtHead. And now what&apos;s pointed to by variableAtHead will
properly indicate if the variable is flushed since it&apos;ll be a Phi or a
SetArgument node.

* Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp:
(JSC::DFG::CPSRethreadingPhase::canonicalizeFlushOrPhantomLocalFor):
(JSC::DFG::CPSRethreadingPhase::canonicalizeLocalsInBlock):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dumpBlockHeader):

Canonical link: <a href="https://commits.webkit.org/252192@main">https://commits.webkit.org/252192@main</a>
</pre>
