### PR TITLE
[WebGPU] Temporarily disable Metal-cpp until we can remove the static initializers

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -82,4 +82,4 @@ TAPI_VERIFY_MODE = Pedantic;
 
 USE_RECURSIVE_SCRIPT_INPUTS_IN_SCRIPT_PHASES = YES;
 
-OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS) -Xlinker -no_warn_inits;
+OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS) -Xlinker -no_inits;

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		1C33755F27FA23B8002F1644 /* IsValidToUseWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C33755D27FA23B8002F1644 /* IsValidToUseWith.h */; };
 		1C5319C027BDC6CC00CD127E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5319BF27BDC6CC00CD127E /* main.swift */; };
 		1C5319C527BDC72700CD127E /* WebGPU.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CEBD7E32716AFBA00A5254D /* WebGPU.framework */; };
-		1C531A2527BDDF5500CD127E /* Metal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C531A2427BDDF5500CD127E /* Metal.cpp */; };
 		1C582FF927E04131009B40F0 /* CommandsMixin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C582FF727E04131009B40F0 /* CommandsMixin.mm */; };
 		1C582FFA27E04131009B40F0 /* CommandsMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C582FF827E04131009B40F0 /* CommandsMixin.h */; };
 		1C58301827E16823009B40F0 /* APIConversions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C58301727E16823009B40F0 /* APIConversions.h */; };
@@ -765,6 +764,7 @@
 				33EA188027BC24E200A1DD52 /* AssignmentStatement.h in Headers */,
 				33EA185E27BC194F00A1DD52 /* ASTNode.h in Headers */,
 				33EA186A27BC1BE600A1DD52 /* Attribute.h in Headers */,
+				33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				33EA187B27BC230E00A1DD52 /* CompoundStatement.h in Headers */,
 				33EA186C27BC1CBC00A1DD52 /* Expression.h in Headers */,
@@ -784,7 +784,6 @@
 				33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */,
 				33EA187427BC204900A1DD52 /* StructureDecl.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
-				33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */,
 				33EA186E27BC1D4C00A1DD52 /* TypeDecl.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* VariableQualifier.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
@@ -1026,7 +1025,6 @@
 				1C5ACAC1273A426D0095F8D5 /* Device.mm in Sources */,
 				1C0F41EE280940650005886D /* HardwareCapabilities.mm in Sources */,
 				1C5ACA94273A41C20095F8D5 /* Instance.mm in Sources */,
-				1C531A2527BDDF5500CD127E /* Metal.cpp in Sources */,
 				1C5ACAE5273A55DD0095F8D5 /* PipelineLayout.mm in Sources */,
 				1C5ACABD273A426D0095F8D5 /* QuerySet.mm in Sources */,
 				1C5ACACB273A426E0095F8D5 /* Queue.mm in Sources */,

--- a/Source/WebGPU/WebGPU/config.h
+++ b/Source/WebGPU/WebGPU/config.h
@@ -30,7 +30,7 @@
 
 #include <Metal/Metal.h>
 
-#include <Metal/Metal.hpp>
+// #include <Metal/Metal.hpp>
 
 #include <wtf/Assertions.h>
 


### PR DESCRIPTION
#### 12bd6574be2bb17efdffc09e67afaad9afeab999
<pre>
[WebGPU] Temporarily disable Metal-cpp until we can remove the static initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242427">https://bugs.webkit.org/show_bug.cgi?id=242427</a>
&lt;rdar://problem/96240816&gt;

Reviewed by Dean Jackson.

Temporarily stop compiling Metal-cpp, and stop our source files from #including it.
This patch leaves in the source in the tree, because we expect to re-enable it soon,
when we can remove the static initializers.

* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/config.h:

Canonical link: <a href="https://commits.webkit.org/252235@main">https://commits.webkit.org/252235@main</a>
</pre>
