### PR TITLE
webkitbot should accept commit identifier (Follow-up fix)

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -62,7 +62,7 @@ function extractRevision(text)
         if (!candidate)
             continue;
 
-        let match = candidate.match(/^r?(\d+|\d+\@[^:\s]+|[0-9a-f]{8}):?$/);
+        let match = candidate.match(/^r?(\d{5,6}|\d+\@[^:\s]+|[0-9a-f]{6,40}):?$/);
         if (!match)
             return null;
 
@@ -453,12 +453,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
     async generateRevertingPatch(revisions, reason)
     {
         dataLogLn("Reverting ", revisions, reason);
-        let revisionsArgument = revisions.map((revision) => {
-            let number = Number.parseInt(revision, 10);
-            if (!Number.isFinite(number))
-                throw new Error(`Invalid svn revision number "${String(revision)}"`);
-            return number;
-        }).join(" ");
+        let revisionsArgument = revisions.join(" ");
 
         if (reason.startsWith("-"))
             throw new Error(`The revert reason may not begin with - ("${reason}")`);


### PR DESCRIPTION
#### 90ac25f7f49f584eff9cceec7841f84fec5efb78
<pre>
webkitbot should accept commit identifier (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=224063">https://bugs.webkit.org/show_bug.cgi?id=224063</a>
&lt;rdar://76114559&gt;

Unreviewed follow-up fix.

* Tools/WebKitBot/src/WebKitBot.mjs: Do not convert all revisions to integers,
support variety of hash lengths.

Canonical link: <a href="https://commits.webkit.org/252080@main">https://commits.webkit.org/252080@main</a>
</pre>
