### PR TITLE
[git-webkit] Add `-o`/`--open` to `git-webkit pr` that automatically opens the created PR

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -97,6 +97,12 @@ class PullRequest(Command):
             help='Explicitly enable or disable automatic pre-flight checks',
             action=arguments.NoAction,
         )
+        parser.add_argument(
+            '-o', '--open',
+            dest='open', default=None,
+            help='Automatically open the PR after creating it.',
+            action=arguments.NoAction,
+        )
 
     @classmethod
     def create_commit(cls, args, repository, **kwargs):
@@ -432,6 +438,9 @@ class PullRequest(Command):
 
         if pr.url:
             print(pr.url)
+
+            if args.open:
+                Terminal.open_url(pr.url)
 
         if callback:
             return callback(pr)


### PR DESCRIPTION
#### 648f3499c7b8ec8e6d8add2b083e0a835684e2c7
<pre>
[git-webkit] Add `-o`/`--open` to `git-webkit pr` that automatically opens the created PR
<a href="https://bugs.webkit.org/show_bug.cgi?id=242398">https://bugs.webkit.org/show_bug.cgi?id=242398</a>
&lt;rdar://problem/93440727&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.parser):
(PullRequest.create_pull_request):

Canonical link: <a href="https://commits.webkit.org/252182@main">https://commits.webkit.org/252182@main</a>
</pre>
