### PR TITLE
[webauthn] Enums should be DOMStrings

### DIFF
--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.cpp
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AttestationConveyancePreference.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSAttestationConveyancePreference.h"
+
+namespace WebCore {
+
+AttestationConveyancePreference toAttestationConveyancePreference(String& preference)
+{
+    if (preference == "direct"_s)
+        return AttestationConveyancePreference::Direct;
+    if (preference == "indirect"_s)
+        return AttestationConveyancePreference::Indirect;
+    return AttestationConveyancePreference::None;
+}
+
+String toString(AttestationConveyancePreference preference)
+{
+    return convertEnumerationToString(preference);
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <wtf/Forward.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -36,6 +37,10 @@ enum class AttestationConveyancePreference {
     Indirect,
     Direct
 };
+
+WEBCORE_EXPORT AttestationConveyancePreference toAttestationConveyancePreference(String& preference);
+
+WEBCORE_EXPORT String toString(AttestationConveyancePreference);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AuthenticatorTransport.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSAuthenticatorTransport.h"
+
+namespace WebCore {
+
+std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport)
+{
+    if (transport == "usb"_s)
+        return AuthenticatorTransport::Usb;
+    if (transport == "nfc"_s)
+        return AuthenticatorTransport::Nfc;
+    if (transport == "ble"_s)
+        return AuthenticatorTransport::Ble;
+    if (transport == "internal"_s)
+        return AuthenticatorTransport::Internal;
+    if (transport == "cable"_s)
+        return AuthenticatorTransport::Cable;
+    if (transport == "hybrid"_s)
+        return AuthenticatorTransport::Hybrid;
+    return std::nullopt;
+}
+
+String toString(AuthenticatorTransport transport)
+{
+    return convertEnumerationToString(transport);
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include <optional>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -39,6 +40,10 @@ enum class AuthenticatorTransport {
     Cable,
     Hybrid
 };
+
+WEBCORE_EXPORT std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport);
+
+WEBCORE_EXPORT String toString(AuthenticatorTransport);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PublicKeyCredentialCreationOptions.h"
+
+#include "AuthenticatorAttachment.h"
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+AttestationConveyancePreference PublicKeyCredentialCreationOptions::attestation() const
+{
+    if (attestationString == "indirect"_s)
+        return AttestationConveyancePreference::Indirect;
+    if (attestationString == "direct"_s)
+        return AttestationConveyancePreference::Direct;
+    return AttestationConveyancePreference::None;
+}
+
+std::optional<ResidentKeyRequirement> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::residentKey() const
+{
+    if (residentKeyString == "required"_s)
+        return ResidentKeyRequirement::Required;
+    if (residentKeyString == "discouraged"_s)
+        return ResidentKeyRequirement::Discouraged;
+    return ResidentKeyRequirement::Preferred;
+}
+
+UserVerificationRequirement PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::userVerification() const
+{
+    if (userVerificationString == "required"_s)
+        return UserVerificationRequirement::Required;
+    if (userVerificationString == "preferred"_s)
+        return UserVerificationRequirement::Preferred;
+    return UserVerificationRequirement::Discouraged;
+}
+
+std::optional<AuthenticatorAttachment> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::authenticatorAttachment() const
+{
+    if (authenticatorAttachmentString == "platform"_s)
+        return AuthenticatorAttachment::Platform;
+    if (authenticatorAttachmentString == "cross-platform"_s)
+        return AuthenticatorAttachment::CrossPlatform;
+    return std::nullopt;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
@@ -65,11 +65,15 @@ struct PublicKeyCredentialCreationOptions {
     };
 
     struct AuthenticatorSelectionCriteria {
-        std::optional<AuthenticatorAttachment> authenticatorAttachment;
+        std::optional<String> authenticatorAttachmentString;
+        WEBCORE_EXPORT std::optional<AuthenticatorAttachment> authenticatorAttachment() const;
+
         // residentKey replaces requireResidentKey, see: https://www.w3.org/TR/webauthn-2/#dictionary-authenticatorSelection
-        std::optional<ResidentKeyRequirement> residentKey;
+        std::optional<String> residentKeyString;
+        WEBCORE_EXPORT std::optional<ResidentKeyRequirement> residentKey() const;
         bool requireResidentKey { false };
-        UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
+        String userVerificationString { "preferred"_s };
+        WEBCORE_EXPORT UserVerificationRequirement userVerification() const;
 
         template<class Encoder> void encode(Encoder&) const;
         template<class Decoder> static std::optional<AuthenticatorSelectionCriteria> decode(Decoder&);
@@ -84,7 +88,8 @@ struct PublicKeyCredentialCreationOptions {
     std::optional<unsigned> timeout;
     Vector<PublicKeyCredentialDescriptor> excludeCredentials;
     std::optional<AuthenticatorSelectionCriteria> authenticatorSelection;
-    AttestationConveyancePreference attestation;
+    String attestationString;
+    WEBCORE_EXPORT AttestationConveyancePreference attestation() const;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
 
     template<class Encoder> void encode(Encoder&) const;
@@ -113,7 +118,7 @@ std::optional<PublicKeyCredentialCreationOptions::Parameters> PublicKeyCredentia
 template<class Encoder>
 void PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::encode(Encoder& encoder) const
 {
-    encoder << authenticatorAttachment << requireResidentKey << userVerification << residentKey;
+    encoder << authenticatorAttachmentString << requireResidentKey << userVerificationString << residentKeyString;
 }
 
 template<class Decoder>
@@ -121,11 +126,11 @@ std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria
 {
     PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria result;
 
-    std::optional<std::optional<AuthenticatorAttachment>> authenticatorAttachment;
-    decoder >> authenticatorAttachment;
-    if (!authenticatorAttachment)
+    std::optional<std::optional<String>> authenticatorAttachmentString;
+    decoder >> authenticatorAttachmentString;
+    if (!authenticatorAttachmentString)
         return std::nullopt;
-    result.authenticatorAttachment = WTFMove(*authenticatorAttachment);
+    result.authenticatorAttachmentString = WTFMove(*authenticatorAttachmentString);
 
     std::optional<bool> requireResidentKey;
     decoder >> requireResidentKey;
@@ -133,14 +138,14 @@ std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria
         return std::nullopt;
     result.requireResidentKey = *requireResidentKey;
 
-    if (!decoder.decode(result.userVerification))
+    if (!decoder.decode(result.userVerificationString))
         return std::nullopt;
 
-    std::optional<std::optional<ResidentKeyRequirement>> residentKey;
-    decoder >> residentKey;
-    if (!residentKey)
+    std::optional<std::optional<String>> residentKeyString;
+    decoder >> residentKeyString;
+    if (!residentKeyString)
         return std::nullopt;
-    result.residentKey = *residentKey;
+    result.residentKeyString = *residentKeyString;
 
     return result;
 }
@@ -151,7 +156,7 @@ void PublicKeyCredentialCreationOptions::encode(Encoder& encoder) const
 {
     encoder << rp.id << rp.name << rp.icon;
     encoder << user.id;
-    encoder << user.displayName << user.name << user.icon << pubKeyCredParams << timeout << excludeCredentials << authenticatorSelection << attestation << extensions;
+    encoder << user.displayName << user.name << user.icon << pubKeyCredParams << timeout << excludeCredentials << authenticatorSelection << attestationString << extensions;
     encoder << static_cast<uint64_t>(challenge.length());
     encoder.encodeFixedLengthData(challenge.data(), challenge.length(), 1);
 }
@@ -192,11 +197,11 @@ std::optional<PublicKeyCredentialCreationOptions> PublicKeyCredentialCreationOpt
         return std::nullopt;
     result.authenticatorSelection = WTFMove(*authenticatorSelection);
 
-    std::optional<AttestationConveyancePreference> attestation;
-    decoder >> attestation;
-    if (!attestation)
+    std::optional<String> attestationString;
+    decoder >> attestationString;
+    if (!attestationString)
         return std::nullopt;
-    result.attestation = WTFMove(*attestation);
+    result.attestationString = WTFMove(*attestationString);
 
     std::optional<std::optional<AuthenticationExtensionsClientInputs>> extensions;
     decoder >> extensions;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -37,7 +37,7 @@ typedef long COSEAlgorithmIdentifier;
     unsigned long timeout;
     sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
     AuthenticatorSelectionCriteria authenticatorSelection;
-    AttestationConveyancePreference attestation = "none";
+    [ImplementedAs=attestationString] DOMString attestation = "none";
     AuthenticationExtensionsClientInputs extensions;
 };
 
@@ -71,8 +71,8 @@ typedef long COSEAlgorithmIdentifier;
 [
     Conditional=WEB_AUTHN,
 ] dictionary AuthenticatorSelectionCriteria {
-    AuthenticatorAttachment      authenticatorAttachment;
-    ResidentKeyRequirement       residentKey;
+    [ImplementedAs=authenticatorAttachmentString] DOMString authenticatorAttachment;
+    [ImplementedAs=residentKeyString] DOMString? residentKey;
     boolean                      requireResidentKey = false;
-    UserVerificationRequirement  userVerification = "preferred";
+    [ImplementedAs=userVerificationString] DOMString? userVerification = "preferred";
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
@@ -36,7 +36,7 @@ namespace WebCore {
 struct PublicKeyCredentialDescriptor {
     PublicKeyCredentialType type;
     BufferSource id;
-    Vector<AuthenticatorTransport> transports;
+    Vector<String> transports;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<PublicKeyCredentialDescriptor> decode(Decoder&);

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
@@ -28,5 +28,5 @@
 ] dictionary PublicKeyCredentialDescriptor {
     required PublicKeyCredentialType type;
     required BufferSource id;
-    sequence<AuthenticatorTransport> transports;
+    sequence<DOMString> transports;
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PublicKeyCredentialRequestOptions.h"
+
+#include "AuthenticatorAttachment.h"
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+UserVerificationRequirement PublicKeyCredentialRequestOptions::userVerification() const
+{
+    if (userVerificationString == "required"_s)
+        return UserVerificationRequirement::Required;
+    if (userVerificationString == "preferred"_s)
+        return UserVerificationRequirement::Preferred;
+    return UserVerificationRequirement::Discouraged;
+}
+
+std::optional<AuthenticatorAttachment> PublicKeyCredentialRequestOptions::authenticatorAttachment() const
+{
+    if (authenticatorAttachmentString == "platform"_s)
+        return AuthenticatorAttachment::Platform;
+    if (authenticatorAttachmentString == "cross-platform"_s)
+        return AuthenticatorAttachment::CrossPlatform;
+    return std::nullopt;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -30,6 +30,6 @@
     unsigned long timeout;
     USVString rpId;
     sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    UserVerificationRequirement userVerification = "preferred";
+    [ImplementedAs=userVerificationString] DOMString userVerification = "preferred";
     AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -31,6 +31,10 @@
 #include "CBORReader.h"
 #include "CBORWriter.h"
 #include "FidoConstants.h"
+#include "JSAttestationConveyancePreference.h"
+#include "JSAuthenticatorAttachment.h"
+#include "JSResidentKeyRequirement.h"
+#include "JSUserVerificationRequirement.h"
 #include "WebAuthenticationConstants.h"
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/JSONValues.h>
@@ -199,6 +203,26 @@ Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& x, const Vector<uint8_
     rawKey.appendVector(x);
     rawKey.appendVector(y);
     return rawKey;
+}
+
+String toString(AttestationConveyancePreference preference)
+{
+    return convertEnumerationToString(preference);
+}
+
+String toString(AuthenticatorAttachment attachment)
+{
+    return convertEnumerationToString(attachment);
+}
+
+String toString(UserVerificationRequirement requirement)
+{
+    return convertEnumerationToString(requirement);
+}
+
+String toString(ResidentKeyRequirement requirement)
+{
+    return convertEnumerationToString(requirement);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
@@ -36,6 +36,10 @@
 
 namespace WebCore {
 
+enum class AuthenticatorAttachment;
+enum class UserVerificationRequirement;
+enum class ResidentKeyRequirement : uint8_t;
+
 WEBCORE_EXPORT Vector<uint8_t> convertBytesToVector(const uint8_t byteArray[], const size_t length);
 
 WEBCORE_EXPORT Vector<uint8_t> convertArrayBufferToVector(ArrayBuffer*);
@@ -66,6 +70,15 @@ WEBCORE_EXPORT cbor::CBORValue::MapValue buildUserEntityMap(const Vector<uint8_t
 
 // encodeRawPublicKey takes X & Y and returns them as a 0x04 || X || Y byte array.
 WEBCORE_EXPORT Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& X, const Vector<uint8_t>& Y);
+
+WEBCORE_EXPORT String toString(AttestationConveyancePreference);
+
+WEBCORE_EXPORT String toString(AuthenticatorAttachment);
+
+WEBCORE_EXPORT String toString(UserVerificationRequirement);
+
+WEBCORE_EXPORT String toString(ResidentKeyRequirement);
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -103,16 +103,16 @@ Vector<uint8_t> encodeMakeCredenitalRequestAsCBOR(const Vector<uint8_t>& hash, c
     CBORValue::MapValue optionMap;
     if (options.authenticatorSelection) {
         // Resident keys are not supported by default.
-        if (options.authenticatorSelection->residentKey) {
-            if (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required
-                || (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
+        if (options.authenticatorSelection->residentKey()) {
+            if (*options.authenticatorSelection->residentKey() == ResidentKeyRequirement::Required
+                || (*options.authenticatorSelection->residentKey() == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
                 optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
         } else if (options.authenticatorSelection->requireResidentKey)
             optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
 
         // User verification is not required by default.
         bool requireUserVerification = false;
-        switch (options.authenticatorSelection->userVerification) {
+        switch (options.authenticatorSelection->userVerification()) {
         case UserVerificationRequirement::Required:
         case UserVerificationRequirement::Preferred:
             requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;
@@ -156,7 +156,7 @@ Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, con
     CBORValue::MapValue optionMap;
     // User verification is not required by default.
     bool requireUserVerification = false;
-    switch (options.userVerification) {
+    switch (options.userVerification()) {
     case UserVerificationRequirement::Required:
     case UserVerificationRequirement::Preferred:
         requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -85,7 +85,7 @@ static std::optional<Vector<uint8_t>> constructU2fSignCommand(const Vector<uint8
 
 bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions& request)
 {
-    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
+    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification() == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
         return false;
     if (request.pubKeyCredParams.findIf([](auto& item) { return item.alg == COSE::ES256; }) == notFound)
         return false;
@@ -94,7 +94,7 @@ bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions&
 
 bool isConvertibleToU2fSignCommand(const PublicKeyCredentialRequestOptions& request)
 {
-    return (request.userVerification != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
+    return (request.userVerification() != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
 }
 
 std::optional<Vector<uint8_t>> convertToU2fRegisterCommand(const Vector<uint8_t>& clientDataHash, const PublicKeyCredentialCreationOptions& request)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -360,7 +360,10 @@ Modules/webauthn/AuthenticatorAssertionResponse.cpp
 Modules/webauthn/AuthenticatorAttestationResponse.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/AuthenticatorResponse.cpp
+Modules/webauthn/AuthenticatorTransport.cpp
 Modules/webauthn/PublicKeyCredential.cpp
+Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
 Modules/webauthn/WebAuthenticationUtils.cpp
 Modules/webauthn/apdu/ApduCommand.cpp
 Modules/webauthn/apdu/ApduResponse.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -798,13 +798,13 @@ static WebCore::AuthenticatorTransport authenticatorTransport(_WKWebAuthenticati
     }
 }
 
-static Vector<WebCore::AuthenticatorTransport> authenticatorTransports(NSArray<NSNumber *> *transports)
+static Vector<String> authenticatorTransports(NSArray<NSNumber *> *transports)
 {
-    Vector<WebCore::AuthenticatorTransport> result;
+    Vector<String> result;
     result.reserveInitialCapacity(transports.count);
 
     for (NSNumber *transport : transports)
-        result.uncheckedAppend(authenticatorTransport((_WKWebAuthenticationTransport)transport.intValue));
+        result.uncheckedAppend(toString(authenticatorTransport((_WKWebAuthenticationTransport)transport.intValue)));
 
     return result;
 }
@@ -870,10 +870,12 @@ static std::optional<WebCore::ResidentKeyRequirement> toWebCore(_WKResidentKeyRe
 static WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria authenticatorSelectionCriteria(_WKAuthenticatorSelectionCriteria *authenticatorSelection)
 {
     WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria result;
-    result.authenticatorAttachment = authenticatorAttachment(authenticatorSelection.authenticatorAttachment);
-    result.residentKey = toWebCore(authenticatorSelection.residentKey);
+    if (auto attachment = authenticatorAttachment(authenticatorSelection.authenticatorAttachment))
+        result.authenticatorAttachmentString = toString(*attachment);
+    if (auto residentKey = toWebCore(authenticatorSelection.residentKey))
+        result.residentKeyString = toString(*residentKey);
     result.requireResidentKey = authenticatorSelection.requireResidentKey;
-    result.userVerification = userVerification(authenticatorSelection.userVerification);
+    result.userVerificationString = toString(userVerification(authenticatorSelection.userVerification));
 
     return result;
 }
@@ -936,7 +938,7 @@ static WebCore::CredentialRequestOptions::MediationRequirement toWebCore(_WKWebA
         result.excludeCredentials = publicKeyCredentialDescriptors(options.excludeCredentials);
     if (options.authenticatorSelection)
         result.authenticatorSelection = authenticatorSelectionCriteria(options.authenticatorSelection);
-    result.attestation = attestationConveyancePreference(options.attestation);
+    result.attestationString = toString(attestationConveyancePreference(options.attestation));
     if (options.extensionsCBOR)
         result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(vectorFromNSData(options.extensionsCBOR));
     else
@@ -1020,8 +1022,9 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
         result.rpId = options.relyingPartyIdentifier;
     if (options.allowCredentials)
         result.allowCredentials = publicKeyCredentialDescriptors(options.allowCredentials);
-    result.userVerification = userVerification(options.userVerification);
-    result.authenticatorAttachment = authenticatorAttachment(options.authenticatorAttachment);
+    result.userVerificationString = toString(userVerification(options.userVerification));
+    if (auto attachment = authenticatorAttachment(options.authenticatorAttachment))
+        result.authenticatorAttachmentString = toString(*attachment);
     result.extensions = authenticationExtensionsClientInputs(options.extensions);
 #endif
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -56,7 +56,7 @@ const unsigned maxTimeOutValue = 120000;
 static AuthenticatorManager::TransportSet collectTransports(const std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria>& authenticatorSelection)
 {
     AuthenticatorManager::TransportSet result;
-    if (!authenticatorSelection || !authenticatorSelection->authenticatorAttachment) {
+    if (!authenticatorSelection || !authenticatorSelection->authenticatorAttachment()) {
         auto addResult = result.add(AuthenticatorTransport::Internal);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         addResult = result.add(AuthenticatorTransport::Usb);
@@ -68,12 +68,12 @@ static AuthenticatorManager::TransportSet collectTransports(const std::optional<
         return result;
     }
 
-    if (authenticatorSelection->authenticatorAttachment == AuthenticatorAttachment::Platform) {
+    if (authenticatorSelection->authenticatorAttachment() == AuthenticatorAttachment::Platform) {
         auto addResult = result.add(AuthenticatorTransport::Internal);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         return result;
     }
-    if (authenticatorSelection->authenticatorAttachment == AuthenticatorAttachment::CrossPlatform) {
+    if (authenticatorSelection->authenticatorAttachment() == AuthenticatorAttachment::CrossPlatform) {
         auto addResult = result.add(AuthenticatorTransport::Usb);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         addResult = result.add(AuthenticatorTransport::Nfc);
@@ -116,11 +116,12 @@ static AuthenticatorManager::TransportSet collectTransports(const Vector<PublicK
             break;
         }
 
-        for (const auto& transport : allowCredential.transports) {
-            if (transport == AuthenticatorTransport::Ble)
+        for (const auto& unparsedTransport : allowCredential.transports) {
+            auto transport = toAuthenticatorTransport(unparsedTransport);
+            if (!transport || *transport == AuthenticatorTransport::Ble)
                 continue;
 
-            result.add(transport);
+            result.add(*transport);
 
             if (result.size() >= AuthenticatorManager::maxTransportNumber)
                 break;
@@ -533,7 +534,7 @@ auto AuthenticatorManager::getTransports() const -> TransportSet
         transports = collectTransports(options.authenticatorSelection);
         processGoogleLegacyAppIdSupportExtension(options.extensions, transports);
     }, [&](const PublicKeyCredentialRequestOptions& options) {
-        transports = collectTransports(options.allowCredentials, options.authenticatorAttachment);
+        transports = collectTransports(options.allowCredentials, options.authenticatorAttachment());
     });
     filterTransports(transports);
     return transports;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -28,11 +28,11 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#import "AuthenticationServicesCoreSoftLink.h"
 #import <Security/SecItem.h>
 #import <WebCore/AuthenticatorAssertionResponse.h>
 #import <WebCore/AuthenticatorAttachment.h>
 #import <WebCore/AuthenticatorAttestationResponse.h>
+#import <WebCore/AuthenticatorTransport.h>
 #import <WebCore/CBORReader.h>
 #import <WebCore/CBORWriter.h>
 #import <WebCore/ExceptionData.h>
@@ -50,6 +50,7 @@
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/StringHash.h>
+#import "AuthenticationServicesCoreSoftLink.h"
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/LocalAuthenticatorAdditions.h>
@@ -80,9 +81,9 @@ const uint16_t credentialIdLength = 20;
 const uint64_t counter = 0;
 const uint8_t aaguid[] = { 0xF2, 0x4A, 0x8E, 0x70, 0xD0, 0xD3, 0xF8, 0x2C, 0x29, 0x37, 0x32, 0x52, 0x3C, 0xC4, 0xDE, 0x5A }; // Randomly generated.
 
-static inline bool emptyTransportsOrContain(const Vector<AuthenticatorTransport>& transports, AuthenticatorTransport target)
+static inline bool emptyTransportsOrContain(const Vector<String>& transports, AuthenticatorTransport target)
 {
-    return transports.isEmpty() ? true : transports.contains(target);
+    return transports.isEmpty() ? true : transports.contains(toString(target));
 }
 
 // A Base64 encoded string of the Credential ID is used as the key of the hash set.
@@ -413,7 +414,7 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
     auto flags = authDataFlags(ClientDataType::Create, verification, shouldUpdateQuery());
     // Step 12.
     // Skip Apple Attestation for none attestation.
-    if (creationOptions.attestation == AttestationConveyancePreference::None) {
+    if (creationOptions.attestation() == AttestationConveyancePreference::None) {
         deleteDuplicateCredential();
 
         auto authData = buildAuthData(*creationOptions.rp.id, flags, counter, buildAttestedCredentialData(Vector<uint8_t>(aaguidLength, 0), credentialId, cosePublicKey));
@@ -463,7 +464,7 @@ void LocalAuthenticator::continueMakeCredentialAfterAttested(Vector<uint8_t>&& c
             cborArray.append(cbor::CBORValue(vectorFromNSData((NSData *)adoptCF(SecCertificateCopyData((__bridge SecCertificateRef)certificates[i])).get())));
         attestationStatementMap[cbor::CBORValue("x5c")] = cbor::CBORValue(WTFMove(cborArray));
     }
-    auto attestationObject = buildAttestationObject(WTFMove(authData), "apple"_s, WTFMove(attestationStatementMap), creationOptions.attestation);
+    auto attestationObject = buildAttestationObject(WTFMove(authData), "apple"_s, WTFMove(attestationStatementMap), creationOptions.attestation());
 
     deleteDuplicateCredential();
     auto response = AuthenticatorAttestationResponse::create(credentialId, attestationObject, AuthenticatorAttachment::Platform, transports());

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -139,9 +139,12 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
     if (transportCount) {
         transports = adoptNS([[NSMutableArray alloc] initWithCapacity:transportCount]);
 
-        for (AuthenticatorTransport transport : descriptor.transports) {
+        for (String unparsedTransport : descriptor.transports) {
+            auto transport = toAuthenticatorTransport(unparsedTransport);
+            if (!transport)
+                continue;
             NSString *transportString = nil;
-            switch (transport) {
+            switch (*transport) {
             case AuthenticatorTransport::Usb:
                 transportString = @"usb";
                 break;
@@ -211,16 +214,16 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     std::optional<ResidentKeyRequirement> residentKeyRequirement;
     std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria> authenticatorSelection = options.authenticatorSelection;
     if (authenticatorSelection) {
-        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment;
+        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment();
         if (attachment == AuthenticatorAttachment::Platform)
             requestTypes = ASCCredentialRequestTypePlatformPublicKeyRegistration;
         else if (attachment == AuthenticatorAttachment::CrossPlatform)
             requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyRegistration;
 
-        userVerification = toNSString(authenticatorSelection->userVerification);
+        userVerification = toNSString(authenticatorSelection->userVerification());
 
         shouldRequireResidentKey = authenticatorSelection->requireResidentKey;
-        residentKeyRequirement = authenticatorSelection->residentKey;
+        residentKeyRequirement = authenticatorSelection->residentKey();
     }
     if (!LocalService::isAvailable())
         requestTypes &= ~ASCCredentialRequestTypePlatformPublicKeyRegistration;
@@ -245,7 +248,7 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
         [credentialCreationOptions setResidentKeyPreference:toASCResidentKeyPreference(residentKeyRequirement, shouldRequireResidentKey)];
     else
         [credentialCreationOptions setShouldRequireResidentKey:shouldRequireResidentKey];
-    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation).get()];
+    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation()).get()];
 
     RetainPtr<NSMutableArray<NSNumber *>> supportedAlgorithmIdentifiers = adoptNS([[NSMutableArray alloc] initWithCapacity:options.pubKeyCredParams.size()]);
     for (PublicKeyCredentialCreationOptions::Parameters algorithmParameter : options.pubKeyCredParams)
@@ -312,13 +315,13 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
     ASCCredentialRequestTypes requestTypes = ASCCredentialRequestTypePlatformPublicKeyAssertion | ASCCredentialRequestTypeSecurityKeyPublicKeyAssertion;
 
     RetainPtr<NSString> userVerification;
-    std::optional<AuthenticatorAttachment> attachment = options.authenticatorAttachment;
+    std::optional<AuthenticatorAttachment> attachment = options.authenticatorAttachment();
     if (attachment == AuthenticatorAttachment::Platform)
         requestTypes = ASCCredentialRequestTypePlatformPublicKeyAssertion;
     else if (attachment == AuthenticatorAttachment::CrossPlatform)
         requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyAssertion;
 
-    userVerification = toNSString(options.userVerification);
+    userVerification = toNSString(options.userVerification());
 
     size_t allowedCredentialCount = options.allowCredentials.size();
     RetainPtr<NSMutableArray<ASCPublicKeyCredentialDescriptor *>> allowedCredentials;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
@@ -44,11 +44,11 @@ UserVerificationRequirement getUserVerificationRequirement(const std::variant<Pu
 {
     if (std::holds_alternative<PublicKeyCredentialCreationOptions>(options)) {
         if (auto authenticatorSelection = std::get<PublicKeyCredentialCreationOptions>(options).authenticatorSelection)
-            return authenticatorSelection->userVerification;
+            return authenticatorSelection->userVerification();
         return UserVerificationRequirement::Preferred;
     }
 
-    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification;
+    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -99,7 +99,7 @@ void CtapAuthenticator::makeCredential()
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     auto residentKeyAvailability = m_info.options().residentKeyAvailability();
     // If UV is required, then either built-in uv or a pin will work.
-    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
+    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification() != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
         cborCmd = encodeMakeCredenitalRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability);
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet)
         cborCmd = encodeMakeCredenitalRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, PinParameters { pin::kProtocolVersion, m_pinAuth });
@@ -115,7 +115,7 @@ void CtapAuthenticator::makeCredential()
 
 void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&& data)
 {
-    auto response = readCTAPMakeCredentialResponse(data, AuthenticatorAttachment::CrossPlatform, transports(), std::get<PublicKeyCredentialCreationOptions>(requestData().options).attestation);
+    auto response = readCTAPMakeCredentialResponse(data, AuthenticatorAttachment::CrossPlatform, transports(), std::get<PublicKeyCredentialCreationOptions>(requestData().options).attestation());
     if (!response) {
         auto error = getResponseCode(data);
 
@@ -144,7 +144,7 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
         auto extensionOutputs = response->extensions();
         
         auto rkSupported = m_info.options().residentKeyAvailability() == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported;
-        auto rkRequested = options.authenticatorSelection && ((options.authenticatorSelection->residentKey && options.authenticatorSelection->residentKey != ResidentKeyRequirement::Discouraged) || options.authenticatorSelection->requireResidentKey);
+        auto rkRequested = options.authenticatorSelection && ((options.authenticatorSelection->residentKey() && options.authenticatorSelection->residentKey() != ResidentKeyRequirement::Discouraged) || options.authenticatorSelection->requireResidentKey);
         extensionOutputs.credProps = AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput { rkSupported && rkRequested };
         response->setExtensions(WTFMove(extensionOutputs));
     }
@@ -158,9 +158,9 @@ void CtapAuthenticator::getAssertion()
     auto& options = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     // If UV is required, then either built-in uv or a pin will work.
-    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
+    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification() != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability);
-    else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification != UserVerificationRequirement::Discouraged)
+    else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification() != UserVerificationRequirement::Discouraged)
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, PinParameters { pin::kProtocolVersion, m_pinAuth });
     else
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -158,7 +158,7 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
         auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
         auto appId = processGoogleLegacyAppIdSupportExtension(options.extensions);
         ASSERT(options.rp.id);
-        auto response = readU2fRegisterResponse(!appId ? *options.rp.id : appId, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation);
+        auto response = readU2fRegisterResponse(!appId ? *options.rp.id : appId, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation());
         if (!response) {
             receiveRespond(ExceptionData { UnknownError, "Couldn't parse the U2F register response."_s });
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -60,9 +60,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParam)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, std::nullopt, true, "preferred"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported);
@@ -83,9 +83,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamNoUVNoRK)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, std::nullopt, false, "discouraged"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported);
@@ -106,9 +106,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamUVRequiredButNotSup
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, std::nullopt, false, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported);
@@ -129,13 +129,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamWithPin)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, std::nullopt, true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, pin);
@@ -156,13 +156,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferred)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, pin);
@@ -183,9 +183,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferredNotSupported)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kNotSupported);
@@ -206,9 +206,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKDiscouraged)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Discouraged, true, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "discouraged"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
     auto serializedData = encodeMakeCredenitalRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported);
@@ -244,7 +244,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -281,7 +281,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Discouraged;
+    options.userVerificationString = "discouraged"_s;
 
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -318,7 +318,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -355,7 +355,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -166,7 +166,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterUserVerificationRequirement)
 {
     auto makeCredentialParam = constructMakeCredentialRequest();
     PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection;
-    selection.userVerification = UserVerificationRequirement::Required;
+    selection.userVerificationString = "required"_s;
     makeCredentialParam.authenticatorSelection = WTFMove(selection);
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
@@ -234,7 +234,7 @@ TEST(U2fCommandConstructorTest, TestU2fSignUserVerificationRequirement)
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
-    getAssertionReq.userVerification = UserVerificationRequirement::Required;
+    getAssertionReq.userVerificationString = "required"_s;
 
     EXPECT_FALSE(isConvertibleToU2fSignCommand(getAssertionReq));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -34,6 +34,7 @@
 #import "WKWebViewConfigurationExtras.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 #import <WebCore/AuthenticatorAttachment.h>
+#import <WebCore/AuthenticatorTransport.h>
 #import <WebCore/ExceptionCode.h>
 #import <WebCore/PublicKeyCredentialCreationOptions.h>
 #import <WebCore/PublicKeyCredentialRequestOptions.h>
@@ -1506,7 +1507,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_EQ(result.excludeCredentials.size(), 0lu);
     EXPECT_EQ(result.authenticatorSelection, std::nullopt);
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
     EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
@@ -1556,11 +1557,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, std::nullopt);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), std::nullopt);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, false);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Preferred);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1623,15 +1624,15 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[2]), AuthenticatorTransport::Internal);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::Platform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::Platform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Required);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Direct);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Direct);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
@@ -1693,15 +1694,15 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[2]), AuthenticatorTransport::Internal);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::CrossPlatform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::CrossPlatform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Discouraged);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Discouraged);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Indirect);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Indirect);
 }
 
 TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
