### PR TITLE
[ews-app] Make retrypatch url work with git hash

### DIFF
--- a/Tools/CISupport/ews-app/ews/views/retrypatch.py
+++ b/Tools/CISupport/ews-app/ews/views/retrypatch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ class RetryPatch(View):
     def post(self, request):
         try:
             patch_id = request.POST.get('patch_id')
-            patch_id = int(patch_id)
         except (ValueError, TypeError) as e:
             return HttpResponse('Invalid patch id')
 


### PR DESCRIPTION
#### c2bb21703486b080a6a27308c7ec9dc0df7fb620
<pre>
[ews-app] Make retrypatch url work with git hash
<a href="https://bugs.webkit.org/show_bug.cgi?id=242463">https://bugs.webkit.org/show_bug.cgi?id=242463</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-app/ews/views/retrypatch.py:
(RetryPatch.post):

Canonical link: <a href="https://commits.webkit.org/252236@main">https://commits.webkit.org/252236@main</a>
</pre>
