### PR TITLE
MediaCapabilities should respect allowed containers and codecs in Captive Portal mode

### DIFF
--- a/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs-expected.txt
@@ -1,0 +1,26 @@
+RUN(internals.settings.setAllowedMediaCodecTypes(null))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+RUN(internals.settings.setAllowedMediaCodecTypes("unkn,none"))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(internals.settings.setAllowedMediaCodecTypes("avc1,mp4a.40"))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs.html
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mediacapabilities-allowed-codecs</title>
+    <script src="../video-test.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        if (!window.internals) {
+            failTest('Requires window.internals');
+            return;
+        }
+
+        video = document.createElement('video');
+        run('internals.settings.setAllowedMediaCodecTypes(null)');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+        run('internals.settings.setAllowedMediaCodecTypes("unkn,none")');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run('internals.settings.setAllowedMediaCodecTypes("avc1,mp4a.40")');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100  } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100  } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers-expected.txt
@@ -1,0 +1,26 @@
+RUN(internals.settings.setAllowedMediaContainerTypes(null))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+RUN(internals.settings.setAllowedMediaContainerTypes("video/null"))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(internals.settings.setAllowedMediaContainerTypes("video/mp4"))
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="avc1"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers.html
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mediacapabilities-allowed-containers</title>
+    <script src="../video-test.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        if (!window.internals) {
+            failTest('Requires window.internals');
+            return;
+        }
+
+        video = document.createElement('video');
+        promise = null;
+
+        run('internals.settings.setAllowedMediaContainerTypes(null)');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+        run('internals.settings.setAllowedMediaContainerTypes("video/null")');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run('internals.settings.setAllowedMediaContainerTypes("video/mp4")');
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100  } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp3', channels: '2', bitrate: 1000, samplerate: 44100  } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", false);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"avc1\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 } });");
+        info = await shouldResolve(promise);
+        testExpected("info.supported", true);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -906,6 +906,10 @@ webkit.org/b/236298 imported/w3c/web-platform-tests/css/css-ui/text-overflow-022
 # Requires support for xHE-HAAC audio codec
 webkit.org/b/239750 media/media-source/media-mp4-xhe-aac.html [ Skip ]
 
