### PR TITLE
[iOS][GPU] Remove more sandbox telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -82,7 +82,7 @@
             (play-media asset-access-filter))))
 
 (define-once (play-audio)
-    (allow mach-lookup (with telemetry)
+    (allow mach-lookup
            (global-name "com.apple.audio.AURemoteIOServer")))
 
 (define-once (play-media . filters)
@@ -94,20 +94,22 @@
                 (extension-class "com.apple.mediaserverd.read"))))
     ;; CoreMedia framework.
     (allow mach-lookup (with telemetry)
-           (global-name "com.apple.coremedia.admin")
-           (global-name "com.apple.coremedia.asset.xpc")
            (global-name "com.apple.coremedia.assetimagegenerator.xpc")
            (global-name "com.apple.coremedia.audiodeviceclock.xpc") ; Needed for CMTimeBase
-           (global-name "com.apple.coremedia.audioprocessingtap.xpc")
            (global-name "com.apple.coremedia.capturesession")      ; Actually for video capture
            (global-name "com.apple.coremedia.capturesource")       ; Also for video capture (<rdar://problem/15794291>).
            (global-name "com.apple.coremedia.cpe.xpc") ; Needed for HDR playback.
+           (global-name "com.apple.coremedia.remotequeue"))
+    (allow mach-lookup
+           (global-name "com.apple.coremedia.admin")
+           (global-name "com.apple.coremedia.asset.xpc")
+           (global-name "com.apple.coremedia.audioprocessingtap.xpc")
            (global-name "com.apple.coremedia.customurlloader.xpc") ; Needed for custom media loading
+           (global-name "com.apple.coremedia.figcpecryptor")
            (global-name "com.apple.coremedia.formatreader.xpc")
            (global-name "com.apple.coremedia.mediaparserd.formatreader.xpc")
            (global-name "com.apple.coremedia.player.xpc")
            (global-name "com.apple.coremedia.remaker")
-           (global-name "com.apple.coremedia.remotequeue")
            (global-name "com.apple.coremedia.routediscoverer.xpc")
            (global-name "com.apple.coremedia.routingcontext.xpc")
            (global-name "com.apple.coremedia.samplebufferaudiorenderer.xpc")
@@ -121,7 +123,6 @@
         (global-name "com.apple.coremedia.cpeprotector.xpc")
         (global-name "com.apple.coremedia.endpoint.xpc")
         (global-name "com.apple.coremedia.figcontentkeysession.xpc")
-        (global-name "com.apple.coremedia.figcpecryptor")
         (global-name "com.apple.coremedia.routingsessionmanager.xpc")
         (global-name "com.apple.coremedia.sts"))
 
@@ -138,7 +139,7 @@
         (literal "/private/var/preferences/com.apple.networkd.plist"))
 
     ;; Required by the MediaPlayer framework.
