### PR TITLE
Adjust mini mode number for libpas

### DIFF
--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -199,8 +199,8 @@ void enableMiniMode()
 {
 #if BENABLE(LIBPAS)
     // Speed up the scavenger.
-    pas_scavenger_period_in_milliseconds = 10.;
-    pas_scavenger_max_epoch_delta = 10ll * 1000ll * 1000ll;
+    pas_scavenger_period_in_milliseconds = 5.;
+    pas_scavenger_max_epoch_delta = 5ll * 1000ll * 1000ll;
 
     // Do eager scavenging anytime pages are allocated or committed.
     pas_physical_page_sharing_pool_balancing_enabled = true;


### PR DESCRIPTION
#### dae5f339d079ff36d14a8697bf738ec84aaf3f2d
<pre>
Adjust mini mode number for libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=242195">https://bugs.webkit.org/show_bug.cgi?id=242195</a>

Reviewed by Mark Lam.

We adjust libpas numbers for mini mode to gain 0.5% RAMification improvement.
The current numbers are just picked to match against libmalloc&apos;s results
with libmalloc tests. Instead, we pick lower numbers in this patch.

* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::enableMiniMode):

Canonical link: <a href="https://commits.webkit.org/252006@main">https://commits.webkit.org/252006@main</a>
</pre>
