### PR TITLE
[webkitperl] Remove warning when building JSC with CMake

### DIFF
--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -190,7 +190,7 @@ if (isCMakeBuild()) {
 
     # This call only returns if nothing wrong happened
     buildCMakeProjectOrExit(0, undef, $buildTarget, @featureArgs, @cmakeArgs);
-    writeCongrats();
+    writeCongrats("JavaScriptCore");
     exit exitStatus(0);
 }
 


### PR DESCRIPTION
#### e01ff328e37bd9db4c1596fd5fbc24f0c7313a8f
<pre>
[webkitperl] Remove warning when building JSC with CMake
<a href="https://bugs.webkit.org/show_bug.cgi?id=242240">https://bugs.webkit.org/show_bug.cgi?id=242240</a>

Reviewed by Adrian Perez de Castro.

We are not telling &apos;writeCongrats&apos; about the project name when we
finish building. We only ever get here when calling build-jsc on CMake
builds, so hardcode JavaScriptCore (Apple/Cocoa does the same but in
the build-jsc file itself).

Fixes the following warning:

Use of uninitialized value $projectName in concatenation (.) or string at /home/igalia/xlopez/WebKit/Tools/Scripts/webkitperl/BuildSubproject.pm line 265.

* Tools/Scripts/webkitperl/BuildSubproject.pm:
(buildMyProject):

Canonical link: <a href="https://commits.webkit.org/252038@main">https://commits.webkit.org/252038@main</a>
</pre>
