### PR TITLE
[iOS] Fix WKTR build after 252016@main

### DIFF
--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -942,7 +942,7 @@ static RetainPtr<UIWindowSceneGeometryPreferences> toWindowSceneGeometryPreferen
         orientations = UIInterfaceOrientationMaskLandscapeRight;
         break;
     }
-    ASSERT(orientation);
+    ASSERT(orientations);
     return adoptNS([[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:orientations]);
 }
 


### PR DESCRIPTION
#### 8cf4b764ace993a01053ddc9371980e77a5260bb
<pre>
[iOS] Fix WKTR build after 252016@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242271">https://bugs.webkit.org/show_bug.cgi?id=242271</a>

Unreviewed build fix.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::toWindowSceneGeometryPreferences):

Canonical link: <a href="https://commits.webkit.org/252072@main">https://commits.webkit.org/252072@main</a>
</pre>
