### PR TITLE
[ews-build.webkit.org] Handle push failure after PR update

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4554,7 +4554,7 @@ class PushCommitToWebKitRepo(shell.ShellCommand):
                         UpdateWorkingDirectory(),
                         CheckOutPullRequest(),
                         AddReviewerToCommitMessage(),
-                        ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True),
+                        ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, verifyObsolete=False),
                         Canonicalize(),
                         PushCommitToWebKitRepo(),
                     ])


### PR DESCRIPTION
#### b2256a4c784ecc119e460e58e64d46e323e0eb25
<pre>
[ews-build.webkit.org] Handle push failure after PR update
<a href="https://bugs.webkit.org/show_bug.cgi?id=242140">https://bugs.webkit.org/show_bug.cgi?id=242140</a>

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(PushCommitToWebKitRepo.evaluateCommand): Allow obsolete PRs on retry.

Canonical link: <a href="https://commits.webkit.org/251992@main">https://commits.webkit.org/251992@main</a>
</pre>
