### PR TITLE
[GTK][WPE] Add a fallback mode for the DMABuf architecture

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -84,6 +84,8 @@ platform/graphics/egl/GLContextEGLX11.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp
+platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
+platform/graphics/gbm/GraphicsContextGLFallback.cpp
 platform/graphics/gbm/GraphicsContextGLGBM.cpp
 platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -75,6 +75,8 @@ platform/graphics/egl/GLContextEGLLibWPE.cpp
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp
+platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
+platform/graphics/gbm/GraphicsContextGLFallback.cpp
 platform/graphics/gbm/GraphicsContextGLGBM.cpp
 platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -160,6 +160,7 @@ if (USE_LIBGBM)
         platform/graphics/gbm/DMABufReleaseFlag.h
         platform/graphics/gbm/GBMBufferSwapchain.h
         platform/graphics/gbm/GBMDevice.h
+        platform/graphics/gbm/GraphicsContextGLFallback.h
         platform/graphics/gbm/GraphicsContextGLGBM.h
         platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.h
     )

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBGL) && USE(ANGLE)
+#include "GraphicsContextGLANGLE.h"
+
+#include "ANGLEHeaders.h"
+#include "GraphicsContextGLFallback.h"
+#include "GraphicsContextGLGBMTextureMapper.h"
+#include "PixelBuffer.h"
+
+namespace WebCore {
+
+RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes)
+{
+#if USE(TEXTURE_MAPPER_DMABUF)
+    auto context = GraphicsContextGLGBMTextureMapper::create(GraphicsContextGLAttributes(attributes));
+    if (context)
+        return context;
+#endif
+
+    return GraphicsContextGLFallback::create(GraphicsContextGLAttributes(attributes));
+}
+
+GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attributes)
+    : GraphicsContextGL(attributes)
+{
+}
+
+GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
+{
+    bool success = makeContextCurrent();
+    ASSERT_UNUSED(success, success);
+    if (m_texture)
+        GL_DeleteTextures(1, &m_texture);
+
+    auto attributes = contextAttributes();
+
+    if (attributes.antialias) {
+        GL_DeleteRenderbuffers(1, &m_multisampleColorBuffer);
+        if (attributes.stencil || attributes.depth)
+            GL_DeleteRenderbuffers(1, &m_multisampleDepthStencilBuffer);
+        GL_DeleteFramebuffers(1, &m_multisampleFBO);
+    } else if (attributes.stencil || attributes.depth) {
+        if (m_depthStencilBuffer)
+            GL_DeleteRenderbuffers(1, &m_depthStencilBuffer);
+    }
+    GL_DeleteFramebuffers(1, &m_fbo);
+}
+
+GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const
+{
+    return m_displayObj;
+}
+
+GCGLConfig GraphicsContextGLANGLE::platformConfig() const
+{
+    return m_configObj;
+}
+
+void GraphicsContextGLANGLE::checkGPUStatus()
+{
+}
+
+void GraphicsContextGLANGLE::platformReleaseThreadResources()
+{
+}
+
+RefPtr<PixelBuffer> GraphicsContextGLANGLE::readCompositedResults()
+{
+    return readRenderingResults();
+}
+
+bool GraphicsContextGLANGLE::makeContextCurrent()
+{
+    static thread_local TLS_MODEL_INITIAL_EXEC GraphicsContextGLANGLE* s_currentContext { nullptr };
+
+    if (s_currentContext == this)
+        return true;
+
+    bool current = !!EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, m_contextObj);
+    if (current)
+        s_currentContext = this;
+    return current;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL) && USE(ANGLE)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(ANGLE)
+
+#include "GraphicsContextGLANGLE.h"
+
+namespace Nicosia {
+class GCGLANGLELayer;
+}
+
+namespace WebCore {
+
+class TextureMapperGCGLPlatformLayer;
+
+class GraphicsContextGLFallback : public GraphicsContextGLANGLE {
+public:
+    static RefPtr<GraphicsContextGLFallback> create(WebCore::GraphicsContextGLAttributes&&);
+    virtual ~GraphicsContextGLFallback();
+
+    // GraphicsContextGLANGLE overrides.
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final;
+#if ENABLE(VIDEO)
+    bool copyTextureFromMedia(MediaPlayer&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, bool premultiplyAlpha, bool flipY) final;
+#endif
+#if ENABLE(MEDIA_STREAM)
+    RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() final;
+#endif
+
+    void setContextVisibility(bool) final;
+    bool reshapeDisplayBufferBacking() final;
+    void prepareForDisplay() final;
+
+    GCGLuint getInternalColorFormat() const { return m_internalColorFormat; }
+
+private:
+    GraphicsContextGLFallback(WebCore::GraphicsContextGLAttributes&&);
+
+    bool platformInitializeContext() final;
+    bool platformInitialize() final;
+
+    void prepareTexture() final;
+
+    std::unique_ptr<Nicosia::GCGLANGLELayer> m_nicosiaLayer;
+    RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
+
+    friend class Nicosia::GCGLANGLELayer;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL) && USE(TEXTURE_MAPPER) && USE(ANGLE)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -94,6 +94,10 @@ protected:
     GraphicsContextGLGBM(WebCore::GraphicsContextGLAttributes&&);
 
 private:
+    bool isDMABufSupportedInPlatform(const char* displayExtensions);
+
+    void allocateDrawBufferObject();
+
     EGLExtensions m_eglExtensions;
     Swapchain m_swapchain;
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
@@ -34,11 +34,6 @@
 
 namespace WebCore {
 
-RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes)
-{
-    return GraphicsContextGLGBMTextureMapper::create(GraphicsContextGLAttributes(attributes));
-}
-
 RefPtr<GraphicsContextGLGBMTextureMapper> GraphicsContextGLGBMTextureMapper::create(GraphicsContextGLAttributes&& attributes)
 {
     auto context = adoptRef(*new GraphicsContextGLGBMTextureMapper(WTFMove(attributes)));

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
@@ -31,6 +31,7 @@
 
 #if USE(NICOSIA) && USE(TEXTURE_MAPPER) && USE(LIBGBM) && USE(ANGLE)
 
+#include "GraphicsContextGLFallback.h"
 #include "GraphicsContextGLGBM.h"
 #include "ImageBuffer.h"
 #include "Logging.h"
@@ -50,11 +51,11 @@ using namespace WebCore;
 void GCGLANGLELayer::swapBuffersIfNeeded()
 {
     auto& proxy = downcast<Nicosia::ContentLayerTextureMapperImpl>(contentLayer().impl()).proxy();
-    auto size = m_context.getInternalFramebufferSize();
 
 #if USE(TEXTURE_MAPPER_DMABUF)
     if (is<TextureMapperPlatformLayerProxyDMABuf>(proxy)) {
-        auto& swapchain = m_context.swapchain();
+        RELEASE_ASSERT(m_contextType == ContextType::Gbm);
+        auto& swapchain = static_cast<GraphicsContextGLGBM&>(m_context).swapchain();
         auto bo = WTFMove(swapchain.displayBO);
         if (bo) {
             Locker locker { proxy.lock() };
@@ -73,36 +74,51 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
     }
 #endif
 
-    // Fallback path, read back texture to main memory
-    RefPtr<WebCore::ImageBuffer> imageBuffer = ImageBuffer::create(size, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    if (!imageBuffer)
-        return;
-    m_context.paintRenderingResultsToCanvas(*imageBuffer.get());
-
-    auto flags = m_context.contextAttributes().alpha ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag;
     {
-        Locker locker { proxy.lock() };
+        // Fallback path, read back texture to main memory
         ASSERT(is<TextureMapperPlatformLayerProxyGL>(proxy));
-        std::unique_ptr<TextureMapperPlatformLayerBuffer> layerBuffer = downcast<TextureMapperPlatformLayerProxyGL>(proxy).getAvailableBuffer(size, m_context.m_internalColorFormat);
-        if (!layerBuffer) {
-            auto texture = BitmapTextureGL::create(TextureMapperContextAttributes::get(), flags, m_context.m_internalColorFormat);
-            layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture), flags);
-        }
+        RELEASE_ASSERT(m_contextType == ContextType::Fallback);
 
-        layerBuffer->textureGL().setPendingContents(ImageBuffer::sinkIntoImage(WTFMove(imageBuffer)));
-        downcast<TextureMapperPlatformLayerProxyGL>(proxy).pushNextBuffer(WTFMove(layerBuffer));
+        auto& context = static_cast<GraphicsContextGLFallback&>(m_context);
+        auto size = context.getInternalFramebufferSize();
+        RefPtr<WebCore::ImageBuffer> imageBuffer = ImageBuffer::create(size, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+        if (!imageBuffer)
+            return;
+
+        context.paintRenderingResultsToCanvas(*imageBuffer.get());
+
+        auto flags = context.contextAttributes().alpha ? BitmapTexture::SupportsAlpha : BitmapTexture::NoFlag;
+        auto proxyOperation = [&proxy, size, flags, imageBuffer = WTFMove(imageBuffer)] () mutable {
+
+            Locker locker { proxy.lock() };
+            if (!proxy.isActive())
+                return;
+
+            std::unique_ptr<TextureMapperPlatformLayerBuffer> layerBuffer = downcast<TextureMapperPlatformLayerProxyGL>(proxy).getAvailableBuffer(size, GL_DONT_CARE);
+            if (!layerBuffer) {
+                auto texture = BitmapTextureGL::create(TextureMapperContextAttributes::get(), flags, GL_DONT_CARE);
+                layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(WTFMove(texture), flags);
+            }
+
+            layerBuffer->textureGL().setPendingContents(ImageBuffer::sinkIntoImage(WTFMove(imageBuffer)));
+            downcast<TextureMapperPlatformLayerProxyGL>(proxy).pushNextBuffer(WTFMove(layerBuffer));
+        };
+
+        downcast<TextureMapperPlatformLayerProxyGL>(proxy).scheduleUpdateOnCompositorThread([proxyOperation] () mutable { proxyOperation(); });
     }
 }
 
-#if USE(TEXTURE_MAPPER_DMABUF)
-using PlatformLayerProxyType = TextureMapperPlatformLayerProxyDMABuf;
-#else
-using PlatformLayerProxyType = TextureMapperPlatformLayerProxyGL;
-#endif
+GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLFallback& context)
+    : m_contextType(ContextType::Fallback)
+    , m_context(context)
+    , m_contentLayer(Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this, adoptRef(*new TextureMapperPlatformLayerProxyGL))))
+{
+}
 
 GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLGBM& context)
