### PR TITLE
Remove ARMv7 SoftFP configurations from Buildbot

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -562,11 +562,6 @@
                       "workernames": ["jsconly-linux-igalia-bot-3"]
                     },
                     {
-                      "name": "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release", "factory": "BuildAndJSCTestsFactory",
-                      "platform": "jsc-only", "configuration": "release", "architectures": ["armv7"],
-                      "workernames": ["jsconly-linux-igalia-bot-5"]
-                    },
-                    {
                       "name": "JSCOnly-Linux-MIPS32el-Release", "factory": "BuildAndJSCTestsFactory",
                       "platform": "jsc-only", "configuration": "release", "architectures": ["mips"],
                       "workernames": ["jsconly-linux-igalia-bot-1"]
@@ -649,7 +644,7 @@
                                        "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
                                        "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
                                        "JSCOnly-Linux-AArch64-Release",
-                                       "JSCOnly-Linux-ARMv7-Thumb2-Release", "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release",
+                                       "JSCOnly-Linux-ARMv7-Thumb2-Release",
                                        "JSCOnly-Linux-MIPS32el-Release", "PlayStation-Release-Build", "PlayStation-Debug-Build",
                                        "WinCairo-64-bit-WKL-Release-Build", "WinCairo-64-bit-WKL-Debug-Build",
                                        "WPE-Linux-64-bit-Release-Build", "WPE-Linux-64-bit-Debug-Build",

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1461,17 +1461,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'compile-webkit',
             'jscore-test'
         ],
-        'JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'compile-webkit',
-            'jscore-test'
-        ],
         'JSCOnly-Linux-MIPS32el-Release': [
             'configure-build',
             'configuration',

--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js
@@ -100,7 +100,6 @@ WebKitBuildbot = function()
         }},
         "JSCOnly ARMv7 Testers": {platform: Dashboard.Platform.LinuxJSCOnly, heading: "ARMv7", combinedQueues: {
             "JSCOnly-Linux-ARMv7-Thumb2-Release": {heading: "ARMv7 Thumb2"},
-            "JSCOnly-Linux-ARMv7-Thumb2-SoftFP-Release": {heading: "ARMv7 Thumb2 SoftFP"},
         }},
         "JSCOnly MIPS Testers": {platform: Dashboard.Platform.LinuxJSCOnly, heading: "MIPS", combinedQueues: {
             "JSCOnly-Linux-MIPS32el-Release": {heading: "MIPS32el"},


### PR DESCRIPTION
#### ad3706c7a44ab79c20b748f7ee25323d025d1e81
<pre>
Remove ARMv7 SoftFP configurations from Buildbot
<a href="https://bugs.webkit.org/show_bug.cgi?id=242247">https://bugs.webkit.org/show_bug.cgi?id=242247</a>

Reviewed by NOBODY (OOPS!).

In 252034@main the support for ARMv7 SoftFP has been removed (HardFP is
still supported, of course); hence we can remove the associated builders
and Buildbot configurations.

* Tools/CISupport/build-webkit-org/config.json: Remove ARMv7 SoftFP configuration.
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps): Ditto.
* Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/WebKitBuildbot.js:
(WebKitBuildbot): Ditto.
</pre>