### PR TITLE
[Gardening]: webanimations/accelerated-animation-after-forward-filling-animation.html

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2293,3 +2293,5 @@ webkit.org/b/227845 [ Debug ] webaudio/audioworket-out-of-memory.html [ Pass Tim
 webkit.org/b/240989 http/tests/media/hls/hls-webvtt-flashing.html [ Pass Failure ]
 
 [ Monterey+ ] fast/text/bulgarian-system-language-shaping.html [ Pass ]
+
+webkit.org/b/242249 [ BigSur+ ] webanimations/accelerated-animation-after-forward-filling-animation.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 226a469a02a64e672d48f5a4b32397011edbc79d
<pre>
[Gardening]: webanimations/accelerated-animation-after-forward-filling-animation.html
Bug web URL: <a href="https://bugs.webkit.org/show_bug.cgi?id=242249">https://bugs.webkit.org/show_bug.cgi?id=242249</a>

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252046@main">https://commits.webkit.org/252046@main</a>
</pre>
