### PR TITLE
[Flatpak SDK] Update Mold to version 1.3.1

### DIFF
--- a/Tools/buildstream/elements/sdk/mold.bst
+++ b/Tools/buildstream/elements/sdk/mold.bst
@@ -13,4 +13,4 @@ sources:
   checkout-submodules: false
   track-tags: true
   track: main
-  ref: v1.3.0-0-ga9a8205be29f36346bfdbfadee8ed147e06aa1f6
+  ref: v1.3.1-0-g7f7d10cc896e0c7513d09723d5ca3d8346bdea49


### PR DESCRIPTION
#### 73c597ea4a015c1ec34435f3608e8f0a6f653081
<pre>
[Flatpak SDK] Update Mold to version 1.3.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=242279">https://bugs.webkit.org/show_bug.cgi?id=242279</a>

Reviewed by Philippe Normand.

* Tools/buildstream/elements/sdk/mold.bst: Bump to version 1.3.1

Canonical link: <a href="https://commits.webkit.org/252097@main">https://commits.webkit.org/252097@main</a>
</pre>
