### PR TITLE
Add Rupin Mittal to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -5881,6 +5881,16 @@
    },
    {
       "emails" : [
+         "rmittal2@apple.com"
+      ],
+      "github" : "RupinMittal",
+      "name" : "Rupin Mittal",
+      "nicks" : [
+         "rupin"
+      ]
+   },
+   {
+      "emails" : [
          "repstein@apple.com"
       ],
       "name" : "Russell Epstein",


### PR DESCRIPTION
#### 007636dcbb9bbbefdbad090d5fecee9a0e328828
<pre>
Add Rupin Mittal to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=242255">https://bugs.webkit.org/show_bug.cgi?id=242255</a>

Reviewed by Jonathan Bedard.

Add Rupin Mittal to contributors.json.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252068@main">https://commits.webkit.org/252068@main</a>
</pre>
