### PR TITLE
Move service worker registration and worker state updates out of main thread for service worker contexts

### DIFF
--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -263,6 +263,7 @@ void Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>
 
 void Worker::forEachWorker(const Function<Function<void(ScriptExecutionContext&)>()>& callback)
 {
+    ASSERT(isMainThread());
     for (auto* worker : allWorkers().values())
         worker->postTaskToWorkerGlobalScope(callback());
 }

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -37,7 +37,10 @@
 #include "ServiceWorkerTypes.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
-#include <wtf/RefCounted.h>
+
+namespace WTF {
+class WorkQueue;
+}
 
 namespace WebCore {
 
@@ -59,7 +62,7 @@ struct ServiceWorkerData;
 struct ServiceWorkerRegistrationData;
 struct WorkerFetchResult;
 
-class SWClientConnection : public RefCounted<SWClientConnection> {
+class SWClientConnection {
 public:
     WEBCORE_EXPORT virtual ~SWClientConnection();
 
@@ -118,13 +121,16 @@ public:
     WEBCORE_EXPORT void registerServiceWorkerClients();
     bool isClosed() const { return m_isClosed; }
 
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
 protected:
     WEBCORE_EXPORT SWClientConnection();
 
     WEBCORE_EXPORT void jobRejectedInServer(ServiceWorkerJobIdentifier, ExceptionData&&);
     WEBCORE_EXPORT void registrationJobResolvedInServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationData&&, ShouldNotifyWhenResolved);
     WEBCORE_EXPORT void startScriptFetchForServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationKey&&, FetchOptions::Cache);
-    WEBCORE_EXPORT void refreshImportedScripts(ServiceWorkerJobIdentifier, FetchOptions::Cache, Vector<URL>&&, ServiceWorkerJob::RefreshImportedScriptsCallback&&);
+    WEBCORE_EXPORT void refreshImportedScripts(ServiceWorkerJobIdentifier, FetchOptions::Cache, Vector<URL>&&, ServiceWorkerJob::RefreshImportedScriptsCallback&&, WTF::WorkQueue&);
     WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, MessageWithMessagePorts&&, ServiceWorkerData&& source, String&& sourceOrigin);
     WEBCORE_EXPORT void updateRegistrationState(ServiceWorkerRegistrationIdentifier, ServiceWorkerRegistrationState, const std::optional<ServiceWorkerData>&);
     WEBCORE_EXPORT void updateWorkerState(ServiceWorkerIdentifier, ServiceWorkerState);

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationData.h
@@ -49,8 +49,8 @@ struct ServiceWorkerRegistrationData {
     std::optional<ServiceWorkerData> waitingWorker;
     std::optional<ServiceWorkerData> activeWorker;
 
-    ServiceWorkerRegistrationData isolatedCopy() const &;
-    ServiceWorkerRegistrationData isolatedCopy() &&;
+    WEBCORE_EXPORT ServiceWorkerRegistrationData isolatedCopy() const &;
+    WEBCORE_EXPORT ServiceWorkerRegistrationData isolatedCopy() &&;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<ServiceWorkerRegistrationData> decode(Decoder&);

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.h
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.h
@@ -28,19 +28,22 @@
 #if ENABLE(SERVICE_WORKER)
 
 #include "SWClientConnection.h"
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
 class WorkerGlobalScope;
 class WorkerThread;
 
-class WorkerSWClientConnection final : public SWClientConnection {
+class WorkerSWClientConnection final : public SWClientConnection, public RefCounted<WorkerSWClientConnection> {
 public:
     static Ref<WorkerSWClientConnection> create(WorkerGlobalScope& scope) { return adoptRef(*new WorkerSWClientConnection { scope }); }
     ~WorkerSWClientConnection();
 
     void registerServiceWorkerClient(const ClientOrigin&, ServiceWorkerClientData&&, const std::optional<ServiceWorkerRegistrationIdentifier>&, String&& userAgent) final;
     void unregisterServiceWorkerClient(ScriptExecutionContextIdentifier) final;
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     explicit WorkerSWClientConnection(WorkerGlobalScope&);

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -97,24 +97,6 @@ RefPtr<ServiceWorkerThreadProxy> SWContextManager::serviceWorkerThreadProxyFromB
     return result;
 }
 
-void SWContextManager::fireInstallEvent(ServiceWorkerIdentifier identifier)
-{
-    auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
-        return;
-
-    serviceWorker->fireInstallEvent();
-}
-
-void SWContextManager::fireActivateEvent(ServiceWorkerIdentifier identifier)
-{
-    auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
-        return;
-
-    serviceWorker->fireActivateEvent();
-}
-
 void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::optional<Vector<uint8_t>>&& data, CompletionHandler<void(bool)>&& callback)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
@@ -138,8 +120,10 @@ void SWContextManager::firePushSubscriptionChangeEvent(ServiceWorkerIdentifier i
 void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier, NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        callback(false);
         return;
+    }
 
     serviceWorker->fireNotificationEvent(WTFMove(data), eventType, WTFMove(callback));
 }

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -100,8 +100,6 @@ public:
     WEBCORE_EXPORT void registerServiceWorkerThreadForInstall(Ref<ServiceWorkerThreadProxy>&&);
     WEBCORE_EXPORT ServiceWorkerThreadProxy* serviceWorkerThreadProxy(ServiceWorkerIdentifier) const;
     WEBCORE_EXPORT RefPtr<ServiceWorkerThreadProxy> serviceWorkerThreadProxyFromBackgroundThread(ServiceWorkerIdentifier) const;
