### PR TITLE
Performing a no-op animated resize cancels any pending resize immediately

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3188,6 +3188,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 
 - (void)_beginAnimatedResizeWithUpdates:(void (^)(void))updateBlock
 {
+    bool hadPendingAnimatedResize = _dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
     CGRect oldBounds = self.bounds;
     WebCore::FloatRect oldUnobscuredContentRect = _page->unobscuredContentRect();
 
@@ -3261,7 +3262,8 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
         return;
     }
 
-    if (CGRectEqualToRect(oldBounds, newBounds)
+    if (!hadPendingAnimatedResize
+        && CGRectEqualToRect(oldBounds, newBounds)
         && oldViewLayoutSize == newViewLayoutSize
         && oldMinimumUnobscuredSize == newMinimumUnobscuredSize
         && oldMaximumUnobscuredSize == newMaximumUnobscuredSize


### PR DESCRIPTION
#### b18af70697f4da911ed70867a325248bd9949367
<pre>
Performing a no-op animated resize cancels any pending resize immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=242233">https://bugs.webkit.org/show_bug.cgi?id=242233</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
_beginAnimatedResizeWithUpdates cancels the resize and completes immediately
if the update block didn&apos;t change any relevant state. For clients who want
to do multiple animated resizes in a row, this can result in a discontinuity
if a impactful animated resize is performed, followed by a no-op animated
resize before the results of the first resize arrive: this results in
the first resize being cancelled, and the web view being shown in an
incompletely-updated state. To avoid this, just avoid cancelling no-op
resizes when there is already a pending resize.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST):
Add a test. Also move all of the other tests into an AnimatedResize test group
to make it easy to run them together. Add a missing `_endAnimatedResize` to
ResizeWithContentHiddenWithSubsequentNoOpResizeCompletes, because previously
it was depending on this bug.

Canonical link: <a href="https://commits.webkit.org/252106@main">https://commits.webkit.org/252106@main</a>
</pre>
