### PR TITLE
[ews] status url results in 500 for unknown patch id

### DIFF
--- a/Tools/CISupport/ews-app/ews/views/status.py
+++ b/Tools/CISupport/ews-app/ews/views/status.py
@@ -22,6 +22,8 @@
 
 from __future__ import unicode_literals
 
+import logging
+
 from django.http import JsonResponse
 from django.views import View
 from ews.common.buildbot import Buildbot
@@ -29,6 +31,7 @@ from ews.models.patch import Patch
 from ews.views.statusbubble import StatusBubble
 import ews.config as config
 
+_log = logging.getLogger(__name__)
 
 class Status(View):
     def _build_status(self, patch, queue):
@@ -44,7 +47,7 @@ class Status(View):
 
     def _build_statuses_for_patch(self, patch):
         if not patch:
-            return []
+            return {}
 
         statuses = {}
         if patch.sent_to_buildbot:
@@ -61,7 +64,8 @@ class Status(View):
         return statuses
 
     def get(self, request, patch_id):
-        patch_id = int(patch_id)
         patch = Patch.get_patch(patch_id)
+        if not patch:
+            _log.info('No patch found for id: {}'.format(patch_id))
         response_data = self._build_statuses_for_patch(patch)
         return JsonResponse(response_data)


### PR DESCRIPTION
#### 2f47d87846dc0084265d7e5fc6efaad2a33cdec4
<pre>
[ews] status url results in 500 for unknown patch id
<a href="https://bugs.webkit.org/show_bug.cgi?id=242440">https://bugs.webkit.org/show_bug.cgi?id=242440</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/views/status.py:
(Status._build_statuses_for_patch):
(Status.get):

Canonical link: <a href="https://commits.webkit.org/252213@main">https://commits.webkit.org/252213@main</a>
</pre>
