### PR TITLE
[WebGPU] Rename TypeConversion to CallableExpression and some refactoring

### DIFF
--- a/Source/WebGPU/WGSL/AST/Expression.h
+++ b/Source/WebGPU/WGSL/AST/Expression.h
@@ -42,7 +42,7 @@ public:
         AbstractFloatLiteral,
         Identifier,
         StructureAccess,
-        TypeConversion,
+        CallableExpression,
     };
 
     Expression(SourceSpan span)
@@ -61,7 +61,7 @@ public:
     bool isAbstractFloatLiteral() const { return kind() == Kind::AbstractFloatLiteral; }
     bool isIdentifier() const { return kind() == Kind::Identifier; }
     bool isStructureAccess() const { return kind() == Kind::StructureAccess; }
-    bool isTypeConversion() const { return kind() == Kind::TypeConversion; }
+    bool isCallableExpression() const { return kind() == Kind::CallableExpression; }
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -30,10 +30,10 @@
 
 #include "AST/Attribute.h"
 #include "AST/Expression.h"
+#include "AST/Expressions/CallableExpression.h"
 #include "AST/Expressions/IdentifierExpression.h"
 #include "AST/Expressions/LiteralExpressions.h"
 #include "AST/Expressions/StructureAccess.h"
-#include "AST/Expressions/TypeConversion.h"
 #include "AST/GlobalDecl.h"
 #include "AST/Statement.h"
 #include "AST/Statements/AssignmentStatement.h"
@@ -626,7 +626,7 @@ Expected<UniqueRef<AST::Expression>, Error> Parser<Lexer>::parsePrimaryExpressio
         if (current().m_type == TokenType::LT || current().m_type == TokenType::ParenLeft) {
             PARSE(type, TypeDeclAfterIdentifier, WTFMove(ident.m_ident), _startOfElementPosition);
             PARSE(arguments, ArgumentExpressionList);
-            RETURN_NODE_REF(TypeConversion, WTFMove(type), WTFMove(arguments));
+            RETURN_NODE_REF(CallableExpression, WTFMove(type), WTFMove(arguments));
         }
         RETURN_NODE_REF(IdentifierExpression, ident.m_ident);
     }

--- a/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
@@ -27,12 +27,12 @@
 #import "Parser.h"
 
 #import "AssignmentStatement.h"
+#import "CallableExpression.h"
 #import "IdentifierExpression.h"
 #import "Lexer.h"
 #import "LiteralExpressions.h"
 #import "ReturnStatement.h"
 #import "StructureAccess.h"
-#import "TypeConversion.h"
 #import "WGSL.h"
 #import <XCTest/XCTest.h>
 #import <wtf/DataLog.h>
@@ -196,14 +196,14 @@
         XCTAssert(func.body().statements()[0]->isReturn());
         WGSL::AST::ReturnStatement& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
         XCTAssert(stmt.maybeExpression());
-        XCTAssert(stmt.maybeExpression()->isTypeConversion());
-        WGSL::AST::TypeConversion& expr = downcast<WGSL::AST::TypeConversion>(*stmt.maybeExpression());
-        XCTAssert(expr.typeDecl()->isParameterized());
+        XCTAssert(stmt.maybeExpression()->isCallableExpression());
+        WGSL::AST::CallableExpression& expr = downcast<WGSL::AST::CallableExpression>(*stmt.maybeExpression());
+        XCTAssert(expr.target().isParameterized());
         XCTAssert(expr.arguments().size() == 4);
-        XCTAssert(expr.arguments()[0]->isAbstractFloatLiteral());
-        XCTAssert(expr.arguments()[1]->isAbstractFloatLiteral());
-        XCTAssert(expr.arguments()[2]->isAbstractFloatLiteral());
-        XCTAssert(expr.arguments()[3]->isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[0].get().isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[1].get().isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[2].get().isAbstractFloatLiteral());
+        XCTAssert(expr.arguments()[3].get().isAbstractFloatLiteral());
     }
 }
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		33EA188027BC24E200A1DD52 /* AssignmentStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA187F27BC24E200A1DD52 /* AssignmentStatement.h */; };
 		33EA188227BC25D000A1DD52 /* IdentifierExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188127BC25D000A1DD52 /* IdentifierExpression.h */; };
 		33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* StructureAccess.h */; };
