### PR TITLE
Web Inspector: Styles: Pop-up for resolved CSS variable values is inconsistent with other pop-ups

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
@@ -123,6 +123,11 @@
     padding: 0 3px;
 }
 
+.inline-swatch-variable-popover .CodeMirror-sizer {
+    /* Override min-height set as inline style by CodeMirror which sizes its container disproportionally tall. */
+    min-height: fit-content !important;
+}
+
 @media (prefers-color-scheme: dark) {
     .inline-swatch.box-shadow > svg,
     .inline-swatch.alignment > span {

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
@@ -342,7 +342,8 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
                 readOnly: true,
             });
             this._valueEditor.codeMirror.on("update", () => {
-                this._popover.update();
+                const shouldAnimate = false;
+                this._popover.update(shouldAnimate);
             });
             break;
         }


### PR DESCRIPTION
#### 8109e785685bbda8ff9a6193cd41c86fa14d9a8d
<pre>
Web Inspector: Styles: Pop-up for resolved CSS variable values is inconsistent with other pop-ups
<a href="https://bugs.webkit.org/show_bug.cgi?id=242315">https://bugs.webkit.org/show_bug.cgi?id=242315</a>

Reviewed by Patrick Angle.

Make the pop-up for `WI.InlineSwatch.Type.Variable` consistent with other pop-ups:
- remove animation of dimensions
- remove unnecessary height from container

* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css:
(.inline-swatch-variable-popover .CodeMirror-sizer):
The CodeMirror document `min-height` is set as an inline style in exact units based on an internal calculation of its contents.
CodeMirror _should have_ respected the `height: auto;` of its host element and grow appropriately: <a href="https://codemirror.net/5/demo/resize.html">https://codemirror.net/5/demo/resize.html</a>
This didn&apos;t happen.

Other solutions suggested by the CodeMirror documentation didn&apos;t work in this context either.
As a fix, we resort to deliberately overwrite the inline style with `min-height: fit-content !important`
to force the CodeMirror document to size itself accordingly.

* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:

Canonical link: <a href="https://commits.webkit.org/252133@main">https://commits.webkit.org/252133@main</a>
</pre>
