### PR TITLE
Unreviewed, fix the build with older macOS Ventura or iOS 16 SDKs after 252183@main

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
@@ -366,6 +366,12 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 #endif // __has_include(<AVFoundation/AVSampleBufferDisplayLayer.h>)
 
+#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+@interface AVSampleBufferDisplayLayer (Staging_94324932)
+- (nullable CVPixelBufferRef)copyDisplayedPixelBuffer;
+@end
+#endif
+
 #if __has_include(<AVFoundation/AVSampleBufferAudioRenderer.h>)
 #import <AVFoundation/AVSampleBufferAudioRenderer.h>
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
#### 9461f8bacd2cba84adb50f866ed398b05f9f166a
<pre>
Unreviewed, fix the build with older macOS Ventura or iOS 16 SDKs after 252183@main

Add a staging declaration for the new SPI method
`-[AVSampleBufferDisplayLayer copyDisplayedPixelBuffer]`.

* Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h:

Canonical link: <a href="https://commits.webkit.org/252222@main">https://commits.webkit.org/252222@main</a>
</pre>
