### PR TITLE
[WPE][GTK] Website data leaked outside specified data/cache directories

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp
@@ -36,7 +36,11 @@ WKTypeID WKWebsiteDataStoreConfigurationGetTypeID()
 
 WKWebsiteDataStoreConfigurationRef WKWebsiteDataStoreConfigurationCreate()
 {
+#if PLATFORM(COCOA)
     auto configuration = WebKit::WebsiteDataStoreConfiguration::create(WebKit::IsPersistent::Yes);
+#else
+    auto configuration = WebKit::WebsiteDataStoreConfiguration::createWithBaseDirectories(nullString(), nullString());
+#endif
     return toAPI(&configuration.leakRef());
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -92,31 +92,31 @@ webkit_website_data_manager_get_base_data_directory                   (WebKitWeb
 WEBKIT_API const gchar *
 webkit_website_data_manager_get_base_cache_directory                  (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_local_storage_directory               (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_disk_cache_directory                  (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_offline_application_cache_directory   (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_indexeddb_directory                   (WebKitWebsiteDataManager *manager);
 
 WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_websql_directory                      (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_hsts_cache_directory                  (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_itp_directory                         (WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_service_worker_registrations_directory(WebKitWebsiteDataManager *manager);
 
-WEBKIT_API const gchar *
+WEBKIT_DEPRECATED const gchar *
 webkit_website_data_manager_get_dom_cache_directory                   (WebKitWebsiteDataManager *manager);
 
 WEBKIT_API WebKitCookieManager *

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -144,17 +144,7 @@ static Ref<WebsiteDataStore> inspectorWebsiteDataStore()
     String baseCacheDirectory = FileSystem::pathByAppendingComponent(FileSystem::userCacheDirectory(), versionedDirectory);
     String baseDataDirectory = FileSystem::pathByAppendingComponent(FileSystem::userDataDirectory(), versionedDirectory);
 
-    auto configuration = WebsiteDataStoreConfiguration::create(IsPersistent::Yes, WillCopyPathsFromExistingConfiguration::Yes);
-    configuration->setNetworkCacheDirectory(FileSystem::pathByAppendingComponent(baseCacheDirectory, "WebKitCache"_s));
-    configuration->setApplicationCacheDirectory(FileSystem::pathByAppendingComponent(baseCacheDirectory, "applications"_s));
-    configuration->setHSTSStorageDirectory(String(baseCacheDirectory));
-    configuration->setCacheStorageDirectory(FileSystem::pathByAppendingComponent(baseCacheDirectory, "CacheStorage"_s));
-    configuration->setLocalStorageDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "localstorage"_s));
-    configuration->setIndexedDBDatabaseDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "indexeddb"_s));
-    configuration->setWebSQLDatabaseDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "databases"_s));
-    configuration->setResourceLoadStatisticsDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "itp"_s));
-    configuration->setServiceWorkerRegistrationDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "serviceworkers"_s));
-    configuration->setDeviceIdHashSaltsStorageDirectory(FileSystem::pathByAppendingComponent(baseDataDirectory, "deviceidhashsalts"_s));
+    auto configuration = WebsiteDataStoreConfiguration::createWithBaseDirectories(baseCacheDirectory, baseDataDirectory);
     return WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -240,7 +240,7 @@ NSString *WebStorageDirectoryDefaultsKey = @"WebKitLocalStorageDatabasePathPrefe
 NSString *WebKitMediaCacheDirectoryDefaultsKey = @"WebKitMediaCacheDirectory";
 NSString *WebKitMediaKeysStorageDirectoryDefaultsKey = @"WebKitMediaKeysStorageDirectory";
 
-String WebsiteDataStore::defaultApplicationCacheDirectory()
+String WebsiteDataStore::defaultApplicationCacheDirectory(const String&)
 {
 #if PLATFORM(IOS_FAMILY)
     // This quirk used to make these apps share application cache storage, but doesn't accomplish that any more.
@@ -257,19 +257,19 @@ String WebsiteDataStore::defaultApplicationCacheDirectory()
     return cacheDirectoryFileSystemRepresentation("OfflineWebApplicationCache"_s);
 }
 
-String WebsiteDataStore::defaultCacheStorageDirectory()
+String WebsiteDataStore::defaultCacheStorageDirectory(const String&)
 {
     return cacheDirectoryFileSystemRepresentation("CacheStorage"_s);
 }
 
