### PR TITLE
[Gardening]: [ macOS wk2 ] fast/css/direct-adjacent-style-sharing-3.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2295,3 +2295,5 @@ webkit.org/b/242249 [ BigSur+ ] webanimations/accelerated-animation-after-forwar
 
 # Requires platform support (see rdar://94324932).
 [ BigSur Monterey ] http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
+
+webkit.org/b/242481 fast/css/direct-adjacent-style-sharing-3.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 4cba28f9aa69476186af0ffb4b15919d13d069ae
<pre>
[Gardening]: [ macOS wk2 ] fast/css/direct-adjacent-style-sharing-3.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242481">https://bugs.webkit.org/show_bug.cgi?id=242481</a>

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252245@main">https://commits.webkit.org/252245@main</a>
</pre>
