### PR TITLE
[Cocoa][MSE] Fix potential memory management issues

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -689,7 +689,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer()
     if (!newPixelBuffer)
         return false;
 
-    m_lastPixelBuffer = newPixelBuffer;
+    m_lastPixelBuffer = WTFMove(newPixelBuffer);
 
     if (m_resourceOwner) {
         if (auto surface = CVPixelBufferGetIOSurface(m_lastPixelBuffer.get()))
@@ -808,10 +808,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayerAndDecompressionSes
     if (shouldEnsureLayer()) {
         destroyDecompressionSession();
         ensureLayer();
-    } else {
-        destroyLayer();
-        ensureDecompressionSession();
+        return;
     }
+    destroyLayer();
+    ensureDecompressionSession();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -863,8 +863,9 @@ void SourceBufferPrivateAVFObjC::trackDidChangeSelected(VideoTrackPrivate& track
         m_parser->setShouldProvideMediaDataForTrackID(true, trackID);
 
         if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([this, trackID] {
-                didBecomeReadyForMoreSamples(trackID);
+            m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, trackID] {
+                if (weakThis)
+                    weakThis->didBecomeReadyForMoreSamples(trackID);
             });
         }
     }
@@ -1458,8 +1459,9 @@ void SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples(const AtomS
     auto trackID = parseIntegerAllowingTrailingJunk<uint64_t>(trackIDString).value_or(0);
     if (trackID == m_enabledVideoTrackID) {
         if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([this, trackID] {
-                didBecomeReadyForMoreSamples(trackID);
+            m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, trackID] {
+                if (weakThis)
+                    weakThis->didBecomeReadyForMoreSamples(trackID);
             });
         }
         if (m_displayLayer) {


### PR DESCRIPTION
#### 2319c56b4e437af7742f9e0f16d82f5ab9cfe80e
<pre>
[Cocoa][MSE] Fix potential memory management issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=242478">https://bugs.webkit.org/show_bug.cgi?id=242478</a>

Reviewed by Eric Carlson.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer):
The pixel buffer should be moved instead of copied.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayerAndDecompressionSession):
An early return here vs. if/else is more idomatic.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::trackDidChangeSelected):
(WebCore::SourceBufferPrivateAVFObjC::notifyClientWhenReadyForMoreSamples):
A lifetime check on the caller should be done before using `this`.

Canonical link: <a href="https://commits.webkit.org/252291@main">https://commits.webkit.org/252291@main</a>
</pre>
