### PR TITLE
[git-webkit] Consider origin when determing branch

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.3',
+    version='5.2.4',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 3)
+version = Version(5, 2, 4)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -390,7 +390,7 @@ nothing to commit, working tree clean
                     )
                 ) if self.find(args[4]) else mocks.ProcessCompletion(returncode=128),
             ), mocks.Subprocess.Route(
-                self.executable, 'branch', '--contains', re.compile(r'.+'),
+                self.executable, 'branch', '--contains', re.compile(r'.+'), '-a',
                 cwd=self.path,
                 generator=lambda *args, **kwargs: mocks.ProcessCompletion(
                     returncode=0,


### PR DESCRIPTION
#### e316c781f551ee683c9291831a844a266740a9f1
<pre>
[git-webkit] Consider origin when determing branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=242094">https://bugs.webkit.org/show_bug.cgi?id=242094</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump versin.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.Cache.populate): Query origin/main and main.
(Git.__init__): Define a default remote.
(Git.default_branch): Use default remote instead of &apos;origin&apos;.
(Git.url): Ditto.
(Git.branches_for): Consider remote branches.
(Git.commit): Consider origin branches.
(Git.fetch): Use default remote instead of &apos;origin&apos;.
(Git.pull): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:

Canonical link: <a href="https://commits.webkit.org/252057@main">https://commits.webkit.org/252057@main</a>
</pre>