-    WEBCORE_EXPORT void fireInstallEvent(ServiceWorkerIdentifier);
-    WEBCORE_EXPORT void fireActivateEvent(ServiceWorkerIdentifier);
     WEBCORE_EXPORT void firePushEvent(ServiceWorkerIdentifier, std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void firePushSubscriptionChangeEvent(ServiceWorkerIdentifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     WEBCORE_EXPORT void fireNotificationEvent(ServiceWorkerIdentifier, NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -170,8 +170,7 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
 
     ASSERT(globalScope.registration().active());
     ASSERT(globalScope.registration().active()->identifier() == globalScope.thread().identifier());
-    // FIXME: we should use the same path for registration changes as for fetch events.
-    ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated || globalScope.registration().active()->state() == ServiceWorkerState::Activating);
+    ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated);
 
     auto* formData = request.httpBody();
     std::optional<FetchBody> body;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -329,19 +329,27 @@ void ServiceWorkerThreadProxy::fireMessageEvent(MessageWithMessagePorts&& messag
 
 void ServiceWorkerThreadProxy::fireInstallEvent()
 {
-    ASSERT(isMainThread());
-    thread().willPostTaskToFireInstallEvent();
-    thread().runLoop().postTask([this, protectedThis = Ref { *this }](auto&) mutable {
-        thread().queueTaskToFireInstallEvent();
+    ASSERT(!isMainThread());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }] {
+        protectedThis->thread().willPostTaskToFireInstallEvent();
+    });
+
+    thread().runLoop().postTask([protectedThis = Ref { *this }](auto&) mutable {
+        protectedThis->thread().queueTaskToFireInstallEvent();
     });
 }
 
 void ServiceWorkerThreadProxy::fireActivateEvent()
 {
-    ASSERT(isMainThread());
-    thread().willPostTaskToFireActivateEvent();
-    thread().runLoop().postTask([this, protectedThis = Ref { *this }](auto&) mutable {
-        thread().queueTaskToFireActivateEvent();
+    ASSERT(!isMainThread());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }] {
+        protectedThis->thread().willPostTaskToFireActivateEvent();
+    });
+
+    thread().runLoop().postTask([protectedThis = Ref { *this }](auto&) mutable {
+        protectedThis->thread().queueTaskToFireActivateEvent();
     });
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -84,8 +84,8 @@ public:
 
     WEBCORE_EXPORT void fireMessageEvent(MessageWithMessagePorts&&, ServiceWorkerOrClientData&&);
 
-    void fireInstallEvent();
-    void fireActivateEvent();
+    WEBCORE_EXPORT void fireInstallEvent();
+    WEBCORE_EXPORT void fireActivateEvent();
     void firePushEvent(std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
     void firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     void fireNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
@@ -141,6 +141,7 @@ void SharedWorkerContextManager::Connection::resumeSharedWorker(SharedWorkerIden
 
 void SharedWorkerContextManager::forEachSharedWorker(const Function<Function<void(ScriptExecutionContext&)>()>& createTask)
 {
+    ASSERT(isMainThread());
     for (auto& worker : m_workerMap.values())
         worker->thread().runLoop().postTask(createTask());
 }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -76,6 +76,12 @@ namespace WebKit {
 using namespace PAL;
 using namespace WebCore;
 
+WorkQueue& WebSWContextManagerConnection::sharedQueue()
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("com.apple.WebKit.ServiceWorkerProcessing", WorkQueue::QOS::UserInitiated));
+    return queue.get();
+}
+
 WebSWContextManagerConnection::WebSWContextManagerConnection(Ref<IPC::Connection>&& connection, WebCore::RegistrableDomain&& registrableDomain, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, PageIdentifier pageID, const WebPreferencesStore& store, RemoteWorkerInitializationData&& initializationData)
     : m_connectionToNetworkProcess(WTFMove(connection))
     , m_registrableDomain(WTFMove(registrableDomain))
@@ -89,7 +95,6 @@ WebSWContextManagerConnection::WebSWContextManagerConnection(Ref<IPC::Connection
     , m_userAgent(standardUserAgent())
 #endif
     , m_userContentController(WebUserContentController::getOrCreate(initializationData.userContentControllerIdentifier))
-    , m_queue(WorkQueue::create("WebSWContextManagerConnection queue", WorkQueue::QOS::UserInitiated))
 {
 #if ENABLE(CONTENT_EXTENSIONS)
     m_userContentController->addContentRuleLists(WTFMove(initializationData.contentRuleLists));
@@ -110,7 +115,7 @@ WebSWContextManagerConnection::~WebSWContextManagerConnection()
 
 void WebSWContextManagerConnection::establishConnection(CompletionHandler<void()>&& completionHandler)
 {
-    m_connectionToNetworkProcess->addWorkQueueMessageReceiver(Messages::WebSWContextManagerConnection::messageReceiverName(), m_queue.get(), *this);
+    m_connectionToNetworkProcess->addWorkQueueMessageReceiver(Messages::WebSWContextManagerConnection::messageReceiverName(), sharedQueue(), *this);
     m_connectionToNetworkProcess->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::EstablishSWContextConnection { m_webPageProxyID, m_registrableDomain, m_serviceWorkerPageIdentifier }, WTFMove(completionHandler), 0);
 }
 
@@ -144,7 +149,7 @@ void WebSWContextManagerConnection::updateAppInitiatedValue(ServiceWorkerIdentif
 
 void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     callOnMainRunLoopAndWait([this, protectedThis = Ref { *this }, contextData = WTFMove(contextData).isolatedCopy(), workerData = WTFMove(workerData).isolatedCopy(), userAgent = WTFMove(userAgent).isolatedCopy(), workerThreadMode]() mutable {
     auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
@@ -213,7 +218,7 @@ void WebSWContextManagerConnection::serviceWorkerFailedToStart(std::optional<Ser
 
 void WebSWContextManagerConnection::cancelFetch(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->cancelFetch(serverConnectionIdentifier, fetchIdentifier);
@@ -221,7 +226,7 @@ void WebSWContextManagerConnection::cancelFetch(SWServerConnectionIdentifier ser
 
 void WebSWContextManagerConnection::continueDidReceiveFetchResponse(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->continueDidReceiveFetchResponse(serverConnectionIdentifier, fetchIdentifier);
@@ -229,7 +234,7 @@ void WebSWContextManagerConnection::continueDidReceiveFetchResponse(SWServerConn
 
 void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceRequest&& request, FetchOptions&& options, IPC::FormDataReference&& formData, String&& referrer, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier);
     if (!serviceWorkerThreadProxy) {
@@ -249,40 +254,38 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
 
 void WebSWContextManagerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier serviceWorkerIdentifier, MessageWithMessagePorts&& message, ServiceWorkerOrClientData&& sourceData)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->fireMessageEvent(WTFMove(message), WTFMove(sourceData));
 }
 
-void WebSWContextManagerConnection::fireInstallEvent(ServiceWorkerIdentifier identifier)
+void WebSWContextManagerConnection::fireInstallEvent(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
-    callOnMainRunLoop([identifier] {
-        SWContextManager::singleton().fireInstallEvent(identifier);
-    });
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
+        serviceWorkerThreadProxy->fireInstallEvent();
 }
 
-void WebSWContextManagerConnection::fireActivateEvent(ServiceWorkerIdentifier identifier)
+void WebSWContextManagerConnection::fireActivateEvent(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
-    callOnMainRunLoop([identifier] {
-        SWContextManager::singleton().fireActivateEvent(identifier);
-    });
+    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
+        serviceWorkerThreadProxy->fireActivateEvent();
 }
 
 void WebSWContextManagerConnection::firePushEvent(ServiceWorkerIdentifier identifier, const std::optional<IPC::DataReference>& ipcData, CompletionHandler<void(bool)>&& callback)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     std::optional<Vector<uint8_t>> data;
     if (ipcData)
         data = Vector<uint8_t> { ipcData->data(), ipcData->size() };
 
-    auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result) mutable {
-        queue->dispatch([result, callback = WTFMove(callback)]() mutable {
+    auto inQueueCallback = [callback = WTFMove(callback)](bool result) mutable {
+        sharedQueue().dispatch([result, callback = WTFMove(callback)]() mutable {
             callback(result);
         });
     };
@@ -294,10 +297,10 @@ void WebSWContextManagerConnection::firePushEvent(ServiceWorkerIdentifier identi
 
 void WebSWContextManagerConnection::fireNotificationEvent(ServiceWorkerIdentifier identifier, NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
-    auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result) mutable {
-        queue->dispatch([result, callback = WTFMove(callback)]() mutable {
+    auto inQueueCallback = [callback = WTFMove(callback)](bool result) mutable {
+        sharedQueue().dispatch([result, callback = WTFMove(callback)]() mutable {
             callback(result);
         });
     };
@@ -308,7 +311,7 @@ void WebSWContextManagerConnection::fireNotificationEvent(ServiceWorkerIdentifie
 
 void WebSWContextManagerConnection::terminateWorker(ServiceWorkerIdentifier identifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     callOnMainRunLoop([identifier] {
         SWContextManager::singleton().terminateWorker(identifier, SWContextManager::workerTerminationTimeout, nullptr);
@@ -318,7 +321,7 @@ void WebSWContextManagerConnection::terminateWorker(ServiceWorkerIdentifier iden
 #if ENABLE(SHAREABLE_RESOURCE) && PLATFORM(COCOA)
 void WebSWContextManagerConnection::didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, ScriptBuffer&& script, HashMap<URL, ScriptBuffer>&& importedScripts)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->didSaveScriptsToDisk(WTFMove(script), WTFMove(importedScripts));
@@ -327,7 +330,7 @@ void WebSWContextManagerConnection::didSaveScriptsToDisk(WebCore::ServiceWorkerI
 
 void WebSWContextManagerConnection::convertFetchToDownload(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->convertFetchToDownload(serverConnectionIdentifier, fetchIdentifier);
@@ -335,7 +338,7 @@ void WebSWContextManagerConnection::convertFetchToDownload(SWServerConnectionIde
 
 void WebSWContextManagerConnection::navigationPreloadIsReady(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceResponse&& response)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->navigationPreloadIsReady(serverConnectionIdentifier, fetchIdentifier, WTFMove(response));
@@ -343,7 +346,7 @@ void WebSWContextManagerConnection::navigationPreloadIsReady(SWServerConnectionI
 
 void WebSWContextManagerConnection::navigationPreloadFailed(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceError&& error)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->navigationPreloadFailed(serverConnectionIdentifier, fetchIdentifier, WTFMove(error));
@@ -378,7 +381,7 @@ void WebSWContextManagerConnection::skipWaiting(ServiceWorkerIdentifier serviceW
 
 void WebSWContextManagerConnection::skipWaitingCompleted(uint64_t requestIdentifier)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     callOnMainRunLoop([protectedThis = Ref { *this }, requestIdentifier]() mutable {
         if (auto callback = protectedThis->m_skipWaitingCallbacks.take(requestIdentifier))
@@ -410,7 +413,7 @@ void WebSWContextManagerConnection::matchAll(WebCore::ServiceWorkerIdentifier se
 
 void WebSWContextManagerConnection::matchAllCompleted(uint64_t requestIdentifier, Vector<ServiceWorkerClientData>&& clientsData)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     callOnMainRunLoop([protectedThis = Ref { *this }, requestIdentifier, clientsData = crossThreadCopy(WTFMove(clientsData))]() mutable {
         if (auto callback = protectedThis->m_matchAllRequests.take(requestIdentifier))
@@ -474,7 +477,7 @@ void WebSWContextManagerConnection::close()
 
 void WebSWContextManagerConnection::setThrottleState(bool isThrottleable)
 {
-    assertIsCurrent(m_queue.get());
+    assertIsCurrent(sharedQueue());
 
     callOnMainRunLoop([protectedThis = Ref { *this }, isThrottleable] {
         RELEASE_LOG(ServiceWorker, "Service worker throttleable state is set to %d", isThrottleable);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -71,6 +71,8 @@ public:
     void ref() const final { IPC::Connection::WorkQueueMessageReceiver::ref(); }
     void deref() const final { IPC::Connection::WorkQueueMessageReceiver::deref(); }
 
+    static WorkQueue& sharedQueue();
+
 private:
     WebSWContextManagerConnection(Ref<IPC::Connection>&&, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, RemoteWorkerInitializationData&&);
 
@@ -137,7 +139,6 @@ private:
     bool m_isThrottleable { true };
     Ref<WebUserContentController> m_userContentController;
     std::optional<WebPreferencesStore> m_preferencesStore;
-    Ref<WorkQueue> m_queue;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1181,8 +1181,9 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
 
 #if ENABLE(SERVICE_WORKER)
+        auto& serviceWorkerConnection = m_networkProcessConnection->serviceWorkerConnection();
         if (!Document::allDocuments().isEmpty() || SharedWorkerThreadProxy::hasInstances())
-            m_networkProcessConnection->serviceWorkerConnection().registerServiceWorkerClients();
+            serviceWorkerConnection.registerServiceWorkerClients();
 #endif
 
 #if HAVE(LSDATABASECONTEXT)


### PR DESCRIPTION
#### 9e9572d0776c904af029a6f550b8df49e24c1c84
<pre>
Move service worker registration and worker state updates out of main thread for service worker contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=242383">https://bugs.webkit.org/show_bug.cgi?id=242383</a>
rdar://problem/96510954

Reviewed by NOBODY (OOPS!).

We are now handling some of the IPC message going to service workers on a background queue.
Some other messages to service workers are going through main thread as they are WebSWClientConnection messages.
This includes worker/registration state updates.

To make things more tight, we are now handling WebSWClientConnection messages on the same queue as WebSWContextManagerConnection.
When messages are to be sent to service workers, we directly hop to the service worker thread.
This allows the service worker messages to use the same path in WebSWClientConnection and WebSWContextManagerConnection.
For WebSWClientConnection messages that require getting to other workers or documents, we keep hopping to main thread.
Minor drive-by fix to make sure to call the completion handler in SWContextManager::fireNotificationEvent in case the worker is not there.

Changes are covered by existing tests.

* Source/WebCore/workers/Worker.cpp:
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::SWClientConnection::jobRejectedInServer):
(WebCore::SWClientConnection::registrationJobResolvedInServer):
(WebCore::SWClientConnection::startScriptFetchForServer):
(WebCore::SWClientConnection::refreshImportedScripts):
(WebCore::SWClientConnection::postMessageToServiceWorkerClient):
(WebCore::forAllDedicatedAndSharedWorkers):
(WebCore::doUpdateRegistrationState):
(WebCore::SWClientConnection::updateRegistrationState):
(WebCore::doUpdateWorkerState):
(WebCore::SWClientConnection::updateWorkerState):
(WebCore::doFireUpdateFoundEvent):
(WebCore::SWClientConnection::fireUpdateFoundEvent):
(WebCore::doSetRegistrationLastUpdateTime):
(WebCore::SWClientConnection::setRegistrationLastUpdateTime):
(WebCore::doSetRegistrationUpdateViaCache):
(WebCore::SWClientConnection::setRegistrationUpdateViaCache):
(WebCore::SWClientConnection::notifyClientsOfControllerChange):
(WebCore::SWClientConnection::registerServiceWorkerClients):
(WebCore::forAllWorkers): Deleted.
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerRegistrationData.h:
* Source/WebCore/workers/service/WorkerSWClientConnection.h:
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::fireNotificationEvent):
(WebCore::SWContextManager::fireInstallEvent): Deleted.
(WebCore::SWContextManager::fireActivateEvent): Deleted.
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::fireInstallEvent):
(WebCore::ServiceWorkerThreadProxy::fireActivateEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didReceiveMessage):
(WebKit::NetworkProcessConnection::didReceiveSyncMessage):
(WebKit::NetworkProcessConnection::serviceWorkerConnection):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::~WebSWClientConnection):
(WebKit::WebSWClientConnection::establishConnection):
(WebKit::WebSWClientConnection::closeConnection):
(WebKit::WebSWClientConnection::messageSenderConnection const):
(WebKit::WebSWClientConnection::scheduleJobInServer):
(WebKit::WebSWClientConnection::finishFetchingScriptInServer):
(WebKit::WebSWClientConnection::addServiceWorkerRegistrationInServer):
(WebKit::WebSWClientConnection::removeServiceWorkerRegistrationInServer):
(WebKit::WebSWClientConnection::scheduleUnregisterJobInServer):
(WebKit::WebSWClientConnection::mayHaveServiceWorkerRegisteredForOrigin const):
(WebKit::WebSWClientConnection::setSWOriginTableSharedMemory):
(WebKit::WebSWClientConnection::setSWOriginTableIsImported):
(WebKit::WebSWClientConnection::runOrDelayTaskForImport):
(WebKit::WebSWClientConnection::whenRegistrationReady):
(WebKit::WebSWClientConnection::setServiceWorkerClientIsControlled):
(WebKit::WebSWClientConnection::connectionToServerLost):
(WebKit::WebSWClientConnection::clear):
(WebKit::WebSWClientConnection::terminateWorkerForTesting):
(WebKit::WebSWClientConnection::whenServiceWorkerIsTerminatedForTesting):
(WebKit::WebSWClientConnection::updateThrottleState):
(WebKit::WebSWClientConnection::storeRegistrationsOnDiskForTesting):
(WebKit::WebSWClientConnection::subscribeToPushService):
(WebKit::WebSWClientConnection::unsubscribeFromPushService):
(WebKit::WebSWClientConnection::getPushSubscription):
(WebKit::WebSWClientConnection::getPushPermissionState):
(WebKit::WebSWClientConnection::getNotifications):
(WebKit::WebSWClientConnection::enableNavigationPreload):
(WebKit::WebSWClientConnection::disableNavigationPreload):
(WebKit::WebSWClientConnection::setNavigationPreloadHeaderValue):
(WebKit::WebSWClientConnection::getNavigationPreloadState):
(WebKit::WebSWClientConnection::focusServiceWorkerClient):
(WebKit::WebSWClientConnection::refreshImportedScripts):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::sharedQueue):
(WebKit::m_userContentController):
(WebKit::WebSWContextManagerConnection::establishConnection):
(WebKit::WebSWContextManagerConnection::installServiceWorker):
(WebKit::WebSWContextManagerConnection::cancelFetch):
(WebKit::WebSWContextManagerConnection::continueDidReceiveFetchResponse):
(WebKit::WebSWContextManagerConnection::startFetch):
(WebKit::WebSWContextManagerConnection::postMessageToServiceWorker):
(WebKit::WebSWContextManagerConnection::fireInstallEvent):
(WebKit::WebSWContextManagerConnection::fireActivateEvent):
(WebKit::WebSWContextManagerConnection::firePushEvent):
(WebKit::WebSWContextManagerConnection::fireNotificationEvent):
(WebKit::WebSWContextManagerConnection::terminateWorker):
(WebKit::WebSWContextManagerConnection::didSaveScriptsToDisk):
(WebKit::WebSWContextManagerConnection::convertFetchToDownload):
(WebKit::WebSWContextManagerConnection::navigationPreloadIsReady):
(WebKit::WebSWContextManagerConnection::navigationPreloadFailed):
(WebKit::WebSWContextManagerConnection::skipWaitingCompleted):
(WebKit::WebSWContextManagerConnection::matchAllCompleted):
(WebKit::WebSWContextManagerConnection::setThrottleState):
(WebKit::m_queue): Deleted.
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
</pre>