### PR TITLE
Add WKNavigation SPI to check if the navigation had a user interaction

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -49,6 +49,11 @@
     return _navigation->originalRequest().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
 }
 
+- (BOOL)_isUserInitiated
+{
+    return _navigation->wasUserInitiated();
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 - (WKContentMode)effectiveContentMode

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
@@ -27,4 +27,5 @@
 
 @interface WKNavigation (WKPrivate)
 @property (nonatomic, readonly, copy) NSURLRequest *_request;
+@property (nonatomic, readonly, getter=_isUserInitiated) BOOL _userInitiated;
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2181,6 +2181,7 @@ private:
     void didFinishLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const UserData&);
     void didFailLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const WebCore::ResourceError&, const UserData&);
     void didSameDocumentNavigationForFrame(WebCore::FrameIdentifier, uint64_t navigationID, uint32_t sameDocumentNavigationType, URL&&, const UserData&);
+    void didSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier, uint32_t type, URL, NavigationActionData&&, const UserData&);
     void didChangeMainDocument(WebCore::FrameIdentifier);
     void didExplicitOpenForFrame(WebCore::FrameIdentifier, URL&&, String&& mimeType);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -140,6 +140,7 @@ messages -> WebPageProxy {
     DidRunInsecureContentForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
     DidDetectXSSForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData)
     DidSameDocumentNavigationForFrame(WebCore::FrameIdentifier frameID, uint64_t navigationID, uint32_t type, URL url, WebKit::UserData userData)
+    DidSameDocumentNavigationForFrameViaJSHistoryAPI(WebCore::FrameIdentifier frameID, uint32_t type, URL url, struct WebKit::NavigationActionData navigationActionData, WebKit::UserData userData);
     DidChangeMainDocument(WebCore::FrameIdentifier frameID)
     DidExplicitOpenForFrame(WebCore::FrameIdentifier frameID, URL url, String mimeType)
     DidDestroyNavigation(uint64_t navigationID)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SameDocumentNavigationType.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/FrameLoaderClient.h>
 #include <pal/SessionID.h>
@@ -112,6 +113,7 @@ private:
     void dispatchDidPushStateWithinPage() final;
     void dispatchDidReplaceStateWithinPage() final;
     void dispatchDidPopStateWithinPage() final;
+    void didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationType);
     void dispatchWillClose() final;
     void dispatchDidStartProvisionalLoad() final;
     void dispatchDidReceiveTitle(const WebCore::StringWithDirection&) final;


### PR DESCRIPTION
#### e5037a0c9f52948bded15d581895a2018bba787a
<pre>
Add WKNavigation SPI to check if the navigation had a user interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=242203">https://bugs.webkit.org/show_bug.cgi?id=242203</a>
&lt;rdar://96231513&gt;

Reviewed by Geoffrey Garen.

Add WKNavigation SPI to check if the navigation had a user interaction.

Also make sure that the value is correct for same-document navigations. In
particular, navigations via history.pushState() / history.popState() / history.replaceState()
would previously reuse the last WKNavigation object as they wouldn&apos;t get their
own navigation object. I have made it so that these navigations now get their
own navigation object and that the _isUserInitiated flag is correct for this
navigation object.

* Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm:
(-[WKNavigation _isUserInitiated]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebFrameLoaderClient::dispatchDidPushStateWithinPage):
(WebKit::WebFrameLoaderClient::dispatchDidReplaceStateWithinPage):
(WebKit::WebFrameLoaderClient::dispatchDidPopStateWithinPage):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm:
(-[WKBackForwardNavigationDelegate webView:didFinishNavigation:]):
(-[WKBackForwardNavigationDelegate _webView:navigation:didSameDocumentNavigation:]):
(TEST):

Canonical link: <a href="https://commits.webkit.org/252020@main">https://commits.webkit.org/252020@main</a>
</pre>
