### PR TITLE
[Gardening]: [ MacOS Monterey wk2 Release ] imported/w3c/web-platform-tests/IndexedDB/string-list-ordering.htm is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1722,3 +1722,5 @@ webkit.org/b/242138 imported/w3c/web-platform-tests/css/css-transforms/huge-leng
 webkit.org/b/242212 [ Monterey+ ] media/media-source/media-webm-vorbis-partial.html [ Failure ]
 
 webkit.org/b/227555 http/tests/privateClickMeasurement/attribution-conversion-through-fetch-keepalive.html [ Pass Failure ]
+
+webkit.org/b/242462 [ Monterey Release ] imported/w3c/web-platform-tests/IndexedDB/string-list-ordering.htm [ Pass Crash ]


### PR DESCRIPTION
#### 597c15091ccfa10f9f9f614198a5da73f30501b5
<pre>
[Gardening]: [ MacOS Monterey wk2 Release ] imported/w3c/web-platform-tests/IndexedDB/string-list-ordering.htm is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242462">https://bugs.webkit.org/show_bug.cgi?id=242462</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252240@main">https://commits.webkit.org/252240@main</a>
</pre>
