### PR TITLE
[JSC] Drop support for the softfp ABI on ARMv7

### DIFF
--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -5527,7 +5527,6 @@ void testStoreBaseIndex()
         CHECK_EQ(array[4], UINT8_MAX - 42);
     }
 
-#if CPU(ARM_HARDFP)
     // storeDouble
     {
         auto test = compile([=](CCallHelpers& jit) {
@@ -5575,7 +5574,6 @@ void testStoreBaseIndex()
         invoke<void>(test, array, static_cast<UCPURegister>(3), 42.0f);
         CHECK_EQ(array[4], 42.0f);
     }
-#endif
 }
 
 static void testCagePreservesPACFailureBit()

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1082,15 +1082,6 @@ public:
 #endif
     }
 
-#if CPU(ARM_THUMB2) && !CPU(ARM_HARDFP)
-    JITCompiler::Call appendCallSetResult(const FunctionPtr<CFunctionPtrTag> function, FPRReg result)
-    {
-        JITCompiler::Call call = appendCall(function);
-        if (result != InvalidFPRReg)
-            m_jit.assembler().vmov(result, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR2);
-        return call;
-    }
-#else // CPU(X86_64) || (CPU(ARM_THUMB2) && CPU(ARM_HARDFP)) || CPU(ARM64) || CPU(MIPS)
     JITCompiler::Call appendCallSetResult(const FunctionPtr<CFunctionPtrTag> function, FPRReg result)
     {
         JITCompiler::Call call = appendCall(function);
@@ -1098,7 +1089,6 @@ public:
             m_jit.moveDouble(FPRInfo::returnValueFPR, result);
         return call;
     }
-#endif
 
     void branchDouble(JITCompiler::DoubleCondition cond, FPRReg left, FPRReg right, BasicBlock* destination)
     {

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -195,7 +195,7 @@ private:
         }
     }
 
-#if CPU(MIPS) || (CPU(ARM_THUMB2) && !CPU(ARM_HARDFP))
+#if CPU(MIPS)
     template<unsigned NumCrossSources, unsigned NumberOfRegisters>
     ALWAYS_INLINE void setupStubCrossArgs(std::array<GPRReg, NumberOfRegisters> destinations, std::array<FPRReg, NumberOfRegisters> sources) {
         for (unsigned i = 0; i < NumCrossSources; i++) {
@@ -448,7 +448,7 @@ private:
     {
         static_assert(std::is_same<CURRENT_ARGUMENT_TYPE, double>::value, "We should only be passing FPRRegs to a double");
 
-        // MIPS and ARM-hardfp pass FP arguments in FP registers.
+        // MIPS and ARM (hardfp, which we require) pass FP arguments in FP registers.
 #if CPU(MIPS)
         unsigned numberOfFPArgumentRegisters = FPRInfo::numberOfArgumentRegisters;
         unsigned currentFPArgCount = argSourceRegs.argCount(arg);
@@ -459,7 +459,7 @@ private:
             setupArgumentsImpl<OperationType>(updatedArgSourceRegs.addGPRExtraArg().addGPRExtraArg(), args...);
             return;
         }
-#elif CPU(ARM_THUMB2) && CPU(ARM_HARDFP)
+#elif CPU(ARM_THUMB2)
         unsigned numberOfFPArgumentRegisters = FPRInfo::numberOfArgumentRegisters;
         unsigned currentFPArgCount = argSourceRegs.argCount(arg);
 
@@ -470,8 +470,8 @@ private:
         }
 #endif
 
-#if CPU(MIPS) || (CPU(ARM_THUMB2) && !CPU(ARM_HARDFP))
-        // On MIPS and ARM-softfp FP arguments can be passed in GP registers.
+#if CPU(MIPS)
+        // On MIPS arguments can be passed in GP registers.
         unsigned numberOfGPArgumentRegisters = GPRInfo::numberOfArgumentRegisters;
         unsigned currentGPArgCount = argSourceRegs.argCount(GPRInfo::regT0);
         unsigned alignedGPArgCount = roundUpToMultipleOf<2>(currentGPArgCount);
@@ -737,7 +737,7 @@ private:
         static_assert(fprArgsCount<TraitsType>(std::make_index_sequence<TraitsType::arity>()) == numFPRArgs);
 
         setupStubArgs<numGPRSources, GPRReg>(clampArrayToSize<numGPRSources, GPRReg>(argSourceRegs.gprDestinations), clampArrayToSize<numGPRSources, GPRReg>(argSourceRegs.gprSources));
-#if CPU(MIPS) || (CPU(ARM_THUMB2) && !CPU(ARM_HARDFP))
+#if CPU(MIPS)
         setupStubCrossArgs<numCrossSources>(argSourceRegs.crossDestinations, argSourceRegs.crossSources);
 #else
         static_assert(!numCrossSources, "shouldn't be used on this architecture.");

--- a/Source/JavaScriptCore/jit/FPRInfo.h
+++ b/Source/JavaScriptCore/jit/FPRInfo.h
@@ -108,11 +108,7 @@ public:
     typedef FPRReg RegisterType;
     static constexpr unsigned numberOfRegisters = 8;
 
-#if CPU(ARM_HARDFP)
     static constexpr unsigned numberOfArgumentRegisters = 8;
-#else
-    static constexpr unsigned numberOfArgumentRegisters = 0;
-#endif
 
     // Temporary registers.
     // d8-d15 are callee saved, d15 is use by the MacroAssembler as fpTempRegister.
@@ -136,11 +132,8 @@ public:
     // value is also actually in integer registers, for now
     // we'll return in d0 for simplicity.
     static constexpr FPRReg returnValueFPR = ARMRegisters::d0; // fpRegT0
-
-#if CPU(ARM_HARDFP)
     static constexpr FPRReg argumentFPR0 = ARMRegisters::d0; // fpRegT0
     static constexpr FPRReg argumentFPR1 = ARMRegisters::d1; // fpRegT1
-#endif
 
     // FPRReg mapping is direct, the machine regsiter numbers can
     // be used directly as indices into the FPR RegisterBank.
@@ -161,13 +154,11 @@ public:
         return (unsigned)reg;
     }
 
