### PR TITLE
Web Inspector: Typo in error handling for picking color from screen

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
@@ -109,7 +109,7 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         let pickedColorCSSString = null;
         try {
             pickedColorCSSString = await InspectorFrontendHost.pickColorFromScreen();
-        } catch (e) {
+        } catch (error) {
             WI.reportInternalError(error);
         }
 


### PR DESCRIPTION
#### bf9a884fa78b3e931af3b360ab29f3dc62837a3e
<pre>
Web Inspector: Typo in error handling for picking color from screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=242133">https://bugs.webkit.org/show_bug.cgi?id=242133</a>
rdar://problem/96165101

Reviewed by Devin Rousso.

* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:

Canonical link: <a href="https://commits.webkit.org/251964@main">https://commits.webkit.org/251964@main</a>
</pre>
