### PR TITLE
REGRESSION (250816@main): composite option in Element.animate() is ignored

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -538,10 +538,11 @@ ExceptionOr<Ref<KeyframeEffect>> KeyframeEffect::create(JSGlobalObject& lexicalG
                 keyframeEffectOptions.direction
             };
 
-            if (document.settings().webAnimationsIterationCompositeEnabled()) {
+            if (document.settings().webAnimationsCompositeOperationsEnabled())
                 keyframeEffect->setComposite(keyframeEffectOptions.composite);
+
+            if (document.settings().webAnimationsIterationCompositeEnabled())
                 keyframeEffect->setIterationComposite(keyframeEffectOptions.iterationComposite);
-            }
         }
         auto updateTimingResult = keyframeEffect->updateTiming(timing);
         if (updateTimingResult.hasException())


### PR DESCRIPTION
#### 4fa06c18977aec2cd709a9c764f7e471af25a268
<pre>
REGRESSION (250816@main): composite option in Element.animate() is ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=242178">https://bugs.webkit.org/show_bug.cgi?id=242178</a>

Reviewed by Tim Nguyen.

We used to guard the `iterationComposite` property with the same runtime flag as the `composite` property.
When we introduced a dedicated flag for the iterationComposite property (bug 240727) we mistakenly switched
the guard in `KeyframeEffect::create()` which governed both properties from the `composite` guard to the
`iterationComposite` guard, instead of adding the two guards, one for each property. As a result, the
`composite` property can no longer be set via Element.animate() or the KeyframeEffect constructor.

We now check for those guards individually to set the right property.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::create):

Canonical link: <a href="https://commits.webkit.org/251998@main">https://commits.webkit.org/251998@main</a>
</pre>
