### PR TITLE
[GStreamer][VideoCapture] Use GRefPtr for GstSample in pushSample

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -219,7 +219,7 @@ public:
         });
     }
 
-    void pushSample(GstSample* sample)
+    void pushSample(GRefPtr<GstSample>&& sample)
     {
         ASSERT(m_src);
         if (!m_src || !m_isObserving)
@@ -229,8 +229,8 @@ public:
         webkitMediaStreamSrcEnsureStreamCollectionPosted(parent);
 
         bool drop = m_enoughData;
-        auto* buffer = gst_sample_get_buffer(sample);
-        auto* caps = gst_sample_get_caps(sample);
+        auto* buffer = gst_sample_get_buffer(sample.get());
+        auto* caps = gst_sample_get_caps(sample.get());
         if (!GST_CLOCK_TIME_IS_VALID(m_firstBufferPts)) {
             m_firstBufferPts = GST_BUFFER_PTS(buffer);
             auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
@@ -251,7 +251,7 @@ public:
             m_needsDiscont = false;
         }
 
-        gst_app_src_push_sample(GST_APP_SRC(m_src.get()), sample);
+        gst_app_src_push_sample(GST_APP_SRC(m_src.get()), sample.get());
     }
 
     void trackStarted(MediaStreamTrackPrivate&) final { };
@@ -309,7 +309,7 @@ public:
 
         if (m_track.enabled()) {
             GST_TRACE_OBJECT(m_src.get(), "Pushing video frame from enabled track");
-            pushSample(gstSample);
+            pushSample(WTFMove(gstSample));
             return;
         }
 


### PR DESCRIPTION
#### 45a54d033d592a49098393f66a1807659a161abc
<pre>
[GStreamer][VideoCapture] Use GRefPtr for GstSample in pushSample
<a href="https://bugs.webkit.org/show_bug.cgi?id=242332">https://bugs.webkit.org/show_bug.cgi?id=242332</a>

Reviewed by NOBODY (OOPS!).

This appears to be needed for the sample to get unref&apos;d properly.

Appears to fix:
webkitmediastreamsrc GStreamerMediaStreamSource.cpp:311:videoFrameAvailable:&lt;videosrc&gt; Pushing video frame from enabled track
webkitmediastreamsrc GStreamerMediaStreamSource.cpp:245:pushSample:&lt;videosrc&gt; Video queue full already... not pushing

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
</pre>