### PR TITLE
[Gardening]: [iOS wk2 iPad] platform/ipad/media/modern-media-controls/media-documents/media-document-video-ios-sizing.html is a flaky timeout (230419)

### DIFF
--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -109,8 +109,6 @@ webkit.org/b/197960 imported/w3c/web-platform-tests/html/dom/idlharness.https.ht
 
 webkit.org/b/228663 fast/canvas/canvas-color-space-display-p3.html [ ImageOnlyFailure ]
 
-webkit.org/b/230419 platform/ipad/media/modern-media-controls/media-documents/media-document-video-ios-sizing.html [ Pass Timeout Crash ]
-
 webkit.org/b/231611 [ Debug ] imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html [ Pass Failure ]
 
 webkit.org/b/231616 [ Debug ] compositing/layer-creation/scale-rotation-transition-overlap.html [ Pass Failure Timeout ]


### PR DESCRIPTION
#### 1520cea8158f140f10dee7fd1a4cda38e4cc559f
<pre>
[Gardening]: [iOS wk2 iPad] platform/ipad/media/modern-media-controls/media-documents/media-document-video-ios-sizing.html is a flaky timeout (230419)
<a href="https://bugs.webkit.org/show_bug.cgi?id=230419">https://bugs.webkit.org/show_bug.cgi?id=230419</a>

Unreviewed test gardening.

* LayoutTests/platform/ipad/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252052@main">https://commits.webkit.org/252052@main</a>
</pre>
