### PR TITLE
[GLIB] Fix memory leak in KeyedEncoderGlib finishEncoding()

### DIFF
--- a/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
@@ -136,7 +136,7 @@ RefPtr<SharedBuffer> KeyedEncoderGlib::finishEncoding()
 {
     g_assert(m_variantBuilderStack.last() == &m_variantBuilder);
     GRefPtr<GVariant> variant = g_variant_builder_end(&m_variantBuilder);
-    GRefPtr<GBytes> data = g_variant_get_data_as_bytes(variant.get());
+    GRefPtr<GBytes> data = adoptGRef(g_variant_get_data_as_bytes(variant.get()));
     return SharedBuffer::create(static_cast<const unsigned char*>(g_bytes_get_data(data.get(), nullptr)), static_cast<unsigned>(g_bytes_get_size(data.get())));
 }
 


### PR DESCRIPTION
#### 025cae4a4ff50e5f8b8a14cb1b4bbd8832e3a428
<pre>
[GLIB] Fix memory leak in KeyedEncoderGlib finishEncoding()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242295">https://bugs.webkit.org/show_bug.cgi?id=242295</a>

Reviewed by Michael Catanzaro.

We need to use adoptGRef when calling g_variant_get_data_as_bytes as
the return is already ref&apos;d.

See:
<a href="https://github.com/GNOME/glib/blob/2.72.3/glib/gvariant-core.c#L975">https://github.com/GNOME/glib/blob/2.72.3/glib/gvariant-core.c#L975</a>

Fixes:
==3126== 330 (120 direct, 210 indirect) bytes in 3 blocks are definitely lost in loss record 3,105 of 3,199
==3126==    at 0x48447ED: malloc (vg_replace_malloc.c:381)
==3126==    by 0xA87B2E8: g_malloc (gmem.c:106)
==3126==    by 0xA892E44: g_slice_alloc (gslice.c:1072)
==3126==    by 0xA84B005: g_bytes_new_with_free_func (gbytes.c:186)
==3126==    by 0xA84B067: g_bytes_new_take (gbytes.c:128)
==3126==    by 0xA8B934D: g_variant_ensure_serialised (gvariant-core.c:460)
==3126==    by 0xA8B958E: g_variant_get_data_as_bytes (gvariant-core.c:961)
==3126==    by 0x8765214: WebCore::KeyedEncoderGlib::finishEncoding() (KeyedEncoderGlib.cpp:139)
==3126==    by 0x53CF40E: WebKit::writeToDisk(std::unique_ptr&lt;WebCore::KeyedEncoder, std::default_delete&lt;WebCore::KeyedEncoder&gt; &gt;&amp;&amp;, WTF::String&amp;&amp;) (PersistencyUtils.cpp:53)
==3126==    by 0x545EF8C: operator() (DeviceIdHashSaltStorage.cpp:201)
==3126==    by 0x545EF8C: WTF::Detail::CallableWrapper&lt;WebKit::DeviceIdHashSaltStorage::storeHashSaltToDisk(WebKit::DeviceIdHashSaltStorage::HashSaltForOrigin const&amp;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==3126==    by 0x6E52DE9: operator() (Function.h:82)
==3126==    by 0x6E52DE9: operator() (WorkQueueGeneric.cpp:70)
==3126==    by 0x6E52DE9: WTF::Detail::CallableWrapper&lt;WTF::WorkQueueBase::dispatch(WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==3126==    by 0x6DF490F: operator() (Function.h:82)
==3126==    by 0x6DF490F: WTF::RunLoop::performWork() (RunLoop.cpp:133)
==3126==    by 0x6E55171: WTF::RunLoop::RunLoop()::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:80)
==3126==    by 0x6E55D61: operator() (RunLoopGLib.cpp:53)
==3126==    by 0x6E55D61: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==3126==    by 0xA8723AB: g_main_dispatch (gmain.c:3381)
==3126==    by 0xA875839: g_main_context_dispatch (gmain.c:4099)
==3126==    by 0xA8759A7: g_main_context_iterate (gmain.c:4175)
==3126==    by 0xA875D41: g_main_loop_run (gmain.c:4373)
==3126==    by 0x6E5613C: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==3126==    by 0x6E52E14: operator() (WorkQueueGeneric.cpp:51)
==3126==    by 0x6E52E14: WTF::Detail::CallableWrapper&lt;WTF::WorkQueueBase::platformInitialize(char const*, WTF::WorkQueueBase::Type, WTF::Thread::QOS)::{lambda()#1}, void&gt;::call() (Function.h:53)
==3126==    by 0x6DF6FD7: operator() (Function.h:82)
==3126==    by 0x6DF6FD7: WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) (Threading.cpp:236)
==3126==    by 0x6E59A3F: WTF::wtfThreadEntryPoint(void*) (ThreadingPOSIX.cpp:242)
==3126==    by 0xA9D6DC2: start_thread (pthread_create.c:442)
==3126==    by 0xAA4FA0F: clone (clone.S:100)
==3126==

* Source/WebCore/platform/glib/KeyedEncoderGlib.cpp:
(WebCore::KeyedEncoderGlib::finishEncoding):

Canonical link: <a href="https://commits.webkit.org/252100@main">https://commits.webkit.org/252100@main</a>
</pre>
