### PR TITLE
[FreeType] Add an implementation for FontPlatformData::familyName()

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -68,14 +68,6 @@ FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source,
 }
 #endif
 
-#if !USE(CORE_TEXT) && !PLATFORM(WIN)
-String FontPlatformData::familyName() const
-{
-    // FIXME: Not implemented yet.
-    return { };
-}
-#endif
-
 #if !PLATFORM(COCOA)
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames) const
 {

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -191,6 +191,13 @@ String FontPlatformData::description() const
 }
 #endif
 
+String FontPlatformData::familyName() const
+{
+    FcChar8* family = nullptr;
+    FcPatternGetString(m_pattern.get(), FC_FAMILY, 0, &family);
+    return String::fromUTF8(family);
+}
+
 void FontPlatformData::buildScaledFont(cairo_font_face_t* fontFace)
 {
     ASSERT(m_pattern);


### PR DESCRIPTION
#### 3db59430108ca0e3f01ec4d6ac7adbc8ec6fa7c4
<pre>
[FreeType] Add an implementation for FontPlatformData::familyName()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242310">https://bugs.webkit.org/show_bug.cgi?id=242310</a>

Reviewed by Michael Catanzaro.

This will make the font name to be shown in the inspector.

* Source/WebCore/platform/graphics/FontPlatformData.cpp:
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::familyName const):

Canonical link: <a href="https://commits.webkit.org/252129@main">https://commits.webkit.org/252129@main</a>
</pre>
