### PR TITLE
[Gardening]: [ macOS iOS EWS ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3661,5 +3661,5 @@ fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 # Accessibility bold only exists on iOS.
 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Pass Failure ]
-fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ Pass ImageOnlyFailure ]
+webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2293,3 +2293,5 @@ webkit.org/b/227845 [ Debug ] webaudio/audioworket-out-of-memory.html [ Pass Tim
 webkit.org/b/240989 http/tests/media/hls/hls-webvtt-flashing.html [ Pass Failure ]
 
 [ Monterey+ ] fast/text/bulgarian-system-language-shaping.html [ Pass ]
+
+webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 5f221672cd2a7563d90e56d9191da75798dd2bc7
<pre>
[Gardening]: [ macOS iOS EWS ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242139">https://bugs.webkit.org/show_bug.cgi?id=242139</a>
&lt;rdar://96170698&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251966@main">https://commits.webkit.org/251966@main</a>
</pre>
