### PR TITLE
REGRESSION (iOS 16): RemoteLayerTreeDrawingAreaProxy::commitLayerTree is more expensive

### DIFF
--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
@@ -41,32 +41,11 @@ class LocalCurrentTraitCollection {
 
 public:
     WEBCORE_EXPORT LocalCurrentTraitCollection(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
-    WEBCORE_EXPORT LocalCurrentTraitCollection(UITraitCollection *);
     WEBCORE_EXPORT ~LocalCurrentTraitCollection();
-
-    bool usingDarkAppearance() const
-    {
-#if HAVE(OS_DARK_MODE_SUPPORT)
-        return m_usingDarkAppearance;
-#else
-        return false;
-#endif
-    }
-
-    bool usingElevatedUserInterfaceLevel() const
-    {
-#if HAVE(OS_DARK_MODE_SUPPORT)
-        return m_usingElevatedUserInterfaceLevel;
-#else
-        return false;
-#endif
-    }
 
 private:
 #if HAVE(OS_DARK_MODE_SUPPORT)
     RetainPtr<UITraitCollection> m_savedTraitCollection;
-    bool m_usingDarkAppearance { false };
-    bool m_usingElevatedUserInterfaceLevel { false };
 #endif
 };
 

--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
@@ -51,30 +51,20 @@ LocalCurrentTraitCollection::LocalCurrentTraitCollection(bool useDarkAppearance,
 {
 #if HAVE(OS_DARK_MODE_SUPPORT)
     m_savedTraitCollection = [PAL::getUITraitCollectionClass() currentTraitCollection];
-    m_usingDarkAppearance = useDarkAppearance;
-    m_usingElevatedUserInterfaceLevel = useElevatedUserInterfaceLevel;
 
-    auto userInterfaceStyleTrait = [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceStyle:m_usingDarkAppearance ? UIUserInterfaceStyleDark : UIUserInterfaceStyleLight];
-    auto backgroundLevelTrait = [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceLevel:m_usingElevatedUserInterfaceLevel ? UIUserInterfaceLevelElevated : UIUserInterfaceLevelBase];
+    auto userInterfaceStyleTrait = [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceStyle:useDarkAppearance ? UIUserInterfaceStyleDark : UIUserInterfaceStyleLight];
+    auto backgroundLevelTrait = [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceLevel:useElevatedUserInterfaceLevel ? UIUserInterfaceLevelElevated : UIUserInterfaceLevelBase];
+
+    // FIXME: <rdar://problem/96607991> `-[UITraitCollection currentTraitCollection]` is not guaranteed
+    // to return a useful set of traits in cases where it has not been explicitly set. Ideally, this
+    // method should also take in a base, full-specified trait collection from the view hierarchy, to be
+    // used when building the new trait collection.
     auto newTraitCollection = adjustedTraitCollection([PAL::getUITraitCollectionClass() traitCollectionWithTraitsFromCollections:@[ m_savedTraitCollection.get(), userInterfaceStyleTrait, backgroundLevelTrait ]]);
 
     [PAL::getUITraitCollectionClass() setCurrentTraitCollection:newTraitCollection];
 #else
     UNUSED_PARAM(useDarkAppearance);
     UNUSED_PARAM(useElevatedUserInterfaceLevel);
-#endif
-}
-
-LocalCurrentTraitCollection::LocalCurrentTraitCollection(UITraitCollection *traitCollection)
-{
-#if HAVE(OS_DARK_MODE_SUPPORT)
-    m_savedTraitCollection = [PAL::getUITraitCollectionClass() currentTraitCollection];
-    m_usingDarkAppearance = traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
-    m_usingElevatedUserInterfaceLevel = traitCollection.userInterfaceLevel == UIUserInterfaceLevelElevated;
-
-    [PAL::getUITraitCollectionClass() setCurrentTraitCollection:traitCollection];
-#else
-    UNUSED_PARAM(traitCollection);
 #endif
 }
 


### PR DESCRIPTION
#### 3a31c6b8c8baeb15d9f50b69df2c813c8e1519c8
<pre>
REGRESSION (iOS 16): RemoteLayerTreeDrawingAreaProxy::commitLayerTree is more expensive
<a href="https://bugs.webkit.org/show_bug.cgi?id=242458">https://bugs.webkit.org/show_bug.cgi?id=242458</a>
rdar://95884521

Reviewed by Tim Horton.

In iOS 16, `-[UITraitCollection currentTraitCollection]` is more expensive when
determining the fallback trait collection, as additional UIScreens are traversed.

`RemoteLayerTreeDrawingAreaProxy::commitLayerTree` results in calls to this method
when updating the scroll view&apos;s background color, via `LocalCurrentTraitCollection`.

While UIKit is working on improving the performance of
`-[UITraitCollection currentTraitCollection]`, we can mitigate the issue in WebKit
by avoiding calls to it entirely.

We now use `-[UITraitCollection performAsTraitCollection]` to temporarily adjust
the trait collection. This method elides calls to `-[UITraitCollection currentTraitCollection]`
in cases where it would compute fallback traits.

From local testing this changes reduces the time spent determining the scroll view
background color from 6.3 μs to 2.6 μs.

* Source/WebCore/platform/ios/LocalCurrentTraitCollection.h:

Removed unused methods and member variables.

(WebCore::LocalCurrentTraitCollection::usingDarkAppearance const): Deleted.
(WebCore::LocalCurrentTraitCollection::usingElevatedUserInterfaceLevel const): Deleted.
(): Deleted.
* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:
(WebCore::LocalCurrentTraitCollection::LocalCurrentTraitCollection):

Using the fallback trait collection in combination with other traits can result
in undefined behavior. In the long term, this method should use a defined trait
collection taken from the view hierarchy.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(scrollViewBackgroundColor):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::contentViewBackgroundColor):

Canonical link: <a href="https://commits.webkit.org/252293@main">https://commits.webkit.org/252293@main</a>
</pre>
