### PR TITLE
[iOS] "A problem repeatedly occurred" error page when safari resuming from background

### DIFF
--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -53,7 +53,7 @@ RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(Web
 {
     for (auto* suspendedPage : allSuspendedPages()) {
         auto& process = suspendedPage->process();
-        if (&process.processPool() == &processPool && process.registrableDomain() == registrableDomain && process.websiteDataStore() == &dataStore && process.crossOriginMode() != CrossOriginMode::Isolated && process.captivePortalMode() == captivePortalMode)
+        if (&process.processPool() == &processPool && process.registrableDomain() == registrableDomain && process.websiteDataStore() == &dataStore && process.crossOriginMode() != CrossOriginMode::Isolated && process.captivePortalMode() == captivePortalMode && !process.wasTerminated())
             return &process;
     }
     return nullptr;

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -160,11 +160,14 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::RegistrableD
 
     auto process = it->value->takeProcess();
     m_processesPerRegistrableDomain.remove(it);
-    WEBPROCESSCACHE_RELEASE_LOG("takeProcess: Taking process from WebProcess cache (size=%u, capacity=%u)", process->processIdentifier(), size(), capacity());
+    WEBPROCESSCACHE_RELEASE_LOG("takeProcess: Taking process from WebProcess cache (size=%u, capacity=%u, processWasTerminated=%d)", process->processIdentifier(), size(), capacity(), process->wasTerminated());
 
     ASSERT(!process->pageCount());
     ASSERT(!process->provisionalPageCount());
     ASSERT(!process->suspendedPageCount());
+
+    if (process->wasTerminated())
+        return nullptr;
 
     return process;
 }


### PR DESCRIPTION
#### 5798b62eae7cd3a697b0caca43ee922c5684d564
<pre>
[iOS] &quot;A problem repeatedly occurred&quot; error page when safari resuming from background
<a href="https://bugs.webkit.org/show_bug.cgi?id=242352">https://bugs.webkit.org/show_bug.cgi?id=242352</a>

Reviewed by Darin Adler.

Follow-up to 252108@main to take care of more cases where we might try to reuse a
terminated WebProcess during crash recovery, because we have not received the crash
notification for the back up process yet.

252108@main took care of processes reused from a related WKWebView. This patch takes
care of processes taken from the WebProcess cache or from a suspended page in the
back/forward list.

* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONNavigationDelegate webViewWebContentProcessDidTerminate:]):

Canonical link: <a href="https://commits.webkit.org/252177@main">https://commits.webkit.org/252177@main</a>
</pre>
