### PR TITLE
[macOS] Allow access to Power log daemon when Task mode query is not present in the macOS version

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -658,7 +658,9 @@
 
 (allow mach-lookup
     (require-all
+#if HAVE(POWERLOG_TASK_MODE_QUERY)
         (extension "com.apple.webkit.extension.mach")
+#endif
         (global-name "com.apple.powerlog.plxpclogger.xpc")))
 
 (with-filter (system-attribute apple-internal)


### PR DESCRIPTION
#### 6e80af06265b17cd59e5fee73eefc1e9fde9cb7d
<pre>
[macOS] Allow access to Power log daemon when Task mode query is not present in the macOS version
<a href="https://bugs.webkit.org/show_bug.cgi?id=242126">https://bugs.webkit.org/show_bug.cgi?id=242126</a>
&lt;rdar://96154445&gt;

Reviewed by Chris Dumez.

Allow access to Power log daemon in the GPU process when HAVE(POWERLOG_TASK_MODE_QUERY) = 0.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/251958@main">https://commits.webkit.org/251958@main</a>
</pre>
