### PR TITLE
run-webkit-tests runs xcodebuild an unnecessary amount of times

### DIFF
--- a/Tools/Scripts/bisect-builds
+++ b/Tools/Scripts/bisect-builds
@@ -207,7 +207,7 @@ def get_s3_location_for_revision(url, revision):
 
 
 def host_platform_name():
-    platform = SystemHost().platform
+    platform = SystemHost.get_default().platform
     version_name = VersionNameMap.strip_name_formatting(platform.os_version_name())
     if version_name is None:
         return platform.os_name

--- a/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py
@@ -299,7 +299,7 @@ class CrashLogsTest(unittest.TestCase):
     DARWIN_MOCK_CRASH_DIRECTORY = '/Users/mock/Library/Logs/DiagnosticReports'
 
     def create_crash_logs_darwin(self):
-        if not SystemHost().platform.is_mac():
+        if not SystemHost.get_default().platform.is_mac():
             return
 
         self.older_mock_crash_report = make_mock_crash_report_darwin('DumpRenderTree', 28528)
@@ -329,7 +329,7 @@ class CrashLogsTest(unittest.TestCase):
         return crash_logs
 
     def test_find_all_log_darwin(self):
-        if not SystemHost().platform.is_mac():
+        if not SystemHost.get_default().platform.is_mac():
             return
 
         crash_logs = self.create_crash_logs_darwin()
@@ -342,7 +342,7 @@ class CrashLogsTest(unittest.TestCase):
                 self.assertTrue(test == "Unknown" or int(test.split("-")[1]) in range(28527, 28531))
 
     def test_duplicate_log_darwin(self):
-        if not SystemHost().platform.is_mac():
+        if not SystemHost.get_default().platform.is_mac():
             return
 
         crash_logs = self.create_crash_logs_darwin()
@@ -356,7 +356,7 @@ class CrashLogsTest(unittest.TestCase):
             self.assertIn(log, expected_logs)
 
     def test_find_log_darwin(self):
-        if not SystemHost().platform.is_mac():
+        if not SystemHost.get_default().platform.is_mac():
             return
 
         crash_logs = self.create_crash_logs_darwin()
@@ -388,7 +388,7 @@ class CrashLogsTest(unittest.TestCase):
         self.assertIn('OSError: No such file or directory', log)
 
     def test_find_log_win(self):
-        if not SystemHost().platform.is_win():
+        if not SystemHost.get_default().platform.is_win():
             return
 
         older_mock_crash_report = make_mock_crash_report_win('DumpRenderTree', 28528)
@@ -425,7 +425,7 @@ class CrashLogsTest(unittest.TestCase):
         self.assertIn('IOError: No such file or directory', log)
 
     def test_get_timestamp_from_logs_darwin(self):
-        if not SystemHost().platform.is_mac():
+        if not SystemHost.get_default().platform.is_mac():
             return
 
         crash_report = make_mock_crash_report_darwin('DumpRenderTree', 28528)

--- a/Tools/Scripts/webkitpy/common/system/path_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/path_unittest.py
@@ -37,7 +37,7 @@ from webkitpy.common.system import path
 
 class AbspathTest(unittest.TestCase):
     def platforminfo(self):
-        return SystemHost().platform
+        return SystemHost.get_default().platform
 
     def test_abspath_to_uri_cygwin(self):
         if sys.platform != 'cygwin':

--- a/Tools/Scripts/webkitpy/common/system/systemhost.py
+++ b/Tools/Scripts/webkitpy/common/system/systemhost.py
@@ -36,6 +36,8 @@ from webkitcorepy import FileLock
 
 
 class SystemHost(object):
+    _default_system_host = None
+
     def __init__(self):
         self.executive = executive.Executive()
         self.filesystem = filesystem.FileSystem()
@@ -62,3 +64,9 @@ class SystemHost(object):
     @property
     def device_type(self):
         return None
+
+    @staticmethod
+    def get_default():
+        if not SystemHost._default_system_host:
+            SystemHost._default_system_host = SystemHost()
+        return SystemHost._default_system_host

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -45,7 +45,7 @@ class VersionNameMap(object):
     def __init__(self, platform=None):
         if platform is None:
             from webkitpy.common.system.systemhost import SystemHost
-            platform = SystemHost().platform
+            platform = SystemHost.get_default().platform
         self.mapping = {}
 
         self.default_system_platform = platform.os_name

--- a/Tools/Scripts/webkitpy/common/version_name_map_unittest.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map_unittest.py
@@ -31,7 +31,7 @@ from webkitpy.common.version_name_map import VersionNameMap
 class VersionMapTestCase(unittest.TestCase):
 
     def test_default_system_platform(self):
