### PR TITLE
Unreviewed, Revert [251953@main] Enable OFFLINE_ASM_USE_ALT_ENTRY on Mac and Apple platforms using newer SDKs.

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -478,17 +478,8 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 // Define the opcode dispatch mechanism when using an ASM loop:
 //
 
-#if PLATFORM(MAC) \
-    || (PLATFORM(MACCATALYST) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) \
-    || (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) \
-    || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 160000) \
-    || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 90000)
-// Except for Mac, this requires a newer linker in order to work. Linkers from
-// older SDKs would hang. ref: rdar://93876735
-#define OFFLINE_ASM_USE_ALT_ENTRY 1
-#else
+// We're disabling this for now because of a suspected linker issue.
 #define OFFLINE_ASM_USE_ALT_ENTRY 0
-#endif
 
 #if COMPILER(CLANG)
 


### PR DESCRIPTION
#### b788a207e50b117f6161b2b0bae6b95d63399e27
<pre>
Unreviewed, Revert [251953@main] Enable OFFLINE_ASM_USE_ALT_ENTRY on Mac and Apple platforms using newer SDKs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242088">https://bugs.webkit.org/show_bug.cgi?id=242088</a>
&lt;rdar://problem/94232529&gt;

Speculative fix for JetStream2 crashes.

* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:

Canonical link: <a href="https://commits.webkit.org/252018@main">https://commits.webkit.org/252018@main</a>
</pre>
