### PR TITLE
[GStreamer][VideoCapture] Remove video/x-raw mime-type caps filters

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -135,8 +135,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
 
         switch (deviceType()) {
         case CaptureDevice::DeviceType::Camera: {
-            auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
-            gst_device_monitor_add_filter(m_deviceMonitor.get(), "Video/Source", caps.get());
+            gst_device_monitor_add_filter(m_deviceMonitor.get(), "Video/Source", nullptr);
             break;
         }
         case CaptureDevice::DeviceType::Microphone: {


### PR DESCRIPTION
#### 696df7229c41ce048133698debfb9faea81a4d08
<pre>
[GStreamer][VideoCapture] Remove video/x-raw mime-type caps filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=242256">https://bugs.webkit.org/show_bug.cgi?id=242256</a>

Reviewed by Philippe Normand.

We support image/jpeg mime-type sources so having a video/x-raw
mime-type caps filter doesn&apos;t seem correct.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):

Canonical link: <a href="https://commits.webkit.org/252103@main">https://commits.webkit.org/252103@main</a>
</pre>
