### PR TITLE
[Gardening]: [ iOS Release ] media/media-can-play-mpeg-audio.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1350,8 +1350,6 @@ webkit.org/b/228167 media/media-fragments/TC0003.html [ Pass Crash ]
 
 webkit.org/b/228171 media/media-usage-state-private-browsing.html [ Pass Crash ]
 
-webkit.org/b/232025 [ Release ] media/media-can-play-mpeg-audio.html [ Pass Failure ]
-
 # <rdar://problem/56761171> [ iOS ] Layout Test fast/css-custom-paint/simple-hidpi.html is a Flaky Failure (203637)
 webkit.org/b/203637 fast/css-custom-paint/simple-hidpi.html [ Pass ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 07f9e0f6d3430a6a9327678e52ba5706c15ec0e0
<pre>
[Gardening]: [ iOS Release ] media/media-can-play-mpeg-audio.html is a flaky failure
https://bugs.webkit.org/show_bug.cgi?id=232025

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252225@main">https://commits.webkit.org/252225@main</a>
</pre>
