### PR TITLE
Make RenderSVGResourceGradient lazily recompute gradients when referencing element is changed

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -218,12 +218,11 @@ void RenderSVGResourceContainer::registerResource()
     }
 }
 
-bool RenderSVGResourceContainer::shouldTransformOnTextPainting(const RenderElement& renderer, AffineTransform& resourceTransform)
+float RenderSVGResourceContainer::computeTextPaintingScale(const RenderElement& renderer)
 {
 #if USE(CG)
     UNUSED_PARAM(renderer);
-    UNUSED_PARAM(resourceTransform);
-    return false;
+    return 1;
 #else
     // This method should only be called for RenderObjects that deal with text rendering. Cmp. RenderObject.h's is*() methods.
     ASSERT(renderer.isSVGText() || renderer.isSVGTextPath() || renderer.isSVGInline());
@@ -231,11 +230,7 @@ bool RenderSVGResourceContainer::shouldTransformOnTextPainting(const RenderEleme
     // In text drawing, the scaling part of the graphics context CTM is removed, compare SVGInlineTextBox::paintTextWithShadows.
     // So, we use that scaling factor here, too, and then push it down to pattern or gradient space
     // in order to keep the pattern or gradient correctly scaled.
-    float scalingFactor = SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
-    if (scalingFactor == 1)
-        return false;
-    resourceTransform.scale(scalingFactor);
-    return true;
+    return SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
 #endif
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -38,7 +38,7 @@ public:
 
     bool isSVGResourceContainer() const final { return true; }
 
-    static bool shouldTransformOnTextPainting(const RenderElement&, AffineTransform&);
+    static float computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
 
     void idChanged();

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -122,9 +122,9 @@ PatternData* RenderSVGResourcePattern::buildPattern(RenderElement& renderer, Opt
 
     // Account for text drawing resetting the context to non-scaled, see SVGInlineTextBox::paintTextWithShadows.
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToText)) {
-        AffineTransform additionalTextTransformation;
-        if (shouldTransformOnTextPainting(renderer, additionalTextTransformation))
-            patternData->transform *= additionalTextTransformation;
+        auto textScale = computeTextPaintingScale(renderer);
+        if (textScale != 1)
+            patternData->transform.scale(textScale);
     }
 
     // Build pattern.


### PR DESCRIPTION
#### 4f72aae07eff92f9633061e2c0bad2c73282090f
<pre>
Make RenderSVGResourceGradient lazily recompute gradients when referencing element is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=242421">https://bugs.webkit.org/show_bug.cgi?id=242421</a>
&lt;rdar://problem/96570524&gt;

Reviewed by Said Abou-Hallawa.

When an SVG element that has a gradient in its fill or stroke property
is relaid out, we call SVGResourcesCache::clientLayoutChanged to remove
and then rebuild the entire SVGResources for the element. This is
wasteful in many situations, where the specific thing that changed
during layout does not affect anything in the GradientData object that
we have stored in RenderSVGResourceGradient::m_gradientMap.

This patch changes SVGResourcesCache so that it stores any dependencies
it requires from the client RenderElement, and lazily invalidates
anything stored in GradientData under
RenderSVGResourceGradient::applyResource if those dependencies have
changed. This allows clientLayoutChanged to skip the removeClientFromCache
call if the only resources being used by the element are gradients.

Although the removeClientFromCache call which we&apos;re skipping would
repaint the client element, all callers of clientLayoutChanged already repaint
the element, so it&apos;s not necessary to add any additional repaint calls.

The new hasResourcesRequiringRemovalOnClientLayoutChange function checks
for all the remaining resource types that rely on the current
removeClientFromCache call to invalidate their cached data. The two
resource types that aren&apos;t mentioned here are markers and solid colors,
neither of which cache any data.

One of the dependencies gradients have, when painting text (on platforms
using CoreGraphics), is the AffineTransform produced by
RenderSVGResourceContainer::shouldTransformOnTextPainting. Since it&apos;s
less data to store, we change this to return the scale factor rather
than modify an existing AffineTransform.

* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::computeTextPaintingScale):
(WebCore::RenderSVGResourceContainer::shouldTransformOnTextPainting): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::computeInputs):
(WebCore::RenderSVGResourceGradient::applyResource):
(WebCore::RenderSVGResourceGradient::postApplyResource):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
(WebCore::GradientData::Inputs::operator==):
(WebCore::GradientData::validate):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::buildPattern):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::hasPaintResourceRequiringRemovalOnClientLayoutChange):
(WebCore::hasResourcesRequiringRemovalOnClientLayoutChange):
(WebCore::SVGResourcesCache::clientLayoutChanged):

Canonical link: <a href="https://commits.webkit.org/252268@main">https://commits.webkit.org/252268@main</a>
</pre>
