### PR TITLE
[resultsdb] Expose reported flakiness information in the UI

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -232,7 +232,7 @@ DOM.inject(
             view.ref.state.children.forEach((child) => {
                 child.timeline.update();
             });
-        }, false),
+        }, false, false, true, false),
         LimitSlider(() => {view.reload()}),
         BranchSelector(() => {
             CommitBank.reload();

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html
@@ -175,7 +175,7 @@ ${Drawer([
         for (let suite in view.children) {
             view.children[suite].update();
         }
-    }, true, true),
+    }, true, true, false, true),
     LimitSlider(() => {view.reload()}),
     BranchSelector(() => {
         CommitBank.reload();


### PR DESCRIPTION
#### 654dea109d948b85be30afb75031b9b2377802c3
<pre>
[resultsdb] Expose reported flakiness information in the UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=238809">https://bugs.webkit.org/show_bug.cgi?id=238809</a>

Reviewed by Jonathan Bedard.

Aggregate the number of flaky tests in an upload. In the suites view,
provide a &apos;Show number of flaky tests&apos; toggle. In the search view,
provide a &apos;Show test flakiness&apos; toggle. Make the per-dot tag into an
array of information. Toggling all possible tag values on at once will
certainly result in text overlap).

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/model/suite_context.py:
(SuiteContext.register):
(SuiteContext.register.callback):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(TimelineFromEndpoint.const.options.prototype.renderFactory):
(result.div.label.Show.test.flakiness.label.label):
(result.div.label.Number.of.flakes.label.label):
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html:

Canonical link: <a href="https://commits.webkit.org/252114@main">https://commits.webkit.org/252114@main</a>
</pre>
