### PR TITLE
Pressing shift+tab when focused in the middle of a contenteditable element doesn't work

### DIFF
--- a/LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text-expected.txt
+++ b/LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text-expected.txt
@@ -1,0 +1,6 @@
+To test manually, click between two l's in hello below and press shift+tab.
+Focus should move to the text field.
+
+
+hello
+PASS

--- a/LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text.html
+++ b/LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/ui-helper.js"></script>
+<p>To test manually, click between two l's in hello below and press shift+tab.<br>
+Focus should move to the text field.</p>
+<input id="textField">
+<div contenteditable><span id="hello">hello</span></div>
+<div id="result"></div>
+<script>
+
+onload = runTest;
+didFocus = null;
+
+async function runTest() {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    result.textContent = 'In progress';
+
+    await UIHelper.activateAt(hello.offsetLeft + hello.offsetWidth / 2, hello.offsetTop + 3);
+    await UIHelper.keyDown('\t', ['shiftKey']);
+
+    result.textContent = document.activeElement == textField ? 'PASS' : 'FAIL';
+
+    testRunner.notifyDone();
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -835,6 +835,7 @@ editing/inserting/smart-quote-with-all-configurations.html [ Skip ]
 fast/events/input-event-insert-link.html [ Failure ]
 
 # No tab navigation support on iOS
+fast/events/sequential-focus-navigation-after-clicking-editable-text.html [ Failure ]
 fast/shadow-dom/focus-on-iframe.html [ Failure ]
 webkit.org/b/116046 fast/events/sequential-focus-navigation-starting-point.html [ Skip ]
 webkit.org/b/159240 fast/events/remove-focus-navigation-starting-point-crash.html [ Skip ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4852,6 +4852,8 @@ Element* Document::focusNavigationStartingNode(FocusDirection direction) const
     if (m_focusedElement) {
         if (!m_focusNavigationStartingNode || !m_focusNavigationStartingNode->isDescendantOf(m_focusedElement.get()))
             return m_focusedElement.get();
+        if (m_focusedElement->isRootEditableElement() && m_focusedElement->contains(m_focusNavigationStartingNode.get()))
+            return m_focusedElement.get();
     }
 
     if (!m_focusNavigationStartingNode)


### PR DESCRIPTION
#### d0e9ceb168be38618e1baf19f879055efd7f11dd
<pre>
Pressing shift+tab when focused in the middle of a contenteditable element doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=241902">https://bugs.webkit.org/show_bug.cgi?id=241902</a>

Reviewed by Wenson Hsieh.

The bug was caused by Document::focusNavigationStartingNode returning an element after the root editable element
when m_focusNavigationStartingNode is set to a text node inside the focused element. When moving backwards starting
at this node, we would find the root editable element as the previous focusable element and the focus never moves.

Fixed the bug by detecting this case and returning the focused element as the starting node instead.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::focusNavigationStartingNode const): Return the focused element if the focused element is
a root editable element and the focus navigation starting node is inside this editable element.

* LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text-expected.txt: Added.
* LayoutTests/fast/events/sequential-focus-navigation-after-clicking-editable-text.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252028@main">https://commits.webkit.org/252028@main</a>
</pre>