-        host = SystemHost()
+        host = SystemHost.get_default()
         map = VersionNameMap(platform=host.platform)
         self.assertEqual(map.default_system_platform, host.platform.os_name)
 

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -170,7 +170,7 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         # A real PlatformInfo object is used here instead of a
         # MockPlatformInfo because we need to actually check for
         # Windows and Mac to skip some tests.
-        self._platform = SystemHost().platform
+        self._platform = SystemHost.get_default().platform
 
         # FIXME: Remove this when we fix test-webkitpy to work
         # properly on cygwin (bug 63846).

--- a/Tools/Scripts/webkitpy/port/server_process_unittest.py
+++ b/Tools/Scripts/webkitpy/port/server_process_unittest.py
@@ -106,7 +106,7 @@ class TestServerProcess(unittest.TestCase):
     def serial_test_basic(self):
         # Give -u switch to force stdout and stderr to be unbuffered for Windows
         cmd = [sys.executable, '-uc', 'import sys; print("stdout"); print("again"); {}; sys.stdin.readline();'.format(self.stderr_print)]
-        host = SystemHost()
+        host = SystemHost.get_default()
         factory = PortFactory(host)
         port = factory.get()
         now = time.time()
@@ -141,7 +141,7 @@ class TestServerProcess(unittest.TestCase):
 
     def serial_test_read_after_process_exits(self):
         cmd = [sys.executable, '-uc', 'import sys; print("stdout"); {};'.format(self.stderr_print)]
-        host = SystemHost()
+        host = SystemHost.get_default()
         factory = PortFactory(host)
         port = factory.get()
         now = time.time()
@@ -160,7 +160,7 @@ class TestServerProcess(unittest.TestCase):
     def serial_test_process_crashing(self):
         # Give -u switch to force stdout to be unbuffered for Windows
         cmd = [sys.executable, '-uc', 'import sys; print("stdout 1"); print("stdout 2"); print("stdout 3"); sys.stdin.readline(); sys.exit(1);']
-        host = SystemHost()
+        host = SystemHost.get_default()
         factory = PortFactory(host)
         port = factory.get()
         now = time.time()
@@ -185,7 +185,7 @@ class TestServerProcess(unittest.TestCase):
 
     def serial_test_process_crashing_no_data(self):
         cmd = [sys.executable, '-uc', 'import sys; sys.stdin.readline(); sys.exit(1);']
-        host = SystemHost()
+        host = SystemHost.get_default()
         factory = PortFactory(host)
         port = factory.get()
         now = time.time()

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -166,7 +166,7 @@ class WinPort(ApplePort):
         return None
 
     def show_results_html_file(self, results_filename):
-        self._run_script('run-safari', [abspath_to_uri(SystemHost().platform, results_filename)])
+        self._run_script('run-safari', [abspath_to_uri(SystemHost.get_default().platform, results_filename)])
 
     def _build_path(self, *comps):
         """Returns the full path to the test driver (DumpRenderTree)."""

--- a/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
+++ b/Tools/Scripts/webkitpy/style/checkers/featuredefines.py
@@ -41,7 +41,7 @@ class FeatureDefinesChecker(object):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
-        self._host = SystemHost()
+        self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
     def check(self, inline=None):

--- a/Tools/Scripts/webkitpy/style/checkers/jstest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jstest.py
@@ -92,7 +92,7 @@ class JSTestChecker(object):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
-        self._host = SystemHost()
+        self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
     def check(self, lines):

--- a/Tools/Scripts/webkitpy/style/checkers/png.py
+++ b/Tools/Scripts/webkitpy/style/checkers/png.py
@@ -41,7 +41,7 @@ class PNGChecker(object):
     def __init__(self, file_path, handle_style_error, scm=None, host=None):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
-        self._host = host or SystemHost()
+        self._host = host or SystemHost.get_default()
         self._fs = self._host.filesystem
         self._detector = scm or SCMDetector(self._fs, self._host.executive).detect_scm_system(self._fs.getcwd())
 

--- a/Tools/Scripts/webkitpy/style/checkers/sdkvariant.py
+++ b/Tools/Scripts/webkitpy/style/checkers/sdkvariant.py
@@ -61,7 +61,7 @@ class SDKVariantChecker(object):
         self._file_path = file_path
         self._handle_style_error = handle_style_error
         self._handle_style_error.turn_off_line_filtering()
