### PR TITLE
[WebGPU] Strengthen compiler warnings

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2022 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -22,8 +22,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Version.xcconfig"
-
-WARNING_CFLAGS = -Wall -Wextra -Wcast-qual -Wchar-subscripts -Wconditional-uninitialized -Wextra-tokens -Wformat=2 -Winit-self -Wmissing-format-attribute -Wmissing-noreturn -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-typedef-redefinition -Wno-ignored-qualifiers;
 
 HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(inherited);
 SYSTEM_HEADER_SEARCH_PATHS = $(SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/metal-cpp $(inherited);


### PR DESCRIPTION
#### 7695fde06b253a55eb0fa162f190ec1cf67c4772
<pre>
[WebGPU] Strengthen compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=242326">https://bugs.webkit.org/show_bug.cgi?id=242326</a>

Reviewed by Dean Jackson.

Base.xcconfig has a set of warnings to enable, and WebGPU.xcconfig has a slightly more permissive
set of warnings which override the ones from Base.xcconfig. This patch deletes the override in
WebGPU.xcconfig so the more strict warnings from Base.xcconfig can shine through.

Importantly, this patch has the effect of adding -Wglobal-constructors in WebGPU.

* Source/WebGPU/Configurations/WebGPU.xcconfig:

Canonical link: <a href="https://commits.webkit.org/252147@main">https://commits.webkit.org/252147@main</a>
</pre>
