### PR TITLE
[Gardening]: REGRESSION (251244@main): [ iOS ] TestWebKitAPI.HSTS.Preconnect is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/HSTS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/HSTS.mm
@@ -140,7 +140,8 @@ TEST(HSTS, CrossOriginRedirect)
     EXPECT_EQ(httpServer.totalRequests(), 1u);
 }
 
-TEST(HSTS, Preconnect)
+// FIXME: Re-enable after webkit.org/b/242017 is resolved
+TEST(HSTS, DISABLED_Preconnect)
 {
     bool firstConnectionTerminated { false };
     bool secondConnectionReceived { false };


### PR DESCRIPTION
#### 3a8b3ba34d64ecbb737ee6c4b0a7fd86c0147452
<pre>
[Gardening]: REGRESSION (251244@main): [ iOS ] TestWebKitAPI.HSTS.Preconnect is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242017">https://bugs.webkit.org/show_bug.cgi?id=242017</a>
&lt;rdar://95937659&gt;

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/HSTS.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251946@main">https://commits.webkit.org/251946@main</a>
</pre>
