### PR TITLE
Add a very simple live-ish resize SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -218,6 +218,12 @@ class ViewGestureController;
     std::optional<CGRect> _frozenVisibleContentRect;
     std::optional<CGRect> _frozenUnobscuredContentRect;
 
+    struct LiveResizeParameters {
+        CGFloat viewWidth;
+        CGPoint initialScrollPosition;
+    };
+    std::optional<LiveResizeParameters> _liveResizeParameters;
+
     BOOL _commitDidRestoreScrollPosition;
     std::optional<WebCore::FloatPoint> _scrollOffsetToRestore;
     WebCore::FloatBoxExtent _obscuredInsetsWhenSaved;


### PR DESCRIPTION
#### eb491a86e71bc2485e641ece48a28594034a52f5
<pre>
Add a very simple live-ish resize SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=242431">https://bugs.webkit.org/show_bug.cgi?id=242431</a>

Reviewed by Devin Rousso.

There are a few problems with the existing resize mechanisms on
iOS family platforms:

- Bare `setFrame:` does not make any attempt to synchronize the frame change
  with the incoming asynchronous painting.

- `_beginAnimatedResize:` cannot handle long-duration animations (like those
  that occur during a human-driven resize), and requires nontrivial
  rearchitecture in order to do so (see e.g. 235698@main, which removed all
  support for updating the animated resize transform when intermediate commits
  arrive, which happens frequently during long-running live resizes).
  It is built primarily to drive single-shot rotation animations.

- `_holdLiveResizeSnapshotForReason:` depends on platform support which is not
  always available, and also requires taking many snapshots as the view resizes.

- `setFrame:` + CoreAnimation fencing (which we use on macOS, not iOS) blocks
  non-WebKit UI hosted in the same CAContext, and is generally frowned upon.

So, let&apos;s introduce one more! That will surely help.

`_beginLiveResize` -&gt; repeated `setFrame` -&gt; `_endLiveResize` will do a very
simple, live-*ish* resize. We defer actual frame changes until the end of the
resize, but dynamically scale the existing tiles (and allow them to repaint)
on each frame change.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _processWillSwapOrDidExit]):
(-[WKWebView _updateLiveResizeTransform]):
Scale (and translate) the current tiles to fit in the web view as it is resized.

(-[WKWebView _frameOrBoundsChanged]):
Skip most of _frameOrBoundsChanged while in live-resize, just like we do
for animated resize.

(-[WKWebView _ensureResizeAnimationView]):
(-[WKWebView _destroyResizeAnimationView]):
(-[WKWebView _cancelAnimatedResize]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
Factor out creation of the _resizeAnimationView from animated resize code, and
re-use it for &quot;live&quot; resize.

(-[WKWebView _beginLiveResize]):
Start a live resize.

(-[WKWebView _endLiveResize]):
End a live resize. In order to synchronise the transition from the
resizeAnimationView&apos;s scale to the scale of the pending incoming tiles, we throw
up a temporary snapshot. Ideally this would be removed in the future, but will
require quite a bit of care to avoid flashing; also, it is quite shortlived
so shouldn&apos;t cause much trouble.

Canonical link: <a href="https://commits.webkit.org/252252@main">https://commits.webkit.org/252252@main</a>
</pre>
