### PR TITLE
[ iOS ] 2X fast/text/accessibility-bold-system-font (Layout-tests) are constant failures

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5321,7 +5321,7 @@ fast/attachment/attachment-image-controls-basic.html [ Skip ]
 fast/text/bulgarian-system-language-shaping.html [ ImageOnlyFailure ]
 
 # Accessibility bold only exists on iOS.
-fast/text/accessibility-bold-system-font [ Skip ]
+fast/text/accessibility-bold-system-font [ Pass Failure ImageOnlyFailure ]
 
 # ReadableByteStream has a crash bug (ReadableByteStream is not enabled).
 imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.html [ Skip ]

--- a/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2-expected.html
+++ b/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2-expected.html
@@ -4,6 +4,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body style="font: -apple-system-body; font-weight: 590;">
-<div id="target" style="font-size: 400%;">Hello</div>
+<div id="target" style="font-size: 400%;"><div style="width: 1px; height: 400px; display: inline-block;"></div>Hello</div>
 </body>
 </html>

--- a/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html
+++ b/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html
@@ -8,6 +8,6 @@ if (window.internals)
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body style="font: -apple-system-body;">
-<div id="target" style="font-size: 400%;">Hello</div>
+<div id="target" style="font-size: 400%;"><div style="width: 1px; height: 400px; display: inline-block;"></div>Hello</div>
 </body>
 </html>

--- a/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html
+++ b/LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html
@@ -5,7 +5,7 @@
 if (window.internals)
     internals.settings.setShouldMockBoldSystemFontForAccessibility(true);
 </script>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body style="font: -apple-system-body;">
 <div id="target" style="font-size: 400%;">Hello</div>
@@ -14,6 +14,5 @@ description("This test makes sure that text using the accessibility bold functio
 var target = document.getElementById("target");
 shouldBeEqualToString("window.getComputedStyle(target).getPropertyValue('font-weight')", "400");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3660,8 +3660,6 @@ webkit.org/b/241205 fast/forms/textfield-outline.html [ Pass Failure ]
 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 # Accessibility bold only exists on iOS.
-webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Failure ]
-webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
-fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ Pass ]
+fast/text/accessibility-bold-system-font [ Pass ]
 
 webkit.org/b/242164 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2293,7 +2293,3 @@ webkit.org/b/227845 [ Debug ] webaudio/audioworket-out-of-memory.html [ Pass Tim
 webkit.org/b/240989 http/tests/media/hls/hls-webvtt-flashing.html [ Pass Failure ]
 
 [ Monterey+ ] fast/text/bulgarian-system-language-shaping.html [ Pass ]
-
-webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html [ ImageOnlyFailure ]
-webkit.org/b/242139 fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html [ Failure ]
-webkit.org/b/242139 [ BigSur ] fast/text/accessibility-bold-system-font/accessibility-bold-system-font-3.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### fa781327fe86d62478f5c84397a49c620b15b386
<pre>
[ iOS ] 2X fast/text/accessibility-bold-system-font (Layout-tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=242119">https://bugs.webkit.org/show_bug.cgi?id=242119</a>
&lt;rdar://96150140&gt;

Unreviewed test gardening.

Fixup tests after 251883@main.

* LayoutTests/TestExpectations:
* LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2-expected.html:
* LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font-2.html:
* LayoutTests/fast/text/accessibility-bold-system-font/accessibility-bold-system-font.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/251984@main">https://commits.webkit.org/251984@main</a>
</pre>
