### PR TITLE
[Gardening]: REGRESSION(251564@main-251572@main?): [ Mac wk2 ] media/media-source/media-webm-vorbis-partial.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1726,3 +1726,5 @@ webkit.org/b/241283 fast/animation/request-animation-frame-throttling-detached-i
 webkit.org/b/242164 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]
 
 webkit.org/b/242138 imported/w3c/web-platform-tests/css/css-transforms/huge-length-tiny-scale.html [ Pass Crash ImageOnlyFailure ]
+
+webkit.org/b/242212 [ Monterey+ ] media/media-source/media-webm-vorbis-partial.html [ Failure ]


### PR DESCRIPTION
#### 4b37f687ab666ec795853f9eae9ec97130d454f2
<pre>
[Gardening]: REGRESSION(251564@main-251572@main?): [ Mac wk2 ] media/media-source/media-webm-vorbis-partial.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242212">https://bugs.webkit.org/show_bug.cgi?id=242212</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252022@main">https://commits.webkit.org/252022@main</a>
</pre>
