### PR TITLE
Ensure promise is not garbage collected

### DIFF
--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1124,7 +1124,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
     WeakPtr weakThis { *this };
     auto callback = [index, weakThis, format, importAlgorithm, unwrappedKeyAlgorithm = crossThreadCopyImportParams(*unwrappedKeyAlgorithm), extractable, keyUsagesBitmap](const Vector<uint8_t>& bytes) mutable {
         if (weakThis) {
-            if (auto promise = weakThis->m_pendingPromises.get(index)) {
+            if (RefPtr promise = weakThis->m_pendingPromises.get(index)) {
                 KeyData keyData;
                 switch (format) {
                 case SubtleCrypto::KeyFormat::Spki:


### PR DESCRIPTION
#### c29e5a28c1760dd0bef2da987ab11eb7e8ba50ee
<pre>
Ensure promise is not garbage collected
<a href="https://bugs.webkit.org/show_bug.cgi?id=242287">https://bugs.webkit.org/show_bug.cgi?id=242287</a>

Reviewed by Tim Nguyen.

We need to ensure that the promise always remains alive when in use.
Adding a RefPtr guarantees that it will not be garbage collected.

* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::unwrapKey):

Canonical link: <a href="https://commits.webkit.org/252091@main">https://commits.webkit.org/252091@main</a>
</pre>
