### PR TITLE
Update debug assertion in RtpSenderBase::SetSsrc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
@@ -291,7 +291,7 @@ void RtpSenderBase::SetSsrc(uint32_t ssrc) {
       // we need to copy.
       RtpParameters current_parameters =
           media_channel_->GetRtpSendParameters(ssrc_);
-      RTC_DCHECK_GE(current_parameters.encodings.size(),
+      RTC_CHECK_GE(current_parameters.encodings.size(),
                     init_parameters_.encodings.size());
       for (size_t i = 0; i < init_parameters_.encodings.size(); ++i) {
         init_parameters_.encodings[i].ssrc =


### PR DESCRIPTION
#### 8c5e775d2f16fc74a7cc0387d7a74ab8713ac7cc
<pre>
Update debug assertion in RtpSenderBase::SetSsrc
<a href="https://bugs.webkit.org/show_bug.cgi?id=242339">https://bugs.webkit.org/show_bug.cgi?id=242339</a>

Reviewed by Geoffrey Garen.

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc:

Canonical link: <a href="https://commits.webkit.org/252135@main">https://commits.webkit.org/252135@main</a>
</pre>
