### PR TITLE
[git-webkit] Document checkout pr support

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.4',
+    version='5.2.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 4)
+version = Version(5, 2, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py
@@ -39,7 +39,7 @@ class Checkout(Command):
         parser.add_argument(
             'argument', nargs=1,
             type=str, default=None,
-            help='String representation of a commit or branch to be normalized',
+            help='String representation of a commit, branch or pull request (pr-#) to apply locally',
         )
         parser.add_argument(
             '--remote', dest='remote', type=str, default=None,


### PR DESCRIPTION
#### cf8204d2651edf815d1b9726eb5ddf42c1b2da51
<pre>
[git-webkit] Document checkout pr support
<a href="https://bugs.webkit.org/show_bug.cgi?id=242480">https://bugs.webkit.org/show_bug.cgi?id=242480</a>
&lt;rdar://problem/96625142&gt;

Reviewed by Chris Dumez.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py:
(Checkout.parser): Document that &apos;argument&apos; can be a pull-request.

Canonical link: <a href="https://commits.webkit.org/252246@main">https://commits.webkit.org/252246@main</a>
</pre>
