### PR TITLE
[WebGPU] Support parsing @vertex, @fragment, @compute attributes

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -208,6 +208,7 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
 
     CONSUME_TYPE(Attribute);
     CONSUME_TYPE_NAMED(ident, Identifier);
+
     if (ident.m_ident == "group"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
@@ -215,6 +216,7 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(GroupAttribute, id.m_literalValue);
     }
+
     if (ident.m_ident == "binding"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
@@ -222,18 +224,7 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(BindingAttribute, id.m_literalValue);
     }
-    if (ident.m_ident == "stage"_s) {
-        CONSUME_TYPE(ParenLeft);
-        CONSUME_TYPE_NAMED(stage, Identifier);
-        CONSUME_TYPE(ParenRight);
-        if (stage.m_ident == "compute"_s)
-            RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Compute);
-        if (stage.m_ident == "vertex"_s)
-            RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Vertex);
-        if (stage.m_ident == "fragment"_s)
-            RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Fragment);
-        FAIL("Invalid stage attribute, the only options are 'compute', 'vertex', 'fragment'."_s);
-    }
+
     if (ident.m_ident == "location"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
@@ -241,13 +232,23 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(LocationAttribute, id.m_literalValue);
     }
+
     if (ident.m_ident == "builtin"_s) {
         CONSUME_TYPE(ParenLeft);
         CONSUME_TYPE_NAMED(name, Identifier);
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(BuiltinAttribute, name.m_ident);
     }
-    FAIL("Unknown attribute, the only supported attributes are 'group', 'binding', 'stage'."_s);
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes
+    if (ident.m_ident == "vertex"_s)
+        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Vertex);
+    if (ident.m_ident == "compute"_s)
+        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Compute);
+    if (ident.m_ident == "fragment"_s)
+        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Fragment);
+
+    FAIL("Unknown attribute. Supported attributes are 'group', 'binding', 'location', 'builtin', 'vertex', 'compute', 'fragment'."_s);
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm
@@ -74,7 +74,7 @@
         "@group(0) @binding(0)\n"
         "var<storage, read_write> x: B;\n"
         "\n"
-        "@stage(compute)\n"
+        "@compute\n"
         "fn main() {\n"
         "    x.a = 42;\n"
         "}"_s);
@@ -139,13 +139,10 @@
     checkNextTokenIsIdentifier("B"_s);
     checkNextToken(WGSL::TokenType::Semicolon);
 
-    // @stage(compute)
+    // @compute
     lineNumber += 2;
     checkNextToken(WGSL::TokenType::Attribute);
-    checkNextTokenIsIdentifier("stage"_s);
-    checkNextToken(WGSL::TokenType::ParenLeft);
     checkNextTokenIsIdentifier("compute"_s);
-    checkNextToken(WGSL::TokenType::ParenRight);
 
     // fn main() {
     ++lineNumber;
@@ -172,12 +169,12 @@
 
 - (void) testLexerOnGraphicsShader {
     WGSL::Lexer<LChar> lexer(
-        "@stage(vertex)\n"
+        "@vertex\n"
         "fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {\n"
         "    return x;\n"
         "}\n"
         "\n"
-        "@stage(fragment)\n"
+        "@fragment\n"
         "fn fragmentShader() -> @location(0) vec4<f32> {\n"
         "    return vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
         "}"_s);
@@ -198,12 +195,9 @@
         XCTAssertEqual(result.m_literalValue, literalValue);
     };
 
-    // @stage(vertex)
+    // @vertex
     checkNextToken(WGSL::TokenType::Attribute);
-    checkNextTokenIsIdentifier("stage"_s);
-    checkNextToken(WGSL::TokenType::ParenLeft);
     checkNextTokenIsIdentifier("vertex"_s);
-    checkNextToken(WGSL::TokenType::ParenRight);
 
     ++lineNumber;
     // fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {
@@ -244,13 +238,10 @@
     ++lineNumber;
     checkNextToken(WGSL::TokenType::BraceRight);
 
-    // @stage(fragment)
+    // @fragment
     lineNumber += 2;
     checkNextToken(WGSL::TokenType::Attribute);
-    checkNextTokenIsIdentifier("stage"_s);
-    checkNextToken(WGSL::TokenType::ParenLeft);
     checkNextTokenIsIdentifier("fragment"_s);
-    checkNextToken(WGSL::TokenType::ParenRight);
 
     // fn fragmentShader() -> @location(0) vec4<f32> {
     ++lineNumber;

--- a/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
+++ b/Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm
@@ -98,7 +98,7 @@
 
 - (void)testParsingFunctionDecl {
     auto shader = WGSL::parseLChar(
-        "@stage(compute)\n"
+        "@compute\n"
         "fn main() {\n"
         "    x.a = 42i;\n"
         "}"_s);
@@ -135,11 +135,11 @@
 
 - (void)testTrivialGraphicsShader {
     auto shader = WGSL::parseLChar(
-        "@stage(vertex)\n"
+        "@vertex\n"
         "fn vertexShader(@location(0) x: vec4<f32>) -> @builtin(position) vec4<f32> {\n"
         "    return x;\n"
         "}\n\n"
-        "@stage(fragment)\n"
+        "@fragment\n"
         "fn fragmentShader() -> @location(0) vec4<f32> {\n"
         "    return vec4<f32>(0.4, 0.4, 0.8, 1.0);\n"
         "}"_s);


### PR DESCRIPTION
#### 00d2a9a093d03b1c84bd55e2c194057daf361371
<pre>
[WebGPU] Support parsing @vertex, @fragment, @compute attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=242414">https://bugs.webkit.org/show_bug.cgi?id=242414</a>

Reviewed by Myles C. Maxfield.

In <a href="https://github.com/gpuweb/gpuweb/pull/2652">https://github.com/gpuweb/gpuweb/pull/2652</a>,
shader entry point is now marked using @vertex, @fragment and
@compute instead of @stage(...). This patch changes the parsing
logic to support the new attributes, however these are still
parsed as AST::StageAttribute.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
* Source/WebGPU/WGSLUnitTests/WGSLLexerTests.mm:
(-[WGSLLexerTests testLexerOnComputeShader]):
(-[WGSLLexerTests testLexerOnGraphicsShader]):
* Source/WebGPU/WGSLUnitTests/WGSLParserTests.mm:
(-[WGSLParserTests testParsingFunctionDecl]):
(-[WGSLParserTests testTrivialGraphicsShader]):

Canonical link: <a href="https://commits.webkit.org/252198@main">https://commits.webkit.org/252198@main</a>
</pre>
