### PR TITLE
[macOS] Checkboxes are not rendered

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -262,9 +262,13 @@
             )
 #endif
         )
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 130000
         (deny (with telemetry)
-            iokit-external-trap
-        )
+            iokit-external-trap)
+#else
+        (allow
+            iokit-external-trap)
+#endif
     )
 )
 


### PR DESCRIPTION
#### 977bfd8fa24365a2c7c598c04df98206b816dbcc
<pre>
[macOS] Checkboxes are not rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=242153">https://bugs.webkit.org/show_bug.cgi?id=242153</a>
&lt;rdar://93449777&gt;

Reviewed by Chris Dumez.

Checkboxes are not being rendered on macOS. This is caused by message filtering in the WebContent process.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/251977@main">https://commits.webkit.org/251977@main</a>
</pre>
