### PR TITLE
Web Inspector: Screenshots timeline overview records do not adjust their position when zooming in/out

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.js
@@ -67,10 +67,8 @@ WI.ScreenshotsTimelineOverviewGraph = class ScreenshotsTimelineOverviewGraph ext
         let secondsPerPixel = this.timelineOverview.secondsPerPixel;
 
         for (let record of this._visibleRecords()) {
-            this.element.appendChild(this._imageElementForRecord.getOrInitialize(record, () => {
+            let recordElement = this.element.appendChild(this._imageElementForRecord.getOrInitialize(record, () => {
                 let imageElement = document.createElement("img");
-                imageElement.height = this.height;
-                imageElement.style.left = (record.startTime - this.startTime) / secondsPerPixel + "px";
 
                 imageElement.hidden = true;
                 imageElement.addEventListener("load", (event) => {
@@ -87,6 +85,9 @@ WI.ScreenshotsTimelineOverviewGraph = class ScreenshotsTimelineOverviewGraph ext
 
                 return imageElement;
             }));
+
+            recordElement.style.left = (record.startTime - this.startTime) / secondsPerPixel + "px";
+            recordElement.height = this.height;
         }
 
         if (this._lastSelectedRecordInLayout)


### PR DESCRIPTION
#### 554e2e83586998432ddbbb1bb7b7182c63960697
<pre>
Web Inspector: Screenshots timeline overview records do not adjust their position when zooming in/out
<a href="https://bugs.webkit.org/show_bug.cgi?id=242341">https://bugs.webkit.org/show_bug.cgi?id=242341</a>
rdar://96325691

Reviewed by Devin Rousso.

The position of the images should not only be set during initialization of the record&apos;s image element, but also during
each layout.

* Source/WebInspectorUI/UserInterface/Views/ScreenshotsTimelineOverviewGraph.js:
(WI.ScreenshotsTimelineOverviewGraph.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/252148@main">https://commits.webkit.org/252148@main</a>
</pre>
