### PR TITLE
Fix unused variable warning in RenderElement.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -644,7 +644,7 @@ static void addLayers(const RenderElement& insertedRenderer, RenderElement& curr
             // The special handling of a toplayer/backdrop content may result in trying to insert the associated
             // layer twice as we connect subtrees.
             if (auto* parentLayer = downcast<RenderLayerModelObject>(currentRenderer).layer()->parent()) {
-                ASSERT(parentLayer == currentRenderer.view().layer());
+                ASSERT_UNUSED(parentLayer, parentLayer == currentRenderer.view().layer());
                 return;
             }
             layerToUse = insertedRenderer.view().layer();


### PR DESCRIPTION
#### 93d586729821f3ac372843c93f967c8a8f4996af
<pre>
Fix unused variable warning in RenderElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=242198">https://bugs.webkit.org/show_bug.cgi?id=242198</a>

Reviewed by Simon Fraser.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::addLayers):

Canonical link: <a href="https://commits.webkit.org/252007@main">https://commits.webkit.org/252007@main</a>
</pre>
