### PR TITLE
SharedVideoFrameWriter can hang on its semaphore in case of bad CVPixelBuffers

### DIFF
--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -77,6 +77,8 @@ public:
     bool isDisabled() const { return m_isDisabled; }
 
 private:
+    static constexpr Seconds defaultTimeout = 3_s;
+
     bool wait(const Function<void(IPC::Semaphore&)>&);
     bool allocateStorage(size_t, const Function<void(const SharedMemory::IPCHandle&)>&);
     bool prepareWriting(const WebCore::SharedVideoFrameInfo&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
@@ -85,11 +87,13 @@ private:
 #if USE(LIBWEBRTC)
     std::optional<SharedVideoFrame::Buffer> writeBuffer(webrtc::VideoFrameBuffer&, const Function<void(IPC::Semaphore&)>&, const Function<void(const SharedMemory::IPCHandle&)>&);
 #endif
+    void signalInCaseOfError();
 
     UniqueRef<IPC::Semaphore> m_semaphore;
     RefPtr<SharedMemory> m_storage;
     bool m_isSemaphoreInUse { false };
     bool m_isDisabled { false };
+    bool m_shouldSignalInCaseOfError { false };
 };
 
 class SharedVideoFrameReader {


### PR DESCRIPTION
#### 688b3680bbeb7b00b0174074ee8eb9fa025d1dea
<pre>
SharedVideoFrameWriter can hang on its semaphore in case of bad CVPixelBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242334">https://bugs.webkit.org/show_bug.cgi?id=242334</a>
rdar://95326241

Reviewed by Eric Carlson.

Before writing to shared memory, the writer is waiting on its counterpart reader to signal that memory can be written.
This works fine except if the writer fails to write data, in which case the reader will not notify that memory can be written.
Write failure for instance happens if data cannot be read from the pixel buffer.
To fix this, the writer will signal its semaphore that it does not need to wait in case of write failure.

* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::wait):
(WebKit::SharedVideoFrameWriter::prepareWriting):
(WebKit::SharedVideoFrameWriter::writeBuffer):
(WebKit::SharedVideoFrameWriter::signalInCaseOfError):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/252136@main">https://commits.webkit.org/252136@main</a>
</pre>
