### PR TITLE
[media-controls] promote secondaryValue member from Slider to SliderBase

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider-base.js
@@ -45,6 +45,7 @@ class SliderBase extends LayoutNode
         this.enabled = true;
         this.isActive = false;
         this._disabled = false;
+        this._secondaryValue = 0;
 
         this._allowsRelativeScrubbing = false;
         this._startValue = NaN;
@@ -88,6 +89,20 @@ class SliderBase extends LayoutNode
 
         this._value = value;
         this.markDirtyProperty("value");
+        this.needsLayout = true;
+    }
+
+    get secondaryValue()
+    {
+        return this._secondaryValue;
+    }
+
+    set secondaryValue(secondaryValue)
+    {
+        if (this._secondaryValue === secondaryValue)
+            return;
+
+        this._secondaryValue = secondaryValue;
         this.needsLayout = true;
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.js
@@ -41,25 +41,10 @@ class Slider extends SliderBase
         this.appearanceContainer.children = [fillContainer, this._knob];
 
         this.height = 16;
-        this._secondaryValue = 0;
         this._knobStyle = knobStyle;
     }
 
     // Public
-
-    get secondaryValue()
-    {
-        return this._secondaryValue;
-    }
-
-    set secondaryValue(secondaryValue)
-    {
-        if (this._secondaryValue === secondaryValue)
-            return;
-
-        this._secondaryValue = secondaryValue;
-        this.needsLayout = true;
-    }
 
     get knobStyle()
     {
@@ -116,7 +101,7 @@ class Slider extends SliderBase
         this._primaryFill.element.style.width = `${scrubberCenterX - (scrubberWidth / 2) - scrubberBorder}px`;
         this._trackFill.element.style.left = `${scrubberCenterX + (scrubberWidth / 2) + scrubberBorder}px`;
         this._secondaryFill.element.style.left = `${scrubberCenterX + (scrubberWidth / 2) + scrubberBorder}px`;
-        this._secondaryFill.element.style.right = `${(1 - this._secondaryValue) * 100}%`;
+        this._secondaryFill.element.style.right = `${(1 - this.secondaryValue) * 100}%`;
         this._knob.element.style.left = `${scrubberCenterX}px`;
     }
 


### PR DESCRIPTION
#### 780c2fc34af99164a7f61494cdf45854a21f9395
<pre>
[media-controls] promote secondaryValue member from Slider to SliderBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=242432">https://bugs.webkit.org/show_bug.cgi?id=242432</a>
&lt;rdar://96583766&gt;

Reviewed by Dean Jackson.

This property can be useful to more subclasses, so we promote it from Slider to SliderBase.

* Source/WebCore/Modules/modern-media-controls/controls/slider-base.js:
(SliderBase.prototype.set value):
(SliderBase.prototype.get secondaryValue):
(SliderBase.prototype.set secondaryValue):
* Source/WebCore/Modules/modern-media-controls/controls/slider.js:
(Slider.prototype.commit):
(Slider.prototype.get secondaryValue): Deleted.
(Slider.prototype.set secondaryValue): Deleted.

Canonical link: <a href="https://commits.webkit.org/252223@main">https://commits.webkit.org/252223@main</a>
</pre>
