### PR TITLE
Add threading assertions to ProcessThrottler

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -54,6 +54,7 @@ ProcessThrottler::~ProcessThrottler()
 
 bool ProcessThrottler::addActivity(ForegroundActivity& activity)
 {
+    ASSERT(isMainRunLoop());
     if (!m_allowsActivities) {
         if (!activity.isQuietActivity())
             PROCESSTHROTTLER_RELEASE_LOG("addActivity: not allowed to add foreground activity %s", activity.name().characters());
@@ -67,6 +68,7 @@ bool ProcessThrottler::addActivity(ForegroundActivity& activity)
 
 bool ProcessThrottler::addActivity(BackgroundActivity& activity)
 {
+    ASSERT(isMainRunLoop());
     if (!m_allowsActivities) {
         if (!activity.isQuietActivity())
             PROCESSTHROTTLER_RELEASE_LOG("addActivity: not allowed to add background activity %s", activity.name().characters());
@@ -80,18 +82,21 @@ bool ProcessThrottler::addActivity(BackgroundActivity& activity)
 
 void ProcessThrottler::removeActivity(ForegroundActivity& activity)
 {
+    ASSERT(isMainRunLoop());
     m_foregroundActivities.remove(&activity);
     updateAssertionIfNeeded();
 }
 
 void ProcessThrottler::removeActivity(BackgroundActivity& activity)
 {
+    ASSERT(isMainRunLoop());
     m_backgroundActivities.remove(&activity);
     updateAssertionIfNeeded();
 }
 
 void ProcessThrottler::invalidateAllActivities()
 {
+    ASSERT(isMainRunLoop());
     PROCESSTHROTTLER_RELEASE_LOG("invalidateAllActivities: BEGIN (foregroundActivityCount: %u, backgroundActivityCount: %u)", m_foregroundActivities.size(), m_backgroundActivities.size());
     while (!m_foregroundActivities.isEmpty())
         (*m_foregroundActivities.begin())->invalidate();

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -64,6 +64,7 @@ public:
             : m_throttler(&throttler)
             , m_name(name)
         {
+            ASSERT(isMainRunLoop());
             if (!throttler.addActivity(*this)) {
                 m_throttler = nullptr;
                 return;
@@ -77,6 +78,7 @@ public:
 
         ~Activity()
         {
+            ASSERT(isMainRunLoop());
             if (isValid())
                 invalidate();
         }


### PR DESCRIPTION
#### 28da1be305b5d61b8aa56ea8e99df88959b8e8af
<pre>
Add threading assertions to ProcessThrottler
<a href="https://bugs.webkit.org/show_bug.cgi?id=242192">https://bugs.webkit.org/show_bug.cgi?id=242192</a>
&lt;rdar://94673452&gt;

Reviewed by Tim Horton.

Add threading assertions to ProcessThrottler to help investigate &lt;rdar://94673452&gt;.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::removeActivity):
(WebKit::ProcessThrottler::invalidateAllActivities):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::Activity::Activity):
(WebKit::ProcessThrottler::Activity::~Activity):

Canonical link: <a href="https://commits.webkit.org/252009@main">https://commits.webkit.org/252009@main</a>
</pre>
