### PR TITLE
Mock display capture should skip the window selection step

### DIFF
--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
@@ -57,7 +57,7 @@ private:
     void alertForGetDisplayMedia(WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(DisplayCaptureSessionManager::CaptureSessionType)>&&);
     void showWindowPicker(WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
     void showScreenPicker(WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
-    std::optional<WebCore::CaptureDevice> deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType);
+    std::optional<WebCore::CaptureDevice> deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType, unsigned);
 #endif
 
     std::optional<unsigned> m_indexOfDeviceSelectedForTesting;

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -178,14 +178,12 @@ void DisplayCaptureSessionManager::alertForGetDisplayMedia(WebPageProxy& page, c
     }];
 }
 
-std::optional<WebCore::CaptureDevice> DisplayCaptureSessionManager::deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType deviceType)
+std::optional<WebCore::CaptureDevice> DisplayCaptureSessionManager::deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType deviceType, unsigned indexOfDeviceSelectedForTesting)
 {
-    ASSERT(m_indexOfDeviceSelectedForTesting);
-
     unsigned index = 0;
     for (auto& device : WebCore::RealtimeMediaSourceCenter::singleton().displayCaptureFactory().displayCaptureDeviceManager().captureDevices()) {
         if (device.enabled() && device.type() == deviceType) {
-            if (index == m_indexOfDeviceSelectedForTesting.value())
+            if (index == indexOfDeviceSelectedForTesting)
                 return { device };
             ++index;
         }
@@ -196,8 +194,8 @@ std::optional<WebCore::CaptureDevice> DisplayCaptureSessionManager::deviceSelect
 
 void DisplayCaptureSessionManager::showWindowPicker(WebPageProxy& page, const WebCore::SecurityOriginData& origin, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&& completionHandler)
 {
-    if (m_indexOfDeviceSelectedForTesting) {
-        completionHandler(deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType::Window));
+    if (m_indexOfDeviceSelectedForTesting || page.preferences().mockCaptureDevicesEnabled()) {
+        completionHandler(deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType::Window, m_indexOfDeviceSelectedForTesting.value_or(0)));
         return;
     }
 
@@ -229,8 +227,8 @@ void DisplayCaptureSessionManager::showWindowPicker(WebPageProxy& page, const We
 
 void DisplayCaptureSessionManager::showScreenPicker(WebPageProxy& page, const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&& completionHandler)
 {
-    if (m_indexOfDeviceSelectedForTesting) {
-        completionHandler(deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType::Screen));
+    if (m_indexOfDeviceSelectedForTesting || page.preferences().mockCaptureDevicesEnabled()) {
+        completionHandler(deviceSelectedForTesting(WebCore::CaptureDevice::DeviceType::Screen, m_indexOfDeviceSelectedForTesting.value_or(0)));
         return;
     }
 


### PR DESCRIPTION
#### 2196b9770f22f8a683aef88aae201e08abe1ccaf
<pre>
Mock display capture should skip the window selection step
<a href="https://bugs.webkit.org/show_bug.cgi?id=242390">https://bugs.webkit.org/show_bug.cgi?id=242390</a>
rdar://problem/96519577

Reviewed by Eric Carlson.

With mock capture on, we do not send sandbox extensions to GPUProcess.
This prevents the window picker to work properly.
Given there is no need to select a window for mock, we skip this step when mock capture is on.

* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::deviceSelectedForTesting):
(WebKit::DisplayCaptureSessionManager::showWindowPicker):
(WebKit::DisplayCaptureSessionManager::showScreenPicker):

Canonical link: <a href="https://commits.webkit.org/252207@main">https://commits.webkit.org/252207@main</a>
</pre>
