### PR TITLE
REGRESSION (r221177): Redundant icon fetching in the web process for file inputs

### DIFF
--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -447,7 +447,7 @@ void FileInputType::didCreateFileList(Ref<FileList>&& fileList, RefPtr<Icon>&& i
     ASSERT(!allowsDirectories() || m_directoryFileListCreator);
     m_directoryFileListCreator = nullptr;
 
-    setFiles(WTFMove(fileList), icon ? RequestIcon::Yes : RequestIcon::No, WasSetByJavaScript::No);
+    setFiles(WTFMove(fileList), icon ? RequestIcon::No : RequestIcon::Yes, WasSetByJavaScript::No);
     if (icon && !m_fileList->isEmpty() && element())
         iconLoaded(WTFMove(icon));
 }


### PR DESCRIPTION
#### b58cec34fd854fcdc0279cd343934039f3700590
<pre>
REGRESSION (r221177): Redundant icon fetching in the web process for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=242418">https://bugs.webkit.org/show_bug.cgi?id=242418</a>

Reviewed by Chris Dumez.

In r221177 there was an inadvertent switching from `icon ? RequestIcon::No : RequestIcon::Yes` to
`icon ? RequestIcon::Yes : RequestIcon::No` in what is now FileInputType::didCreateFileList(), which
results in a redundant fetch of the file icon in the web process when the UI process already did
this and supplied the icon. This icon fetching in the web process can trigger sandbox exceptions
(rdar://95988777) so is best avoided.

We can still fetch icons in the web process when restoring state after being killed. This does
triggers sandbox exceptions but the icons do correctly show in the UI.

* Source/WebCore/html/FileInputType.cpp: (WebCore::FileInputType::didCreateFileList):

Canonical link: <a href="https://commits.webkit.org/252215@main">https://commits.webkit.org/252215@main</a>
</pre>
