### PR TITLE
Speed up JSON.stringify by adding a separate fast case algorithm

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4394,7 +4394,6 @@
 		860295FD26FB552D0078EB62 /* ShadowRealmConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShadowRealmConstructor.cpp; sourceTree = "<group>"; };
 		860295FE26FB552D0078EB62 /* ShadowRealmObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShadowRealmObject.h; sourceTree = "<group>"; };
 		860295FF26FB552D0078EB62 /* ShadowRealmPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShadowRealmPrototype.h; sourceTree = "<group>"; };
-		8604F4F2143A6C4400B295F5 /* ChangeLog */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; path = ChangeLog; sourceTree = "<group>"; };
 		8606DDE918DA44AB00A383D0 /* IdentifierInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IdentifierInlines.h; sourceTree = "<group>"; };
 		8612E4CB1522918400C836BE /* MatchResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatchResult.h; sourceTree = "<group>"; };
 		86158AB2155C8B3F00B45C9C /* PropertyName.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertyName.h; sourceTree = "<group>"; };
@@ -5935,7 +5934,6 @@
 			children = (
 				530A63411FA3E31D0026A545 /* Sources.txt */,
 				530A63401FA3E31C0026A545 /* SourcesCocoa.txt */,
-				8604F4F2143A6C4400B295F5 /* ChangeLog */,
 				F68EBB8C0255D4C601FF60F7 /* config.h */,
 				F692A8540255597D01FF60F7 /* create_hash_table */,
 				532631B3218777A5007B8191 /* JavaScriptCore.modulemap */,

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Alexey Shvayka <shvaikalesh@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,11 @@
 #include "ObjectConstructorInlines.h"
 #include "PropertyNameArray.h"
 #include "VMInlines.h"
+#include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/StringBuilder.h>
+
+// Turn this on to log information about fastStringify usage, with a focus on why it failed.
+#define FAST_STRINGIFY_LOG_USAGE 0
 
 namespace JSC {
 
@@ -81,8 +85,7 @@ class Stringifier {
     WTF_MAKE_NONCOPYABLE(Stringifier);
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    Stringifier(JSGlobalObject*, JSValue replacer, JSValue space);
-    JSValue stringify(JSValue);
+    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space);
 
 private:
     class Holder {
@@ -110,6 +113,8 @@ private:
     };
 
     friend class Holder;
+
+    Stringifier(JSGlobalObject*, JSValue replacer, JSValue space);
 
     JSValue toJSON(JSValue, const PropertyNameForFunctionCall&);
 
@@ -261,32 +266,35 @@ Stringifier::Stringifier(JSGlobalObject* globalObject, JSValue replacer, JSValue
     m_gap = gap(globalObject, space);
 }
 
-JSValue Stringifier::stringify(JSValue value)
+String Stringifier::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space)
 {
-    VM& vm = m_globalObject->vm();
+    VM& vm = globalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    Stringifier stringifier(&globalObject, replacer, space);
+    RETURN_IF_EXCEPTION(scope, { });
 
     PropertyNameForFunctionCall emptyPropertyName(vm.propertyNames->emptyIdentifier.impl());
 
     // If the replacer is not callable, root object wrapper is non-user-observable.
     // We can skip creating this wrapper object.
     JSObject* object = nullptr;
-    if (isCallableReplacer()) {
-        object = constructEmptyObject(m_globalObject);
+    if (stringifier.isCallableReplacer()) {
+        object = constructEmptyObject(&globalObject);
         object->putDirect(vm, vm.propertyNames->emptyIdentifier, value);
     }
 
     StringBuilder result(StringBuilder::OverflowHandler::RecordOverflow);
     Holder root(Holder::RootHolder, object);
-    auto stringifyResult = appendStringifiedValue(result, value, root, emptyPropertyName);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    auto stringifyResult = stringifier.appendStringifiedValue(result, value, root, emptyPropertyName);
+    RETURN_IF_EXCEPTION(scope, { });
     if (UNLIKELY(result.hasOverflowed())) {
-        throwOutOfMemoryError(m_globalObject, scope);
-        return jsUndefined();
+        throwOutOfMemoryError(&globalObject, scope);
+        return { };
     }
     if (UNLIKELY(stringifyResult != StringifySucceeded))
-        return jsUndefined();
-    RELEASE_AND_RETURN(scope, jsString(vm, result.toString()));
+        RELEASE_AND_RETURN(scope, { });
+    RELEASE_AND_RETURN(scope, result.toString());
 }
 
 ALWAYS_INLINE JSValue Stringifier::toJSON(JSValue baseValue, const PropertyNameForFunctionCall& propertyName)
@@ -627,6 +635,470 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
     return true;
 }
 