-String WebsiteDataStore::defaultGeneralStorageDirectory()
+String WebsiteDataStore::defaultGeneralStorageDirectory(const String&)
 {
     auto directory = websiteDataDirectoryFileSystemRepresentation("Default"_s);
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // This is the old storage directory, and there might be files left here.
-        auto oldDirectory = cacheDirectoryFileSystemRepresentation("Storage"_s, ShouldCreateDirectory::No);
+        auto oldDirectory = cacheDirectoryFileSystemRepresentation("Storage"_s, { }, ShouldCreateDirectory::No);
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSArray *files = [fileManager contentsOfDirectoryAtPath:oldDirectory error:0];
         if (files) {
@@ -288,68 +288,68 @@ String WebsiteDataStore::defaultGeneralStorageDirectory()
     return directory;
 }
 
-String WebsiteDataStore::defaultNetworkCacheDirectory()
+String WebsiteDataStore::defaultNetworkCacheDirectory(const String&)
 {
     return cacheDirectoryFileSystemRepresentation("NetworkCache"_s);
 }
 
-String WebsiteDataStore::defaultAlternativeServicesDirectory()
+String WebsiteDataStore::defaultAlternativeServicesDirectory(const String&)
 {
-    return cacheDirectoryFileSystemRepresentation("AlternativeServices"_s, ShouldCreateDirectory::No);
+    return cacheDirectoryFileSystemRepresentation("AlternativeServices"_s, { }, ShouldCreateDirectory::No);
 }
 
-String WebsiteDataStore::defaultHSTSStorageDirectory()
+String WebsiteDataStore::defaultHSTSStorageDirectory(const String&)
 {
     return cacheDirectoryFileSystemRepresentation("HSTS"_s);
 }
 
-String WebsiteDataStore::defaultMediaCacheDirectory()
+String WebsiteDataStore::defaultMediaCacheDirectory(const String&)
 {
     return tempDirectoryFileSystemRepresentation("MediaCache"_s);
 }
 
-String WebsiteDataStore::defaultIndexedDBDatabaseDirectory()
+String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String&)
 {
     return websiteDataDirectoryFileSystemRepresentation("IndexedDB"_s);
 }
 
-String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory()
+String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String&)
 {
     return cacheDirectoryFileSystemRepresentation("ServiceWorkers"_s);
 }
 
-String WebsiteDataStore::defaultLocalStorageDirectory()
+String WebsiteDataStore::defaultLocalStorageDirectory(const String&)
 {
     return websiteDataDirectoryFileSystemRepresentation("LocalStorage"_s);
 }
 
-String WebsiteDataStore::defaultMediaKeysStorageDirectory()
+String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String&)
 {
     return websiteDataDirectoryFileSystemRepresentation("MediaKeys"_s);
 }
 
-String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory()
+String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(const String&)
 {
     return websiteDataDirectoryFileSystemRepresentation("DeviceIdHashSalts"_s);
 }
 
-String WebsiteDataStore::defaultWebSQLDatabaseDirectory()
+String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String&)
 {
-    return websiteDataDirectoryFileSystemRepresentation("WebSQL"_s, ShouldCreateDirectory::No);
+    return websiteDataDirectoryFileSystemRepresentation("WebSQL"_s, { }, ShouldCreateDirectory::No);
 }
 
-String WebsiteDataStore::defaultResourceLoadStatisticsDirectory()
+String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String&)
 {
     return websiteDataDirectoryFileSystemRepresentation("ResourceLoadStatistics"_s);
 }
 
-String WebsiteDataStore::defaultJavaScriptConfigurationDirectory()
+String WebsiteDataStore::defaultJavaScriptConfigurationDirectory(const String&)
 {
     return tempDirectoryFileSystemRepresentation("JavaScriptCoreDebug"_s, ShouldCreateDirectory::No);
 }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-String WebsiteDataStore::defaultModelElementCacheDirectory()
+String WebsiteDataStore::defaultModelElementCacheDirectory(const String&)
 {
     return tempDirectoryFileSystemRepresentation("ModelElement"_s, ShouldCreateDirectory::No);
 }
