### PR TITLE
Crash under SQLiteIDBBackingStore::getAllObjectStoreRecords()

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2284,6 +2284,9 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
 
     auto* objectStoreInfo = infoForObjectStore(getAllRecordsData.objectStoreIdentifier);
     ASSERT(objectStoreInfo);
+    if (!objectStoreInfo)
+        return IDBError { UnknownError, "Failed to look up IDBObjectStoreInfo from identifier"_s };
+
     result = { getAllRecordsData.getAllType, objectStoreInfo->keyPath() };
 
     uint32_t targetResults;


### PR DESCRIPTION
#### 607cce5a7d8eef66de98b4ed9c1d2ed693cbe23e
<pre>
Crash under SQLiteIDBBackingStore::getAllObjectStoreRecords()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242257">https://bugs.webkit.org/show_bug.cgi?id=242257</a>
&lt;rdar://71160678&gt;

Reviewed by Sihui Liu.

We have evidence from crashes in the wild that objectStoreInfo can be null here
so add a null check for it.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):

Canonical link: <a href="https://commits.webkit.org/252063@main">https://commits.webkit.org/252063@main</a>
</pre>
