### PR TITLE
REGRESSION (iOS 16): RELEASE_ASSERT in slow_path_wasm_loop_osr

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -75,6 +75,8 @@ public:
         return Base::parseAndValidateModule(m_source.data(), m_source.size());
     }
 
+    static bool planGeneratesLoopOSREntrypoints(const ModuleInformation&);
+
 private:
     bool prepareImpl() final;
     void compileFunction(uint32_t functionIndex) final;

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -188,7 +188,7 @@ WASM_SLOW_PATH_DECL(loop_osr)
     unsigned loopOSREntryBytecodeOffset = callee->bytecodeOffset(pc);
     const auto& osrEntryData = tierUpCounter.osrEntryDataForLoop(loopOSREntryBytecodeOffset);
 
-    if (Options::wasmLLIntTiersUpToBBQ()) {
+    if (Options::wasmLLIntTiersUpToBBQ() && Wasm::BBQPlan::planGeneratesLoopOSREntrypoints(instance->module().moduleInformation())) {
         if (!jitCompileAndSetHeuristics(callee, instance))
             WASM_RETURN_TWO(nullptr, nullptr);
 


### PR DESCRIPTION
#### a1935ab9387bb87df6e60b410ef8186080db0678
<pre>
REGRESSION (iOS 16): RELEASE_ASSERT in slow_path_wasm_loop_osr
<a href="https://bugs.webkit.org/show_bug.cgi?id=242294">https://bugs.webkit.org/show_bug.cgi?id=242294</a>

Reviewed by Yusuke Suzuki.

Fix a regression caused by <a href="https://bugs.webkit.org/show_bug.cgi?id=234587.">https://bugs.webkit.org/show_bug.cgi?id=234587.</a>

This affected only iOS, and only when the WebAssembly module was greater
than 10 MB. In that case, the option `webAssemblyBBQAirModeThreshold`
caused JavaScriptCore/wasm/WasmBBQPlan.cpp to fall back from Air to B3.
However, the change in 234587 in `loop_osr` didn&apos;t correctly handle that
fallback. Changed it to use the old code path in this case.

Test: None (to be added later by @justinmichaud)

* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::planGeneratesLoopOSREntrypoints): Extracted from compileFunction.
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL): If planGeneratesLoopOSREntrypoints, use the old code path.

Canonical link: <a href="https://commits.webkit.org/252167@main">https://commits.webkit.org/252167@main</a>
</pre>