-		33EA188627BC26DF00A1DD52 /* TypeConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* TypeConversion.h */; };
+		33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* CallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
 		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
@@ -333,7 +333,7 @@
 		33EA187F27BC24E200A1DD52 /* AssignmentStatement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AssignmentStatement.h; sourceTree = "<group>"; };
 		33EA188127BC25D000A1DD52 /* IdentifierExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IdentifierExpression.h; sourceTree = "<group>"; };
 		33EA188327BC268600A1DD52 /* StructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructureAccess.h; sourceTree = "<group>"; };
-		33EA188527BC26DF00A1DD52 /* TypeConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TypeConversion.h; sourceTree = "<group>"; };
+		33EA188527BC26DF00A1DD52 /* CallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
 		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
@@ -725,10 +725,10 @@
 		33EA187C27BC246000A1DD52 /* Expressions */ = {
 			isa = PBXGroup;
 			children = (
+				33EA188527BC26DF00A1DD52 /* CallableExpression.h */,
 				33EA188127BC25D000A1DD52 /* IdentifierExpression.h */,
 				33EA188727BC361E00A1DD52 /* LiteralExpressions.h */,
 				33EA188327BC268600A1DD52 /* StructureAccess.h */,
-				33EA188527BC26DF00A1DD52 /* TypeConversion.h */,
 			);
 			path = Expressions;
 			sourceTree = "<group>";
@@ -784,7 +784,7 @@
 				33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */,
 				33EA187427BC204900A1DD52 /* StructureDecl.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
-				33EA188627BC26DF00A1DD52 /* TypeConversion.h in Headers */,
+				33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */,
 				33EA186E27BC1D4C00A1DD52 /* TypeDecl.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* VariableQualifier.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,


### PR DESCRIPTION
#### 04bc9e6c87cb7fbb53e8630d57f5caf4f102f5cc
<pre>
[WebGPU] Rename TypeConversion to CallableExpression and some refactoring
<a href="https://bugs.webkit.org/show_bug.cgi?id=242368">https://bugs.webkit.org/show_bug.cgi?id=242368</a>

Reviewed by Myles C. Maxfield.

TypeConversion represents type casts like &quot;f32(...)&quot;. However, this looks like a function
call with &quot;f32&quot; a hypothetical function that takes in values and returns a f32. For this
reason, we would like to reuse TypeConversion for function calls as well.

To express that a TypeConversion can also represent a function call, this patch renames it to
CallableExpression, so that it represents the generic idea of calling a &quot;callable&quot;, like a
function identifier or type, with a list of arguments surrounded by parentheses.

The actual contents of the class remains unchanged, i.e it still contains a TypeDecl as the
target, and a list of Expressions as the arguments. When CallableExpression represents
a function call, then the target is simply a NamedType of the function identifier. When
CallableExpression represents a type cast, then the target is the target type to be casted to.

The patch also refactors CallableExpression a bit. The &apos;typeDecl&apos; member is renamed to &apos;target&apos;
to better show it&apos;s the target in the callable expression. Also, getters now return the
references inside UniqueRefs, instead of references to UniqueRefs.

* Source/WebGPU/WGSL/AST/Expression.h:
(WGSL::AST::Expression::isCallableExpression const):
(WGSL::AST::Expression::isTypeConversion const): Deleted.
* Source/WebGPU/WGSL/AST/Expressions/CallableExpression.h: Renamed from Source/WebGPU/WGSL/AST/Expressions/TypeConversion.h.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
(-[WGSLParserTests testTrivialGraphicsShader]):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/252174@main">https://commits.webkit.org/252174@main</a>
</pre>
