### PR TITLE
Fix memory leak

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -49,7 +49,7 @@ RefPtr<WebCore::SharedBuffer> AuxiliaryProcessProxy::fetchAudioComponentServerRe
     if (noErr != AudioComponentFetchServerRegistrations(&registrations) || !registrations)
         return nullptr;
 
-    return WebCore::SharedBuffer::create(registrations);
+    return WebCore::SharedBuffer::create(adoptCF(registrations).get());
 }
 #endif
 


### PR DESCRIPTION
#### 02309bba8c6596ade177a5c4e4b55d9dd9422966
<pre>
Fix memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=242259">https://bugs.webkit.org/show_bug.cgi?id=242259</a>
&lt;rdar://96029757&gt;

Reviewed by Chris Dumez.

Fix memory leak after calling AudioComponentFetchServerRegistrations.

* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::fetchAudioComponentServerRegistrations):

Canonical link: <a href="https://commits.webkit.org/252064@main">https://commits.webkit.org/252064@main</a>
</pre>