-    : m_context(context)
-    , m_contentLayer(Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this, adoptRef(*new PlatformLayerProxyType))))
+    : m_contextType(ContextType::Gbm)
+    , m_context(context)
+    , m_contentLayer(Nicosia::ContentLayer::create(Nicosia::ContentLayerTextureMapperImpl::createFactory(*this, adoptRef(*new TextureMapperPlatformLayerProxyDMABuf))))
 {
 }
 

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h
@@ -39,6 +39,8 @@ typedef void *EGLSurface;
 
 namespace WebCore {
 class IntSize;
+class GraphicsContextGLANGLE;
+class GraphicsContextGLFallback;
 class GraphicsContextGLGBM;
 class PlatformDisplay;
 }
@@ -48,6 +50,7 @@ namespace Nicosia {
 class GCGLANGLELayer final : public ContentLayerTextureMapperImpl::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    GCGLANGLELayer(WebCore::GraphicsContextGLFallback&);
     GCGLANGLELayer(WebCore::GraphicsContextGLGBM&);
     virtual ~GCGLANGLELayer();
 
@@ -55,7 +58,13 @@ public:
     void swapBuffersIfNeeded() final;
 
 private:
-    WebCore::GraphicsContextGLGBM& m_context;
+    enum class ContextType {
+        Fallback,
+        Gbm,
+    };
+    ContextType m_contextType;
+
+    WebCore::GraphicsContextGLANGLE& m_context;
     Ref<ContentLayer> m_contentLayer;
 };
 