@@ -384,7 +384,7 @@ String WebsiteDataStore::tempDirectoryFileSystemRepresentation(const String& dir
     return url.absoluteURL.path;
 }
 
-String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory shouldCreateDirectory)
+String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, const String&, ShouldCreateDirectory shouldCreateDirectory)
 {
     static dispatch_once_t onceToken;
     static NeverDestroyed<RetainPtr<NSURL>> cacheURL;
@@ -412,7 +412,7 @@ String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& di
     return url.absoluteURL.path;
 }
 
-String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory shouldCreateDirectory)
+String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String& directoryName, const String&, ShouldCreateDirectory shouldCreateDirectory)
 {
     static dispatch_once_t onceToken;
     static NeverDestroyed<RetainPtr<NSURL>> websiteDataURL;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -341,26 +341,27 @@ public:
     SOAuthorizationCoordinator& soAuthorizationCoordinator(const WebPageProxy&);
 #endif
 
-    static WTF::String defaultServiceWorkerRegistrationDirectory();
-    static WTF::String defaultLocalStorageDirectory();
-    static WTF::String defaultResourceLoadStatisticsDirectory();
-    static WTF::String defaultNetworkCacheDirectory();
-    static WTF::String defaultAlternativeServicesDirectory();
-    static WTF::String defaultApplicationCacheDirectory();
-    static WTF::String defaultWebSQLDatabaseDirectory();
+    static String defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory = nullString());
+    static String defaultLocalStorageDirectory(const String& baseDataDirectory = nullString());
+    static String defaultResourceLoadStatisticsDirectory(const String& baseDataDirectory = nullString());
+    static String defaultNetworkCacheDirectory(const String& baseCacheDirectory = nullString());
+    static String defaultAlternativeServicesDirectory(const String& baseDataDirectory = nullString());
+    static String defaultApplicationCacheDirectory(const String& baseCacheDirectory = nullString());
+    static String defaultWebSQLDatabaseDirectory(const String& baseDataDirectory = nullString());
 #if USE(GLIB) || PLATFORM(COCOA)
-    static WTF::String defaultHSTSStorageDirectory();
+    static String defaultHSTSStorageDirectory(const String& baseCacheDirectory = nullString());
 #endif
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    static WTF::String defaultModelElementCacheDirectory();
+    static String defaultModelElementCacheDirectory(const String& baseCacheDirectory = nullString());
 #endif
-    static WTF::String defaultIndexedDBDatabaseDirectory();
-    static WTF::String defaultCacheStorageDirectory();
-    static WTF::String defaultGeneralStorageDirectory();
-    static WTF::String defaultMediaCacheDirectory();
-    static WTF::String defaultMediaKeysStorageDirectory();
-    static WTF::String defaultDeviceIdHashSaltsStorageDirectory();
-    static WTF::String defaultJavaScriptConfigurationDirectory();
+    static String defaultIndexedDBDatabaseDirectory(const String& baseDataDirectory = nullString());
+    static String defaultCacheStorageDirectory(const String& baseCacheDirectory = nullString());
+    static String defaultGeneralStorageDirectory(const String& baseDataDirectory = nullString());
+    static String defaultMediaCacheDirectory(const String& baseCacheDirectory = nullString());
+    static String defaultMediaKeysStorageDirectory(const String& baseDataDirectory = nullString());
+    static String defaultDeviceIdHashSaltsStorageDirectory(const String& baseDataDirectory = nullString());
+    static String defaultJavaScriptConfigurationDirectory(const String& baseDataDirectory = nullString());
+
     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
     static bool defaultShouldUseCustomStoragePaths();
 
@@ -413,10 +414,12 @@ private:
 
     WebsiteDataStore();
 
+    // FIXME: Only Cocoa ports respect ShouldCreateDirectory, so you cannot rely on it to create
+    // directories. This is confusing.
     enum class ShouldCreateDirectory { No, Yes };
     static String tempDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory = ShouldCreateDirectory::Yes);
