### PR TITLE
[libpas] Add no-shutting-down scavenger mode

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -48,6 +48,13 @@
 #include <wtf/Threading.h>
 #include <wtf/threads/Signals.h>
 
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#if BUSE(LIBPAS)
+#include <bmalloc/pas_scavenger.h>
+#endif
+#endif
+
 namespace JSC {
 
 static_assert(sizeof(bool) == 1, "LLInt and JIT assume sizeof(bool) is always 1 when touching it directly from assembly code.");
@@ -83,6 +90,13 @@ void initialize()
             StructureAlignedMemoryAllocator::initializeStructureAddressSpace();
         }
         Options::finalize();
+
+#if !USE(SYSTEM_MALLOC)
+#if BUSE(LIBPAS)
+        if (Options::libpasSavengeContinuously())
+            pas_scavenger_disable_shut_down();
+#endif
+#endif
 
         JITOperationList::populatePointersInJavaScriptCore();
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -536,6 +536,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useDataICSharing, false, Normal, nullptr) \
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code.") \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
+    v(Bool, libpasSavengeContinuously, false, Normal, nullptr) \
     \
     /* Feature Flags */\
     \

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
@@ -121,6 +121,9 @@ typedef enum {
 PAS_API void pas_scavenger_perform_synchronous_operation(
     pas_scavenger_synchronous_operation_kind kind);
 
+/* This is for debugging purpose only. */
+PAS_API void pas_scavenger_disable_shut_down(void);
+
 PAS_END_EXTERN_C;
 
 #endif /* PAS_SCAVENGER_H */


### PR DESCRIPTION
#### e9e63c08f316c931077953049dbe477c9ae099ec
<pre>
[libpas] Add no-shutting-down scavenger mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=242371">https://bugs.webkit.org/show_bug.cgi?id=242371</a>

Reviewed by Mark Lam.

This patch adds pas_scavenger_disable_shut_down, which can disable libpas&apos;s scavenger&apos;s shutting down.
We also add Options::libpasSavengeContinuously to flip this flag.

* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(scavenger_thread_main):
(pas_scavenger_suspend):
(pas_scavenger_resume):
(pas_scavenger_disable_shut_down):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.h:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/252172@main">https://commits.webkit.org/252172@main</a>
</pre>
