### PR TITLE
[iOS] "A problem repeatedly occurred" error page when safari resuming from background

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -881,9 +881,10 @@ void WebPageProxy::launchProcess(const RegistrableDomain& registrableDomain, Pro
     auto& processPool = m_process->processPool();
 
     auto* relatedPage = m_configuration->relatedPage();
-    if (relatedPage && !relatedPage->isClosed())
+    if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess) {
         m_process = relatedPage->ensureRunningProcess();
-    else
+        WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess: Using process (process=%p, PID=%i) from related page", m_process.ptr(), m_process->processIdentifier());
+    } else
         m_process = processPool.processForRegistrableDomain(m_websiteDataStore.get(), registrableDomain, shouldEnableCaptivePortalMode() ? WebProcessProxy::CaptivePortalMode::Enabled : WebProcessProxy::CaptivePortalMode::Disabled);
 
     m_hasRunningProcess = true;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1000,6 +1000,7 @@ Ref<WebProcessProxy> WebProcessPool::processForRegistrableDomain(WebsiteDataStor
 {
     if (!registrableDomain.isEmpty()) {
         if (auto process = webProcessCache().takeProcess(registrableDomain, websiteDataStore, captivePortalMode)) {
+            WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForRegistrableDomain: Using WebProcess from WebProcess cache (process=%p, PID=%i)", process.get(), process->processIdentifier());
             ASSERT(m_processes.containsIf([&](auto& item) { return item.ptr() == process; }));
             return process.releaseNonNull();
         }


### PR DESCRIPTION
#### e6e28097b53cb99caa8fbf8440f215643e0c0dba
<pre>
[iOS] &quot;A problem repeatedly occurred&quot; error page when safari resuming from background
<a href="https://bugs.webkit.org/show_bug.cgi?id=242292">https://bugs.webkit.org/show_bug.cgi?id=242292</a>
&lt;rdar://96178034&gt;

Reviewed by Darin Adler.

When Safari is suspended in the background, its WebProcesses are idle and thus more
likely to get jetsammed. If they get jetsammed while Safari was suspended, Safari
will only receive the crash notification(s) once it is resumed.

The issue was that when resuming Safari after several WebProcesses have been jetsammed,
we would get a crash notification for a view&apos;s process and let Safari know. This would
cause Safari to call reload on the view to recover from the crash. However, instead of
launching a fresh new process, WebPageProxy::launchProcess() would sometimes try and
be smart and reuse an eligible existing WebProcess, which is usually fine. However,
we can get unlucky and choose a WebProcess that was also jetsammed while suspended,
for which we haven&apos;t received the crash notification yet (but are about to).
When the crash notification for this second process comes in shortly after, we tell
Safari that the view&apos;s process crashes again. This trips some logic in Safari that
causes it to show the &quot;A problem repeatedly occurred&quot; error page since it was told
that the view&apos;s process crashed twice in a row (i.e. failed to recover).

To address the issue, I made the following change:
- WebPageProxy::launchProcess() now only reuses the related WKWebView&apos;s process
  when it is its initial process, not in case of a crash. This was the case in
  the radar.

This fix is covered by a new API test that reproduces the scenario in the radar.

Ideally, we&apos;d prevent WebPageProxy::launchProcess() from reusing processes from
the process cache or suspended pages if they were terminated too. I will look
into this in a follow-up.

* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForRegistrableDomain):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/252108@main">https://commits.webkit.org/252108@main</a>
</pre>
