### PR TITLE
RemoteResourceCacheProxy::clearDecomposedGlyphsMap should deregister observers

### DIFF
--- a/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash-expected.txt
+++ b/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash-expected.txt
@@ -1,0 +1,3 @@
+Test passes if the Web process doesn't crash.
+
+

--- a/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html
+++ b/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForDOMRenderingEnabled=true ] -->
+<script>
+if (window.testRunner && window.internals) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    internals.setForceUseGlyphDisplayListForTesting(true);
+}
+</script>
+<body onload="run()">
+<p>Test passes if the Web process doesn't crash.</p>
+<pre id=log></pre>
+<script>
+function run() {
+    if (window.internals && window.testRunner) {
+        requestAnimationFrame(function() {
+            requestAnimationFrame(function() {
+                if (!internals.cachedGlyphDisplayListsForTextNode(document.querySelector("p").firstChild))
+                    log.textContent = "FAIL: GlyphDisplayList not created";
+                testRunner.terminateGPUProcess();
+                requestAnimationFrame(function() {
+                    internals.setForceUseGlyphDisplayListForTesting(false);
+                    internals.clearGlyphDisplayListCacheForTesting();
+                    testRunner.notifyDone();
+                });
+            });
+        });
+    }
+}
+</script>

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -230,6 +230,11 @@ void TextPainter::setForceUseGlyphDisplayListForTesting(bool enabled)
     forceUseGlyphDisplayListForTesting = enabled;
 }
 
+void TextPainter::clearGlyphDisplayListCacheForTesting()
+{
+    GlyphDisplayListCache::singleton().clear();
+}
+
 String TextPainter::cachedGlyphDisplayListsForTextNodeAsText(Text& textNode, OptionSet<DisplayList::AsTextFlag> flags)
 {
     if (!textNode.renderer())

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -78,6 +78,7 @@ public:
     static bool shouldUseGlyphDisplayList(const PaintInfo&);
     WEBCORE_EXPORT static void setForceUseGlyphDisplayListForTesting(bool);
     WEBCORE_EXPORT static String cachedGlyphDisplayListsForTextNodeAsText(Text&, OptionSet<DisplayList::AsTextFlag>);
+    WEBCORE_EXPORT static void clearGlyphDisplayListCacheForTesting();
 
 private:
     template<typename LayoutRun>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3271,6 +3271,11 @@ void Internals::setForceUseGlyphDisplayListForTesting(bool enabled)
     TextPainter::setForceUseGlyphDisplayListForTesting(enabled);
 }
 
+void Internals::clearGlyphDisplayListCacheForTesting()
+{
+    TextPainter::clearGlyphDisplayListCacheForTesting();
+}
+
 ExceptionOr<String> Internals::cachedGlyphDisplayListsForTextNode(Node& node, unsigned short flags)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -485,6 +485,7 @@ public:
 
     void setForceUseGlyphDisplayListForTesting(bool enabled);
     ExceptionOr<String> cachedGlyphDisplayListsForTextNode(Node&, unsigned short flags);
+    void clearGlyphDisplayListCacheForTesting();
 
     ExceptionOr<void> garbageCollectDocumentResources() const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -620,6 +620,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     undefined setForceUseGlyphDisplayListForTesting(boolean enabled);
     DOMString cachedGlyphDisplayListsForTextNode(Node node, optional unsigned short flags = 0);
+    undefined clearGlyphDisplayListCacheForTesting();
 
     undefined garbageCollectDocumentResources();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -196,6 +196,8 @@ void RemoteResourceCacheProxy::clearImageBufferBackends()
 
 void RemoteResourceCacheProxy::clearDecomposedGlyphsMap()
 {
+    for (auto& decomposedGlyphs : m_decomposedGlyphs.values())
+        decomposedGlyphs->removeObserver(*this);
     m_decomposedGlyphs.clear();
 }
 


### PR DESCRIPTION
#### d1b1809daffb4b06b6626c72be82bf28e5bd2881
<pre>
RemoteResourceCacheProxy::clearDecomposedGlyphsMap should deregister observers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242325">https://bugs.webkit.org/show_bug.cgi?id=242325</a>
rdar://96209023

Reviewed by Myles C. Maxfield.

Similar to clearNativeImageMap, clearDecomposedGlyphsMap should
deregister the DecomposedGlyphs observers when we clear out
m_decomposedGlyphs, since we no longer need to observe them.

* LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash-expected.txt: Added.
* LayoutTests/fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html: Added.
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::clearGlyphDisplayListCacheForTesting):
* Source/WebCore/rendering/TextPainter.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::clearGlyphDisplayListCacheForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::clearDecomposedGlyphsMap):

Canonical link: <a href="https://commits.webkit.org/252170@main">https://commits.webkit.org/252170@main</a>
</pre>
