### PR TITLE
Drop ARM softfp bot

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -125,7 +125,6 @@
                     { "name": "jsconly-linux-igalia-bot-2", "platform": "jsc-only" },
                     { "name": "jsconly-linux-igalia-bot-3", "platform": "jsc-only" },
                     { "name": "jsconly-linux-igalia-bot-4", "platform": "jsc-only" },
-                    { "name": "jsconly-linux-igalia-bot-5", "platform": "jsc-only" },
 
                     { "name": "wpe-linux-bot-1", "platform": "wpe" },
                     { "name": "wpe-linux-bot-2", "platform": "wpe" },
@@ -562,11 +561,6 @@
                       "workernames": ["jsconly-linux-igalia-bot-3"]
                     },
                     {
-                      "name": "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release", "factory": "BuildAndJSCTestsFactory",
-                      "platform": "jsc-only", "configuration": "release", "architectures": ["armv7"],
-                      "workernames": ["jsconly-linux-igalia-bot-5"]
-                    },
-                    {
                       "name": "JSCOnly-Linux-MIPS32el-Release", "factory": "BuildAndJSCTestsFactory",
                       "platform": "jsc-only", "configuration": "release", "architectures": ["mips"],
                       "workernames": ["jsconly-linux-igalia-bot-1"]
@@ -649,7 +643,7 @@
                                        "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                        "JSCOnly-Linux-AArch64-Release",
-                                       "JSCOnly-Linux-ARMv7-Thumb2-Release", "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release",
+                                       "JSCOnly-Linux-ARMv7-Thumb2-Release",
                                        "JSCOnly-Linux-MIPS32el-Release", "PlayStation-Release-Build", "PlayStation-Debug-Build",
                                        "WinCairo-64-bit-WKL-Release-Build", "WinCairo-64-bit-WKL-Debug-Build",
                                        "WPE-Linux-64-bit-Release-Build", "WPE-Linux-64-bit-Debug-Build",

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1461,17 +1461,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'jscore-test'
         ],
-        'JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'compile-webkit',
-            'jscore-test'
-        ],
         'JSCOnly-Linux-MIPS32el-Release': [
             'configure-build',
             'configuration',

--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
@@ -100,7 +100,6 @@ WebKitBuildbot = function()
         }},
         "JSCOnly ARMv7 Testers": {platform: Dashboard.Platform.LinuxJSCOnly, heading: "ARMv7", combinedQueues: {
             "JSCOnly-Linux-ARMv7-Thumb2-Release": {heading: "ARMv7 Thumb2"},
-            "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release": {heading: "ARMv7 Thumb2 SoftFP"},
         }},
         "JSCOnly MIPS Testers": {platform: Dashboard.Platform.LinuxJSCOnly, heading: "MIPS", combinedQueues: {
             "JSCOnly-Linux-MIPS32el-Release": {heading: "MIPS32el"},


### PR DESCRIPTION
#### a5dc4a30262019be32a9623622ebac6e40eb78c6
<pre>
Drop ARM softfp bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=242236">https://bugs.webkit.org/show_bug.cgi?id=242236</a>

Reviewed by Aakash Jain.

The softfp ARMv7 bot has been kept around to ensure that things would
work for users that are depend on vendor libraries that require the
softfp ABI. Recent changes broke softfp and we&apos;re no longer aware of any
users for it. Bug 242172 drops JSC support for the softfp ABI; this bug
is about removing the corresponding buildbot from build.webkit.org.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js:
(WebKitBuildbot):

Canonical link: <a href="https://commits.webkit.org/252115@main">https://commits.webkit.org/252115@main</a>
</pre>
