### PR TITLE
[ews-build.webkit.org] Update PR on Merge-Queue retry

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4563,6 +4563,8 @@ class PushCommitToWebKitRepo(shell.ShellCommand):
                         AddReviewerToCommitMessage(),
                         ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, verifyObsolete=False),
                         Canonicalize(),
+                        PushPullRequestBranch(),
+                        UpdatePullRequest(),
                         PushCommitToWebKitRepo(),
                     ])
                 else:
@@ -4575,8 +4577,6 @@ class PushCommitToWebKitRepo(shell.ShellCommand):
                         AddReviewerToCommitMessage(),
                         ValidateChange(addURLs=False, verifycqplus=True),
                         Canonicalize(),
-                        PushPullRequestBranch(),
-                        UpdatePullRequest(),
                         PushCommitToWebKitRepo(),
                     ])
                 return rc


### PR DESCRIPTION
#### 6102649fa64718f151cdeccf1939022949dc75f9
<pre>
[ews-build.webkit.org] Update PR on Merge-Queue retry
<a href="https://bugs.webkit.org/show_bug.cgi?id=242253">https://bugs.webkit.org/show_bug.cgi?id=242253</a>
&lt;rdar://problem/96299099&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(PushCommitToWebKitRepo.evaluateCommand): Patches can&apos;t update PRs, but
PR based steps should update their PRs on retry.

Canonical link: <a href="https://commits.webkit.org/252212@main">https://commits.webkit.org/252212@main</a>
</pre>
