### PR TITLE
Add const to some fields that are meant to be immutable after construction.

### DIFF
--- a/Source/JavaScriptCore/bindings/ScriptFunctionCall.h
+++ b/Source/JavaScriptCore/bindings/ScriptFunctionCall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,7 +59,7 @@ public:
 
 protected:
     JSC::MarkedArgumentBuffer m_arguments;
-    JSC::JSGlobalObject* m_globalObject;
+    JSC::JSGlobalObject* const m_globalObject;
 
 private:
     // MarkedArgumentBuffer must be stack allocated, so prevent heap

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -263,7 +263,7 @@ public:
     }
     
 private:
-    CodeBlock* m_codeBlock;
+    CodeBlock* const m_codeBlock;
     const Identifier& m_ident;
 };
 
@@ -2350,8 +2350,8 @@ public:
     bool didRecurse() const { return m_didRecurse; }
 
 private:
-    CallFrame* m_startCallFrame;
-    CodeBlock* m_codeBlock;
+    CallFrame* const m_startCallFrame;
+    CodeBlock* const m_codeBlock;
     mutable unsigned m_depthToCheck;
     mutable bool m_foundStartCallFrame;
     mutable bool m_didRecurse;

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -913,8 +913,8 @@ private:
     template<typename Func>
     void forEachStructureStubInfo(Func);
 
-    unsigned m_numCalleeLocals;
-    unsigned m_numVars;
+    const unsigned m_numCalleeLocals;
+    const unsigned m_numVars;
     unsigned m_numParameters;
     unsigned m_numberOfArgumentsToSkip { 0 };
     uint32_t m_osrExitCounter { 0 };
@@ -934,9 +934,9 @@ private:
     WriteBarrier<ScriptExecutable> m_ownerExecutable;
     // m_vm must be a pointer (instead of a reference) because the JSCLLIntOffsetsExtractor
     // cannot handle it being a reference.
-    VM* m_vm;
+    VM* const m_vm;
 
-    const void* m_instructionsRawPointer { nullptr };
+    const void* const m_instructionsRawPointer { nullptr };
     SentinelLinkedList<CallLinkInfo, PackedRawSentinelNode<CallLinkInfo>> m_incomingCalls;
 #if ENABLE(JIT)
     SentinelLinkedList<PolymorphicCallNode, PackedRawSentinelNode<PolymorphicCallNode>> m_incomingPolymorphicCalls;

--- a/Source/JavaScriptCore/bytecode/CodeBlockWithJITType.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockWithJITType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,8 +45,8 @@ public:
         m_codeBlock->dumpAssumingJITType(out, m_jitType);
     }
 private:
-    CodeBlock* m_codeBlock;
-    JITType m_jitType;
+    CodeBlock* const m_codeBlock;
+    JITType const m_jitType;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/FullCodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/FullCodeOrigin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,8 +44,8 @@ public:
     void dumpInContext(PrintStream&, DumpContext*) const;
 
 private:
-    CodeBlock* m_codeBlock;
-    CodeOrigin m_codeOrigin;
+    CodeBlock* const m_codeBlock;
+    const CodeOrigin m_codeOrigin;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.h
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -202,7 +202,7 @@ struct AccessGenerationState {
     {
     }
     VM& m_vm;
-    JSGlobalObject* m_globalObject;
+    JSGlobalObject* const m_globalObject;
     CCallHelpers* jit { nullptr };
     ScratchRegisterAllocator* allocator;
     ScratchRegisterAllocator::PreservedState preservedReusedRegisterState;
@@ -216,7 +216,7 @@ struct AccessGenerationState {
     JSValueRegs valueRegs;
     GPRReg scratchGPR { InvalidGPRReg };
     FPRReg scratchFPR { InvalidFPRReg };
-    ECMAMode m_ecmaMode { ECMAMode::sloppy() };
+    const ECMAMode m_ecmaMode { ECMAMode::sloppy() };
     std::unique_ptr<WatchpointsOnStructureStubInfo> watchpoints;
     Vector<StructureID> weakStructures;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,8 +106,8 @@ public:
     bool isValid() const;
     
 private:
-    CodeBlock* m_codeBlock;
-    StructureStubInfo* m_stubInfo;
+    CodeBlock* const m_codeBlock;
+    StructureStubInfo* const m_stubInfo;
     // FIXME: use less memory for the entries in this Bag:
     // https://bugs.webkit.org/show_bug.cgi?id=202380
     Bag<std::variant<StructureTransitionStructureStubClearingWatchpoint, AdaptiveValueStructureStubClearingWatchpoint>> m_watchpoints;

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
  *
@@ -703,7 +703,7 @@ public:
     }
 
 private:
-    JSGlobalObject* m_globalObject;
+    JSGlobalObject* const m_globalObject;
 };
 
 void Debugger::clearDebuggerRequests(JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
+++ b/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,7 +70,7 @@ public:
     }
 
 private:
