### PR TITLE
AffineTranform variables should be able to be constexpr

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -36,14 +36,13 @@ SourceBrush::SourceBrush(const Color& color, std::optional<Brush>&& brush)
 
 const AffineTransform& SourceBrush::gradientSpaceTransform() const
 {
-    static NeverDestroyed<AffineTransform> identity;
     if (!m_brush)
-        return identity.get();
+        return identity;
 
     if (auto* gradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush))
         return gradient->spaceTransform;
 
-    return identity.get();
+    return identity;
 }
 
 Gradient* SourceBrush::gradient() const

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -56,7 +56,7 @@ FontCascade::FontCascade(const FontPlatformData& fontData, FontSmoothingMode fon
 
 static const AffineTransform& rotateLeftTransform()
 {
-    static AffineTransform result(0, -1, 1, 0, 0, 0);
+    static constexpr AffineTransform result(0, -1, 1, 0, 0, 0);
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -38,28 +38,6 @@
 
 namespace WebCore {
 
-#if COMPILER(MSVC)
-AffineTransform::AffineTransform()
-{
-    m_transform = { 1, 0, 0, 1, 0, 0 };
-}
-
-AffineTransform::AffineTransform(double a, double b, double c, double d, double e, double f)
-{
-    m_transform = { a, b, c, d, e, f };
-}
-#else
-AffineTransform::AffineTransform()
-    : m_transform { { 1, 0, 0, 1, 0, 0 } }
-{
-}
-
-AffineTransform::AffineTransform(double a, double b, double c, double d, double e, double f)
-    : m_transform{ { a, b, c, d, e, f } }
-{
-}
-#endif
-
 void AffineTransform::makeIdentity()
 {
     setMatrix(1, 0, 0, 1, 0, 0);

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -57,8 +57,8 @@ class TransformationMatrix;
 class AffineTransform {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT AffineTransform();
-    WEBCORE_EXPORT AffineTransform(double a, double b, double c, double d, double e, double f);
+    constexpr AffineTransform();
+    constexpr AffineTransform(double a, double b, double c, double d, double e, double f);
 
 #if USE(CG)
     WEBCORE_EXPORT AffineTransform(const CGAffineTransform&);
@@ -218,5 +218,17 @@ private:
 WEBCORE_EXPORT AffineTransform makeMapBetweenRects(const FloatRect& source, const FloatRect& dest);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const AffineTransform&);
+
+constexpr AffineTransform::AffineTransform()
+    : m_transform { { 1, 0, 0, 1, 0, 0 } }
+{
+}
+
+constexpr AffineTransform::AffineTransform(double a, double b, double c, double d, double e, double f)
+    : m_transform { { a, b, c, d, e, f } }
+{
+}
+
+static constexpr inline AffineTransform identity;
 
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1947,13 +1947,11 @@ FloatRect RenderObject::repaintRectInLocalCoordinates() const
 
 AffineTransform RenderObject::localTransform() const
 {
-    static const AffineTransform identity;
-    return identity;
+    return AffineTransform();
 }
 
 const AffineTransform& RenderObject::localToParentTransform() const
 {
-    static const AffineTransform identity;
     return identity;
 }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -67,7 +67,7 @@ public:
     // Important functions used by nearly all SVG renderers centralizing coordinate transformations / repaint rect calculations
     static LayoutRect clippedOverflowRectForRepaint(const RenderElement&, const RenderLayerModelObject* container);
     static std::optional<FloatRect> computeFloatVisibleRectInContainer(const RenderElement&, const FloatRect&, const RenderLayerModelObject* container, RenderObject::VisibleRectContext);
-    static const RenderElement& localToParentTransform(const RenderElement&, AffineTransform &);
+    static const RenderElement& localToParentTransform(const RenderElement&, AffineTransform&);
     static void mapLocalToContainer(const RenderElement&, const RenderLayerModelObject* ancestorContainer, TransformState&, bool* wasFixed);
     static const RenderElement* pushMappingToContainer(const RenderElement&, const RenderLayerModelObject* ancestorToStopAt, RenderGeometryMap&);
     static bool checkForSVGRepaintDuringLayout(const RenderElement&);

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
@@ -240,7 +240,7 @@ public:
 
         auto fromItemsSize = fromItems.size();
 
-        static const AffineTransform zerosAffineTransform = { 0, 0, 0, 0, 0, 0 };
+        static constexpr AffineTransform zerosAffineTransform = { 0, 0, 0, 0, 0, 0 };
         const SVGTransformValue& to = toItems[0]->value();
         const SVGTransformValue zerosTransform = SVGTransformValue(to.type(), zerosAffineTransform);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/AffineTransform.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/AffineTransform.cpp
@@ -955,8 +955,6 @@ TEST(AffineTransform, ToTransformationMatrix)
 
 TEST(AffineTransform, MakeMapBetweenRects)
 {
-    WebCore::AffineTransform transform;
-
     WebCore::FloatRect fromRect(10.0f, 10.0f, 100.0f, 100.0f);
     WebCore::FloatRect toRect(70.0f, 70.0f, 200.0f, 50.0f);
 
@@ -968,6 +966,14 @@ TEST(AffineTransform, MakeMapBetweenRects)
     EXPECT_DOUBLE_EQ(0.5, mapBetween.d());
     EXPECT_DOUBLE_EQ(60.0, mapBetween.e());
     EXPECT_DOUBLE_EQ(60.0, mapBetween.f());
+}
+
+TEST(AffineTransform, Constexpr)
+{
+    static constexpr WebCore::AffineTransform transform;
+    UNUSED_VARIABLE(transform);
+    static constexpr WebCore::AffineTransform transform2(1, 2, 3, 4, 5, 6);
+    UNUSED_VARIABLE(transform2);
 }
 
 #if USE(CG)


### PR DESCRIPTION
#### 9aa7ca7e355a7c79be8fb60dc61f6ebea652c605
<pre>
AffineTranform variables should be able to be constexpr
<a href="https://bugs.webkit.org/show_bug.cgi?id=242323">https://bugs.webkit.org/show_bug.cgi?id=242323</a>

Reviewed by Cameron McCormack.

If we make the AffineTransform constructor constexpr by moving it into the header,
it will then be possible to have AffineTransform variables be constexpr.

The style checker fails because it says the parameter names in
AffineTransform(double a, double b, double c, double d, double e, double f)
are redundant. However, these names are terms-of-art for the values in an affine
transformation matrix.

* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::gradientSpaceTransform const):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::rotateLeftTransform):
* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(WebCore::AffineTransform::AffineTransform): Deleted.
* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
(WebCore::AffineTransform::AffineTransform):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localTransform const):
(WebCore::RenderObject::localToParentTransform const):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h:
(WebCore::SVGAnimationTransformListFunction::animate):
* Tools/TestWebKitAPI/Tests/WebCore/AffineTransform.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252127@main">https://commits.webkit.org/252127@main</a>
</pre>
