### PR TITLE
[Gardening]: REGRESSION (251723@main): [ iOS ] compositing/images/positioned-image-content-rect.html is a flaky image failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3663,3 +3663,5 @@ fast/text/bulgarian-system-language-shaping.html [ Pass ]
 fast/text/accessibility-bold-system-font [ Pass ]
 
 webkit.org/b/242164 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]
+
+webkit.org/b/242194 compositing/images/positioned-image-content-rect.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 769fc294900af6ea368d8fe1de5cd75463d2410c
<pre>
[Gardening]: REGRESSION (251723@main): [ iOS ] compositing/images/positioned-image-content-rect.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242194">https://bugs.webkit.org/show_bug.cgi?id=242194</a>
&lt;rdar://96230716&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252003@main">https://commits.webkit.org/252003@main</a>
</pre>
