### PR TITLE
Partition sessionStorage by top-level origin

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned-expected.txt
@@ -1,0 +1,19 @@
+Tests that an origin's third-party sessionStorage area is partitioned from its first-party storage area.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS expectedResultStrings[currentStep-1] is undefined.
+PASS event.data.result is "1: Successfully retrieved sessionStorage from localhost frame: 1234."
+PASS event.data.result is "2: Retrieving sessionStorage from loopback failed: null"
+PASS event.data.result is "3: Successfully retrieved sessionStorage from localhost frame: 4321, http://localhost:8000."
+PASS event.data.result is "4: Retrieving sessionStorage from loopback failed: null"
+PASS expectedResultStrings[currentStep-1] is undefined.
+PASS expectedResultStrings[currentStep-1] is undefined.
+PASS expectedResultStrings[currentStep-1] is undefined.
+PASS event.data.result is "8: Retrieving sessionStorage from localhost failed: null"
+PASS event.data.result is "9: Retrieving sessionStorage from loopback failed: null"
+PASS expectedResultStrings[currentStep-1] is undefined.
+PASS event.data.result is "11: Successfully retrieved sessionStorage from localhost frame: 4321, http://localhost:8000."
+PASS event.data.result is "12: Successfully retrieved sessionStorage from loopback frame: 4321, http://127.0.0.1:8000."
+

--- a/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned.html
+++ b/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script>
+        description("Tests that an origin's third-party sessionStorage area is partitioned from its first-party storage area.")
+        jsTestIsAsync = true;
+
+        const testResourcePath = "/security/resources/cross-origin-main-frame-for-partitioned-session-storage.html";
+        const testValue = "1234";
+        let frames = 2;
+        let testWindow;
+        let localhostWindowTestCompleted = false;
+
+        // Step:
+        //   1) Verify stored item in main frame is accessible in localhost subframe.
+        //   2) Verify stored item in main frame is not accessible in loopback subframe.
+        //   3) Store new item in subframe and verify it is accessible in localhost main frame.
+        //   4) Store new item in subframe and verify it is not accessible in loopback main frame.
+        //   5) Stored item in localhost subframe.
+        //   6) Stored item in loopback subframe.
+        //   7) Execute navigation to loopback URL in localhost window.
+        //   8) Verify item stored by localhost subframe is not accessible in main frame.
+        //   9) Verify item stored by loopback subframe is not accessible in main frame.
+        //  10) Return main frame to localhost.
+        //  11) Verify stored item is accessible in localhost subframe.
+        //  12) Verify stored item is accessible in loopback subframe.
+        var currentStep = 1;
+
+        let expectedResultStrings = [
+            undefined,
+            '1: Successfully retrieved sessionStorage from localhost frame: 1234.',
+            '2: Retrieving sessionStorage from loopback failed: null',
+            '3: Successfully retrieved sessionStorage from localhost frame: 4321, http://localhost:8000.',
+            '4: Retrieving sessionStorage from loopback failed: null',
+            undefined,
+            undefined,
+            undefined,
+            '8: Retrieving sessionStorage from localhost failed: null',
+            '9: Retrieving sessionStorage from loopback failed: null',
+            undefined,
+            '11: Successfully retrieved sessionStorage from localhost frame: 4321, http://localhost:8000.',
+            '12: Successfully retrieved sessionStorage from loopback frame: 4321, http://127.0.0.1:8000.'
+        ];
+
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('message', (event) => {
+            if (event.origin !== "http://localhost:8000" && event.origin !== "http://127.0.0.1:8000") {
+                testFailed(`Message from unexpected origin: ${event.origin}`);
+                return;
+            }
+
+            if (event.data === "loopbackFrame not defined." || event.data === "localhostFrame not defined.") {
+                testFailed(`Loading subframe failed: ${event.data}`);
+                return;
+            }
+
+            if (event.data.result)
+                shouldBeEqualToString('event.data.result', expectedResultStrings[currentStep-1]);
+            else
+                shouldBeUndefined('expectedResultStrings[currentStep-1]');
+
+            switch (currentStep) {
+            case 1:
+            case 2:
+                event.source.postMessage({'step': currentStep, 'testValue': testValue}, "*");
+                break;
+            case 3:
+            case 4:
+                event.source.postMessage({'step': currentStep}, "*");
+                break;
+            case 5:
+            case 6:
+                event.source.postMessage({'step': currentStep}, "*");
+                break;
+            case 7:
+                testWindow = window.open(`http://127.0.0.1:8000${testResourcePath}`, "testWindow");
+                break;
+            case 8:
+            case 9:
+            case 11:
+            case 12:
+                event.source.postMessage({'step': currentStep, 'testValue': testValue}, "*");
+                break;
+            case 10:
+                event.source.postMessage({'step': currentStep}, "*");
+                break;
+            case 13:
+                if (window.testRunner)
+                    testRunner.notifyDone();
+                break;
+            default:
+                testFailed(`Reached unexpected default case. step: ${currentStep}, data:`, event.data ? event.data : "no event data" );
+            }
+
+            currentStep += 1;
+        }, false);
+
+        // Begin with localhost main frame
+        testWindow = window.open(`http://localhost:8000${testResourcePath}`, "testWindow");
+
+    </script>
+</head>
+<body>
+    <div id="logging"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/cross-origin-iframe-for-partitioned-session-storage.html
+++ b/LayoutTests/http/tests/security/resources/cross-origin-iframe-for-partitioned-session-storage.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <script>
+        window.addEventListener('message', (event) => {
+            /* Allow messages from all origins */
+            let testValue = `4321, ${window.origin}`;
+            let {step, testKey} = event.data;
+            switch (step) {
+            case 1:
+            case 2: {
+                let result = window.sessionStorage.getItem(testKey);
+                event.source.postMessage({"step": step, "result": result}, event.origin);
+                break;
+            }
+            case 3:
+            case 4: {
+                window.sessionStorage.setItem(testKey, testValue);
+                event.source.postMessage({"step": step, "testValue": testValue}, event.origin);
+                break;
+            }
+            case 5:
+            case 6: {
+                window.sessionStorage.setItem(testKey, testValue);
+                event.source.postMessage({"step": step}, event.origin);
+                break;
+            }
+            case 8:
+            case 9:
+            case 11:
+            case 12: {
+                let result = window.sessionStorage.getItem(testKey);
+                event.source.postMessage({"step": step, "result": result}, event.origin);
+                break;
+            }
+            default:
+                document.write(`Reached unexpected default case. step: ${step}, data: ${event.data}`);
+            }
+        }, false);
+
+        //window.top.postMessage("go", "*");
+    </script>
+</body>
+</head>

