### PR TITLE
[GLib] Tools/glib/apply-build-revision-to-files.py fails on Git worktrees

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -65,7 +65,7 @@ def get_build_revision():
                 revision_from_git = get_revision_from_most_recent_git_commit()
                 if revision_from_git:
                     revision = revision_from_git
-        elif os.path.isdir('.git'):
+        elif os.path.isdir('.git') or os.path.isfile('.git'):
             revision_from_git = get_revision_from_most_recent_git_commit()
             if revision_from_git:
                 revision = revision_from_git


### PR DESCRIPTION
#### 56353fd580f3cffa5d2abe69b552016f933f14b6
<pre>
[GLib] Tools/glib/apply-build-revision-to-files.py fails on Git worktrees
<a href="https://bugs.webkit.org/show_bug.cgi?id=242176">https://bugs.webkit.org/show_bug.cgi?id=242176</a>

Reviewed by Philippe Normand.

* Tools/glib/apply-build-revision-to-files.py:
(get_build_revision): Cover the case where .git is a regular file, as
used for worktrees.

Canonical link: <a href="https://commits.webkit.org/251991@main">https://commits.webkit.org/251991@main</a>
</pre>
