### PR TITLE
[Flatpak SDK] Update to pipewire master

### DIFF
--- a/Tools/buildstream/patches/fdo-0001-pipewire-base-Track-master-branch.patch
+++ b/Tools/buildstream/patches/fdo-0001-pipewire-base-Track-master-branch.patch
@@ -8,20 +8,22 @@ Subject: [PATCH] pipewire-base: Track master branch
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/elements/components/pipewire-base.bst b/elements/components/pipewire-base.bst
-index 2c5686a89..01ffe8a01 100644
+index 2c5686a89..497106149 100644
 --- a/elements/components/pipewire-base.bst
 +++ b/elements/components/pipewire-base.bst
-@@ -38,6 +38,9 @@ variables:
+@@ -37,7 +37,11 @@ variables:
+     -Dman=enabled
      -Dbluez5-codec-ldac=disabled
      -Dbluez5-codec-aptx=disabled
++    -Dbluez5-codec-lc3plus=disabled
      -Dlibcamera=disabled
 +    -Dlibcanberra=disabled
 +    -Dlv2=disabled
 +    -Dsession-managers=
      -Dlibjack-path=%{libdir}
      -Dudevrulesdir=$(pkg-config --variable=udevdir udev)/rules.d
- 
-@@ -107,9 +110,7 @@ public:
+
+@@ -107,9 +111,7 @@ public:
  sources:
  - kind: git_tag
    url: freedesktop:PipeWire/pipewire.git
@@ -32,7 +34,7 @@ index 2c5686a89..01ffe8a01 100644
 -  ref: 0.3.36-0-g4997d47f63ed2c91d74bc8e5b229e57200354ee5
 -- kind: patch
 -  path: patches/pipewire/remove-useless-rpaths.patch
-+  ref: 0.3.51-0-gebc775674a0cf254cebd6d4694944006405807e3
++  ref: 0.3.54-7-ga293e079d1be41c00b6e4f831cc216964cbfbf15
 -- 
 2.35.1
 


### PR DESCRIPTION
#### 2714a632e8244522f368470a8851063adebaa53f
<pre>
[Flatpak SDK] Update to pipewire master
<a href="https://bugs.webkit.org/show_bug.cgi?id=242455">https://bugs.webkit.org/show_bug.cgi?id=242455</a>

Reviewed by Michael Catanzaro.

The GStreamer pipewiresrc element from 0.3.51 has invalid buffer
memory bug which was fixed in the master branch.

Fixes a hard crash when using pipewiresrc for cameras.

* Tools/buildstream/patches/fdo-0001-pipewire-base-Track-master-branch.patch:

Canonical link: <a href="https://commits.webkit.org/252230@main">https://commits.webkit.org/252230@main</a>
</pre>
