### PR TITLE
Add null check for drawingArea in RemoteScrollingCoordinatorProxy::layerTreeHost()

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -388,7 +388,11 @@ UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent(UISc
     ASSERT(scrollView == this->scrollView());
 
     auto& scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
-    return WebKit::findActingScrollParent(scrollView, *scrollingCoordinatorProxy.layerTreeHost());
+    auto host = scrollingCoordinatorProxy.layerTreeHost();
+    if (!host)
+        return nullptr;
+    
+    return WebKit::findActingScrollParent(scrollView, *host);
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)


### PR DESCRIPTION
#### b712db6f6c9516e6148cfac7c990e511f40daa42
<pre>
Add null check for drawingArea in RemoteScrollingCoordinatorProxy::layerTreeHost()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242207">https://bugs.webkit.org/show_bug.cgi?id=242207</a>
&lt;rdar://85499764&gt;

Reviewed by Simon Fraser.

Add null check for fix of rdar://85499764.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::layerTreeHost const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent):

Canonical link: <a href="https://commits.webkit.org/252028@main">https://commits.webkit.org/252028@main</a>
</pre>
