### PR TITLE
[FreeType] Add implementation for FontPlatformData::variationAxes()

### DIFF
--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -68,7 +68,7 @@ FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source,
 }
 #endif
 
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && !USE(FREETYPE)
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames) const
 {
     // FIXME: <webkit.org/b/219614> Not implemented yet.

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h
@@ -19,12 +19,28 @@
 
 #pragma once
 
+#include "FontTaggedSettings.h"
+#include "ShouldLocalizeAxisNames.h"
+#include <wtf/HashMap.h>
+
 typedef struct FT_FaceRec_* FT_Face;
 
 namespace WebCore {
 class FontDescription;
 
 #if ENABLE(VARIATION_FONTS)
+struct VariationDefaults {
+    String axisName;
+    float defaultValue;
+    float minimumValue;
+    float maximumValue;
+};
+
+typedef HashMap<FontTag, VariationDefaults, FourCharacterTagHash, FourCharacterTagHashTraits> VariationDefaultsMap;
+typedef HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits> VariationsMap;
+
+VariationDefaultsMap defaultVariationValues(FT_Face, ShouldLocalizeAxisNames);
+
 String buildVariationSettings(FT_Face, const FontDescription&);
 #endif
 };


### PR DESCRIPTION
#### ba912621d7bd2e408678b84f167c7982a70ff909
<pre>
[FreeType] Add implementation for FontPlatformData::variationAxes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242337">https://bugs.webkit.org/show_bug.cgi?id=242337</a>

Reviewed by Michael Catanzaro.

This will make font variation values to be shown in the inspector.

* Source/WebCore/platform/graphics/FontPlatformData.cpp:
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::fontNameMapName): Helper to get a name from a font name table.
(WebCore::defaultVariationValues): Make it public and add
ShouldLocalizeAxisNames parameter.
(WebCore::buildVariationSettings): Pass ShouldLocalizeAxisNames::No to
defaultVariationValues.
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.h:
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::variationAxes const):

Canonical link: <a href="https://commits.webkit.org/252134@main">https://commits.webkit.org/252134@main</a>
</pre>
