### PR TITLE
[iOS 15.3+] Crash at -[UIViewController presentViewController:withAnimationController:completion:], called on a wrong thread

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,7 +57,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MediaDevices);
 
 inline MediaDevices::MediaDevices(Document& document)
     : ActiveDOMObject(document)
-    , m_scheduledEventTimer(*this, &MediaDevices::scheduledEventTimerFired)
+    , m_scheduledEventTimer(RunLoop::main(), this, &MediaDevices::scheduledEventTimerFired)
     , m_eventNames(eventNames())
     , m_groupIdHashSalt(createVersion4UUIDString())
 {

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,9 +40,9 @@
 #include "IDLTypes.h"
 #include "MediaTrackConstraints.h"
 #include "RealtimeMediaSourceCenter.h"
-#include "Timer.h"
 #include "UserMediaClient.h"
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/RunLoop.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -124,7 +124,7 @@ private:
     };
     bool computeUserGesturePriviledge(GestureAllowedRequest);
 
-    Timer m_scheduledEventTimer;
+    RunLoop::Timer<MediaDevices> m_scheduledEventTimer;
     UserMediaClient::DeviceChangeObserverToken m_deviceChangeToken;
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
     bool m_listeningForDeviceChanges { false };

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -190,6 +190,8 @@ static NSString *doNotAllowButtonText(MediaPermissionReason reason)
 
 void alertForPermission(WebPageProxy& page, MediaPermissionReason reason, const WebCore::SecurityOriginData& origin, CompletionHandler<void(bool)>&& completionHandler)
 {
+    ASSERT(isMainRunLoop());
+
 #if PLATFORM(IOS_FAMILY)
     if (reason == MediaPermissionReason::DeviceOrientation) {
         if (auto& userPermissionHandler = page.deviceOrientationUserPermissionHandlerForTesting())


### PR DESCRIPTION
#### 4dbd5bdfdbf72b81f0dd0f75f547df62aee50c13
<pre>
[iOS 15.3+] Crash at -[UIViewController presentViewController:withAnimationController:completion:], called on a wrong thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=242235">https://bugs.webkit.org/show_bug.cgi?id=242235</a>
rdar://96305779

Reviewed by Chris Dumez.

* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::MediaDevices): Use a RunLoop::Timer as this code runs in the UI process.
* Source/WebCore/Modules/mediastream/MediaDevices.h:

* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertForPermission): Assert if not called on the main thread.

* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
(UIDelegate::UIClient::promptForDisplayCapturePermission): Use ensureOnMainRunLoop so we are on
the main thread when showing UI.
(UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest): Ditto.

Canonical link: <a href="https://commits.webkit.org/252189@main">https://commits.webkit.org/252189@main</a>
</pre>
