### PR TITLE
[JSC] Remove unused type StackVisitor::Status

### DIFF
--- a/Source/JavaScriptCore/interpreter/StackVisitor.h
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.h
@@ -131,13 +131,8 @@ public:
         friend class StackVisitor;
     };
 
-    enum Status {
-        Continue = 0,
-        Done = 1
-    };
-
     // StackVisitor::visit() expects a Functor that implements the following method:
-    //     Status operator()(StackVisitor&) const;
+    //     IterationStatus operator()(StackVisitor&) const;
 
     enum EmptyEntryFrameAction {
         ContinueIfTopEntryFrameIsEmpty,


### PR DESCRIPTION
#### 330a922ec379abe32be6465f794aba4f7df6dae3
<pre>
[JSC] Remove unused type StackVisitor::Status
<a href="https://bugs.webkit.org/show_bug.cgi?id=242117">https://bugs.webkit.org/show_bug.cgi?id=242117</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/interpreter/StackVisitor.h:

Canonical link: <a href="https://commits.webkit.org/251956@main">https://commits.webkit.org/251956@main</a>
</pre>
