### PR TITLE
spurious `RELEASE_LOG` when adjusting the size of a `WKWebView`

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2060,14 +2060,14 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         }).get()];
 
         RunLoop::main().dispatchAfter(1_s, [weakSelf = WeakObjCPtr<WKWebView>(self), didInvalidateResizeAssertions] {
-            auto strongSelf = weakSelf.get();
-            WKWEBVIEW_RELEASE_LOG("WKWebview %p next visible content rect update took too long; clearing resize assertions", strongSelf.get());
-            if (!strongSelf)
-                return;
-
             if (*didInvalidateResizeAssertions)
                 return;
 
+            auto strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            WKWEBVIEW_RELEASE_LOG("WKWebView %p next visible content rect update took too long; clearing resize assertions", strongSelf.get());
             [strongSelf _invalidateResizeAssertions];
 
             *didInvalidateResizeAssertions = true;


### PR DESCRIPTION
#### 2ce665843818077b23671c0f26b4f0446bb89b9f
<pre>
spurious `RELEASE_LOG` when adjusting the size of a `WKWebView`
<a href="https://bugs.webkit.org/show_bug.cgi?id=242475">https://bugs.webkit.org/show_bug.cgi?id=242475</a>

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _acquireResizeAssertionForReason:]):

Canonical link: <a href="https://commits.webkit.org/252243@main">https://commits.webkit.org/252243@main</a>
</pre>
