### PR TITLE
[iOS][GPUP] Block unused process-info

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -457,8 +457,8 @@
 
 (allow mach-task-name (with telemetry) (target self))
 
-(allow process-info* (with telemetry))
-(allow process-info-pidinfo (target self))
+(deny process-info*)
+(allow process-info-pidinfo)
 (allow process-info-pidfdinfo (target self))
 (allow process-info-pidfileportinfo (target self))
 (allow process-info-setcontrol (target self))


### PR DESCRIPTION
#### 2995d38ba0b304f686bb20d0fbad6925d9c6db2e
<pre>
[iOS][GPUP] Block unused process-info
<a href="https://bugs.webkit.org/show_bug.cgi?id=242479">https://bugs.webkit.org/show_bug.cgi?id=242479</a>
&lt;rdar://problem/96624880&gt;

Reviewed by Chris Dumez.

Block unused process-info in the GPU process on iOS. This is based on collected telemetry.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/252273@main">https://commits.webkit.org/252273@main</a>
</pre>
