### PR TITLE
[webkitpy] runtime error in function _fill from local/git.py

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -74,10 +74,7 @@ class Git(Scm):
 
         def _fill(self, branch):
             default_branch = self.repo.default_branch
-            if branch == default_branch:
-                branch_point = None
-            else:
-                branch_point = int(self._hash_to_identifiers[self._ordered_commits[branch][0]].split('@')[0])
+            branch_point = None
 
             index = len(self._ordered_commits[branch]) - 1
             while index:


### PR DESCRIPTION
#### 010d6162472c3e6a435b0738f71957dff8dd9add
<pre>
[webkitpy] runtime error in function _fill from local/git.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=242238">https://bugs.webkit.org/show_bug.cgi?id=242238</a>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.Cache._fill): Initialize &apos;branch_point&apos; always to None.
</pre>