### PR TITLE
[Alternate WebM Player] Add wireless playback support

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -47,6 +47,7 @@ namespace WebCore {
 class AudioTrackPrivateWebM;
 class FragmentedSharedBuffer;
 class MediaDescription;
+class MediaPlaybackTarget;
 class MediaSample;
 class MediaSampleAVFObjC;
 class ResourceError;
@@ -151,6 +152,13 @@ private:
     bool requiresTextTrackRepresentation() const final;
     void setTextTrackRepresentation(TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
+        
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    bool isCurrentPlaybackTargetWireless() const final;
+    void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) final;
+    void setShouldPlayToPlaybackTarget(bool) final;
+    bool wirelessVideoPlaybackDisabled() const final { return false; }
+#endif
 
     void enqueueSample(Ref<MediaSample>&&, uint64_t);
     void reenqueSamples(uint64_t);
@@ -223,6 +231,10 @@ private:
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    RefPtr<MediaPlaybackTarget> m_playbackTarget;
+    bool m_shouldPlayToTarget { false };
+#endif
     Ref<const Logger> m_logger;
     const void* m_logIdentifier;
     std::unique_ptr<VideoLayerManagerObjC> m_videoLayerManager;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -31,6 +31,7 @@
 #import "AudioTrackPrivateWebM.h"
 #import "FloatSize.h"
 #import "Logging.h"
+#import "MediaPlaybackTarget.h"
 #import "MediaPlayer.h"
 #import "MediaSampleAVFObjC.h"
 #import "NotImplemented.h"
@@ -501,6 +502,35 @@ void MediaPlayerPrivateWebM::setTextTrackRepresentation(TextTrackRepresentation*
     auto* representationLayer = representation ? representation->platformLayer() : nil;
     m_videoLayerManager->setTextTrackRepresentationLayer(representationLayer);
 }
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+void MediaPlayerPrivateWebM::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& target)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_playbackTarget = WTFMove(target);
+}
+
+void MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget(bool shouldPlayToTarget)
+{
+    if (shouldPlayToTarget == m_shouldPlayToTarget)
+        return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, shouldPlayToTarget);
+    m_shouldPlayToTarget = shouldPlayToTarget;
+
+    m_player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless());
+}
+
+bool MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless() const
+{
+    if (!m_playbackTarget)
+        return false;
+
+    auto hasTarget = m_shouldPlayToTarget && m_playbackTarget->hasActiveRoute();
+    INFO_LOG(LOGIDENTIFIER, hasTarget);
+    return hasTarget;
+}
+#endif
 
 void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, uint64_t trackId)
 {


### PR DESCRIPTION
#### b29e62f86fe411d46c963e3d0a5c0049e8d94b3d
<pre>
[Alternate WebM Player] Add wireless playback support
<a href="https://bugs.webkit.org/show_bug.cgi?id=242321">https://bugs.webkit.org/show_bug.cgi?id=242321</a>

Reviewed by Eric Carlson.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless const):

Canonical link: <a href="https://commits.webkit.org/252141@main">https://commits.webkit.org/252141@main</a>
</pre>
