### PR TITLE
[results.webkit.org] Link test names to Github

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(3, 1, 8)
+version = Version(3, 1, 9)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
@@ -197,4 +197,22 @@ function elapsedTime(startTimestamp, endTimestamp)
     return result;
 }
 
-export {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, QueryModifier, escapeHTML, linkify, percentage, elapsedTime};
+function toGithubLink(file, suite) {
+    let baseURL = 'https://github.com/WebKit/WebKit/blob/main/';
+    switch (suite) {
+        case 'api-tests':
+            return '#';
+        case 'javascriptcore-tests':
+            return '#';
+        case 'layout-tests':
+            baseURL += 'LayoutTests';
+            break;
+        case 'webkitpy-tests':
+            baseURL += 'Tools/Scripts/libraries/';
+            baseURL += file.split('.')[0] + '/';
+            file = file.replace('.', '/');
+    }
+    return baseURL + '/' + file;
+}
+
+export {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, QueryModifier, escapeHTML, linkify, percentage, elapsedTime, toGithubLink};

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -31,7 +31,7 @@
 
 <script type="module">
 import {CommitBank} from '/assets/js/commit.js';
-import {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, escapeHTML} from '/assets/js/common.js';
+import {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, escapeHTML, toGithubLink} from '/assets/js/common.js';
 import {Configuration} from '/assets/js/configuration.js';
 import {Drawer, BranchSelector, ConfigurationSelectors, LimitSlider, CommitRepresentation} from '/assets/js/drawer.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
@@ -117,7 +117,10 @@ class SearchView {
 
                     return `<div class="section">
                             <div class="header">
-                                <div class="title" style="font-size:var(--smallSize);word-break:break-word;">${escapeHTML(child.test)} (${escapeHTML(child.suite)})</div>
+                                <div class="title" style="font-size:var(--smallSize);word-break:break-word;">
+                                    <a href="${toGithubLink(escapeHTML(child.test), child.suite)}" target="_blank">${escapeHTML(child.test)}</a>
+                                    (${escapeHTML(child.suite)})
+                                </div>
                                 <div class="actions">
                                 <div class="list">
                                     <a class="item link-button" ref="${exitRef}">X</a>

--- a/Tools/Scripts/libraries/resultsdbpy/setup.py
+++ b/Tools/Scripts/libraries/resultsdbpy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='resultsdbpy',
-    version='3.1.8',
+    version='3.1.9',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 65689f0028ca107f662ae813f56a88c16b45a240
<pre>
[results.webkit.org] Link test names to Github
<a href="https://bugs.webkit.org/show_bug.cgi?id=242320">https://bugs.webkit.org/show_bug.cgi?id=242320</a>

Reviewed by NOBODY (OOPS!).

This patch allows the test names in the webkit test results viewer to be
clickable, linking to the contents of the test.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js:
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html:
* Tools/Scripts/libraries/resultsdbpy/setup.py:
</pre>