+// ------------------------------ FastStringifier --------------------------------
+
+// FastStringifier does a no-side-effects stringify of the most common types of
+// objects and arrays. It bails out if the serialization is any longer than a
+// fixed buffer and handles only the simplest cases, including only 8-bit character
+// strings. Instead of explicit checks to prevent excessive recursion and cycles,
+// it counts on hitting the buffer size limit to catch those things. If it fails,
+// since there is no side effect, the full general purpose Stringifier can be used
+// and the only cost of the fast stringifying attempt is the time wasted.
+
+class FastStringifier {
+public:
+    // Returns null string if the fast case fails.
+    static String stringify(JSGlobalObject&, JSValue, JSValue replacer, JSValue space);
+
+private:
+    explicit FastStringifier(JSGlobalObject&);
+    void append(JSValue);
+    String result() const;
+
+    void append(char, char, char, char);
+    void append(char, char, char, char, char);
+    template<typename T> void recordFailure(T&& reason);
+    void recordBufferFull();
+    String firstGetterSetterPropertyName() const;
+    void recordFastPropertyEnumerationFailure(JSObject&);
+    bool haveFailure() const;
+    unsigned remainingCapacity() const;
+    bool mayHaveToJSON(JSObject&) const;
+
+    static void logOutcome(ASCIILiteral);
+    static void logOutcome(String&&);
+
+    JSGlobalObject& m_globalObject;
+    VM& m_vm;
+    unsigned m_length { 0 };
+    bool m_checkedObjectPrototype { false };
+    bool m_checkedArrayPrototype { false };
+
+    // Note that this buffer needs to be kept reasonably small; it acts as a recursion limit and a cycle detector as well.
+    LChar m_buffer[6000];
+};
+
+#if !FAST_STRINGIFY_LOG_USAGE
+
+inline void FastStringifier::logOutcome(ASCIILiteral)
+{
+}
+
+#else
+
+void FastStringifier::logOutcome(ASCIILiteral outcome)
+{
+    logOutcome(String { outcome });
+}
+
+void FastStringifier::logOutcome(String&& outcome)
+{
+    static NeverDestroyed<HashCountedSet<String>> set;
+    static std::atomic<unsigned> count;
+    set->add(outcome);
+    if (!(++count % 100)) {
+        Vector<KeyValuePair<String, unsigned>> vector;
+        for (auto& pair : set.get())
+            vector.append(pair);
+        std::sort(vector.begin(), vector.end(), [](auto& a, auto &b) {
+            return a.value != b.value ? a.value > b.value : codePointCompareLessThan(a.key, b.key);
+        });
+        dataLogLn("fastStringify outcomes");
+        for (auto& pair : vector) {
+            dataLogF("%5u", pair.value);
+            dataLogLn(": ", pair.key);
+        }
+    }
+}
+
+#endif
+
+inline FastStringifier::FastStringifier(JSGlobalObject& globalObject)
+    : m_globalObject(globalObject)
+    , m_vm(globalObject.vm())
+{
+}
+
+inline bool FastStringifier::haveFailure() const
+{
+    return m_length > std::size(m_buffer);
+}
+
+inline String FastStringifier::result() const
+{
+    if (haveFailure())
+        return { };
+#if FAST_STRINGIFY_LOG_USAGE
+    static std::atomic<unsigned> maxSizeSeen;
+    if (m_length > maxSizeSeen) {
+        maxSizeSeen = m_length;
+        dataLogLn("max fastStringify buffer size used: ", m_length);
+    }
+    logOutcome("success"_s);
+#endif
+    return { m_buffer, m_length };
+}
+
+template<typename T> inline void FastStringifier::recordFailure(T&& reason)
+{
+    if (!haveFailure())
+        logOutcome(std::forward<T>(reason));
+    m_length = std::size(m_buffer) + 1;
+}
+
+inline void FastStringifier::recordBufferFull()
+{
+    recordFailure("buffer full"_s);
+}
+
+inline unsigned FastStringifier::remainingCapacity() const
+{
+    ASSERT(!haveFailure());
+    return std::size(m_buffer) - m_length;
+}
+
+#if !FAST_STRINGIFY_LOG_USAGE
+
+inline void FastStringifier::recordFastPropertyEnumerationFailure(JSObject&)
+{
+    recordFailure("!canPerformFastPropertyEnumerationForJSONStringify"_s);
+}
+
+#else
+
+String FastStringifier::firstGetterSetterPropertyName(JSObject& object) const
+{
+    auto scope = DECLARE_THROW_SCOPE(m_vm);
+    PropertyNameArray names(m_vm, PropertyNameMode::Strings, PrivateSymbolMode::Include);
+    JSObject::getOwnPropertyNames(&object, &m_globalObject, names, DontEnumPropertiesMode::Include);
+    CLEAR_AND_RETURN_IF_EXCEPTION(scope, "getOwnPropertyNames exception occurred"_s);
+    for (auto& name : names) {
+        PropertySlot slot(&object, PropertySlot::InternalMethodType::Get);
+        JSObject::getOwnPropertySlot(&object, &m_globalObject, name, slot);
+        CLEAR_AND_RETURN_IF_EXCEPTION(scope, "getOwnPropertySlot exception occurred"_s);
+        if (slot.isAccessor())
+            RELEASE_AND_RETURN(scope, name.string());
+    }
+    RELEASE_AND_RETURN(scope, "not found"_s);
+}
+
+void FastStringifier::recordFastPropertyEnumerationFailure(JSObject& object)
+{
+    auto& structure = *object.structure();
+    if (structure.typeInfo().overridesGetOwnPropertySlot())
+        recordFailure("overridesGetOwnPropertySlot"_s);
+    else if (structure.typeInfo().overridesAnyFormOfGetOwnPropertyNames())
+        recordFailure("overridesAnyFormOfGetOwnPropertyNames"_s);
+    else if (hasIndexedProperties(structure.indexingType()))
+        recordFailure("hasIndexedProperties"_s);
+    else if (structure.hasGetterSetterProperties())
+        recordFailure("getter/setter: "_s + firstGetterSetterPropertyName(object));
+    else if (structure.hasReadOnlyOrGetterSetterPropertiesExcludingProto())
+        recordFailure("hasReadOnlyOrGetterSetterPropertiesExcludingProto"_s);
+    else if (structure.hasCustomGetterSetterProperties())
+        recordFailure("hasCustomGetterSetterProperties"_s);
+    else if (structure.isUncacheableDictionary())
+        recordFailure("isUncacheableDictionary"_s);
+    else if (structure.hasUnderscoreProtoPropertyExcludingOriginalProto())
+        recordFailure("hasUnderscoreProtoPropertyExcludingOriginalProto"_s);
+    else
+        recordFailure("!canPerformFastPropertyEnumerationForJSONStringify mystery"_s);
+}
+
+#endif
+
+inline bool FastStringifier::mayHaveToJSON(JSObject& object) const
+{
+    if (auto function = object.structure()->cachedSpecialProperty(CachedSpecialPropertyKey::ToJSON))
+        return !function.isUndefined();
+    if (UNLIKELY(object.noSideEffectMayHaveNonIndexProperty(m_vm, m_vm.propertyNames->toJSON))) {
+        // Getting the property value so we can cache it could cause side effects; instead return true without caching anything.
+        return true;
+    }
+    // Cache this so we can answer false next time without redoing the noSideEffectMayHaveNonIndexProperty work.
+    PropertySlot slot { &object, PropertySlot::InternalMethodType::Get };
+    object.structure()->cacheSpecialProperty(&m_globalObject, m_vm, jsUndefined(), CachedSpecialPropertyKey::ToJSON, slot);
+    return false;
+}
+
+inline void FastStringifier::append(char a, char b, char c, char d)
+{
+    if (UNLIKELY(remainingCapacity() < 4)) {
+        recordBufferFull();
+        return;
+    }
+    m_buffer[m_length] = a;
+    m_buffer[m_length + 1] = b;
+    m_buffer[m_length + 2] = c;
+    m_buffer[m_length + 3] = d;
+    m_length += 4;
+}
+
+inline void FastStringifier::append(char a, char b, char c, char d, char e)
+{
+    if (UNLIKELY(remainingCapacity() < 5)) {
+        recordBufferFull();
+        return;
+    }
+    m_buffer[m_length] = a;
+    m_buffer[m_length + 1] = b;
+    m_buffer[m_length + 2] = c;
+    m_buffer[m_length + 3] = d;
+    m_buffer[m_length + 4] = e;
+    m_length += 5;
+}
+
+void FastStringifier::append(JSValue value)
+{
+    if (value.isNull()) {
+        append('n', 'u', 'l', 'l');
+        return;
+    }
+
+    if (value.isTrue()) {
+        append('t', 'r', 'u', 'e');
+        return;
+    }
+
+    if (value.isFalse()) {
+        append('f', 'a', 'l', 's', 'e');
+        return;
+    }
+
+    if (value.isInt32()) {
+        auto number = value.asInt32();
+        auto length = lengthOfIntegerAsString(number);
+        if (UNLIKELY(remainingCapacity() < length)) {
+            recordBufferFull();
+            return;
+        }
+        writeIntegerToBuffer(number, &m_buffer[m_length]);
+        m_length += length;
+        return;
+    }
+
+    if (value.isDouble()) {
+        auto number = value.asDouble();
+        if (!std::isfinite(number)) {
+            append('n', 'u', 'l', 'l');
+            return;
+        }
+        if (UNLIKELY(remainingCapacity() < sizeof(NumberToStringBuffer))) {
+            recordBufferFull();
+            return;
+        }
+        WTF::double_conversion::StringBuilder builder { reinterpret_cast<char*>(&m_buffer[m_length]), sizeof(NumberToStringBuffer) };
+        WTF::double_conversion::DoubleToStringConverter::EcmaScriptConverter().ToShortest(number, &builder);
+        m_length += builder.position();
+        return;
+    }
+
+    if (UNLIKELY(!value.isCell())) {
+        recordFailure("value type"_s);
+        return;
+    }
+    auto& cell = *value.asCell();
+
+    switch (cell.type()) {
+    case StringType: {
+        auto& string = asString(&cell)->tryGetValue();
+        if (UNLIKELY(string.isNull())) {
+            recordFailure("String::tryGetValue"_s);
+            return;
+        }
+        if (UNLIKELY(!string.is8Bit())) {
+            recordFailure("16-bit string"_s);
+            return;
+        }
+        auto stringLength = string.length();
+        if (UNLIKELY(remainingCapacity() < 1 + stringLength + 1)) {
+            recordBufferFull();
+            return;
+        }
+        m_buffer[m_length] = '"';
+        auto* characters = string.characters8();
+        for (unsigned i = 0; i < stringLength; ++i) {
+            auto character = characters[i];
+            if (UNLIKELY(WTF::escapedFormsForJSON[character])) {
+                recordFailure("string character needs escaping"_s);
+                return;
+            }
+            m_buffer[m_length + 1 + i] = character;
+        }
+        m_buffer[m_length + 1 + stringLength] = '"';
+        m_length += 1 + stringLength + 1;
+        return;
+    }
+
+    case ObjectType:
+    case FinalObjectType: {
+        auto& object = *asObject(&cell);
+        if (UNLIKELY(object.isCallable())) {
+            recordFailure("callable object"_s);
+            return;
+        }
+        auto& structure = *object.structure();
+        if (UNLIKELY(structure.hasPolyProto())) {
+            recordFailure("hasPolyProto"_s);
+            return;
+        }
+        if (UNLIKELY(structure.storedPrototype() != m_globalObject.objectPrototype())) {
+            recordFailure("non-standard object prototype"_s);
+            return;
+        }
+        if (!m_checkedObjectPrototype) {
+            if (UNLIKELY(mayHaveToJSON(*m_globalObject.objectPrototype()))) {
+                recordFailure("object prototype may have toJSON"_s);
+                return;
+            }
+            m_checkedObjectPrototype = true;
+        }
+        if (UNLIKELY(!remainingCapacity())) {
+            recordBufferFull();
+            return;
+        }
+        m_buffer[m_length++] = '{';
+        if (UNLIKELY(!canPerformFastPropertyEnumerationForJSONStringify(&structure))) {
+            recordFastPropertyEnumerationFailure(object);
+            return;
+        }
+        structure.forEachProperty(m_vm, [&](const PropertyTableEntry& entry) -> bool {
+            if (entry.attributes() & PropertyAttribute::DontEnum)
+                return true;
+            auto& name = *entry.key();
+            if (UNLIKELY(name.isSymbol())) {
+                recordFailure("symbol"_s);
+                return false;
+            }
+            if (UNLIKELY(!name.is8Bit())) {
+                recordFailure("16-bit property name"_s);
+                return false;
+            }
+            bool needComma = m_buffer[m_length - 1] != '{';
+            unsigned nameLength = name.length();
+            if (UNLIKELY(remainingCapacity() < needComma + 1 + nameLength + 2)) {
+                recordBufferFull();
+                return false;
+            }
+            if (needComma)
+                m_buffer[m_length++] = ',';
+            m_buffer[m_length] = '"';
+            auto* characters = name.characters8();
+            for (unsigned i = 0; i < nameLength; ++i) {
+                auto character = characters[i];
+                if (UNLIKELY(WTF::escapedFormsForJSON[character])) {
+                    recordFailure("property name character needs escaping"_s);
+                    return false;
+                }
+                m_buffer[m_length + 1 + i] = character;
+            }
+            m_buffer[m_length + 1 + nameLength] = '"';
+            m_buffer[m_length + 1 + nameLength + 1] = ':';
+            m_length += 1 + nameLength + 2;
+            if (UNLIKELY(object.structure() != &structure)) {
+                ASSERT_NOT_REACHED();
+                recordFailure("unexpected structure transition"_s);
+                return false;
+            }
+            append(object.getDirect(entry.offset()));
+            return !haveFailure();
+        });
+        if (UNLIKELY(haveFailure()))
+            return;
+        if (UNLIKELY(!remainingCapacity())) {
+            recordBufferFull();
+            return;
+        }
+        m_buffer[m_length++] = '}';
+        return;
+    }
+
+    case ArrayType: {
+        auto& array = *asArray(&cell);
+        if (!m_checkedArrayPrototype) {
+            if (UNLIKELY(mayHaveToJSON(*m_globalObject.arrayPrototype()))) {
+                recordFailure("array prototype may have toJSON"_s);
+                return;
+            }
+            m_checkedArrayPrototype = true;
+        }
+        auto& structure = *array.structure();
+        if (UNLIKELY(!m_globalObject.isOriginalArrayStructure(&structure))) {
+            structure.forEachProperty(m_vm, [&](const PropertyTableEntry& entry) -> bool {
+                if (UNLIKELY(entry.key() == m_vm.propertyNames->toJSON)) {
+                    recordFailure("array has toJSON"_s);
+                    return false;
+                }
+                return true;
+            });
+            if (haveFailure())
+                return;
+        }
+        if (UNLIKELY(!remainingCapacity())) {
+            recordBufferFull();
+            return;
+        }
+        m_buffer[m_length++] = '[';
+        for (unsigned i = 0, length = array.length(); i < length; ++i) {
+            if (i) {
+                if (UNLIKELY(!remainingCapacity())) {
+                    recordBufferFull();
+                    return;
+                }
+                m_buffer[m_length++] = ',';
+            }
+            if (UNLIKELY(!array.canGetIndexQuickly(i))) {
+                recordFailure("!canGetIndexQuickly"_s);
+                return;
+            }
+            append(array.getIndexQuickly(i));
+            if (UNLIKELY(haveFailure()))
+                return;
+        }
+        if (UNLIKELY(!remainingCapacity())) {
+            recordBufferFull();
+            return;
+        }
+        m_buffer[m_length++] = ']';
+        return;
+    }
+
+    case JSFunctionType:
+        recordFailure("function"_s);
+        return;
+
+    default:
+        recordFailure("object type"_s);
+    }
+}
+
+inline String FastStringifier::stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space)
+{
+    if (replacer.isObject()) {
+        logOutcome("replacer"_s);
+        return { };
+    }
+    if (!space.isUndefined()) {
+        logOutcome("space"_s);
+        return { };
+    }
+    FastStringifier stringifier(globalObject);
+    stringifier.append(value);
+    return stringifier.result();
+}
+
+static inline String stringify(JSGlobalObject& globalObject, JSValue value, JSValue replacer, JSValue space)
+{
+    if (String result = FastStringifier::stringify(globalObject, value, replacer, space); !result.isNull())
+        return result;
+    String result = Stringifier::stringify(globalObject, value, replacer, space);
+#if FAST_STRINGIFY_LOG_USAGE
+    if (!result.isNull())
+        dataLogLn("Not fastStringify: ", result);
+#endif
+    return result;
+}
+
 // ------------------------------ JSONObject --------------------------------
 
 const ClassInfo JSONObject::s_info = { "JSON"_s, &JSNonFinalObject::s_info, &jsonTable, nullptr, CREATE_METHOD_TABLE(JSONObject) };
