### PR TITLE
Add telemetry to dump how long it takes to remove background from an image

### DIFF
--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -312,11 +312,13 @@ void requestBackgroundRemoval(CGImageRef image, CompletionHandler<void(CGImageRe
         return;
     }
 
-    auto completionBlock = makeBlockPtr([completion = WTFMove(completion)](CGImageRef result, NSError *error) mutable {
+    auto startTime = MonotonicTime::now();
+    auto completionBlock = makeBlockPtr([completion = WTFMove(completion), startTime](CGImageRef result, NSError *error) mutable {
         if (error)
             RELEASE_LOG(ImageAnalysis, "Remove background failed with error: %@", error);
 
-        callOnMainRunLoop([protectedResult = RetainPtr { result }, completion = WTFMove(completion)]() mutable {
+        callOnMainRunLoop([protectedResult = RetainPtr { result }, completion = WTFMove(completion), startTime]() mutable {
+            RELEASE_LOG(ImageAnalysis, "Remove background finished in %.0f ms (found subject? %d)", (MonotonicTime::now() - startTime).milliseconds(), !!protectedResult);
             completion(protectedResult.get());
         });
     });


### PR DESCRIPTION
#### 6fd8ee0d2f200ce45da947a5e48836d03d075d20
<pre>
Add telemetry to dump how long it takes to remove background from an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=242412">https://bugs.webkit.org/show_bug.cgi?id=242412</a>
Work towards rdar://94488144

Reviewed by Devin Rousso.

Print how long it takes to complete image analysis when checking for the ability to perform Remove
Background (or Copy Subject) on an image.

* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::requestBackgroundRemoval):

Canonical link: <a href="https://commits.webkit.org/252191@main">https://commits.webkit.org/252191@main</a>
</pre>
