### PR TITLE
Crash under IPC::Connection::sendSync<Messages::WebPageProxy::RootViewToScreen>()

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -239,13 +239,18 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [[self parent] accessibilityAttributeValue:NSAccessibilityTopLevelUIElementAttribute];
     if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
         return [[self parent] accessibilityAttributeValue:NSAccessibilityWindowAttribute];
-    if ([attribute isEqualToString:NSAccessibilitySizeAttribute])
-        return [NSValue valueWithSize:_pdfPlugin->boundsOnScreen().size()];
+    if ([attribute isEqualToString:NSAccessibilitySizeAttribute]) {
+        return [NSValue valueWithSize:WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntSize>([protectedSelf = retainPtr(self)] {
+            return protectedSelf.get().pdfPlugin->boundsOnScreen().size();
+        })];
+    }
     if ([attribute isEqualToString:NSAccessibilityEnabledAttribute])
         return [[self parent] accessibilityAttributeValue:NSAccessibilityEnabledAttribute];
-    if ([attribute isEqualToString:NSAccessibilityPositionAttribute])
-        return [NSValue valueWithPoint:_pdfPlugin->boundsOnScreen().location()];
-
+    if ([attribute isEqualToString:NSAccessibilityPositionAttribute]) {
+        return [NSValue valueWithPoint:WebCore::Accessibility::retrieveValueFromMainThread<WebCore::IntPoint>([protectedSelf = retainPtr(self)] {
+            return protectedSelf.get().pdfPlugin->boundsOnScreen().location();
+        })];
+    }
     if ([attribute isEqualToString:NSAccessibilityChildrenAttribute])
         return @[ _pdfLayerController ];
     if ([attribute isEqualToString:NSAccessibilityRoleAttribute])
@@ -264,7 +269,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if ([attribute isEqualToString:NSAccessibilityBoundsForRangeParameterizedAttribute]) {
         NSRect boundsInPDFViewCoordinates = [[_pdfLayerController accessibilityBoundsForRangeAttributeForParameter:parameter] rectValue];
-        NSRect boundsInScreenCoordinates = _pdfPlugin->convertFromPDFViewToScreen(boundsInPDFViewCoordinates);
+        NSRect boundsInScreenCoordinates = WebCore::Accessibility::retrieveValueFromMainThread<NSRect>([protectedSelf = retainPtr(self), boundsInPDFViewCoordinates] {
+            return protectedSelf.get().pdfPlugin->convertFromPDFViewToScreen(boundsInPDFViewCoordinates);
+        });
         return [NSValue valueWithRect:boundsInScreenCoordinates];
     }
 


### PR DESCRIPTION
#### 9462b117de1b72cc5e077a7658e31277fb1c3156
<pre>
Crash under IPC::Connection::sendSync&lt;Messages::WebPageProxy::RootViewToScreen&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242132">https://bugs.webkit.org/show_bug.cgi?id=242132</a>
&lt;rdar://96098823&gt;

Reviewed by Tim Horton.

The issue is that [WKPDFPluginAccessibilityObject accessibilityAttributeValue:] is getting called
off the main thread, and would end up interacting with the PDFPlugin and then the WebPage, which
are main thread objects. To address the issue, we now make sure to dispatch to the main thread
before interacting with the PDFPlugin.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject accessibilityAttributeValue:]):
(-[WKPDFPluginAccessibilityObject accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/251967@main">https://commits.webkit.org/251967@main</a>
</pre>