### PR DESCRIPTION
#### 7a3669210b66dee7b16f591ded098bb6424870b5
<pre>
[GTK][WPE] Add a fallback mode for the DMABuf architecture
<a href="https://bugs.webkit.org/show_bug.cgi?id=242108">https://bugs.webkit.org/show_bug.cgi?id=242108</a>

Reviewed by Žan Doberšek.

Adding a new fallback mode for the DMABuf architecture in Linux, for the
situations where DMABuf technology is not an option. This implementation
detects if DMABuf technology is supported and creates a GraphicsContextGLGBM
or a GraphicsContextGLFallback class accordingly. The selection of the
graphics context is implemented in createWebProcessGraphicsContextGL
function.

This change fixes the layout tests for the gtk port, because now it
detects the backend does not support DMABuf and uses the fallback
graphics context. This fallback context is slower because it copies the
memory to send it to the compositor thread but it is good enough for
testing situations.

* Source/WebCore/SourcesGTK.txt: Add the new GraphicsContextGLFallback
  and GraphicsContextGLANGLELinux classes.
* Source/WebCore/SourcesWPE.txt: Ditto.
* Source/WebCore/platform/TextureMapper.cmake: Added the
  GraphicsContextGLFallback header file.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp:
  Added with the implementations of the GraphicsContextGLANGLE class
  shared by the linux graphics contexts.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp:
  Copied from Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.h:
  Copied from Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp: Moved
  the implementation of the GraphicsContextGLANGLE functions to
  GraphicsContextGLANGLELinux.cpp.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp:
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp:
(Nicosia::GCGLANGLELayer::swapBuffersIfNeeded): Reworked the
implementation of the fallback mode, we need to execute part of the code
in a lambda to make it run in the composition thread.
(Nicosia::GCGLANGLELayer::GCGLANGLELayer): Choose the implementation of
the graphics context we are going to  use.
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.h:

Canonical link: <a href="https://commits.webkit.org/252208@main">https://commits.webkit.org/252208@main</a>
</pre>
