### PR TITLE
Make RenderSVGResourceClipper lazily recompute clip-path data when referencing element is changed

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -35,7 +35,11 @@ struct GradientData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     struct Inputs {
-        bool operator==(const Inputs& other) const { return objectBoundingBox == other.objectBoundingBox && textPaintingScale == other.textPaintingScale; }
+        bool operator==(const Inputs& other) const
+        {
+            return std::tie(objectBoundingBox, textPaintingScale) == std::tie(other.objectBoundingBox, other.textPaintingScale);
+        }
+
         bool operator!=(const Inputs& other) const { return !(*this == other); }
 
         std::optional<FloatRect> objectBoundingBox;

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -86,7 +86,7 @@ static bool hasPaintResourceRequiringRemovalOnClientLayoutChange(RenderSVGResour
 
 static bool hasResourcesRequiringRemovalOnClientLayoutChange(SVGResources& resources)
 {
-    return resources.clipper() || resources.masker() || resources.filter() || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.fill()) || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.stroke());
+    return resources.masker() || resources.filter() || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.fill()) || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.stroke());
 }
 
 void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)


### PR DESCRIPTION
#### ce878379210ced398d994217e26519b433761149
<pre>
Make RenderSVGResourceClipper lazily recompute clip-path data when referencing element is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=242423">https://bugs.webkit.org/show_bug.cgi?id=242423</a>
&lt;rdar://problem/96571459&gt;

Reviewed by Said Abou-Hallawa.

Like <a href="https://bugs.webkit.org/show_bug.cgi?id=242421">https://bugs.webkit.org/show_bug.cgi?id=242421</a> did for SVG gradient
resources, this patch gives RenderSVGResourceClipper the ability to
lazily invalidate its cached data for a given client by storing its
dependencies and validating them in applyClippingToContext.

* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::removeAllClientsFromCache):
(WebCore::RenderSVGResourceClipper::removeClientFromCache):
(WebCore::RenderSVGResourceClipper::computeInputs):
(WebCore::RenderSVGResourceClipper::applyClippingToContext):
(WebCore::RenderSVGResourceClipper::resourceBoundingBox):
(WebCore::RenderSVGResourceClipper::addRendererToClipper): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
(WebCore::ClipperData::Inputs::operator==):
(WebCore::ClipperData::validate):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::hasResourcesRequiringRemovalOnClientLayoutChange):

Canonical link: <a href="https://commits.webkit.org/252311@main">https://commits.webkit.org/252311@main</a>
</pre>
