### PR TITLE
[WebAuthn] Stop storing last modified time in application tag

### DIFF
--- a/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
@@ -80,9 +80,6 @@ enum class ClientDataType : bool {
 
 constexpr const char LocalAuthenticatorAccessGroup[] = "com.apple.webkit.webauthn";
 
-// User entity extension
-constexpr const char userEntityLastModifiedKey[] = "last_modified";
-
 // Credential serialization
 constexpr const char privateKeyKey[] = "priv";
 constexpr const char keyTypeKey[] = "key_type";

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -347,7 +347,6 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
     userEntityMap[cbor::CBORValue(fido::kEntityIdMapKey)] = cbor::CBORValue(creationOptions.user.id);
     userEntityMap[cbor::CBORValue(fido::kEntityNameMapKey)] = cbor::CBORValue(creationOptions.user.name);
     userEntityMap[cbor::CBORValue(fido::kDisplayNameMapKey)] = cbor::CBORValue(creationOptions.user.displayName);
-    userEntityMap[cbor::CBORValue(userEntityLastModifiedKey)] = cbor::CBORValue((int64_t)WallTime::now().secondsSinceEpoch().value());
     auto userEntity = cbor::CBORWriter::write(cbor::CBORValue(WTFMove(userEntityMap)));
     ASSERT(userEntity);
     auto secAttrApplicationTag = toNSData(*userEntity);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1956,7 +1956,6 @@ TEST(WebAuthenticationPanel, GetAssertionLA)
     EXPECT_EQ([credentialsBefore count], 1lu);
     EXPECT_NOT_NULL([credentialsBefore firstObject]);
     EXPECT_EQ([[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialCreationDateKey]], 0);
-    EXPECT_EQ([[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialLastUsedDateKey]], 0);
     EXPECT_GE([[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:beforeTime.get()], 0);
 
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
@@ -1977,9 +1976,7 @@ TEST(WebAuthenticationPanel, GetAssertionLA)
         EXPECT_NOT_NULL(credentialsAfter);
         EXPECT_EQ([credentialsAfter count], 1lu);
         EXPECT_NOT_NULL([credentialsAfter firstObject]);
-        EXPECT_EQ([[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialCreationDateKey]], 0);
-        EXPECT_LE([[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialLastUsedDateKey]], 0);
-        EXPECT_GE([[credentialsBefore firstObject][_WKLocalAuthenticatorCredentialLastUsedDateKey] compare:beforeTime.get()], 0);
+        EXPECT_GE([[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialLastModificationDateKey] compare:[credentialsAfter firstObject][_WKLocalAuthenticatorCredentialCreationDateKey]], 0);
         cleanUpKeychain("example.com"_s);
 
         EXPECT_NULL(error);


### PR DESCRIPTION
#### 9ca3dbde75bd019376c938e4ea083c2c8010854b
<pre>
[WebAuthn] Stop storing last modified time in application tag
<a href="https://bugs.webkit.org/show_bug.cgi?id=242474">https://bugs.webkit.org/show_bug.cgi?id=242474</a>
rdar://problem/96621199

Reviewed by Brent Fulgham.

Due to internal concerns, this will be handled outside of WebKit.

* Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel setDisplayNameForLocalCredentialWithGroupAndID:credential:displayName:]):
(+[_WKWebAuthenticationPanel setNameForLocalCredentialWithGroupAndID:credential:name:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252303@main">https://commits.webkit.org/252303@main</a>
</pre>
