### PR TITLE
REGRESSION(251219@main): xml-stripblanks requires executable xmllint

### DIFF
--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -56,6 +56,7 @@ PACKAGES=(
     libwayland-dev
     libwebp-dev
     libwoff-dev
+    libxml2-utils
     libxslt1-dev
     ninja-build
     patch


### PR DESCRIPTION
#### d1180e87e6eb8e4a6b67dd8bda19df791fc4ffd3
<pre>
REGRESSION(251219@main): xml-stripblanks requires executable xmllint
<a href="https://bugs.webkit.org/show_bug.cgi?id=242237">https://bugs.webkit.org/show_bug.cgi?id=242237</a>

Reviewed by Philippe Normand.

* Tools/glib/dependencies/apt: Add package &apos;libxml2-utils&apos;, provides
  &apos;xmllint&apos;.

Canonical link: <a href="https://commits.webkit.org/252043@main">https://commits.webkit.org/252043@main</a>
</pre>
