### PR TITLE
The script webkit-filter-log is broken since the github migration

### DIFF
--- a/Tools/Scripts/webkit-filter-log
+++ b/Tools/Scripts/webkit-filter-log
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright (C) 2021 Igalia S.L.
 #
@@ -25,16 +25,13 @@
 import logging
 import optparse
 import os
+import subprocess
 import sys
 
-from webkitpy.common.checkout.scm.detection import SCMDetector
-from webkitpy.common.checkout.checkout import Checkout
 from webkitpy.common.host import Host
-from webkitpy.common.system.executive import Executive, ScriptError
-from webkitpy.common.system.filesystem import FileSystem
-from webkitpy.common.net.bugzilla import Bugzilla
-from xml.sax.saxutils import unescape
+from webkitscmpy import local
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 _log = logging.getLogger(__name__)
 
 option_parser = optparse.OptionParser(usage='usage: %prog [options] revision')
@@ -53,7 +50,7 @@ except NotImplementedError as e:
     _log.error(str(e))
     sys.exit(-1)
 
-scm = SCMDetector(FileSystem(), Executive()).default_scm()
+scm = local.Git(os.getcwd())
 
 filter_dirs = [ 'gobject', 'glib', 'soup', 'cairo', 'gstreamer', 'atspi', 'adwaita',
                 'unix', 'linux', 'CoordinatedGraphics', 'texmap', 'nicosia',
@@ -64,41 +61,12 @@ elif port.name() == 'wpe':
     filter_dirs.extend([ 'wpe', 'libwpe', 'epoxy' ])
 
 log_dirs = []
-for root, dirs, dummy in os.walk(os.path.join(scm.checkout_root, 'Source')):
+for root, dirs, dummy in os.walk(os.path.join(scm.root_path, 'Source')):
     for d in dirs:
         if d in filter_dirs:
             log_dirs.append(os.path.join(root, d))
 
-command = ['git', 'log', '--pretty=%H', args[0] + '..', 'master', '--']
+command = ['git', 'log', '--no-decorate', '--format=%h %s%n', args[0] + '..', 'origin/main', '--']
 command.extend (log_dirs)
-revisions = Executive().run_command(command).splitlines()
+subprocess.call(command)
 
-co = Checkout(scm)
-bugs = {}
-for rev in revisions:
-    try:
-        info = co.commit_info_for_revision(scm.svn_revision_from_git_commit(rev))
-    except Exception as e:
-        _log.warn('Error: no commit info found for git revision %s: %s' % (rev, str(e)))
-        continue
-
-    if not info:
-        _log.warn('Error: no commit info found for git revision %s' % rev)
-        continue
-
-    bug_id = info.bug_id()
-    if bug_id:
-        author_name = info.author_name()
-        authors = bugs.setdefault(bug_id, [])
-        if author_name not in authors:
-            authors.append(author_name)
-
-bugzilla = Bugzilla()
-for bug_id in bugs:
-    try:
-        bug_title = bugzilla.fetch_bug_dictionary(bug_id)['title']
-    except:
-        _log.error('Error getting info for bug #%s' % (bug_id))
-        continue
-    bug_title = unescape(bug_title, {"&apos;": "'", "&quot;": '"'})
-    print(u'Bug %s – %s (%s)' % (bug_id, bug_title, u', '.join(bugs[bug_id])))


### PR DESCRIPTION
#### f2bacb5cfc5f9996e51e2dda6e43b38e448afd7f
<pre>
The script webkit-filter-log is broken since the github migration
<a href="https://bugs.webkit.org/show_bug.cgi?id=242434">https://bugs.webkit.org/show_bug.cgi?id=242434</a>

Reviewed by Jonathan Bedard.

Just call git log with a simple format showing the info we need for the
directories containing changes specific to a given port.

* Tools/Scripts/webkit-filter-log:

Canonical link: <a href="https://commits.webkit.org/252265@main">https://commits.webkit.org/252265@main</a>
</pre>
