### PR TITLE
Insert break instructions in the LLInt asm to ensure that some global labels are not aliased.

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -137,8 +137,14 @@
 # You can assume that ft1-ft5 or fa1-fa3 are never fr, and that ftX is never
 # faY if X != Y.
 
-# First come the common protocols that both interpreters use. Note that each
-# of these must have an ASSERT() in LLIntData.cpp
+# Do not put any code after this.
+global _llintPCRangeStart
+_llintPCRangeStart:
+    # This break instruction is needed so that the synthesized llintPCRangeStart# label
+    # doesn't point to the exact same location as vmEntryToJavaScript which comes after it.
+    # Otherwise, libunwind will report vmEntryToJavaScript as llintPCRangeStart in
+    # stack traces.
+    break
 
 # Work-around for the fact that the toolchain's awareness of armv7k / armv7s
 # results in a separate slab in the fat binary, yet the offlineasm doesn't know
@@ -147,6 +153,9 @@ if ARMv7k
 end
 if ARMv7s
 end
+
+# First come the common protocols that both interpreters use. Note that each
+# of these must have an ASSERT() in LLIntData.cpp
 
 # These declarations must match interpreter/JSStack.h.
 
@@ -1669,13 +1678,6 @@ macro doReturn()
     end
 end
 
-# This break instruction is needed so that the synthesized llintPCRangeStart label
-# doesn't point to the exact same location as vmEntryToJavaScript which comes after it.
-# Otherwise, libunwind will report vmEntryToJavaScript as llintPCRangeStart in
-# stack traces.
-
-    break
-
 # stub to call into JavaScript or Native functions
 # EncodedJSValue vmEntryToJavaScript(void* code, VM* vm, ProtoCallFrame* protoFrame)
 # EncodedJSValue vmEntryToNativeFunction(void* code, VM* vm, ProtoCallFrame* protoFrame)
@@ -2721,9 +2723,11 @@ end
 
 global _wasmLLIntPCRangeStart
 _wasmLLIntPCRangeStart:
+    break # FIXME: rdar://96556827
 wasmScope()
 global _wasmLLIntPCRangeEnd
 _wasmLLIntPCRangeEnd:
+    break # FIXME: rdar://96556827
 
 else
 
@@ -2759,3 +2763,8 @@ _wasm_trampoline_wasm_call_ref_no_tls_wide32:
 end
 
 include? LowLevelInterpreterAdditions
+
+global _llintPCRangeEnd
+_llintPCRangeEnd:
+    break # FIXME: rdar://96556827
+# Do not put any code after this.

--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -64,24 +64,12 @@ class Assembler
         @outp.puts ""
         putStr "OFFLINE_ASM_BEGIN" if !$emitWinAsm
 
-        if !$emitWinAsm
-            putStr "OFFLINE_ASM_GLOBAL_LABEL(llintPCRangeStart)"
-        else
-            putsProc("llintPCRangeStart", "")
-            putsProcEndIfNeeded
-        end
         @state = :asm
         SourceFile.outputDotFileList(@outp) if $enableDebugAnnotations
     end
     
     def leaveAsm
         putsProcEndIfNeeded if $emitWinAsm
-        if !$emitWinAsm
-            putStr "OFFLINE_ASM_GLOBAL_LABEL(llintPCRangeEnd)"
-        else
-            putsProc("llintPCRangeEnd", "")
-            putsProcEndIfNeeded
-        end
         putsLastComment
         if not @deferredOSDarwinActions.size.zero?
             putStr("#if OS(DARWIN)")


### PR DESCRIPTION
#### 98df1786d72c59c770f0bad52daa2ce228012e39
<pre>
Insert break instructions in the LLInt asm to ensure that some global labels are not aliased.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242417">https://bugs.webkit.org/show_bug.cgi?id=242417</a>
&lt;rdar://problem/94232529&gt;

Reviewed by Yusuke Suzuki.

This is needed because the linker may not handle aliased global labels (multiple global
labels pointing to the same location) well.

To achieve this, we also remove the hacks in offlineasm&apos;s enterAsm and leaveAsm functions
that use to add the _llintPCRangeStart and _llintPCRangeEnd labels.  Instead, we&apos;ll add
them explicitly in LowLevelInterpreter.asm.  This allows us to easily append a break
instruction after _llintPCRangeEnd.

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/offlineasm/asm.rb:

Canonical link: <a href="https://commits.webkit.org/252214@main">https://commits.webkit.org/252214@main</a>
</pre>
