### PR TITLE
[libpas] Fix local_allocator stop race

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
@@ -242,6 +242,40 @@ bool pas_local_allocator_stop(
     allocator->scavenger_data.is_in_use = true;
     pas_compiler_fence();
 
+    /* The scavenger thread may race with the client thread on calling pas_local_allocator_stop.
+       The scavenger will first suspend the client thread before checking the is_in_use flag.
+       If is_in_use is set, the scavenger will not call pas_local_allocator_scavenger_data_stop, and move on.
+       If is_in_use is not set, the scavenger will call pas_local_allocator_scavenger_data_stop,
+       which in turn calls pas_local_allocator_stop to stop the local_allocator.
+
+       Normally, if the scavenger has already completed its call to pas_local_allocator_stop
+       before the client calls it, pas_local_allocator_stop will just return early for the client.
+       This is because pas_local_allocator_stop first check pas_local_allocator_scavenger_data_is_stopped
+       before doing the work to stop the local_allocator.
+
+       However, if the client thread is already in the process of executing pas_local_allocator_stop,
+       gets the past pas_local_allocator_scavenger_data_is_stopped check , and then, gets suspended by
+       the scavenger before setting the is_in_use flag, the scavenger can stop the local_allocator
+       after the client already checked and thinks it is not stopped yet. When the client thread
+       resumes from suspension, it will be unhappy to find that the local_allocator is already
+       stopped, and corrupt data structures.
+
+       The fix is to re-check pas_local_allocator_scavenger_data_is_stopped after setting the
+       is_in_use flag.
+
+       If the re-check shows that the local_allocator is already stopped, then pas_local_allocator_stop
+       can return early like the first pas_local_allocator_scavenger_data_is_stopped check. This is
+       fine to do because the caller expects this as a possible outcome.
+
+       Before returning early due to the re-check, we also need to clear the is_in_use flag.
+       The is_in_use flag is meant to be set like with an RAII scope. Hence, it is correct and
+       required that we also clear it here before we return.
+    */
+    if (pas_local_allocator_scavenger_data_is_stopped(&allocator->scavenger_data)) {
+        allocator->scavenger_data.is_in_use = false;
+        return true;
+    }
+
     result = stop_impl(allocator, page_lock_mode, heap_lock_hold_mode);
 
     if (result) {

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -77,10 +77,16 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_commit_if_necessary_impl(pas_l
        And then we end up in here.
     
        Therefore, we cannot assert that is_in_use is true. But, when we return from here, it must be true. */
-    if (PAS_LIKELY(allocator->scavenger_data.kind == pas_local_allocator_allocator_kind))
+    if (PAS_LIKELY(allocator->scavenger_data.kind == pas_local_allocator_allocator_kind)) {
+        /* This is safe. Once is_in_use = true is set, the scavenger will not stop this local allocator.
+         * Whenever the scavenger stops a local allocator, it first checks if is_in_use is false and then sets scavenger_data.kind to
+         * non pas_local_allocator_allocator_kind. If we set is_in_use = true before and kind is pas_local_allocator_allocator_kind,
+         * it ensures that (1) this allocator is not stopped and (2) this allocator will not be stopped until we put is_in_use = false */
         return;
+    }
 
     if (config.kind == pas_heap_config_kind_pas_utility) {
+        /* This is safe. We never stop local allocators for pas_heap_config_kind_pas_utility. */
         allocator->scavenger_data.kind = pas_local_allocator_allocator_kind;
         return;
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c
@@ -104,6 +104,11 @@ void pas_local_allocator_scavenger_data_commit_if_necessary_slow(
         
         done = false;
         
+        /* Taking scavenger_lock ensures that this page will not be decommitted while we
+         * change data->kind below to indicate that we're keeping the page.
+         * Since data->kind is set to pas_local_allocator_decommitted_kind before decommit,
+         * if it is not pas_local_allocator_decommitted_kind by this point, this allocator is not
+         * decommited. */
         pas_lock_lock_conditionally(&cache->node->scavenger_lock, scavenger_lock_hold_mode);
         pas_lock_testing_assert_held(&cache->node->scavenger_lock);
         switch (data->kind) {

--- a/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
@@ -131,7 +131,7 @@ bool pas_local_view_cache_stop(pas_local_view_cache* cache,
        before doing the work to stop the local_view_cache.
 
        However, if the client thread is already in the process of executing pas_local_view_cache_stop,
-       gets passed the pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
+       gets the past pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
        the scavenger before setting the is_in_use flag, the scavenger can stop the local_view_cache
        after the client already checked and thinks it is not stopped yet. When the client thread
        resumes from suspension, it will be unhappy to find that the local_view_cache is already
@@ -141,7 +141,7 @@ bool pas_local_view_cache_stop(pas_local_view_cache* cache,
        is_in_use flag.
 
        If the re-check shows that the local_view_cache is already stopped, then pas_local_view_cache_stop
-       can return early like first pas_local_allocator_scavenger_data_is_stopped check. This is
+       can return early like the first pas_local_allocator_scavenger_data_is_stopped check. This is
        fine to do because the caller expects this as a possible outcome.
 
        Before returning early due to the re-check, we also need to clear the is_in_use flag.


### PR DESCRIPTION
#### b1948459dca702969a89d6e2d0298e5cf6e94805
<pre>
[libpas] Fix local_allocator stop race
<a href="https://bugs.webkit.org/show_bug.cgi?id=242422">https://bugs.webkit.org/show_bug.cgi?id=242422</a>
rdar://90119067

Reviewed by Mark Lam.

pas_local_allocator_stop can be called from the target running thread and the scavenger thread.
And it has the same issue to 484126cfed9edfd1e9e0a937fbbddad27dbfe0e5: if the running thread
is suspended just before setting `is_in_use = true`, we will run stop operation again onto the
already stopped local allocator. This breaks the local allocator, and ends up crashing in pas_local_allocator_commit_if_necessary_impl,
because we could revive already decommited local allocator by partially setting stopped local allocator information.
In this case, the rest of the fields are zero.
This patch also adds comments on how TLC decommit works in various conditions.

* Source/bmalloc/libpas/src/libpas/pas_local_allocator.c:
(pas_local_allocator_stop):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_commit_if_necessary_impl):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c:
(pas_local_allocator_scavenger_data_commit_if_necessary_slow):

Canonical link: <a href="https://commits.webkit.org/252228@main">https://commits.webkit.org/252228@main</a>
</pre>
