### PR TITLE
Adding iframe flushes microtasks synchronously with dirty stack

### DIFF
--- a/LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint-expected.txt
+++ b/LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint-expected.txt
@@ -1,0 +1,34 @@
+This tests inserting an empty iframe after scheduling a microtask.
+WebKit should not perform a microtask checkpoint.
+
+
+empty
+begin inserting iframe
+load event
+end inserting iframe
+microtask
+
+about:blank
+begin inserting iframe
+load event
+end inserting iframe
+microtask
+
+hello.html
+begin inserting iframe
+end inserting iframe
+microtask
+load event
+
+data URL
+begin inserting iframe
+end inserting iframe
+microtask
+load event
+
+srcdoc
+begin inserting iframe
+end inserting iframe
+microtask
+load event
+

--- a/LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint.html
+++ b/LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests inserting an empty iframe after scheduling a microtask.<br>
+WebKit should not perform a microtask checkpoint.</p>
+<pre id="log"></pre>
+<script>
+let logCount = 0;
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+const testCases = [
+    {name: 'empty', test: (iframe) => {}},
+    {name: 'about:blank', test: (iframe) => iframe.src = 'about:blank'},
+    {name: 'hello.html', test: (iframe) => iframe.src = 'resources/hello.html'},
+    {name: 'data URL', test: (iframe) => iframe.src = 'data:text/html,<!DOCTYPE html>data'},
+    {name: 'srcdoc', test: (iframe) => iframe.srcdoc = '<!DOCTYPE html>srcdoc'},
+]
+
+function test(name, testFunction) {
+    function log(message) {
+        document.getElementById('log').textContent += `${message}\n`;
+    }
+
+    return new Promise((resolve) => {
+        document.getElementById('log').textContent += `\n${name}\n`;
+
+        queueMicrotask(() => {
+            log('microtask');
+        });
+
+        const iframe = document.createElement("iframe");
+        iframe.onload = () => {
+            log('load event');
+            setTimeout(nextTest);
+        }
+        testFunction(iframe);
+        log('begin inserting iframe');
+        document.body.appendChild(iframe);
+        log('end inserting iframe');
+    });
+}
+
+onload = nextTest;
+
+let testIndex = 0;
+function nextTest() {
+    if (testIndex >= testCases.length) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+    test(testCases[testIndex].name, testCases[testIndex].test);
+    testIndex++;
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/eventloop/resources/hello.html
+++ b/LayoutTests/http/tests/eventloop/resources/hello.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>hello</p>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6217,9 +6217,9 @@ void Document::finishedParsing()
     }
 
     // FIXME: Schedule a task to fire DOMContentLoaded event instead. See webkit.org/b/82931
-    if (auto* documentLoader = loader(); documentLoader && documentLoader->isInFinishedLoadingOfEmptyDocument())
-        ; // Don't perform a microtask checkpoint when inserting an iframe.
-    else
+    auto* documentLoader = loader();
+    bool isInMiddleOfInitializingIframe = documentLoader && documentLoader->isInFinishedLoadingOfEmptyDocument();
+    if (!isInMiddleOfInitializingIframe)
         eventLoop().performMicrotaskCheckpoint();
     dispatchEvent(Event::create(eventNames().DOMContentLoadedEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6217,7 +6217,10 @@ void Document::finishedParsing()
     }
 
     // FIXME: Schedule a task to fire DOMContentLoaded event instead. See webkit.org/b/82931
-    eventLoop().performMicrotaskCheckpoint();
+    if (auto* documentLoader = loader(); documentLoader && documentLoader->isInFinishedLoadingOfEmptyDocument())
+        ; // Don't perform a microtask checkpoint when inserting an iframe.
+    else
+        eventLoop().performMicrotaskCheckpoint();
     dispatchEvent(Event::create(eventNames().DOMContentLoadedEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 
     if (!m_eventTiming.domContentLoadedEventEnd) {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2034,6 +2034,7 @@ bool DocumentLoader::maybeLoadEmpty()
         }
     }
 
+    SetForScope isInFinishedLoadingOfEmptyDocument { m_isInFinishedLoadingOfEmptyDocument, true };
     finishedLoading();
     return true;
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -459,6 +459,7 @@ public:
     bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoadAfterProvisionalLoadStarted; }
     void setIsContinuingLoadAfterProvisionalLoadStarted(bool isContinuingLoadAfterProvisionalLoadStarted) { m_isContinuingLoadAfterProvisionalLoadStarted = isContinuingLoadAfterProvisionalLoadStarted; }
 
+    bool isInFinishedLoadingOfEmptyDocument() const { return m_isInFinishedLoadingOfEmptyDocument; }
 #if ENABLE(CONTENT_FILTERING)
     bool contentFilterWillHandleProvisionalLoadFailure(const ResourceError&);
     void contentFilterHandleProvisionalLoadFailure(const ResourceError&);
@@ -604,6 +605,7 @@ private:
     bool m_isClientRedirect { false };
     bool m_isLoadingMultipartContent { false };
     bool m_isContinuingLoadAfterProvisionalLoadStarted { false };
+    bool m_isInFinishedLoadingOfEmptyDocument { false };
 
     // FIXME: Document::m_processingLoadEvent and DocumentLoader::m_wasOnloadDispatched are roughly the same
     // and should be merged.


### PR DESCRIPTION
#### c2b33e7ae2788a349ad48660cab239925ca2ab54
<pre>
Adding iframe flushes microtasks synchronously with dirty stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=235322">https://bugs.webkit.org/show_bug.cgi?id=235322</a>

Reviewed by NOBODY (OOPS!).

The bug was caused by Document::finishedParsing synchronously performing a microtask checkpoint.
When this function also gets called during the initialization of iframe newly connected to a document,
it erroneously executes microtasks associated with the current event loop.

This is likely a regression from <a href="http://commits.webkit.org/r234944">http://commits.webkit.org/r234944</a> where we introduced this workaround
for firing DOMContentLoaded synchronously. Avoid calling this function in this specific circumstances.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::finishedParsing): Fixed the bug by skipping the aforementioned workaround when
we&apos;re in the middle of initializing an iframe.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::maybeLoadEmpty): Added. Set m_isInFinishedLoadingOfEmptyDocument to true
while calling DocumentLoader::finishedParsing.
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isInFinishedLoadingOfEmptyDocument const): Added.

* LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint-expected.txt: Added.
* LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint.html: Added.
</pre>
----------------------------------------------------------------------
#### 2b952ea413ddc0319201d87d425508575b97addd
<pre>
Adding iframe flushes microtasks synchronously with dirty stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=235322">https://bugs.webkit.org/show_bug.cgi?id=235322</a>

Reviewed by NOBODY (OOPS!).

The bug was caused by Document::finishedParsing synchronously performing a microtask checkpoint.
When this function also gets called during the initialization of iframe newly connected to a document,
it erroneously executes microtasks associated with the current event loop.

This is likely a regression from <a href="http://commits.webkit.org/r234944">http://commits.webkit.org/r234944</a> where we introduced this workaround
for firing DOMContentLoaded synchronously. Avoid calling this function in this specific circumstances.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::finishedParsing): Fixed the bug by skipping the aforementioned workaround when
we&apos;re in the middle of initializing an iframe.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::maybeLoadEmpty): Added. Set m_isInFinishedLoadingOfEmptyDocument to true
while calling DocumentLoader::finishedParsing.
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isInFinishedLoadingOfEmptyDocument const): Added.

* LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint-expected.txt: Added.
* LayoutTests/http/tests/eventloop/inserting-iframe-should-not-perform-microtask-checkpoint.html: Added.
</pre>