### PR TITLE
[Gardening]: [ iOS Release ]  Two http/wpt/service-workers/ tests are a flaky failures

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3663,3 +3663,6 @@ fast/text/accessibility-bold-system-font [ Pass ]
 webkit.org/b/242164 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]
 
 webkit.org/b/242194 compositing/images/positioned-image-content-rect.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/242225 http/wpt/service-workers/cache-control-request.html [ Pass Failure ]
+webkit.org/b/242225 http/wpt/service-workers/about-blank-iframe.html [ Pass Failure ]


### PR DESCRIPTION
#### 4ed4074f3a8e0a09d6228f480f688fc3a4c535a8
<pre>
[Gardening]: [ iOS Release ]  Two http/wpt/service-workers/ tests are a flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=242225">https://bugs.webkit.org/show_bug.cgi?id=242225</a>
&lt;rdar://96268616&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252026@main">https://commits.webkit.org/252026@main</a>
</pre>
