### PR TITLE
REGRESSION (r289765-r289784): [iOS] Flaky crash under WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree()

### DIFF
--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1728,6 +1728,8 @@ void TestInvocation::done()
     m_gotFinalMessage = true;
     invalidateWaitToDumpWatchdogTimer();
     invalidateWaitForPostDumpWatchdogTimer();
+    if (m_pendingUIScriptInvocationData)
+        outputText("FAIL - test completed with pending UI scripts\n"_s);
     RunLoop::main().dispatch([] {
         TestController::singleton().notifyDone();
     });


### PR DESCRIPTION
#### d21a2a736a57331ce7a5944478d2233c3499c6b7
<pre>
REGRESSION (r289765-r289784): [iOS] Flaky crash under WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree()
<a href="https://bugs.webkit.org/show_bug.cgi?id=236794">https://bugs.webkit.org/show_bug.cgi?id=236794</a>
&lt;rdar://89100788&gt;

Reviewed by NOBODY (OOPS!).

WIP: see what tests are still failing this.

* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::done):
</pre>