--- a/LayoutTests/http/tests/security/resources/cross-origin-main-frame-for-partitioned-session-storage.html
+++ b/LayoutTests/http/tests/security/resources/cross-origin-main-frame-for-partitioned-session-storage.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+    <script src="/js-test-resources/js-test-pre.js"></script>
+<head>
+</head>
+<body>
+    <script>
+        var isOnHistoryBack = false;
+        var opener = window.opener;
+        var loopbackFrame;
+        var localhostFrame;
+        var cachedInfo;
+
+        function localhostFrameLoaded() {
+            localhostFrame = document.getElementById("localhost-frame");
+            if (localhostFrame === undefined) {
+                opener.postMessage("localhostFrame not defined.");
+                return;
+            }
+            if (localhostFrame && loopbackFrame)
+                opener.postMessage("go", "*");
+        }
+
+        function loopbackFrameLoaded() {
+            loopbackFrame = document.getElementById("loopback-frame");
+            if (loopbackFrame === undefined) {
+                opener.postMessage("loopbackFrame not defined.");
+                return;
+            }
+            if (localhostFrame && loopbackFrame)
+                opener.postMessage("go", "*");
+        }
+
+        // Continuation on history.back().
+        window.addEventListener("pageshow", (event) => {
+            if (isOnHistoryBack)
+                opener.postMessage({}, "*");
+        });
+
+        window.addEventListener('message', (event) => {
+            // Handle messages from both opener context and subframes
+            let messageFromOpener = (event.source === opener);
+            let { step } = event.data;
+            switch (step) {
+            case 1:
+            case 2: {
+                const isLocalhostTest = step == 1;
+                let testKey = isLocalhostTest ? "mainFrameLocalhostTest" : "mainFrameLoopbackTest";
+                let targetOrigin = isLocalhostTest ? "localhost" : "loopback";
+                if (messageFromOpener) {
+                    let {_, testValue} = event.data;
+                    cachedInfo = testValue;
+                    let subframe = isLocalhostTest ? localhostFrame : loopbackFrame;
+                    window.sessionStorage.setItem(testKey, testValue);
+                    subframe.contentWindow.postMessage({"step": step, "testKey": testKey}, "*");
+                    break;
+                }
+                // Message from subframe.
+                let {_, result} = event.data;
+                let resultMsg;
+                if (result === cachedInfo)
+                    resultMsg = `${step}: Successfully retrieved sessionStorage from ${targetOrigin} frame: ${result}.`;
+                else
+                    resultMsg = `${step}: Retrieving sessionStorage from ${targetOrigin} failed: ${result}`;
+                opener.postMessage({"result": resultMsg}, "*");
+                break;
+            }
+            case 3:
+            case 4: {
+                const isLocalhostTest = step == 3;
+                let testKey = isLocalhostTest ? "subFrameLocalhostTest" : "subFrameLoopbackTest";
+                let targetOrigin = isLocalhostTest ? "localhost" : "loopback";
+                if (messageFromOpener) {
+                    let {_, param} = event.data;
+                    let testValue = param;
+                    let subframe = isLocalhostTest ? localhostFrame : loopbackFrame;
+                    subframe.contentWindow.postMessage({"step": step, "testKey": testKey}, "*");
+                    break;
+                }
+                // Message from subframe.
+                let {_, testValue} = event.data;
+                let result = window.sessionStorage.getItem(testKey);
+                let resultMsg;
+                if (result === testValue)
+                    resultMsg = `${step}: Successfully retrieved sessionStorage from ${targetOrigin} frame: ${result}.`;
+                else
+                    resultMsg = `${step}: Retrieving sessionStorage from ${targetOrigin} failed: ${result}`;
+                opener.postMessage({"result": resultMsg}, "*");
+                window.sessionStorage.clear();
+                break;
+            }
+            case 5:
+            case 6: {
+                const isLocalhostTest = step == 5;
+                let testKey = isLocalhostTest ? "subFrameLocalhostTest" : "subFrameLoopbackTest";
+                let targetOrigin = isLocalhostTest ? "localhost" : "loopback";
+                if (messageFromOpener) {
+                    let subframe = isLocalhostTest ? localhostFrame : loopbackFrame;
+                    subframe.contentWindow.postMessage({"step": step, "testKey": testKey}, "*");
+                    break;
+                }
+                // Message from subframe.
+                opener.postMessage({}, "*");
+                // Step 7 is when the page is navigated, therefore the next time this variable is accessed will be when returning from that navigation.
+                isOnHistoryBack = true;
+                break;
+            }
+            case 8:
+            case 9:
+            case 11:
+            case 12: {
+                const isLocalhostTest = (step == 8 || step == 11);
+                let testKey = isLocalhostTest ? "subFrameLocalhostTest" : "subFrameLoopbackTest";
+                let targetOrigin = isLocalhostTest ? "localhost" : "loopback";
+                if (messageFromOpener) {
+                    let subframe = isLocalhostTest ? localhostFrame : loopbackFrame;
+                    subframe.contentWindow.postMessage({"step": step, "testKey": testKey}, "*");
+                    break;
+                }
+                // Message from subframe.
+
+                let {_, result} = event.data;
+                let resultMsg;
+                if (result !== null)
+                    resultMsg = `${step}: Successfully retrieved sessionStorage from ${targetOrigin} frame: ${result}.`;
+                else
+                    resultMsg = `${step}: Retrieving sessionStorage from ${targetOrigin} failed: ${result}`;
+                opener.postMessage({"result": resultMsg}, "*");
+                break;
+            }
+            case 10:
+                history.back();
+                break;
+            default:
+                testFailed(`Reached unexpected default case. step: ${step}, data:`, event.data);
+            }
+        }, false);
+    </script>
+    <iframe id="localhost-frame" src="http://localhost:8000/security/resources/cross-origin-iframe-for-partitioned-session-storage.html" onload="localhostFrameLoaded()"></iframe>
+    <iframe id="loopback-frame" src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-partitioned-session-storage.html" onload="loopbackFrameLoaded()"></iframe>
+    <div id="logging"></div>
+</body>
+</head>
+

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -213,9 +213,10 @@ RefPtr<StorageArea> InspectorDOMStorageAgent::findStorageArea(Protocol::ErrorStr
         return nullptr;
     }
 
