### PR TITLE
[JSC] Activate wasm fault handler when signaling memory is used

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3755,9 +3755,6 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
     VM& vm = VM::create(HeapType::Large).leakRef();
     if (!isWorker && options.m_canBlockIsFalse)
         vm.m_typedArrayController = adoptRef(new JSC::SimpleTypedArrayController(false));
-#if ENABLE(WEBASSEMBLY)
-    Wasm::enableFastMemory();
-#endif
 
     int result;
     bool success = true;

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -112,7 +112,7 @@ void initialize()
 #endif
         VMTraps::initializeSignals();
 #if ENABLE(WEBASSEMBLY)
-        Wasm::prepareFastMemory();
+        Wasm::prepareSignalingMemory();
 #endif
 
         WTF::compilerFence();

--- a/Source/JavaScriptCore/shell/playstation/TestShell.cpp
+++ b/Source/JavaScriptCore/shell/playstation/TestShell.cpp
@@ -50,9 +50,6 @@ extern "C" void setupTestRun()
 
     JSC::initialize();
 
-#if ENABLE(WEBASSEMBLY)
-    JSC::Wasm::enableFastMemory();
-#endif
     Gigacage::forbidDisablingPrimitiveGigacage();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -50,8 +50,6 @@ static constexpr bool verbose = false;
 }
 }
 
-static bool fastHandlerInstalled { false };
-
 #if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
 
 static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegisters& context)
@@ -107,12 +105,7 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
 
 #endif // ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
 
-bool fastMemoryEnabled()
-{
-    return fastHandlerInstalled;
-}
-
-void enableFastMemory()
+void activateSignalingMemory()
 {
 #if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static std::once_flag once;
@@ -124,13 +117,11 @@ void enableFastMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
-
-        fastHandlerInstalled = true;
     });
-#endif
+#endif // ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
 }
 
-void prepareFastMemory()
+void prepareSignalingMemory()
 {
 #if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     static std::once_flag once;

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -31,9 +31,8 @@ namespace JSC {
 
 namespace Wasm {
 
-bool fastMemoryEnabled();
-JS_EXPORT_PRIVATE void prepareFastMemory();
-JS_EXPORT_PRIVATE void enableFastMemory();
+void activateSignalingMemory();
+void prepareSignalingMemory();
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -25,11 +25,12 @@
 
 #include "config.h"
 #include "WasmMemory.h"
-#include "WasmInstance.h"
 
 #if ENABLE(WEBASSEMBLY)
 
 #include "Options.h"
+#include "WasmFaultSignalHandler.h"
+#include "WasmInstance.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/Gigacage.h>
@@ -301,10 +302,10 @@ MemoryHandle::MemoryHandle(void* memory, size_t size, size_t mappedCapacity, Pag
     , m_initial(initial)
     , m_maximum(maximum)
 {
-#if ASSERT_ENABLED
     if (sharingMode == MemorySharingMode::Default && mode == MemoryMode::BoundsChecking)
         ASSERT(mappedCapacity == size);
-#endif
+    else
+        activateSignalingMemory();
 }
 
 MemoryHandle::~MemoryHandle()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -595,10 +595,6 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
 #endif
     SharedWorkerProvider::setSharedProvider(WebSharedWorkerProvider::singleton());
 
-#if ENABLE(WEBASSEMBLY)
-    JSC::Wasm::enableFastMemory();
-#endif
-
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION) && !RELEASE_LOG_DISABLED
     WebResourceLoadObserver::setShouldLogUserInteraction(parameters.shouldLogUserInteraction);
 #endif


### PR DESCRIPTION
#### bb92169c6b02262a312c99848948a8996dcb80ac
<pre>
[JSC] Activate wasm fault handler when signaling memory is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=242358">https://bugs.webkit.org/show_bug.cgi?id=242358</a>
rdar://96056675

Reviewed by Mark Lam.

<a href="https://github.com/WebKit/WebKit/commit/42ad6e4af024381a287ea6a587da469ef43f2819">https://github.com/WebKit/WebKit/commit/42ad6e4af024381a287ea6a587da469ef43f2819</a> broke JavaScriptCore.framework&apos;s wasm signal handler
since it is no longer installed. This patch activates that handler when wasm memory is created with signaling requirement, which is
Signaling or Shared memory. We do not activate this in JSC::initialize since LLDB has a bug that it cannot handle mach exception.
We defer this initialization only when we use Wasm::Memory with necessary features.

* Source/JavaScriptCore/jsc.cpp:
(runJSC):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/shell/playstation/TestShell.cpp:
(setupTestRun):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::initializeSignalingMemory): Deleted.
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::MemoryHandle::MemoryHandle):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/252164@main">https://commits.webkit.org/252164@main</a>
</pre>
