### PR TITLE
[Gardening]: [ BigSure wk1 Debug ] fast/selectors/pseudo-element-inside-any.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1021,8 +1021,6 @@ webkit.org/b/179853 imported/blink/fast/text/international-iteration-simple-text
 
 webkit.org/b/230062 fast/text/FontFaceSet-check-after-style-update.html [ Pass Failure ]
 
-webkit.org/b/232046 [ BigSur Debug ] fast/selectors/pseudo-element-inside-any.html [ Pass Crash ]
-
 # Skip anything related to WebAuthN
 http/wpt/credential-management/ [ Skip ]
 http/wpt/webauthn/ [ Skip ]


### PR DESCRIPTION
#### e36b05647cc7b60f59a9c96872d4f562c9514e7c
<pre>
[Gardening]: [ BigSure wk1 Debug ] fast/selectors/pseudo-element-inside-any.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=232046">https://bugs.webkit.org/show_bug.cgi?id=232046</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252161@main">https://commits.webkit.org/252161@main</a>
</pre>