-#if CPU(ARM_HARDFP)
     static FPRReg toArgumentRegister(unsigned index)
     {
         ASSERT(index < numberOfArgumentRegisters);
         return static_cast<FPRReg>(index);
     }
-#endif
 
     static const char* debugName(FPRReg reg)
     {

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -585,13 +585,13 @@
 #endif
 
 #if USE(JSVALUE32_64)
-#if !CPU(ARM_HARDFP)
+#if CPU(MIPS)
 #undef ENABLE_WEBASSEMBLY
 #define ENABLE_WEBASSEMBLY 0
 #undef ENABLE_WEBASSEMBLY_B3JIT
 #define ENABLE_WEBASSEMBLY_B3JIT 0
 #endif
-#if (CPU(ARM_THUMB2) || CPU(MIPS)) && OS(LINUX)
+#if ((CPU(ARM_THUMB2) && CPU(ARM_HARDFP)) || CPU(MIPS)) && OS(LINUX)
 /* On ARMv7 and MIPS on Linux the JIT is enabled unless explicitly disabled. */
 #if !defined(ENABLE_JIT)
 #define ENABLE_JIT 1


### PR DESCRIPTION
#### a2ec4ef1997d6fafa6ffc607bffb54e76168a918
<pre>
[JSC] Drop support for the softfp ABI on ARMv7
<a href="https://bugs.webkit.org/show_bug.cgi?id=242172">https://bugs.webkit.org/show_bug.cgi?id=242172</a>

Reviewed by Yusuke Suzuki.

Remove for all purposes the ARM_HARDFP option and just delete all code
enabled when it&apos;s false. It remains used in PlatformEnable.h, so we
enable CLOOP for ARMv7 builds using the softfp ABI.

* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testStoreBaseIndex):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::appendCallSetResult):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::setupArgumentsImpl):
* Source/JavaScriptCore/jit/FPRInfo.h:
(JSC::FPRInfo::toArgumentRegister):
* Source/WTF/wtf/PlatformCPU.h:
* Source/WTF/wtf/PlatformEnable.h:

Canonical link: <a href="https://commits.webkit.org/252034@main">https://commits.webkit.org/252034@main</a>
</pre>
