### PR TITLE
[git-webkit] Support bitbucket URLs in -C arguments

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.6',
+    version='5.2.7',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 6)
+version = Version(5, 2, 7)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -60,7 +60,7 @@ class Scm(ScmBase):
         from webkitscmpy import remote
 
         if 'bitbucket' in url or 'stash' in url:
-            match = re.match(r'(?P<protocol>https?)://(?P<host>.+)/(?P<project>.+)/(?P<repo>.+)', url)
+            match = re.match(r'(?P<protocol>https?)://(?P<host>[^/]+)/(projects/)?(?P<project>[^/]+)/(repos/)?(?P<repo>[^/]+)', url)
             url = '{}://{}/projects/{}/repos/{}'.format(
                 match.group('protocol'),
                 match.group('host'),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py
@@ -79,6 +79,29 @@ class TestFind(testing.PathTestCase):
             ))
         self.assertEqual(captured.stdout.getvalue(), '4@trunk | r6 | 6th commit\n')
 
+    def test_basic_github_remote(self):
+        with OutputCapture() as captured, mocks.remote.GitHub():
+            self.assertEqual(0, program.main(
+                args=('-C', 'https://github.example.com/WebKit/WebKit', 'find', 'bae5d1e90999', '-q'),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stdout.getvalue(), '4@main | bae5d1e90999 | 8th commit\n')
+
+    def test_basic_bitbucket_remote(self):
+        with OutputCapture() as captured, mocks.remote.BitBucket():
+            self.assertEqual(0, program.main(
+                args=('-C', 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit', 'find', 'bae5d1e90999', '-q'),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stdout.getvalue(), '4@main | bae5d1e90999 | 8th commit\n')
+
+        with OutputCapture() as captured, mocks.remote.BitBucket():
+            self.assertEqual(0, program.main(
+                args=('-C', 'https://bitbucket.example.com/WEBKIT/webkit', 'find', 'bae5d1e90999', '-q'),
+                path=self.path,
+            ))
+        self.assertEqual(captured.stdout.getvalue(), '4@main | bae5d1e90999 | 8th commit\n')
+
     def test_branch_tilde(self):
         with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True), mocks.local.Svn(), MockTime:
             self.assertEqual(0, program.main(


### PR DESCRIPTION
#### ff14670590272ecccc9caecd9980f23feb55d565
<pre>
[git-webkit] Support bitbucket URLs in -C arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=242488">https://bugs.webkit.org/show_bug.cgi?id=242488</a>
&lt;rdar://problem/96632709&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.from_url): Support bitbucket web URLs.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/find_unittest.py:
(TestFind.test_basic_github_remote):
(TestFind.test_basic_bitbucket_remote):

Canonical link: <a href="https://commits.webkit.org/252282@main">https://commits.webkit.org/252282@main</a>
</pre>
