### PR TITLE
[Curl] Report HTTP/3 in NetworkLoadMetrics

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -83,6 +83,7 @@ constexpr const char* EnvironmentVariableReader::sscanTemplate<unsigned>() { ret
 static const ASCIILiteral httpVersion10 { "http/1.0"_s };
 static const ASCIILiteral httpVersion11 { "http/1.1"_s };
 static const ASCIILiteral httpVersion2 { "h2"_s };
+static const ASCIILiteral httpVersion3 { "h3"_s };
 
 // CurlContext -------------------------------------------------------------------
 
@@ -838,6 +839,8 @@ std::optional<NetworkLoadMetrics> CurlHandle::getNetworkLoadMetrics(MonotonicTim
         networkLoadMetrics.protocol = httpVersion11;
     else if (version == CURL_HTTP_VERSION_2)
         networkLoadMetrics.protocol = httpVersion2;
+    else if (version == CURL_HTTP_VERSION_3)
+        networkLoadMetrics.protocol = httpVersion3;
 
     return networkLoadMetrics;
 }


### PR DESCRIPTION
#### 1dcadc12a73c3e270c53acae005f25aa28b2c6de
<pre>
[Curl] Report HTTP/3 in NetworkLoadMetrics
<a href="https://bugs.webkit.org/show_bug.cgi?id=242272">https://bugs.webkit.org/show_bug.cgi?id=242272</a>

Reviewed by Alex Christensen.

When a curl connection is using HTTP/3 report it to NetworkLoadMetrics as &quot;h3&quot;. Ensures that the
protocol in Web Inspector&apos;s Network tab is correct.

* Source/WebCore/platform/network/curl/CurlContext.cpp:

Canonical link: <a href="https://commits.webkit.org/252081@main">https://commits.webkit.org/252081@main</a>
</pre>
