### PR TITLE
Parse and add experimental flag for content-visibility

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -103,6 +103,7 @@ PASS contain-intrinsic-width
 PASS container-name
 PASS container-type
 PASS content
+PASS content-visibility
 PASS counter-increment
 PASS counter-reset
 PASS cursor

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-026-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-026-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL content-visibility:hidden does not affect computed value of 'contain' assert_equals: expected (string) "hidden" but got (undefined) undefined
-FAIL content-visibility:auto does not affect computed value of 'contain' assert_equals: expected (string) "auto" but got (undefined) undefined
+PASS content-visibility:hidden does not affect computed value of 'contain'
+PASS content-visibility:auto does not affect computed value of 'contain'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Content-visibility is not animatable assert_equals: expected (string) "visible" but got (undefined) undefined
+PASS Content-visibility is not animatable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/inheritance-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Property content-visibility has initial value visible assert_true: content-visibility doesn't seem to be supported in the computed style expected true got false
-FAIL Property content-visibility does not inherit assert_true: expected true got false
+PASS Property content-visibility has initial value visible
+PASS Property content-visibility does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property content-visibility value 'visible' assert_true: content-visibility doesn't seem to be supported in the computed style expected true got false
-FAIL Property content-visibility value 'auto' assert_true: content-visibility doesn't seem to be supported in the computed style expected true got false
-FAIL Property content-visibility value 'hidden' assert_true: content-visibility doesn't seem to be supported in the computed style expected true got false
+PASS Property content-visibility value 'visible'
+PASS Property content-visibility value 'auto'
+PASS Property content-visibility value 'hidden'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-valid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['content-visibility'] = "visible" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['content-visibility'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['content-visibility'] = "hidden" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['content-visibility'] = "visible" should set the property value
+PASS e.style['content-visibility'] = "auto" should set the property value
+PASS e.style['content-visibility'] = "hidden" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 392
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 392
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 392
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 393
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-ua-stylesheet-expected.txt
@@ -1,10 +1,10 @@
 
 PASS hidden-ua-stylesheet
-FAIL div.removeAttribute('hidden') assert_equals: div.removeAttribute('hidden') should not affect the div's content-visibility property. expected (string) "visible" but got (undefined) undefined
-FAIL div.setAttribute('hidden', '') assert_equals: div.setAttribute('hidden', '') should not affect the div's content-visibility property. expected (string) "visible" but got (undefined) undefined
-FAIL div.setAttribute('hidden', 'asdf') assert_equals: div.setAttribute('hidden', 'asdf') should not affect the div's content-visibility property. expected (string) "visible" but got (undefined) undefined
+PASS div.removeAttribute('hidden')
+PASS div.setAttribute('hidden', '')
+PASS div.setAttribute('hidden', 'asdf')
 FAIL div.setAttribute('hidden', 'until-found') assert_equals: div.setAttribute('hidden', 'until-found') should not affect the div's display property. expected "block" but got "none"
 FAIL div.setAttribute('hidden', 'UNTIL-FOUND') assert_equals: div.setAttribute('hidden', 'UNTIL-FOUND') should not affect the div's display property. expected "block" but got "none"
 FAIL div.setAttribute('hidden', 'UnTiL-FoUnD') assert_equals: div.setAttribute('hidden', 'UnTiL-FoUnD') should not affect the div's display property. expected "block" but got "none"
-FAIL div.setAttribute('hidden', '0') assert_equals: div.setAttribute('hidden', '0') should not affect the div's content-visibility property. expected (string) "visible" but got (undefined) undefined
+PASS div.setAttribute('hidden', '0')
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -103,6 +103,7 @@ PASS contain-intrinsic-width
 PASS container-name
 PASS container-type
 PASS content
+PASS content-visibility
 PASS counter-increment
 PASS counter-reset
 PASS cursor

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 391
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 392
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -103,6 +103,7 @@ PASS contain-intrinsic-width
 PASS container-name
 PASS container-type
 PASS content
+PASS content-visibility
 PASS counter-increment
 PASS counter-reset
 PASS cursor

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 395
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 395
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 395
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 395
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -103,6 +103,7 @@ PASS contain-intrinsic-width
 PASS container-name
 PASS container-type
 PASS content
+PASS content-visibility
 PASS counter-increment
 PASS counter-reset
 PASS cursor

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -103,6 +103,7 @@ PASS contain-intrinsic-width
 PASS container-name
 PASS container-type
 PASS content
+PASS content-visibility
 PASS counter-increment
 PASS counter-reset
 PASS cursor

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -272,6 +272,18 @@ CSSContainmentEnabled:
     WebCore:
       default: true
 
+CSSContentVisibilityEnabled:
+  type: bool
+  humanReadableName: "CSS Content Visibility"
+  humanReadableDescription: "Enable CSS content-visibility"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSCounterStyleAtRuleImageSymbolsEnabled:
   type: bool
   humanReadableName: "CSS @counter-style <image> symbols"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3495,6 +3495,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyContainer:
         case CSSPropertyContainerName:
         case CSSPropertyContainerType:
+        case CSSPropertyContentVisibility:
         case CSSPropertyFallback:
         case CSSPropertyFlex:
         case CSSPropertyFlexFlow:

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -3793,6 +3793,14 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return valueForContainIntrinsicSize(style, style.containIntrinsicWidthType(), style.containIntrinsicWidth());
         case CSSPropertyContainIntrinsicHeight:
             return valueForContainIntrinsicSize(style, style.containIntrinsicHeightType(), style.containIntrinsicHeight());
+        case CSSPropertyContentVisibility:
+            if (!m_element->document().settings().cssContentVisibilityEnabled())
+                return nullptr;
+            if (style.contentVisibilityHidden())
+                return cssValuePool.createIdentifierValue(CSSValueHidden);
+            if (style.contentVisibility() == ContentVisibility::Auto)
+                return cssValuePool.createIdentifierValue(CSSValueAuto);
+            return cssValuePool.createIdentifierValue(CSSValueVisible);
         case CSSPropertyBackfaceVisibility:
             return cssValuePool.createIdentifierValue((style.backfaceVisibility() == BackfaceVisibility::Hidden) ? CSSValueHidden : CSSValueVisible);
         case CSSPropertyBorderImage:

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -5636,4 +5636,38 @@ template<> inline CSSPrimitiveValue::operator ContainerType() const
     return ContainerType::Normal;
 }
 
