### PR TITLE
[GPU Process] RemoteRenderingBackend must ignore resource messages once m_remoteResourceCache is cleared

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -104,8 +104,6 @@ private:
     RemoteRenderingBackend(GPUConnectionToWebProcess&, RemoteRenderingBackendCreationParameters&&, IPC::Attachment&&, IPC::StreamConnectionBuffer&&);
     void startListeningForIPC();
 
-    std::optional<SharedMemory::IPCHandle> updateSharedMemoryForGetPixelBufferHelper(size_t byteCount);
-
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override;
@@ -144,7 +142,6 @@ private:
     WebCore::ProcessIdentity m_resourceOwner;
     RenderingBackendIdentifier m_renderingBackendIdentifier;
     RefPtr<SharedMemory> m_getPixelBufferSharedMemory;
-    ScopedRenderingResourcesRequest m_renderingResourcesRequest;
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
 #endif

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -49,7 +49,7 @@ public:
     void removeStreamConnection(StreamServerConnection&);
 
     void dispatch(WTF::Function<void()>&&) final;
-    void stopAndWaitForCompletion();
+    void stopAndWaitForCompletion(WTF::Function<void()>&& cleanupFunction = nullptr);
 
     void wakeUp();
 
@@ -69,6 +69,7 @@ private:
     mutable Lock m_lock;
     RefPtr<Thread> m_processingThread WTF_GUARDED_BY_LOCK(m_lock);
     Deque<Function<void()>> m_functions WTF_GUARDED_BY_LOCK(m_lock);
+    WTF::Function<void()> m_cleanupFunction WTF_GUARDED_BY_LOCK(m_lock);
     HashCountedSet<Ref<StreamServerConnection>> m_connections WTF_GUARDED_BY_LOCK(m_lock);
     friend void assertIsCurrent(const StreamConnectionWorkQueue&);
 };


### PR DESCRIPTION
#### 682daa7855096d0abf3c178d4d139b0f2f99c689
<pre>
[GPU Process] RemoteRenderingBackend must ignore resource messages once m_remoteResourceCache is cleared
<a href="https://bugs.webkit.org/show_bug.cgi?id=242142">https://bugs.webkit.org/show_bug.cgi?id=242142</a>
rdar://94143906

Reviewed by Chris Dumez.

RemoteRenderingBackend::stopListeningForIPC() is calling StreamServerConnection
::stopReceivingMessages() after it dispatches a code block to clear its
m_remoteResourceCache. But incoming messages can still be dispatched to
RemoteRenderingBackend between executing the clearing block and and stopping
receiving messages.

If the RemoteRenderingBackend::ReleaseRemoteResource message is received after
clearing m_remoteResourceCache, GPUProcess will simulate-crash with the message:
&quot;Resource is being released before being cached.&quot;

The fix is to ensure that the clearing block is executed the last thing on the
WorkQueue after processing all the queued messages and before stopping receiving
new messages. This can be done by passing the clearing block to stopReceivingMessages()
which is going to be executed when m_shouldQuit is true and calling processStreams()
in StreamConnectionWorkQueue::startProcessingThread().

Remove RemoteRenderingBackend::m_renderingResourcesRequest and
updateSharedMemoryForGetPixelBufferHelper() since they are not used.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::stopListeningForIPC):

Canonical link: <a href="https://commits.webkit.org/252187@main">https://commits.webkit.org/252187@main</a>
</pre>
