### PR TITLE
[Gardening]: REGRESSION(r289770):[ iPad ] imported/blink/svg/filters/filter-huge-clamping.svg is a constant image failure - Accelerated Drawing

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3666,3 +3666,5 @@ webkit.org/b/242194 compositing/images/positioned-image-content-rect.html [ Pass
 
 webkit.org/b/242225 http/wpt/service-workers/cache-control-request.html [ Pass Failure ]
 webkit.org/b/242225 http/wpt/service-workers/about-blank-iframe.html [ Pass Failure ]
+
+webkit.org/b/237569 imported/blink/svg/filters/filter-huge-clamping.svg [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### bb3989fba3794bb836da052046927fbd9a4d5232
<pre>
[Gardening]: REGRESSION(r289770):[ iPad ] imported/blink/svg/filters/filter-huge-clamping.svg is a constant image failure - Accelerated Drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=237569">https://bugs.webkit.org/show_bug.cgi?id=237569</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252027@main">https://commits.webkit.org/252027@main</a>
</pre>
