### PR TITLE
[Gardening]: [ BigSur wk2 ] http/tests/cache/disk-cache/shattered-deduplication.html is flaky image failure (230650)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -791,8 +791,6 @@ webkit.org/b/163136 http/tests/xmlhttprequest/auth-reject-protection-space.html 
 
 webkit.org/b/162975 http/tests/cache/disk-cache/memory-cache-revalidation-updates-disk-cache.html [ Pass Failure ]
 
-webkit.org/b/230650 [ BigSur+ ] http/tests/cache/disk-cache/shattered-deduplication.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/161653 [ Debug ] storage/indexeddb/key-generator.html [ Pass Timeout ]
 
 webkit.org/b/163702 platform/mac-wk2/plugins/muted-state.html [ Failure ]


### PR DESCRIPTION
#### 509728275e47091007820463688ff2b9414c199a
<pre>
[Gardening]: [ BigSur wk2 ] http/tests/cache/disk-cache/shattered-deduplication.html is flaky image failure (230650)
<a href="https://bugs.webkit.org/show_bug.cgi?id=230650">https://bugs.webkit.org/show_bug.cgi?id=230650</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252056@main">https://commits.webkit.org/252056@main</a>
</pre>