-    JSGlobalObject* m_globalObject;
+    JSGlobalObject* const m_globalObject;
     bool m_evalWasDisabled { false };
 #if ASSERT_ENABLED
     DebuggerEvalEnabler::Mode m_mode;

--- a/Source/JavaScriptCore/debugger/ScriptProfilingScope.h
+++ b/Source/JavaScriptCore/debugger/ScriptProfilingScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,9 +81,9 @@ private:
         return true;
     }
 
-    JSGlobalObject* m_globalObject { nullptr };
+    JSGlobalObject* const m_globalObject { nullptr };
     std::optional<Seconds> m_startTime;
-    ProfilingReason m_reason;
+    const ProfilingReason m_reason;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -256,7 +256,7 @@ private:
     
     bool handleConstantDivOp(Node*);
 
-    CodeBlock* m_codeBlock;
+    CodeBlock* const m_codeBlock;
     Graph& m_graph;
     VM& m_vm;
     AbstractStateType& m_state;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1123,9 +1123,9 @@ private:
 
     bool needsDynamicLookup(ResolveType, OpcodeID);
 
-    VM* m_vm;
-    CodeBlock* m_codeBlock;
-    CodeBlock* m_profiledBlock;
+    VM* const m_vm;
+    CodeBlock* const m_codeBlock;
+    CodeBlock* const m_profiledBlock;
     Graph& m_graph;
 
     // The current block being generated.
@@ -1139,16 +1139,16 @@ private:
     // True if it's OK to OSR exit right now.
     bool m_exitOK { false };
 
-    FrozenValue* m_constantUndefined;
-    FrozenValue* m_constantNull;
-    FrozenValue* m_constantNaN;
-    FrozenValue* m_constantOne;
+    FrozenValue* const m_constantUndefined;
+    FrozenValue* const m_constantNull;
+    FrozenValue* const m_constantNaN;
+    FrozenValue* const m_constantOne;
     Vector<Node*, 16> m_constants;
 
     HashMap<InlineCallFrame*, Vector<ArgumentPosition*>, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>> m_inlineCallFrameToArgumentPositions;
 
     // The number of arguments passed to the function.
-    unsigned m_numArguments;
+    const unsigned m_numArguments;
     // The number of locals (vars + temporaries) used by the bytecode for the function.
     unsigned m_numLocals;
     // The max number of temps used for forwarding data to an OSR exit checkpoint.
