### PR TITLE
Add ability to mask URLs in Error.stack.

### DIFF
--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -176,7 +176,7 @@ void getBytecodeIndex(VM& vm, CallFrame* startCallFrame, Vector<StackFrame>* sta
         bytecodeIndex = stackTrace->at(stackIndex).bytecodeIndex();
 }
 
-bool getLineColumnAndSource(Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL)
+bool getLineColumnAndSource(VM& vm, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL)
 {
     line = 0;
     column = 0;
@@ -189,7 +189,7 @@ bool getLineColumnAndSource(Vector<StackFrame>* stackTrace, unsigned& line, unsi
         StackFrame& frame = stackTrace->at(i);
         if (frame.hasLineAndColumnInfo()) {
             frame.computeLineAndColumn(line, column);
-            sourceURL = frame.sourceURL();
+            sourceURL = frame.sourceURL(vm);
             return true;
         }
     }
@@ -206,7 +206,7 @@ bool addErrorInfo(VM& vm, Vector<StackFrame>* stackTrace, JSObject* obj)
         unsigned line;
         unsigned column;
         String sourceURL;
-        getLineColumnAndSource(stackTrace, line, column, sourceURL);
+        getLineColumnAndSource(vm, stackTrace, line, column, sourceURL);
         obj->putDirect(vm, vm.propertyNames->line, jsNumber(line));
         obj->putDirect(vm, vm.propertyNames->column, jsNumber(column));
         if (!sourceURL.isEmpty())

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -68,7 +68,7 @@ JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension,
 
 std::unique_ptr<Vector<StackFrame>> getStackTrace(JSGlobalObject*, VM&, JSObject*, bool useCurrentFrame);
 void getBytecodeIndex(VM&, CallFrame*, Vector<StackFrame>*, CallFrame*&, BytecodeIndex&);
-bool getLineColumnAndSource(Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL);
+bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL);
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);
 JSObject* addErrorInfo(VM&, JSObject* error, int line, const SourceCode&);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -236,7 +236,7 @@ void ErrorInstance::computeErrorInfo(VM& vm)
     ASSERT(!m_errorInfoMaterialized);
 
     if (m_stackTrace && !m_stackTrace->isEmpty()) {
-        getLineColumnAndSource(m_stackTrace.get(), m_line, m_column, m_sourceURL);
+        getLineColumnAndSource(vm, m_stackTrace.get(), m_line, m_column, m_sourceURL);
         m_stackString = Interpreter::stackTraceAsString(vm, *m_stackTrace.get());
         m_stackTrace = nullptr;
     }

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -58,16 +58,22 @@ SourceID StackFrame::sourceID() const
     return m_codeBlock->ownerExecutable()->sourceID();
 }
 
-String StackFrame::sourceURL() const
+String StackFrame::sourceURL(VM& vm) const
 {
     if (m_isWasmFrame)
         return "[wasm code]"_s;
 
-    if (!m_codeBlock) {
+    if (!m_codeBlock)
         return "[native code]"_s;
-    }
 
     String sourceURL = m_codeBlock->ownerExecutable()->sourceURL();
+
+    if (vm.clientData && !sourceURL.startsWithIgnoringASCIICase("http"_s)) {
+        String overrideURL = vm.clientData->overrideSourceURL(*this, sourceURL);
+        if (!overrideURL.isNull())
+            return overrideURL;
+    }
+
     if (!sourceURL.isNull())
         return sourceURL;
     return emptyString();
@@ -92,11 +98,13 @@ String StackFrame::functionName(VM& vm) const
             ASSERT_NOT_REACHED();
         }
     }
+
     String name;
     if (m_callee) {
         if (m_callee->isObject())
             name = getCalculatedDisplayName(vm, jsCast<JSObject*>(m_callee.get())).impl();
     }
+
     return name.isNull() ? emptyString() : name;
 }
 
