### PR TITLE
[WebGPU] Support creating WebGPU Texture backed by IOSurface

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* CallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
 		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
+		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
@@ -335,6 +336,7 @@
 		33EA188527BC26DF00A1DD52 /* CallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
 		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
+		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -360,6 +362,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */,
 				1CBAB0922718CCA0006080BB /* JavaScriptCore.framework in Frameworks */,
 				1CEBD8262716CACC00A5254D /* libwgsl.a in Frameworks */,
 				1C2CEDEE271E8A7300EDC16F /* Metal.framework in Frameworks */,
@@ -679,6 +682,7 @@
 		1CEBD8252716CACC00A5254D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				664C92FC286A66090008D143 /* IOSurface.framework */,
 				1CEBD82B2716CAFB00A5254D /* CoreFoundation.framework */,
 				1CEBD82D2716CB1600A5254D /* Foundation.framework */,
 				1C023D4A274495B9001DB734 /* JavaScriptCore.framework */,

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -27,6 +27,7 @@
 
 #import "Adapter.h"
 #import "HardwareCapabilities.h"
+#import <IOSurface/IOSurfaceRef.h>
 #import "Queue.h"
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
@@ -84,7 +85,7 @@ public:
     Ref<Sampler> createSampler(const WGPUSamplerDescriptor&);
     Ref<ShaderModule> createShaderModule(const WGPUShaderModuleDescriptor&);
     Ref<SwapChain> createSwapChain(const Surface&, const WGPUSwapChainDescriptor&);
-    Ref<Texture> createTexture(const WGPUTextureDescriptor&);
+    Ref<Texture> createTexture(const WGPUTextureDescriptor&, IOSurfaceRef = nullptr);
     void destroy();
     size_t enumerateFeatures(WGPUFeatureName* features);
     bool getLimits(WGPUSupportedLimits&);
@@ -118,6 +119,7 @@ private:
     bool validatePopErrorScope() const;
     id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     bool validateCreateTexture(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats);
+    bool validateCreateIOSurfaceBackedTexture(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats, IOSurfaceRef backing);
 
     void makeInvalid() { m_device = nil; }
 


### PR DESCRIPTION
#### b5f8e33ec9c453271a02ead84582fa3e2dd3c76e
<pre>
[WebGPU] Support creating WebGPU Texture backed by IOSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=242197">https://bugs.webkit.org/show_bug.cgi?id=242197</a>
&lt;rdar://96612079&gt;

Reviewed by Myles C. Maxfield.

On Apple platforms, WebGL content is composited into the web view by rendering
into an IOSurface, then providing that IOSurface to the compositor. We&apos;d like to
do the same with WebGPU. In WebGPU, content is rendered into render attachments, which
themselves are textures. This patch adds support for creating WebGPU textures backed
by an IOSurface, so that when contents are rendered into a texture, the actual pixel
data is stored inside the IOSurface, which can then be passed to the compositor.
This is straightforward to implement because WebGPU textures are Metal textures under
the hood, and Metal provides official API to create IOSurface-backed textures.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj: Link to IOSurface.framework.
* Source/WebGPU/WebGPU/Device.h: Add parameter to createTexture() to optionally take
a IOSurfaceRef. Declare new method to validate IOSurface-backed texture descriptors.
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Device::validateCreateIOSurfaceBackedTexture): Add method to validate
IOSurface-backed texture descriptors.
(WebGPU::storageMode): On Mac / Mac Catalyst, force storage mode to MTLStorageModeManaged
when the texture is backed by an IOSurface. This is required by the Metal driver.
(WebGPU::Device::createTexture): Add logic to validate and create IOSurface-backed texture.

Canonical link: <a href="https://commits.webkit.org/252674@main">https://commits.webkit.org/252674@main</a>
</pre>
