### PR TITLE
Fix combined DEPTH_STENCIL_ATTACHMENT binding in WebGL 2.0

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3802,6 +3802,7 @@ webgl/2.0.y [ Skip ]
 # Explicitly enable tests which we have fixed and do not have corresponding 2.0.0 test functionality.
 webgl/2.0.y/conformance/canvas/to-data-url-test.html [ Pass ]
 webgl/2.0.y/conformance/misc/invalid-passed-params.html [ Pass ]
+webgl/2.0.y/conformance/misc/expando-loss.html [ Pass ]
 webgl/2.0.y/conformance/glsl/bugs/character-set.html [ Pass ]
 webgl/2.0.y/conformance/glsl/misc/fragcolor-fragdata-invariant.html [ Pass ]
 webgl/2.0.y/conformance/extensions/webgl-multi-draw.html [ Pass Slow ]


### PR DESCRIPTION
#### 70f7b05838c50bc578c505ddbab309df084939d3
<pre>
Fix combined DEPTH_STENCIL_ATTACHMENT binding in WebGL 2.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=223337">https://bugs.webkit.org/show_bug.cgi?id=223337</a>

Reviewed by Darin Adler.

In WebGL 2.0 contexts, DEPTH_STENCIL_ATTACHMENT is considered
an alias for DEPTH_ATTACHMENT + STENCIL_ATTACHMENT.

Fixes forthcoming strengthened conformance test in
<a href="https://github.com/KhronosGroup/WebGL/pull/3455">https://github.com/KhronosGroup/WebGL/pull/3455</a>

* LayoutTests/TestExpectations:
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::setAttachmentInternal):
(WebCore::WebGLFramebuffer::removeAttachmentInternal):

Canonical link: <a href="https://commits.webkit.org/252695@main">https://commits.webkit.org/252695@main</a>
</pre>
