### PR TITLE
[GStreamer][VideoCapture] do not call reconfigure() in settingsDidChange unless size or framerate sucessfully changes

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -153,17 +153,21 @@ GStreamerVideoCaptureSource::~GStreamerVideoCaptureSource()
 
 void GStreamerVideoCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)
 {
+    bool reconfigure = false;
     if (settings.containsAny({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height })) {
         if (m_deviceType == CaptureDevice::DeviceType::Window || m_deviceType == CaptureDevice::DeviceType::Screen)
             ensureIntrinsicSizeMaintainsAspectRatio();
 
-        m_capturer->setSize(size().width(), size().height());
+        if (m_capturer->setSize(size().width(), size().height()))
+            reconfigure = true;
     }
 
     if (settings.contains(RealtimeMediaSourceSettings::Flag::FrameRate))
-        m_capturer->setFrameRate(frameRate());
+        if (m_capturer->setFrameRate(frameRate()))
+            reconfigure = true;
 
-    m_capturer->reconfigure();
+    if (reconfigure)
+        m_capturer->reconfigure();
 }
 
 void GStreamerVideoCaptureSource::sourceCapsChanged(const GstCaps* caps)


### PR DESCRIPTION
#### c8d60e9c25fabe4663f8a961a3e8e98f6f329900
<pre>
[GStreamer][VideoCapture] do not call reconfigure() in settingsDidChange unless size or framerate sucessfully changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=242291">https://bugs.webkit.org/show_bug.cgi?id=242291</a>

Reviewed by Philippe Normand.

This appears to eliminate a redundant reconfigure call during stream shutdown.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::settingsDidChange):

Canonical link: <a href="https://commits.webkit.org/252102@main">https://commits.webkit.org/252102@main</a>
</pre>
