### PR TITLE
Vorbis decoding no longer works following bug 241339

### DIFF
--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -34,6 +34,7 @@
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ScreenProperties.h>
+#import <WebCore/WebMAudioUtilitiesCocoa.h>
 #import <pal/spi/cocoa/CoreServicesSPI.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <sysexits.h>
@@ -71,6 +72,11 @@ void GPUProcess::initializeSandbox(const AuxiliaryProcessInitializationParameter
 {
     // Need to overide the default, because service has a different bundle ID.
     NSBundle *webKit2Bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+
+#if defined(USE_VORBIS_AUDIOCOMPONENT_WORKAROUND)
+    // We need to initialize the Vorbis decoder before the sandbox gets setup; this is a one off action.
+    WebCore::registerVorbisDecoderIfNeeded();
+#endif
 
     sandboxParameters.setOverrideSandboxProfilePath([webKit2Bundle pathForResource:@"com.apple.WebKit.GPUProcess" ofType:@"sb"]);
 

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -102,6 +102,11 @@ function mac_process_gpu_entitlements()
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
         fi
 
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
+        then
+            plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
+        fi
+
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
         then
             plistbuddy Add :com.apple.private.gpu-restricted bool YES


### PR DESCRIPTION
#### 092367a88f872d642bff95d39b0fef220437b92d
<pre>
Vorbis decoding no longer works following bug 241339
<a href="https://bugs.webkit.org/show_bug.cgi?id=242040">https://bugs.webkit.org/show_bug.cgi?id=242040</a>
&lt;rdar://96023176&gt;

Reviewed by Per Arne Vollan.

To be able to register the vorbis decoder we need an entitlement now that
we&apos;ve switched to using AudioComponentFetchServerRegistrations.

Covered by existing tests, however those are disable as the code is non-functional
with non-signed binaries.

* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeSandbox):
* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/252211@main">https://commits.webkit.org/252211@main</a>
</pre>
