### PR TITLE
[GStreamer] Build failure with ENABLE_MEDIA_CAPTURE=ON

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp
@@ -965,7 +965,7 @@ void webkit_dom_html_input_element_set_capture_type(WebKitDOMHTMLInputElement* s
     g_return_if_fail(WEBKIT_DOM_IS_HTML_INPUT_ELEMENT(self));
     g_return_if_fail(value);
     WebCore::HTMLInputElement* item = WebKit::core(self);
-    WTF::String convertedValue = WTF::String::fromUTF8(value);
+    auto convertedValue = WTF::AtomString::fromUTF8(value);
     item->setAttributeWithoutSynchronization(WebCore::HTMLNames::captureAttr, convertedValue);
 #else
     UNUSED_PARAM(self);


### PR DESCRIPTION
#### 47ee94dc05bcba6c53389da75efb73b878d5f85d
<pre>
[GStreamer] Build failure with ENABLE_MEDIA_CAPTURE=ON
<a href="https://bugs.webkit.org/show_bug.cgi?id=242309">https://bugs.webkit.org/show_bug.cgi?id=242309</a>

Reviewed by Philippe Normand.

* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLInputElement.cpp:
(webkit_dom_html_input_element_set_capture_type): Switch from outdated
usage of WTF::String to WTF::AtomString.

Canonical link: <a href="https://commits.webkit.org/252113@main">https://commits.webkit.org/252113@main</a>
</pre>
