### PR TITLE
Provide correct icon size when requesting icon from the UI process

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -337,7 +337,7 @@ RefPtr<WebKit::ShareableBitmap> WebPageProxy::iconForAttachment(const String& fi
 #else
     auto image = RenderThemeMac::iconForAttachment(fileName, contentType, title);
 #endif
-    return convertPlatformImageToBitmap(image.get(), size);
+    return convertPlatformImageToBitmap(image.get(), iconSize);
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### 91e710f11d802298346174a15f5284d3e4e94d95
<pre>
Provide correct icon size when requesting icon from the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242152">https://bugs.webkit.org/show_bug.cgi?id=242152</a>
&lt;rdar://90663179&gt;

Reviewed by Geoffrey Garen.

When the WebContent process is requesting icon rendering in the UI process, create the bitmap with
the &apos;iconSize&apos; constant. We use the same constant when generating bitmaps for the thumbnail icons
in the UI process.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::iconForAttachment):

Canonical link: <a href="https://commits.webkit.org/252066@main">https://commits.webkit.org/252066@main</a>
</pre>
