### PR TITLE
Revert "[Gardening]: REGRESSION (250044@main?): [ Monterey Debug wk2 ] webgl/1.0.3/conformance/attribs/gl-vertexattribpointer-offsets.html is an almost consistent timeout"

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1706,8 +1706,6 @@ webkit.org/b/240927 [ BigSur Debug ] storage/indexeddb/request-with-null-open-db
 webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Pass Failure ]
 webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Pass Failure ]
 
-webkit.org/b/241191 [ Monterey Debug ] webgl/1.0.3/conformance/attribs/gl-vertexattribpointer-offsets.html [ Pass Timeout ]
-
 webkit.org/b/241265 [ Debug ] imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html [ Pass Crash ]
 
 webkit.org/b/241283 fast/animation/request-animation-frame-throttling-detached-iframe.html [ Pass Failure ]


### PR DESCRIPTION
#### cdfaa09d52b4459bf6f8e31a957eaa42ae152f52
<pre>
Revert &quot;[Gardening]: REGRESSION (250044@main?): [ Monterey Debug wk2 ] webgl/1.0.3/conformance/attribs/gl-vertexattribpointer-offsets.html is an almost consistent timeout&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=241191">https://bugs.webkit.org/show_bug.cgi?id=241191</a>

Reviewed by Jonathan Bedard and Myles C. Maxfield.

All tests timeout when:
- run-webkit-tests selects large core count on x86_64
- the binaries have not been run ever before
- the test runs for more than 5 seconds

This is due to the system verification processes that verify binaries
if they have not been verified before.

This is a spurious failure that is not solved by adding a timeout expectation
to a single WebGL test. Bug 242106 tracks the underlying reason.

* LayoutTests/platform/mac-wk2/TestExpectations:
Remove the timeout expectation.

Canonical link: <a href="https://commits.webkit.org/252025@main">https://commits.webkit.org/252025@main</a>
</pre>