-    (allow mach-lookup (with telemetry)
+    (allow mach-lookup
         (global-name "com.apple.audio.AudioSession"))
 
     (allow mach-lookup (with telemetry)
@@ -153,9 +154,8 @@
 (define-once (media-remote)
     (mobile-preferences-read
         "com.apple.mediaremote")
-    (allow mach-lookup (with telemetry)
-           (global-name "com.apple.mediaremoted.xpc"))
-)
+    (allow mach-lookup
+        (global-name "com.apple.mediaremoted.xpc")))
 
 (define-once (media-capture-support)
     ;; Media capture, microphone access
@@ -171,7 +171,8 @@
 
     ;; Support incoming video connections
     (allow mach-lookup (with telemetry)
-        (global-name "com.apple.coremedia.compressionsession")
+        (global-name "com.apple.coremedia.compressionsession"))
+    (allow mach-lookup
         (global-name "com.apple.coremedia.decompressionsession")
         (global-name "com.apple.coremedia.videoqueue"))
 )
@@ -197,7 +198,7 @@
 ;;; Declare that the application uses the OpenGL, Metal, and CoreML hardware & frameworks.
 ;;;
 (define-once (opengl)
-    (allow iokit-open (with telemetry)
+    (allow iokit-open
            (iokit-connection "IOGPU")
            (iokit-user-client-class
                 "AGXDeviceUserClient"))
@@ -214,7 +215,7 @@
     (allow sysctl-read
         (sysctl-name #"kern.bootsessionuuid"))
 
-    (allow mach-lookup (with telemetry)
+    (allow mach-lookup
        ;; <rdar://problem/47268166>
        (xpc-service-name "com.apple.MTLCompilerService"))
     
@@ -255,7 +256,7 @@
     (deny file-read* file-write*
           (vnode-type BLOCK-DEVICE CHARACTER-DEVICE))
 
-    (allow file-read* file-write-data file-ioctl (with telemetry)
+    (allow file-read* file-write-data file-ioctl
            (literal "/dev/dtracehelper"))
 
     (allow file-read* (with telemetry)
@@ -278,7 +279,7 @@
         (global-name "com.apple.CARenderServer"))
 
     ; UIKit-required IOKit nodes.
-    (allow iokit-open (with telemetry)
+    (allow iokit-open
         (iokit-user-client-class "IOSurfaceAcceleratorClient")
         ;; Requires by UIView -> UITextMagnifierRenderer -> UIWindow
         (iokit-user-client-class "IOSurfaceRootUserClient"))
@@ -358,7 +359,7 @@
             (extension
                 "com.apple.app-sandbox.read-write")
             (allow file-write* (with telemetry))
-            (allow file-issue-extension (with telemetry)
+            (allow file-issue-extension
                    (extension-class "com.apple.app-sandbox.read-write"
                                     "com.apple.mediaserverd.read-write"))))
 
@@ -398,7 +399,7 @@
     (global-name "com.apple.logd")
     (global-name "com.apple.logd.events"))
 
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (global-name "com.apple.tccd"))
 
 (allow mach-lookup
@@ -419,7 +420,7 @@
     (deny ipc-posix-sem-create ipc-posix-sem-post ipc-posix-sem-unlink ipc-posix-sem-wait)
     (allow ipc-posix-sem-open (with telemetry)))
 
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (global-name "com.apple.runningboard")) ;; Needed by process assertion code (ProcessTaskStateObserver).
 
 (allow system-sched (with telemetry)
@@ -438,12 +439,10 @@
 
 ;; ObjC map_images needs to send logging data to syslog. <rdar://problem/39778918>
 (with-filter (system-attribute apple-internal)
-    (allow network-outbound (with telemetry)
-       (literal "/private/var/run/syslog")
-    )
-)
+    (allow network-outbound
+       (literal "/private/var/run/syslog")))
 
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
        (global-name "com.apple.system.notification_center"))
 (allow ipc-posix-shm-read*
        (ipc-posix-name "apple.shm.notification_center"))
@@ -640,10 +639,10 @@
 
 ;; Sandbox extensions
 (define (apply-read-and-issue-extension op path-filter)
-    (op file-read* (with telemetry) path-filter)
+    (op file-read* path-filter)
     (op file-issue-extension (require-all (extension-class "com.apple.app-sandbox.read") path-filter)))
 (define (apply-write-and-issue-extension op path-filter)
-    (op file-write* (with telemetry) path-filter)
+    (op file-write* path-filter)
     (op file-issue-extension (require-all (extension-class "com.apple.app-sandbox.read-write") path-filter)))
 (define (read-only-and-issue-extensions path-filter)
     (apply-read-and-issue-extension allow path-filter))
@@ -696,27 +695,23 @@
     (xpc-service-name "com.apple.audio.toolbox.reporting.service")
 )
 
-(deny mach-lookup (with no-log) (with telemetry)
+(deny mach-lookup (with no-log)
     (global-name "com.apple.audio.AudioComponentRegistrar"))
 
-(deny mach-lookup (with telemetry)
+(deny mach-lookup
     (xpc-service-name "com.apple.iconservices")
     (global-name
         "com.apple.PowerManagement.control"
         "com.apple.iconservices"
-        "com.apple.frontboard.systemappservices"
-    )
-)
+        "com.apple.frontboard.systemappservices"))
 
-(allow mach-lookup (with telemetry)
-    (global-name "com.apple.systemstatus.activityattribution")
-)
+(allow mach-lookup
+    (global-name "com.apple.systemstatus.activityattribution"))
 
 (media-capture-support)
 
-(allow mach-lookup (with telemetry)
-  (global-name "com.apple.audio.AudioQueueServer")
-)
+(allow mach-lookup
+    (global-name "com.apple.audio.AudioQueueServer"))
 
 ;; These services have been identified as unused during living-on.
 ;; This list overrides some definitions above and in common.sb.


### PR DESCRIPTION
#### 10521e725cec28f85fab81e8bc969cc55c58b605
<pre>
[iOS][GPU] Remove more sandbox telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=242461">https://bugs.webkit.org/show_bug.cgi?id=242461</a>
&lt;rdar://problem/96464281&gt;

Reviewed by Chris Dumez.

Remove sandbox telemetry in GPUP on iOS for rules that are known to be hit.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/252272@main">https://commits.webkit.org/252272@main</a>
</pre>
