### PR TITLE
Ensure m_backend is valid during use in RTCRtpTransform::attachToSender

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
@@ -85,7 +85,8 @@ void RTCRtpTransform::attachToSender(RTCRtpSender& sender, RTCRtpTransform* prev
         m_backend = previousTransform->takeBackend();
     else if (auto* backend = sender.backend())
         m_backend = backend->rtcRtpTransformBackend();
-    else
+
+    if (!m_backend)
         return;
 
     switchOn(m_transform, [&](RefPtr<RTCRtpSFrameTransform>& sframeTransform) {


### PR DESCRIPTION
#### f5d45fe8d0dac54bc7c36a3d64244ac9ae44a3b4
<pre>
Ensure m_backend is valid during use in RTCRtpTransform::attachToSender
<a href="https://bugs.webkit.org/show_bug.cgi?id=242405">https://bugs.webkit.org/show_bug.cgi?id=242405</a>

Reviewed by Darin Adler.

Add check to ensure that the previousTransform has a valid backend before
attempting to use it.

* Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp:
(WebCore::RTCRtpTransform::attachToSender):

Canonical link: <a href="https://commits.webkit.org/252204@main">https://commits.webkit.org/252204@main</a>
</pre>
