### PR TITLE
[WebAuthn] Create local authenticator get credentials by RP/credential id SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -123,6 +123,9 @@ WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 @property (nullable, nonatomic, weak) id <_WKWebAuthenticationPanelDelegate> delegate;
 
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentials WK_API_AVAILABLE(macos(12.0), ios(15.0));
++ (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithRPID:(NSString *)rpID WK_API_AVAILABLE(macos(13.0), ios(16.0));
++ (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithCredentialID:(NSData *)credentialID WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
 + (void)deleteLocalAuthenticatorCredentialWithID:(NSData *)credentialID WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)deleteLocalAuthenticatorCredentialWithGroupAndID:(NSString * _Nullable)group credential:(NSData *)credentialID WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)clearAllLocalAuthenticatorCredentials WK_API_AVAILABLE(macos(12.0), ios(15.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h
@@ -40,6 +40,9 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 
 + (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithAccessGroup:(NSString *)accessGroup WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
++ (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithRPIDAndAccessGroup:(NSString *)accessGroup rpID:(NSString *)rpID WK_API_AVAILABLE(macos(13.0), ios(16.0));
++ (NSArray<NSDictionary *> *)getAllLocalAuthenticatorCredentialsWithCredentialIDAndAccessGroup:(NSString *)accessGroup credentialID:(NSData *)credentialID WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
 // For details of configuration, refer to MockWebAuthenticationConfiguration.h.
 @property (nonatomic, copy) NSDictionary *mockConfiguration;
 


### PR DESCRIPTION
#### 605a46e559cb52dca2222117b79b4d0dca452cef
<pre>
[WebAuthn] Create local authenticator get credentials by RP/credential id SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=242355">https://bugs.webkit.org/show_bug.cgi?id=242355</a>
&lt;rdar://96461832&gt;

Reviewed by Brent Fulgham.

These SPI provide the ability to filter platform credentials by ID or RP ID
for internal needs.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentials]):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithAccessGroup:]):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithRPID:]):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithCredentialID:]):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithRPIDAndAccessGroup:rpID:]):
(+[_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithCredentialIDAndAccessGroup:credentialID:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252289@main">https://commits.webkit.org/252289@main</a>
</pre>