@@ -121,7 +129,7 @@ void StackFrame::computeLineAndColumn(unsigned& line, unsigned& column) const
 String StackFrame::toString(VM& vm) const
 {
     String functionName = this->functionName(vm);
-    String sourceURL = this->sourceURL();
+    String sourceURL = this->sourceURL(vm);
 
     if (sourceURL.isEmpty() || !hasLineAndColumnInfo())
         return makeString(functionName, '@', sourceURL);

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -45,11 +45,12 @@ public:
     StackFrame(Wasm::IndexOrName);
 
     bool hasLineAndColumnInfo() const { return !!m_codeBlock; }
-    
+    CodeBlock* codeBlock() const { return m_codeBlock.get(); }
+
     void computeLineAndColumn(unsigned& line, unsigned& column) const;
     String functionName(VM&) const;
     SourceID sourceID() const;
-    String sourceURL() const;
+    String sourceURL(VM&) const;
     String toString(VM&) const;
 
     bool hasBytecodeIndex() const { return m_bytecodeIndex && !m_isWasmFrame; }

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -133,6 +133,7 @@ class ShadowChicken;
 class SharedJITStubSet;
 class SourceProvider;
 class SourceProviderCache;
+class StackFrame;
 class Structure;
 class Symbol;
 class TypedArrayController;
@@ -255,6 +256,8 @@ public:
 
     struct ClientData {
         JS_EXPORT_PRIVATE virtual ~ClientData() = 0;
+
+        JS_EXPORT_PRIVATE virtual String overrideSourceURL(const StackFrame&, const String& originalSourceURL) const = 0;
     };
 
     bool isSharedInstance() { return vmType == APIShared; }

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -182,5 +182,24 @@ void JSVMClientData::initNormalWorld(VM* vm, WorkerThreadType type)
     vm->m_typedArrayController = adoptRef(new WebCoreTypedArrayController(type == WorkerThreadType::DedicatedWorker || type == WorkerThreadType::Worklet));
 }
 
+String JSVMClientData::overrideSourceURL(const JSC::StackFrame& frame, const String& originalSourceURL) const
+{
+    if (originalSourceURL.isEmpty())
+        return nullString();
+
+    auto* codeBlock = frame.codeBlock();
+    RELEASE_ASSERT(codeBlock);
+
+    auto* globalObject = codeBlock->globalObject();
+    if (!globalObject->inherits<JSDOMWindowBase>())
+        return nullString();
+
+    auto* document = jsCast<const JSDOMWindowBase*>(globalObject)->wrapped().document();
+    if (!document)
+        return nullString();
+
+    return document->maskedURLForBindingsIfNeeded(URL(originalSourceURL)).string();
+}
+
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -123,6 +123,8 @@ public:
         m_worldSet.remove(&world);
     }
 
+    virtual String overrideSourceURL(const JSC::StackFrame&, const String& originalSourceURL) const;
+
     JSHeapData& heapData() { return *m_heapData; }
 
     WebCoreBuiltinNames& builtinNames() { return m_builtinNames; }


### PR DESCRIPTION
#### 2aac2a8e244e3f071c691d0e69d4985a564fab64
<pre>
Add ability to mask URLs in Error.stack.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242278">https://bugs.webkit.org/show_bug.cgi?id=242278</a>
rdar://81991245

Reviewed by Darin Adler and Yusuke Suzuki.

Have StackFrame&apos;s toString consult a new overrideSourceURL() method on VM::ClientData
that is implemented in WebCore&apos;s JSVMClientData that uses the new maskedURLForBindingsIfNeeded()
to mask certain URLs from the Error.stack string returned to JavaScript.

* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::extractSourceInformationFromException): Pass vm to getLineColumnAndSource().
(Inspector::createScriptCallStackFromException): Pass vm to sourceURL().
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::getLineColumnAndSource): Add vm parameter and pass it to sourceURL().
(JSC::addErrorInfo): Pass vm to getLineColumnAndSource().
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::computeErrorInfo): Pass vm to getLineColumnAndSource().
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::StackFrame::sourceURL const): Add vm parameter and call overrideSourceURL() on clientData.
(JSC::StackFrame::functionName const): Add some newlines.
(JSC::StackFrame::toString const): Pass vm to sourceURL().
* Source/JavaScriptCore/runtime/StackFrame.h:
(JSC::StackFrame::codeBlock const): Added.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::ClientData::overrideSourceURL const): Added.
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
(WebCore::JSVMClientData::overrideSourceURL const): Added. Use maskedURLForBindingsIfNeeded() to mask sourceURLs.
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:
(TEST(WebKit, ConfigurationMaskedURLSchemes)): Added user script tests with Error.stack.

Canonical link: <a href="https://commits.webkit.org/252253@main">https://commits.webkit.org/252253@main</a>
</pre>
