### PR TITLE
REGRESSION(251359@main) Subtitles in PiP and Fullscreen are blank

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -192,11 +192,10 @@ RefPtr<Image> ImageBuffer::sinkIntoImage(RefPtr<ImageBuffer> source, PreserveRes
     if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes)
         image = sinkIntoNativeImage(WTFMove(source));
     else {
-        auto copySize = source->logicalSize();
-        auto copyBuffer = source->context().createImageBuffer(copySize, 1.f, source->colorSpace());
+        auto copyBuffer = source->context().createImageBuffer(source->logicalSize(), 1.f, source->colorSpace());
         if (!copyBuffer)
             return nullptr;
-        drawConsuming(WTFMove(source), copyBuffer->context(), FloatRect { { }, copySize }, FloatRect { 0, 0, -1, -1 }, CompositeOperator::Copy);
+        copyBuffer->context().drawConsumingImageBuffer(WTFMove(source), FloatRect { { }, copyBuffer->logicalSize() }, CompositeOperator::Copy);
         image = ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
     }
     if (!image)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -130,13 +130,13 @@ public:
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     virtual RefPtr<Image> filteredImage(Filter&) = 0;
 
-    virtual void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect = FloatRect(0, 0, -1, -1), const ImagePaintingOptions& = { }) = 0;
+    virtual void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) = 0;
     virtual void drawPattern(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { }) = 0;
 
     static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);
 
     WEBCORE_EXPORT static RefPtr<Image> sinkIntoImage(RefPtr<ImageBuffer>, PreserveResolution = PreserveResolution::No);
-    static void drawConsuming(RefPtr<ImageBuffer>, GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect = FloatRect(0, 0, -1, -1), const ImagePaintingOptions& = { });
+    static void drawConsuming(RefPtr<ImageBuffer>, GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& = { });
     
     virtual void clipToMask(GraphicsContext&, const FloatRect& destRect) = 0;
 

--- a/Tools/TestWebKitAPI/TestUtilities.h
+++ b/Tools/TestWebKitAPI/TestUtilities.h
@@ -28,6 +28,8 @@
 #include "Test.h"
 #include "WTFStringUtilities.h"
 #include <WebCore/Color.h>
+#include <WebCore/FloatRect.h>
+#include <WebCore/FloatSize.h>
 #include <wtf/text/TextStream.h>
 
 namespace TestWebKitAPI {
@@ -40,6 +42,20 @@ namespace TestWebKitAPI {
 namespace WebCore {
 
 inline std::ostream& operator<<(std::ostream& os, const WebCore::Color& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatSize& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatRect& value)
 {
     TextStream s { TextStream::LineMode::SingleLine };
     s << value;


### PR DESCRIPTION
#### bf1f57bf41dde0738270650832819bc2bc2927a8
<pre>
REGRESSION(251359@main) Subtitles in PiP and Fullscreen are blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=242239">https://bugs.webkit.org/show_bug.cgi?id=242239</a>

Reviewed by Simon Fraser.

ImageBuffer::sinkToImage() would call ImageBuffer::drawConsuming() with the
srcRect = FloatRect { 0, 0, -1, -1 } with the intention that it would mean
to use the full source size. This intention was derived from the drawConsuming
srcRect default argument. In reality, this would be a no-op.

Fix by using the explicit source size.
Also remove the ImageBuffer::drawConsuming() and ImageBuffer::draw() default
arguments, as those would render the calls no-ops.

Add tests for ImageBuffer::sinkToImage() for all testable configurations.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::sinkIntoImage):
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::draw):
(WebCore::ImageBuffer::drawConsuming):
* Tools/TestWebKitAPI/TestUtilities.h:
(WebCore::operator&lt;&lt;):
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::imageBufferPixelIs):
(TestWebKitAPI::hasTestPattern):
(TestWebKitAPI::drawTestPattern):
(TestWebKitAPI::TEST):
(TestWebKitAPI::PrintTo):
(TestWebKitAPI::PreserveResolutionOperationTest::deviceScaleFactor const):
(TestWebKitAPI::PreserveResolutionOperationTest::imageBufferOptions const):
(TestWebKitAPI::PreserveResolutionOperationTest::operationPreserveResolution):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/252193@main">https://commits.webkit.org/252193@main</a>
</pre>
