### PR TITLE
Web Inspector: [Cocoa] `RemoteInspector` fails to send automatic inspection candidates created on a non-main thread

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -180,9 +180,7 @@ void RemoteInspector::setupFailed(TargetID targetIdentifier)
     Locker locker { m_mutex };
 
     m_targetConnectionMap.remove(targetIdentifier);
-
-    if (targetIdentifier == m_automaticInspectionCandidateTargetIdentifier)
-        m_automaticInspectionPaused = false;
+    m_pausedAutomaticInspectionCandidates.remove(targetIdentifier);
 
     updateHasActiveDebugSession();
     updateTargetListing(targetIdentifier);
@@ -193,14 +191,14 @@ void RemoteInspector::setupCompleted(TargetID targetIdentifier)
 {
     Locker locker { m_mutex };
 
-    if (targetIdentifier == m_automaticInspectionCandidateTargetIdentifier)
-        m_automaticInspectionPaused = false;
+    m_pausedAutomaticInspectionCandidates.remove(targetIdentifier);
 }
 
-bool RemoteInspector::waitingForAutomaticInspection(TargetID)
+bool RemoteInspector::waitingForAutomaticInspection(TargetID targetIdentifier)
 {
-    // We don't take the lock to check this because we assume it will be checked repeatedly.
-    return m_automaticInspectionPaused;
+    Locker locker { m_mutex };
+
+    return m_pausedAutomaticInspectionCandidates.contains(targetIdentifier);
 }
 
 void RemoteInspector::clientCapabilitiesDidChange()

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -38,6 +38,7 @@
 
 #if PLATFORM(COCOA)
 #include "RemoteInspectorXPCConnection.h"
+#include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -183,9 +184,11 @@ private:
     TargetID nextAvailableTargetIdentifier();
 
     enum class StopSource { API, XPCMessage };
-    void stopInternal(StopSource);
+    void stopInternal(StopSource) WTF_REQUIRES_LOCK(m_mutex);
 
 #if PLATFORM(COCOA)
+    void initialize();
+    void setPendingMainThreadInitialization(bool pendingInitialization);
     void setupXPCConnectionIfNeeded();
 #endif
 #if USE(GLIB)
@@ -213,24 +216,24 @@ private:
     void updateHasActiveDebugSession();
     void updateClientCapabilities();
 
-    void sendAutomaticInspectionCandidateMessage();
+    void sendAutomaticInspectionCandidateMessage(TargetID) WTF_REQUIRES_LOCK(m_mutex);
 
 #if PLATFORM(COCOA)
     void xpcConnectionReceivedMessage(RemoteInspectorXPCConnection*, NSString *messageName, NSDictionary *userInfo) final;
     void xpcConnectionFailed(RemoteInspectorXPCConnection*) final;
     void xpcConnectionUnhandledMessage(RemoteInspectorXPCConnection*, xpc_object_t) final;
 
-    void receivedSetupMessage(NSDictionary *userInfo);
-    void receivedDataMessage(NSDictionary *userInfo);
-    void receivedDidCloseMessage(NSDictionary *userInfo);
-    void receivedGetListingMessage(NSDictionary *userInfo);
-    void receivedWakeUpDebuggables(NSDictionary *userInfo);
-    void receivedIndicateMessage(NSDictionary *userInfo);
-    void receivedProxyApplicationSetupMessage(NSDictionary *userInfo);
-    void receivedConnectionDiedMessage(NSDictionary *userInfo);
-    void receivedAutomaticInspectionConfigurationMessage(NSDictionary *userInfo);
-    void receivedAutomaticInspectionRejectMessage(NSDictionary *userInfo);
-    void receivedAutomationSessionRequestMessage(NSDictionary *userInfo);
+    void receivedSetupMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedDataMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedDidCloseMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedGetListingMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedWakeUpDebuggables(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedIndicateMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedProxyApplicationSetupMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedConnectionDiedMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedAutomaticInspectionConfigurationMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedAutomaticInspectionRejectMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedAutomationSessionRequestMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
 #endif
 #if USE(INSPECTOR_SOCKET_SERVER)
     HashMap<String, CallHandler>& dispatchMap() final;
@@ -269,6 +272,8 @@ private:
 #if PLATFORM(COCOA)
     RefPtr<RemoteInspectorXPCConnection> m_relayConnection;
     bool m_shouldReconnectToRelayOnFailure { false };
+
+    bool m_pendingMainThreadInitialization WTF_GUARDED_BY_LOCK(m_mutex) { false };
 #endif
 #if USE(GLIB)
     RefPtr<SocketConnection> m_socketConnection;
@@ -301,9 +306,8 @@ private:
     bool m_messageDataTypeChunkSupported { false };
 #endif
     bool m_shouldSendParentProcessInformation { false };
-    bool m_automaticInspectionEnabled { false };
-    bool m_automaticInspectionPaused { false };
-    TargetID m_automaticInspectionCandidateTargetIdentifier { 0 };
+    bool m_automaticInspectionEnabled WTF_GUARDED_BY_LOCK(m_mutex) { false };
+    HashSet<TargetID, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_pausedAutomaticInspectionCandidates WTF_GUARDED_BY_LOCK(m_mutex);
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -94,7 +94,7 @@ void RemoteInspector::stopInternal(StopSource)
 
     updateHasActiveDebugSession();
 
-    m_automaticInspectionPaused = false;
+    m_pausedAutomaticInspectionCandidates.clear();
     m_socketConnection = nullptr;
 }
 
