### PR TITLE
[Gardening]: [ iOS Release ] http/tests/paymentrequest/updateWith-shippingOptions.https.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1020,7 +1020,7 @@ webkit.org/b/145432 media/video-transformed-by-javascript.html [ Failure ]
 http/tests/paymentrequest/payment-address-attributes-and-toJSON-method.https.html [ DumpJSConsoleLogInStdErr ]
 http/tests/paymentrequest/payment-request-change-shipping-option.https.html [ DumpJSConsoleLogInStdErr ]
 http/tests/paymentrequest/payment-response-retry-method.https.html [ DumpJSConsoleLogInStdErr ]
-http/tests/paymentrequest/updateWith-shippingOptions.https.html [ DumpJSConsoleLogInStdErr ]
+http/tests/paymentrequest/updateWith-shippingOptions.https.html [ DumpJSConsoleLogInStdErr Pass Failure ]
 imported/w3c/web-platform-tests/payment-request/payment-request-constructor.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/payment-request/payment-request-shippingOption-attribute.https.html [ DumpJSConsoleLogInStdErr ]
 


### PR DESCRIPTION
#### 63dbb0d3060d6c0b0b1fd4ab7c6986bf12c30fb8
<pre>
[Gardening]: [ iOS Release ] http/tests/paymentrequest/updateWith-shippingOptions.https.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242264">https://bugs.webkit.org/show_bug.cgi?id=242264</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252150@main">https://commits.webkit.org/252150@main</a>
</pre>
