### PR TITLE
webkitbot should accept commit identifier

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/checkout.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout.py
@@ -96,7 +96,7 @@ for l in lines[1:]:
 
     def _changelog_data_for_revision(self, revision):
         repo = local.Scm.from_path(self._scm.checkout_root)
-        commit = repo.commit(revision=revision)
+        commit = repo.find(revision)
 
         return {
             "bug_id": parse_bug_id_from_changelog(commit.message),

--- a/Tools/Scripts/webkitpy/common/checkout/checkout_mock.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout_mock.py
@@ -104,6 +104,11 @@ class MockCheckout(object):
         self._filesystem = MockFileSystem()
 
     def commit_info_for_revision(self, svn_revision):
+        if isinstance(svn_revision, str) and svn_revision.startswith('r'):
+            svn_revision = svn_revision[1:]
+        if isinstance(svn_revision, str) and not svn_revision.isdigit():
+            return None
+        svn_revision = int(svn_revision)
         # There are legacy tests that all expected these revision numbers to map
         # to the same commit description (now mock_revisions[1])
         if svn_revision in [32, 123, 852, 853, 854, 1234, 21654, 21655, 21656]:

--- a/Tools/Scripts/webkitpy/common/config/urls.py
+++ b/Tools/Scripts/webkitpy/common/config/urls.py
@@ -35,7 +35,9 @@ def view_source_url(local_path):
 
 
 def view_revision_url(revision_number):
-    return 'https://commits.webkit.org/r{}'.format(revision_number)
+    if isinstance(revision_number, int) or revision_number.isdigit():
+        return 'https://commits.webkit.org/r{}'.format(revision_number)
+    return 'https://commits.webkit.org/{}'.format(revision_number)
 
 
 def view_identifier_url(identifier):

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/attachment.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/attachment.py
@@ -37,8 +37,8 @@ _log = logging.getLogger(__name__)
 
 class Attachment(object):
     fast_cq_preamble = "[fast-cq] "
-    revert_preamble = "REVERT of r"
-    rollout_preamble = "ROLLOUT of r"
+    revert_preamble = "REVERT of "
+    rollout_preamble = "ROLLOUT of "
 
     def __init__(self, attachment_dictionary, bug):
         self._attachment_dictionary = attachment_dictionary

--- a/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
@@ -64,16 +64,21 @@ class AbstractRevertPrepCommandTest(unittest.TestCase):
         command._commit_info = lambda revision: mock_commit_info
 
         state = command._prepare_state(None, ["124 123 125", "Reason"], None)
-        self.assertEqual(123, state["revision"])
-        self.assertEqual([123, 124, 125], state["revision_list"])
+        self.assertEqual('r123', state["revision"])
+        self.assertEqual(['r123', 'r124', 'r125'], state["revision_list"])
 
-        self.assertRaises(ScriptError, command._prepare_state, options=None, args=["125 r122  123", "Reason"], tool=None)
-        self.assertRaises(ScriptError, command._prepare_state, options=None, args=["125 foo 123", "Reason"], tool=None)
+        state = command._prepare_state(None, ["125 r122 123", "Reason"], None)
+        self.assertEqual('r122', state["revision"])
+        self.assertEqual(['r122', 'r123', 'r125'], state["revision_list"])
+
+        state = command._prepare_state(None, ["125 1234@main 123", "Reason"], None)
+        self.assertEqual('r123', state["revision"])
+        self.assertEqual(['r123', 'r125', '1234@main'], state["revision_list"])
 
         command._commit_info = lambda revision: None
         state = command._prepare_state(None, ["124 123 125", "Reason"], None)
-        self.assertEqual(123, state["revision"])
-        self.assertEqual([123, 124, 125], state["revision_list"])
+        self.assertEqual('r123', state["revision"])
+        self.assertEqual(['r123', 'r124', 'r125'], state["revision_list"])
 
 
 class DownloadCommandsTest(CommandsTest):

--- a/Tools/Scripts/webkitpy/tool/steps/reopenbugafterrevert.py
+++ b/Tools/Scripts/webkitpy/tool/steps/reopenbugafterrevert.py
@@ -39,7 +39,7 @@ _log = logging.getLogger(__name__)
 class ReopenBugAfterRevert(AbstractStep):
     def run(self, state):
         commit_comment = bug_comment_from_commit_text(self._tool.scm(), state["commit_text"])
-        revision_list = string_utils.join(['r' + str(revision) for revision in state["revision_list"]])
+        revision_list = string_utils.join(state["revision_list"])
         comment_text = "Reverted %s for reason:\n\n%s\n\n%s" % (revision_list, state["reason"], commit_comment)
         bug_ids = state["bug_id_list"]
         if not bug_ids:

--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -62,7 +62,7 @@ function extractRevision(text)
         if (!candidate)
             continue;
 
-        let match = candidate.match(/^r?(\d+):?$/);
+        let match = candidate.match(/^r?(\d+|\d+\@[^:\s]+|[0-9a-f]{8}):?$/);
         if (!match)
             return null;
 


### PR DESCRIPTION
#### bb9553870ebc05557accce6781852762de4fef01
<pre>
webkitbot should accept commit identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=224063">https://bugs.webkit.org/show_bug.cgi?id=224063</a>
&lt;rdar://76114559&gt;

Reviewed by Stephanie Lewis.

* Tools/Scripts/webkitpy/common/checkout/checkout.py:
(_changelog_data_for_revision): Support any commit argument.
* Tools/Scripts/webkitpy/common/checkout/checkout_mock.py:
(MockCheckout.commit_info_for_revision): Support r prefixed strings.
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.changed_files_for_revision): Use git_commit_from_string.
(Git.git_commit_from_string): Renamed from git_commit_from_svn_revision.
(Git.contents_at_revision): Use git_commit_from_string.
(Git.diff_for_revision): Ditto
(Git.committer_email_for_revision): Ditto.
(Git.apply_reverse_diff): Ditto.
(Git.git_commit_from_svn_revision): Rename git_commit_from_string.
* Tools/Scripts/webkitpy/common/config/urls.py:
(view_revision_url): Support any commit argument.
* Tools/Scripts/webkitpy/common/net/bugzilla/attachment.py:
(Attachment): Caller should prefix r, if appropriate.
* Tools/Scripts/webkitpy/tool/commands/download.py:
(AbstractRevertPrepCommand._prepare_state): Handle multiple types of commit arguments.
(CreateRevert._prepare_state): Remove r prefix.
* Tools/Scripts/webkitpy/tool/commands/download_unittest.py:
(AbstractRevertPrepCommandTest.test_prepare_state):
* Tools/Scripts/webkitpy/tool/steps/reopenbugafterrevert.py:
(ReopenBugAfterRevert.run): Remove r prefix.
* Tools/WebKitBot/src/WebKitBot.mjs: Allow hashes and identifiers in webkitbot.

Canonical link: <a href="https://commits.webkit.org/252075@main">https://commits.webkit.org/252075@main</a>
</pre>
