### PR TITLE
[Media] Destroy media player on fatal playback error

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2250,21 +2250,18 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
     // https://html.spec.whatwg.org/#loading-the-media-resource:dom-media-have_nothing-2
     // 17 March 2021
 
-    // 1 - The user agent should cancel the fetching process.
-    stopPeriodicTimers();
-    m_loadState = WaitingForSource;
+    const String playerErrMsg = m_player ? m_player->lastErrorMessage() : ""_s;
 
     const auto getErrorMessage = [&] (String&& defaultMessage) {
-        String message = WTFMove(defaultMessage);
-        if (!m_player)
-            return message;
-
-        auto lastErrorMessage = m_player->lastErrorMessage();
-        if (!lastErrorMessage)
-            return message;
-
-        return makeString(message, ": ", lastErrorMessage);
+        if (playerErrMsg.isEmpty())
+            return WTFMove(defaultMessage);
+        return makeString(WTFMove(defaultMessage), ": ", playerErrMsg);
     };
+
+    ERROR_LOG(LOGIDENTIFIER, "error = ", static_cast<int>(error));
+
+    // 1 - The user agent should cancel the fetching process.
+    clearMediaPlayer();
 
     // 2 - Set the error attribute to a new MediaError object whose code attribute is
     // set to MEDIA_ERR_NETWORK/MEDIA_ERR_DECODE.
@@ -2274,10 +2271,6 @@ void HTMLMediaElement::mediaLoadingFailedFatally(MediaPlayer::NetworkState error
         m_error = MediaError::create(MediaError::MEDIA_ERR_DECODE, getErrorMessage("Media failed to decode"_s));
     else
         ASSERT_NOT_REACHED();
-
-#if ENABLE(MEDIA_SOURCE)
-    detachMediaSource();
-#endif
 
     // 3 - Set the element's networkState attribute to the NETWORK_IDLE value.
     m_networkState = NETWORK_IDLE;


### PR DESCRIPTION
#### 1c9cc6e485dc2ebd5604ba671a580ba5e7a9c7b7
<pre>
[Media] Destroy media player on fatal playback error
<a href="https://bugs.webkit.org/show_bug.cgi?id=242395">https://bugs.webkit.org/show_bug.cgi?id=242395</a>

Reviewed by Xabier Rodriguez-Calvar.

Under some circumstances, the SourceBuffer.append() can generate an EOS internally in glib ports, which
reaches HTMLMediaElement as DecodeError. This triggers detachMediaSource() while the player is still playing
fine (it&apos;s not aware of any issue). Eventually, the player reaches EOS when running out of samples and the
playback is ended. The JavaScript app may try to resume video with video.play(), triggering seek(0), which
triggers other internal operations. One of those operations was a MediaPlayerPrivateGStreamerMSE::sourceSetup()
call that was trying to setPrivateAndOpen() on the MediaSource that was already detached and this was crashing.
The crash itself was fixed in <a href="https://bugs.webkit.org/show_bug.cgi?id=220091">https://bugs.webkit.org/show_bug.cgi?id=220091</a> by reopening MediaSource on
load() only, but the player private still keeps this detached MediaSource that may cause different issues.

The proper way to avoid this invalid state where a reference to MediaSource is kept by the player private is
to ensure that the player is destroyed on error. It will be recreated again if needed if a fresh src is set in
the future.

Original author: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/899">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/899</a>

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaLoadingFailedFatally): Clear media player on error.

Canonical link: <a href="https://commits.webkit.org/253522@main">https://commits.webkit.org/253522@main</a>
</pre>
