### PR TITLE
REGRESSION (iOS 15 / r275792): rAF sometimes seems to lose connection to v-sync signal and runs at < 60 fps

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1008,6 +1008,13 @@ void WebPageProxy::swapToProvisionalPage(std::unique_ptr<ProvisionalPageProxy> p
 
     finishAttachingToWebProcess(ProcessLaunchReason::ProcessSwap);
 
+#if PLATFORM(IOS_FAMILY)
+    // On iOS, the displayID is derived from the webPageID.
+    m_displayID = generateDisplayIDFromPageID();
+    // FIXME: We may want to send WindowScreenDidChange on non-iOS platforms too.
+    send(Messages::WebPage::WindowScreenDidChange(*m_displayID, std::nullopt));
+#endif
+
 #if PLATFORM(COCOA)
     auto accessibilityToken = provisionalPage->takeAccessibilityToken();
     if (!accessibilityToken.isEmpty())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1119,9 +1119,15 @@ public:
     float deviceScaleFactor() const;
     void setIntrinsicDeviceScaleFactor(float);
     void setCustomDeviceScaleFactor(float);
+
+    void accessibilitySettingsDidChange();
+
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<unsigned> nominalFramesPerSecond);
     std::optional<WebCore::PlatformDisplayID> displayId() const { return m_displayID; }
-    void accessibilitySettingsDidChange();
+
+#if PLATFORM(IOS_FAMILY)
+    WebCore::PlatformDisplayID generateDisplayIDFromPageID() const;
+#endif
 
     void setUseFixedLayout(bool);
     void setFixedLayoutSize(const WebCore::IntSize&);

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -174,12 +174,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     _page->setDelegatesScrolling(true);
     _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);
 
-    // In order to ensure that we get a unique DisplayRefreshMonitor per-DrawingArea (necessary because DisplayRefreshMonitor
-    // is driven by this class), give each page a unique DisplayID derived from WebPage's unique ID.
-    // FIXME: While using the high end of the range of DisplayIDs makes a collision with real, non-RemoteLayerTreeDrawingArea
-    // DisplayIDs less likely, it is not entirely safe to have a RemoteLayerTreeDrawingArea and TiledCoreAnimationDrawingArea
-    // coeexist in the same process.
-    _page->windowScreenDidChange(std::numeric_limits<uint32_t>::max() - _page->webPageID().toUInt64(), std::nullopt);
+    _page->windowScreenDidChange(_page->generateDisplayIDFromPageID(), std::nullopt);
 
 #if ENABLE(FULLSCREEN_API)
     _page->setFullscreenClient(makeUnique<WebKit::FullscreenClient>(self.webView));

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -92,6 +92,16 @@ void WebPageProxy::platformInitialize()
 {
 }
 
+PlatformDisplayID WebPageProxy::generateDisplayIDFromPageID() const
+{
+    // In order to ensure that we get a unique DisplayRefreshMonitor per-DrawingArea (necessary because DisplayRefreshMonitor
+    // is driven by that class), give each page a unique DisplayID derived from WebPage's unique ID.
+    // FIXME: While using the high end of the range of DisplayIDs makes a collision with real, non-RemoteLayerTreeDrawingArea
+    // DisplayIDs less likely, it is not entirely safe to have a RemoteLayerTreeDrawingArea and TiledCoreAnimationDrawingArea
+    // coeexist in the same process.
+    return std::numeric_limits<uint32_t>::max() - webPageID().toUInt64();
+}
+
 String WebPageProxy::userAgentForURL(const URL&)
 {
     return userAgent();


### PR DESCRIPTION
#### 0842b6a96626f0904674fb3b973d3d6d90e17d07
<pre>
REGRESSION (iOS 15 / r275792): rAF sometimes seems to lose connection to v-sync signal and runs at &lt; 60 fps
<a href="https://bugs.webkit.org/show_bug.cgi?id=234923">https://bugs.webkit.org/show_bug.cgi?id=234923</a>
&lt;rdar://87465488&gt;

Reviewed by Chris Dumez.

In the web process, DisplayRefreshMonitorManager ensures a unique DisplayRefreshMonitor per physical
display by comparing PlatformDisplayIDs.

On iOS, we use fake PlatformDisplayIDs derived from the WebPageID, creating a one-to-one mapping
from RemoteLayerTreeDrawingArea to RemoteLayerTreeDisplayRefreshMonitor.
RemoteLayerTreeDisplayRefreshMonitor has a WeakPtr back to the RemoteLayerTreeDrawingArea, and when
this bug occurred, we were using an old RemoteLayerTreeDisplayRefreshMonitor whose WeakPtr was null.
This happened when a stale PlatformDisplayID caused us to re-use an old
RemoteLayerTreeDisplayRefreshMonitor.

The PlatformDisplayID is held in the UI process by a WebPageProxy, and in the Web process on Page.
However, the ProvisionalPageProxy can create drawing areas, and which then get assigned to a real
WebPageProxy via WebPageProxy::swapToProvisionalPage(). When this happens, we need to do two things:
synthesize a new PlatformDisplayIDs for the WebPageProxy from the webPageID, and tell the web
process that it changed via windowScreenDidChange.

Not easily testable since measuring requestAnimationFrame frequency in an API test will be unreliable.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::generateDisplayIDFromPageID const):

Canonical link: <a href="https://commits.webkit.org/252188@main">https://commits.webkit.org/252188@main</a>
</pre>
