### PR TITLE
[ Mac EWS ] imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/wpt/shared-workers/connect-event-ordering-expected.txt
+++ b/LayoutTests/http/wpt/shared-workers/connect-event-ordering-expected.txt
@@ -1,0 +1,3 @@
+
+PASS connect event should fire following SharedWorker creation order
+

--- a/LayoutTests/http/wpt/shared-workers/connect-event-ordering-sharedworker.js
+++ b/LayoutTests/http/wpt/shared-workers/connect-event-ordering-sharedworker.js
@@ -1,0 +1,6 @@
+let ports = [];
+onconnect = (e) => {
+    const port = e.ports[0];
+    ports.push(port);
+    port.postMessage("worker" + ports.length);
+}

--- a/LayoutTests/http/wpt/shared-workers/connect-event-ordering.html
+++ b/LayoutTests/http/wpt/shared-workers/connect-event-ordering.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+
+promise_test(async (t) => {
+    const worker1 = new SharedWorker('connect-event-ordering-sharedworker.js');
+    const worker2 = new SharedWorker('connect-event-ordering-sharedworker.js');
+
+    let promise1 = new Promise(resolve => { worker1.port.onmessage = (event) => resolve(event.data) });
+    let promise2 = new Promise(resolve => { worker2.port.onmessage = (event) => resolve(event.data) });
+
+    assert_equals(await promise1, "worker1");
+    assert_equals(await promise2, "worker2");
+}, "connect event should fire following SharedWorker creation order");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -510,6 +510,9 @@ fast/events/ghostly-mousemoves-in-subframe.html [ Skip ]
 # WK1 does not filter response headers.
 http/wpt/loading/redirect-headers.html [ Skip ]
 
+# No shared worker implementation for WK1
+http/wpt/shared-workers [ Skip ]
+
 # No service worker implementation for WK1
 http/tests/appcache/main-resource-redirect-with-sw.html [ Skip ]
 http/tests/cache-storage [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1604,8 +1604,6 @@ webkit.org/b/235681 [ BigSur Release ]  imported/w3c/web-platform-tests/html/can
 [ Monterey+ ] accessibility/model-element-attributes.html [ Skip ]
 [ Monterey+ ] model-element/model-element-interactive.html [ Skip ]
 
-webkit.org/b/237095 imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html [ Pass Failure ]
-
 webkit.org/b/233621 http/tests/webgpu [ Skip ]
 
 fast/text/install-font-style-recalc.html [ Pass ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -3958,6 +3958,9 @@ webkit.org/b/174801 fast/text/line-height-minimumFontSize-zoom.html [ ImageOnlyF
 webkit.org/b/174801 fast/text/line-height-minimumFontSize-autosize.html [ Failure ]
 webkit.org/b/174801 fast/text/line-height-minimumFontSize.html [ Failure ]
 
+# No shared worker implementation for WK1
+http/wpt/shared-workers [ Skip ]
+
 # No service worker implementation for WK1
 http/tests/appcache/main-resource-redirect-with-sw.html [ Skip ]
 http/tests/cache-storage [ Skip ]

--- a/LayoutTests/platform/wincairo-wk1/TestExpectations
+++ b/LayoutTests/platform/wincairo-wk1/TestExpectations
@@ -306,6 +306,9 @@ http/tests/multipart/multipart-wait-before-boundary.html [ Timeout ]
 [ Release ] http/tests/misc/redirect-to-external-url.html [ Failure ]
 [ Debug ] http/tests/misc/redirect-to-external-url.html [ Skip ]
 
+# No shared worker implementation for WK1
+http/wpt/shared-workers [ Skip ]
+
 # Skip Service Workers in WK1
 http/tests/workers/service [ Skip ]
 http/wpt/push-api [ Skip ]


### PR DESCRIPTION
#### 82a9cba7856539aef1c00e8c064036876d3f3579
<pre>
[ Mac EWS ] imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=237095">https://bugs.webkit.org/show_bug.cgi?id=237095</a>
rdar://problem/89367636

Patch by Youenn Fablet &lt;youennf@gmail.com&gt; on 2022-06-23
Reviewed by Chris Dumez.

As per <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a>,
a WorkerGlobalScope owner set should preserve the insertion order.
imported/w3c/web-platform-tests/workers/semantics/multiple-workers/004.html might be flakky as we sometimes do not run the shared worker synchronously.
In that case, we will send the connect event on the shared worker set.
Before the patch, the shared worker set would not be ordered so it might happen that the first connect event is related to an iframe SharedWorker.
After the patch, we ensure that the first SharedWorker (NetworkProcess being the place where insertion happens) will be the first to trigger the connect event.
This is done by changing the SharedWorker object set from a Map to a ListHashSet.
Covered by added LayoutTests/http/wpt/service-workers/shared-workers/connect-event-ordering.html

* LayoutTests/http/wpt/shared-workers: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wincairo-wk1/TestExpectations:

* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:

Canonical link: <a href="https://commits.webkit.org/252267@main">https://commits.webkit.org/252267@main</a>
git-svn-id: <a href="https://svn.webkit.org/repository/webkit/trunk@295776">https://svn.webkit.org/repository/webkit/trunk@295776</a> 268f45cc-cd09-0410-ab3c-d52691b4dbfc
</pre>
