### PR TITLE
Avoid unnecessary isolatedCopy() calls when decoding strings in WKRemoteObjectCoder.mm

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -984,13 +984,13 @@ static NSInvocation *decodeInvocation(WKRemoteObjectDecoder *decoder)
     return invocation;
 }
 
-static NSString *decodeString(WKRemoteObjectDecoder *decoder)
+static RetainPtr<NSString> decodeString(WKRemoteObjectDecoder *decoder)
 {
     API::String* string = decoder->_currentDictionary->get<API::String>(stringKey);
     if (!string)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"String missing"];
 
-    return string->string();
+    return string->stringView().createNSString();
 }
 
 static id decodeObject(WKRemoteObjectDecoder *decoder)
@@ -1011,13 +1011,13 @@ static id decodeObject(WKRemoteObjectDecoder *decoder)
         return decodeInvocation(decoder);
 
     if (objectClass == [NSString class])
-        return decodeString(decoder);
+        return decodeString(decoder).autorelease();
     
     if (objectClass == [NSError class])
         return decodeError(decoder).autorelease();
 
     if (objectClass == [NSMutableString class])
-        return [NSMutableString stringWithString:decodeString(decoder)];
+        return [NSMutableString stringWithString:decodeString(decoder).get()];
 
     return decodeObjCObject(decoder, objectClass).autorelease();
 }


### PR DESCRIPTION
#### f6600b2b275f5308b0d5773bfadf24342ac40881
<pre>
Avoid unnecessary isolatedCopy() calls when decoding strings in WKRemoteObjectCoder.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=242413">https://bugs.webkit.org/show_bug.cgi?id=242413</a>

Reviewed by Darin Adler.

decodeString() was calling APIString::string() which would call isolatedCopy() on
its internal String. This was unnecessary since decodeString() converts this String
to a NSString * anyway.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(decodeString):
(decodeObject):

Canonical link: <a href="https://commits.webkit.org/252217@main">https://commits.webkit.org/252217@main</a>
</pre>
