### PR TITLE
run-webkit-tests with many child processes timeout for initial invocation

### DIFF
--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -40,6 +40,7 @@ from webkitpy.common.version_name_map import VersionNameMap
 from webkitpy.port.base import Port
 from webkitpy.port.config import apple_additions, Config
 from webkitpy.port.darwin import DarwinPort
+from webkitpy.port.driver import DriverInput
 
 _log = logging.getLogger(__name__)
 
@@ -328,6 +329,12 @@ class MacPort(DarwinPort):
                 configuration['model'] = match.group('model')
 
         return configuration
+
+    def setup_test_run(self, device_type=None):
+        super(MacPort, self).setup_test_run(device_type)
+        _log.debug('Warming up the runner ...')
+        warmup_driver = self.create_driver(0)
+        warmup_driver.run_test(DriverInput('file:///warmup-does-not-exist', 60000., None, should_run_pixel_test=False), stop_when_done=True)
 
 
 class MacCatalystPort(MacPort):

--- a/Tools/Scripts/webkitpy/port/server_process_mock.py
+++ b/Tools/Scripts/webkitpy/port/server_process_mock.py
@@ -30,9 +30,12 @@ from webkitcorepy import string_utils
 
 
 class MockServerProcess(object):
-    def __init__(self, port_obj=None, name=None, cmd=None, env=None, universal_newlines=False, lines=None, crashed=False, target_host=None, crash_message=None):
+    _next_pid = 77
+
+    def __init__(self, port_obj=None, name=None, cmd=None, env=None, universal_newlines=False, lines=None, crashed=False, target_host=None, crash_message=None, err_lines=None):
         self.timed_out = False
         self.lines = [string_utils.encode(line) for line in (lines or [])]
+        self.err_lines = [string_utils.encode(line) for line in (err_lines or [])]
         self.crashed = crashed
         self.writes = []
         self.cmd = cmd
@@ -56,38 +59,56 @@ class MockServerProcess(object):
             return None
         return self.lines.pop(0) + b'\n'
 
+    def read_stderr_line(self, deadline):
+        if self.has_crashed():
+            return None
+        return self.err_lines.pop(0) + b'\n'
+
     def has_available_stdout(self):
         if self.has_crashed():
             return False
         return bool(self.lines)
 
-    def read_stdout(self, deadline, size):
+    def _read_impl(self, deadline, size, lines):
         if self.has_crashed():
             return None
-        first_line = self.lines[0]
+        first_line = lines[0]
         if size > len(first_line):
-            self.lines.pop(0)
+            lines.pop(0)
             remaining_size = size - len(first_line) - 1
             if not remaining_size:
                 return first_line + b'\n'
-            return first_line + b'\n' + self.read_stdout(deadline, remaining_size)
-        result = self.lines[0][:size]
-        self.lines[0] = self.lines[0][size:]
+            return first_line + b'\n' + self._read_impl(deadline, remaining_size, lines)
+        result = lines[0][:size]
+        lines[0] = lines[0][size:]
         return result
+
+    def read_stdout(self, deadline, size):
+        return self._read_impl(deadline, size, self.lines)
+
+    def read_stderr(self, deadline, size):
+        return self._read_impl(deadline, size, self.err_lines)
 
     def pop_all_buffered_stderr(self):
         return ''
 
     def read_either_stdout_or_stderr_line(self, deadline):
-        # FIXME: We should have tests which intermix stderr and stdout lines.
-        return self.read_stdout_line(deadline), None
+        result = self.read_stdout_line(deadline)
+        if result:
+            return result, None
+        return None, self.read_stderr_line(deadline)
 
     def start(self):
         self.started = True
+        self._pid = MockServerProcess._next_pid
+        MockServerProcess._next_pid += 1
 
     def stop(self, kill_directly=False):
         self.stopped = True
-        return
+        return (None, None)
 
     def kill(self):
         return
+
+    def pid(self):
+        return self._pid


### PR DESCRIPTION
#### 8c0aacc3b0078c0f94aa7cee9efee4f386af6a2b
<pre>
run-webkit-tests with many child processes timeout for initial invocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242106">https://bugs.webkit.org/show_bug.cgi?id=242106</a>

Reviewed by Jonathan Bedard.

Add a warmup invocation of WebKitTestRunner. This will force the
operating system to cache in the binaries used by the process. This
ensures that the platforms which run lenghty verification procedures
are able to run the tests consistently.

This fixes the case on macOS where the intial batch of tests would
timeout on initial invocation of run-webkit-tests if the --child-processes
would be high enough. For example certain iMac Pro and MacBook models
would experience timeouts because high number of cores would use
high number of child processes, and this would cause the first-time
binary verification run many times in parallel, trashing the system
and causing timeout. For MacBook, the initial warm-up in this scenario
takes 25s and subsequent warm-ups &lt;1s.

This also ensures that the timing calculations are not skewed that much
by the position in which the test is run.

* Tools/Scripts/webkitpy/port/mac.py:
(MacPort.setup_test_run):
Tools/Scripts/webkitpy/port/server_process_mock.py:

Canonical link: <a href="https://commits.webkit.org/252037@main">https://commits.webkit.org/252037@main</a>
</pre>