+    auto& document = *targetFrame->document();
     if (!*isLocalStorage)
-        return m_inspectedPage.sessionStorage()->storageArea(targetFrame->document()->securityOrigin());
-    return m_inspectedPage.storageNamespaceProvider().localStorageArea(*targetFrame->document());
+        return m_inspectedPage.storageNamespaceProvider().sessionStorageArea(document);
+    return m_inspectedPage.storageNamespaceProvider().localStorageArea(document);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -493,6 +493,9 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
             : m_sessionID(sessionID)
         {
         }
+
+        const SecurityOrigin* topLevelOrigin() const final { return nullptr; };
+
     private:
         Ref<StorageArea> storageArea(const SecurityOrigin&) final { return adoptRef(*new EmptyStorageArea); }
         Ref<StorageNamespace> copy(Page&) final { return adoptRef(*new EmptyStorageNamespace { m_sessionID }); }
@@ -502,10 +505,11 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
         PAL::SessionID m_sessionID;
     };
 
-    Ref<StorageNamespace> createSessionStorageNamespace(Page&, unsigned) final;
     Ref<StorageNamespace> createLocalStorageNamespace(unsigned, PAL::SessionID) final;
     Ref<StorageNamespace> createTransientLocalStorageNamespace(SecurityOrigin&, unsigned, PAL::SessionID) final;
 
+    void copySessionStorageNamespace(Page&, Page&) final { };
+    RefPtr<StorageNamespace> sessionStorageNamespace(const SecurityOrigin&, Page&, ShouldCreateNamespace) final;
 };
 
 class EmptyUserContentProvider final : public UserContentProvider {
@@ -1146,7 +1150,7 @@ void EmptyEditorClient::registerRedoStep(UndoStep&)
 {
 }
 
-Ref<StorageNamespace> EmptyStorageNamespaceProvider::createSessionStorageNamespace(Page& page, unsigned)
+RefPtr<StorageNamespace> EmptyStorageNamespaceProvider::sessionStorageNamespace(const SecurityOrigin&, Page& page, ShouldCreateNamespace)
 {
     return adoptRef(*new EmptyStorageNamespace { page.sessionID() });
 }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -51,6 +51,7 @@
 #include "Settings.h"
 #include "ShareData.h"
 #include "StorageNamespace.h"
+#include "StorageNamespaceProvider.h"
 #include "WindowFeatures.h"
 #include <JavaScriptCore/VM.h>
 #include <wtf/SetForScope.h>
@@ -195,10 +196,8 @@ Page* Chrome::createWindow(Frame& frame, const WindowFeatures& features, const N
     if (!newPage)
         return nullptr;
 
-    if (!features.noopener && !features.noreferrer) {
-        if (auto* oldSessionStorage = m_page.sessionStorage(false))
-            newPage->setSessionStorage(oldSessionStorage->copy(*newPage));
-    }
+    if (!features.noopener && !features.noreferrer)
+        m_page.storageNamespaceProvider().copySessionStorageNamespace(m_page, *newPage);
 
     return newPage;
 }

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -848,7 +848,7 @@ ExceptionOr<Storage*> DOMWindow::sessionStorage()
     if (!page)
         return nullptr;
 
-    auto storageArea = page->sessionStorage()->storageArea(document->securityOrigin());
+    auto storageArea = page->storageNamespaceProvider().sessionStorageArea(*document);
     m_sessionStorage = Storage::create(*this, WTFMove(storageArea));
     if (hasEventListeners(eventNames().storageEvent))
         windowsInterestedInStorageEvents().add(*this);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -372,6 +372,8 @@ Page::Page(PageConfiguration&& pageConfiguration)
     pageCounter.increment();
 #endif
 
+    m_storageNamespaceProvider->setSessionStorageQuota(m_settings->sessionStorageQuota());
+
 #if ENABLE(REMOTE_INSPECTOR)
     if (m_inspectorController->inspectorClient() && m_inspectorController->inspectorClient()->allowRemoteInspectionToPageDirectly())
         m_inspectorDebuggable->init();
@@ -2142,21 +2144,6 @@ void Page::setDebugger(JSC::Debugger* debugger)
         frame->windowProxy().attachDebugger(m_debugger);
 }
 
