### PR TITLE
Crash under ~TimerBase() from LibWebRTCAudioModule

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -145,7 +145,7 @@ private:
     bool m_isPlaying { false };
     webrtc::AudioTransport* m_audioTransport { nullptr };
     MonotonicTime m_pollingTime;
-    Timer m_logTimer;
+    std::unique_ptr<Timer> m_logTimer;
     int m_timeSpent { 0 };
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 1fc2703d9a777902d1cb161a4badf201f6f3520d
<pre>
Crash under ~TimerBase() from LibWebRTCAudioModule
<a href="https://bugs.webkit.org/show_bug.cgi?id=242262">https://bugs.webkit.org/show_bug.cgi?id=242262</a>
&lt;rdar://81438938&gt;

Reviewed by Eric Carlson.

LibWebRTCAudioModule has a Timer data member which gets constructed on the main thread,
gets started / stopped on the main thread and fires on the main thread. However, the
LibWebRTCAudioModule can get destroyed on a non-main thread, which would also destroy
the Timer on that thread. This wasn&apos;t safe and would result in crashes.

To address the issue, I now do a callOnMainThreadAndWait() in the LibWebRTCAudioModule
destructor and make sure to destroy the timer on the main thread. The &quot;AndWait&quot; part
is necessary since the timer may fire on the main thread during the execution on the
LibWebRTCAudioModule destructor on the background thread.

* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::LibWebRTCAudioModule):
(WebCore::LibWebRTCAudioModule::~LibWebRTCAudioModule):
(WebCore::LibWebRTCAudioModule::StartPlayout):
(WebCore::LibWebRTCAudioModule::StopPlayout):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:

Canonical link: <a href="https://commits.webkit.org/252085@main">https://commits.webkit.org/252085@main</a>
</pre>
