### PR TITLE
Ensure m_backend is valid during use in RTCRtpTransform::attachToReceiver

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
@@ -67,7 +67,8 @@ void RTCRtpTransform::attachToReceiver(RTCRtpReceiver& receiver, RTCRtpTransform
         m_backend = previousTransform->takeBackend();
     else if (auto* backend = receiver.backend())
         m_backend = backend->rtcRtpTransformBackend();
-    else
+
+    if (!m_backend)
         return;
 
     switchOn(m_transform, [&](RefPtr<RTCRtpSFrameTransform>& sframeTransform) {


### PR DESCRIPTION
#### f9969ede8c6440c72138bb26eaed6e5139040380
<pre>
Ensure m_backend is valid during use in RTCRtpTransform::attachToReceiver
<a href="https://bugs.webkit.org/show_bug.cgi?id=242437">https://bugs.webkit.org/show_bug.cgi?id=242437</a>

Reviewed by Youenn Fablet.

Add check to ensure that the previousTransform has a valid backend before
attempting to use it.

* Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp:
(WebCore::RTCRtpTransform::attachToReceiver):

Canonical link: <a href="https://commits.webkit.org/252232@main">https://commits.webkit.org/252232@main</a>
</pre>
