### PR TITLE
Crash under NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup()

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -896,7 +896,8 @@ void NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContex
     auto loader = m_connection->takeNetworkResourceLoader(coreIdentifier());
     ASSERT(loader == this);
     auto existingNetworkResourceLoadIdentifierToResume = loader->identifier();
-    m_connection->networkSession()->addLoaderAwaitingWebProcessTransfer(loader.releaseNonNull());
+    if (auto* session = m_connection->networkSession())
+        session->addLoaderAwaitingWebProcessTransfer(loader.releaseNonNull());
     RegistrableDomain responseDomain { response.url() };
     m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::TriggerBrowsingContextGroupSwitchForNavigation(m_parameters.webPageProxyID, m_parameters.navigationID, browsingContextGroupSwitchDecision, responseDomain, existingNetworkResourceLoadIdentifierToResume), [existingNetworkResourceLoadIdentifierToResume, session = WeakPtr { connectionToWebProcess().networkSession() }](bool success) {
         if (success)


### PR DESCRIPTION
#### 96058d2d1d61b544613d8ac6f45e9afc043c0737
<pre>
Crash under NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242150">https://bugs.webkit.org/show_bug.cgi?id=242150</a>
&lt;rdar://85454011&gt;

Reviewed by Alex Christensen.

Looking at the symbolicated crash in the wild, I believe the NetworkSession object is null
when calling `session-&gt;addLoaderAwaitingWebProcessTransfer(loader.releaseNonNull());`. Add
a null check to address the issue.

It is in theory possible for the network session object to be null if the session was just
destroyed, while the load was going on.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup):

Canonical link: <a href="https://commits.webkit.org/252019@main">https://commits.webkit.org/252019@main</a>
</pre>