@@ -219,12 +219,10 @@ void RemoteInspector::pushListingsSoon()
     });
 }
 
-void RemoteInspector::sendAutomaticInspectionCandidateMessage()
+void RemoteInspector::sendAutomaticInspectionCandidateMessage(TargetID)
 {
     ASSERT(m_enabled);
     ASSERT(m_automaticInspectionEnabled);
-    ASSERT(m_automaticInspectionPaused);
-    ASSERT(m_automaticInspectionCandidateTargetIdentifier);
     ASSERT(m_socketConnection);
     // FIXME: Implement automatic inspection.
 }

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -112,7 +112,7 @@ void RemoteInspector::stopInternal(StopSource)
 
     updateHasActiveDebugSession();
 
-    m_automaticInspectionPaused = false;
+    m_pausedAutomaticInspectionCandidates.clear();
 }
 
 TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspectionTarget& target) const
@@ -188,12 +188,10 @@ void RemoteInspector::pushListingsSoon()
     });
 }
 
-void RemoteInspector::sendAutomaticInspectionCandidateMessage()
+void RemoteInspector::sendAutomaticInspectionCandidateMessage(TargetID)
 {
     ASSERT(m_enabled);
     ASSERT(m_automaticInspectionEnabled);
-    ASSERT(m_automaticInspectionPaused);
-    ASSERT(m_automaticInspectionCandidateTargetIdentifier);
     // FIXME: Implement automatic inspection.
 }
 


### PR DESCRIPTION
#### 2cf06cdf0b2a0ecb699830de3b55221120003e7a
<pre>
Web Inspector: [Cocoa] `RemoteInspector` fails to send automatic inspection candidates created on a non-main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=242267">https://bugs.webkit.org/show_bug.cgi?id=242267</a>
rdar://51415024

Reviewed by Devin Rousso.

Automatic inspection of JSContexts works by spinning the thread a JSContext is created on when the feature is enabled at
the device level (via webinspectord) until we can ask an attached debugger(s) if we should automatically inspect that
context. At that same time, the attached debugger will let us know if we should formally pause script execution, or if
we should allow execution to continue normally. Upon receiving the yes/no from the debugger, we unspin the thread and if
requested start the debug session/pause JS execution.

This previously only reliably worked for the main thread and for contexts created after a JSContext was created on the
main thread. This was because there is initialization that must be done on the main thread (WTF::initialize). The issues
arose because while we would schedule initialization to later occur on the main thread, non-main-threads would still
carry on checking to see if, among other things, automatic inspection was enabled. Because the device-global automatic
inspection enablement wasn&apos;t read until after main thread initialization, we always declined to automatically inspect
non-main-thread contexts created before initialization had completed on the main thread.

This tangle of dependancies is unravelled by doing a few different things in tandem:
1. Get the global automatic inspection state before scheduling initialization - `notify_get_state` is designed for
cross-process and cross-thread messaging, so there is no need for us to be on the main thread to do so.
2. Keep track of the RemoteInspector singleton pending initialization.
3. Consider a &quot;targets&quot; (called debuggables by the client) for automatic inspection and spin them if automatic
inspection is enabled (since we now get that state before this point for all threads) and only bail if we are both
disabled and not pending initialization.

As part of this, it is now much more likely that multiple JSContexts may need to be considered candidates for automatic
inspection at the same time, so we also fix an existing limitation by allowing ourselves to keep track of multiple
candidates, since we may build a small set of candidates before initialization has completed.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
(Inspector::RemoteInspector::setupFailed):
(Inspector::RemoteInspector::setupCompleted):
(Inspector::RemoteInspector::waitingForAutomaticInspection):
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::singleton):
(Inspector::RemoteInspector::initialize):
(Inspector::RemoteInspector::setPendingMainThreadInitialization):
(Inspector::RemoteInspector::updateAutomaticInspectionCandidate):
(Inspector::RemoteInspector::sendAutomaticInspectionCandidateMessage):
(Inspector::RemoteInspector::start):
(Inspector::RemoteInspector::stopInternal):
(Inspector::RemoteInspector::setupXPCConnectionIfNeeded):
(Inspector::RemoteInspector::xpcConnectionFailed):
(Inspector::RemoteInspector::receivedSetupMessage):
(Inspector::RemoteInspector::receivedAutomaticInspectionConfigurationMessage):
(Inspector::RemoteInspector::receivedAutomaticInspectionRejectMessage):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::stopInternal):
(Inspector::RemoteInspector::sendAutomaticInspectionCandidateMessage):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::stopInternal):
(Inspector::RemoteInspector::sendAutomaticInspectionCandidateMessage):

Canonical link: <a href="https://commits.webkit.org/252569@main">https://commits.webkit.org/252569@main</a>
</pre>