@@ -875,12 +1347,8 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncParse, (JSGlobalObject* globalObject, Call
 // ECMA-262 v5 15.12.3
 JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncStringify, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    Stringifier stringifier(globalObject, callFrame->argument(1), callFrame->argument(2));
-    RETURN_IF_EXCEPTION(scope, { });
-    RELEASE_AND_RETURN(scope, JSValue::encode(stringifier.stringify(callFrame->argument(0))));
+    String result = stringify(*globalObject, callFrame->argument(0), callFrame->argument(1), callFrame->argument(2));
+    return result.isNull() ? encodedJSUndefined() : JSValue::encode(jsString(globalObject->vm(), WTFMove(result)));
 }
 
 JSValue JSONParse(JSGlobalObject* globalObject, const String& json)
@@ -899,19 +1367,12 @@ JSValue JSONParse(JSGlobalObject* globalObject, const String& json)
 
 String JSONStringify(JSGlobalObject* globalObject, JSValue value, JSValue space)
 {
-    VM& vm = globalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    Stringifier stringifier(globalObject, jsNull(), space);
-    RETURN_IF_EXCEPTION(throwScope, { });
-    JSValue result = stringifier.stringify(value);
-    if (UNLIKELY(throwScope.exception()) || result.isUndefinedOrNull())
-        return String();
-    return result.getString(globalObject);
+    return stringify(*globalObject, value, jsNull(), space);
 }
 
 String JSONStringify(JSGlobalObject* globalObject, JSValue value, unsigned indent)
 {
-    return JSONStringify(globalObject, value, jsNumber(indent));
+    return stringify(*globalObject, value, jsNull(), jsNumber(indent));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -165,6 +165,7 @@ public:
     template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
 
     JSValue getIfPropertyExists(JSGlobalObject*, PropertyName);
+    bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
 
 private:
     static bool getOwnPropertySlotImpl(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
+		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93934BD318A1E8C300D0D6A1 /* StringViewCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93934BD218A1E8C300D0D6A1 /* StringViewCocoa.mm */; };
 		93934BD518A1F16900D0D6A1 /* StringViewCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93934BD418A1F16900D0D6A1 /* StringViewCF.cpp */; };
 		93B07ED826B8717000A09B34 /* SuspendableWorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93B07ED726B8715B00A09B34 /* SuspendableWorkQueue.cpp */; };
