### PR TITLE
[iOS] Mail occasionally crashes under WebKit: API::Attachment::enclosingImageData()

### DIFF
--- a/Source/WebKit/UIProcess/API/APIAttachment.cpp
+++ b/Source/WebKit/UIProcess/API/APIAttachment.cpp
@@ -70,10 +70,11 @@ void Attachment::invalidate()
     m_filePath = { };
     m_contentType = { };
     m_webPage.clear();
+    m_insertionState = InsertionState::NotInserted;
 #if PLATFORM(COCOA)
+    Locker locker { m_fileWrapperLock };
     m_fileWrapper.clear();
 #endif
-    m_insertionState = InsertionState::NotInserted;
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2875,7 +2875,7 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
             capturedHandler(true);
     });
 #if HAVE(QUICKLOOK_THUMBNAILING)
-    _page->requestThumbnailWithFileWrapper(fileWrapper, identifier);
+    _page->requestThumbnail(attachment, identifier);
 #endif
     return wrapper(attachment);
 #else

--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -4442,13 +4442,14 @@ void WebViewImpl::writeToURLForFilePromiseProvider(NSFilePromiseProvider *provid
     }
 
     WKPromisedAttachmentContext *info = (WKPromisedAttachmentContext *)userInfo;
-    auto attachment = m_page->attachmentForIdentifier(info.attachmentIdentifier);
-    if (NSFileWrapper *fileWrapper = attachment ? attachment->fileWrapper() : nil) {
+    if (auto attachment = m_page->attachmentForIdentifier(info.attachmentIdentifier)) {
         NSError *attachmentWritingError = nil;
-        if ([fileWrapper writeToURL:fileURL options:0 originalContentsURL:nil error:&attachmentWritingError])
-            completionHandler(nil);
-        else
-            completionHandler(attachmentWritingError);
+        attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
+            if ([fileWrapper writeToURL:fileURL options:0 originalContentsURL:nil error:&attachmentWritingError])
+                completionHandler(nil);
+            else
+                completionHandler(attachmentWritingError);
+        });
         return;
     }
 

--- a/Source/WebKit/UIProcess/QuickLookThumbnailLoader.h
+++ b/Source/WebKit/UIProcess/QuickLookThumbnailLoader.h
@@ -27,6 +27,10 @@
 
 #import "CocoaImage.h"
 
+namespace API {
+class Attachment;
+}
+
 @interface WKQLThumbnailQueueManager : NSObject
 
 @property (nonatomic, readonly, retain) NSOperationQueue *queue;
@@ -45,7 +49,7 @@
 @property (nonatomic, readonly, copy) NSString *identifier;
 @property (nonatomic, readonly, retain) CocoaImage *thumbnail;
 
-- (instancetype)initWithAttachment:(NSFileWrapper *)fileWrapper identifier:(NSString *)identifier;
+- (instancetype)initWithAttachment:(const API::Attachment&)attachment identifier:(NSString *)identifier;
 - (instancetype)initWithURL:(NSString *)fileURL identifier:(NSString *)identifier;
 
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1781,8 +1781,7 @@ public:
 #if HAVE(QUICKLOOK_THUMBNAILING)
     void updateAttachmentThumbnail(const String&, const RefPtr<ShareableBitmap>&);
     void requestThumbnailWithPath(const String&, const String&);
-    void requestThumbnailWithFileWrapper(NSFileWrapper *, const String&);
-    void requestThumbnailWithOperation(WKQLThumbnailLoadOperation *);
+    void requestThumbnail(const API::Attachment&, const String&);
 #endif
     enum class ShouldUpdateAttachmentAttributes : bool { No, Yes };
     ShouldUpdateAttachmentAttributes willUpdateAttachmentAttributes(const API::Attachment&);
@@ -2595,6 +2594,10 @@ private:
     void requestAttachmentIcon(const String& identifier, const String& type, const String& path, const String& title, const WebCore::FloatSize&);
 
     RefPtr<WebKit::ShareableBitmap> iconForAttachment(const String& fileName, const String& contentType, const String& title, WebCore::FloatSize&);
