### PR TITLE
Ignore RID that appears without an a=simulcast entry

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc
@@ -3294,7 +3294,6 @@ bool ParseContent(const std::string& message,
 
   // If simulcast is specifed, split the rids into send and receive.
   // Rids that do not appear in simulcast attribute will be removed.
-  // If it is not specified, we assume that all rids are for send layers.
   std::vector<RidDescription> send_rids;
   std::vector<RidDescription> receive_rids;
   if (!simulcast.empty()) {
@@ -3321,7 +3320,11 @@ bool ParseContent(const std::string& message,
 
     media_desc->set_simulcast_description(simulcast);
   } else {
-    send_rids = rids;
+    // RID is specified in RFC 8851, which identifies a lot of usages.
+    // We only support RFC 8853 usage of RID, not anything else.
+    // Ignore all RID parameters when a=simulcast is missing.
+    // In particular do NOT do send_rids = rids;
+    RTC_LOG(LS_VERBOSE) << "Ignoring send_rids without simulcast";
   }
 
   media_desc->set_receive_rids(receive_rids);


### PR DESCRIPTION
#### 83a32e412dec246ceab6ddded22e22b9728cc43a
<pre>
Ignore RID that appears without an a=simulcast entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=242435">https://bugs.webkit.org/show_bug.cgi?id=242435</a>
rdar://problem/96586416

Reviewed by Eric Carlson.

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_simulcast_unittest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc:

Canonical link: <a href="https://commits.webkit.org/252218@main">https://commits.webkit.org/252218@main</a>
</pre>
