### PR TITLE
[GLib] Add a websetting gating WebRTC support

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitSettings.h
@@ -515,6 +515,13 @@ WEBKIT_API void
 webkit_settings_set_media_content_types_requiring_hardware_support (WebKitSettings *settings,
                                                                     const gchar *content_types);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_webrtc                              (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_webrtc                              (WebKitSettings *settings,
+                                                                gboolean enabled);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitSettings.h
@@ -472,6 +472,13 @@ WEBKIT_API void
 webkit_settings_set_media_content_types_requiring_hardware_support (WebKitSettings *settings,
                                                                     const gchar *content_types);
 
+WEBKIT_API gboolean
+webkit_settings_get_enable_webrtc                              (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_enable_webrtc                              (WebKitSettings *settings,
+                                                                gboolean enabled);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -281,6 +281,11 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_enable_media_stream(settings, FALSE);
     g_assert_false(webkit_settings_get_enable_media_stream(settings));
 
+    // By default, WebRTC is disabled
+    g_assert_false(webkit_settings_get_enable_webrtc(settings));
+    webkit_settings_set_enable_webrtc(settings, TRUE);
+    g_assert_true(webkit_settings_get_enable_webrtc(settings));
+
     // By default, SpatialNavigation is disabled
     g_assert_false(webkit_settings_get_enable_spatial_navigation(settings));
     webkit_settings_set_enable_spatial_navigation(settings, TRUE);


### PR DESCRIPTION
#### feef4553836dd7f7126823f41a21d60c0f9481b3
<pre>
[GLib] Add a websetting gating WebRTC support
<a href="https://bugs.webkit.org/show_bug.cgi?id=242103">https://bugs.webkit.org/show_bug.cgi?id=242103</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

WebRTC support in WPE and GTK ports is now opt-in through the enable-webrtc web-setting.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsConstructed):
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
(webkit_settings_set_enable_media_stream):
(webkit_settings_get_enable_webrtc):
(webkit_settings_set_enable_webrtc):
* Source/WebKit/UIProcess/API/gtk/WebKitSettings.h:
* Source/WebKit/UIProcess/API/wpe/WebKitSettings.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Canonical link: <a href="https://commits.webkit.org/251951@main">https://commits.webkit.org/251951@main</a>
</pre>