+
+#if HAVE(QUICKLOOK_THUMBNAILING)
+    void requestThumbnail(WKQLThumbnailLoadOperation *);
+#endif
 #endif
 
     void reportPageLoadResult(const WebCore::ResourceError& = { });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -1925,6 +1925,7 @@ TEST(WKAttachmentTestsMac, DraggingAttachmentBackedImagePreservesRangedSelection
 
     [webView waitForImageElementSizeToBecome:CGSizeMake(215, 174)];
 
+    [[webView window] orderFrontRegardless];
     [webView mouseEnterAtPoint:CGPointMake(125, 125)];
     [webView mouseMoveToPoint:CGPointMake(125, 125) withFlags:0];
     [webView mouseDownAtPoint:CGPointMake(125, 125) simulatePressure:NO];


### PR DESCRIPTION
#### 9e3eed2f674c733b94419096a8d9859ee3278c23
<pre>
[iOS] Mail occasionally crashes under WebKit: API::Attachment::enclosingImageData()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242251">https://bugs.webkit.org/show_bug.cgi?id=242251</a>
rdar://96131691

Reviewed by Chris Dumez.

The QuickLook attachment thumbnailing codepath, which uses `WKQLThumbnailLoadOperation` to request
an icon image for API-backed attachments, reads data out of the file wrapper from a background
thread. If anything simultaneously tries to access the file wrapper&apos;s content from the main thread,
the file wrapper&apos;s cached data blob will be left in a bad state (smashed, or overreleased, etc.),
potentially causing Mail to crash.

After the changes in 250772@main, we now automatically trigger QuickLook thumbnail requests when
inserting attachments via the pasteboard (i.e. drag-and-drop or copy-paste), at the same time as we
update attachment attributes (calling `enclosingImageData()` in the process on the main thread). As
a result, we hit the thread safety issue and crash described above much more frequently, resulting
in various API-attachment-related crashes that all occur when the main thread tries to read from the
file wrapper while QuickLook thumbnail operation queue is also active.

To fix this, we add a compile-time guard to ensure that access to each attachment&apos;s `m_fileWrapper`
is guarded behind a `m_fileWrapperLock`; we additionally refactor the code so that instead of
exposing a `Attachment::fileWrapper()` getter method, we have `Attachment::doWithFileWrapper()`,
which takes a C++ lambda and calls the lambda with the `NSFileWrapper`, after grabbing the lock.

* Source/WebKit/UIProcess/API/APIAttachment.cpp:
(API::Attachment::invalidate):
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::setFileWrapper):
(API::Attachment::doWithFileWrapper const):

Replaces the `fileWrapper()` getter.

(API::Attachment::fileName const):
(API::Attachment::fileSizeForDisplay const):
(API::Attachment::enclosingImageData const):
(API::Attachment::enclosingImageNSData const):
(API::Attachment::isEmpty const):
(API::Attachment::createSerializedRepresentation const):
(API::Attachment::fileWrapper const): Deleted.

Adopt `doWithFileWrapper` everywhere we currently use either `m_fileWrapper` directly, or the now-
deleted `fileWrapper()` getter.

(API::Attachment::invalidateGeneratedFileWrapper): Deleted.
(API::Attachment::setFileWrapperGenerator): Deleted.

Delete support for delayed file wrapper generation; this was initially introduced in r238538 for
Apple pencil support in Mail, but was ultimately implemented using an alternate approach.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _insertAttachmentWithFileWrapper:contentType:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachmentInfo initWithAttachment:]):

Make this take an `API::Attachment` instead of a file wrapper (and other attachment metadata) as
separate arguments. This allows us to use `doWithFileWrapper()` to access the attachment&apos;s file
wrapper behind a lock.

(-[_WKAttachmentInfo data]):
(-[_WKAttachmentInfo name]):
(-[_WKAttachmentInfo fileWrapper]):
(-[_WKAttachment info]):
(-[_WKAttachmentInfo initWithFileWrapper:filePath:mimeType:utiType:]): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::platformCloneAttachment):
(WebKit::WebPageProxy::requestThumbnail):
(WebKit::WebPageProxy::requestThumbnailWithPath):
(WebKit::WebPageProxy::requestThumbnailWithOperation): Deleted.
(WebKit::WebPageProxy::requestThumbnailWithFileWrapper): Deleted.

Drive-by refactoring: rename a couple of methods to the more succinct `requestThumbnail()`, relying
on C++ method overloading.

* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(WebKit::WebViewImpl::writeToURLForFilePromiseProvider):
* Source/WebKit/UIProcess/QuickLookThumbnailLoader.h:
* Source/WebKit/UIProcess/QuickLookThumbnailLoader.mm:
(-[WKQLThumbnailLoadOperation initWithAttachment:identifier:]):

Make this take an `API::Attachment` instead of taking the attachment&apos;s file wrapper directly. This
allows us to use `doWithFileWrapper` to read from the file wrapper when generating the attachment
thumbnail.

(-[WKQLThumbnailLoadOperation start]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::updateAttachmentAttributes):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _prepareToDragPromisedAttachment:]):
(createItemProvider):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST):

Drive-by fix: make `WKAttachmentTestsMac.DraggingAttachmentBackedImagePreservesRangedSelection` pass
when running API tests locally, when the TestWebKitAPI window is not ordered to the front. When
running this test from command line from Terminal, the API test&apos;s window ends up behind the terminal
window, which causes the drag session to never end.

Canonical link: <a href="https://commits.webkit.org/252118@main">https://commits.webkit.org/252118@main</a>
</pre>
