### PR TITLE
gtk builds shouldn't fail when there is issue with commit identifier calculation

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -30,7 +30,7 @@ def get_build_revision():
     try:
         repository = local.Scm.from_path(str(WEBKIT_TOP_LEVEL), contributors=None)
         return str(repository.find("HEAD", include_log=False))
-    except (local.Scm.Exception, TypeError, OSError):
+    except (local.Scm.Exception, TypeError, OSError, KeyError):
         # This may happen with shallow checkouts whose HEAD has been
         # modified; there is no origin reference anymore, and git
         # will fail - let's pretend that this is not a repo at all


### PR DESCRIPTION
#### dc0f535d0eb37c7f3527b855d2f0497b49f2f39c
<pre>
gtk builds shouldn&apos;t fail when there is issue with commit identifier calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242443">https://bugs.webkit.org/show_bug.cgi?id=242443</a>

Reviewed by Jonathan Bedard.

* Tools/glib/apply-build-revision-to-files.py:
(get_build_revision):

Canonical link: <a href="https://commits.webkit.org/252216@main">https://commits.webkit.org/252216@main</a>
</pre>
