### PR TITLE
Adjust call inline candidate parameter for DFG

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -271,9 +271,9 @@ bool canUseWebAssemblyFastMemory();
     \
     v(Unsigned, maximumOptimizationCandidateBytecodeCost, 100000, Normal, nullptr) \
     \
-    v(Unsigned, maximumFunctionForCallInlineCandidateBytecodeCost, 120, Normal, nullptr) \
-    v(Unsigned, maximumFunctionForClosureCallInlineCandidateBytecodeCost, 100, Normal, nullptr) \
-    v(Unsigned, maximumFunctionForConstructInlineCandidateBytecoodeCost, 100, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForCallInlineCandidateBytecodeCost, 100, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForClosureCallInlineCandidateBytecodeCost, 80, Normal, nullptr) \
+    v(Unsigned, maximumFunctionForConstructInlineCandidateBytecoodeCost, 80, Normal, nullptr) \
     \
     v(Unsigned, maximumFTLCandidateBytecodeCost, 20000, Normal, nullptr) \
     \


### PR DESCRIPTION
#### 8cb250c9ca5720e9887a3035ba8113660301df89
<pre>
Adjust call inline candidate parameter for DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=242496">https://bugs.webkit.org/show_bug.cgi?id=242496</a>

Reviewed by Yusuke Suzuki.

This patach tunes the parameters for inline calls optimized for DFG
to gain 0.7% progression on RAMification for macOS and iOS. And the
perf results of Speedometer2 and JetStream2 are neutral.

* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/252263@main">https://commits.webkit.org/252263@main</a>
</pre>