-    static String cacheDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory = ShouldCreateDirectory::Yes);
-    static String websiteDataDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory = ShouldCreateDirectory::Yes);
+    static String cacheDirectoryFileSystemRepresentation(const String& directoryName, const String& baseCacheDirectory = nullString(), ShouldCreateDirectory = ShouldCreateDirectory::Yes);
+    static String websiteDataDirectoryFileSystemRepresentation(const String& directoryName, const String& baseDataDirectory = nullString(), ShouldCreateDirectory = ShouldCreateDirectory::Yes);
     void createHandleFromResolvedPathIfPossible(const String& resolvedPath, SandboxExtension::Handle&, SandboxExtension::Type = SandboxExtension::Type::ReadWrite);
 
     HashSet<RefPtr<WebProcessPool>> processPools(size_t limit = std::numeric_limits<size_t>::max()) const;

--- a/Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp
@@ -46,62 +46,62 @@ void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
     notImplemented();
 }
 
-String WebsiteDataStore::defaultApplicationCacheDirectory()
+String WebsiteDataStore::defaultApplicationCacheDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultCacheStorageDirectory()
+String WebsiteDataStore::defaultCacheStorageDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultGeneralStorageDirectory()
+String WebsiteDataStore::defaultGeneralStorageDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultNetworkCacheDirectory()
+String WebsiteDataStore::defaultNetworkCacheDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultIndexedDBDatabaseDirectory()
+String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory()
+String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultLocalStorageDirectory()
+String WebsiteDataStore::defaultLocalStorageDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultMediaKeysStorageDirectory()
+String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultWebSQLDatabaseDirectory()
+String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::defaultResourceLoadStatisticsDirectory()
+String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String&)
 {
     return { };
 }
 
-String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory)
+String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String&, ShouldCreateDirectory)
 {
     return { };
 }
 
-String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory)
+String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String&, ShouldCreateDirectory)
 {
     return { };
 }

--- a/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp
@@ -46,63 +46,87 @@ void WebsiteDataStore::platformRemoveRecentSearches(WallTime)
     notImplemented();
 }
 
-String WebsiteDataStore::defaultApplicationCacheDirectory()
+String WebsiteDataStore::defaultApplicationCacheDirectory(const String& baseCacheDirectory)
 {
+    if (!baseCacheDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "ApplicationCache"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ApplicationCache"_s);
 }
 
-String WebsiteDataStore::defaultCacheStorageDirectory()
+String WebsiteDataStore::defaultCacheStorageDirectory(const String& baseCacheDirectory)
 {
+    if (!baseCacheDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "CacheStorage"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "CacheStorage"_s);
 }
 
-String WebsiteDataStore::defaultGeneralStorageDirectory()
+String WebsiteDataStore::defaultNetworkCacheDirectory(const String& baseCacheDirectory)
 {
-    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "Storage"_s);
-}
-
-String WebsiteDataStore::defaultNetworkCacheDirectory()
-{
+    if (!baseCacheDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseCacheDirectory, "NetworkCache"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "NetworkCache"_s);
 }
 
-String WebsiteDataStore::defaultIndexedDBDatabaseDirectory()
+String WebsiteDataStore::defaultGeneralStorageDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "Storage"_s);
+    return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "Storage"_s);
+}
+
+String WebsiteDataStore::defaultIndexedDBDatabaseDirectory(const String& baseDataDirectory)
+{
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "IndexedDB"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "IndexedDB"_s);
 }
 
-String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory()
+String WebsiteDataStore::defaultServiceWorkerRegistrationDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "ServiceWorkers"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ServiceWorkers"_s);
 }
 
-String WebsiteDataStore::defaultLocalStorageDirectory()
+String WebsiteDataStore::defaultLocalStorageDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "LocalStorage"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "LocalStorage"_s);
 }
 
-String WebsiteDataStore::defaultMediaKeysStorageDirectory()
+String WebsiteDataStore::defaultMediaKeysStorageDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "MediaKeyStorage"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "MediaKeyStorage"_s);
 }
 
-String WebsiteDataStore::defaultWebSQLDatabaseDirectory()
+String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "WebSQL"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "WebSQL"_s);
 }
 
-String WebsiteDataStore::defaultResourceLoadStatisticsDirectory()
+String WebsiteDataStore::defaultResourceLoadStatisticsDirectory(const String& baseDataDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, "ResourceLoadStatistics"_s);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), "ResourceLoadStatistics"_s);
 }
 
-String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory)
+String WebsiteDataStore::cacheDirectoryFileSystemRepresentation(const String& directoryName, const String& baseCacheDirectory, ShouldCreateDirectory)
 {
+    if (!baseCacheDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseCacheDirectory, directoryName);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), directoryName);
 }
 
