### PR TITLE
REGRESSION (iOS 16): Characters outside a font-face's unicode-range attribute don't render when characters in that range are present

### DIFF
--- a/LayoutTests/fast/text/font-face-fall-off-end-expected.html
+++ b/LayoutTests/fast/text/font-face-fall-off-end-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+This test makes sure that fonts which support a letter but have that character omitted from its unicode-range don't cause a crash. The test passes if there is no crash.
+</body>
+</html>

--- a/LayoutTests/fast/text/font-face-fall-off-end.html
+++ b/LayoutTests/fast/text/font-face-fall-off-end.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Gulf-regular.ttf");
+    unicode-range: U+0041;
+}
+</style>
+</head>
+<body>
+This test makes sure that fonts which support a letter but have that character omitted from its unicode-range don't cause a crash. The test passes if there is no crash.
+<div style="position: relative;">
+<div style="font-family: 'Helvetica';">AeAe</div>
+<div style="font-family: 'WebFont', 'Helvetica';">AeAe</div>
+<div style="font-family: 'WebFont';">AeAe</div>
+<div style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; background: white;"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -594,6 +594,7 @@ static SystemFallbackCache& systemFallbackCache()
 
 RefPtr<Font> Font::systemFallbackFontForCharacter(UChar32 character, const FontDescription& description, IsForPlatformFont isForPlatformFont) const
 {
+    // FIXME: https://github.com/w3c/csswg-drafts/issues/7449 This function should never return a web font.
     auto fontAddResult = systemFallbackCache().add(this, CharacterFallbackMap());
 
     if (!character) {

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -224,9 +224,9 @@ public:
 #endif
     };
 
-    const std::optional<CreationData>& creationData() const
+    const CreationData* creationData() const
     {
-        return m_creationData;
+        return m_creationData ? &m_creationData.value() : nullptr;
     }
 
 private:

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -1565,7 +1565,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
 
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont, description, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
 
-    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode());
+    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), platformData.creationData());
 
     return fontForPlatformData(alternateFont);
 }

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -558,7 +558,7 @@ RefPtr<Font> Font::createFontWithoutSynthesizableFeatures() const
     float size = m_platformData.size();
     CTFontSymbolicTraits fontTraits = CTFontGetSymbolicTraits(m_platformData.font());
     RetainPtr<CTFontRef> ctFont = createCTFontWithoutSynthesizableFeatures(m_platformData.font());
-    return createDerivativeFont(ctFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData() ? &m_platformData.creationData().value() : nullptr);
+    return createDerivativeFont(ctFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData());
 }
 
 RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleFactor) const
@@ -568,7 +568,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     RetainPtr<CTFontDescriptorRef> fontDescriptor = adoptCF(CTFontCopyFontDescriptor(m_platformData.font()));
     RetainPtr<CTFontRef> scaledFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
 
-    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData() ? &m_platformData.creationData().value() : nullptr);
+    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData());
 }
 
 float Font::platformWidthForGlyph(Glyph glyph) const


### PR DESCRIPTION
#### 7b14522b6997c35323528528352225edfbf1d935
<pre>
REGRESSION (iOS 16): Characters outside a font-face&apos;s unicode-range attribute don&apos;t render when characters in that range are present
<a href="https://bugs.webkit.org/show_bug.cgi?id=241831">https://bugs.webkit.org/show_bug.cgi?id=241831</a>
&lt;rdar://95646820&gt;

Reviewed by Alan Bujtas.

When we fall off the end of the font fallback list, we create a &quot;system fallback&quot; font. It&apos;s possible for
this font to be a web font (see <a href="https://github.com/w3c/csswg-drafts/issues/7449">https://github.com/w3c/csswg-drafts/issues/7449</a> for discussion about this).
If it is a web font, we need to preserve the CreationData of the font so it can be transferred across IPC.

Test: fast/text/font-face-fall-off-end.html

* LayoutTests/fast/text/font-face-fall-off-end-expected.html:
* LayoutTests/fast/text/font-face-fall-off-end.html:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::systemFallbackForCharacters):

Canonical link: <a href="https://commits.webkit.org/252096@main">https://commits.webkit.org/252096@main</a>
</pre>
