### PR TITLE
[Media Player] Fix media engine fallback logic

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -724,6 +724,7 @@ private:
     Timer m_reloadTimer;
     std::unique_ptr<MediaPlayerPrivateInterface> m_private;
     const MediaPlayerFactory* m_currentMediaEngine { nullptr };
+    HashSet<const MediaPlayerFactory*> m_attemptedEngines;
     URL m_url;
     ContentType m_contentType;
     String m_keySystem;


### PR DESCRIPTION
#### 8f6c0209fc8a6de79d8865a040f5c7868e615f13
<pre>
[Media Player] Fix media engine fallback logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=242202">https://bugs.webkit.org/show_bug.cgi?id=242202</a>

Reviewed by Eric Carlson.

Currently the logic for falling back to a different media player in the
occasion that the current media player is unable to load the media resource
assumes that there exists a &quot;next best&quot; media engine (which means another
media engine supports the current MIME type).

This does not consider the case when none of the registered media engines
know if they can support the content based on the MIME type. In such a scenario,
the next registered media engine should attempt to load the content.

A HashSet is used to keep track of the attempted media engines to prevent
an infinite cycle of reloads.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::networkStateChanged):
(WebCore::bestMediaEngineForSupportParameters):
(WebCore::MediaPlayer::nextMediaEngine):
(WebCore::MediaPlayer::nextBestMediaEngine):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
* Source/WebCore/platform/graphics/MediaPlayer.h:

Canonical link: <a href="https://commits.webkit.org/252088@main">https://commits.webkit.org/252088@main</a>
</pre>
