### PR TITLE
Extend build-and-collect-pgo-profiles to automatically save profiles for testing

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -7,7 +7,7 @@ set -o pipefail
 DisplayHelp() {
     echo "Usage: build-and-collect-pgo-profiles [ options ]"
     echo "  -h              Show this help message."
-    echo "  -b <directory>  Base directory in which output files are stored. Default: /Volumes/WebKit/BenchmarkProfiles/."
+    echo "  -o <directory>  Directory in which output files are stored. Default: /Volumes/WebKit/BenchmarkProfiles/."
     echo "  -a <app>        Path to Safari.app to generate profiles for. If not specified, the script will build WebKit."
     echo "  -d <directory>  Path to build directory. Use seperately from -a."
     echo "  -y              Use for automated collection. No user input."
@@ -15,9 +15,9 @@ DisplayHelp() {
 
 BASE="/Volumes/WebKit/BenchmarkProfiles/"
 
-while getopts "b:a:d:yh" flag; do
+while getopts "o:a:d:yh" flag; do
     case "${flag}" in
-        b) BASE=${OPTARG};;
+        o) BASE=${OPTARG};;
         a) APP=${OPTARG};;
         d) BUILD=${OPTARG};;
         y) NINPUT=true ;;
@@ -27,8 +27,14 @@ while getopts "b:a:d:yh" flag; do
     esac
 done
 
-echo "app: $APP"
-echo "build: $BUILD"
+if [[ -n $APP ]] ; then
+    echo "app: $APP"
+fi
+
+if [[ -n $BUILD ]]; then
+    echo "build: $BUILD"
+fi
+
 echo "base: $BASE"
 
 if [ ! -z $APP ] && [ ! -z $BUILD ] ; then
@@ -37,7 +43,7 @@ if [ ! -z $APP ] && [ ! -z $BUILD ] ; then
     exit
 fi
 
-while ! "$NINPUT" ; do
+while [[ ! "$NINPUT" ]] ; do
     read -p "Have you read the source of this script, and do you understand that it is potentially destructive? [y/N]" yn
     case $yn in
         [Yy]* ) break;;
@@ -49,9 +55,8 @@ done
 echo "Using output directory: $BASE"
 
 if [[ ! -d "$BASE" ]] ; then
-    echo "$BASE is missing, aborting."
-    DisplayHelp
-    exit
+    echo "$BASE is missing, creating directory."
+    mkdir -p "$BASE"
 fi
 
 rm -rf "$BASE/*"


### PR DESCRIPTION
#### 04478f06ac46e9c5fea55604f1cc85d6ba5731a6
<pre>
Extend build-and-collect-pgo-profiles to automatically save profiles for testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=242416">https://bugs.webkit.org/show_bug.cgi?id=242416</a>
rdar://96560886

Reviewed by Dewei Zhu.

Change -b flag to -o, taking an output directory to store profiles.

* Tools/Scripts/build-and-collect-pgo-profiles:

Canonical link: <a href="https://commits.webkit.org/252250@main">https://commits.webkit.org/252250@main</a>
</pre>
