### PR TITLE
Crash under MediaPlayerPrivateRemote::durationMediaTime()

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -74,7 +74,7 @@ public:
     void seekCompleted() final;
     void setTimeFudgeFactor(const MediaTime&) final;
 
-    MediaTime duration() const { return m_client->duration(); }
+    MediaTime duration() const { return m_client ? m_client->duration() : MediaTime(); }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }


### PR DESCRIPTION
#### 96f399638f0c5bcdd5b8f8af44a330e1c1ea67a2
<pre>
Crash under MediaPlayerPrivateRemote::durationMediaTime()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242453">https://bugs.webkit.org/show_bug.cgi?id=242453</a>
&lt;rdar://96267301&gt;

Reviewed by Eric Carlson.

m_client is a WeakPtr and based on crashes in the wild, we have evidence that
it can be null when MediaPlayerPrivateRemote::durationMediaTime() get called.

To address the issue, add a null check for m_client, like it is done in other
functions in MediaSourcePrivateRemote.

* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/252226@main">https://commits.webkit.org/252226@main</a>
</pre>
