### PR TITLE
WebGL: Fix texStorage2D target validation

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -399,6 +399,26 @@ RefPtr<WebGLTexture> WebGL2RenderingContext::validateTexImageBinding(const char*
     return validateTexture2DBinding(functionName, target);
 }
 
+RefPtr<WebGLTexture> WebGL2RenderingContext::validateTextureStorage2DBinding(const char* functionName, GCGLenum target)
+{
+    RefPtr<WebGLTexture> texture;
+    switch (target) {
+    case GraphicsContextGL::TEXTURE_2D:
+        texture = m_textureUnits[m_activeTextureUnit].texture2DBinding;
+        break;
+    case GraphicsContextGL::TEXTURE_CUBE_MAP:
+        texture = m_textureUnits[m_activeTextureUnit].textureCubeMapBinding;
+        break;
+    default:
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid texture target");
+        return nullptr;
+    }
+
+    if (!texture)
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no texture");
+    return texture;
+}
+
 RefPtr<WebGLTexture> WebGL2RenderingContext::validateTexture3DBinding(const char* functionName, GCGLenum target)
 {
     RefPtr<WebGLTexture> texture;
@@ -876,7 +896,7 @@ void WebGL2RenderingContext::texStorage2D(GCGLenum target, GCGLsizei levels, GCG
     if (isContextLostOrPending())
         return;
 
-    auto texture = validateTextureBinding("texStorage2D", target);
+    auto texture = validateTextureStorage2DBinding("texStorage2D", target);
     if (!texture)
         return;
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -319,6 +319,11 @@ private:
     // null. Otherwise, return the texture bound to the target.
     RefPtr<WebGLTexture> validateTexture3DBinding(const char* functionName, GCGLenum target);
 
+    // Helper function to check immutable texture 2D target and texture bound to the target.
+    // Generate GL errors and return 0 if target is invalid or texture bound is
+    // null. Otherwise, return the texture bound to the target.
+    RefPtr<WebGLTexture> validateTextureStorage2DBinding(const char* functionName, GCGLenum target);
+
     bool validateTexFuncLayer(const char*, GCGLenum texTarget, GCGLint layer);
     GCGLint maxTextureLevelForTarget(GCGLenum target) final;
 


### PR DESCRIPTION
#### 78f7319cdcb5670eb247d033fe00d5c1edba29de
<pre>
WebGL: Fix texStorage2D target validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=237427">https://bugs.webkit.org/show_bug.cgi?id=237427</a>

Reviewed by Kenneth Russell.

Added a new validation helper because the list of allowed target
enums for texStorage2D does not match other texture entry points.

The validation should be removed, as same is done in ANGLE,
but for consistency it should be removed from all functions.

Until removal, use correct WebKit-side validation.

See deqp/functional/gles3/negativetextureapi.html

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateTextureStorage2DBinding):
(WebCore::WebGL2RenderingContext::texStorage2D):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:

Canonical link: <a href="https://commits.webkit.org/252896@main">https://commits.webkit.org/252896@main</a>
</pre>
