### PR TITLE
[Gardening]: [iOS] http/tests/navigation/back-to-slow-frame.html is a flaky crash under MediaPlayer::getSupportedTypes (230434)

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2099,8 +2099,6 @@ webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/active-select
 
 webkit.org/b/230412 imported/w3c/web-platform-tests/service-workers/service-worker/clients-matchall-client-types.https.html [ Pass Failure ]
 
-webkit.org/b/230434 http/tests/navigation/back-to-slow-frame.html [ Pass Crash ]
-
 webkit.org/b/217114 compositing/debug-borders-dynamic.html [ Pass Failure ]
 
 webkit.org/b/230695 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-003.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### e6a652dd92c35a2e34ec71fe93cd2a8f27d935bd
<pre>
[Gardening]: [iOS] http/tests/navigation/back-to-slow-frame.html is a flaky crash under MediaPlayer::getSupportedTypes (230434)
<a href="https://bugs.webkit.org/show_bug.cgi?id=230434">https://bugs.webkit.org/show_bug.cgi?id=230434</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252055@main">https://commits.webkit.org/252055@main</a>
</pre>
