### PR TITLE
[GStreamer][VideoCapture] Fix video/x-raw mime-type format check

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -323,7 +323,7 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->mimeType = gst_structure_get_name(structure);
                 selector->format = nullptr;
                 if (gst_structure_has_name(structure, "video/x-raw")) {
-                    if (gst_structure_has_name(structure, "format"))
+                    if (gst_structure_has_field(structure, "format"))
                         selector->format = gst_structure_get_string(structure, "format");
                     else
                         return TRUE;
@@ -338,7 +338,7 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->mimeType = gst_structure_get_name(structure);
                 selector->format = nullptr;
                 if (gst_structure_has_name(structure, "video/x-raw")) {
-                    if (gst_structure_has_name(structure, "format"))
+                    if (gst_structure_has_field(structure, "format"))
                         selector->format = gst_structure_get_string(structure, "format");
                     else
                         return TRUE;


### PR DESCRIPTION
#### f05c325263ced383379a8bcc4c0824d3e37b7b45
<pre>
[GStreamer][VideoCapture] Fix video/x-raw mime-type format check
<a href="https://bugs.webkit.org/show_bug.cgi?id=242296">https://bugs.webkit.org/show_bug.cgi?id=242296</a>

Reviewed by Philippe Normand.

Should use gst_structure_has_field not gst_structure_has_name for this
check.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):

Canonical link: <a href="https://commits.webkit.org/252104@main">https://commits.webkit.org/252104@main</a>
</pre>
