### PR TITLE
Fix some typos in comments.

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -679,7 +679,7 @@ public:
         
         m_preOrder = m_graph.blocksInPreOrder();
         
-        // First figure out what gets clobbered by blocks. Node that this uses the preOrder list
+        // First figure out what gets clobbered by blocks. Note that this uses the preOrder list
         // for convenience only.
         for (unsigned i = m_preOrder.size(); i--;) {
             m_block = m_preOrder[i];
@@ -689,7 +689,7 @@ public:
         }
         
         // Based on my experience doing this before, what follows might have to be made iterative.
-        // Right now it doesn't have to be iterative because everything is dominator-bsed. But when
+        // Right now it doesn't have to be iterative because everything is dominator-based. But when
         // validation is enabled, we check if iterating would find new CSE opportunities.
 
         bool changed = iterate();

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -137,7 +137,7 @@
 # You can assume that ft1-ft5 or fa1-fa3 are never fr, and that ftX is never
 # faY if X != Y.
 
-# Do not put any code after this.
+# Do not put any code before this.
 global _llintPCRangeStart
 _llintPCRangeStart:
     # This break instruction is needed so that the synthesized llintPCRangeStart# label

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
@@ -254,7 +254,7 @@ bool pas_local_allocator_stop(
        before doing the work to stop the local_allocator.
 
        However, if the client thread is already in the process of executing pas_local_allocator_stop,
-       gets the past pas_local_allocator_scavenger_data_is_stopped check , and then, gets suspended by
+       gets past the pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
        the scavenger before setting the is_in_use flag, the scavenger can stop the local_allocator
        after the client already checked and thinks it is not stopped yet. When the client thread
        resumes from suspension, it will be unhappy to find that the local_allocator is already

--- a/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c
@@ -131,7 +131,7 @@ bool pas_local_view_cache_stop(pas_local_view_cache* cache,
        before doing the work to stop the local_view_cache.
 
        However, if the client thread is already in the process of executing pas_local_view_cache_stop,
-       gets the past pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
+       gets past the pas_local_allocator_scavenger_data_is_stopped check, and then, gets suspended by
        the scavenger before setting the is_in_use flag, the scavenger can stop the local_view_cache
        after the client already checked and thinks it is not stopped yet. When the client thread
        resumes from suspension, it will be unhappy to find that the local_view_cache is already


### PR DESCRIPTION
#### 1fe26aa9391f16fa075727a1524ca825f03396ca
<pre>
Fix some typos in comments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242469">https://bugs.webkit.org/show_bug.cgi?id=242469</a>

Unreviewed.

* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator.c:
(pas_local_allocator_stop):
* Source/bmalloc/libpas/src/libpas/pas_local_view_cache.c:
(pas_local_view_cache_stop):

Canonical link: <a href="https://commits.webkit.org/252234@main">https://commits.webkit.org/252234@main</a>
</pre>
