### PR TITLE
remoteFunctionCallForJSFunction should placate MarkedArgumentBuffer overflow check.

### DIFF
--- a/JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check.js
+++ b/JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check.js
@@ -1,0 +1,18 @@
+//@ requireOptions("--watchdog=10", "--watchdog-exception-ok")
+
+try {
+    function foo() {
+      let shadowRealm = new ShadowRealm();
+      for (let i = 0; i < 1000; i++) {
+        let fn = shadowRealm.evaluate(`()=>{}`);
+        let u = new Uint8Array(10000);
+        fn(...u);
+      }
+    }
+
+    foo();
+    for (let i = 0; i < 100; i++) {
+      runString(`(${foo.toString()})()`);
+    }
+} catch (e) {
+}

--- a/JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check2.js
+++ b/JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check2.js
@@ -1,0 +1,10 @@
+//@ requireOptions("--watchdog=1", "--watchdog-exception-ok")
+
+try {
+    let shadowRealm = new ShadowRealm();
+    for (let i = 0; i < 1000; i++) {
+      let fn = shadowRealm.evaluate(`()=>{}`);
+      fn(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+} catch (e) {
+}

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -91,9 +91,17 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallForJSFunction, (JSGlobalObject* globa
     JSGlobalObject* targetGlobalObject = targetFunction->globalObject();
 
     MarkedArgumentBuffer args;
+    auto clearArgOverflowCheckAndReturnAbortValue = [&] () -> EncodedJSValue {
+        // This is only called because we'll be imminently returning due to an
+        // exception i.e. we won't be using the args, and we don't care if they
+        // overflowed. However, we still need to call overflowCheckNotNeeded()
+        // to placate an ASSERT in the MarkedArgumentBuffer destructor.
+        args.overflowCheckNotNeeded();
+        return { };
+    };
     for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
         JSValue wrappedValue = wrapArgument(globalObject, targetGlobalObject, callFrame->uncheckedArgument(i));
-        RETURN_IF_EXCEPTION(scope, { });
+        RETURN_IF_EXCEPTION(scope, clearArgOverflowCheckAndReturnAbortValue());
         args.append(wrappedValue);
     }
     if (UNLIKELY(args.hasOverflowed())) {


### PR DESCRIPTION
#### 3ab9efd04e2c947f8418cca7e538cc4311ca1eea
<pre>
remoteFunctionCallForJSFunction should placate MarkedArgumentBuffer overflow check.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242125">https://bugs.webkit.org/show_bug.cgi?id=242125</a>
&lt;rdar://problem/96143046&gt;

Reviewed by Yusuke Suzuki.

remoteFunctionCallForJSFunction may abort and return early while still appending
arguments. If it returns early this way, it will not go thru the code path that
placates the MarkedArgumentBuffer&apos;s debugging aid that expects an overflow check
to have been done.  In this case, an overflow check is not needed because we&apos;re
aborting and won&apos;t be using the args regardless of whether they overflowed or not.

This patch placates the overflow check requirement by calling overflowCheckNotNeeded()
if we&apos;re aborting and returning early.

* JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check.js: Added.
(foo):
* JSTests/stress/remoteFunctionCallForJSFunction-should-placate-overflow-check2.js: Added.
(i.let.fn.shadowRealm.evaluate):
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/252000@main">https://commits.webkit.org/252000@main</a>
</pre>
