### PR TITLE
Make code look safer in ScriptBufferSourceProvider::source()

### DIFF
--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -62,12 +62,12 @@ public:
         if (!m_contiguousBuffer && (!m_containsOnlyASCII || *m_containsOnlyASCII))
             m_contiguousBuffer = m_scriptBuffer.buffer()->makeContiguous();
         if (!m_containsOnlyASCII) {
-            m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->data(), m_scriptBuffer.buffer()->size());
+            m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->data(), m_contiguousBuffer->size());
             if (*m_containsOnlyASCII)
-                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->data(), m_scriptBuffer.buffer()->size());
+                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->data(), m_contiguousBuffer->size());
         }
         if (*m_containsOnlyASCII)
-            return { m_contiguousBuffer->data(), static_cast<unsigned>(m_scriptBuffer.buffer()->size()) };
+            return { m_contiguousBuffer->data(), static_cast<unsigned>(m_contiguousBuffer->size()) };
 
         if (!m_cachedScriptString) {
             m_cachedScriptString = m_scriptBuffer.toString();


### PR DESCRIPTION
#### fcd1d36de2ca84f2d8736165fbc08cd6251f9578
<pre>
Make code look safer in ScriptBufferSourceProvider::source()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242116">https://bugs.webkit.org/show_bug.cgi?id=242116</a>

Reviewed by Alex Christensen.

Get data and size from the same buffer to make the code look safer.
In theory, both buffers should have the same size anyway but there is
no reason to make the code look so unsafe.

* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:

Canonical link: <a href="https://commits.webkit.org/252019@main">https://commits.webkit.org/252019@main</a>
</pre>
