### PR TITLE
[Gardening]: [ iOS ] fast/events/ios/dragstart-on-image-by-long-pressing.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3675,3 +3675,5 @@ webkit.org/b/242228 http/tests/privateClickMeasurement/attribution-conversion-th
 webkit.org/b/242250 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/joint_session_history/002.html [ Pass Timeout ]
 
 webkit.org/b/242270 fast/encoding/char-after-fast-path-ascii-decoding.html [ Pass Failure ]
+
+webkit.org/b/242273 fast/events/ios/dragstart-on-image-by-long-pressing.html [ Pass Failure ]


### PR DESCRIPTION
#### 970afaedeb565b91d260e28d1223b49073d0f81b
<pre>
[Gardening]: [ iOS ] fast/events/ios/dragstart-on-image-by-long-pressing.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242273">https://bugs.webkit.org/show_bug.cgi?id=242273</a>
&lt;rdar://96317337&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252076@main">https://commits.webkit.org/252076@main</a>
</pre>
