### PR TITLE
Avoid invalidating SVG resources when referencing element changes style

### DIFF
--- a/Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp
@@ -109,7 +109,7 @@ void LegacyRenderSVGModelObject::styleDidChange(StyleDifference diff, const Rend
             setNeedsTransformUpdate();
     }
     RenderElement::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 bool LegacyRenderSVGModelObject::nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation&, const LayoutPoint&, HitTestAction)

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -178,7 +178,7 @@ void LegacyRenderSVGRoot::layout()
         // Invalidate resource clients, which may mark some nodes for layout.
         for (auto& resource :  m_resourcesNeedingToInvalidateClients) {
             resource->removeAllClientsFromCache();
-            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, resource->style());
+            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, nullptr, resource->style());
         }
 
         m_isLayoutSizeChanged = false;
@@ -326,7 +326,7 @@ void LegacyRenderSVGRoot::styleDidChange(StyleDifference diff, const RenderStyle
         m_hasBoxDecorations = hasVisibleBoxDecorationStyle();
 
     RenderReplaced::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 // RenderBox methods will expect coordinates w/o any transforms in coordinates

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -102,7 +102,7 @@ void RenderSVGBlock::styleDidChange(StyleDifference diff, const RenderStyle* old
 #endif
         setNeedsBoundariesUpdate();
     RenderBlockFlow::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 void RenderSVGBlock::computeOverflow(LayoutUnit oldClientAfterEdge, bool recomputeFloats)

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -113,7 +113,7 @@ void RenderSVGInline::styleDidChange(StyleDifference diff, const RenderStyle* ol
     if (diff == StyleDifference::Layout)
         setNeedsBoundariesUpdate();
     RenderInline::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 void RenderSVGInline::updateFromStyle()

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -162,7 +162,7 @@ void RenderSVGModelObject::styleDidChange(StyleDifference diff, const RenderStyl
     if (hasSVGMask && hasLayer() && style().visibility() != Visibility::Visible)
         layer()->setHasVisibleContent();
 
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 void RenderSVGModelObject::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode> mode, TransformState& transformState) const

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -213,7 +213,7 @@ void RenderSVGResourceContainer::registerResource()
         auto* renderer = client->renderer();
         if (!renderer)
             continue;
-        SVGResourcesCache::clientStyleChanged(*renderer, StyleDifference::Layout, renderer->style());
+        SVGResourcesCache::clientStyleChanged(*renderer, StyleDifference::Layout, nullptr, renderer->style());
         renderer->setNeedsLayout();
     }
 }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -221,7 +221,7 @@ void RenderSVGRoot::layoutChildren()
         // Invalidate resource clients, which may mark some nodes for layout.
         for (auto& resource :  m_resourcesNeedingToInvalidateClients) {
             resource->removeAllClientsFromCache();
-            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, resource->style());
+            SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, nullptr, resource->style());
         }
 
         SetForScope clearLayoutSizeChanged(m_isLayoutSizeChanged, false);
@@ -382,7 +382,7 @@ void RenderSVGRoot::willBeRemovedFromTree(IsInternalMove isInternalMove)
 void RenderSVGRoot::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderReplaced::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, style());
+    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 void RenderSVGRoot::updateFromStyle()

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.h
@@ -53,7 +53,7 @@ public:
     static void clientLayoutChanged(RenderElement&);
 
     // Called from all SVG renderers styleDidChange() methods.
-    static void clientStyleChanged(RenderElement&, StyleDifference, const RenderStyle& newStyle);
+    static void clientStyleChanged(RenderElement&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
 
     // Called from RenderSVGResourceContainer::willBeDestroyed().
     static void resourceDestroyed(RenderSVGResourceContainer&);


### PR DESCRIPTION
#### fda943aadc10f120d2b316f616372209eeeae430
<pre>
Avoid invalidating SVG resources when referencing element changes style
<a href="https://bugs.webkit.org/show_bug.cgi?id=242425">https://bugs.webkit.org/show_bug.cgi?id=242425</a>
&lt;rdar://problem/96572561&gt;

Reviewed by Nikolas Zimmermann.

SVGResourcesCache::clientStyleChanged will destroy then recreate the SVG
resources for an element when it is restyled and the StyleDifference is not
Repaint or RepaintIfText. This is not necessary for many property changes. We
only need to do this if there is a change in which resource is being referenced
(i.e., the clip-path, mask-image, fill, etc. property changed), or if there is
a property change on the element that a cached resource depends on.

For now, we don&apos;t bother to pinpoint the specific resources that need
removing, and instead continue to destroy and recreate the entire
SVGResources object when a relevant property changes. Doing this in a
more targeted way would not be trivial, since SVGResources::buildCachedResources
handles cyclic dependency removal.

* Source/WebCore/rendering/svg/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::styleDidChange):
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::layout):
(WebCore::LegacyRenderSVGRoot::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::registerResource):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layout):
(WebCore::RenderSVGRoot::styleDidChange):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientStyleChanged):
* Source/WebCore/rendering/svg/SVGResourcesCache.h:

Canonical link: <a href="https://commits.webkit.org/252484@main">https://commits.webkit.org/252484@main</a>
</pre>
