### PR TITLE
[WPE][GTK] web process leak if webkit_download_set_destination is called with empty destination

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
@@ -501,6 +501,7 @@ void webkit_download_set_destination(WebKitDownload* download, const gchar* uri)
 {
     g_return_if_fail(WEBKIT_IS_DOWNLOAD(download));
     g_return_if_fail(uri);
+    g_return_if_fail(uri[0] != '\0');
 
     WebKitDownloadPrivate* priv = download->priv;
     if (priv->destinationURI == uri)


### PR DESCRIPTION
#### c985acc37157f1ac8e7601e494ebd71bd76e6509
<pre>
[WPE][GTK] web process leak if webkit_download_set_destination is called with empty destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=242217">https://bugs.webkit.org/show_bug.cgi?id=242217</a>

Reviewed by Michael Catanzaro.

Fail if download destination is set to &quot;&quot;.

 * Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
  (webkit_download_set_destination):

Canonical link: <a href="https://commits.webkit.org/256737@main">https://commits.webkit.org/256737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a37d8abfd8f7bb2e62312879b5ec76ba1073bf4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106134 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6060 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34602 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102845 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4518 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83211 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31499 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74414 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40333 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43676 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40412 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->