-        self._host = SystemHost()
+        self._host = SystemHost.get_default()
         self._fs = self._host.filesystem
 
     def check(self, inline=None):

--- a/Tools/Scripts/webkitpy/test/printer.py
+++ b/Tools/Scripts/webkitpy/test/printer.py
@@ -59,7 +59,7 @@ class Printer(object):
             log_level = logging.DEBUG
 
         self.meter = MeteredStream(self.stream, (options.verbose == 2),
-            number_of_columns=SystemHost().platform.terminal_width())
+                                   number_of_columns=SystemHost.get_default().platform.terminal_width())
 
         handler = logging.StreamHandler(self.stream)
         # We constrain the level on the handler rather than on the root

--- a/Tools/Scripts/webkitpy/tool/steps/addsvnmimetypeforpng.py
+++ b/Tools/Scripts/webkitpy/tool/steps/addsvnmimetypeforpng.py
@@ -35,7 +35,7 @@ class AddSvnMimetypeForPng(AbstractStep):
     def __init__(self, tool, options, host=None, scm=None):
         self._tool = tool
         self._options = options
-        self._host = host or SystemHost()
+        self._host = host or SystemHost.get_default()
         self._fs = self._host.filesystem
         self._detector = scm or SCMDetector(self._fs, self._host.executive).detect_scm_system(self._fs.getcwd())
 

--- a/Tools/Scripts/webkitpy/tool/steps/formatcppfiles.py
+++ b/Tools/Scripts/webkitpy/tool/steps/formatcppfiles.py
@@ -66,7 +66,7 @@ class FormatCppFiles(AbstractStep):
     def __init__(self, tool, options, host=None, scm=None):
         self._tool = tool
         self._options = options
-        self._host = host or SystemHost()
+        self._host = host or SystemHost.get_default()
 
     def run(self, state):
         if not self._options.format_cpp_files:

--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -129,7 +129,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def populate_available_devices(host=None):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if not host.platform.is_mac():
             return
 
@@ -165,14 +165,14 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def available_devices(host=None):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if SimulatedDeviceManager.AVAILABLE_DEVICES == []:
             SimulatedDeviceManager.populate_available_devices(host)
         return SimulatedDeviceManager.AVAILABLE_DEVICES
 
     @staticmethod
     def device_by_filter(filter, host=None):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         result = []
         for device in SimulatedDeviceManager.available_devices(host):
             if filter(device):
@@ -277,7 +277,7 @@ class SimulatedDeviceManager(object):
     @staticmethod
     def _create_or_find_device_for_request(request, host=None, name_base='Managed'):
         assert isinstance(request, DeviceRequest)
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
 
         device = SimulatedDeviceManager._find_exisiting_device_for_request(request)
         if device:
@@ -361,7 +361,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def _boot_device(device, host=None):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         _log.debug(u"Booting device '{}'".format(device.udid))
         device.platform_device.booted_by_script = True
         host.executive.run_command([SimulatedDeviceManager.xcrun, 'simctl', 'boot', device.udid])
@@ -371,7 +371,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def device_count_for_type(device_type, host=None, use_booted_simulator=True, **kwargs):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if not host.platform.is_mac():
             return 0
 
@@ -386,7 +386,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def initialize_devices(requests, host=None, name_base='Managed', simulator_ui=True, timeout=SIMULATOR_BOOT_TIMEOUT, **kwargs):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if SimulatedDeviceManager.INITIALIZED_DEVICES is not None:
             return SimulatedDeviceManager.INITIALIZED_DEVICES
 
@@ -443,7 +443,7 @@ class SimulatedDeviceManager(object):
     @staticmethod
     @memoized
     def max_supported_simulators(host=None):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if not host.platform.is_mac():
             return 0
 
@@ -472,7 +472,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def swap(device, request, host=None, name_base='Managed', timeout=SIMULATOR_BOOT_TIMEOUT):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if SimulatedDeviceManager.INITIALIZED_DEVICES is None:
             raise RuntimeError('Cannot swap when there are no initialized devices')
         if device not in SimulatedDeviceManager.INITIALIZED_DEVICES:
@@ -496,7 +496,7 @@ class SimulatedDeviceManager(object):
 
     @staticmethod
     def tear_down(host=None, timeout=SIMULATOR_BOOT_TIMEOUT):
-        host = host or SystemHost()
+        host = host or SystemHost.get_default()
         if SimulatedDeviceManager._managing_simulator_app:
             host.executive.run_command(['killall', '-9', 'Simulator.app'], return_exit_code=True)
             SimulatedDeviceManager._managing_simulator_app = False

