### PR TITLE
[VideoCapture] Use LogMedia for non-WebRTC MediaStream loggers

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -383,7 +383,7 @@ bool MediaStream::virtualHasPendingActivity() const
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStream::logChannel() const
 {
-    return LogWebRTC;
+    return LogMedia;
 }
 #endif
     

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -679,7 +679,7 @@ bool MediaStreamTrack::isCapturingAudio() const
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStreamTrack::logChannel() const
 {
-    return LogWebRTC;
+    return LogMedia;
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -321,7 +321,7 @@ void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStreamPrivate::logChannel() const
 {
-    return LogWebRTC;
+    return LogMedia;
 }
 #endif
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -290,7 +290,7 @@ void MediaStreamTrackPrivate::audioUnitWillStart()
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStreamTrackPrivate::logChannel() const
 {
-    return LogWebRTC;
+    return LogMedia;
 }
 #endif
 


### PR DESCRIPTION
#### 041fe47311f947ccb3622b09acf369d36c21e8cc
<pre>
[VideoCapture] Use LogMedia for non-WebRTC MediaStream loggers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242349">https://bugs.webkit.org/show_bug.cgi?id=242349</a>

Reviewed by NOBODY (OOPS!).

LogWebRTC should not be used unless the message is WebRTC specifc.

* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::logChannel const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::logChannel const):
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::logChannel const):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::logChannel const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::logChannel const):
</pre>