### PR TITLE
[Filters] Implement identity filters

### DIFF
--- a/LayoutTests/css3/filters/identity-filters-expected.html
+++ b/LayoutTests/css3/filters/identity-filters-expected.html
@@ -1,0 +1,76 @@
+<style>
+    td {
+        padding: 5px;
+        text-align: center;
+    }
+    svg {
+        width: 100px;
+        height: 100px;
+    }
+    .box {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        display: inline-block;
+    }
+</style>
+<body>
+    <table>
+        <tr>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+        </tr>
+        <tr>
+            <td>blur</td>
+            <td>brightness</td>
+            <td>contrast</td>
+            <td>drop-shadow</td>
+        </tr>
+        <tr>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+        </tr>
+        <tr>
+            <td>grayscale</td>
+            <td>hue-rotate</td>
+            <td>invert</td>
+            <td>opacity</td>
+        </tr>
+        <tr>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+        </tr>
+        <tr>
+            <td>saturate</td>
+            <td>sepia</td>
+            <td>ref-blur</td>
+            <td>ref-morphology</td>
+        </tr>
+        <tr>
+            <td>
+                <svg>
+                    <rect width="100%" height="100%" fill="green"/>
+                </svg>
+            </td>
+            <td>
+                <svg>
+                    <rect width="100%" height="100%" fill="green"/>
+                </svg>
+            </td>
+            <td><div class="box"></div></td>
+            <td><div class="box"></div></td>
+        </tr>
+        <tr>
+            <td>svg-blur</td>
+            <td>svg-morphology</td>
+            <td>grayscale <br/> ref-blur</td>
+            <td>ref-morphology <br/> contrast</td>
+        </tr>
+    </table>
+</body>

