### PR TITLE
Web Inspector: Lazily create SourceCodeTextRange for search result objects

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js
@@ -29,12 +29,14 @@ WI.DOMSearchMatchObject = class DOMSearchMatchObject
     {
         console.assert(resource instanceof WI.Resource);
         console.assert(domNode instanceof WI.DOMNode);
+        console.assert(textRange instanceof WI.TextRange, textRange);
 
         this._resource = resource;
         this._domNode = domNode;
         this._title = title;
         this._searchTerm = searchTerm;
-        this._sourceCodeTextRange = resource.createSourceCodeTextRange(textRange);
+        this._textRange = textRange;
+        this._sourceCodeTextRange = null;
     }
 
     // Static
@@ -85,6 +87,8 @@ WI.DOMSearchMatchObject = class DOMSearchMatchObject
 
     // Public
 
+    get textRange() { return this._textRange; }
+
     get resource()
     {
         return this._resource;
@@ -115,6 +119,8 @@ WI.DOMSearchMatchObject = class DOMSearchMatchObject
 
     get sourceCodeTextRange()
     {
+        this._sourceCodeTextRange ??= this._resource.createSourceCodeTextRange(this._textRange);
+
         return this._sourceCodeTextRange;
     }
 
@@ -122,8 +128,7 @@ WI.DOMSearchMatchObject = class DOMSearchMatchObject
     {
         cookie[WI.DOMSearchMatchObject.URLCookieKey] = this._resource.url.hash;
         cookie[WI.DOMSearchMatchObject.TitleKey] = this._title;
-        var textRange = this._sourceCodeTextRange.textRange;
-        cookie[WI.DOMSearchMatchObject.TextRangeKey] = [textRange.startLine, textRange.startColumn, textRange.endLine, textRange.endColumn].join();
+        cookie[WI.DOMSearchMatchObject.TextRangeKey] = [this._textRange.startLine, this._textRange.startColumn, this._textRange.endLine, this._textRange.endColumn].join();
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js
@@ -28,11 +28,13 @@ WI.SourceCodeSearchMatchObject = class SourceCodeSearchMatchObject
     constructor(sourceCode, lineText, searchTerm, textRange)
     {
         console.assert(sourceCode instanceof WI.SourceCode);
+        console.assert(textRange instanceof WI.TextRange, textRange)
 
         this._sourceCode = sourceCode;
         this._lineText = lineText;
         this._searchTerm = searchTerm;
-        this._sourceCodeTextRange = sourceCode.createSourceCodeTextRange(textRange);
+        this._textRange = textRange;
+        this._sourceCodeTextRange = null;
     }
 
     // Public
@@ -40,7 +42,14 @@ WI.SourceCodeSearchMatchObject = class SourceCodeSearchMatchObject
     get sourceCode() { return this._sourceCode; }
     get title() { return this._lineText; }
     get searchTerm() { return this._searchTerm; }
-    get sourceCodeTextRange() { return this._sourceCodeTextRange; }
+    get textRange() { return this._textRange; }
+
+    get sourceCodeTextRange()
+    {
+        this._sourceCodeTextRange ??= this._sourceCode.createSourceCodeTextRange(this._textRange);
+
+        return this._sourceCodeTextRange;
+    }
 
     get className()
     {
@@ -52,8 +61,7 @@ WI.SourceCodeSearchMatchObject = class SourceCodeSearchMatchObject
         if (this._sourceCode.url)
             cookie[WI.SourceCodeSearchMatchObject.URLCookieKey] = this._sourceCode.url.hash;
 
-        var textRange = this._sourceCodeTextRange.textRange;
-        cookie[WI.SourceCodeSearchMatchObject.TextRangeKey] = [textRange.startLine, textRange.startColumn, textRange.endLine, textRange.endColumn].join();
+        cookie[WI.SourceCodeSearchMatchObject.TextRangeKey] = [this._textRange.startLine, this._textRange.startColumn, this._textRange.endLine, this._textRange.endColumn].join();
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js
@@ -29,21 +29,18 @@ WI.SearchResultTreeElement = class SearchResultTreeElement extends WI.GeneralTre
     {
         console.assert(representedObject instanceof WI.DOMSearchMatchObject || representedObject instanceof WI.SourceCodeSearchMatchObject);
 
-        var title = WI.SearchResultTreeElement.truncateAndHighlightTitle(representedObject.title, representedObject.searchTerm, representedObject.sourceCodeTextRange);
+        var title = WI.SearchResultTreeElement.truncateAndHighlightTitle(representedObject.title, representedObject.searchTerm, representedObject.textRange);
         const subtitle = null;
         super(representedObject.className, title, subtitle, representedObject);
     }
 
     // Static
 
-    static truncateAndHighlightTitle(title, searchTerm, sourceCodeTextRange)
+    static truncateAndHighlightTitle(title, searchTerm, textRange)
     {
         let isRTL = WI.resolvedLayoutDirection() === WI.LayoutDirection.RTL;
         const charactersToShowBeforeSearchMatch = isRTL ? 20 : 15;
         const charactersToShowAfterSearchMatch = isRTL ? 15 : 50;
-
-        // Use the original location, since those line/column offsets match the line text in title.
-        var textRange = sourceCodeTextRange.textRange;
 
         let searchTermIndex = textRange.startColumn;
         let searchTermLength = textRange.endColumn - textRange.startColumn;


### PR DESCRIPTION
#### 7fb9668bb2d3f662dc4f3be8ad7e062c1ae99ac8
<pre>
Web Inspector: Lazily create SourceCodeTextRange for search result objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=242450">https://bugs.webkit.org/show_bug.cgi?id=242450</a>
rdar://problem/96601780

Reviewed by Devin Rousso.

Improve performance of the Search tab by lazily creating SourceCodeTextRange objects only when needed, since creating
this object is expensive because it tracks changes to the source code, but we never take advantage of that tracking and
just immediately use the info to create the title strings for search results. We also already notify users that they
need to search again if content on the page changes.

This accounts for about 50% of the performance improvements that have taken searching for the letter `a` on webkit.org
from ~13 seconds to under a second (using manual stopwatch testing across 5 tests before and after). The other 50% of
the improvement is from bug 242419 (Web Inspector: Search tab should lazily insert/remove its navigation sidebar tree
items during scrolling). Note that very large sites still pose a problem, but instrumenting search performance has been
tricky because they lock up and never return performance/timing data.

* Source/WebInspectorUI/UserInterface/Models/DOMSearchMatchObject.js:
(WI.DOMSearchMatchObject):
(WI.DOMSearchMatchObject.prototype.get textRange):
(WI.DOMSearchMatchObject.prototype.get sourceCodeTextRange):
(WI.DOMSearchMatchObject.prototype.saveIdentityToCookie):
* Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js:
(WI.SourceCodeSearchMatchObject):
(WI.SourceCodeSearchMatchObject.prototype.get textRange):
(WI.SourceCodeSearchMatchObject.prototype.get sourceCodeTextRange):
(WI.SourceCodeSearchMatchObject.prototype.saveIdentityToCookie):
* Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js:
(WI.SearchResultTreeElement):
(WI.SearchResultTreeElement.truncateAndHighlightTitle):

Canonical link: <a href="https://commits.webkit.org/252277@main">https://commits.webkit.org/252277@main</a>
</pre>
