### PR TITLE
[Alternate WebM Player] Allow device sleep during playback

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -966,9 +966,14 @@ void MediaPlayerPrivateWebM::ensureLayer()
     m_displayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
     [m_displayLayer setName:@"MediaPlayerPrivateWebM AVSampleBufferDisplayLayer"];
 
-    ERROR_LOG_IF(!m_displayLayer, LOGIDENTIFIER, "Creating the AVSampleBufferDisplayLayer failed.");
-    if (!m_displayLayer)
+    if (!m_displayLayer) {
+        ERROR_LOG(LOGIDENTIFIER, "Creating the AVSampleBufferDisplayLayer failed.");
+        setNetworkState(MediaPlayer::NetworkState::DecodeError);
         return;
+    }
+    
+    if ([m_displayLayer respondsToSelector:@selector(setPreventsDisplaySleepDuringVideoPlayback:)])
+        m_displayLayer.get().preventsDisplaySleepDuringVideoPlayback = NO;
 
     @try {
         [m_synchronizer addRenderer:m_displayLayer.get()];


### PR DESCRIPTION
#### f7c86d502522e88c4a9dc8da5730059d7d6b6f87
<pre>
[Alternate WebM Player] Allow device sleep during playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=242317">https://bugs.webkit.org/show_bug.cgi?id=242317</a>

Reviewed by Jer Noble.

Currently the AVSampleBufferDisplayLayer will prevent the display from
sleeping by default. However, in order to improve battery life on devices,
the display should be able to sleep regardless of whether or not a video
is playing within the layer.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::ensureLayer):

Canonical link: <a href="https://commits.webkit.org/252123@main">https://commits.webkit.org/252123@main</a>
</pre>
