### PR TITLE
Add a null check in TextManipulationController::replace

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -38,6 +38,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "InputTypeNames.h"
+#include "Logging.h"
 #include "NodeRenderStyle.h"
 #include "NodeTraversal.h"
 #include "PseudoElement.h"
@@ -842,6 +843,11 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
 
     while (lastChildOfCommonAncestorInRange && lastChildOfCommonAncestorInRange->parentNode() != commonAncestor)
         lastChildOfCommonAncestorInRange = lastChildOfCommonAncestorInRange->parentNode();
+
+    if (!lastChildOfCommonAncestorInRange) {
+        RELEASE_LOG_ERROR(TextManipulation, "%p - TextManipulationController::replace lastChildOfCommonAncestorInRange is null", this);
+        return ManipulationFailureType::ContentChanged;
+    }
 
     for (auto node = commonAncestor; node; node = node->parentNode())
         nodesToRemove.remove(*node);

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -119,6 +119,7 @@ namespace WebCore {
     M(SVG) \
     M(TextAutosizing) \
     M(TextFragment) \
+    M(TextManipulation) \
     M(TextShaping) \
     M(Tiling) \
     M(Threading) \


### PR DESCRIPTION
#### 311e4085d5afb86066639a563538dff56eaa8681
<pre>
Add a null check in TextManipulationController::replace
<a href="https://bugs.webkit.org/show_bug.cgi?id=242216">https://bugs.webkit.org/show_bug.cgi?id=242216</a>

Reviewed by Wenson Hsieh.

According to crashes in rdar://95164204, lastChildOfCommonAncestorInRange can be null. It&apos;s not trivial to create a test
case that would make lastChildOfCommonAncestorInRange null, so let&apos;s add a null check to avoid crashing the process.
The added logging should help us find such case if we see one later.

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/252048@main">https://commits.webkit.org/252048@main</a>
</pre>
