### PR TITLE
[Gardening]: [ macOS iOS EWS ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3660,6 +3660,6 @@ webkit.org/b/241205 fast/forms/textfield-outline.html [ Pass Failure ]
 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 # Accessibility bold only exists on iOS.
-fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Pass Failure ]
+webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Failure ]
 webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2295,3 +2295,5 @@ webkit.org/b/240989 http/tests/media/hls/hls-webvtt-flashing.html [ Pass Failure
 [ Monterey+ ] fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
+webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Failure ]
+webkit.org/b/242139 [ BigSur ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 0bf2f168cb26a6636921c094f098918b37e345d9
<pre>
[Gardening]: [ macOS iOS EWS ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242139">https://bugs.webkit.org/show_bug.cgi?id=242139</a>
&lt;rdar://96170698&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251968@main">https://commits.webkit.org/251968@main</a>
</pre>
