### PR TITLE
RemoteRenderingBackend::prepareBuffersForDisplay should move its result into the completion handler

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -398,7 +398,7 @@ void RemoteRenderingBackend::prepareBuffersForDisplay(Vector<PrepareBackingStore
     for (unsigned i = 0; i < swapBuffersInput.size(); ++i)
         prepareLayerBuffersForDisplay(swapBuffersInput[i], outputData[i]);
 
-    completionHandler(outputData);
+    completionHandler(WTFMove(outputData));
 }
 
 // This is the GPU Process version of RemoteLayerBackingStore::prepareBuffers().


### PR DESCRIPTION
#### 29e7147feebc237f99fa2c95dbd9ad5e3b98d16c
<pre>
RemoteRenderingBackend::prepareBuffersForDisplay should move its result into the completion handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=242158">https://bugs.webkit.org/show_bug.cgi?id=242158</a>

Reviewed by Tim Horton.

We currently copy the contents of the PrepareBackingStoreBuffersOutputData
vector, which means retaining and releasing a Mach send right unnecessarily.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::prepareBuffersForDisplay):

Canonical link: <a href="https://commits.webkit.org/251976@main">https://commits.webkit.org/251976@main</a>
</pre>
