### PR TITLE
[ews] send data to ews django app for PR based builds

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -158,7 +158,7 @@ class Events(service.BuildbotService):
             "type": self.type_prefix + "build",
             "status": "started",
             "hostname": self.master_hostname,
-            "patch_id": self.extractProperty(build, 'patch_id'),
+            "patch_id": self.extractProperty(build, 'patch_id') or self.extractProperty(build, 'github.head.sha'),
             "build_id": build.get('buildid'),
             "builder_id": build.get('builderid'),
             "number": build.get('number'),
@@ -209,17 +209,13 @@ class Events(service.BuildbotService):
         build['description'] = builder.get('description', '?')
 
         if self.extractProperty(build, 'github.number'):
-            return self.buildFinishedGitHub(build)
-
-        patch_id = self.extractProperty(build, 'patch_id')
-        if not patch_id:
-            return
+            self.buildFinishedGitHub(build)
 
         data = {
             "type": self.type_prefix + "build",
             "status": "finished",
             "hostname": self.master_hostname,
-            "patch_id": self.extractProperty(build, 'patch_id'),
+            "patch_id": self.extractProperty(build, 'patch_id') or self.extractProperty(build, 'github.head.sha'),
             "build_id": build.get('buildid'),
             "builder_id": build.get('builderid'),
             "number": build.get('number'),


### PR DESCRIPTION
#### 38d3e4e70ddf969232c35975fe8528b9cb29b443
<pre>
[ews] send data to ews django app for PR based builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=242357">https://bugs.webkit.org/show_bug.cgi?id=242357</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/events.py:
(Events.buildStarted):
(Events.buildFinished):

Canonical link: <a href="https://commits.webkit.org/252209@main">https://commits.webkit.org/252209@main</a>
</pre>
