### PR TITLE
Don't repaint the outline bounds for (Legacy)RenderSVGModelObjects when their layout changes

### DIFF
--- a/Source/WebCore/rendering/LayoutRepainter.h
+++ b/Source/WebCore/rendering/LayoutRepainter.h
@@ -32,9 +32,11 @@ namespace WebCore {
 class RenderElement;
 class RenderLayerModelObject;
 
+enum class RepaintOutlineBounds : bool { No, Yes };
+
 class LayoutRepainter {
 public:
-    LayoutRepainter(RenderElement&, bool checkForRepaint);
+    LayoutRepainter(RenderElement&, bool checkForRepaint, RepaintOutlineBounds = RepaintOutlineBounds::Yes);
 
     bool checkForRepaint() const { return m_checkForRepaint; }
 
@@ -46,8 +48,9 @@ private:
     const RenderLayerModelObject* m_repaintContainer { nullptr };
     // We store these values as LayoutRects, but the final invalidations will be pixel snapped
     LayoutRect m_oldBounds;
-    LayoutRect m_oldOutlineBox;
+    LayoutRect m_oldOutlineBounds;
     bool m_checkForRepaint;
+    bool m_repaintOutlineBounds;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp
@@ -57,7 +57,7 @@ void LegacyRenderSVGContainer::layout()
     // LegacyRenderSVGRoot disables paint offset cache for the SVG rendering tree.
     ASSERT(!view().frameView().layoutContext().isPaintOffsetCacheEnabled());
 
-    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) || selfWillPaint());
+    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) || selfWillPaint(), RepaintOutlineBounds::No);
 
     // Allow RenderSVGViewportContainer to update its viewport.
     calcViewport();

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
@@ -144,7 +144,7 @@ bool LegacyRenderSVGShape::strokeContains(const FloatPoint& point, bool requires
 void LegacyRenderSVGShape::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
-    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) && selfNeedsLayout());
+    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) && selfNeedsLayout(), RepaintOutlineBounds::No);
 
     bool updateCachedBoundariesInParents = false;
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -87,7 +87,7 @@ void RenderSVGContainer::layout()
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
 
-    LayoutRepainter repainter(*this, checkForRepaintDuringLayout());
+    LayoutRepainter repainter(*this, checkForRepaintDuringLayout(), RepaintOutlineBounds::No);
 
     calculateViewport();
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -135,7 +135,7 @@ void RenderSVGImage::layout()
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
 
-    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) && selfNeedsLayout());
+    LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) && selfNeedsLayout(), RepaintOutlineBounds::No);
     updateImageViewport();
 
     bool transformOrBoundariesUpdate = m_needsTransformUpdate || m_needsBoundariesUpdate;

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -144,7 +144,7 @@ void RenderSVGShape::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
 
-    LayoutRepainter repainter(*this, checkForRepaintDuringLayout());
+    LayoutRepainter repainter(*this, checkForRepaintDuringLayout(), RepaintOutlineBounds::No);
     if (m_needsShapeUpdate) {
         // FIXME: [LBSE] Upstream SVGLengthContext changes
         // graphicsElement().updateLengthContext();


### PR DESCRIPTION
#### afe58473f11377d6373185ca3b3330898cf5feeb
<pre>
Don&apos;t repaint the outline bounds for (Legacy)RenderSVGModelObjects when their layout changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=242426">https://bugs.webkit.org/show_bug.cgi?id=242426</a>
&lt;rdar://problem/96574197&gt;

Reviewed by Simon Fraser.

LayoutRepainter repaints two rectangles: the &quot;clipped overflow rect&quot; and
the &quot;outline bounds&quot;. The outline bounds contains the CSS outline and any
box shadows. For SVG objects inheriting from (Legacy)RenderSVGModelObjects,
the CSS outline is already included in the clipped overflow rect (due to
it being included in SVGRenderSupport::computeFloatVisibleRectInContainer)
and SVG elements do not support box shadows, so for them, repainting the
outline bounds is wasted work.

Add an argument to LayoutRepainter to skip repainting the outline
bounds.

* Source/WebCore/rendering/LayoutRepainter.cpp:
(WebCore::LayoutRepainter::LayoutRepainter):
(WebCore::LayoutRepainter::repaintAfterLayout):
* Source/WebCore/rendering/LayoutRepainter.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::layout):
* Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::layout):
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::layout):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::layout):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::layout):

Canonical link: <a href="https://commits.webkit.org/252244@main">https://commits.webkit.org/252244@main</a>
</pre>
