### PR TITLE
Make sure we protect |this| in the lambda in WebPermissionController::tryProcessingRequests()

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -105,7 +105,8 @@ void WebPermissionController::tryProcessingRequests()
 
         currentRequest.isWaitingForReply = true;
         m_page->sendWithAsyncReply(Messages::WebPageProxy::QueryPermission(currentRequest.origin, currentRequest.descriptor), [this, weakThis = WeakPtr { *this }](auto state, bool shouldCache) {
-            if (!weakThis)
+            RefPtr protectedThis { weakThis.get() };
+            if (!protectedThis)
                 return;
 
             auto takenRequest = m_requests.takeFirst();


### PR DESCRIPTION
#### 5f8ea992f3a89c913217a13f39b051d957eedf4b
<pre>
Make sure we protect |this| in the lambda in WebPermissionController::tryProcessingRequests()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242120">https://bugs.webkit.org/show_bug.cgi?id=242120</a>

Reviewed by Sihui Liu.

Make sure we convert the WeakPtr into a RefPtr inside the lambda to guarantee
that |this| stays alive through the entire execution of the lambda. Some of
the code being called during the lambda looks like it might be able to cause
|this| to get destroyed otherwise.

* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::tryProcessingRequests):

Canonical link: <a href="https://commits.webkit.org/251957@main">https://commits.webkit.org/251957@main</a>
</pre>
