### PR TITLE
[macOS] Allow syscall used during launch of the WebContent process

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2061,6 +2061,13 @@
 (with-filter (uid 0)
     (allow syscall-unix (syscall-number SYS_gettid))) ;; Needed for base system, see <rdar://problem/48651255>
 
+#if HAVE(SANDBOX_STATE_FLAGS)
+(if (not (equal? (param "CPU") "arm64"))
+    (with-filter (require-not (state-flag "WebContentProcessLaunched"))
+        (allow syscall-unix
+            (syscall-number SYS_quotactl))))
+#endif
+
 #if HAVE(ADDITIONAL_APPLE_CAMERA_SERVICE)
 (if (equal? (param "CPU") "arm64")
     (with-filter (extension "com.apple.webkit.camera")


### PR DESCRIPTION
#### cbded7d2834291b7f8d82f5783dadca70c71696d
<pre>
[macOS] Allow syscall used during launch of the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242218">https://bugs.webkit.org/show_bug.cgi?id=242218</a>
&lt;rdar://95210336&gt;

Reviewed by Chris Dumez and Alexey Proskuryakov.

Add SYS_quotactl to the WebContent process&apos; sandbox on macOS. It is only required on Intel during launch, and will be blocked post launch.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252054@main">https://commits.webkit.org/252054@main</a>
</pre>
