### PR TITLE
[media-controls] Remove additionalControlScaleFactor() from layout traits

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -202,8 +202,8 @@ class Button extends LayoutItem
 
     _updateImageMetrics()
     {
-        let width = this._imageSource.width * this._scaleFactor * this.layoutTraits.additionalControlScaleFactor();
-        let height = this._imageSource.height * this._scaleFactor * this.layoutTraits.additionalControlScaleFactor();
+        let width = this._imageSource.width * this._scaleFactor;
+        let height = this._imageSource.height * this._scaleFactor;
 
         if (this._iconName.type === "png" || this._iconName.type === "pdf") {
             width /= window.devicePixelRatio;

--- a/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
@@ -102,11 +102,6 @@ class LayoutTraits
     {
         throw "Derived class must implement this function.";
     }
-
-    additionalControlScaleFactor()
-    {
-        return 1;
-    }
 }
 
 LayoutTraits.Mode = {


### PR DESCRIPTION
#### a98667bf0f02f1c2e4bf11809014ae388a233eb4
<pre>
[media-controls] Remove additionalControlScaleFactor() from layout traits
<a href="https://bugs.webkit.org/show_bug.cgi?id=242473">https://bugs.webkit.org/show_bug.cgi?id=242473</a>
&lt;rdar://96619325&gt;

Reviewed by Devin Rousso and Dean Jackson.

* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype._updateImageMetrics):
(Button):
* Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js:
(LayoutTraits.prototype.supportsPiP):
(LayoutTraits):
(LayoutTraits.prototype.additionalControlScaleFactor): Deleted.

Canonical link: <a href="https://commits.webkit.org/252242@main">https://commits.webkit.org/252242@main</a>
</pre>
