### PR TITLE
Move WebRTC H265 flag from experimental to internal

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1756,19 +1756,6 @@ WebRTCH264LowLatencyEncoderEnabled:
     WebKit:
       default: true
 
-WebRTCH265CodecEnabled:
-  type: bool
-  condition: ENABLE(WEB_RTC)
-  humanReadableName: "WebRTC H265 codec"
-  humanReadableDescription: "Enable WebRTC H265 codec"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 WebRTCPlatformTCPSocketsEnabled:
   type: bool
   humanReadableName: "WebRTC Platform TCP Sockets"

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -1039,6 +1039,19 @@ WebRTCH264SimulcastEnabled:
     WebKit:
       default: true
 
+WebRTCH265CodecEnabled:
+  type: bool
+  condition: ENABLE(WEB_RTC)
+  humanReadableName: "WebRTC H265 codec"
+  humanReadableDescription: "Enable WebRTC H265 codec"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 WebRTCMDNSICECandidatesEnabled:
   type: bool


### PR DESCRIPTION
#### 78bfb4f405f50bd751536c8b9c026455b00ef936
<pre>
Move WebRTC H265 flag from experimental to internal
<a href="https://bugs.webkit.org/show_bug.cgi?id=242385">https://bugs.webkit.org/show_bug.cgi?id=242385</a>

Reviewed by Eric Carlson.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:

Canonical link: <a href="https://commits.webkit.org/252203@main">https://commits.webkit.org/252203@main</a>
</pre>
