### PR TITLE
css/css-fonts/animations/font-variation-settings-composition.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-variation-settings-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-variation-settings-composition-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (-0.3) should be ['test' 120] assert_equals: expected "\" test \" 120 " but got "\" test \" 70 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (0) should be ['test' 150] assert_equals: expected "\" test \" 150 " but got "\" test \" 100 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (0.5) should be ['test' 200] assert_equals: expected "\" test \" 200 " but got "\" test \" 150 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (1) should be ['test' 250] assert_equals: expected "\" test \" 250 " but got "\" test \" 200 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (1.5) should be ['test' 300] assert_equals: expected "\" test \" 300 " but got "\" test \" 250 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (-0.3) should be ['test' 135] assert_equals: expected "\" test \" 135 " but got "\" test \" 70 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (0) should be ['test' 150] assert_equals: expected "\" test \" 150 " but got "\" test \" 100 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (0.5) should be ['test' 175] assert_equals: expected "\" test \" 175 " but got "\" test \" 150 "
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (-0.3) should be ['test' 120]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (0) should be ['test' 150]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (0.5) should be ['test' 200]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (1) should be ['test' 250]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to add ['test' 200] at (1.5) should be ['test' 300]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (-0.3) should be ['test' 135]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (0) should be ['test' 150]
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (0.5) should be ['test' 175]
 PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (1) should be ['test' 200]
-FAIL Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (1.5) should be ['test' 225] assert_equals: expected "\" test \" 225 " but got "\" test \" 250 "
+PASS Compositing: property <font-variation-settings> underlying ['test' 50] from add ['test' 100] to replace ['test' 200] at (1.5) should be ['test' 225]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to replace ['test' 200] at (-0.3) should be [normal]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to replace ['test' 200] at (0) should be [normal]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to replace ['test' 200] at (0.5) should be ['test' 200]
@@ -16,14 +16,14 @@ PASS Compositing: property <font-variation-settings> underlying ['test' 100] fro
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to replace ['test' 200] at (1.5) should be ['test' 200]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (-0.3) should be [normal]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (0) should be [normal]
-FAIL Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (0.5) should be ['test' 300] assert_equals: expected "\" test \" 300 " but got "\" test \" 200 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (1) should be ['test' 300] assert_equals: expected "\" test \" 300 " but got "\" test \" 200 "
-FAIL Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (1.5) should be ['test' 300] assert_equals: expected "\" test \" 300 " but got "\" test \" 200 "
-FAIL Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (-0.3) should be ['aaaa' 117, 'bbbb' 235] assert_equals: expected "\" bbbb \" 235 , \" aaaa \" 117 " but got "\" bbbb \" 35 , \" aaaa \" 17 "
-FAIL Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0) should be ['aaaa' 120, 'bbbb' 250] assert_equals: expected "\" bbbb \" 250 , \" aaaa \" 120 " but got "\" bbbb \" 50 , \" aaaa \" 20 "
-FAIL Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0.5) should be ['aaaa' 125, 'bbbb' 275] assert_equals: expected "\" bbbb \" 275 , \" aaaa \" 125 " but got "\" bbbb \" 75 , \" aaaa \" 25 "
-FAIL Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (1) should be ['aaaa' 130, 'bbbb' 300] assert_equals: expected "\" bbbb \" 300 , \" aaaa \" 130 " but got "\" bbbb \" 100 , \" aaaa \" 30 "
-FAIL Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (1.5) should be ['aaaa' 135, 'bbbb' 325] assert_equals: expected "\" bbbb \" 325 , \" aaaa \" 135 " but got "\" bbbb \" 125 , \" aaaa \" 35 "
+PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (0.5) should be ['test' 300]
+PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (1) should be ['test' 300]
+PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add [normal] to add ['test' 200] at (1.5) should be ['test' 300]
+PASS Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (-0.3) should be ['aaaa' 117, 'bbbb' 235]
+PASS Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0) should be ['aaaa' 120, 'bbbb' 250]
+PASS Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0.5) should be ['aaaa' 125, 'bbbb' 275]
+PASS Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (1) should be ['aaaa' 130, 'bbbb' 300]
+PASS Compositing: property <font-variation-settings> underlying ['aaaa' 100, 'bbbb' 200] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (1.5) should be ['aaaa' 135, 'bbbb' 325]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (-0.3) should be ['aaaa' 17, 'bbbb' 35]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0) should be ['aaaa' 20, 'bbbb' 50]
 PASS Compositing: property <font-variation-settings> underlying ['test' 100] from add ['aaaa' 20, 'bbbb' 50] to add ['aaaa' 30, 'bbbb' 100] at (0.5) should be ['aaaa' 25, 'bbbb' 75]

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -273,7 +273,7 @@ PASS font-variant-position (type: discrete) has testAccumulation function
 PASS font-variant-position: "super" onto "sub"
 PASS font-variant-position: "sub" onto "super"
 PASS font-variation-settings (type: fontVariationSettings) has testAccumulation function
-FAIL font-variation-settings with composite type accumulate assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 1.2"
+FAIL font-variation-settings with composite type accumulate assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 2.1999998"
 PASS font-variation-settings (type: discrete) has testAccumulation function
 PASS font-variation-settings: ""wdth" 5" onto ""wdth" 1, "wght" 1.1"
 FAIL font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5" assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -273,7 +273,7 @@ PASS font-variant-position (type: discrete) has testAddition function
 PASS font-variant-position: "super" onto "sub"
 PASS font-variant-position: "sub" onto "super"
 PASS font-variation-settings (type: fontVariationSettings) has testAddition function
-FAIL font-variation-settings with composite type add assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 1.2"
+FAIL font-variation-settings with composite type add assert_equals: The value should be "wght" 2.2 at 250ms expected "\"wght\" 2.2" but got "\"wght\" 2.1999998"
 PASS font-variation-settings (type: discrete) has testAddition function
 PASS font-variation-settings: ""wdth" 5" onto ""wdth" 1, "wght" 1.1"
 FAIL font-variation-settings: ""wdth" 1, "wght" 1.1" onto ""wdth" 5" assert_equals: The value should be "wdth" 1, "wght" 1.1 at 0ms expected "\"wdth\" 1, \"wght\" 1.1" but got "\"wght\" 1.1, \"wdth\" 1"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -565,11 +565,10 @@ static inline NinePieceImage blendFunc(const NinePieceImage& from, const NinePie
 
 static inline FontVariationSettings blendFunc(const FontVariationSettings& from, const FontVariationSettings& to, const CSSPropertyBlendingContext& context)
 {
-    if (!context.progress)
-        return from;
-
-    if (context.progress == 1.0)
-        return to;
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1.0);
+        return context.progress ? to : from;
+    }
 
     ASSERT(from.size() == to.size());
     FontVariationSettings result;


### PR DESCRIPTION
#### 152a12cf1bfbcb45bb6c57aab606be7ca3e3bc61
<pre>
css/css-fonts/animations/font-variation-settings-composition.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=235774">https://bugs.webkit.org/show_bug.cgi?id=235774</a>
&lt;rdar://88487842&gt;

Reviewed by Antti Koivisto.

We should only return the from and to values if we&apos;re dealing with a discrete animation, since otherwise
we could be dealing with an additive animation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-variation-settings-composition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):

Canonical link: <a href="https://commits.webkit.org/252035@main">https://commits.webkit.org/252035@main</a>
</pre>
