### PR TITLE
WebKit should track regions for content which is not scrolled by the main scroll view

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -181,6 +181,10 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;
 #endif
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+- (NSArray<NSData *> *)_overlayRegions;
+#endif
+
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -60,6 +60,10 @@ public:
 
     CALayer *layerWithIDForTesting(uint64_t) const;
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    void updateOverlayRegionsWithIDs(const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> &overlayRegions) { m_remoteLayerTreeHost->updateOverlayRegionsWithIDs(overlayRegions); }
+#endif
+
 private:
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -76,6 +76,10 @@ public:
     CALayer *layerWithIDForTesting(uint64_t) const;
 
     bool replayCGDisplayListsIntoBackingStore() const;
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect>& overlayRegionsWithIDs() const { return m_overlayRegionsWithIDs; }
+    void updateOverlayRegionsWithIDs(const HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> &overlayRegions) { m_overlayRegionsWithIDs = overlayRegions; }
+#endif
 
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
@@ -89,6 +93,9 @@ private:
     RemoteLayerTreeNode* m_rootNode { nullptr };
     HashMap<WebCore::GraphicsLayer::PlatformLayerID, std::unique_ptr<RemoteLayerTreeNode>> m_nodes;
     HashMap<WebCore::GraphicsLayer::PlatformLayerID, RetainPtr<WKAnimationDelegate>> m_animationDelegates;
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    HashMap<WebCore::GraphicsLayer::PlatformLayerID, CGRect> m_overlayRegionsWithIDs;
+#endif
     bool m_isDebugLayerTreeHost { false };
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -111,6 +111,11 @@ public:
     void resetStateAfterProcessExited();
     WebCore::ScrollingTreeScrollingNode* rootNode() const;
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    void removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>&);
+    const HashSet<WebCore::GraphicsLayer::PlatformLayerID>& fixedScrollingNodeLayerIDs() const { return m_fixedScrollingNodeLayerIDs; }
+#endif
+
 private:
     void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&);
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&);
@@ -129,6 +134,9 @@ private:
     std::optional<unsigned> m_currentVerticalSnapPointIndex;
     bool m_propagatesMainFrameScrolls { true };
     HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_layersWithScrollingRelations;
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_fixedScrollingNodeLayerIDs;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -72,13 +72,27 @@ UIScrollView *RemoteScrollingCoordinatorProxy::scrollViewForScrollingNodeID(Scro
     return nil;
 }
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+void RemoteScrollingCoordinatorProxy::removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>& destroyedLayers)
+{
+    for (auto layerID : destroyedLayers)
+        m_fixedScrollingNodeLayerIDs.remove(layerID);
+}
+#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+
 void RemoteScrollingCoordinatorProxy::connectStateNodeLayers(ScrollingStateTree& stateTree, const RemoteLayerTreeHost& layerTreeHost)
 {
     using PlatformLayerID = GraphicsLayer::PlatformLayerID;
 
     for (auto& currNode : stateTree.nodeMap().values()) {
-        if (currNode->hasChangedProperty(ScrollingStateNode::Property::Layer))
-            currNode->setLayer(layerTreeHost.layerForID(PlatformLayerID { currNode->layer() }));
+        if (currNode->hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+            auto platformLayerID = PlatformLayerID { currNode->layer() };
+            currNode->setLayer(layerTreeHost.layerForID(platformLayerID));
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+            if (platformLayerID && currNode->isFixedNode())
+                m_fixedScrollingNodeLayerIDs.add(platformLayerID);
+#endif
+        }
         
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -548,6 +548,13 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 
 #endif // HAVE(PEPPER_UI_CORE)
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+- (NSArray<NSData *> *)overlayRegions
+{
+    return [_internalDelegate _overlayRegions];
+}
+#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 3723ab78e840d398c2c74c7758f7fbfc9b1477a4
<pre>
WebKit should track regions for content which is not scrolled by the main scroll view
<a href="https://bugs.webkit.org/show_bug.cgi?id=242406">https://bugs.webkit.org/show_bug.cgi?id=242406</a>

Reviewed by Tim Horton.

Compute a set of fixed rectangles which are not scrolled by
the main scroll view.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):
Update the overlay regions.

(addOverlayEventRegions):
Recursive function which builds overlay regions from the child layers.

(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
If there are destroyed or changed layers, recompute the set of overlay
regions and cleanup any removed layers which may exist in the fixed IDs
map as well as the overlay region map.

(-[WKWebView _overlayRegions]):
Compute the overlay regions as an array of NSData instances.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::fixedScrollingNodeLayerIDs const):
Return a reference to the fixed node IDs.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxy::removeFixedScrollingNodeLayerIDs):
Remove layerIDs for layers which no longer exist.

(WebKit::RemoteScrollingCoordinatorProxy::connectStateNodeLayers):
Save the fixed node IDs.

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView overlayRegions]):
Call into the web view to get the overlay regions.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
Add mutator for WKWebView to update the overlay regions.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::overlayRegionsWithIDs const):
Add hash map for tracking overlay regions.

(WebKit::RemoteLayerTreeHost::updateOverlayRegionsWithIDs):
Allow updating the hash map.

Canonical link: <a href="https://commits.webkit.org/252477@main">https://commits.webkit.org/252477@main</a>
</pre>
