### PR TITLE
Remove unused function from SQLitedatabase

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -680,11 +680,6 @@ void SQLiteDatabase::setCollationFunction(const String& collationName, Function<
     sqlite3_create_collation_v2(m_db, collationName.utf8().data(), SQLITE_UTF8, functionObject, callCollationFunction, destroyCollationFunction);
 }
 
-void SQLiteDatabase::removeCollationFunction(const String& collationName)
-{
-    sqlite3_create_collation_v2(m_db, collationName.utf8().data(), SQLITE_UTF8, nullptr, nullptr, nullptr);
-}
-
 void SQLiteDatabase::releaseMemory()
 {
     if (!m_db)

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -148,7 +148,6 @@ public:
     WEBCORE_EXPORT bool turnOnIncrementalAutoVacuum();
 
     WEBCORE_EXPORT void setCollationFunction(const String& collationName, Function<int(int, const void*, int, const void*)>&&);
-    void removeCollationFunction(const String& collationName);
 
     // Set this flag to allow access from multiple threads.  Not all multi-threaded accesses are safe!
     // See http://www.sqlite.org/cvstrac/wiki?p=MultiThreading for more info.


### PR DESCRIPTION
#### 6fe0158b88e945a7d11ae3d3c68ee8acd6cbef81
<pre>
Remove unused function from SQLitedatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=242205">https://bugs.webkit.org/show_bug.cgi?id=242205</a>

Reviewed by Geoffrey Garen.

The function removeCollationFunction is not used anywhere.

* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::removeCollationFunction): Deleted.
* Source/WebCore/platform/sql/SQLiteDatabase.h:

Canonical link: <a href="https://commits.webkit.org/252065@main">https://commits.webkit.org/252065@main</a>
</pre>
