### PR TITLE
Float color buffer extensions must extend renderbufferStorage

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -4714,8 +4714,19 @@ void WebGLRenderingContextBase::renderbufferStorageImpl(GCGLenum target, GCGLsiz
     case GraphicsContextGL::RGB565:
     case GraphicsContextGL::STENCIL_INDEX8:
     case GraphicsContextGL::SRGB8_ALPHA8_EXT:
+    case GraphicsContextGL::RGB16F:
+    case GraphicsContextGL::RGBA16F:
+    case GraphicsContextGL::RGBA32F:
         if (internalformat == GraphicsContextGL::SRGB8_ALPHA8_EXT && !m_extsRGB) {
-            synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid internalformat");
+            synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "EXT_sRGB not enabled");
+            return;
+        }
+        if ((internalformat == GraphicsContextGL::RGB16F || internalformat == GraphicsContextGL::RGBA16F) && !m_extColorBufferHalfFloat) {
+            synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "EXT_color_buffer_half_float not enabled");
+            return;
+        }
+        if (internalformat == GraphicsContextGL::RGBA32F && !m_webglColorBufferFloat) {
+            synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "WEBGL_color_buffer_float not enabled");
             return;
         }
         m_context->renderbufferStorage(target, internalformat, width, height);


### PR DESCRIPTION
#### 6d9735fc11e427d58c8e605e8350976f033655ff
<pre>
Float color buffer extensions must extend renderbufferStorage
<a href="https://bugs.webkit.org/show_bug.cgi?id=242168">https://bugs.webkit.org/show_bug.cgi?id=242168</a>

Reviewed by Kimmo Kinnunen.

Allow WebGL 1.0 renderbuffers with float and half-float
formats and check if the corresponding extensions are enabled.

Improved the error message when EXT_sRGB is not enabled.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::renderbufferStorageImpl):

Canonical link: <a href="https://commits.webkit.org/252005@main">https://commits.webkit.org/252005@main</a>
</pre>
