### PR TITLE
Refine JSDOMGuardedObject

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.cpp
@@ -35,13 +35,12 @@ DOMGuardedObject::DOMGuardedObject(JSDOMGlobalObject& globalObject, JSCell& guar
     , m_guarded(&guarded)
     , m_globalObject(&globalObject)
 {
-    globalObject.vm().writeBarrier(&globalObject, &guarded);
     if (globalObject.vm().heap.mutatorShouldBeFenced()) {
         Locker locker { globalObject.gcLock() };
         globalObject.guardedObjects().add(this);
-        return;
-    }
-    globalObject.guardedObjects(NoLockingNecessary).add(this);
+    } else
+        globalObject.guardedObjects(NoLockingNecessary).add(this);
+    globalObject.vm().writeBarrier(&globalObject, &guarded);
 }
 
 DOMGuardedObject::~DOMGuardedObject()
@@ -54,12 +53,11 @@ void DOMGuardedObject::clear()
     ASSERT(!m_guarded || m_globalObject);
     removeFromGlobalObject();
     m_guarded.clear();
-    m_globalObject.clear();
 }
 
 void DOMGuardedObject::removeFromGlobalObject()
 {
-    if (!m_guarded || !m_globalObject)
+    if (!m_globalObject)
         return;
 
     if (m_globalObject->vm().heap.mutatorShouldBeFenced()) {
@@ -67,6 +65,8 @@ void DOMGuardedObject::removeFromGlobalObject()
         m_globalObject->guardedObjects().remove(this);
     } else
         m_globalObject->guardedObjects(NoLockingNecessary).remove(this);
+
+    m_globalObject.clear();
 }
 
 void DOMGuardedObject::contextDestroyed()


### PR DESCRIPTION
#### ecad671df9fca030da0d5dfcbee0ee66f95e8234
<pre>
Refine JSDOMGuardedObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=242282">https://bugs.webkit.org/show_bug.cgi?id=242282</a>
rdar://94649571

Reviewed by Mark Lam.

This patch fixes the following issues.

1. JSDOMGuardedObject should emit write-barrier after storing a reference to JSDOMGlobalObject.
2. Regardless of m_guarded status, we should unregister itself from JSDOMGlobalObject if JSDOMGlobalObject
   is live since we register it in the constructor.

* Source/WebCore/bindings/js/JSDOMGuardedObject.cpp:
(WebCore::DOMGuardedObject::DOMGuardedObject):
(WebCore::DOMGuardedObject::clear):
(WebCore::DOMGuardedObject::removeFromGlobalObject):

Canonical link: <a href="https://commits.webkit.org/252086@main">https://commits.webkit.org/252086@main</a>
</pre>