+template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ContentVisibility contentVisibility)
+    : CSSValue(PrimitiveClass)
+{
+    setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
+    switch (contentVisibility) {
+    case ContentVisibility::Visible:
+        m_value.valueID = CSSValueVisible;
+        break;
+    case ContentVisibility::Hidden:
+        m_value.valueID = CSSValueHidden;
+        break;
+    case ContentVisibility::Auto:
+        m_value.valueID = CSSValueAuto;
+        break;
+    }
+}
+
+template<> inline CSSPrimitiveValue::operator ContentVisibility() const
+{
+    ASSERT(isValueID());
+    switch (m_value.valueID) {
+    case CSSValueVisible:
+        return ContentVisibility::Visible;
+    case CSSValueHidden:
+        return ContentVisibility::Hidden;
+    case CSSValueAuto:
+        return ContentVisibility::Auto;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return ContentVisibility::Visible;
+}
+
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5390,6 +5390,23 @@
                 "url": "https://drafts.csswg.org/css-contain-3/#container-queries"
             }
         },
+        "content-visibility": {
+            "codegen-properties": {
+                "settings-flag": "cssContentVisibilityEnabled"
+            },
+            "values": [
+                "visible",
+                "hidden",
+                "auto"
+            ],
+            "status": {
+                "status": "experimental"
+            },
+            "specification": {
+                "category": "css-content-visibility",
+                "url": "https://www.w3.org/TR/css-contain-2/#content-visibility"
+            }
+        },
         "backface-visibility": {
             "codegen-properties": {
                 "aliases": [
@@ -7878,6 +7895,11 @@
             "shortname": "CSS Generated Content",
             "longname": "CSS Generated Content Module",
             "url": "https://www.w3.org/TR/css-content-3/"
+        },
+        "css-content-visibility": {
+            "shortname": "CSS Content Visibility",
+            "longname": "CSS Content Visibility Module",
+            "url": "https://www.w3.org/TR/css-contain-2/#content-visibility"
         },
         "css-counter-styles": {
             "shortname": "CSS Counter Styles",

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -68,6 +68,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , colorContrastEnabled { document.settings().cssColorContrastEnabled() }
     , colorMixEnabled { document.settings().cssColorMixEnabled() }
     , constantPropertiesEnabled { document.settings().constantPropertiesEnabled() }
+    , contentVisibilityEnabled { document.settings().cssContentVisibilityEnabled() }
     , counterStyleAtRuleImageSymbolsEnabled { document.settings().cssCounterStyleAtRuleImageSymbolsEnabled() }
     , cssColor4 { document.settings().cssColor4() }
     , relativeColorSyntaxEnabled { document.settings().cssRelativeColorSyntaxEnabled() }
@@ -100,6 +101,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.colorContrastEnabled == b.colorContrastEnabled
         && a.colorMixEnabled == b.colorMixEnabled
         && a.constantPropertiesEnabled == b.constantPropertiesEnabled
+        && a.contentVisibilityEnabled == b.contentVisibilityEnabled
         && a.counterStyleAtRuleImageSymbolsEnabled == b.counterStyleAtRuleImageSymbolsEnabled
         && a.cssColor4 == b.cssColor4
         && a.relativeColorSyntaxEnabled == b.relativeColorSyntaxEnabled
@@ -142,7 +144,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.gradientPremultipliedAlphaInterpolationEnabled << 16
         | context.gradientInterpolationColorSpacesEnabled   << 17
         | context.subgridEnabled                            << 18
-        | (uint64_t)context.mode                            << 19; // This is multiple bits, so keep it last.
+        | context.contentVisibilityEnabled                  << 19
+        | (uint64_t)context.mode                            << 20; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -58,6 +58,7 @@ struct CSSParserContext {
     bool colorContrastEnabled { false };
     bool colorMixEnabled { false };
     bool constantPropertiesEnabled { false };
+    bool contentVisibilityEnabled { false };
     bool counterStyleAtRuleImageSymbolsEnabled { false };
     bool cssColor4 { false };
     bool relativeColorSyntaxEnabled { false };

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -4137,6 +4137,13 @@ static RefPtr<CSSValue> consumeContainIntrinsicSize(CSSParserTokenRange& range)
     return list;
 }
 
+static RefPtr<CSSValue> consumeContentVisibility(CSSParserTokenRange& range)
+{
+    if (auto singleValue = consumeIdent<CSSValueVisible, CSSValueAuto, CSSValueHidden>(range))
+        return singleValue;
+    return nullptr;
+}
+
 static RefPtr<CSSValue> consumeTextEmphasisPosition(CSSParserTokenRange& range)
 {
     bool foundOverOrUnder = false;
@@ -4747,6 +4754,10 @@ RefPtr<CSSValue> CSSPropertyParser::parseSingleValue(CSSPropertyID property, CSS
         return consumeAspectRatio(m_range);
     case CSSPropertyContain:
         return consumeContain(m_range);
+    case CSSPropertyContentVisibility:
+        if (!m_context.contentVisibilityEnabled)
+            return nullptr;
+        return consumeContentVisibility(m_range);
     case CSSPropertyTextEmphasisPosition:
         return consumeTextEmphasisPosition(m_range);
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2024,6 +2024,12 @@ void RenderObject::setPaintContainmentApplies(bool paintContainmentApplies)
         ensureRareData().setPaintContainmentApplies(paintContainmentApplies);
 }
 
+void RenderObject::setLayoutContainmentApplies(bool layoutContainmentApplies)
+{
+    if (layoutContainmentApplies || hasRareData())
+        ensureRareData().setLayoutContainmentApplies(layoutContainmentApplies);
+}
+
 RenderObject::RareDataMap& RenderObject::rareDataMap()
 {
     static NeverDestroyed<RareDataMap> map;
@@ -2053,6 +2059,7 @@ RenderObject::RenderObjectRareData::RenderObjectRareData()
     , m_isRenderFragmentedFlow(false)
     , m_hasOutlineAutoAncestor(false)
     , m_paintContainmentApplies(false)
+    , m_layoutContainmentApplies(false)
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     , m_hasSVGTransform(false)
 #endif

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -431,6 +431,7 @@ public:
     bool isRenderFragmentedFlow() const { return m_bitfields.hasRareData() && rareData().isRenderFragmentedFlow(); }
     bool hasOutlineAutoAncestor() const { return m_bitfields.hasRareData() && rareData().hasOutlineAutoAncestor(); }
     bool paintContainmentApplies() const { return m_bitfields.hasRareData() && rareData().paintContainmentApplies(); }
+    bool layoutContainmentApplies() const { return m_bitfields.hasRareData() && rareData().layoutContainmentApplies(); }
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     bool hasSVGTransform() const { return m_bitfields.hasRareData() && rareData().hasSVGTransform(); }
@@ -537,6 +538,7 @@ public:
     void setIsRenderFragmentedFlow(bool = true);
     void setHasOutlineAutoAncestor(bool = true);
     void setPaintContainmentApplies(bool = true);
+    void setLayoutContainmentApplies(bool = true);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     void setHasSVGTransform(bool = true);
 #endif
@@ -975,6 +977,7 @@ private:
         ADD_BOOLEAN_BITFIELD(isRenderFragmentedFlow, IsRenderFragmentedFlow);
         ADD_BOOLEAN_BITFIELD(hasOutlineAutoAncestor, HasOutlineAutoAncestor);
         ADD_BOOLEAN_BITFIELD(paintContainmentApplies, PaintContainmentApplies);
+        ADD_BOOLEAN_BITFIELD(layoutContainmentApplies, LayoutContainmentApplies);
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         ADD_BOOLEAN_BITFIELD(hasSVGTransform, HasSVGTransform);
 #endif

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -545,6 +545,9 @@ public:
     ContainerType containerType() const { return static_cast<ContainerType>(m_rareNonInheritedData->containerType); }
     const Vector<AtomString>& containerNames() const { return m_rareNonInheritedData->containerNames; }
 
+    ContentVisibility contentVisibility() const { return static_cast<ContentVisibility>(m_rareNonInheritedData->contentVisibility); }
+    bool contentVisibilityHidden() const { return contentVisibility() == ContentVisibility::Hidden; }
+
     ContainIntrinsicSizeType containIntrinsicWidthType() const { return static_cast<ContainIntrinsicSizeType>(m_rareNonInheritedData->containIntrinsicWidthType); }
     ContainIntrinsicSizeType containIntrinsicHeightType() const { return static_cast<ContainIntrinsicSizeType>(m_rareNonInheritedData->containIntrinsicHeightType); }
     std::optional<Length> containIntrinsicWidth() const { return m_rareNonInheritedData->containIntrinsicWidth; }
@@ -1106,6 +1109,8 @@ public:
     void setContainIntrinsicHeightType(ContainIntrinsicSizeType containIntrinsicHeightType) { SET_VAR(m_rareNonInheritedData, containIntrinsicHeightType, static_cast<unsigned>(containIntrinsicHeightType)); }
     void setContainIntrinsicWidth(std::optional<Length> width) { SET_VAR(m_rareNonInheritedData, containIntrinsicWidth, width); }
     void setContainIntrinsicHeight(std::optional<Length> height) { SET_VAR(m_rareNonInheritedData, containIntrinsicHeight, height); }
+
+    void setContentVisibility(ContentVisibility value) { SET_VAR(m_rareNonInheritedData, contentVisibility, static_cast<unsigned>(value)); }
 
     void setListStyleStringValue(const AtomString& value) { SET_VAR(m_rareInheritedData, listStyleStringValue, value); }
     void setListStyleType(ListStyleType v) { m_inheritedFlags.listStyleType = static_cast<unsigned>(v); }
@@ -1719,6 +1724,7 @@ public:
     static OptionSet<Containment> strictContainment() { return OptionSet<Containment> { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
     static OptionSet<Containment> contentContainment() { return OptionSet<Containment> { Containment::Layout, Containment::Paint, Containment::Style }; }
     static ContainerType initialContainerType() { return ContainerType::Normal; }
+    static ContentVisibility initialContentVisibility() { return ContentVisibility::Visible; }
     static Vector<AtomString> initialContainerNames() { return { }; }
     static double initialAspectRatioWidth() { return 1.0; }
     static double initialAspectRatioHeight() { return 1.0; }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1216,6 +1216,12 @@ enum class ContainIntrinsicSizeType : uint8_t {
     AutoAndLength
 };
 
+enum class ContentVisibility : uint8_t {
+    Visible,
+    Auto,
+    Hidden,
+};
+
 CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 extern const float defaultMiterLimit;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -97,6 +97,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , effectiveAppearance(static_cast<unsigned>(RenderStyle::initialAppearance()))
     , textDecorationStyle(static_cast<unsigned>(RenderStyle::initialTextDecorationStyle()))
     , aspectRatioType(static_cast<unsigned>(RenderStyle::initialAspectRatioType()))
+    , contentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
 #if ENABLE(CSS_COMPOSITING)
     , effectiveBlendMode(static_cast<unsigned>(RenderStyle::initialBlendMode()))
     , isolation(static_cast<unsigned>(RenderStyle::initialIsolation()))
@@ -206,6 +207,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , effectiveAppearance(o.effectiveAppearance)
     , textDecorationStyle(o.textDecorationStyle)
     , aspectRatioType(o.aspectRatioType)
+    , contentVisibility(o.contentVisibility)
 #if ENABLE(CSS_COMPOSITING)
     , effectiveBlendMode(o.effectiveBlendMode)
     , isolation(o.isolation)
@@ -331,6 +333,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && applePayButtonType == o.applePayButtonType
 #endif
         && aspectRatioType == o.aspectRatioType
+        && contentVisibility == o.contentVisibility
         && objectFit == o.objectFit
         && breakAfter == o.breakAfter
         && breakBefore == o.breakBefore

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -213,7 +213,8 @@ public:
 
     unsigned textDecorationStyle : 3; // TextDecorationStyle
 
-    unsigned aspectRatioType : 3;
+    unsigned aspectRatioType : 2;
+    unsigned contentVisibility : 2;
 
 #if ENABLE(CSS_COMPOSITING)
     unsigned effectiveBlendMode: 5; // EBlendMode


### PR DESCRIPTION
#### f736ee1e974429c5b1a0b3b3b480234ad77b7aa0
<pre>
Parse and add experimental flag for content-visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=236371">https://bugs.webkit.org/show_bug.cgi?id=236371</a>

Reviewed by NOBODY (OOPS!).

Parsing of the content-visibility property according to [1]. This is controlled
the experimental flag CSSContentVisibilityEnabled.

[1] <a href="https://www.w3.org/TR/css-contain-2/#content-visibility">https://www.w3.org/TR/css-contain-2/#content-visibility</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-026-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-077-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/parsing/content-visibility-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::operator ContentVisibility const):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeContentVisibility):
(WebCore::CSSPropertyParser::parseSingleValue):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setLayoutContainmentApplies):
(WebCore::RenderObject::RenderObjectRareData::RenderObjectRareData):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::layoutContainmentApplies const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::contentVisibility const):
(WebCore::RenderStyle::contentVisibilityHidden const):
(WebCore::RenderStyle::setContentVisibility):
(WebCore::RenderStyle::initialContentVisibility):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
</pre>