### PR TITLE
REGRESSION (10/5/2021?): [iOS] http/wpt/cross-origin-opener-policy/single-request-to-server.html is a flaky failure

### DIFF
--- a/LayoutTests/http/wpt/cross-origin-opener-policy/single-request-to-server.html
+++ b/LayoutTests/http/wpt/cross-origin-opener-policy/single-request-to-server.html
@@ -13,8 +13,7 @@ async_test((t) => {
     let w = open("resources/single-request-to-server-popup.py?token=" + token());
     bc.onmessage = t.step_func((event) => {
         assert_equals(event.data, "not_already_loaded");
-        assert_true(w.closed, "Should switch browsing context group");
-        t.done();
+        t.step_wait_func_done(() => w.closed);
     });
 }, "Make sure we make a single request to the HTTP server when switching browsing context group");
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3557,8 +3557,6 @@ webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-gamut-00
 
 webkit.org/b/237694 [ Debug ] webgl/1.0.3/conformance/uniforms/uniform-samplers-test.html [ Timeout Pass ]
 
-webkit.org/b/233284 http/wpt/cross-origin-opener-policy/single-request-to-server.html [ Pass Failure ]
-
 [ Release ] editing/spelling/toggle-spellchecking.html [ Failure Pass ]
 pointerevents/mouse/pointer-event-basic-properties.html [ Timeout ]
 imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html [ Failure Pass ]


### PR DESCRIPTION
#### 59340788443f8ffc2a1e09742962e074a70eb9d1
<pre>
REGRESSION (10/5/2021?): [iOS] http/wpt/cross-origin-opener-policy/single-request-to-server.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=233284">https://bugs.webkit.org/show_bug.cgi?id=233284</a>
&lt;rdar://85520978&gt;

Reviewed by Geoffrey Garen.

The test was synchronously checking that the popup would be closed once receiving the broadcast message
from the popup, due to process isolation. However, because the popup code actually runs in a new process,
the broadcast message may get received before the previous process reports the popup as closed.

To address the issue, we now make sure the popup eventually closes instead.

* LayoutTests/http/wpt/cross-origin-opener-policy/single-request-to-server.html:

Canonical link: <a href="https://commits.webkit.org/252004@main">https://commits.webkit.org/252004@main</a>
</pre>
