### PR TITLE
HTMLCanvasElement::removedFromAncestor() triggers IOSurface creation

### DIFF
--- a/Source/WebCore/platform/ProcessCapabilities.cpp
+++ b/Source/WebCore/platform/ProcessCapabilities.cpp
@@ -31,8 +31,10 @@ namespace WebCore {
 #if USE(CG)
 static bool s_HEICDecodingEnabled = false;
 static bool s_AVIFDecodingEnabled = false;
-static bool s_hardwareAcceleratedDecodingDisabled = false;
 #endif
+
+static bool s_hardwareAcceleratedDecodingDisabled = false;
+static bool s_canUseAcceleratedBuffers = true;
 
 #if USE(CG)
 void ProcessCapabilities::setHEICDecodingEnabled(bool value)
@@ -54,6 +56,7 @@ bool ProcessCapabilities::isAVIFDecodingEnabled()
 {
     return s_AVIFDecodingEnabled;
 }
+#endif
 
 void ProcessCapabilities::setHardwareAcceleratedDecodingDisabled(bool value)
 {
@@ -64,6 +67,15 @@ bool ProcessCapabilities::isHardwareAcceleratedDecodingDisabled()
 {
     return s_hardwareAcceleratedDecodingDisabled;
 }
-#endif
+
+void ProcessCapabilities::setCanUseAcceleratedBuffers(bool value)
+{
+    s_canUseAcceleratedBuffers = value;
+}
+
+bool ProcessCapabilities::canUseAcceleratedBuffers()
+{
+    return s_canUseAcceleratedBuffers;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ProcessCapabilities.h
+++ b/Source/WebCore/platform/ProcessCapabilities.h
@@ -36,10 +36,13 @@ public:
 
     WEBCORE_EXPORT static void setAVIFDecodingEnabled(bool);
     static bool isAVIFDecodingEnabled();
+#endif
 
     WEBCORE_EXPORT static void setHardwareAcceleratedDecodingDisabled(bool);
     static bool isHardwareAcceleratedDecodingDisabled();
-#endif
+
+    WEBCORE_EXPORT static void setCanUseAcceleratedBuffers(bool);
+    static bool canUseAcceleratedBuffers();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsContext.h"
 #include "HostWindow.h"
 #include "PlatformImageBuffer.h"
+#include "ProcessCapabilities.h"
 
 namespace WebCore {
 
@@ -59,7 +60,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
     if (imageBuffer)
         return imageBuffer;
 
-    if (options.contains(ImageBufferOptions::Accelerated))
+    if (options.contains(ImageBufferOptions::Accelerated) && ProcessCapabilities::canUseAcceleratedBuffers())
         imageBuffer = AcceleratedImageBuffer::create(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
     
     if (!imageBuffer)

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -32,6 +32,7 @@
 #import "IOSurfacePool.h"
 #import "Logging.h"
 #import "PlatformScreen.h"
+#import "ProcessCapabilities.h"
 #import "ProcessIdentity.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Assertions.h>
@@ -46,6 +47,8 @@ namespace WebCore {
 
 std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, const DestinationColorSpace& colorSpace, Format pixelFormat)
 {
+    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+
     if (pool) {
         if (auto cachedSurface = pool->takeSurface(size, colorSpace, pixelFormat)) {
             cachedSurface->releaseGraphicsContext();
@@ -67,6 +70,8 @@ std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, 
 
 std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& sendRight, const DestinationColorSpace& colorSpace)
 {
+    ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
+
     auto surface = adoptCF(IOSurfaceLookupFromMachPort(sendRight.sendRight()));
     return IOSurface::createFromSurface(surface.get(), colorSpace);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -922,6 +922,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         // This call should be replaced with proper API when available.
         CFPreferencesGetAppIntegerValue(CFSTR("key"), CFSTR("com.apple.WebKit.WebContent.AppCacheDisabled"), nullptr);
     }
+#endif
 
     auto blockIOKit = parameters.store.getBoolValueForKey(WebPreferencesKey::blockIOKitInWebContentSandboxKey())
 #if ENABLE(WEBGL)
@@ -932,10 +933,12 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         && m_shouldPlayMediaInGPUProcess;
 
     if (blockIOKit) {
+#if HAVE(SANDBOX_STATE_FLAGS)
         CFPreferencesGetAppIntegerValue(CFSTR("key"), CFSTR("com.apple.WebKit.WebContent.BlockIOKitInWebContentSandbox"), nullptr);
-        ProcessCapabilities::setHardwareAcceleratedDecodingDisabled(true);
-    }
 #endif
+        ProcessCapabilities::setHardwareAcceleratedDecodingDisabled(true);
+        ProcessCapabilities::setCanUseAcceleratedBuffers(false);
+    }
 
     updateThrottleState();
 }


### PR DESCRIPTION
#### 545cf3895bf1228fc21b4a61eb2ad22f6daf347f
<pre>
HTMLCanvasElement::removedFromAncestor() triggers IOSurface creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242098">https://bugs.webkit.org/show_bug.cgi?id=242098</a>
&lt;rdar://95618211&gt;

Reviewed by Ryosuke Niwa.

In some circumstances (e.g. a detached iframe), HTMLCanvasElement::createImageBuffer() can&apos;t access
a `hostWindow` and therefore doesn&apos;t use the code path that delegates buffer creation to the
ChromeClient. The fallback code tries to make an accelerated image buffer, which will trigger a
sandbox exception if IOKit is blocked.

To avoid this, and to allow simulator testing to detect when WebContent erroneously attempts to
create accelerated buffers, add a setting to ProcessCapabilities to store whether accelerated
buffers are allowed. This setting is set in WebPage where we turn on IOKit sandboxing (with some

The non-hostWindow fallback path in ImageBuffer::create() consults the setting, and we assert on it
in IOSurface creation.

* Source/WebCore/platform/ProcessCapabilities.cpp:
(WebCore::ProcessCapabilities::setCanUseAcceleratedBuffers):
(WebCore::ProcessCapabilities::canUseAcceleratedBuffers):
* Source/WebCore/platform/ProcessCapabilities.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::create):
(WebCore::IOSurface::createFromSendRight):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:

Canonical link: <a href="https://commits.webkit.org/252021@main">https://commits.webkit.org/252021@main</a>
</pre>