@@ -1163,10 +1163,10 @@ private:
     unsigned m_numPassedVarArgs;
 
     struct InlineStackEntry {
-        ByteCodeParser* m_byteCodeParser;
+        ByteCodeParser* const m_byteCodeParser;
         
-        CodeBlock* m_codeBlock;
-        CodeBlock* m_profiledBlock;
+        CodeBlock* const m_codeBlock;
+        CodeBlock* const m_profiledBlock;
         InlineCallFrame* m_inlineCallFrame;
         
         ScriptExecutable* executable() { return m_codeBlock->ownerExecutable(); }
@@ -1205,7 +1205,7 @@ private:
         // Pointers to the argument position trackers for this slice of code.
         Vector<ArgumentPosition*> m_argumentPositions;
         
-        InlineStackEntry* m_caller;
+        InlineStackEntry* const m_caller;
         
         InlineStackEntry(
             ByteCodeParser*,
@@ -1265,7 +1265,7 @@ private:
     Vector<DelayedSetLocal, 2> m_setLocalQueue;
 
     const JSInstruction* m_currentInstruction;
-    bool m_hasDebuggerEnabled;
+    const bool m_hasDebuggerEnabled;
     bool m_hasAnyForceOSRExits { false };
 };
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1088,8 +1088,8 @@ public:
     StackCheck m_stackChecker;
     VM& m_vm;
     Plan& m_plan;
-    CodeBlock* m_codeBlock;
-    CodeBlock* m_profiledBlock;
+    CodeBlock* const m_codeBlock;
+    CodeBlock* const m_profiledBlock;
 
     Vector<RefPtr<BasicBlock>, 8> m_blocks;
     Vector<BasicBlock*, 1> m_roots;

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -62,9 +62,8 @@ MarkedBlock::Handle* MarkedBlock::tryCreate(Heap& heap, AlignedMemoryAllocator* 
 MarkedBlock::Handle::Handle(Heap& heap, AlignedMemoryAllocator* alignedMemoryAllocator, void* blockSpace)
     : m_alignedMemoryAllocator(alignedMemoryAllocator)
     , m_weakSet(heap.vm())
+    , m_block(new (NotNull, blockSpace) MarkedBlock(heap.vm(), *this))
 {
-    m_block = new (NotNull, blockSpace) MarkedBlock(heap.vm(), *this);
-    
     heap.didAllocateBlock(blockSize);
 }
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -236,7 +236,7 @@ public:
         BlockDirectory* m_directory { nullptr };
         WeakSet m_weakSet;
         
-        MarkedBlock* m_block { nullptr };
+        MarkedBlock* const m_block { nullptr };
     };
 
 private:    
@@ -259,7 +259,7 @@ public:
         Handle& m_handle;
         // m_vm must remain a pointer (instead of a reference) because JSCLLIntOffsetsExtractor
         // will fail otherwise.
-        VM* m_vm;
+        VM* const m_vm;
         Subspace* m_subspace;
 
         CountingLock m_lock;

--- a/Source/JavaScriptCore/heap/WeakSet.h
+++ b/Source/JavaScriptCore/heap/WeakSet.h
@@ -76,7 +76,7 @@ private:
     DoublyLinkedList<WeakBlock> m_blocks;
     // m_vm must be a pointer (instead of a reference) because the JSCLLIntOffsetsExtractor
     // cannot handle it being a reference.
-    VM* m_vm;
+    VM* const m_vm;
 };
 
 inline WeakSet::WeakSet(VM& vm)

