### PR TITLE
Web Driver: [Cocoa] Viewport snapshots do not correctly represent CSS transforms

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -4817,10 +4817,7 @@ RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot()
     if (!surface)
         return nullptr;
 
-    auto snapshot = ViewSnapshot::create(WTFMove(surface));
-    snapshot->setVolatile(true);
-
-    return WTFMove(snapshot);
+    return ViewSnapshot::create(WTFMove(surface));
 }
 
 void WebViewImpl::saveBackForwardSnapshotForCurrentItem()


### PR DESCRIPTION
#### dc2acd22d6be4307f9ac8b57b2b26a7ac3437dfe
<pre>
Web Driver: [Cocoa] Viewport snapshots do not correctly represent CSS transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=242214">https://bugs.webkit.org/show_bug.cgi?id=242214</a>
rdar://33925578

Reviewed by Devin Rousso.

In order to get accurate snapshots of CSS Transforms, we have to capture the snapshot from the UIProcess. By doing so we
get the actual pixels that would be/are drawn onto the screen at the expense of an inability to capture a snapshot of
any pixels that are not within the visible viewport at the time of capture. For that reason this patch falls back to the
existing WebProcess snapshotting for element snapshots, since an element may not be entirely within the viewport. This
change to the viewport snapshot behavior progresses a number of WPT tests that previously failed including but not
limited to:
- css/css-transforms/perspective-origin-001.html (through 006)
- css/css-transforms/perspective-origin-001.html
- css/css-transforms/perspective-origin-002.html
- css/css-transforms/perspective-origin-003.html
- css/css-transforms/perspective-origin-004.html
- css/css-transforms/perspective-origin-005.html
- css/css-transforms/perspective-origin-006.html
- css/css-transforms/perspective-origin-x.html
- css/css-transforms/perspective-origin-xy.html
- css/css-transforms/perspective-translateZ-0.html
- css/css-transforms/perspective-translateZ-negative.html
- css/css-transforms/perspective-translateZ-positive.html
- css/css-transforms/text-perspective-001.html

There is a minor annoyance for viewport snapshots on macOS which is that the bottom left and right corners will appear
rounded, which is an unfortunate side effect of taking the snapshot of the window (taking a snapshot of the view itself
results in an empty image). I believe however this is a worthwhile tradeoff for passing all these tests, and likely many
more. iOS in not affected in this way.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::getBase64EncodedPNGData):
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):

* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(WebKit::WebViewImpl::takeViewSnapshot):
- Match the behavior of -[WKWebViewIOS _takeViewSnapshot] and return a non-volatile surface, otherwise the bits are
often missing by the time we are trying to base64 encode them.

Canonical link: <a href="https://commits.webkit.org/252201@main">https://commits.webkit.org/252201@main</a>
</pre>
