### PR TITLE
Avoid accessing an invalid parent node in SimplifyMarkupCommand::doApply

### DIFF
--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -53,7 +53,7 @@ void SimplifyMarkupCommand::doApply()
     // from a verbose fragment.
     // We look at inline elements as well as non top level divs that don't have attributes. 
     for (Node* node = m_firstNode.get(); node && node != m_nodeAfterLast; node = NodeTraversal::next(*node)) {
-        if (node->firstChild() || (node->isTextNode() && node->nextSibling()))
+        if (node->firstChild() || (node->isTextNode() && node->nextSibling()) || !node->parentNode())
             continue;
         
         Node* startingNode = node->parentNode();


### PR DESCRIPTION
#### 07745dfe9af284cf6084f52518d7a1903d1cff5c
<pre>
Avoid accessing an invalid parent node in SimplifyMarkupCommand::doApply
<a href="https://bugs.webkit.org/show_bug.cgi?id=242404">https://bugs.webkit.org/show_bug.cgi?id=242404</a>

Reviewed by Wenson Hsieh.

We cannot rely on the parent node always being valid when performing
various editing operations. Adding check to verify parent is present before using it.

* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
(WebCore::SimplifyMarkupCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/252206@main">https://commits.webkit.org/252206@main</a>
</pre>