--- a/Source/JavaScriptCore/interpreter/VMEntryRecord.h
+++ b/Source/JavaScriptCore/interpreter/VMEntryRecord.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,10 +40,10 @@ struct VMEntryRecord {
      * This record stored in a vmEntryTo{JavaScript,Host} allocated frame. It is allocated on the stack
      * after callee save registers where local variables would go.
      */
-    VM* m_vm;
-    CallFrame* m_prevTopCallFrame;
-    EntryFrame* m_prevTopEntryFrame;
-    JSObject* m_callee;
+    VM* const m_vm;
+    CallFrame* const m_prevTopCallFrame;
+    EntryFrame* const m_prevTopEntryFrame;
+    JSObject* const m_callee;
 
     JSObject* callee() const { return m_callee; }
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1955,8 +1955,8 @@ public:
 protected:
     void copyCalleeSavesToEntryFrameCalleeSavesBufferImpl(GPRReg calleeSavesBuffer);
 
-    CodeBlock* m_codeBlock;
-    CodeBlock* m_baselineCodeBlock;
+    CodeBlock* const m_codeBlock;
+    CodeBlock* const m_baselineCodeBlock;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -76,11 +76,11 @@ JIT::JIT(VM& vm, CodeBlock* codeBlock, BytecodeIndex loopOSREntryBytecodeIndex)
     , m_canBeOptimized(false)
     , m_shouldEmitProfiling(false)
     , m_loopOSREntryBytecodeIndex(loopOSREntryBytecodeIndex)
+    , m_profiledCodeBlock(codeBlock)
+    , m_unlinkedCodeBlock(codeBlock->unlinkedCodeBlock())
 {
     auto globalObjectConstant = addToConstantPool(JITConstantPool::Type::GlobalObject);
     ASSERT_UNUSED(globalObjectConstant, globalObjectConstant == s_globalObjectConstant);
-    m_profiledCodeBlock = codeBlock;
-    m_unlinkedCodeBlock = codeBlock->unlinkedCodeBlock();
 }
 
 JIT::~JIT()

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -959,8 +959,8 @@ namespace JSC {
         bool m_shouldEmitProfiling;
         BytecodeIndex m_loopOSREntryBytecodeIndex;
 
-        CodeBlock* m_profiledCodeBlock { nullptr };
-        UnlinkedCodeBlock* m_unlinkedCodeBlock { nullptr };
+        CodeBlock* const m_profiledCodeBlock { nullptr };
+        UnlinkedCodeBlock* const m_unlinkedCodeBlock { nullptr };
 
         MathICHolder m_mathICs;
         RefPtr<BaselineJITCode> m_jitCode;

--- a/Source/JavaScriptCore/jit/JITDisassembler.h
+++ b/Source/JavaScriptCore/jit/JITDisassembler.h
@@ -78,7 +78,7 @@ private:
     
     void dumpDisassembly(PrintStream&, LinkBuffer&, MacroAssembler::Label from, MacroAssembler::Label to);
     
-    CodeBlock* m_codeBlock;
+    CodeBlock* const m_codeBlock;
     MacroAssembler::Label m_startOfCode;
     Vector<MacroAssembler::Label> m_labelForBytecodeIndexInMainPath;
     Vector<MacroAssembler::Label> m_labelForBytecodeIndexInSlowPath;

--- a/Source/JavaScriptCore/jit/JSInterfaceJIT.h
+++ b/Source/JavaScriptCore/jit/JSInterfaceJIT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ namespace JSC {
 
         VM* vm() const { return m_vm; }
 
-        VM* m_vm;
+        VM* const m_vm;
     };
 
 #if USE(JSVALUE32_64)

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ public:
     
 private:
     CallVariant m_variant;
-    CodeBlock* m_codeBlock;
+    CodeBlock* const m_codeBlock;
 };
 
 class PolymorphicCallStubRoutine final : public GCAwareJITStubRoutine {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1896,7 +1896,7 @@ private:
     IterationStatus visit(JSObject*);
 
     Vector<JSObject*>& m_foundObjects;
-    JSGlobalObject* m_globalObject { nullptr }; // Only used for SingleBadTimeGlobal mode.
+    JSGlobalObject* const m_globalObject { nullptr }; // Only used for SingleBadTimeGlobal mode.
     HashSet<JSGlobalObject*>* m_globalObjects { nullptr }; // Only used for BadTimeGlobalGraph mode;
     bool m_needsMultiGlobalsScan { false };
 };

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -292,7 +292,7 @@ private:
 
     // m_vm must be a pointer (instead of a reference) because the JSCLLIntOffsetsExtractor
     // cannot handle it being a reference.
-    VM* m_vm;
+    VM* const m_vm;
 
 // Our hashtable code-generator tries to access these properties, so we make them public.
 // However, we'd like it better if they could be protected.
@@ -421,7 +421,6 @@ public:
     FunctionStructures m_builtinFunctions;
     FunctionStructures m_ordinaryFunctions;
 
-    PropertyOffset m_functionNameOffset;
     WriteBarrierStructureID m_shadowRealmObjectStructure;
     WriteBarrierStructureID m_regExpStructure;
 
@@ -863,7 +862,6 @@ public:
     Structure* customGetterFunctionStructure() const { return m_customGetterFunctionStructure.get(this); }
     Structure* customSetterFunctionStructure() const { return m_customSetterFunctionStructure.get(this); }
     Structure* nativeStdFunctionStructure() const { return m_nativeStdFunctionStructure.get(this); }
-    PropertyOffset functionNameOffset() const { return m_functionNameOffset; }
     Structure* numberObjectStructure() const { return m_numberObjectStructure.get(this); }
     Structure* regExpStructure() const { return m_regExpStructure.get(); }
     Structure* shadowRealmStructure() const { return m_shadowRealmObjectStructure.get(); }

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -202,10 +202,10 @@ private:
 
     void setErrorMessageForToken(TokenType);
 
-    JSGlobalObject* m_globalObject;
-    CodeBlock* m_nullOrCodeBlock;
+    JSGlobalObject* const m_globalObject;
+    CodeBlock* const m_nullOrCodeBlock;
     typename LiteralParser<CharType>::Lexer m_lexer;
-    ParserMode m_mode;
+    const ParserMode m_mode;
     String m_parseErrorMessage;
 };
 

