### PR TITLE
ServiceWorkerFetch::dispatchFetchEvent active registration assert is no longer true

### DIFF
--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -170,7 +170,8 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
 
     ASSERT(globalScope.registration().active());
     ASSERT(globalScope.registration().active()->identifier() == globalScope.thread().identifier());
-    ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated);
+    // FIXME: we should use the same path for registration changes as for fetch events.
+    ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated || globalScope.registration().active()->state() == ServiceWorkerState::Activating);
 
     auto* formData = request.httpBody();
     std::optional<FetchBody> body;


### PR DESCRIPTION
#### 57b6a2102bd23f06e30ccd29385de8eb19782544
<pre>
ServiceWorkerFetch::dispatchFetchEvent active registration assert is no longer true
<a href="https://bugs.webkit.org/show_bug.cgi?id=241627">https://bugs.webkit.org/show_bug.cgi?id=241627</a>
rdar://problem/95670031

Reviewed by Chris Dumez.

Update the assert to account for the potential race condition between fetch event messages
and messages to update the registration from activating to activated.

* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):

Canonical link: <a href="https://commits.webkit.org/252152@main">https://commits.webkit.org/252152@main</a>
</pre>
