### PR TITLE
Restructure AVVideoCaptureSource::setupSession to deal with AVCaptureSession allocation failure

### DIFF
--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#import "Logging.h"
 #import "MediaPermissionUtilities.h"
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/RealtimeMediaSourceCenter.h>
@@ -79,17 +80,23 @@ void GPUConnectionToWebProcess::setTCCIdentity()
 {
 #if !PLATFORM(MACCATALYST)
     auto auditToken = gpuProcess().parentProcessConnection()->getAuditToken();
-    if (!auditToken)
+    if (!auditToken) {
+        RELEASE_LOG_ERROR(WebRTC, "getAuditToken returned null");
         return;
+    }
 
     NSError *error = nil;
     auto bundleProxy = [LSBundleProxy bundleProxyWithAuditToken:*auditToken error:&error];
-    if (error)
+    if (error) {
+        RELEASE_LOG_ERROR(WebRTC, "-[LSBundleProxy bundleProxyWithAuditToken:error:] failed with error %s", [[error localizedDescription] UTF8String]);
         return;
+    }
 
     auto identity = adoptOSObject(tcc_identity_create(TCC_IDENTITY_CODE_BUNDLE_ID, [bundleProxy.bundleIdentifier UTF8String]));
-    if (!identity)
+    if (!identity) {
+        RELEASE_LOG_ERROR(WebRTC, "tcc_identity_create returned null");
         return;
+    }
 
     WebCore::RealtimeMediaSourceCenter::singleton().setIdentity(WTFMove(identity));
 #endif // !PLATFORM(MACCATALYST)


### PR DESCRIPTION
#### b9dc4e5eb87aa63a07bc080c35cd3193ab4d4d98
<pre>
Restructure AVVideoCaptureSource::setupSession to deal with AVCaptureSession allocation failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242482">https://bugs.webkit.org/show_bug.cgi?id=242482</a>
rdar://96626753

Reviewed by Brent Fulgham.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupSession): Replace `#else` with `#endif` so we fallthrough.
Add more failure case logging.

* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setTCCIdentity): Log failures.

Canonical link: <a href="https://commits.webkit.org/252248@main">https://commits.webkit.org/252248@main</a>
</pre>
