### PR TITLE
vw units doesn't get updated inside shadow trees as frame is resized

### DIFF
--- a/LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units-expected.html
+++ b/LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div style="width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units.html
+++ b/LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+const iframe = document.createElement('iframe');
+iframe.scrolling = 'no';
+iframe.style = 'border: none; width: 50px; height: 50px; overflow: hidden';
+iframe.src = `data:text/html,<!DOCTYPE html><style>head,html,body { padding: 0; margin: 0; }</style>
+<div style="width: 100vw; height: 50vw; background: green"></div>
+<div style="width: 100px; height: 100px; background: red;"><div id="host"></div></div>
+<script>host.attachShadow({mode: 'closed'}).innerHTML =
+    '<style> div { width: 100vw; height: 50vw; background: green; }</style><div></div>';
+host.getBoundingClientRect();
+</sc` + `ript>`;
+iframe.onload = () => {
+    iframe.style.width = '100px';
+    iframe.style.height = '100px';
+}
+document.body.appendChild(iframe);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4351,17 +4351,7 @@ void Document::evaluateMediaQueriesAndReportChanges()
 
 void Document::updateViewportUnitsOnResize()
 {
-    if (!hasStyleWithViewportUnits())
-        return;
-
-    styleScope().resolver().clearCachedDeclarationsAffectedByViewportUnits();
-
-    // FIXME: Ideally, we should save the list of elements that have viewport units and only iterate over those.
-    for (RefPtr element = ElementTraversal::firstWithin(rootNode()); element; element = ElementTraversal::nextIncludingPseudo(*element)) {
-        auto* renderer = element->renderer();
-        if (renderer && renderer->style().usesViewportUnits())
-            element->invalidateStyle();
-    }
+    styleScope().didChangeViewportSize();
 }
 
 void Document::setNeedsDOMWindowResizeEvent()

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -107,6 +107,8 @@ public:
     // The change is assumed to potentially affect all author and user stylesheets including shadow roots.
     WEBCORE_EXPORT void didChangeStyleSheetEnvironment();
 
+    void didChangeViewportSize();
+
     void invalidateMatchedDeclarationsCache();
 
     bool hasPendingUpdate() const { return m_pendingUpdate || m_hasDescendantWithPendingUpdate; }


### PR DESCRIPTION
#### 183e16cd8e477213dff4b6a30f78d95e21c528fa
<pre>
vw units doesn&apos;t get updated inside shadow trees as frame is resized
<a href="https://bugs.webkit.org/show_bug.cgi?id=216240">https://bugs.webkit.org/show_bug.cgi?id=216240</a>

Reviewed by Simon Fraser.

The bug was caused by Document::updateViewportUnitsOnResize only updating the style resolver of
the document and invalidating styles of nodes in the document tree. Fixed the bug by also
updating the style resolver and invalidating styles of nodes in each shadow tree.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateViewportUnitsOnResize):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::didChangeViewportSize): Added. Moved from updateViewportUnitsOnResize.
* Source/WebCore/style/StyleScope.h:

* LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units-expected.html: Added.
* LayoutTests/fast/shadow-dom/shadow-style-invalidation-vw-units.html: Added.

Canonical link: <a href="https://commits.webkit.org/252148@main">https://commits.webkit.org/252148@main</a>
</pre>
