### PR TITLE
[Make] Recognize feature flags in BUILD_WEBKIT_OPTIONS

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -46,6 +46,7 @@ use List::Util;
 use POSIX;
 use Time::HiRes qw(usleep);
 use VCSUtils;
+use webkitperl::FeatureList qw(getFeatureOptionList);
 
 unless (defined(&decode_json)) {
     eval "use JSON::XS;";
@@ -1053,6 +1054,16 @@ sub XcodeOptions
     push @options, @baseProductDirOption;
     push @options, "ARCHS=$architecture" if $architecture;
     push @options, "SDKROOT=$xcodeSDK" if $xcodeSDK;
+
+    my @features = getFeatureOptionList();
+    foreach (@features) {
+        if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
+            push @options, "$_->{define}=";
+        } 
+        if (checkForArgumentAndRemoveFromARGV("--$_->{option}")) {
+            push @options, "$_->{define}=$_->{define}";
+        }   
+    }
 
     # When this environment variable is set Tools/Scripts/check-for-weak-vtables-and-externals
     # treats errors as non-fatal when it encounters missing symbols related to coverage.

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -187,8 +187,6 @@ my (
     $xsltSupport,
 );
 
-prohibitUnknownPort();
-
 my @features = (
     { option => "3d-rendering", desc => "Toggle 3D rendering support",
       define => "ENABLE_3D_TRANSFORMS", value => \$threeDTransformsSupport },
@@ -571,6 +569,7 @@ my @features = (
 
 sub getFeatureOptionList()
 {
+    prohibitUnknownPort();
     return @features;
 }
 


### PR DESCRIPTION
#### 97a065060b7d6bdf750db4aea26fac29445d5ac7
<pre>
[Make] Recognize feature flags in BUILD_WEBKIT_OPTIONS
<a href="https://bugs.webkit.org/show_bug.cgi?id=242258">https://bugs.webkit.org/show_bug.cgi?id=242258</a>

Reviewed by Jonathan Bedard.

Refactor XcodeOptions to look for feature flags (--&lt;feature&gt; and
--no-&lt;feature&gt;) in argv and pass the corresponding build settings to
Xcode.

With this change,

    build-webkit --debug --&lt;feature&gt;

and

    make debug BUILD_WEBKIT_OPTIONS=--&lt;feature&gt;

provide the same feature settings for Xcode-based platforms.

This doesn&apos;t change the code path build-webkit uses for feature flags,
because it handles their parsing in its top-level Getopt::GetOptions
call.

* Tools/Scripts/webkitdirs.pm:
(XcodeOptions):
* Tools/Scripts/webkitperl/FeatureList.pm:
(getFeatureOptionList): Lazily call prohibitUnknownPort when the feature
list is queried, instead of when it&apos;s loaded, to avoid a circular
dependency preventing this file from being imported by webkitdirs.

Canonical link: <a href="https://commits.webkit.org/252082@main">https://commits.webkit.org/252082@main</a>
</pre>
