### PR TITLE
[WebAuthn] Test fix after should reject rp with empty id

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1490,7 +1490,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimun)
 
     EXPECT_WK_STREQ(result.rp.name, "example.com");
     EXPECT_TRUE(result.rp.icon.isNull());
-    EXPECT_TRUE(!result.rp.id);
+    EXPECT_TRUE(result.rp.id && result.rp.id->isNull());
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_TRUE(result.user.icon.isNull());
@@ -1534,7 +1534,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 
     EXPECT_WK_STREQ(result.rp.name, "example.com");
     EXPECT_TRUE(result.rp.icon.isNull());
-    EXPECT_TRUE(!result.rp.id);
+    EXPECT_TRUE(result.rp.id && result.rp.id->isNull());
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_TRUE(result.user.icon.isNull());


### PR DESCRIPTION
#### cee228875878559f12d3b5a2e03fc8022ca86204
<pre>
[WebAuthn] Test fix after should reject rp with empty id
<a href="https://bugs.webkit.org/show_bug.cgi?id=242448">https://bugs.webkit.org/show_bug.cgi?id=242448</a>

Reviewed by Brent Fulgham.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

In <a href="https://bugs.webkit.org/show_bug.cgi?id=242091">https://bugs.webkit.org/show_bug.cgi?id=242091</a>, present but empty
options.rp.id values are rejected to conform to spec.

This shouldn&apos;t apply to values from SPI as they aren&apos;t directly from
the web.

Canonical link: <a href="https://commits.webkit.org/252224@main">https://commits.webkit.org/252224@main</a>
</pre>
