### PR TITLE
[Gardening]: [ macOS wk2 ] http/tests/xmlhttprequest/access-control-repeated-failed-preflight-crash.html is a flaky crash: exception 'NSInternalInconsistencyException', reason: 'This task has already been stopped'

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -573,8 +573,6 @@ webkit.org/b/151709 [ Release ] http/tests/xmlhttprequest/workers/methods.html [
 
 webkit.org/b/231372 [ BigSur arm64 Debug ] http/tests/xmlhttprequest/access-control-response-with-body.html [ Pass Crash ]
 
-webkit.org/b/231831 http/tests/xmlhttprequest/access-control-repeated-failed-preflight-crash.html [ Pass Crash ]
-
 ### END OF (1) Classified failures with bug reports
 ########################################
 


### PR DESCRIPTION
#### 8d024500127d0270d1a8bdd46d42417766f859e9
<pre>
[Gardening]: [ macOS wk2 ] http/tests/xmlhttprequest/access-control-repeated-failed-preflight-crash.html is a flaky crash: exception &apos;NSInternalInconsistencyException&apos;, reason: &apos;This task has already been stopped&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=231831">https://bugs.webkit.org/show_bug.cgi?id=231831</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252151@main">https://commits.webkit.org/252151@main</a>
</pre>