--- a/Source/JavaScriptCore/runtime/RegExpCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpCache.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2010 University of Szeged
  * Copyright (C) 2010 Renata Hodovan (hodovan@inf.u-szeged.hu)
  * All rights reserved.
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +73,7 @@ private:
     int m_nextEntryInStrongCache;
     std::array<Strong<RegExp>, maxStrongCacheableEntries> m_strongCache; // Holds a select few regular expressions that have compiled and executed
     Strong<RegExp> m_emptyRegExp;
-    VM* m_vm;
+    VM* const m_vm;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -110,7 +110,7 @@ private:
     DECLARE_VISIT_CHILDREN;
 
     Ref<Wasm::Instance> m_instance;
-    VM* m_vm;
+    VM* const m_vm;
 
     WriteBarrier<JSGlobalObject> m_globalObject;
     WriteBarrier<JSWebAssemblyModule> m_module;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2019 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -4106,6 +4106,7 @@ public:
         : m_jit(jit)
         , m_vm(vm)
         , m_codeBlock(codeBlock)
+        , m_boyerMooreData(static_cast<YarrBoyerMoyerData*>(codeBlock))
         , m_regs(regs)
         , m_pattern(pattern)
         , m_patternString(patternString)
@@ -4118,7 +4119,6 @@ public:
         , m_parenContextSizes(compileMode == JITCompileMode::IncludeSubpatterns ? m_pattern.m_numSubpatterns : 0, m_pattern.m_body->m_callFrameSize)
 #endif
     {
-        m_boyerMooreData = static_cast<YarrBoyerMoyerData*>(m_codeBlock);
     }
 
     YarrGenerator(CCallHelpers& jit, const VM* vm, YarrBoyerMoyerData* yarrBMData, const YarrJITRegs& regs, YarrPattern& pattern, StringView patternString, CharSize charSize, JITCompileMode compileMode)
@@ -4654,26 +4654,26 @@ public:
 
 private:
     CCallHelpers& m_jit;
-    const VM* m_vm;
-    YarrCodeBlock* m_codeBlock;
-    YarrBoyerMoyerData* m_boyerMooreData;
+    const VM* const m_vm;
+    YarrCodeBlock* const m_codeBlock;
+    YarrBoyerMoyerData* const m_boyerMooreData;
     const YarrJITRegs& m_regs;
 
     StackCheck* m_compilationThreadStackChecker { nullptr };
     YarrPattern& m_pattern;
     const StringView m_patternString;
 
-    CharSize m_charSize;
-    JITCompileMode m_compileMode;
+    const CharSize m_charSize;
+    const JITCompileMode m_compileMode;
 
     // Used to detect regular expression constructs that are not currently
     // supported in the JIT; fall back to the interpreter when this is detected.
     std::optional<JITFailureReason> m_failureReason;
 
-    bool m_decodeSurrogatePairs;
-    bool m_unicodeIgnoreCase;
+    const bool m_decodeSurrogatePairs;
+    const bool m_unicodeIgnoreCase;
     bool m_usesT2 { false };
-    CanonicalMode m_canonicalMode;
+    const CanonicalMode m_canonicalMode;
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
     bool m_containsNestedSubpatterns { false };
     ParenContextSizes m_parenContextSizes;

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,7 +184,7 @@ private:
         threadGlobalData().setCurrentState(lexicalGlobalObject);
     }
 
