### PR TITLE
Rename libpasSavengeContinuously to libpasScavengeContinuously.

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -93,7 +93,7 @@ void initialize()
 
 #if !USE(SYSTEM_MALLOC)
 #if BUSE(LIBPAS)
-        if (Options::libpasSavengeContinuously())
+        if (Options::libpasScavengeContinuously())
             pas_scavenger_disable_shut_down();
 #endif
 #endif

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -536,7 +536,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useDataICSharing, false, Normal, nullptr) \
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code.") \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
-    v(Bool, libpasSavengeContinuously, false, Normal, nullptr) \
+    v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
     \
     /* Feature Flags */\
     \


### PR DESCRIPTION
#### fa5039190a8dbee5ff7bf37ff589840bde76f74c
<pre>
Rename libpasSavengeContinuously to libpasScavengeContinuously.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242382">https://bugs.webkit.org/show_bug.cgi?id=242382</a>

Reviewed by Antti Koivisto.

* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/252176@main">https://commits.webkit.org/252176@main</a>
</pre>
