### PR TITLE
[macOS][GPUP] Address audio related sandbox violations

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -145,6 +145,7 @@
 (deny process-info*)
 (allow process-info-dirtycontrol (target self))
 (allow process-info-pidinfo)
+(allow process-info-rusage (target self))
 (allow process-info-setcontrol (target self))
 (allow process-codesigning-status*)
 
@@ -648,6 +649,9 @@
 (allow mach-lookup
     (global-name "com.apple.audio.AudioComponentRegistrar"))
 #endif
+
+(deny mach-lookup (with no-log)
+    (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
 
 #if !ENABLE(CFPREFS_DIRECT_MODE)
 (allow mach-lookup (with telemetry)


### PR DESCRIPTION
#### 63a2f9b05dc295999e4298319081441bb6f30cb9
<pre>
[macOS][GPUP] Address audio related sandbox violations
<a href="https://bugs.webkit.org/show_bug.cgi?id=242464">https://bugs.webkit.org/show_bug.cgi?id=242464</a>
&lt;rdar://96300319&gt;

Reviewed by Chris Dumez.

Address audio related sandbox violations in GPUP on macOS. This patch allows access to process-info-rusage for target
self, since we already allow that on iOS.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252271@main">https://commits.webkit.org/252271@main</a>
</pre>
