### PR TITLE
Fix AttributeError: 'PullRequest' object has no attribute 'link'

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -256,7 +256,7 @@ class PullRequest(Command):
         for line in commit.message.split():
             tracker = Tracker.from_string(line)
             if tracker:
-                tracker.add_comment('Reverted by {}'.format(pr.link))
+                tracker.add_comment('Reverted by {}'.format(pr.url))
                 tracker.set(opened=True)
                 continue
         return 0


### PR DESCRIPTION
#### c4e941b1c00272581776616f918efc154116a00b
<pre>
Fix AttributeError: &apos;PullRequest&apos; object has no attribute &apos;link&apos;

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.add_comment_to_reverted_commit_bug_tracker):

Canonical link: <a href="https://commits.webkit.org/252162@main">https://commits.webkit.org/252162@main</a>
</pre>
