### PR TITLE
[JSC] Use memchr in WTF::find for long strings

### DIFF
--- a/JSTests/microbenchmarks/string-index-of-10000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000000, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000000, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000000, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000000, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100000, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100000, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100000, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100000, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-100001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10000, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-100001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10000, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-100001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10000, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-100001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10000, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-10001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1000, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-1001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(100, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-101-404.js
+++ b/JSTests/microbenchmarks/string-index-of-101-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-101-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-101-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-101-end.js
+++ b/JSTests/microbenchmarks/string-index-of-101-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-101-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-101-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(10, 0, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-11-404.js
+++ b/JSTests/microbenchmarks/string-index-of-11-404.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1, 2, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-11-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-11-beg.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1, -1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-11-end.js
+++ b/JSTests/microbenchmarks/string-index-of-11-end.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1, 1, !!utf16);
+}
+all(false);

--- a/JSTests/microbenchmarks/string-index-of-11-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-11-mid.js
@@ -1,0 +1,61 @@
+function bench(string, func)
+{
+    for (var i = 0; i < 1000; ++i)
+        func();
+}
+noInline(bench);
+
+function forRepeatCount(count, pos, utf16) {
+    var base = "lalalalala".repeat(count);
+    if (utf16) {
+        base += "ϧ"; // arbitrary utf-16
+    }
+
+    var input = base;
+    var label;
+    const charToFind = !utf16 ? "z" : String.fromCodePoint(0x0245);
+    switch (pos) {
+        case -1: {
+            input = charToFind + base;
+            label = `beg ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+        case 0: {
+            label = `mid ${utf16 ? "UChar" : "LChar"}`;
+            input =
+            base.substring(0, (base.length / 2) | 0) +
+            charToFind +
+            base.substring((base.length / 2) | 0);
+            break;
+        }
+        case 1: {
+            label = `end ${utf16 ? "UChar" : "LChar"}`;
+            input = base + charToFind;
+            break;
+        }
+            // not found
+        case 2: {
+            label = `404 ${utf16 ? "UChar" : "LChar"}`;
+            break;
+        }
+    }
+
+    // force it to not be a rope
+    input = input.split("").join("");
+
+    function target() {
+        input.indexOf(charToFind)
+    }
+    noInline(target);
+    return bench(
+        `<${label}> [${new Intl.NumberFormat()
+                .format(input.length)
+                .padStart("10,000,001".length)} chars] indexOf`,
+        target
+    );
+}
+
+function all(utf16) {
+    forRepeatCount(1, 0, !!utf16);
+}
+all(false);


### PR DESCRIPTION
#### 88a058cae9d1e44810fd89f0fcbfca392f564b53
<pre>
[JSC] Use memchr in WTF::find for long strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=242305">https://bugs.webkit.org/show_bug.cgi?id=242305</a>

Reviewed by Darin Adler.

For long strings, memchr is massively faster than normal for-loop-based WTF::find.
This patch upstreams a fast path from Jarred&apos;s bun. If the given string is 16 or longer,
we use memchr if the input is LChar. This can offer up to 13x performance improvement
for long strings.

                                             ToT                     Patched

    string-index-of-10000001-mid     2205.4979+-4.2592     ^    221.0630+-0.8919        ^ definitely 9.9768x faster
    string-index-of-1001-404            0.9214+-0.0703     ^      0.5419+-0.0703        ^ definitely 1.7002x faster
    string-index-of-101-mid             0.4619+-0.0156     ?      0.5250+-0.0745        ? might be 1.1365x slower
    string-index-of-11-404              0.4681+-0.0378     ?      0.5084+-0.0671        ? might be 1.0862x slower
    string-index-of-100001-end         43.2624+-0.2025     ^      3.4478+-0.0448        ^ definitely 12.5478x faster
    string-index-of-1001-beg            0.5792+-0.1128            0.5020+-0.0307          might be 1.1537x faster
    string-index-of-1000001-mid       219.6133+-0.6721     ^     21.7715+-0.1868        ^ definitely 10.0872x faster
    string-index-of-11-beg              0.5390+-0.0957            0.4938+-0.0488          might be 1.0916x faster
    string-index-of-100001-404         43.1607+-0.1565     ^      3.4266+-0.0339        ^ definitely 12.5959x faster
    string-index-of-11-end              0.5703+-0.1035            0.4993+-0.0671          might be 1.1424x faster
    string-index-of-100001-beg          1.4254+-0.0285     ?      1.4297+-0.0293        ?
    string-index-of-1001-end            0.8898+-0.0155     ^      0.5397+-0.0434        ^ definitely 1.6486x faster
    string-index-of-10001-mid           2.6381+-0.0128     ^      0.6968+-0.0194        ^ definitely 3.7859x faster
    string-index-of-100001-mid         22.3904+-0.0908     ^      2.4405+-0.0278        ^ definitely 9.1745x faster
    string-index-of-10001-beg           0.5799+-0.0275     ?      0.6409+-0.0848        ? might be 1.1052x slower
    string-index-of-1000001-end       429.8451+-1.0909     ^     33.0243+-0.1489        ^ definitely 13.0160x faster
    string-index-of-10000001-end     4311.6106+-8.5017     ^    342.4604+-2.5696        ^ definitely 12.5901x faster
    string-index-of-10001-404           4.7512+-0.0329     ^      0.8011+-0.0209        ^ definitely 5.9309x faster
    string-index-of-101-end             0.4812+-0.0131     ?      0.4917+-0.0246        ? might be 1.0220x slower
    string-index-of-101-404             0.5520+-0.0778            0.5100+-0.0671          might be 1.0824x faster
    string-index-of-1000001-beg        10.0429+-0.0882     ?     10.0694+-0.1024        ?
    string-index-of-11-mid              0.4578+-0.0236     ?      0.5159+-0.0519        ? might be 1.1271x slower
    string-index-of-10000001-404     4318.2034+-9.4519     ^    343.7710+-2.7918        ^ definitely 12.5613x faster
    string-index-of-1001-mid            0.6977+-0.0197            0.6024+-0.1121          might be 1.1581x faster
    string-index-of-10001-end           4.7425+-0.0291     ^      0.8022+-0.0152        ^ definitely 5.9117x faster
    string-index-of-101-beg             0.5055+-0.0720     ?      0.5122+-0.0789        ? might be 1.0132x slower
    string-index-of-1000001-404       428.1418+-0.6700     ^     33.0665+-0.1926        ^ definitely 12.9479x faster
    string-index-of-10000001-beg      105.1998+-2.6163          102.6464+-1.9531          might be 1.0249x faster

    &lt;geometric&gt;                         7.5209+-0.0853     ^      2.7424+-0.0300        ^ definitely 2.7425x faster

* JSTests/microbenchmarks/string-index-of-10000001-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10000001-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10000001-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10000001-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1000001-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1000001-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1000001-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1000001-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-100001-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-100001-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-100001-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-100001-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10001-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10001-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10001-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-10001-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1001-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1001-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1001-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-1001-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-101-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-101-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-101-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-101-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-11-404.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-11-beg.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-11-end.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* JSTests/microbenchmarks/string-index-of-11-mid.js: Added.
(bench):
(target):
(forRepeatCount):
(all):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::find):

Canonical link: <a href="https://commits.webkit.org/252121@main">https://commits.webkit.org/252121@main</a>
</pre>
