### PR TITLE
[webkitbot] Use commits.webkit.org instead of trac.webkit.org

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -229,7 +229,12 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
             try {
                 await this._web.chat.postMessage({
                     channel: event.channel,
-                    text: `<@${event.user}> Preparing revert for ${revisions.map((revision) => `<${escapeForSlackText(`https://trac.webkit.org/r${revision}|r${revision}`)}>`).join(" ")} ...`,
+                    text: `<@${event.user}> Preparing revert for ${revisions.map((revision) => {
+                        let revRepr = revision;
+                        if (revRepr.match(/^\d+$/))
+                            revRepr = `r${revRepr}`;
+                        return `<${escapeForSlackText(`https://commits.webkit.org/${revRepr}|${revRepr}`)}>`;
+                    }).join(" ")} ...`,
                 });
                 let bugId = await this._taskQueue.postOrFailWhenExceedingLimit({
                     command: "revert",


### PR DESCRIPTION
#### 8bb4fc96fa82de731246ca184f986ada93a2523c
<pre>
[webkitbot] Use commits.webkit.org instead of trac.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=242280">https://bugs.webkit.org/show_bug.cgi?id=242280</a>
&lt;rdar://problem/96321862&gt;

Reviewed by Yusuke Suzuki.

* Tools/WebKitBot/src/WebKitBot.mjs:

Canonical link: <a href="https://commits.webkit.org/252145@main">https://commits.webkit.org/252145@main</a>
</pre>
