### PR TITLE
Change adoptNode() for a DocumentFragment with host

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS appendChild() and DocumentFragment with host
-FAIL adoptNode() and DocumentFragment with host assert_equals: expected Document node with 0 children but got Document node with 2 children
+PASS adoptNode() and DocumentFragment with host
 PASS appendChild() and DocumentFragment
 PASS adoptNode() and DocumentFragment
 PASS appendChild() and ShadowRoot

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Template content should throw when its ancestor is being appended.
-FAIL Template content should throw exception when its ancestor in a different document but connected via host is being append. assert_equals: expected Document node with 0 children but got Document node with 2 children
+PASS Template content should throw exception when its ancestor in a different document but connected via host is being append.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Template element content is correctly serialized
-FAIL HTML fragment serialization algorithm should be applied to the template content assert_equals: expected "<div xml:lang=\"en-us\" p:attr=\"v\"></div>" but got "<div xmlns=\"xx\" xml:lang=\"en-us\" p:attr=\"v\" xmlns:p=\"uri2\"/>"
+PASS HTML fragment serialization algorithm should be applied to the template content
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -362,6 +362,9 @@ static inline bool isChildTypeAllowed(ContainerNode& newParent, Node& child)
 
 static bool containsIncludingHostElements(const Node& possibleAncestor, const Node& node)
 {
+    if (LIKELY(!node.isInShadowTree() && !node.document().templateDocumentHost()))
+        return possibleAncestor.contains(node);
+
     const Node* currentNode = &node;
     do {
         if (currentNode == &possibleAncestor)
@@ -370,8 +373,8 @@ static bool containsIncludingHostElements(const Node& possibleAncestor, const No
         if (!parent) {
             if (auto shadowRoot = dynamicDowncast<ShadowRoot>(currentNode))
                 parent = shadowRoot->host();
-            else if (is<DocumentFragment>(*currentNode) && downcast<DocumentFragment>(*currentNode).isTemplateContent())
-                parent = static_cast<const TemplateContentDocumentFragment*>(currentNode)->host();
+            else if (auto fragment = dynamicDowncast<TemplateContentDocumentFragment>(*currentNode))
+                parent = fragment->host();
         }
         currentNode = parent;
     } while (currentNode);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -244,6 +244,7 @@
 #include "StyleSheetList.h"
 #include "StyleTreeResolver.h"
 #include "SubresourceLoader.h"
+#include "TemplateContentDocumentFragment.h"
 #include "TextAutoSizing.h"
 #include "TextEvent.h"
 #include "TextManipulationController.h"
@@ -1159,6 +1160,11 @@ ExceptionOr<Ref<Node>> Document::adoptNode(Node& source)
         if (source.isShadowRoot()) {
             // ShadowRoot cannot disconnect itself from the host node.
             return Exception { HierarchyRequestError };
+        }
+        if (is<TemplateContentDocumentFragment>(source)) {
+            // TemplateContentDocumentFragment::host is never null until its destruction.
+            ASSERT(downcast<TemplateContentDocumentFragment>(source).host());
+            return Ref<Node> { source };
         }
         if (is<HTMLFrameOwnerElement>(source)) {
             auto& frameOwnerElement = downcast<HTMLFrameOwnerElement>(source);

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -55,3 +55,12 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TemplateContentDocumentFragment)
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* fragment = dynamicDowncast<WebCore::DocumentFragment>(node);
+        return fragment && is<WebCore::TemplateContentDocumentFragment>(*fragment);
+    }
+    static bool isType(const WebCore::DocumentFragment& node) { return node.isTemplateContent(); }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### ab3c0b8cf2a411231da9526614ad5167971dcdd5
<pre>
Change adoptNode() for a DocumentFragment with host
<a href="https://bugs.webkit.org/show_bug.cgi?id=204980">https://bugs.webkit.org/show_bug.cgi?id=204980</a>

Reviewed by Darin Adler.

Disallow adoptNode on a TemplateContentDocumentFragment to align with the spec.

Also re-introduce a fast path in containsIncludingHostElements that was removed
in <a href="https://commits.webkit.org/r272703">https://commits.webkit.org/r272703</a> to handle this particular case.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::containsIncludingHostElements):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::adoptNode): Return early when a node is TemplateContentDocumentFragment (i.e.
it&apos;s not a shadow root but has a host).
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
(isType): Added.

Canonical link: <a href="https://commits.webkit.org/252098@main">https://commits.webkit.org/252098@main</a>
</pre>
