### PR TITLE
css/motion/animation/offset-rotate-composition.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/animation/offset-rotate-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/animation/offset-rotate-composition-expected.txt
@@ -1,38 +1,38 @@
 
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (-0.3) should be [27deg] assert_equals: expected "27deg " but got "7deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0) should be [30deg] assert_equals: expected "30deg " but got "10deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0.3) should be [33deg] assert_equals: expected "33deg " but got "13deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0.6) should be [36deg] assert_equals: expected "36deg " but got "16deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (1) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (1.5) should be [45deg] assert_equals: expected "45deg " but got "25deg "
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (-0.3) should be [27deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0) should be [30deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0.3) should be [33deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (0.6) should be [36deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (1) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to add [20deg] at (1.5) should be [45deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (-0.3) should be [7deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (0) should be [10deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (0.3) should be [13deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (0.6) should be [16deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (1) should be [20deg]
 PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [10deg] to add [20deg] at (1.5) should be [25deg]
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (-0.3) should be [auto 261deg] assert_equals: expected "auto 261deg " but got "auto 241deg "
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0) should be [auto 210deg] assert_equals: expected "auto 210deg " but got "auto 190deg "
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0.3) should be [auto 159deg] assert_equals: expected "auto 159deg " but got "auto 139deg "
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0.6) should be [auto 108deg] assert_equals: expected "auto 108deg " but got "auto 88deg "
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (1) should be [auto 40deg] assert_equals: expected "auto 40deg " but got "auto 20deg "
-FAIL Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (1.5) should be [auto -45deg] assert_equals: expected "auto - 45deg " but got "auto - 65deg "
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (-0.3) should be [auto 261deg]
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0) should be [auto 210deg]
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0.3) should be [auto 159deg]
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (0.6) should be [auto 108deg]
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (1) should be [auto 40deg]
+PASS Compositing: property <offset-rotate> underlying [auto 20deg] from add [reverse 10deg] to add [auto 20deg] at (1.5) should be [auto -45deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (-0.3) should be [auto 190deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (0) should be [auto 190deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (0.3) should be [auto 190deg]
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (0.6) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (1) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (1.5) should be [40deg] assert_equals: expected "40deg " but got "20deg "
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (0.6) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (1) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [reverse 10deg] to add [20deg] at (1.5) should be [40deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (-0.3) should be [auto 190deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (0) should be [auto 190deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (0.3) should be [auto 190deg]
-FAIL Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (0.6) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (1) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (1.5) should be [40deg] assert_equals: expected "40deg " but got "20deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (-0.3) should be [36deg] assert_equals: expected "36deg " but got "10deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0) should be [30deg] assert_equals: expected "30deg " but got "10deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0.3) should be [24deg] assert_equals: expected "24deg " but got "10deg "
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0.6) should be [18deg] assert_equals: expected "18deg " but got "10deg "
+PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (0.6) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (1) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from replace [reverse 10deg] to add [20deg] at (1.5) should be [40deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (-0.3) should be [36deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0) should be [30deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0.3) should be [24deg]
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (0.6) should be [18deg]
 PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (1) should be [10deg]
-FAIL Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (1.5) should be [0deg] assert_equals: expected "0deg " but got "10deg "
+PASS Compositing: property <offset-rotate> underlying [20deg] from add [10deg] to replace [10deg] at (1.5) should be [0deg]
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -598,11 +598,10 @@ static inline std::optional<FontSelectionValue> blendFunc(std::optional<FontSele
 
 static inline OffsetRotation blendFunc(const OffsetRotation& from, const OffsetRotation& to, const CSSPropertyBlendingContext& context)
 {
-    if (!context.progress)
-        return from;
-
-    if (context.progress == 1)
-        return to;
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1.0);
+        return context.progress ? to : from;
+    }
 
     ASSERT(from.hasAuto() == to.hasAuto());
 


### PR DESCRIPTION
#### eff6e4939a797686bf8d635b1adb3920a29e0b2c
<pre>
css/motion/animation/offset-rotate-composition.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=235786">https://bugs.webkit.org/show_bug.cgi?id=235786</a>
&lt;rdar://88487956&gt;

Reviewed by Antti Koivisto.

We should only return the from and to values if we&apos;re dealing with a discrete animation, since otherwise
we could be dealing with an additive animation.

* LayoutTests/imported/w3c/web-platform-tests/css/motion/animation/offset-rotate-composition-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):

Canonical link: <a href="https://commits.webkit.org/252035@main">https://commits.webkit.org/252035@main</a>
</pre>
