### PR TITLE
WorkerCacheStorageConnection should check for its worker thread run loop to not be terminated when initialising its connection

### DIFF
--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
@@ -133,7 +133,8 @@ static Ref<CacheStorageConnection> createMainThreadConnection(WorkerGlobalScope&
 {
     RefPtr<CacheStorageConnection> mainThreadConnection;
     callOnMainThreadAndWait([workerThread = Ref { scope.thread() }, &mainThreadConnection]() mutable {
-        mainThreadConnection = workerThread->workerLoaderProxy().createCacheStorageConnection();
+        if (!workerThread->runLoop().terminated())
+            mainThreadConnection = workerThread->workerLoaderProxy().createCacheStorageConnection();
         if (!mainThreadConnection) {
             RELEASE_LOG_INFO(ServiceWorker, "Creating stopped WorkerCacheStorageConnection");
             mainThreadConnection = StoppedCacheStorageConnection::create();


### PR DESCRIPTION
#### f6fbd1d5f621579fdc17521ee9beaa5f4a04ca7b
<pre>
WorkerCacheStorageConnection should check for its worker thread run loop to not be terminated when initialising its connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=242336">https://bugs.webkit.org/show_bug.cgi?id=242336</a>
rdar://54340159

Reviewed by Chris Dumez.

We do not need to get the real connection if the worker is already stopped.

* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::createMainThreadConnection):

Canonical link: <a href="https://commits.webkit.org/252328@main">https://commits.webkit.org/252328@main</a>
</pre>