-String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory)
+String WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation(const String& directoryName, const String& baseDataDirectory, ShouldCreateDirectory)
 {
+    if (!baseDataDirectory.isNull())
+        return FileSystem::pathByAppendingComponent(baseDataDirectory, directoryName);
     return FileSystem::pathByAppendingComponent(FileSystem::localUserSpecificStorageDirectory(), directoryName);
 }
 

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -447,6 +447,7 @@ static void gotWebsiteDataCallback(WebKitWebsiteDataManager *manager, GAsyncResu
         "</script></head><body>\n");
 
     guint64 pageID = webkit_web_view_get_page_id(webkit_uri_scheme_request_get_web_view(dataRequest->request));
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     aboutDataFillTable(result, dataRequest, dataList, "Cookies", WEBKIT_WEBSITE_DATA_COOKIES, NULL, pageID);
     aboutDataFillTable(result, dataRequest, dataList, "Device Id Hash Salt", WEBKIT_WEBSITE_DATA_DEVICE_ID_HASH_SALT, NULL, pageID);
     aboutDataFillTable(result, dataRequest, dataList, "Memory Cache", WEBKIT_WEBSITE_DATA_MEMORY_CACHE, NULL, pageID);
@@ -461,6 +462,7 @@ static void gotWebsiteDataCallback(WebKitWebsiteDataManager *manager, GAsyncResu
     aboutDataFillTable(result, dataRequest, dataList, "Service Worker Registratations", WEBKIT_WEBSITE_DATA_SERVICE_WORKER_REGISTRATIONS,
         webkit_website_data_manager_get_service_worker_registrations_directory(manager), pageID);
     aboutDataFillTable(result, dataRequest, dataList, "DOM Cache", WEBKIT_WEBSITE_DATA_DOM_CACHE, webkit_website_data_manager_get_dom_cache_directory(manager), pageID);
+    G_GNUC_END_IGNORE_DEPRECATIONS
 
     result = g_string_append(result, "</body></html>");
     gsize streamLength = result->len;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -162,6 +162,8 @@ public:
 
 static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+
     // Base directories are not used by TestMain.
     g_assert_null(webkit_website_data_manager_get_base_data_directory(test->m_manager));
     g_assert_null(webkit_website_data_manager_get_base_cache_directory(test->m_manager));
@@ -272,6 +274,8 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_manager_get_service_worker_registrations_directory(baseDataManager.get()), ==, swRegistrationsDirectory.get());
     g_assert_cmpstr(webkit_website_data_manager_get_dom_cache_directory(baseDataManager.get()), ==, domCacheDirectory.get());
     g_assert_cmpstr(webkit_website_data_manager_get_disk_cache_directory(baseDataManager.get()), ==, Test::dataDirectory());
+
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 static void ephemeralViewloadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent, WebViewTest* test)
@@ -288,6 +292,8 @@ static void testWebsiteDataEphemeral(WebViewTest* test, gconstpointer)
     g_assert_true(webkit_website_data_manager_is_ephemeral(manager.get()));
     g_assert_null(webkit_website_data_manager_get_base_data_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_base_cache_directory(manager.get()));
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     g_assert_null(webkit_website_data_manager_get_local_storage_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_disk_cache_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_offline_application_cache_directory(manager.get()));
@@ -295,6 +301,7 @@ static void testWebsiteDataEphemeral(WebViewTest* test, gconstpointer)
     g_assert_null(webkit_website_data_manager_get_hsts_cache_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_itp_directory(manager.get()));
     g_assert_null(webkit_website_data_manager_get_service_worker_registrations_directory(manager.get()));
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Configuration is ignored when is-ephemeral is used.
     manager = adoptGRef(WEBKIT_WEBSITE_DATA_MANAGER(g_object_new(WEBKIT_TYPE_WEBSITE_DATA_MANAGER, "base-data-directory", Test::dataDirectory(), "is-ephemeral", TRUE, nullptr)));
