### PR TITLE
[Gardening]: [ iOS ] fast/mediastream/apply-constraints-video.html is a flaky failure (231618)

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1438,8 +1438,6 @@ webkit.org/b/208590 [ Debug ] fast/events/beforeunload-prompt.html [ Pass Crash 
 
 webkit.org/b/232106 media/modern-media-controls/media-documents/media-document-video-with-initial-audio-layout.html [ Pass Timeout ]
 
-webkit.org/b/231618 [ Release ] fast/mediastream/apply-constraints-video.html [ Pass Failure ]
-
 webkit.org/b/230012 media/modern-media-controls/media-documents/media-document-invalid.html [ Pass Crash ]
 
 webkit.org/b/229810 fast/mediastream/get-display-media-capabilities.html [ Skip ]


### PR DESCRIPTION
#### ca4d6e3ace334c84ff3a2c2951b617fe36d13052
<pre>
[Gardening]: [ iOS ] fast/mediastream/apply-constraints-video.html is a flaky failure (231618)
<a href="https://bugs.webkit.org/show_bug.cgi?id=231618">https://bugs.webkit.org/show_bug.cgi?id=231618</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252061@main">https://commits.webkit.org/252061@main</a>
</pre>