--- a/Tools/lldb/dump_class_layout_unittest.py
+++ b/Tools/lldb/dump_class_layout_unittest.py
@@ -48,7 +48,7 @@ def destroy_cached_debug_session():
 class TestDumpClassLayout(unittest.TestCase):
     @classmethod
     def shouldSkip(cls):
-        return not SystemHost().platform.is_mac()
+        return not SystemHost.get_default().platform.is_mac()
 
     @classmethod
     def setUpClass(cls):

--- a/Tools/lldb/lldb_dump_class_layout.py
+++ b/Tools/lldb/lldb_dump_class_layout.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 
 from webkitpy.common.system.systemhost import SystemHost
-sys.path.append(SystemHost().path_to_lldb_python_directory())
+sys.path.append(SystemHost.get_default().path_to_lldb_python_directory())
 import lldb
 
 # lldb Python reference:

--- a/Tools/lldb/lldb_webkit_unittest.py
+++ b/Tools/lldb/lldb_webkit_unittest.py
@@ -85,7 +85,7 @@ class LLDBDebugSession(object):
 class TestSummaryProviders(unittest.TestCase):
     @classmethod
     def shouldSkip(cls):
-        return not SystemHost().platform.is_mac()
+        return not SystemHost.get_default().platform.is_mac()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
#### 41fac762fe6cbe087ff7ec9f7c50fcedc22e7b55
<pre>
run-webkit-tests runs xcodebuild an unnecessary amount of times
<a href="https://bugs.webkit.org/show_bug.cgi?id=216568">https://bugs.webkit.org/show_bug.cgi?id=216568</a>

Reviewed by Jonathan Bedard.

Avoid constructing new SystemHost instances, instead use the default instance
for all the operations that need a default instance.

time run-webkit-tests tt

MacBookPro18,2 before: 2.9s, after: 1.9s
MacBookPro16,1 before: 5s after: 3s

To be effective for internal builds, need similar change in internal repository.

* Tools/Scripts/bisect-builds:
* Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py:
* Tools/Scripts/webkitpy/common/system/path_unittest.py:
(AbspathTest.platforminfo):
* Tools/Scripts/webkitpy/common/system/systemhost.py:
(SystemHost):
(SystemHost.device_type):
(SystemHost.get_default):
* Tools/Scripts/webkitpy/common/version_name_map.py:
(VersionNameMap.__init__):
* Tools/Scripts/webkitpy/common/version_name_map_unittest.py:
(VersionMapTestCase.test_default_system_platform):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.setUp):
* Tools/Scripts/webkitpy/port/server_process_unittest.py:
(TestServerProcess.serial_test_basic):
(TestServerProcess.serial_test_read_after_process_exits):
(TestServerProcess.serial_test_process_crashing):
(TestServerProcess.serial_test_process_crashing_no_data):
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.show_results_html_file):
* Tools/Scripts/webkitpy/style/checkers/featuredefines.py:
(FeatureDefinesChecker.__init__):
* Tools/Scripts/webkitpy/style/checkers/jstest.py:
(JSTestChecker.__init__):
* Tools/Scripts/webkitpy/style/checkers/png.py:
(PNGChecker.__init__):
* Tools/Scripts/webkitpy/style/checkers/sdkvariant.py:
(SDKVariantChecker.__init__):
* Tools/Scripts/webkitpy/test/printer.py:
(Printer.configure):
* Tools/Scripts/webkitpy/tool/steps/addsvnmimetypeforpng.py:
(AddSvnMimetypeForPng.__init__):
* Tools/Scripts/webkitpy/tool/steps/formatcppfiles.py:
(FormatCppFiles.__init__):
* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager.populate_available_devices):
(SimulatedDeviceManager.available_devices):
(SimulatedDeviceManager.device_by_filter):
(SimulatedDeviceManager._create_or_find_device_for_request):
(SimulatedDeviceManager._boot_device):
(SimulatedDeviceManager.device_count_for_type):
(SimulatedDeviceManager.initialize_devices):
(SimulatedDeviceManager.max_supported_simulators):
(SimulatedDeviceManager.swap):
(SimulatedDeviceManager.tear_down):
* Tools/lldb/dump_class_layout_unittest.py:
(TestDumpClassLayout.shouldSkip):
* Tools/lldb/lldb_dump_class_layout.py:
* Tools/lldb/lldb_webkit_unittest.py:
(TestSummaryProviders.shouldSkip):

Canonical link: <a href="https://commits.webkit.org/252046@main">https://commits.webkit.org/252046@main</a>
</pre>