@@ -695,7 +702,9 @@ static void testWebsiteDataDeviceIdHashSalt(WebsiteDataTest* test, gconstpointer
 
 static void testWebsiteDataITP(WebsiteDataTest* test, gconstpointer)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     const char* itpDirectory = webkit_website_data_manager_get_itp_directory(test->m_manager);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     GUniquePtr<char> itpDatabaseFile(g_build_filename(itpDirectory, "observations.db", nullptr));
 
     // Delete any previous data.


### PR DESCRIPTION
#### 38ffac2857ee4b460882c7a67b1e3b63d949cb93
<pre>
[WPE][GTK] Website data leaked outside specified data/cache directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=239521">https://bugs.webkit.org/show_bug.cgi?id=239521</a>

Reviewed by Adrian Perez de Castro.

Currently whenever somebody adds a new type of website data, you have to
add new public WPE/GTK API to WebKitWebsiteDataManager to allow
configuring the data location. If this step is not performed, the data
will leak outside the expected directory locations, which is a serious
privacy issue. Sadly, this step is usually missed in practice. We released
2.36 without accounting for the new general storage directory, resulting
in the general storage directory being created outside the base data
directory, which is not acceptable. Similarly, we missed
deviceidhashsalts, which was added *four years ago*. This case is a little
weird because we did add a WEBKIT_WEBSITE_DATA_DEVICE_ID_HASH_SALT
WebKitWebsiteDataTypes flag to allow deleting the data, but
unfortunately we missed that configuring a directory under the base data
directory was required.

This is bad. Apple developers shouldn&apos;t be expected to write Linux-specific
code when making cross-platform changes. Linux developers shouldn&apos;t need
to worry that oversights will lead to data being stored outside
permitted locations.

This commit attempts to fix this *comprehensively*.

First: we need to make sure the default directories only get used when
base data directory or base cache directory is NULL, and also ensure
this is hard to mess up. I considered many different approaches but
ultimately decided the simplest way to do it is to make all the default
directories relative to the base directories. This requires some
cross-platform changes in WebsiteDataStoreConfiguration, but nothing too
disruptive. I&apos;ve used a default null string parameter to minimize the
amount of code changes required in Apple ports, and left the base
directories unused for Apple. For Windows, I&apos;ve gone ahead and
implemented even though they are unused, because the implementation is
so simple. I&apos;ve also added an assert to make sure WPE/GTK always use the
base directories. By pushing the base directory logic from
WebKitWebsiteDataManager down to WebsiteDataStoreConfiguration, it&apos;s now
hopefully quite difficult to mess up, and the burden on Apple developers
is limited to just choosing whether the new directory should be data or
cache.

I&apos;ve also renamed WillCopyPathsFromExistingConfiguration to
ShouldInitializePaths, in order to better match the new semantics, and
brought it inside the class since it is no longer needed by the public
WebsiteDataStoreConfiguration::create methods.

Next problem: the default WebsiteDataStore. For cross-platform WebKit, I
suppose this can be used whenever a specific WebsiteDataStore is not
configured, and therefore it ought to be a persistent data store that
actually stores data on disk. This should never happen for WPE and GTK:
a specific WebsiteDataStore must always be used. This is currently
ensured by WebKitWebContext, which creates its own WebKitWebsiteDataStore
if the application does not do so itself. The default WebsiteDataStore
is still needed for prewarmed processes, but I hope for nothing else.
Accordingly, we can safely make it nonpersistent for WPE and GTK, but
not for other ports. This is required to comprehensively ensure there is
no way to create a WebsiteDataStoreConfiguration without initializing
the base data and base cache directories unless it is an ephemeral
store. In particular, we can assert the WebsiteDataStoreConfiguration
is either created with base directories, or ephemeral.

Finally, I got a bit carried away and decided to deprecate all the
non-base directory configuration APIs from WebKitWebsiteDataManager.
These are of very limited utility because frankly, who cares what each
particular subdirectory is named? What applications really want to do is
ensure that all data gets stored only where the application expects it
to be stored, a use case that can be achieved by configuring only the
base data and base cache directories. By deprecating these, we remove
the expectation that we should add more in the future or keep the list
of directories here updated, and we can remove them in the upcoming GTK
4 API version. I&apos;ve included some documentation updates to remove
references to the deprecated properties and functions, and snuck in a
few drive-by fixes. All of this could have been done separately, but it
makes sense to do here so as to eliminate the temptation to add new APIs
to configure the general storage directory and hash salts.

Future consideration: in future API versions, where
WebKitWebsiteDataManager&apos;s localstorage and IndexedDB directory
configuration APIs are removed, we can change
WebsiteDataStore::defaultShouldUseCustomStoragePaths to allow WPE and
GTK to use the new general storage directory instead of the legacy
custom localstorage and IndexedDB directories. Cannot do that yet
because the old APIs must still be supported even if deprecated.

* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreConfigurationRef.cpp:
(WKWebsiteDataStoreConfigurationCreate):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkitWebsiteDataManagerGetProperty):
(webkit_website_data_manager_class_init):
(webkitWebsiteDataManagerGetDataStore):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in:
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::inspectorWebsiteDataStore):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultApplicationCacheDirectory):
(WebKit::WebsiteDataStore::defaultCacheStorageDirectory):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::defaultNetworkCacheDirectory):
(WebKit::WebsiteDataStore::defaultAlternativeServicesDirectory):
(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaCacheDirectory):
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStore::defaultLocalStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaKeysStorageDirectory):
(WebKit::WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory):
(WebKit::WebsiteDataStore::defaultWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultResourceLoadStatisticsDirectory):
(WebKit::WebsiteDataStore::defaultJavaScriptConfigurationDirectory):
(WebKit::WebsiteDataStore::defaultModelElementCacheDirectory):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::defaultDataStoreIsPersistent):
(WebKit::WebsiteDataStore::defaultDataStore):
(WebKit::WebsiteDataStore::defaultMediaCacheDirectory):
(WebKit::WebsiteDataStore::defaultAlternativeServicesDirectory):
(WebKit::WebsiteDataStore::defaultJavaScriptConfigurationDirectory):
(WebKit::WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration):
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::create):
(WebKit::WebsiteDataStoreConfiguration::createWithBaseDirectories):
* Source/WebKit/UIProcess/WebsiteData/playstation/WebsiteDataStorePlayStation.cpp:
(WebKit::WebsiteDataStore::defaultApplicationCacheDirectory):
(WebKit::WebsiteDataStore::defaultCacheStorageDirectory):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::defaultNetworkCacheDirectory):
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStore::defaultLocalStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaKeysStorageDirectory):
(WebKit::WebsiteDataStore::defaultWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultResourceLoadStatisticsDirectory):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Source/WebKit/UIProcess/WebsiteData/win/WebsiteDataStoreWin.cpp:
(WebKit::WebsiteDataStore::defaultApplicationCacheDirectory):
(WebKit::WebsiteDataStore::defaultCacheStorageDirectory):
(WebKit::WebsiteDataStore::defaultNetworkCacheDirectory):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStore::defaultLocalStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaKeysStorageDirectory):
(WebKit::WebsiteDataStore::defaultWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultResourceLoadStatisticsDirectory):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp:
(WebKit::WebsiteDataStore::defaultApplicationCacheDirectory):
(WebKit::WebsiteDataStore::defaultNetworkCacheDirectory):
(WebKit::WebsiteDataStore::defaultCacheStorageDirectory):
(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory):
(WebKit::WebsiteDataStore::defaultGeneralStorageDirectory):
(WebKit::WebsiteDataStore::defaultIndexedDBDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultServiceWorkerRegistrationDirectory):
(WebKit::WebsiteDataStore::defaultLocalStorageDirectory):
(WebKit::WebsiteDataStore::defaultMediaKeysStorageDirectory):
(WebKit::WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory):
(WebKit::WebsiteDataStore::defaultWebSQLDatabaseDirectory):
(WebKit::WebsiteDataStore::defaultResourceLoadStatisticsDirectory):
(WebKit::programName):
(WebKit::WebsiteDataStore::cacheDirectoryFileSystemRepresentation):
(WebKit::WebsiteDataStore::websiteDataDirectoryFileSystemRepresentation):
* Tools/MiniBrowser/gtk/main.c:
(gotWebsiteDataCallback):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebsiteDataConfiguration):
(testWebsiteDataEphemeral):
(testWebsiteDataITP):

Canonical link: <a href="https://commits.webkit.org/253824@main">https://commits.webkit.org/253824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6209144d0f0d10c5ee5999731ce46a087f0b5236

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96226 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149770 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29648 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91209 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74002 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79172 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27373 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13009 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2697 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29005 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33301 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->