### PR TITLE
Rename flag for build-and-collect-pgo-profiles

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -20,7 +20,7 @@ while getopts "b:a:d:yh" flag; do
         b) BASE=${OPTARG};;
         a) APP=${OPTARG};;
         d) BUILD=${OPTARG};;
-        n) NINPUT=true ;;
+        y) NINPUT=true ;;
         h)
           DisplayHelp
           exit;;


### PR DESCRIPTION
#### 2ad2d2597921ea90a0f26ce9502572d6287b0651
<pre>
Rename flag for build-and-collect-pgo-profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=242127">https://bugs.webkit.org/show_bug.cgi?id=242127</a>

Reviewed by Dewei Zhu.

Missed one instance when changing the flag. Fixed to match the others.

* Tools/Scripts/build-and-collect-pgo-profiles:

Canonical link: <a href="https://commits.webkit.org/252002@main">https://commits.webkit.org/252002@main</a>
</pre>