@@ -1200,6 +1201,7 @@
 		93156C8D262C982200EAE27B /* SortedArrayMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SortedArrayMap.h; sourceTree = "<group>"; };
 		93241657243BC2E50032FAAE /* VectorCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VectorCocoa.h; sourceTree = "<group>"; };
 		933D63191FCB6AB90032ECD6 /* StringHasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringHasher.h; sourceTree = "<group>"; };
+		93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EscapedFormsForJSON.h; sourceTree = "<group>"; };
 		93934BD218A1E8C300D0D6A1 /* StringViewCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringViewCocoa.mm; sourceTree = "<group>"; };
 		93934BD418A1F16900D0D6A1 /* StringViewCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringViewCF.cpp; sourceTree = "<group>"; };
 		93AC91A718942FC400244939 /* LChar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LChar.h; sourceTree = "<group>"; };
@@ -2395,6 +2397,7 @@
 				0F8F2B9B172F2594007DBDA5 /* ConversionMode.h */,
 				A8A47321151A825B004123FF /* CString.cpp */,
 				A8A47322151A825B004123FF /* CString.h */,
+				93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */,
 				50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */,
 				50DE35F4215BB01500B979C7 /* ExternalStringImpl.h */,
 				26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */,
@@ -2889,6 +2892,7 @@
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
 				DD3DC92627A4BF8E007E5B61 /* CPUTime.h in Headers */,
 				DDF3071127C086CC006A526F /* CrashReporter.h in Headers */,
