### PR TITLE
[macOS] "text/uri-list" is always empty when dragging and dropping from the unified field in Safari

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -4391,7 +4391,6 @@ bool WebViewImpl::performDragOperation(id <NSDraggingInfo> draggingInfo)
     }
 
     String draggingPasteboardName = draggingInfo.draggingPasteboard.name;
-    m_page->grantAccessToCurrentPasteboardData(draggingPasteboardName);
     m_page->performDragOperation(*dragData, draggingPasteboardName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionForUpload));
 
     return true;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2760,6 +2760,9 @@ void WebPageProxy::dragExited(DragData& dragData, const String& dragStorageName)
 
 void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload)
 {
+#if PLATFORM(COCOA)
+    grantAccessToCurrentPasteboardData(dragStorageName);
+#endif
     performDragControllerAction(DragControllerAction::PerformDragOperation, dragData, dragStorageName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload));
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9666,7 +9666,6 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
         WebKit::SandboxExtension::Handle sandboxExtensionHandle;
         Vector<WebKit::SandboxExtension::Handle> sandboxExtensionForUpload;
         auto dragPasteboardName = WebCore::Pasteboard::nameOfDragPasteboard();
-        retainedSelf->_page->grantAccessToCurrentPasteboardData(dragPasteboardName);
         retainedSelf->_page->createSandboxExtensionsIfNeeded(filenames, sandboxExtensionHandle, sandboxExtensionForUpload);
         retainedSelf->_page->performDragOperation(capturedDragData, dragPasteboardName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionForUpload));
         if (shouldSnapshotView) {

--- a/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm
@@ -116,6 +116,29 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
     EXPECT_EQ(1, [webView stringByEvaluatingJavaScript:@"filecount.textContent"].integerValue);
 }
 
+TEST(DragAndDropTests, ReadURLWhenDroppingPromisedWebLoc)
+{
+    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    auto *webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
+
+    [simulator writePromisedWebLoc:[NSURL URLWithString:@"https://webkit.org/"]];
+    [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(375, 375)];
+
+    NSString *s = [webView stringByEvaluatingJavaScript:@"output.value"];
+    BOOL success = TestWebKitAPI::Util::jsonMatchesExpectedValues(s, @{
+        @"dragover" : @{
+            @"Files": @"",
+            @"text/uri-list": @""
+        },
+        @"drop": @{
+            @"Files": @"",
+            @"text/uri-list": @"https://webkit.org/"
+        }
+    });
+    EXPECT_TRUE(success);
+}
+
 TEST(DragAndDropTests, DragImageFileIntoFileUpload)
 {
     auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -125,6 +125,8 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 
 #if PLATFORM(MAC)
 
+- (void)writePromisedWebLoc:(NSURL *)url;
+
 @property (nonatomic, readonly) id <NSDraggingInfo> draggingInfo;
 @property (nonatomic, readonly) NSPoint initialDragImageLocationInView;
 @property (nonatomic, readonly) NSDragOperation currentDragOperation;

--- a/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
@@ -393,6 +393,15 @@ static BOOL getFilePathsAndTypeIdentifiers(NSArray<NSURL *> *fileURLs, NSArray<N
     return YES;
 }
 
+- (void)writePromisedWebLoc:(NSURL *)url
+{
+    _externalPromisedFiles = @[ url ];
+    _externalDragPasteboard = NSPasteboard.pasteboardWithUniqueName;
+    [_externalDragPasteboard declareTypes:@[ NSFilesPromisePboardType, NSPasteboardTypeURL ] owner:nil];
+    [_externalDragPasteboard setPropertyList:@[ @"com.apple.web-internet-location" ] forType:NSFilesPromisePboardType];
+    [_externalDragPasteboard setString:url.absoluteString forType:NSPasteboardTypeURL];
+}
+
 - (void)writePromisedFiles:(NSArray<NSURL *> *)fileURLs
 {
     NSArray *paths = nil;


### PR DESCRIPTION
#### 15a84a83d45966d96d4bc5f5a54a3e47e490cd14
<pre>
[macOS] &quot;text/uri-list&quot; is always empty when dragging and dropping from the unified field in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=242143">https://bugs.webkit.org/show_bug.cgi?id=242143</a>
rdar://96074318

Reviewed by Devin Rousso.

When dragging from the unified search field on macOS, Safari writes a promised `.webloc` file to the
pasteboard. This causes us to go down the `legacyFilesPromisePasteboardType()` handling codepath in
`WebViewImpl::performDragOperation`, which asynchronously receives promised files from the drag
pasteboard, creates sandbox extensions for these promised files, and then calls into
`performDragOperation()` with these files and extensions.

However, this codepath is missing a call to `grantAccessToCurrentPasteboardData`, which means that
the access level for the drag pasteboard that&apos;s granted to the web page when dropping promised files
is still `PasteboardAccessType::Types` rather than `PasteboardAccessType::TypesAndData`. (Somewhat
surprisingly), this doesn&apos;t have much effect when dragging and dropping files, since the actual data
in each of dropped files is accessible through file URLs on the `DragData` that&apos;s already in the web
process, and we generally only end up asking the platform pasteboard for the list of types (in order
to expose &quot;Files&quot; as one of the `DataTransfer` types).

However, this means that in the case where we&apos;re dropping a `.webloc` file, we end up exposing the
`&quot;text/uri-list&quot;` type on the DataTransfer (since the web process is able to read the list of
pasteboard types), but we&apos;re unable to actually grab the URL, since the UI process hasn&apos;t granted
access to `TypesAndData`.

To fix this, we simply move the check down into `WebPageProxy::performDragOperation`, instead of
requiring each individual call site to `grantAccessToCurrentPasteboardData()`. This also allows us
to remove an explicit call to `grantAccessToCurrentPasteboardData()` in iOS-specific drop handling
code in `WKContentViewInteraction.mm`; see below for more details.

Test: DragAndDropTests.ReadURLWhenDroppingPromisedWebLoc

* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(WebKit::WebViewImpl::performDragOperation):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragOperation):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Consolidate all calls to `grantAccessToCurrentPasteboardData` during drop into `WebPageProxy`.

(-[WKContentView dropInteraction:performDrop:]):
* Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm:
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm:
(-[DragAndDropSimulator writePromisedWebLoc:]):
* Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm:
(writeToWebLoc):
(-[TestFilePromiseReceiver receivePromisedFilesAtDestination:options:operationQueue:reader:]):

Add support for `DragAndDropSimulator` to write a `.webloc` file with a URL when dragging; this
simulates dragging from the unified field in Safari.

Canonical link: <a href="https://commits.webkit.org/251996@main">https://commits.webkit.org/251996@main</a>
</pre>