@@ -1851,7 +1852,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_TRUE(result.rpId.isNull());
     EXPECT_EQ(result.allowCredentials.size(), 0lu);
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
     EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
@@ -1877,7 +1878,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
     EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1911,11 +1912,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.allowCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.allowCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.allowCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.allowCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[2]), AuthenticatorTransport::Internal);
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Required);
     EXPECT_WK_STREQ(result.extensions->appid, "https//www.example.com/fido");
 }
 


### PR DESCRIPTION
#### 0ed0c27171acbc8f4ad016356ff60912c267f9f7
<pre>
[webauthn] Enums should be DOMStrings
<a href="https://bugs.webkit.org/show_bug.cgi?id=241517">https://bugs.webkit.org/show_bug.cgi?id=241517</a>
&lt;rdar://94835072&gt;

Reviewed by Brent Fulgham.

WebAuthn enums should be DOMStrings instead, see the discussion on the spec [1]. If a value is not valid,
it should be treated as not present (which usually means it should be converted into the default). This
applies to AuthenticatorAttachment, ResidentKeyRequirement, UserVerificationRequirement, and AttestationConveyancePreference.
<a href="https://github.com/w3c/webauthn/issues/1738">https://github.com/w3c/webauthn/issues/1738</a>

* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h:
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::encode const):
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::decode):
(WebCore::PublicKeyCredentialCreationOptions::encode const):
(WebCore::PublicKeyCredentialCreationOptions::decode):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
(WebCore::PublicKeyCredentialRequestOptions::encode const):
(WebCore::PublicKeyCredentialRequestOptions::decode):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::toString):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeMakeCredenitalRequestAsCBOR):
(fido::encodeGetAssertionRequestAsCBOR):
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::isConvertibleToU2fRegisterCommand):
(fido::isConvertibleToU2fSignCommand):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(authenticatorSelectionCriteria):
(+[_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:]):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::WebCore::collectTransports):
(WebKit::AuthenticatorManager::getTransports const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterAttested):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::configureRegistrationRequestContext):
(WebKit::configurationAssertionRequestContext):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp:
(WebKit::getUserVerificationRequirement):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::getAssertion):
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):
* Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252298@main">https://commits.webkit.org/252298@main</a>
</pre>
