### PR TITLE
iOS: click event doesn't get dispatched when there is a click event listener on ShadowRoot

### DIFF
--- a/LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root-expected.txt
+++ b/LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root-expected.txt
@@ -1,0 +1,12 @@
+ALERT: PASS
+Test click works when there is an event listner on shadow root.
+To manually test, click on "Click here" below.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didClick is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click here

--- a/LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root.html
+++ b/LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<div id="host">Click here</div>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+description('Test click works when there is an event listner on shadow root.<br>To manually test, click on "Click here" below.');
+jsTestIsAsync = true;
+
+let didClick = false;
+host.addEventListener('click', () => {
+    didClick = true;
+    alert('PASS');
+});
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+let shadowRoot = host.attachShadow({mode: 'closed'});
+shadowRoot.addEventListener('click', () => { });
+shadowRoot.innerHTML = '<span style="border: solid 1px black"><slot></slot></span>';
+
+async function runTest() {
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.activateAt(host.offsetLeft + 5, host.offsetTop + 5);
+
+    shouldBeTrue('didClick');
+
+    finishJSTest();
+}
+
+onload = runTest;
+
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1140,6 +1140,8 @@ void WebPage::commitPotentialTap(OptionSet<WebEvent::Modifier> modifiers, Transa
         bool targetRenders = m_potentialTapNode->renderer();
         if (!targetRenders && is<Element>(m_potentialTapNode))
             targetRenders = downcast<Element>(*m_potentialTapNode).renderOrDisplayContentsStyle();
+        if (!targetRenders && is<ShadowRoot>(m_potentialTapNode))
+            targetRenders = downcast<ShadowRoot>(*m_potentialTapNode).host()->renderOrDisplayContentsStyle();
         invalidTargetForSingleClick = !targetRenders && !is<HTMLAreaElement>(m_potentialTapNode);
     }
     if (invalidTargetForSingleClick) {


### PR DESCRIPTION
#### b01e40564c2149ac330006002babf439d1ecded4
<pre>
iOS: click event doesn&apos;t get dispatched when there is a click event listener on ShadowRoot
<a href="https://bugs.webkit.org/show_bug.cgi?id=218923">https://bugs.webkit.org/show_bug.cgi?id=218923</a>

Reviewed by Wenson Hsieh.

The bug was caused by WebPage::commitPotentialTap falsely treating ShadowRoot as an invalid tap target
because it doesn&apos;t have a renderer. Fixed the bug by checking the shadow host&apos;s renderer instead
much like <a href="http://commits.webkit.org/r246404">http://commits.webkit.org/r246404</a> for display: contents.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::commitPotentialTap): Fixed the bug.

* LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root-expected.txt: Added.
* LayoutTests/fast/shadow-dom/click-eventlistener-on-shadow-root.html: Added.

Canonical link: <a href="https://commits.webkit.org/252107@main">https://commits.webkit.org/252107@main</a>
</pre>
