### PR TITLE
Switch test results from Trac to Github links

### DIFF
--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -793,7 +793,7 @@ class TestResultsController
 
     layoutTestURL(testResult)
     {
-        if (this.shouldUseTracLinks())
+        if (this.shouldUseGithubLinks())
             return this.layoutTestsBasePath() + testResult.name;
 
         return this.testToURL(testResult, this.layoutTestsBasePath());
@@ -802,12 +802,9 @@ class TestResultsController
     layoutTestsBasePath()
     {
         let basePath;
-        if (this.shouldUseTracLinks()) {
-            let revision = this.testResults.revision;
-            basePath = 'http://trac.webkit.org';
-            basePath += revision ? ('/export/' + revision) : '/browser';
-            basePath += '/trunk/LayoutTests/';
-        } else
+        if (this.shouldUseGithubLinks())
+            basePath = 'https://github.com/WebKit/WebKit/blob/main/LayoutTests/';
+        else
             basePath = this.testResults.layoutTestsDir() + '/';
 
         return basePath;
@@ -824,14 +821,14 @@ class TestResultsController
         return fullURL;
     }
 
-    shouldUseTracLinks()
+    shouldUseGithubLinks()
     {
         return !this.testResults.layoutTestsDir() || !location.toString().indexOf('file://') == 0;
     }
 
     checkServerIsRunning(event)
     {
-        if (this.shouldUseTracLinks())
+        if (this.shouldUseGithubLinks())
             return;
 
         let url = event.target.href;
@@ -1105,8 +1102,8 @@ class TestResultsController
         let layoutTestsIndex = src.indexOf('LayoutTests');
         let name;
         if (layoutTestsIndex != -1) {
-            let hasTrac = src.indexOf('trac.webkit.org') != -1;
-            let prefix = hasTrac ? 'trac.webkit.org/.../' : '';
+            let hasGithub = src.indexOf('github.com/WebKit/WebKit/') != -1;
+            let prefix = hasGithub ? 'github.com/WebKit/WebKit/.../' : '';
             name = prefix + src.substring(layoutTestsIndex + 'LayoutTests/'.length);
         } else {
             let lastDashIndex = src.lastIndexOf('-pretty');

--- a/ManualTests/resources/test-results-page.html
+++ b/ManualTests/resources/test-results-page.html
@@ -792,7 +792,7 @@ class TestResultsController
 
     layoutTestURL(testResult)
     {
-        if (this.shouldUseTracLinks())
+        if (this.shouldUseGithubLinks())
             return this.layoutTestsBasePath() + testResult.name;
 
         return this.testToURL(testResult, this.layoutTestsBasePath());
@@ -801,12 +801,9 @@ class TestResultsController
     layoutTestsBasePath()
     {
         let basePath;
-        if (this.shouldUseTracLinks()) {
-            let revision = this.testResults.revision;
-            basePath = 'http://trac.webkit.org';
-            basePath += revision ? ('/export/' + revision) : '/browser';
-            basePath += '/trunk/LayoutTests/';
-        } else
+        if (this.shouldUseGithubLinks())
+            basePath = 'https://github.com/WebKit/WebKit/blob/main/LayoutTests/';
+        else
             basePath = this.testResults.layoutTestsDir() + '/';
 
         return basePath;
@@ -823,14 +820,14 @@ class TestResultsController
         return fullURL;
     }
 
-    shouldUseTracLinks()
+    shouldUseGithubLinks()
     {
         return !this.testResults.layoutTestsDir() || !location.toString().indexOf('file://') == 0;
     }
 
     checkServerIsRunning(event)
     {
-        if (this.shouldUseTracLinks())
+        if (this.shouldUseGithubLinks())
             return;
 
         let url = event.target.href;
@@ -1104,8 +1101,8 @@ class TestResultsController
         let layoutTestsIndex = src.indexOf('LayoutTests');
         let name;
         if (layoutTestsIndex != -1) {
-            let hasTrac = src.indexOf('trac.webkit.org') != -1;
-            let prefix = hasTrac ? 'trac.webkit.org/.../' : '';
+            let hasGithub = src.indexOf('github.com/WebKit/WebKit/') != -1;
+            let prefix = hasGithub ? 'github.com/WebKit/WebKit/.../' : '';
             name = prefix + src.substring(layoutTestsIndex + 'LayoutTests/'.length);
         } else {
             let lastDashIndex = src.lastIndexOf('-pretty');


### PR DESCRIPTION
#### 16168e138f9bd3ffb0ca218a92366de8447b0a77
<pre>
Switch test results from Trac to Github links
<a href="https://bugs.webkit.org/show_bug.cgi?id=242316">https://bugs.webkit.org/show_bug.cgi?id=242316</a>

Reviewed by Jonathan Bedard.

* LayoutTests/fast/harness/results.html:
* ManualTests/resources/test-results-page.html:

Canonical link: <a href="https://commits.webkit.org/252138@main">https://commits.webkit.org/252138@main</a>
</pre>
