### PR TITLE
[Mac] General WKWebViews need display capture to happen in GPUProcess

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1515,7 +1515,7 @@ UseGPUProcessForDisplayCapture:
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
-      default: false
+      default: true
 
 UseGPUProcessForWebGLEnabled:
   type: bool


### PR DESCRIPTION
#### 8d0c5651e81c71e3b535df0ac26f579e9ebc6781
<pre>
[Mac] General WKWebViews need display capture to happen in GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=242391">https://bugs.webkit.org/show_bug.cgi?id=242391</a>

Reviewed by Eric Carlson.

If we do not run display capture in GPUProcess, we are not able to use the window/screen pickers.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:

Canonical link: <a href="https://commits.webkit.org/252337@main">https://commits.webkit.org/252337@main</a>
</pre>
