### PR TITLE
[GPU Process] Vertical text is incorrectly displaced

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2206,8 +2206,6 @@ model-element/model-element-interactive.html [ Skip ]
 
 webkit.org/b/237358 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-005.html [ Failure ]
 
-webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-writing-modes/full-width-003.html [ Pass ]
-
 webkit.org/b/233621 http/tests/webgpu [ Skip ]
 
 webkit.org/b/237849 imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-003.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### d6a26214265522f7390962f6f4e88d9ba368f46d
<pre>
[GPU Process] Vertical text is incorrectly displaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=239484">https://bugs.webkit.org/show_bug.cgi?id=239484</a>
&lt;rdar://91187123&gt;

Reviewed by Said Abou-Hallawa and Darin Adler.

Implement computeVerticalAdvancesFromPositions() as the mathematical inverse of
fillVectorWithVerticalGlyphPositions().

Covered by existing tests (with the GPU process enabled).
imported/w3c/web-platform-tests/css/css-writing-modes/full-width-003.html has always
failed, but it was reported as passing because it&apos;s an -expected-mismatch test and
there was floating point precision differences. This patch correctly marks the test
as failing.

* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::computeHorizontalAdvancesFromPositions):
(WebCore::computeVerticalAdvancesFromPositions):
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
(WebCore::computeAdvancesFromPositions): Deleted.
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::computeBaseOverallTextMatrix):
(WebCore::computeBaseVerticalTextMatrix):
(WebCore::fillVectorWithVerticalGlyphPositions):

Canonical link: <a href="https://commits.webkit.org/251981@main">https://commits.webkit.org/251981@main</a>
</pre>
