### PR TITLE
REGRESSION (249800@main): Cannot edit compose body field on outlook.com

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -172,6 +172,9 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     if (linkedBefore(dyld_spring_2022_os_versions, DYLD_IOS_VERSION_15_4, DYLD_MACOSX_VERSION_12_3))
         disableBehavior(SDKAlignedBehavior::AuthorizationHeaderOnSameOriginRedirects);
 
+    if (linkedBefore(dyld_fall_2022_os_versions, DYLD_IOS_VERSION_16_0, DYLD_MACOSX_VERSION_13_0))
+        disableBehavior(SDKAlignedBehavior::UserSelectAllDoesNotAffectEditability);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -95,6 +95,7 @@ enum class SDKAlignedBehavior {
     WKContentViewDoesNotOverrideKeyCommands,
     WKWebsiteDataStoreInitReturningNil,
     UIBackForwardSkipsHistoryItemsWithoutUserGesture,
+    UserSelectAllDoesNotAffectEditability,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3653,6 +3653,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 #endif
         case CSSPropertyWebkitUserDrag:
         case CSSPropertyWebkitUserModify:
+        case CSSPropertyWebkitUserSelect:
         case CSSPropertyUserSelect:
             continue;
         default:

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -3901,6 +3901,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
 #endif
         case CSSPropertyWebkitUserDrag:
             return cssValuePool.createValue(style.userDrag());
+        case CSSPropertyWebkitUserSelect:
         case CSSPropertyUserSelect:
             return cssValuePool.createValue(style.userSelect());
         case CSSPropertyBorderBottomLeftRadius:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7280,11 +7280,25 @@
             ],
             "status": "non-standard"
         },
+        "-webkit-user-select": {
+            "codegen-properties": {
+                "related-property": "user-select"
+            },
+            "inherited": true,
+            "values": [
+                "none",
+                "auto",
+                "text",
+                "all",
+                {
+                    "value": "contain",
+                    "status": "unimplemented"
+                }
+            ]
+        },
         "user-select": {
             "codegen-properties": {
-                "aliases": [
-                    "-webkit-user-select"
-                ]
+                "related-property": "-webkit-user-select"
             },
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -42,6 +42,9 @@
 #include "HashTools.h"
 #include "StyleColor.h"
 #include "StylePropertyShorthand.h"
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 namespace WebCore {
 
@@ -827,8 +830,17 @@ bool CSSParserFastPaths::isValidKeywordPropertyAndValue(CSSPropertyID propertyId
         return valueID == CSSValueAuto || valueID == CSSValueNone || valueID == CSSValueElement;
     case CSSPropertyWebkitUserModify: // read-only | read-write
         return valueID == CSSValueReadOnly || valueID == CSSValueReadWrite || valueID == CSSValueReadWritePlaintextOnly;
-    case CSSPropertyUserSelect: // auto | none | text | all
+    case CSSPropertyWebkitUserSelect: // auto | none | text | all
         return valueID == CSSValueAuto || valueID == CSSValueNone || valueID == CSSValueText || valueID == CSSValueAll;
+    case CSSPropertyUserSelect: // auto | none | text | all
+        if (valueID == CSSValueAll) {
+#if PLATFORM(COCOA)
+            return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::UserSelectAllDoesNotAffectEditability);
+#else
+            return true;
+#endif
+        }
+        return valueID == CSSValueAuto || valueID == CSSValueNone || valueID == CSSValueText;
     case CSSPropertyWritingMode:
         // Note that horizontal-bt is not supported by the unprefixed version of
         // the property, only by the -webkit- version.
@@ -992,6 +1004,7 @@ bool CSSParserFastPaths::isKeywordPropertyID(CSSPropertyID propertyId)
     case CSSPropertyWebkitTextZoom:
     case CSSPropertyWebkitUserDrag:
     case CSSPropertyWebkitUserModify:
+    case CSSPropertyWebkitUserSelect:
     case CSSPropertyUserSelect:
     case CSSPropertyWhiteSpace:
     case CSSPropertyWordBreak:

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -95,6 +95,10 @@
 #include "ContentChangeObserver.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Node);
@@ -756,8 +760,10 @@ static Node::Editability computeEditabilityFromComputedStyle(const RenderStyle& 
 
     // Elements with user-select: all style are considered atomic
     // therefore non editable.
-    if (treatment == Node::UserSelectAllIsAlwaysNonEditable && style.effectiveUserSelect() == UserSelect::All)
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::UserSelectAllDoesNotAffectEditability) && treatment == Node::UserSelectAllIsAlwaysNonEditable && style.effectiveUserSelect() == UserSelect::All)
         return Node::Editability::ReadOnly;
+#endif
 
     if (pageIsEditable == PageIsEditable::Yes)
         return Node::Editability::CanEditRichly;


### PR DESCRIPTION
#### 295e194d0352aec270b3a8a9b9eac4dc62f1b389
<pre>
REGRESSION (249800@main): Cannot edit compose body field on outlook.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=242006">https://bugs.webkit.org/show_bug.cgi?id=242006</a>
&lt;rdar://94619119&gt;

Reviewed by NOBODY (OOPS!).

- Stop supporting unprefixed user-select: all on old SDKs and preserve old editability behavior on it
- Support unprefixed user-select: all on new SDKs with new editability behavior

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::CSSParserFastPaths::isValidKeywordPropertyAndValue):
(WebCore::CSSParserFastPaths::isKeywordPropertyID):
* Source/WebCore/dom/Node.cpp:
(WebCore::computeEditabilityFromComputedStyle):
</pre>