### PR TITLE
[Gardening]: [ iOS15 Debug ] media/media-fragments/TC0001.html is a flaky timeout

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2134,8 +2134,6 @@ webkit.org/b/231623 [ Debug ] fast/scrolling/ios/click-events-during-momentum-sc
 
 webkit.org/b/231631 [ Debug ] fast/selectors/case-insensitive-attribute-bascis.html [ Pass Timeout ]
 
-webkit.org/b/231636 [ Debug ] media/media-fragments/TC0001.html [ Pass Timeout ]
-
 webkit.org/b/231638 [ Debug ] webgl/pending/conformance/glsl/misc/shader-with-reserved-words-2.html [ Pass Timeout ]
 
 webkit.org/b/228127 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html [ Pass Crash Failure ]


### PR DESCRIPTION
#### da0a4644678146f4b7bcb28d6b247f958aedacd3
<pre>
[Gardening]: [ iOS15 Debug ] media/media-fragments/TC0001.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=231636">https://bugs.webkit.org/show_bug.cgi?id=231636</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252163@main">https://commits.webkit.org/252163@main</a>
</pre>
