### PR TITLE
[webkitscmpy] List files changed in commit

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.9',
+    version='5.3.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 9)
+version = Version(5, 3, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -1058,3 +1058,18 @@ class Git(Scm):
         while line:
             yield line.rstrip()
             line = proc.stdout.readline()
+
+    def files_changed(self, argument=None):
+        if not argument:
+            return self.modified()
+        commit = self.find(argument, include_log=False, include_identifier=False)
+        if not commit:
+            raise ValueError("'{}' is not an argument recognized by git".format(argument))
+
+        output = run(
+            [self.executable(), 'show', commit.hash, '--pretty=', '--name-only'],
+            cwd=self.root_path, capture_output=True, encoding='utf-8',
+        )
+        if output.returncode:
+            raise ValueError("'{}' is not an argument recognized by git".format(argument))
+        return output.stdout.rstrip().splitlines()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -579,6 +579,14 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.reset_commit(args[2]),
             ),  mocks.Subprocess.Route(
+                self.executable, 'show', re.compile(r'.+'), '--pretty=', '--name-only',
+                cwd=self.path,
+                # FIXME: All mock commits have the same set of files changed with this implementation
+                completion=mocks.ProcessCompletion(
+                    returncode=0,
+                    stdout='Source/main.cpp\nSource/main.h\n',
+                ),
+            ),  mocks.Subprocess.Route(
                 self.executable,
                 cwd=self.path,
                 completion=mocks.ProcessCompletion(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
@@ -203,6 +203,16 @@ class BitBucket(mocks.Requests):
             return self._tags(url, params or {})
 
         if stripped_url.startswith('{}/rest/api/1.0/{}/commits/'.format(self.hosts[0], self.project)):
+            if stripped_url.endswith('/changes'):
+                # FIXME: All mock commits have the same set of files changed with this implementation
+                return mocks.Response.fromJson(dict(
+                    values=[dict(
+                        path=dict(
+                            components=path.split('/'),
+                            toString=path,
+                        )
+                    ) for path in ('Source/main.cpp', 'Source/main.h')],
+                ))
             commit = self.commit(stripped_url.split('/')[-1])
             if not commit:
                 return mocks.Response.create404(url)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -213,6 +213,8 @@ class GitHub(bmocks.GitHub):
                 'url': 'https://{}/git/commits/{}'.format(self.api_remote, commit.hash),
             }, 'url': 'https://{}/commits/{}'.format(self.api_remote, commit.hash),
             'html_url': 'https://{}/commit/{}'.format(self.remote, commit.hash),
+            # FIXME: All mock commits have the same set of files changed with this implementation
+            'files': [dict(filename=name) for name in ('Source/main.cpp', 'Source/main.h')],
         }, url=url)
 
     def _compare_response(self, url, ref_a, ref_b):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -525,3 +525,16 @@ class BitBucket(Scm):
         if not commit_data:
             raise ValueError("'{}' is not an argument recognized by git".format(argument))
         return self.commit(hash=commit_data['id'], include_log=include_log, include_identifier=include_identifier)
+
+    def files_changed(self, argument=None):
+        if not argument:
+            return self.modified()
+        commit = self.find(argument, include_log=False, include_identifier=False)
+        if not commit:
+            raise ValueError("'{}' is not an argument recognized by git".format(argument))
+
+        return [
+            change.get('path', {}).get('toString')
+            for change in self.request('commits/{}/changes'.format(commit.hash))
+            if change.get('path', {}).get('toString')
+        ]

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -650,3 +650,16 @@ class GitHub(Scm):
         if not commit_data:
             raise ValueError("'{}' is not an argument recognized by git".format(argument))
         return self.commit(hash=commit_data['sha'], include_log=include_log, include_identifier=include_identifier)
+
+    def files_changed(self, argument=None):
+        if not argument:
+            return self.modified()
+        commit = self.find(argument, include_log=False, include_identifier=False)
+        if not commit:
+            raise ValueError("'{}' is not an argument recognized by git".format(argument))
+
+        return [
+            file.get('filename')
+            for file in self.request('commits/{}'.format(commit.hash)).get('files', [])
+            if file.get('filename')
+        ]

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -190,3 +190,6 @@ class ScmBase(object):
             sys.stderr.write(message + '\n')
         else:
             log.log(level, message)
+
+    def files_changed(self, argument=None):
+        raise NotImplementedError()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -551,6 +551,13 @@ CommitDate: {time_c}
 
             self.assertEqual(local.Git(self.path).source_remotes(), ['origin', 'security'])
 
+    def test_files_changed(self):
+        with mocks.local.Git(self.path), OutputCapture():
+            self.assertEqual(
+                local.Git(self.path).files_changed('4@main'),
+                ['Source/main.cpp', 'Source/main.h'],
+            )
+
 
 class TestGitHub(testing.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'
@@ -711,6 +718,13 @@ class TestGitHub(testing.TestCase):
                 [str(commit) for commit in git.commits(begin=dict(argument='a30ce849'), end=dict(argument='branch-b'))],
             )
 
+    def test_files_changed(self):
+        with mocks.remote.GitHub():
+            self.assertEqual(
+                remote.GitHub(self.remote).files_changed('4@main'),
+                ['Source/main.cpp', 'Source/main.h'],
+            )
+
 
 class TestBitBucket(testing.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
@@ -842,3 +856,10 @@ class TestBitBucket(testing.TestCase):
 
     def test_id(self):
         self.assertEqual(remote.BitBucket(self.remote).id, 'webkit')
+
+    def test_files_changed(self):
+        with mocks.remote.BitBucket():
+            self.assertEqual(
+                remote.BitBucket(self.remote).files_changed('4@main'),
+                ['Source/main.cpp', 'Source/main.h'],
+            )


### PR DESCRIPTION
#### dd3875cc54d511a02c75692e9cce79bad970d568
<pre>
[webkitscmpy] List files changed in commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=242485">https://bugs.webkit.org/show_bug.cgi?id=242485</a>
&lt;rdar://problem/96631179&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.files_changed): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub._commit_response): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.files_changed): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.files_changed): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py:
(ScmBase.files_changed): List files changed for commit.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/252606@main">https://commits.webkit.org/252606@main</a>
</pre>
