### PR TITLE
Remove assert in RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole when no clippingStack is present

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4853,10 +4853,8 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole(
 {
     auto* scrollingCoordinator = this->scrollingCoordinator();
     auto* clippingStack = layer.backing()->ancestorClippingStack();
-    if (!clippingStack) {
-        ASSERT_NOT_REACHED();
+    if (!clippingStack)
         return treeState.parentNodeID.value_or(0);
-    }
 
     ScrollingNodeID nodeID = 0;
     for (auto& entry : clippingStack->stack()) {


### PR DESCRIPTION
#### 71887900b099c9ef2bcb9a8fb5b0c00b4cf82d57
<pre>
Remove assert in RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole when no clippingStack is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=242415">https://bugs.webkit.org/show_bug.cgi?id=242415</a>

Reviewed by Simon Fraser.

Removing debug assert when no clippingStack is present. This assert was being triggered
under certain conditions.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole):

Canonical link: <a href="https://commits.webkit.org/252205@main">https://commits.webkit.org/252205@main</a>
</pre>
