### PR TITLE
[GStreamer][VideoCapture] Ensure video/x-raw mime-type caps have a format

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -321,7 +321,13 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
                 selector->mimeType = gst_structure_get_name(structure);
-                selector->format = gst_structure_get_string(structure, "format");
+                selector->format = nullptr;
+                if (gst_structure_has_name(structure, "video/x-raw")) {
+                    if (gst_structure_has_name(structure, "format"))
+                        selector->format = gst_structure_get_string(structure, "format");
+                    else
+                        return TRUE;
+                }
                 return FALSE;
             }
 
@@ -330,7 +336,13 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
                 selector->mimeType = gst_structure_get_name(structure);
-                selector->format = gst_structure_get_string(structure, "format");
+                selector->format = nullptr;
+                if (gst_structure_has_name(structure, "video/x-raw")) {
+                    if (gst_structure_has_name(structure, "format"))
+                        selector->format = gst_structure_get_string(structure, "format");
+                    else
+                        return TRUE;
+                }
             }
 
             return TRUE;


### PR DESCRIPTION
#### 92cc4d5d99140da8ed1154a4eb309eba647841d9
<pre>
[GStreamer][VideoCapture] Ensure video/x-raw mime-type caps have a format
<a href="https://bugs.webkit.org/show_bug.cgi?id=242243">https://bugs.webkit.org/show_bug.cgi?id=242243</a>

Reviewed by Philippe Normand.

Replicate the logic from gst_video_info_from_caps so that we can
avoid selecting video/x-raw caps that don&apos;t have a format.

See:
<a href="https://github.com/GStreamer/gstreamer/blob/1.20.2/subprojects/gst-plugins-base/gst-libs/gst/video/video-info.c#L409-L411">https://github.com/GStreamer/gstreamer/blob/1.20.2/subprojects/gst-plugins-base/gst-libs/gst/video/video-info.c#L409-L411</a>

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):

Canonical link: <a href="https://commits.webkit.org/252039@main">https://commits.webkit.org/252039@main</a>
</pre>
