### PR TITLE
Remove validateDefaultFramebufferAttachment side-effect

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2673,13 +2673,10 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     return result;
 }
 
-static bool validateDefaultFramebufferAttachment(GCGLenum& attachment)
+static bool validateDefaultFramebufferAttachment(GCGLenum attachment)
 {
     switch (attachment) {
     case GraphicsContextGL::BACK:
-        // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
-        attachment = GraphicsContextGL::COLOR_ATTACHMENT0;
-        return true;
     case GraphicsContextGL::DEPTH:
     case GraphicsContextGL::STENCIL:
         return true;


### PR DESCRIPTION
#### a523acecfd064fd2d347880d8c72b1ba0e854e72
<pre>
Remove validateDefaultFramebufferAttachment side-effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=242408">https://bugs.webkit.org/show_bug.cgi?id=242408</a>

Reviewed by Kenneth Russell.

This function must not modify its argument
because the caller does not expect that.

Fixes 8 failures in
conformance2/state/gl-object-get-calls.html

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::validateDefaultFramebufferAttachment):

Canonical link: <a href="https://commits.webkit.org/252898@main">https://commits.webkit.org/252898@main</a>
</pre>