+				93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */,
 				DDF306DC27C08654006A526F /* CrashReporterClientSPI.h in Headers */,
 				DD3DC96D27A4BF8E007E5B61 /* CrossThreadCopier.h in Headers */,
 				DD3DC8F127A4BF8E007E5B61 /* CrossThreadQueue.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -361,6 +361,7 @@ set(WTF_PUBLIC_HEADERS
     text/CString.h
     text/CodePointIterator.h
     text/ConversionMode.h
+    text/EscapedFormsForJSON.h
     text/ExternalStringImpl.h
     text/IntegerToStringConversion.h
     text/LChar.h

--- a/Source/WTF/wtf/dtoa/double-conversion.h
+++ b/Source/WTF/wtf/dtoa/double-conversion.h
@@ -356,9 +356,9 @@ class DoubleToStringConverter {
 
  private:
   // Implementation for ToShortest and ToShortestSingle.
-  bool ToShortestIeeeNumber(double value,
-                            StringBuilder* result_builder,
-                            DtoaMode mode) const;
+  WTF_EXPORT_PRIVATE bool ToShortestIeeeNumber(double value,
+                                               StringBuilder* result_builder,
+                                               DtoaMode mode) const;
 
   // If the value is a special value (NaN or Infinity) constructs the
   // corresponding string using the configured infinity/nan-symbol.

--- a/Source/WTF/wtf/text/EscapedFormsForJSON.h
+++ b/Source/WTF/wtf/text/EscapedFormsForJSON.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
+ * Copyright (C) 2017 Mozilla Foundation. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace WTF {
+
+// This table for escaping was originally taken from SpiderMonkey.
+constexpr char escapedFormsForJSON[0x100] = {
+    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
+    'b', 't', 'n', 'u', 'f', 'r', 'u', 'u',
+    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
+    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
+    0,   0,   '"', 0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,  '\\', 0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,
+};
+
+}

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -12,46 +12,11 @@
 #include "config.h"
 #include <wtf/text/StringBuilder.h>
 
+#include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/StringBuilderInternals.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
-
-// This table driven escaping is ported from SpiderMonkey.
-static const constexpr LChar escapedFormsForJSON[0x100] = {
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    'b', 't', 'n', 'u', 'f', 'r', 'u', 'u',
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    'u', 'u', 'u', 'u', 'u', 'u', 'u', 'u',
-    0,   0,  '\"', 0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,  '\\', 0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-    0,   0,   0,   0,   0,   0,   0,   0,
-};
 
 template<typename OutputCharacterType, typename InputCharacterType>
 ALWAYS_INLINE static void appendQuotedJSONStringInternal(OutputCharacterType*& output, const InputCharacterType* input, unsigned length)


### PR DESCRIPTION
#### e608d7dc9893576537a6f09a31e89dbecfec28e9
<pre>
Speed up JSON.stringify by adding a separate fast case algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=242286">https://bugs.webkit.org/show_bug.cgi?id=242286</a>

Reviewed by Mark Lam and Yusuke Suzuki.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
Removed ChangeLog since that file doesn&apos;t exist any more.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::stringify): Change this to be a static member function and the
main entry point for the full stringifier. Return a String instead of a JSValue.
(JSC::FastStringifier::logOutcome): Added. When FAST_STRINGIFY_LOG_USAGE is on,
collect outcomes so we can write out the histogram of reasons we were unable to
use the fast stringify.
(JSC::FastStringifier::FastStringifier): Added.
(JSC::FastStringifier::haveFailure const): Added.
(JSC::FastStringifier::result const): Added.
(JSC::FastStringifier::recordFailure): Added.
(JSC::FastStringifier::recordBufferFull): Added.
(JSC::FastStringifier::remainingCapacity const): Added.
(JSC::FastStringifier::firstGetterSetterPropertyName): Added.
(JSC::FastStringifier::recordFastPropertyEnumerationFailure): Added.
(JSC::FastStringifier::mayHaveToJSON const): Check if there may be a toJSON
function. If the prototype does not have one, we can use the fast stringifier.
(JSC::FastStringifier::append): Added.
(JSC::FastStringifier::stringify): Added.
(JSC::stringify): Try FastStringifier first, then use the full Stringifier only
if that fails.
(JSC::jsonProtoFuncStringify): Call stringify.
(JSC::JSONStringify): Call stringify.

* Source/JavaScriptCore/runtime/JSObject.h: Added
noSideEffectMayHaveNonIndexProperty.

* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::noSideEffectMayHaveNonIndexProperty): Added.

* Source/WTF/WTF.xcodeproj/project.pbxproj: Added EscapedFormsForJSON.h.
* Source/WTF/wtf/CMakeLists.txt: Ditto.

* Source/WTF/wtf/dtoa/double-conversion.h: Add WTF_EXPORT_PRIVATE so we can
use DoubleToStringConverter::ToShortest from JavaScriptCore.

* Source/WTF/wtf/text/EscapedFormsForJSON.h: Added.
* Source/WTF/wtf/text/StringBuilderJSON.cpp: Moved the escapedFormsForJSON
array into the header so it can bs used by JSONObject.cpp too.

Canonical link: <a href="https://commits.webkit.org/252326@main">https://commits.webkit.org/252326@main</a>
</pre>
