### PR TITLE
Constructing a custom element should immediately execute microtasks if there are no scripts

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/microtasks-and-constructors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/microtasks-and-constructors-expected.txt
@@ -1,6 +1,7 @@
+CONSOLE MESSAGE: NotSupportedError: A newly constructed custom element must not have attributes
 
 PASS Microtasks evaluate immediately when the stack is empty inside the parser
-FAIL Microtasks evaluate immediately when the stack is empty inside the parser, causing the checks on no attributes to fail assert_false: The attribute must not be present expected false got true
+PASS Microtasks evaluate immediately when the stack is empty inside the parser, causing the checks on no attributes to fail
 PASS Microtasks evaluate afterward when the stack is not empty using createElement()
 PASS Microtasks evaluate afterward when the stack is not empty using the constructor
 PASS Microtasks evaluate afterward when the stack is not empty due to upgrades

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -51,6 +51,8 @@ class JSDOMGlobalObject;
 class MathMLElement;
 class SVGElement;
 
+enum class ParserConstructElementWithEmptyStack { No, Yes };
+
 class JSCustomElementInterface : public RefCounted<JSCustomElementInterface>, public ActiveDOMCallback {
 public:
     static Ref<JSCustomElementInterface> create(const QualifiedName& name, JSC::JSObject* callback, JSDOMGlobalObject* globalObject)
@@ -58,7 +60,7 @@ public:
         return adoptRef(*new JSCustomElementInterface(name, callback, globalObject));
     }
 
-    Ref<Element> constructElementWithFallback(Document&, const AtomString&);
+    Ref<Element> constructElementWithFallback(Document&, const AtomString&, ParserConstructElementWithEmptyStack = ParserConstructElementWithEmptyStack::No);
     Ref<Element> constructElementWithFallback(Document&, const QualifiedName&);
 
     void upgradeElement(Element&);
@@ -96,7 +98,7 @@ public:
 private:
     JSCustomElementInterface(const QualifiedName&, JSC::JSObject* callback, JSDOMGlobalObject*);
 
-    RefPtr<Element> tryToConstructCustomElement(Document&, const AtomString&);
+    RefPtr<Element> tryToConstructCustomElement(Document&, const AtomString&, ParserConstructElementWithEmptyStack);
 
     void invokeCallback(Element&, JSC::JSObject* callback, const Function<void(JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::MarkedArgumentBuffer&)>& addArguments = [](JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::MarkedArgumentBuffer&) { });
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -230,7 +230,8 @@ void HTMLDocumentParser::runScriptsForPausedTreeBuilder()
 
             CustomElementReactionStack reactionStack(document()->globalObject());
             auto& elementInterface = constructionData->elementInterface.get();
-            auto newElement = elementInterface.constructElementWithFallback(*document(), constructionData->name);
+            auto newElement = elementInterface.constructElementWithFallback(*document(), constructionData->name,
+                m_scriptRunner && !m_scriptRunner->isExecutingScript() ? ParserConstructElementWithEmptyStack::Yes : ParserConstructElementWithEmptyStack::No);
             m_treeBuilder->didCreateCustomOrFallbackElement(WTFMove(newElement), *constructionData);
         }
         return;


### PR DESCRIPTION
#### e7be2359033b5a89111f70b799953e17421eeede
<pre>
Constructing a custom element should immediately execute microtasks if there are no scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=188629">https://bugs.webkit.org/show_bug.cgi?id=188629</a>

Reviewed by Chris Dumez.

Perform a microtask check point when constructing a custom element with no script execution in the parser.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/microtasks-and-constructors-expected.txt:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::constructElementWithFallback):
(WebCore::JSCustomElementInterface::tryToConstructCustomElement):
(WebCore::constructCustomElementSynchronously):
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::runScriptsForPausedTreeBuilder):

Canonical link: <a href="https://commits.webkit.org/252190@main">https://commits.webkit.org/252190@main</a>
</pre>
