### PR TITLE
Crash after unparenting an editable WKWebView twice

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -350,6 +350,7 @@ void WebViewImpl::computeHasVisualSearchResults(const URL& imageURL, ShareableBi
     WebKit::WebViewImpl *_impl;
 
     BOOL _didRegisterForLookupPopoverCloseNotifications;
+    BOOL _shouldObserveFontPanel;
 }
 
 - (instancetype)initWithView:(NSView *)view impl:(WebKit::WebViewImpl&)impl;
@@ -415,6 +416,9 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
     [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:NSScreenColorSpaceDidChangeNotification object:nil];
 
+    if (_shouldObserveFontPanel)
+        [self startObservingFontPanel];
+
     [window addObserver:self forKeyPath:@"contentLayoutRect" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
     [window addObserver:self forKeyPath:@"titlebarAppearsTransparent" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
 }
@@ -442,7 +446,7 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
     [defaultNotificationCenter removeObserver:self name:NSScreenColorSpaceDidChangeNotification object:nil];
 
-    if (_impl->isEditable())
+    if (_shouldObserveFontPanel)
         [[NSFontPanel sharedFontPanel] removeObserver:self forKeyPath:@"visible" context:keyValueObservingContext];
     [window removeObserver:self forKeyPath:@"contentLayoutRect" context:keyValueObservingContext];
     [window removeObserver:self forKeyPath:@"titlebarAppearsTransparent" context:keyValueObservingContext];
@@ -450,6 +454,7 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 - (void)startObservingFontPanel
 {
+    _shouldObserveFontPanel = YES;
     [[NSFontPanel sharedFontPanel] addObserver:self forKeyPath:@"visible" options:0 context:keyValueObservingContext];
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
@@ -549,6 +549,25 @@ TEST(FontManagerTests, SetSelectedSystemFontAfterTogglingBold)
     EXPECT_EQ([selectedFontAfterBoldingAgain pointSize], 16.);
 }
 
+TEST(FontManagerTests, ObservingFontPanelShouldNotCrashWhenUnparentingViewTwice)
+{
+    NSFontManager *fontManager = NSFontManager.sharedFontManager;
+    auto webView = webViewForFontManagerTesting(fontManager);
+
+    [webView removeFromSuperview];
+    [webView addToTestWindow];
+    [webView removeFromSuperview];
+    [webView addToTestWindow];
+
+    [webView selectWord:nil];
+    [webView waitForNextPresentationUpdate];
+    [fontManager addFontTrait:menuItemCellForFontAction(NSBoldFontMask).get()];
+    EXPECT_WK_STREQ("700", [webView stylePropertyAtSelectionStart:@"font-weight"]);
+    EXPECT_WK_STREQ("700", [webView stylePropertyAtSelectionEnd:@"font-weight"]);
+    EXPECT_WK_STREQ("Times-Bold", [fontManager selectedFont].fontName);
+
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 1bce1f244af2c9a54cdee203044f0df73732f313
<pre>
Crash after unparenting an editable WKWebView twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=242160">https://bugs.webkit.org/show_bug.cgi?id=242160</a>
&lt;rdar://87728837&gt;

Reviewed by Wenson Hsieh.

-[WKWindowVisibilityObserver stopObserving] unconditionally unregisters the
font panel observer for editable web views, but nothing ever re-installs it
when reparented. Thus, if you remove an editable WKWebView from a window,
parent it again, and then unparent it again, we try to remove a non-existent
observer, resulting in an exception.

Add a bit of state tracking whether we have ever installed a font panel observer,
and if we ever have, we&apos;ll keep re-installing it when we start observing a fresh
window. This fixes both the exception, and also makes the font panel work
correctly when an editable WKWebView is removed and re-added to the view hierarchy.

* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving:]):
(-[WKWindowVisibilityObserver startObservingFontPanel]):
* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/251978@main">https://commits.webkit.org/251978@main</a>
</pre>
