### PR TITLE
[Gardening]: REGRESSION (251523@main): [ iOS ][ macOS Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3663,3 +3663,5 @@ fast/text/bulgarian-system-language-shaping.html [ Pass ]
 webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Failure ]
 webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ Pass ]
+
+webkit.org/b/242164 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1722,3 +1722,5 @@ webkit.org/b/241283 fast/animation/request-animation-frame-throttling-detached-i
 [ Ventura+ ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker.html [ Pass ]
 [ Ventura+ ] http/tests/workers/service/getnotifications-stop.html [ Pass ]
 [ Ventura+ ] http/tests/workers/service/getnotifications.html [ Pass ]
+
+webkit.org/b/242164 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]


### PR DESCRIPTION
#### e542a291dc57598d1143c9107dff9a43551a67c8
<pre>
[Gardening]: REGRESSION (251523@main): [ iOS ][ macOS Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242164">https://bugs.webkit.org/show_bug.cgi?id=242164</a>
&lt;rdar://96190028&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251980@main">https://commits.webkit.org/251980@main</a>
</pre>
