### PR TITLE
Web Inspector: REGRESSION (Bug 241817 ) Filter bars missing from Styles and Computed panels

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js
@@ -128,7 +128,7 @@ WI.GeneralStyleDetailsSidebarPanel = class GeneralStyleDetailsSidebarPanel exten
 
     initialLayout()
     {
-        this._showPanel(this._panel);
+        this.contentView.addSubview(this._panel);
 
         if (this._classListContainerToggledSetting) {
             this._classListContainer = this.element.createChild("div", "class-list-container");
@@ -174,6 +174,8 @@ WI.GeneralStyleDetailsSidebarPanel = class GeneralStyleDetailsSidebarPanel exten
             this._filterBar = new WI.FilterBar;
             this._filterBar.addEventListener(WI.FilterBar.Event.FilterDidChange, this._filterDidChange, this);
             this._filterBar.inputField.addEventListener("keydown", this._handleFilterBarInputFieldKeyDown.bind(this));
+            this.contentView.element.classList.add("has-filter-bar");
+
             optionsContainer.appendChild(this._filterBar.element);
         }
 
@@ -209,14 +211,6 @@ WI.GeneralStyleDetailsSidebarPanel = class GeneralStyleDetailsSidebarPanel exten
     }
 
     // Private
-
-    _showPanel()
-    {
-        this.contentView.addSubview(this._panel);
-        this.contentView.element.classList.toggle("has-filter-bar", !!this._filterBar);
-        if (this._filterBar)
-            this.contentView.element.classList.toggle(WI.GeneralStyleDetailsSidebarPanel.FilterInProgressClassName, this._filterBar.hasActiveFilters());
-    }
 
     _updateClassListContainer()
     {


### PR DESCRIPTION
#### 27afcd755691b9e231a72d7d57720827c718029c
<pre>
Web Inspector: REGRESSION (Bug 241817 ) Filter bars missing from Styles and Computed panels
<a href="https://bugs.webkit.org/show_bug.cgi?id=242186">https://bugs.webkit.org/show_bug.cgi?id=242186</a>

Reviewed by Devin Rousso and Patrick Angle.

The visibility of the filter bar was guarded on the truthiness of `this._filterBar`,
a check that occured in `_showPanel()` before the filter bar was created in `initialLayout()`.
This resulted in a filter bar that was eventually created but remained hidden.

This patch inlines the contents of `WI.GeneralStyleDetailsSidebarPanel._showPanel()`
into `WI.GeneralStyleDetailsSidebarPanel.initialLayout()` ensuring the filter bar is
always visible if created.

* Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.js:
 (WI.GeneralStyleDetailsSidebarPanel.prototype.initialLayout):
 (WI.GeneralStyleDetailsSidebarPanel.prototype._showPanel): Deleted.

Canonical link: <a href="https://commits.webkit.org/252093@main">https://commits.webkit.org/252093@main</a>
</pre>
