### PR TITLE
[Mac] Display capture is broken in GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -985,6 +985,7 @@
         SYS_fcntl
         SYS_fcntl_nocancel
         SYS_fgetxattr
+        SYS_fileport_makefd
         SYS_flock
         SYS_fsgetpath
         SYS_fstat


### PR DESCRIPTION
#### ebb143fd26834c1e81dcba25937e6c8700b5c254
<pre>
[Mac] Display capture is broken in GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=242389">https://bugs.webkit.org/show_bug.cgi?id=242389</a>
rdar://problem/96516944

Reviewed by Per Arne Vollan.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
Allow SYS_fileport_makefd.

Canonical link: <a href="https://commits.webkit.org/252179@main">https://commits.webkit.org/252179@main</a>
</pre>
