### PR TITLE
[Gardening]: [ iOS 14 & 15 ] fast/images/image-subsampling.html is a flaky image failure (230857)

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1396,8 +1396,6 @@ fast/layoutformattingcontext/ [ Skip ]
 
 webkit.org/b/208018 [ Release ] perf/clone-with-focus.html [ Pass Failure ]
 
-webkit.org/b/230857 fast/images/image-subsampling.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/208030 http/tests/workers/service/registration-clear-redundant-worker.html [ Pass Timeout ]
 
 webkit.org/b/207038 compositing/webgl/webgl-reflection.html [ Pass Failure ]


### PR DESCRIPTION
#### d26049d74aa87622770a4dc3e21cd1b087c80e54
<pre>
[Gardening]: [ iOS 14 &amp; 15 ] fast/images/image-subsampling.html is a flaky image failure (230857)
<a href="https://bugs.webkit.org/show_bug.cgi?id=230857">https://bugs.webkit.org/show_bug.cgi?id=230857</a>

Unreviewed test gardening.

* LayoutTests/platform/win/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252059@main">https://commits.webkit.org/252059@main</a>
</pre>
