### PR TITLE
:lang pseudo class should work across shadow boundaries

### DIFF
--- a/LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries-expected.html
+++ b/LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>Test passes if you see a single 100px by 100px green box below.</p>
+        <div style="width: 100px; height: 100px; background: green;"></div>
+    </body>
+</html>

--- a/LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries.html
+++ b/LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if you see a single 100px by 100px green box below.</p>
+<style>
+#testCases div { width: 100px; height: 25px; }
+#host1:lang(zh) { background: green; }
+#host3 > :lang(ja) { background: green; }
+#host4 > div { background: red; }
+</style>
+<div id="testCases">
+<div id="host1" lang="zh"><div></div></div>
+<div id="host2" lang="de"><div></div></div>
+<div id="host3" lang="ja"><div></div></div>
+<div id="host4"><div></div></div>
+</div>
+<script>
+host1.attachShadow({mode: 'closed'}).innerHTML = '<slot></slot>';
+host2.attachShadow({mode: 'closed'}).innerHTML = '<style> div { width: 100px; height: 25px; background: red; } div:lang(de) { background: green; } </style><div></div>';
+host3.attachShadow({mode: 'closed'}).innerHTML = '<slot lang="en"></slot>';
+host4.attachShadow({mode: 'closed'}).innerHTML = '<style> :lang(ja)::slotted(*) { background: green !important; } </style><slot lang="ja"></slot>';
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3829,8 +3829,8 @@ unsigned Element::rareDataChildIndex() const
 AtomString Element::computeInheritedLanguage() const
 {
     // The language property is inherited, so we iterate over the parents to find the first language.
-    for (auto& element : lineageOfType<Element>(*this)) {
-        if (auto* elementData = element.elementData()) {
+    for (auto* element = this; element; element = element->parentOrShadowHostElement()) {
+        if (auto* elementData = element->elementData()) {
             if (auto* attribute = elementData->findLanguageAttribute())
                 return attribute->value();
         }


### PR DESCRIPTION
#### d8c2040cc29812679728f3dd3f5d5011b9e4626c
<pre>
:lang pseudo class should work across shadow boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=235020">https://bugs.webkit.org/show_bug.cgi?id=235020</a>

Reviewed by Antti Koivisto.

Fixed the bug that :lang pseudo class doesn&apos;t work across shadow boundaries.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::computeInheritedLanguage const): Walk up the shadow-including ancestors.
Note that we don&apos;t use parentElementInComposedTree as we don&apos;t want to traverse up to a slot.

* LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries-expected.html: Added.
* LayoutTests/fast/shadow-dom/lang-pseudo-class-across-shadow-boundaries.html: Added.

Canonical link: <a href="https://commits.webkit.org/252099@main">https://commits.webkit.org/252099@main</a>
</pre>