+# Requires unsupported captive portal codec and container restrictions
+webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Skip ]
+webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Expected failures.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -176,6 +176,9 @@ static void gatherDecodingInfo(Document& document, MediaDecodingConfiguration&& 
     if (!document.settings().mediaCapabilitiesExtensionsEnabled() && configuration.video)
         configuration.video.value().alphaChannel.reset();
 
+    configuration.allowedMediaContainerTypes = document.settings().allowedMediaContainerTypes();
+    configuration.allowedMediaCodecTypes = document.settings().allowedMediaCodecTypes();
+
 #if ENABLE(VP9)
     configuration.canExposeVP9 = document.settings().vp9DecoderEnabled();
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -32,6 +32,7 @@
 #import "AVAssetTrackUtilities.h"
 #import "AVStreamDataParserMIMETypeCache.h"
 #import "CDMSessionAVStreamSession.h"
+#import "ContentTypeUtilities.h"
 #import "GraphicsContext.h"
 #import "IOSurface.h"
 #import "Logging.h"
@@ -270,6 +271,9 @@ MediaPlayer::SupportsType MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndC
 {
     // This engine does not support non-media-source sources.
     if (!parameters.isMediaSource)
+        return MediaPlayer::SupportsType::IsNotSupported;
+
+    if (!contentTypeMeetsContainerAndCodecTypeRequirements(parameters.type, parameters.allowedMediaContainerTypes, parameters.allowedMediaCodecTypes))
         return MediaPlayer::SupportsType::IsNotSupported;
 
     auto supported = SourceBufferParser::isContentTypeSupported(parameters.type);

--- a/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
@@ -63,6 +63,8 @@ static std::optional<MediaCapabilitiesInfo> computeMediaCapabilitiesInfo(const M
     if (configuration.video) {
         auto& videoConfiguration = configuration.video.value();
         MediaEngineSupportParameters parameters { };
+        parameters.allowedMediaContainerTypes = configuration.allowedMediaContainerTypes;
+        parameters.allowedMediaCodecTypes = configuration.allowedMediaCodecTypes;
 
         switch (configuration.type) {
         case MediaDecodingType::File:
@@ -136,6 +138,9 @@ static std::optional<MediaCapabilitiesInfo> computeMediaCapabilitiesInfo(const M
         MediaEngineSupportParameters parameters { };
         parameters.type = ContentType(configuration.audio.value().contentType);
         parameters.isMediaSource = configuration.type == MediaDecodingType::MediaSource;
+        parameters.allowedMediaContainerTypes = configuration.allowedMediaContainerTypes;
+        parameters.allowedMediaCodecTypes = configuration.allowedMediaCodecTypes;
+
         if (MediaPlayer::supportsType(parameters) != MediaPlayer::SupportsType::IsSupported)
             return std::nullopt;
 

--- a/Source/WebCore/platform/mediacapabilities/MediaConfiguration.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaConfiguration.h
@@ -35,6 +35,9 @@ struct MediaConfiguration {
     std::optional<VideoConfiguration> video;
     std::optional<AudioConfiguration> audio;
 
+    std::optional<Vector<String>> allowedMediaContainerTypes;
+    std::optional<Vector<String>> allowedMediaCodecTypes;
+
     MediaConfiguration isolatedCopy() const &;
     MediaConfiguration isolatedCopy() &&;
 
@@ -44,12 +47,12 @@ struct MediaConfiguration {
 
 inline MediaConfiguration MediaConfiguration::isolatedCopy() const &
 {
-    return { crossThreadCopy(video),  crossThreadCopy(audio) };
+    return { crossThreadCopy(video),  crossThreadCopy(audio), crossThreadCopy(allowedMediaContainerTypes), crossThreadCopy(allowedMediaCodecTypes) };
 }
 
 inline MediaConfiguration MediaConfiguration::isolatedCopy() &&
 {
-    return { crossThreadCopy(WTFMove(video)),  crossThreadCopy(WTFMove(audio)) };
+    return { crossThreadCopy(WTFMove(video)),  crossThreadCopy(WTFMove(audio)), crossThreadCopy(WTFMove(allowedMediaContainerTypes)), crossThreadCopy(WTFMove(allowedMediaCodecTypes)) };
 }
 
 template<class Encoder>
@@ -57,6 +60,8 @@ void MediaConfiguration::encode(Encoder& encoder) const
 {
     encoder << video;
     encoder << audio;
+    encoder << allowedMediaContainerTypes;
+    encoder << allowedMediaCodecTypes;
 }
 
 template<class Decoder>
@@ -72,9 +77,21 @@ std::optional<MediaConfiguration> MediaConfiguration::decode(Decoder& decoder)
     if (!audio)
         return std::nullopt;
 
+    std::optional<std::optional<Vector<String>>> allowedMediaContainerTypes;
+    decoder >> allowedMediaContainerTypes;
+    if (!allowedMediaContainerTypes)
+        return std::nullopt;
+
+    std::optional<std::optional<Vector<String>>> allowedMediaCodecTypes;
+    decoder >> allowedMediaCodecTypes;
+    if (!allowedMediaCodecTypes)
+        return std::nullopt;
+
     return {{
         *video,
         *audio,
+        *allowedMediaContainerTypes,
+        *allowedMediaCodecTypes,
     }};
 }
 


### PR DESCRIPTION
#### aa2c0e352a3c9b9a0c918dec9b64b9afd6fa553a
<pre>
MediaCapabilities should respect allowed containers and codecs in Captive Portal mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=242145">https://bugs.webkit.org/show_bug.cgi?id=242145</a>
&lt;rdar://92419877&gt;

Reviewed by Eric Carlson.

Pipe the allowedMediaContainerTypes and allowedMediaCodecTypes document Settings into
MediaConfiguration, and from there MediaEngineSupportParameters, when determining
decoding capabilities.

Previously, these settings were enforced in MediaSource itself, but for MediaCapabilities,
they must also be checked by MediaPlayerPrivateMediaSourceAVFObjC.

(Slightly changing commit message in order to force-push/retry building.)

* LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs-expected.txt: Added.
* LayoutTests/media/mediacapabilities/mediacapabilities-allowed-codecs.html: Added.
* LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers-expected.txt: Added.
* LayoutTests/media/mediacapabilities/mediacapabilities-allowed-containers.html: Added.
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::gatherDecodingInfo):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs):
* Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo):
* Source/WebCore/platform/mediacapabilities/MediaConfiguration.h:
(WebCore::MediaConfiguration::isolatedCopy const):
(WebCore::MediaConfiguration::isolatedCopy):
(WebCore::MediaConfiguration::encode const):
(WebCore::MediaConfiguration::decode):

Canonical link: <a href="https://commits.webkit.org/252233@main">https://commits.webkit.org/252233@main</a>
</pre>