-StorageNamespace* Page::sessionStorage(bool optionalCreate)
-{
-    if (!m_sessionStorage && optionalCreate) {
-        ASSERT(m_settings->sessionStorageQuota() != StorageMap::noQuota);
-        m_sessionStorage = m_storageNamespaceProvider->createSessionStorageNamespace(*this, m_settings->sessionStorageQuota());
-    }
-
-    return m_sessionStorage.get();
-}
-
-void Page::setSessionStorage(RefPtr<StorageNamespace>&& newStorage)
-{
-    m_sessionStorage = WTFMove(newStorage);
-}
-
 bool Page::hasCustomHTMLTokenizerTimeDelay() const
 {
     return m_settings->maxParseDuration() != -1;
@@ -3138,8 +3125,11 @@ void Page::setSessionID(PAL::SessionID sessionID)
     if (sessionID != m_sessionID)
         m_idbConnectionToServer = nullptr;
 
-    if (sessionID != m_sessionID && m_sessionStorage)
-        m_sessionStorage->setSessionIDForTesting(sessionID);
+    if (sessionID != m_sessionID) {
+        constexpr auto doNotCreate = StorageNamespaceProvider::ShouldCreateNamespace::No;
+        if (auto sessionStorage = m_storageNamespaceProvider->sessionStorageNamespace(m_mainFrame->document()->topOrigin(), *this, doNotCreate))
+            sessionStorage->setSessionIDForTesting(sessionID);
+    }
 
     bool privateBrowsingStateChanged = (sessionID.isEphemeral() != m_sessionID.isEphemeral());
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -674,9 +674,6 @@ public:
 
     void invalidateInjectedStyleSheetCacheInAllFrames();
 
-    StorageNamespace* sessionStorage(bool optionalCreate = true);
-    void setSessionStorage(RefPtr<StorageNamespace>&&);
-
     bool hasCustomHTMLTokenizerTimeDelay() const;
     double customHTMLTokenizerTimeDelay() const;
 
@@ -1143,8 +1140,6 @@ private:
     JSC::Debugger* m_debugger { nullptr };
 
     bool m_canStartMedia { true };
-
-    RefPtr<StorageNamespace> m_sessionStorage;
 
     TimerThrottlingState m_timerThrottlingState { TimerThrottlingState::Disabled };
     MonotonicTime m_timerThrottlingStateLastChangedTime;

--- a/Source/WebCore/storage/StorageNamespace.h
+++ b/Source/WebCore/storage/StorageNamespace.h
@@ -42,6 +42,7 @@ class StorageNamespace : public RefCounted<StorageNamespace> {
 public:
     virtual ~StorageNamespace() = default;
     virtual Ref<StorageArea> storageArea(const SecurityOrigin&) = 0;
+    virtual const SecurityOrigin* topLevelOrigin() const = 0;
 
     // FIXME: This is only valid for session storage and should probably be moved to a subclass.
     virtual Ref<StorageNamespace> copy(Page& newPage) = 0;

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -60,6 +60,15 @@ Ref<StorageArea> StorageNamespaceProvider::localStorageArea(Document& document)
     return storageNamespace->storageArea(document.securityOrigin());
 }
 
+Ref<StorageArea> StorageNamespaceProvider::sessionStorageArea(Document& document)
+{
+    // This StorageNamespaceProvider was retrieved from the Document's Page,
+    // so the Document had better still actually have a Page.
+    ASSERT(document.page());
+
+    return sessionStorageNamespace(document.topOrigin(), *document.page())->storageArea(document.securityOrigin());
+}
+
 StorageNamespace& StorageNamespaceProvider::localStorageNamespace(PAL::SessionID sessionID)
 {
     if (!m_localStorageNamespace)

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -46,14 +46,20 @@ public:
     WEBCORE_EXPORT StorageNamespaceProvider();
     WEBCORE_EXPORT virtual ~StorageNamespaceProvider();
 
-    virtual Ref<StorageNamespace> createSessionStorageNamespace(Page&, unsigned quota) = 0;
-
     Ref<StorageArea> localStorageArea(Document&);
+    Ref<StorageArea> sessionStorageArea(Document&);
+
+    enum class ShouldCreateNamespace : bool { No, Yes };
+    virtual RefPtr<StorageNamespace> sessionStorageNamespace(const SecurityOrigin&, Page&, ShouldCreateNamespace = ShouldCreateNamespace::Yes) = 0;
 
     WEBCORE_EXPORT void setSessionIDForTesting(PAL::SessionID);
 
+    void setSessionStorageQuota(unsigned quota) { m_sessionStorageQuota = quota; }
+    virtual void copySessionStorageNamespace(Page&, Page&) = 0;
+
 protected:
     StorageNamespace* optionalLocalStorageNamespace() { return m_localStorageNamespace.get(); }
+    unsigned sessionStorageQuota() const { return m_sessionStorageQuota; }
 
 private:
     friend class Internals;
@@ -65,6 +71,8 @@ private:
 
     RefPtr<StorageNamespace> m_localStorageNamespace;
     HashMap<SecurityOriginData, RefPtr<StorageNamespace>> m_transientLocalStorageNamespaces;
+
+    unsigned m_sessionStorageQuota { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -693,6 +693,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     m_page = makeUnique<Page>(WTFMove(pageConfiguration));
 
+    WebStorageNamespaceProvider::incrementUseCount(*m_pageGroup, sessionStorageNamespaceIdentifier());
+
 #if PLATFORM(IOS)
     setAllowsDeprecatedSynchronousXMLHttpRequestDuringUnload(parameters.allowsDeprecatedSynchronousXMLHttpRequestDuringUnload);
 #endif
@@ -1093,6 +1095,8 @@ WebPage::~WebPage()
     if (m_footerBanner)
         m_footerBanner->detachFromPage();
 #endif
+
+    WebStorageNamespaceProvider::decrementUseCount(*m_pageGroup, sessionStorageNamespaceIdentifier());
 
 #ifndef NDEBUG
     webPageCounter.decrement();

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
@@ -42,19 +42,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<StorageNamespaceImpl::Identifier, StorageNamespaceImpl*>& sessionStorageNamespaces()
+Ref<StorageNamespaceImpl> StorageNamespaceImpl::createSessionStorageNamespace(Identifier identifier, PageIdentifier pageID, const WebCore::SecurityOrigin& topLevelOrigin, unsigned quotaInBytes)
 {
-    static NeverDestroyed<HashMap<StorageNamespaceImpl::Identifier, StorageNamespaceImpl*>> map;
-    return map;
-}
-
-Ref<StorageNamespaceImpl> StorageNamespaceImpl::createSessionStorageNamespace(Identifier identifier, PageIdentifier pageID, unsigned quotaInBytes)
-{
-    // The identifier of a session storage namespace is the WebPageProxyIdentifier. It is possible we have several WebPage objects in a single process for the same
-    // WebPageProxyIdentifier and these need to share the same namespace instance so we know where to route the IPC to.
-    if (auto* existingNamespace = sessionStorageNamespaces().get(identifier))
-        return *existingNamespace;
-    return adoptRef(*new StorageNamespaceImpl(StorageType::Session, identifier, pageID, nullptr, quotaInBytes));
+    return adoptRef(*new StorageNamespaceImpl(StorageType::Session, identifier, pageID, &topLevelOrigin, quotaInBytes));
 }
 
 Ref<StorageNamespaceImpl> StorageNamespaceImpl::createLocalStorageNamespace(Identifier identifier, unsigned quotaInBytes)
@@ -67,7 +57,7 @@ Ref<StorageNamespaceImpl> StorageNamespaceImpl::createTransientLocalStorageNames
     return adoptRef(*new StorageNamespaceImpl(StorageType::TransientLocal, identifier, std::nullopt, &topLevelOrigin, quotaInBytes));
 }
 
-StorageNamespaceImpl::StorageNamespaceImpl(WebCore::StorageType storageType, Identifier storageNamespaceID, const std::optional<PageIdentifier>& pageIdentifier, WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes)
+StorageNamespaceImpl::StorageNamespaceImpl(WebCore::StorageType storageType, Identifier storageNamespaceID, const std::optional<PageIdentifier>& pageIdentifier, const WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes)
     : m_storageType(storageType)
     , m_storageNamespaceID(storageNamespaceID)
     , m_sessionPageID(pageIdentifier)
@@ -75,19 +65,6 @@ StorageNamespaceImpl::StorageNamespaceImpl(WebCore::StorageType storageType, Ide
     , m_quotaInBytes(quotaInBytes)
 {
     ASSERT(storageType == StorageType::Session || !m_sessionPageID);
-    
-    if (m_storageType == StorageType::Session) {
-        ASSERT(!sessionStorageNamespaces().contains(m_storageNamespaceID));
-        sessionStorageNamespaces().add(m_storageNamespaceID, this);
-    }
-}
-
-StorageNamespaceImpl::~StorageNamespaceImpl()
-{
-    if (m_storageType == StorageType::Session) {
-        bool wasRemoved = sessionStorageNamespaces().remove(m_storageNamespaceID);
-        ASSERT_UNUSED(wasRemoved, wasRemoved);
-    }
 }
 
 PAL::SessionID StorageNamespaceImpl::sessionID() const
@@ -112,9 +89,6 @@ Ref<StorageNamespace> StorageNamespaceImpl::copy(Page& newPage)
 {
     ASSERT(m_storageNamespaceID);
     ASSERT(m_storageType == StorageType::Session);
-
-    if (auto networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection())
-        networkProcessConnection->connection().send(Messages::NetworkStorageManager::CloneSessionStorageNamespace(m_storageNamespaceID, WebPage::fromCorePage(newPage).sessionStorageNamespaceIdentifier()), 0);
 
     return adoptRef(*new StorageNamespaceImpl(m_storageType, WebPage::fromCorePage(newPage).sessionStorageNamespaceIdentifier(), WebPage::fromCorePage(newPage).identifier(), m_topLevelOrigin.get(), m_quotaInBytes));
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h
@@ -45,18 +45,18 @@ class StorageNamespaceImpl final : public WebCore::StorageNamespace {
 public:
     using Identifier = StorageNamespaceIdentifier;
 
-    static Ref<StorageNamespaceImpl> createSessionStorageNamespace(Identifier, WebCore::PageIdentifier, unsigned quotaInBytes);
+    static Ref<StorageNamespaceImpl> createSessionStorageNamespace(Identifier, WebCore::PageIdentifier, const WebCore::SecurityOrigin&, unsigned quotaInBytes);
     static Ref<StorageNamespaceImpl> createLocalStorageNamespace(Identifier, unsigned quotaInBytes);
     static Ref<StorageNamespaceImpl> createTransientLocalStorageNamespace(Identifier, WebCore::SecurityOrigin& topLevelOrigin, uint64_t quotaInBytes);
 
-    virtual ~StorageNamespaceImpl();
+    virtual ~StorageNamespaceImpl() = default;
 
     WebCore::StorageType storageType() const { return m_storageType; }
     Identifier storageNamespaceID() const { return m_storageNamespaceID; }
     // Namespace IDs for local storage namespaces are currently equivalent to web page group IDs.
     WebCore::PageIdentifier sessionStoragePageID() const;
     PageGroupIdentifier pageGroupID() const;
-    WebCore::SecurityOrigin* topLevelOrigin() const { return m_topLevelOrigin.get(); }
+    const WebCore::SecurityOrigin* topLevelOrigin() const final { return m_topLevelOrigin.get(); }
     unsigned quotaInBytes() const { return m_quotaInBytes; }
     PAL::SessionID sessionID() const override;
 
@@ -65,7 +65,7 @@ public:
     void setSessionIDForTesting(PAL::SessionID) override;
 
 private:
-    StorageNamespaceImpl(WebCore::StorageType, Identifier, const std::optional<WebCore::PageIdentifier>&, WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes);
+    StorageNamespaceImpl(WebCore::StorageType, Identifier, const std::optional<WebCore::PageIdentifier>&, const WebCore::SecurityOrigin* topLevelOrigin, unsigned quotaInBytes);
 
     Ref<WebCore::StorageArea> storageArea(const WebCore::SecurityOrigin&) final;
     uint64_t storageAreaMapCountForTesting() const final { return m_storageAreaMaps.size(); }
@@ -77,8 +77,8 @@ private:
     const Identifier m_storageNamespaceID;
     std::optional<WebCore::PageIdentifier> m_sessionPageID;
 
-    // Only used for transient local storage namespaces.
-    const RefPtr<WebCore::SecurityOrigin> m_topLevelOrigin;
+    // Used for transient local storage and session storage namespaces, nullptr otherwise.
+    const RefPtr<const WebCore::SecurityOrigin> m_topLevelOrigin;
 
     const unsigned m_quotaInBytes;
 

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "WebStorageNamespaceProvider.h"
 
-#include "StorageNamespaceImpl.h"
 #include "WebPage.h"
 #include "WebPageGroupProxy.h"
 #include "WebProcess.h"
@@ -53,6 +52,33 @@ Ref<WebStorageNamespaceProvider> WebStorageNamespaceProvider::getOrCreate(WebPag
     return *result;
 }
 
+void WebStorageNamespaceProvider::incrementUseCount(const WebPageGroupProxy& pageGroup, const StorageNamespaceImpl::Identifier identifier)
+{
+    auto storageNamespaceIt = storageNamespaceProviders().find(pageGroup.localStorageNamespaceIdentifier());
+    ASSERT(storageNamespaceIt != storageNamespaceProviders().end());
+    ASSERT(storageNamespaceIt->value);
+    auto& sessionStorageNamespaces = storageNamespaceIt->value->m_sessionStorageNamespaces.add(identifier, SessionStorageNamespaces { }).iterator->value;
+    ++sessionStorageNamespaces.useCount;
+}
+
+void WebStorageNamespaceProvider::decrementUseCount(const WebPageGroupProxy& pageGroup, const StorageNamespaceImpl::Identifier identifier)
+{
+    auto namespaceProviderIt = storageNamespaceProviders().find(pageGroup.localStorageNamespaceIdentifier());
+
+    if (namespaceProviderIt == storageNamespaceProviders().end() || !namespaceProviderIt->value)
+        return;
+
+    auto& namespaces = namespaceProviderIt->value->m_sessionStorageNamespaces;
+
+    auto it = namespaces.find(identifier);
+    ASSERT(it != namespaces.end());
+    auto& sessionStorageNamespaces = it->value;
+    ASSERT(sessionStorageNamespaces.useCount);
+    --sessionStorageNamespaces.useCount;
+    if (!sessionStorageNamespaces.useCount)
+        namespaces.remove(identifier);
+}
+
 WebStorageNamespaceProvider::WebStorageNamespaceProvider(StorageNamespaceIdentifier localStorageNamespaceIdentifier)
     : m_localStorageNamespaceIdentifier(localStorageNamespaceIdentifier)
 {
@@ -65,12 +91,6 @@ WebStorageNamespaceProvider::~WebStorageNamespaceProvider()
     storageNamespaceProviders().remove(m_localStorageNamespaceIdentifier);
 }
 
-Ref<WebCore::StorageNamespace> WebStorageNamespaceProvider::createSessionStorageNamespace(Page& page, unsigned quota)
-{
-    auto& webPage = WebPage::fromCorePage(page);
-    return StorageNamespaceImpl::createSessionStorageNamespace(webPage.sessionStorageNamespaceIdentifier(), webPage.identifier(), quota);
-}
-
 Ref<WebCore::StorageNamespace> WebStorageNamespaceProvider::createLocalStorageNamespace(unsigned quota, PAL::SessionID sessionID)
 {
     ASSERT_UNUSED(sessionID, sessionID == WebProcess::singleton().sessionID());
@@ -81,6 +101,60 @@ Ref<WebCore::StorageNamespace> WebStorageNamespaceProvider::createTransientLocal
 {
     ASSERT_UNUSED(sessionID, sessionID == WebProcess::singleton().sessionID());
     return StorageNamespaceImpl::createTransientLocalStorageNamespace(m_localStorageNamespaceIdentifier, topLevelOrigin, quota);
+}
+
+RefPtr<WebCore::StorageNamespace> WebStorageNamespaceProvider::sessionStorageNamespace(const WebCore::SecurityOrigin& topLevelOrigin, WebCore::Page& page, ShouldCreateNamespace shouldCreate)
+{
+    ASSERT(sessionStorageQuota() != WebCore::StorageMap::noQuota);
+
+    auto& webPage = WebPage::fromCorePage(page);
+
+    // The identifier of a session storage namespace is the WebPageProxyIdentifier. It is possible we have several WebPage objects in a single process for the same
+    // WebPageProxyIdentifier and these need to share the same namespace instance so we know where to route the IPC to.
+    auto namespacesIt = m_sessionStorageNamespaces.find(webPage.sessionStorageNamespaceIdentifier());
+    if (namespacesIt == m_sessionStorageNamespaces.end()) {
+        if (shouldCreate == ShouldCreateNamespace::No)
+            return nullptr;
+        namespacesIt = m_sessionStorageNamespaces.set(webPage.sessionStorageNamespaceIdentifier(), SessionStorageNamespaces { }).iterator;
+    }
+
+    auto& sessionStorageNamespacesMap = namespacesIt->value.map;
+    auto it = sessionStorageNamespacesMap.find(topLevelOrigin.data());
+    if (it == sessionStorageNamespacesMap.end()) {
+        if (shouldCreate == ShouldCreateNamespace::No)
+            return nullptr;
+        auto sessionStorageNamespace = StorageNamespaceImpl::createSessionStorageNamespace(webPage.sessionStorageNamespaceIdentifier(), webPage.identifier(), topLevelOrigin, sessionStorageQuota());
+        it = sessionStorageNamespacesMap.set(topLevelOrigin.data(), WTFMove(sessionStorageNamespace)).iterator;
+    }
+    return it->value;
+}
+
+void WebStorageNamespaceProvider::copySessionStorageNamespace(WebCore::Page& srcPage, WebCore::Page& dstPage)
+{
+    ASSERT(sessionStorageQuota() != WebCore::StorageMap::noQuota);
+
+    const auto& srcWebPage = WebPage::fromCorePage(srcPage);
+    const auto& dstWebPage = WebPage::fromCorePage(dstPage);
+
+    auto srcNamespacesIt = m_sessionStorageNamespaces.find(srcWebPage.sessionStorageNamespaceIdentifier());
+    if (srcNamespacesIt == m_sessionStorageNamespaces.end())
+        return;
+
+    ASSERT(srcNamespacesIt->value.useCount);
+
+    auto& srcNamespacesMap = srcNamespacesIt->value.map;
+
+    auto& dstSessionStorageNamespaces = static_cast<WebStorageNamespaceProvider&>(dstPage.storageNamespaceProvider()).m_sessionStorageNamespaces;
+    auto dstNamespacesIt = dstSessionStorageNamespaces.find(dstWebPage.sessionStorageNamespaceIdentifier());
+    ASSERT(dstNamespacesIt != dstSessionStorageNamespaces.end());
+    ASSERT(dstNamespacesIt->value.useCount == 1);
+    auto& dstNamespacesMap = dstNamespacesIt->value.map;
+
+    if (auto networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection())
+        networkProcessConnection->connection().send(Messages::NetworkStorageManager::CloneSessionStorageNamespace(srcWebPage.sessionStorageNamespaceIdentifier(), dstWebPage.sessionStorageNamespaceIdentifier()), 0);
+
+    for (auto& [origin, srcNamespace] : srcNamespacesMap)
+        dstNamespacesMap.set(origin, srcNamespace->copy(dstPage));
 }
 
 }

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "StorageNamespaceIdentifier.h"
+#include "StorageNamespaceImpl.h"
 #include <WebCore/StorageNamespaceProvider.h>
 
 namespace WebKit {
@@ -37,14 +38,26 @@ public:
     static Ref<WebStorageNamespaceProvider> getOrCreate(WebPageGroupProxy&);
     virtual ~WebStorageNamespaceProvider();
 
+    static void incrementUseCount(const WebPageGroupProxy&, const StorageNamespaceImpl::Identifier);
+    static void decrementUseCount(const WebPageGroupProxy&, const StorageNamespaceImpl::Identifier);
+
 private:
     explicit WebStorageNamespaceProvider(StorageNamespaceIdentifier localStorageIdentifier);
 
-    Ref<WebCore::StorageNamespace> createSessionStorageNamespace(WebCore::Page&, unsigned quota) override;
     Ref<WebCore::StorageNamespace> createLocalStorageNamespace(unsigned quota, PAL::SessionID) override;
     Ref<WebCore::StorageNamespace> createTransientLocalStorageNamespace(WebCore::SecurityOrigin&, unsigned quota, PAL::SessionID) override;
 
+    RefPtr<WebCore::StorageNamespace> sessionStorageNamespace(const WebCore::SecurityOrigin&, WebCore::Page&, ShouldCreateNamespace) final;
+    void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
+
     const StorageNamespaceIdentifier m_localStorageNamespaceIdentifier;
+
+    struct SessionStorageNamespaces {
+        unsigned useCount { 0 };
+        HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>> map;
+    };
+
+    HashMap<StorageNamespaceImpl::Identifier, SessionStorageNamespaces> m_sessionStorageNamespaces;
 };
 
 }

--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
@@ -56,6 +56,7 @@ public:
 
     PAL::SessionID sessionID() const final { return m_sessionID; }
     void setSessionIDForTesting(PAL::SessionID) final;
+    const WebCore::SecurityOrigin* topLevelOrigin() const final { return nullptr; };
 
 private:
     StorageNamespaceImpl(WebCore::StorageType, const String& path, unsigned quota, PAL::SessionID);

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StorageNamespaceProvider.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 struct SecurityOriginData;
@@ -49,11 +50,14 @@ public:
 private:
     explicit WebStorageNamespaceProvider(const String& localStorageDatabasePath);
 
-    Ref<WebCore::StorageNamespace> createSessionStorageNamespace(WebCore::Page&, unsigned quota) override;
     Ref<WebCore::StorageNamespace> createLocalStorageNamespace(unsigned quota, PAL::SessionID) override;
     Ref<WebCore::StorageNamespace> createTransientLocalStorageNamespace(WebCore::SecurityOrigin&, unsigned quota, PAL::SessionID) override;
 
+    RefPtr<WebCore::StorageNamespace> sessionStorageNamespace(const WebCore::SecurityOrigin&, WebCore::Page&, ShouldCreateNamespace) final;
+    void copySessionStorageNamespace(WebCore::Page&, WebCore::Page&) final;
+
     const String m_localStorageDatabasePath;
+    WeakHashMap<WebCore::Page, HashMap<WebCore::SecurityOriginData, RefPtr<WebCore::StorageNamespace>>> m_sessionStorageNamespaces;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### d5739b8e09742e6df2e40e0691a98f1801280db3
<pre>
Partition sessionStorage by top-level origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=210776">https://bugs.webkit.org/show_bug.cgi?id=210776</a>
rdar://57674840

Reviewed by Alex Christensen and Sihui Liu.

A page could access its origin&apos;s sessionStorage in both first-party and
third-party contexts. This differs from other storage systems and caches where
in a third-party context those storage areas are partitioned based on the
first-party (top-level) origin. This issue is addressed by ensuring that a
Window&apos;s sessionStorage takes the top-level origin into account at access-time.

This accounting is accomplished by keying the StorageNamespace by top-level
origin and the namespace identifier. One complexity was how the Page object
caches the resulting StorageNamespace, now partitioned by origin. This change
interacted poorly with the creation and destruction of the Page object during
navigation. As a result, ownership of the StorageNamespace is moved from the
Page into the StorageNamespaceProvider.

* LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned-expected.txt: Added.
* LayoutTests/http/tests/security/cross-origin-session-storage-third-party-partitioned.html: Added.
* LayoutTests/http/tests/security/resources/cross-origin-iframe-for-partitioned-session-storage.html: Added.
* LayoutTests/http/tests/security/resources/cross-origin-main-frame-for-partitioned-session-storage.html: Added.
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::findStorageArea):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyStorageNamespaceProvider::sessionStorageNamespace):
(WebCore::EmptyStorageNamespaceProvider::createSessionStorageNamespace): Deleted.
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createWindow const):
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/Page.cpp:
(WebCore::m_contentSecurityPolicyModeForExtension):
(WebCore::Page::setSessionID):
(WebCore::Page::sessionStorage): Deleted.
(WebCore::Page::setSessionStorage): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/storage/StorageNamespace.h:
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::sessionStorageArea):
* Source/WebCore/storage/StorageNamespaceProvider.h:
(WebCore::StorageNamespaceProvider::setSessionStorageQuota):
(WebCore::StorageNamespaceProvider::sessionStorageQuota const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::~WebPage):
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
(WebKit::StorageNamespaceImpl::createSessionStorageNamespace):
(WebKit::StorageNamespaceImpl::StorageNamespaceImpl):
(WebKit::StorageNamespaceImpl::copy):
(): Deleted.
(WebKit::StorageNamespaceImpl::~StorageNamespaceImpl): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.h:
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::incrementUseCount):
(WebKit::WebStorageNamespaceProvider::decrementUseCount):
(WebKit::WebStorageNamespaceProvider::sessionStorageNamespace):
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace):
(WebKit::WebStorageNamespaceProvider::createSessionStorageNamespace): Deleted.
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/Storage/StorageNamespaceImpl.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::sessionStorageNamespace):
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace):
(WebKit::WebStorageNamespaceProvider::createSessionStorageNamespace): Deleted.
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:

Canonical link: <a href="https://commits.webkit.org/253762@main">https://commits.webkit.org/253762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51341ee40d08ab0f2754512cb0d9da83ca444a71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95726 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149483 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29342 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25677 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90950 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23692 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73755 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23717 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66722 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27093 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36703 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33119 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->