### PR TITLE
Move some Mac-only code to WebProcessPoolCocoa

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -603,6 +603,7 @@ private:
     void startObservingPreferenceChanges();
 #endif
 
+    static void registerDisplayConfigurationCallback();
     static void registerHighDynamicRangeChangeCallback();
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### ee66d840dabcdf7d066f0dd2717c5ad8192b999f
<pre>
Move some Mac-only code to WebProcessPoolCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=242148">https://bugs.webkit.org/show_bug.cgi?id=242148</a>

Reviewed by Tim Horton.

Move Mac code into the Cocoa file.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::displayReconfigurationCallBack):
(WebKit::WebProcessPool::registerDisplayConfigurationCallback):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::registerDisplayConfigurationCallback):
(WebKit::WebProcessPool::initializeNewWebProcess):
(WebKit::displayReconfigurationCallBack): Deleted.
(WebKit::registerDisplayConfigurationCallback): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/251975@main">https://commits.webkit.org/251975@main</a>
</pre>
