### PR TITLE
[iOS] Add support for keyboard shortcut and menu item to find using the current selection

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -353,6 +353,10 @@ typedef id<NSCoding, NSCopying> _UITextSearchDocumentIdentifier;
 @property (nonatomic, strong) id<_UITextSearching> searchableObject;
 @end
 
+@interface UIFindInteraction ()
+@property (class, nonatomic, copy, getter=_globalFindBuffer, setter=_setGlobalFindBuffer:) NSString *_globalFindBuffer;
+@end
+
 #endif // HAVE(UIFINDINTERACTION)
 
 typedef enum {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -134,6 +134,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)findNext:(id)sender;
 - (void)findPrevious:(id)sender;
 - (void)findAndReplace:(id)sender;
+- (void)useSelectionForFind:(id)sender;
+- (void)_findSelected:(id)sender;
 
 - (id<UITextSearching>)_searchableObject;
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -166,7 +166,9 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
     M(find) \
     M(findNext) \
     M(findPrevious) \
-    M(findAndReplace)
+    M(findAndReplace) \
+    M(useSelectionForFind) \
+    M(_findSelected)
 #else
 #define FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M)
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/Document.h>
 #include <WebCore/DocumentMarkerController.h>
 #include <WebCore/Editor.h>
+#include <WebCore/FocusController.h>
 #include <WebCore/Frame.h>
 #include <WebCore/FrameView.h>
 #include <WebCore/GeometryUtilities.h>
@@ -304,6 +305,13 @@ void WebFoundTextRangeController::setTextIndicatorWithRange(const WebCore::Simpl
     OptionSet options { WebCore::TextIndicatorOption::IncludeMarginIfRangeMatchesSelection, WebCore::TextIndicatorOption::DoNotClipToVisibleRect };
     if (WebCore::ImageOverlay::isInsideOverlay(range))
         options.add({ WebCore::TextIndicatorOption::PaintAllContent, WebCore::TextIndicatorOption::PaintBackgrounds });
+
+#if PLATFORM(IOS_FAMILY)
+    Ref frame = CheckedRef(m_webPage->corePage()->focusController())->focusedOrMainFrame();
+    frame->selection().setUpdateAppearanceEnabled(true);
+    frame->selection().updateAppearance();
+    frame->selection().setUpdateAppearanceEnabled(false);
+#endif
 
     m_textIndicator = WebCore::TextIndicator::createWithRange(range, options, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize(indicatorMargin, indicatorMargin));
 }


### PR DESCRIPTION
#### e921f41ad5bcd9d1f27b55d1a13c95b586113b29
<pre>
[iOS] Add support for keyboard shortcut and menu item to find using the current selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=242196">https://bugs.webkit.org/show_bug.cgi?id=242196</a>
rdar://93530469

Reviewed by Wenson Hsieh.

This patch adds support for:
- The CMD+E keyboard shortcut, which populates the search text for the current find interaction
- A &quot;Find Selection&quot; item in the callout bar, which populates the search text and presents the find panel

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView useSelectionForFindForWebView:]):
(-[WKContentView _findSelectedForWebView:]):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::setTextIndicatorWithRange):

Fix the appearance of the highlighted range in cases where it is equal to the
current selection.

If the selection before enabling appearance updates is equal to the range to
highlight, the TemporarySelectionChange used by TextIndicator to generate a
snapshot will exit early and fail to call updateAppearance. This means that
the selection won&apos;t be pushed to the render tree, and the TextIndicator will
have a blank snapshot.

This logic matches the existing update logic in FindControllerIOS.

Canonical link: <a href="https://commits.webkit.org/252144@main">https://commits.webkit.org/252144@main</a>
</pre>
