### PR TITLE
Rename offlineasm's asm.deferAction to asm.deferOSDarwinAction.

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -1235,11 +1235,9 @@ class Instruction
             $asm.putStr("#error Missing globaladdr implementation")
             $asm.putStr("#endif")
 
-            $asm.deferAction {
+            $asm.deferOSDarwinAction {
                 # On Darwin, also include the .loh directive using the generated labels.
-                $asm.putStr("#if OS(DARWIN)")
                 $asm.puts ".loh AdrpLdrGot Ljsc_llint_loh_adrp_#{uid}, Ljsc_llint_loh_ldr_#{uid}"
-                $asm.putStr("#endif")
             }
 
         when "andf", "andd"

--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ class Assembler
         @codeOrigin = nil
         @numLocalLabels = 0
         @numGlobalLabels = 0
-        @deferredActions = []
+        @deferredOSDarwinActions = []
         @deferredNextLabelActions = []
         @count = 0
         @debugAnnotationStr = nil
@@ -83,16 +83,20 @@ class Assembler
             putsProcEndIfNeeded
         end
         putsLastComment
-        (@deferredNextLabelActions + @deferredActions).each {
-            | action |
-            action.call()
-        }
+        if not @deferredOSDarwinActions.size.zero?
+            putStr("#if OS(DARWIN)")
+            (@deferredNextLabelActions + @deferredOSDarwinActions).each {
+                | action |
+                action.call()
+            }
+            putStr("#endif // OS(DARWIN)")
+        end
         putStr "OFFLINE_ASM_END" if !$emitWinAsm
         @state = :cpp
     end
     
-    def deferAction(&proc)
-        @deferredActions << proc
+    def deferOSDarwinAction(&proc)
+        @deferredOSDarwinActions << proc
     end
 
     def deferNextLabelAction(&proc)


### PR DESCRIPTION
#### 816faa4c60735f96636b3ca0db78f75e81372cb3
<pre>
Rename offlineasm&apos;s asm.deferAction to asm.deferOSDarwinAction.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242301">https://bugs.webkit.org/show_bug.cgi?id=242301</a>

Reviewed by Yusuke Suzuki.

Similarly, rename the underlying field from @deferredAction to @deferredOSDarwinAction.
This deferAction was only used for OS(DARWIN) anyway.  By changing it to be OS(DARWIN)
specific to indicate its actual usage, we can make the generated LLIntAssembly.h more
readable (less cluttered).

Previously, we emit this code:

      OFFLINE_ASM_GLOBAL_LABEL(llintPCRangeEnd)
      #if OS(DARWIN)
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_1, Ljsc_llint_loh_ldr_1 \n&quot;
      #endif
      #if OS(DARWIN)
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_2, Ljsc_llint_loh_ldr_2 \n&quot;
      #endif
      ...
      #if OS(DARWIN)
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_2308, Ljsc_llint_loh_ldr_2308 \n&quot;
      #endif
      OFFLINE_ASM_END

Now, we emit this instead:

      OFFLINE_ASM_GLOBAL_LABEL(llintPCRangeEnd)
      #if OS(DARWIN)
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_1, Ljsc_llint_loh_ldr_1 \n&quot;
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_2, Ljsc_llint_loh_ldr_2 \n&quot;
          ...
          &quot;.loh AdrpLdrGot Ljsc_llint_loh_adrp_2308, Ljsc_llint_loh_ldr_2308 \n&quot;
      #endif // OS(DARWIN)
      OFFLINE_ASM_END

* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/offlineasm/asm.rb:

Canonical link: <a href="https://commits.webkit.org/252109@main">https://commits.webkit.org/252109@main</a>
</pre>