--- a/LayoutTests/css3/filters/identity-filters.html
+++ b/LayoutTests/css3/filters/identity-filters.html
@@ -1,0 +1,146 @@
+<style>
+    td {
+        padding: 5px;
+        text-align: center;
+    }
+    svg {
+        width: 100px;
+        height: 100px;
+    }
+    .box {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        display: inline-block;
+    }
+    .noop-blur {
+        filter: blur(0);
+    }
+    .noop-brightness {
+        filter: brightness(1);
+    }
+    .noop-contrast {
+        filter: contrast(1);
+    }
+    .noop-drop-shadow {
+        filter: drop-shadow(0px 0px 0px 0px);
+    }
+    .noop-grayscale {
+        filter: grayscale(0);
+    }
+    .noop-hue-rotate {
+        filter: hue-rotate(0);
+    }
+    .noop-invert {
+        filter: invert(0);
+    }
+    .noop-opacity {
+        filter: opacity(1);
+    }
+    .noop-saturate {
+        filter: saturate(1);
+    }
+    .noop-sepia {
+        filter: sepia(0);
+    }
+    .noop-ref-blur {
+        filter: url(#noop-svg-blur);
+    }
+    .noop-ref-morphology {
+        filter: url(#noop-svg-morphology);  
+    }
+</style>
+<body>
+    <table>
+        <tr>
+            <td>
+                <div class="box noop-blur"></div>
+            </td>
+            <td>
+                <div class="box noop-brightness"></div>
+            </td>
+            <td>
+                <div class="box noop-contrast"></div>
+            </td>
+            <td>
+                <div class="box noop-drop-shadow"></div>
+            </td>
+        </tr>
+        <tr>
+            <td>blur</td>
+            <td>brightness</td>
+            <td>contrast</td>
+            <td>drop-shadow</td>
+        </tr>
+        <tr>
+            <td>
+                <div class="box noop-grayscale"></div>
+            </td>
+            <td>
+                <div class="box noop-hue-rotate"></div>
+            </td>
+            <td>
+                <div class="box noop-invert"></div>
+            </td>
+            <td>
+                <div class="box noop-opacity"></div>
+            </td>
+        </tr>
+        <tr>
+            <td>grayscale</td>
+            <td>hue-rotate</td>
+            <td>invert</td>
+            <td>opacity</td>
+        </tr>
+        <tr>
+            <td>
+                <div class="box noop-saturate"></div>
+            </td>
+            <td>
+                <div class="box noop-sepia"></div>
+            </td>
+            <td>
+                <div class="box noop-ref-blur"></div>
+            </td>
+            <td>
+                <div class="box noop-ref-morphology"></div>
+            </td>
+        </tr>
+        <tr>
+            <td>saturate</td>
+            <td>sepia</td>
+            <td>ref-blur</td>
+            <td>ref-morphology</td>
+        </tr>
+        <tr>
+            <td>
+                <svg>
+                    <filter id="noop-svg-blur" x="-5%" y="-5%" width="110%" height="110%">
+                        <feGaussianBlur in="SourceGraphic" stdDeviation="0"/>
+                    </filter>
+                    <rect width="100%" height="100%" fill="green" filter="url(#noop-svg-blur)"/>
+                </svg>
+            </td>
+            <td>
+                <svg>
+                     <filter id="noop-svg-morphology" x="-5%" y="-5%" width="110%" height="110%">
+                        <feMorphology operator="erode" radius="0"/>
+                    </filter>
+                    <rect width="100%" height="100%" fill="green" filter="url(#noop-svg-morphology)"/>
+                </svg>
+            </td>
+            <td>
+                <div class="box noop-grayscale noop-ref-blur"></div>
+            </td>
+            <td>
+                <div class="box noop-ref-morphology"></div>
+            </td>
+        </tr>
+        <tr>
+            <td>svg-blur</td>
+            <td>svg-morphology</td>
+            <td>grayscale <br/> ref-blur</td>
+            <td>ref-morphology <br/> contrast</td>
+        </tr>
+    </table>
+</body>

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
@@ -65,6 +65,13 @@ bool ReferenceFilterOperation::operator==(const FilterOperation& operation) cons
     return m_url == downcast<ReferenceFilterOperation>(operation).m_url;
 }
 
+bool ReferenceFilterOperation::isIdentity() const
+{
+    // Answering this question requires access to the renderer and the referenced filterElement.
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 void ReferenceFilterOperation::loadExternalDocumentIfNeeded(CachedResourceLoader& cachedResourceLoader, const ResourceLoaderOptions& options)
 {
     if (m_cachedSVGDocumentReference)

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -97,6 +97,8 @@ public:
 
     bool isSameType(const FilterOperation& o) const { return o.type() == m_type; }
 
+    virtual bool isIdentity() const { return false; }
+
     // True if the alpha channel of any pixel can change under this operation.
     virtual bool affectsOpacity() const { return false; }
     // True if the value of one pixel can affect the value of another pixel under this operation, such as blur.
@@ -195,6 +197,8 @@ private:
 
     bool operator==(const FilterOperation&) const override;
 
+    bool isIdentity() const override;
+
     String m_url;
     AtomString m_fragment;
     std::unique_ptr<CachedSVGDocumentReference> m_cachedSVGDocumentReference;
@@ -227,6 +231,11 @@ private:
         : FilterOperation(type)
         , m_amount(amount)
     {
+    }
+
+    bool isIdentity() const override
+    {
+        return m_type == SATURATE ? (m_amount == 1) : !m_amount;
     }
 
     bool transformColor(SRGBA<float>&) const override;
@@ -262,6 +271,11 @@ private:
         : FilterOperation(type)
         , m_amount(amount)
     {
+    }
+
+    bool isIdentity() const override
+    {
+        return m_type == INVERT ? !m_amount : (m_amount == 1);
     }
 
     bool transformColor(SRGBA<float>&) const override;
@@ -323,6 +337,11 @@ private:
     {
     }
 
+    bool isIdentity() const override
+    {
+        return m_stdDeviation.isZero() || m_stdDeviation.isNegative();
+    }
+
     Length m_stdDeviation;
 };
 
@@ -358,6 +377,11 @@ private:
         , m_stdDeviation(stdDeviation)
         , m_color(color)
     {
+    }
+
+    bool isIdentity() const override
+    {
+        return m_stdDeviation < 0 || (!m_stdDeviation && m_location.isZero());
     }
 
     IntPoint m_location; // FIXME: should location be in Lengths?

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -52,6 +52,7 @@ public:
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
 
+    static bool isIdentity(RenderElement&, const FilterOperations&);
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -869,7 +869,10 @@ bool RenderLayer::paintsWithFilters() const
 {
     if (!renderer().hasFilter())
         return false;
-        
+
+    if (RenderLayerFilters::isIdentity(renderer()))
+        return false;
+
     if (!isComposited())
         return true;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -111,6 +111,12 @@ void RenderLayerFilters::removeReferenceFilterClients()
     m_internalSVGReferences.clear();
 }
 
+bool RenderLayerFilters::isIdentity(RenderElement& renderer)
+{
+    const auto& operations = renderer.style().filter();
+    return CSSFilter::isIdentity(renderer, operations);
+}
+
 IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const FloatRect& targetBoundingBox)
 {
     const auto& operations = renderer.style().filter();

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -61,6 +61,7 @@ public:
     void setRenderingMode(RenderingMode renderingMode) { m_renderingMode = renderingMode; }
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
 
+    static bool isIdentity(RenderElement&);
     static IntOutsets calculateOutsets(RenderElement&, const FloatRect& targetBoundingBox);
 
     // Per render

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -48,6 +48,11 @@ RenderSVGResourceFilter::RenderSVGResourceFilter(SVGFilterElement& element, Rend
 
 RenderSVGResourceFilter::~RenderSVGResourceFilter() = default;
 
+bool RenderSVGResourceFilter::isIdentity() const
+{
+    return SVGFilter::isIdentity(filterElement());
+}
+
 void RenderSVGResourceFilter::removeAllClientsFromCache(bool markForInvalidation)
 {
     LOG(Filters, "RenderSVGResourceFilter %p removeAllClientsFromCache", this);
@@ -89,7 +94,7 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
 
     auto addResult = m_rendererFilterDataMap.set(&renderer, makeUnique<FilterData>());
     auto filterData = addResult.iterator->value.get();
-    
+
     auto targetBoundingBox = renderer.objectBoundingBox();
     auto filterRegion = SVGLengthContext::resolveRectangle<SVGFilterElement>(&filterElement(), filterElement().filterUnits(), targetBoundingBox);
     if (filterRegion.isEmpty()) {
@@ -97,7 +102,7 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
         return false;
     }
 
-    // Determine absolute transformation matrix for filter. 
+    // Determine absolute transformation matrix for filter.
     auto absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
     if (!absoluteTransform.isInvertible()) {
         m_rendererFilterDataMap.remove(&renderer);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -61,6 +61,7 @@ public:
     virtual ~RenderSVGResourceFilter();
 
     inline SVGFilterElement& filterElement() const;
+    bool isIdentity() const;
 
     void removeAllClientsFromCache(bool markForInvalidation = true) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -161,7 +161,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
 
     if (!isRenderingMask) {
         m_filter = resources->filter();
-        if (m_filter) {
+        if (m_filter && !m_filter->isIdentity()) {
             m_savedContext = &m_paintInfo->context();
             m_savedPaintRect = m_paintInfo->rect;
             // Return with false here may mean that we don't need to draw the content

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -136,6 +136,11 @@ bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& effect, cons
     return false;
 }
 
+bool SVGFEDropShadowElement::isIdentity() const
+{
+    return !stdDeviationX() && !stdDeviationY() && !dx() && !dy();
+}
+
 IntOutsets SVGFEDropShadowElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
     auto offset = SVGFilter::calculateResolvedSize({ dx(), dy() }, targetBoundingBox, primitiveUnits);

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -55,6 +55,7 @@ private:
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
+    bool isIdentity() const override;
     IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -123,6 +123,11 @@ bool SVGFEGaussianBlurElement::setFilterEffectAttribute(FilterEffect& effect, co
     return false;
 }
 
+bool SVGFEGaussianBlurElement::isIdentity() const
+{
+    return !stdDeviationX() && !stdDeviationY();
+}
+
 IntOutsets SVGFEGaussianBlurElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
     auto stdDeviation = SVGFilter::calculateResolvedSize({ stdDeviationX(), stdDeviationY() }, targetBoundingBox, primitiveUnits);

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -55,6 +55,7 @@ private:
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
+    bool isIdentity() const override;
     IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -113,6 +113,11 @@ void SVGFEMorphologyElement::svgAttributeChanged(const QualifiedName& attrName)
     SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
 }
 
+bool SVGFEMorphologyElement::isIdentity() const
+{
+    return !radiusX() && !radiusY();
+}
+
 RefPtr<FilterEffect> SVGFEMorphologyElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
     if (radiusX() < 0 || radiusY() < 0)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -82,6 +82,7 @@ private:
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
+    bool isIdentity() const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     PropertyRegistry m_propertyRegistry { *this };

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -98,6 +98,11 @@ bool SVGFEOffsetElement::setFilterEffectAttribute(FilterEffect& effect, const Qu
     return false;
 }
 
+bool SVGFEOffsetElement::isIdentity() const
+{
+    return !dx() && !dy();
+}
+
 IntOutsets SVGFEOffsetElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
     auto offset = SVGFilter::calculateResolvedSize({ dx(), dy() }, targetBoundingBox, primitiveUnits);

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -49,6 +49,7 @@ private:
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
+    bool isIdentity() const override;
     IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -54,6 +54,7 @@ public:
     OptionSet<FilterEffectGeometry::Flags> effectGeometryFlags() const;
 
     virtual Vector<AtomString> filterEffectInputsNames() const { return { }; }
+    virtual bool isIdentity() const { return false; }
     virtual IntOutsets outsets(const FloatRect&, SVGUnitTypes::SVGUnitType) const { return { }; }
     RefPtr<FilterEffect> filterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext);
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -138,7 +138,8 @@ std::optional<SVGFilterExpression> SVGFilter::buildExpression(SVGFilterElement& 
 
 static std::optional<SVGFilterPrimitivesGraph> buildFilterPrimitivesGraph(SVGFilterElement& filterElement)
 {
-    if (filterElement.countChildNodes() > maxCountChildNodes)
+    auto countChildNodes = filterElement.countChildNodes();
+    if (!countChildNodes || countChildNodes > maxCountChildNodes)
         return std::nullopt;
 
     SVGFilterPrimitivesGraph graph;
@@ -151,6 +152,21 @@ static std::optional<SVGFilterPrimitivesGraph> buildFilterPrimitivesGraph(SVGFil
     }
 
     return graph;
+}
+
+bool SVGFilter::isIdentity(SVGFilterElement& filterElement)
+{
+    auto graph = buildFilterPrimitivesGraph(filterElement);
+    if (!graph)
+        return false;
+
+    bool isIdentity = true;
+    graph->visit([&](SVGFilterPrimitiveStandardAttributes& primitive, unsigned) {
+        if (!primitive.isIdentity())
+            isIdentity = false;
+    });
+
+    return isIdentity;
 }
 
 IntOutsets SVGFilter::calculateOutsets(SVGFilterElement& filterElement, const FloatRect& targetBoundingBox)

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -39,6 +39,7 @@ public:
     static RefPtr<SVGFilter> create(SVGFilterElement&, RenderingMode, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static RefPtr<SVGFilter> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
 
+    static bool isIdentity(SVGFilterElement&);
     static IntOutsets calculateOutsets(SVGFilterElement&, const FloatRect& targetBoundingBox);
 
     FloatRect targetBoundingBox() const { return m_targetBoundingBox; }


### PR DESCRIPTION
#### 4ac8e180ed02f9af4ed1cc1742b6365bea860c7d
<pre>
[Filters] Implement identity filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=242359">https://bugs.webkit.org/show_bug.cgi?id=242359</a>
rdar://96907495

Reviewed by Simon Fraser.

We should draw the element as if there was no filter applied if the whole filter
chain is no-operation. Identity filters are common scenario after transitioning
the filter parameters to identity values. This is a performance and  memory
enhancement for filers.

* LayoutTests/css3/filters/noop-filters-expected.html: Added.
* LayoutTests/css3/filters/noop-filters.html: Added.
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::isNoopBlurEffect):
(WebCore::isNoopComponentTransferFilterffect):
(WebCore::isNoopDropShadowEffect):
(WebCore::isNoopColorMatrixFilterEffect):
(WebCore::isNoopReferenceFilter):
(WebCore::CSSFilter::isNoop):
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintsWithFilters const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::isNoop):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
(WebCore::RenderSVGResourceFilter::postApplyResource):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::isNoop const):
* Source/WebCore/svg/SVGFEDropShadowElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::isNoop const):
* Source/WebCore/svg/SVGFEGaussianBlurElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::isNoop const):
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::isNoop const):
* Source/WebCore/svg/SVGFEOffsetElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
(WebCore::SVGFilterPrimitiveStandardAttributes::isNoop const):
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::isNoop):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:

Canonical link: <a href="https://commits.webkit.org/253098@main">https://commits.webkit.org/253098@main</a>
</pre>
