### PR TITLE
Adjust VM heap growth factor

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -198,8 +198,8 @@ bool canUseWebAssemblyFastMemory();
     v(Double, smallHeapGrowthFactor, 2, Normal, nullptr) \
     v(Double, mediumHeapRAMFraction, 0.5, Normal, nullptr) \
     v(Double, mediumHeapGrowthFactor, 1.5, Normal, nullptr) \
-    v(Double, largeHeapGrowthFactor, 1.24, Normal, nullptr) \
-    v(Double, miniVMHeapGrowthFactor, 1.27, Normal, nullptr) \
+    v(Double, largeHeapGrowthFactor, 1.20, Normal, nullptr) \
+    v(Double, miniVMHeapGrowthFactor, 1.20, Normal, nullptr) \
     v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold") \
     v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)") \
     v(Double, minimumMutatorUtilization, 0, Normal, nullptr) \


### PR DESCRIPTION
#### 34d0653dff22775b387c17d94eb63277fa7ac3c0
<pre>
Adjust VM heap growth factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=242347">https://bugs.webkit.org/show_bug.cgi?id=242347</a>

Reviewed by Yusuke Suzuki.

We adjust VM heap growth factor to gain 0.5% RAMification progression.

* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/252169@main">https://commits.webkit.org/252169@main</a>
</pre>
