### PR TITLE
REGRESSION (251473@main): [watchOS] Crash when focusing an input field with spellcheck="false"

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5926,7 +5926,8 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
             traits.smartQuotesType = UITextSmartQuotesTypeNo;
         if ([traits respondsToSelector:@selector(setSmartDashesType:)])
             traits.smartDashesType = UITextSmartDashesTypeNo;
-        traits.spellCheckingType = UITextSpellCheckingTypeNo;
+        if ([traits respondsToSelector:@selector(setSpellCheckingType:)])
+            traits.spellCheckingType = UITextSpellCheckingTypeNo;
     }
 
     switch (_focusedElementInformation.inputMode) {


### PR DESCRIPTION
#### 23bcedb746a5bf0acc19d095c5f5afd3134d5d97
<pre>
REGRESSION (251473@main): [watchOS] Crash when focusing an input field with spellcheck=&quot;false&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=242364">https://bugs.webkit.org/show_bug.cgi?id=242364</a>
rdar://96458889

Reviewed by Aditya Keerthi.

Add a missing `-respondsToSelector:` check before attempting to set `spellCheckingType`. `spellCheckingType` is an
optional property on the `UITextInputTraits` protocol, and (importantly) isn&apos;t implemented on watchOS.

This crash is already exercised by `fast/forms/watchos/enter-text-with-spellcheck-disabled.html`, which (unfortunately)
doesn&apos;t run in pre- or post-commit non-internal automation.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraits:]):

Canonical link: <a href="https://commits.webkit.org/252166@main">https://commits.webkit.org/252166@main</a>
</pre>
