### PR TITLE
Partial revert of 252235@main which broke the ASAN build

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -82,4 +82,4 @@ TAPI_VERIFY_MODE = Pedantic;
 
 USE_RECURSIVE_SCRIPT_INPUTS_IN_SCRIPT_PHASES = YES;
 
-OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS) -Xlinker -no_inits;
+OTHER_LDFLAGS = $(inherited) $(SOURCE_VERSION_LDFLAGS) -Xlinker -no_warn_inits;


### PR DESCRIPTION
#### 2dcac3cc89d934a0db1a4801f14a689391ebd94c
<pre>
Partial revert of 252235@main which broke the ASAN build
<a href="https://bugs.webkit.org/show_bug.cgi?id=242487">https://bugs.webkit.org/show_bug.cgi?id=242487</a>

Unreviewed.

ASAN uses static initializers.

I&apos;m going to be doing this in a more thorough/correct way in <a href="https://github.com/WebKit/WebKit/pull/2158.">https://github.com/WebKit/WebKit/pull/2158.</a>

* Source/WebGPU/Configurations/WebGPU.xcconfig:

Canonical link: <a href="https://commits.webkit.org/252249@main">https://commits.webkit.org/252249@main</a>
</pre>
