### PR TITLE
[ews-app] Make status url work with git hash

### DIFF
--- a/Tools/CISupport/ews-app/ews/urls.py
+++ b/Tools/CISupport/ews-app/ews/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     # ex: /retry/
     url(r'^retry/$', RetryPatch.as_view(), name='retrypatch'),
     # ex: /status/5
-    url(r'^status/(?P<patch_id>[0-9]+)/$', Status.as_view(), name='status'),
+    url(r'^status/(?P<patch_id>[a-fA-F0-9]+)/$', Status.as_view(), name='status'),
     # ex: /status-bubble/5 , /status-bubble/ac980a0f
     url(r'^status-bubble/(?P<patch_id>[a-fA-F0-9]+)/$', StatusBubble.as_view(), name='statusbubble'),
     # ex: /submit-to-ews/

--- a/Tools/CISupport/ews-app/ews/views/status.py
+++ b/Tools/CISupport/ews-app/ews/views/status.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,11 +50,10 @@ class Status(View):
             return {}
 
         statuses = {}
-        if patch.sent_to_buildbot:
-            for queue in StatusBubble.ALL_QUEUES:
-                status = self._build_status(patch, queue)
-                if status:
-                    statuses[queue] = status
+        for queue in StatusBubble.ALL_QUEUES:
+            status = self._build_status(patch, queue)
+            if status:
+                statuses[queue] = status
 
         if patch.sent_to_commit_queue:
             cq_status = self._build_status(patch, 'commit')


### PR DESCRIPTION
#### 1d008ad6b91c0b2995914ded7c87377c0b950054
<pre>
[ews-app] Make status url work with git hash
<a href="https://bugs.webkit.org/show_bug.cgi?id=242442">https://bugs.webkit.org/show_bug.cgi?id=242442</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/urls.py:
* Tools/CISupport/ews-app/ews/views/status.py:
(Status._build_statuses_for_patch):

Canonical link: <a href="https://commits.webkit.org/252227@main">https://commits.webkit.org/252227@main</a>
</pre>
