### PR TITLE
[Gardening]: [ iOS ] imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/joint_session_history/002.html is a flaky failure timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3671,3 +3671,5 @@ webkit.org/b/242225 http/wpt/service-workers/about-blank-iframe.html [ Pass Fail
 webkit.org/b/237569 imported/blink/svg/filters/filter-huge-clamping.svg [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242228 http/tests/privateClickMeasurement/attribution-conversion-through-fetch-keepalive.html [ Pass Failure Timeout ]
+
+webkit.org/b/242250 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/joint_session_history/002.html [ Pass Timeout ]


### PR DESCRIPTION
#### ddb335ad559cd536d3996abeb7f28b9a17c65021
<pre>
[Gardening]: [ iOS ] imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/joint_session_history/002.html is a flaky failure timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242250">https://bugs.webkit.org/show_bug.cgi?id=242250</a>
&lt;rdar://96294857&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252045@main">https://commits.webkit.org/252045@main</a>
</pre>
