### PR TITLE
Regression(252033@main) Sometimes plays audio without video when going fullscreen

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -258,10 +258,10 @@ bool VideoFullscreenManager::supportsVideoFullscreen(WebCore::HTMLMediaElementEn
 
 bool VideoFullscreenManager::supportsVideoFullscreenStandby() const
 {
-#if PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)
-    return false;
-#else
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
     return true;
+#else
+    return false;
 #endif
 }
 


### PR DESCRIPTION
#### 9b27c49c3b67f4ec9ae2d97bdc0007a5672d792b
<pre>
Regression(252033@main) Sometimes plays audio without video when going fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=242410">https://bugs.webkit.org/show_bug.cgi?id=242410</a>
rdar://96484603

Reviewed by Eric Carlson.

`252033@main` had unintentionally enabled the &quot;VideoFullscreenStandby&quot; codepath on macOS. Restore
pre-`252033@main` behavior for macOS by changing the platform guards so that it&apos;s only enabled when
`HAVE(UIKIT_WEBKIT_INTERNALS)` is set.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::supportsVideoFullscreenStandby const):

Canonical link: <a href="https://commits.webkit.org/252197@main">https://commits.webkit.org/252197@main</a>
</pre>