-    JSC::JSGlobalObject* m_previousState;
+    JSC::JSGlobalObject* const m_previousState;
     JSC::JSLockHolder m_lock;
 
     static void didLeaveScriptContext(JSC::JSGlobalObject*);
@@ -211,7 +211,7 @@ public:
     }
 
 private:
-    JSC::JSGlobalObject* m_previousState;
+    JSC::JSGlobalObject* const m_previousState;
     CustomElementReactionStack m_customElementReactionStack;
 };
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -552,7 +552,7 @@ protected:
         m_failed = true;
     }
 
-    JSGlobalObject* m_lexicalGlobalObject;
+    JSGlobalObject* const m_lexicalGlobalObject;
     bool m_failed;
     MarkedArgumentBuffer m_gcBuffer;
 };
@@ -3872,11 +3872,11 @@ private:
         return false;
     }
 
-    JSGlobalObject* m_globalObject;
-    bool m_isDOMGlobalObject;
-    bool m_canCreateDOMObject;
+    JSGlobalObject* const m_globalObject;
+    const bool m_isDOMGlobalObject;
+    const bool m_canCreateDOMObject;
     const uint8_t* m_ptr;
-    const uint8_t* m_end;
+    const uint8_t* const m_end;
     unsigned m_version;
     Vector<CachedString> m_constantPool;
     const Vector<RefPtr<MessagePort>>& m_messagePorts;
@@ -3896,8 +3896,8 @@ private:
     Vector<RefPtr<RTCDataChannel>> m_rtcDataChannels;
 #endif
 #if ENABLE(WEBASSEMBLY)
-    WasmModuleArray* m_wasmModules;
-    WasmMemoryHandleArray* m_wasmMemoryHandles;
+    WasmModuleArray* const m_wasmModules;
+    WasmMemoryHandleArray* const m_wasmMemoryHandles;
 #endif
 
     String blobFilePathForBlobURL(const String& blobURL)

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -166,8 +166,8 @@ private:
     WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);
 
     CustomElementQueue* m_queue { nullptr }; // Use raw pointer to avoid generating delete in the destructor.
-    CustomElementReactionStack* m_previousProcessingStack;
-    JSC::JSGlobalObject* m_state;
+    CustomElementReactionStack* const m_previousProcessingStack;
+    JSC::JSGlobalObject* const m_state;
 
     WEBCORE_EXPORT static CustomElementReactionStack* s_currentProcessingStack;
 


### PR DESCRIPTION
#### 7433e6a2671bb4e8bd382f24dbd741b8ddf7f114
<pre>
Add const to some fields that are meant to be immutable after construction.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242353">https://bugs.webkit.org/show_bug.cgi?id=242353</a>

Reviewed by Yusuke Suzuki.

This helps provides a hint to the compiler that a previously fetched constant
field need not be re-fetched.  Secondly, it documents for the reader that the
intention that the field will not change after construction.

* Source/JavaScriptCore/bindings/ScriptFunctionCall.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/CodeBlockWithJITType.h:
* Source/JavaScriptCore/bytecode/FullCodeOrigin.h:
* Source/JavaScriptCore/bytecode/PolymorphicAccess.h:
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
* Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h:
* Source/JavaScriptCore/debugger/ScriptProfilingScope.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::Handle):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/WeakSet.h:
* Source/JavaScriptCore/interpreter/VMEntryRecord.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::JIT):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITDisassembler.h:
* Source/JavaScriptCore/jit/JSInterfaceJIT.h:
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::nativeStdFunctionStructure const):
(JSC::JSGlobalObject::functionNameOffset const): Deleted.
* Source/JavaScriptCore/runtime/LiteralParser.h:
* Source/JavaScriptCore/runtime/RegExpCache.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/WebCore/bindings/js/JSExecState.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
* Source/WebCore/dom/CustomElementReactionQueue.h:

Canonical link: <a href="https://commits.webkit.org/252168@main">https://commits.webkit.org/252168@main</a>
</pre>
