### PR TITLE
[WebAuthn] Add support for authenticators over CCID

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
+
+PASS PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator.
+PASS PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator with contactless.
+

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html><!-- webkit-test-runner -->
+<title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock ccid authenticator.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script src="./resources/cbor.js"></script>
+<script>
+    // Default mock configuration. Tests need to override if they need different configuration.
+    if (window.internals)
+        internals.setMockWebAuthenticationConfiguration({ ccid: { payloadBase64: [testCcidNoUidBase64, testNfcCtapVersionBase64, testGetInfoResponseApduBase64, testCreationMessageApduBase64] } });
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true /* isNoneAttestation */, ["smart-card"]);
+        });
+    }, "PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator.");
+
+    promise_test(t => {
+        if (window.internals)
+        internals.setMockWebAuthenticationConfiguration({ ccid: { payloadBase64: [testCcidValidUidBase64, testNfcCtapVersionBase64, testGetInfoResponseApduBase64, testCreationMessageApduBase64] } });
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true /* isNoneAttestation */, ["nfc"]);
+        });
+    }, "PublicKeyCredential's [[create]] with minimum options in a mock ccid authenticator with contactless.");
+</script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS PublicKeyCredential's [[get]] with minimum options in a mock ccid authenticator.
+

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
+<title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock nfc authenticator.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script>
+    // Default mock configuration. Tests need to override if they need different configuration.
+    if (window.internals)
+        internals.setMockWebAuthenticationConfiguration({ ccid: { payloadBase64: [testCcidValidUidBase64, testNfcCtapVersionBase64, testGetInfoResponseApduBase64, testAssertionMessageApduBase64] } });
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 100
+            }
+        };
+
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with minimum options in a mock ccid authenticator.");
+</script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -141,6 +141,8 @@ const testAssertionMessageApduBase64 =
     "Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hHMEUCIQCSFTuuBWgB" +
     "4/F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6/6qNs8OutzhP2C" +
     "QoJ1L7Fe64G9uBeQAA==";
+const testCcidNoUidBase64 = "aIE=";
+const testCcidValidUidBase64 = "CH+d1ZAA";
 
 const RESOURCES_DIR = "/WebKit/webauthn/resources/";
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl
@@ -31,5 +31,6 @@
     "ble",
     "internal",
     "cable",
-    "hybrid"
+    "hybrid",
+    "smart-card"
 };

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h
@@ -92,7 +92,9 @@ constexpr auto authenticatorTransportNfc = "nfc"_s;
 constexpr auto authenticatorTransportBle = "ble"_s;
 constexpr auto authenticatorTransportInternal = "internal"_s;
 constexpr auto authenticatorTransportCable = "cable"_s;
+constexpr auto authenticatorTransportSmartCard = "smart-card"_s;
 constexpr auto authenticatorTransportHybrid = "hybrid"_s;
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -102,6 +102,8 @@ static String toString(WebCore::AuthenticatorTransport transport)
         return WebCore::authenticatorTransportCable;
     case WebCore::AuthenticatorTransport::Hybrid:
         return WebCore::authenticatorTransportHybrid;
+    case WebCore::AuthenticatorTransport::SmartCard:
+        return WebCore::authenticatorTransportSmartCard;
     default:
         break;
     }

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -68,6 +68,8 @@ static std::optional<AuthenticatorTransport> convertStringToAuthenticatorTranspo
         return AuthenticatorTransport::Cable;
     if (transport == authenticatorTransportHybrid)
         return AuthenticatorTransport::Hybrid;
+    if (transport == authenticatorTransportSmartCard)
+        return AuthenticatorTransport::SmartCard;
     return std::nullopt;
 }
 

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -75,6 +75,7 @@
     MockLocalConfiguration local;
     MockHidConfiguration hid;
     MockNfcConfiguration nfc;
+    MockCcidConfiguration ccid;
 };
 
 [
@@ -112,4 +113,10 @@
     sequence<DOMString> payloadBase64;
     boolean multipleTags = false;
     boolean multiplePhysicalTags = false;
+};
+
+[
+    Conditional=WEB_AUTHN,
+] dictionary MockCcidConfiguration {
+    sequence<DOMString> payloadBase64;
 };

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -587,6 +587,8 @@ UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
 UIProcess/WebAuthentication/Cocoa/AppAttestInternalSoftLink.mm @no-unify
 UIProcess/WebAuthentication/Cocoa/AuthenticationServicesCoreSoftLink.mm @no-unify
 UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+UIProcess/WebAuthentication/Cocoa/CcidService.mm
 UIProcess/WebAuthentication/Cocoa/HidConnection.mm
 UIProcess/WebAuthentication/Cocoa/HidService.mm
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticationSoftLink.mm @no-unify
@@ -604,6 +606,7 @@ UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
 UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
 UIProcess/WebAuthentication/Mock/MockLocalService.mm
 UIProcess/WebAuthentication/Mock/MockNfcService.mm
+UIProcess/WebAuthentication/Mock/MockCcidService.mm
 
 UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -65,6 +65,8 @@ static AuthenticatorManager::TransportSet collectTransports(const std::optional<
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         addResult = result.add(AuthenticatorTransport::Ble);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
+        addResult = result.add(AuthenticatorTransport::SmartCard);
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
         return result;
     }
 
@@ -79,6 +81,8 @@ static AuthenticatorManager::TransportSet collectTransports(const std::optional<
         addResult = result.add(AuthenticatorTransport::Nfc);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         addResult = result.add(AuthenticatorTransport::Ble);
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
+        addResult = result.add(AuthenticatorTransport::SmartCard);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         return result;
     }
@@ -104,6 +108,8 @@ static AuthenticatorManager::TransportSet collectTransports(const Vector<PublicK
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
         addResult = result.add(AuthenticatorTransport::Ble);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
+        addResult = result.add(AuthenticatorTransport::SmartCard);
+        ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 
     for (auto& allowCredential : allowCredentials) {
@@ -112,6 +118,7 @@ static AuthenticatorManager::TransportSet collectTransports(const Vector<PublicK
             result.add(AuthenticatorTransport::Usb);
             result.add(AuthenticatorTransport::Nfc);
             result.add(AuthenticatorTransport::Ble);
+            result.add(AuthenticatorTransport::SmartCard);
 
             break;
         }
@@ -133,6 +140,7 @@ static AuthenticatorManager::TransportSet collectTransports(const Vector<PublicK
             result.remove(AuthenticatorTransport::Usb);
             result.remove(AuthenticatorTransport::Nfc);
             result.remove(AuthenticatorTransport::Ble);
+            result.remove(AuthenticatorTransport::SmartCard);
         }
 
         if (authenticatorAttachment == AuthenticatorAttachment::CrossPlatform)
@@ -175,7 +183,7 @@ static String getUserName(const std::variant<PublicKeyCredentialCreationOptions,
 
 } // namespace
 
-const size_t AuthenticatorManager::maxTransportNumber = 4;
+const size_t AuthenticatorManager::maxTransportNumber = 5;
 
 AuthenticatorManager::AuthenticatorManager()
     : m_requestTimeOutTimer(RunLoop::main(), this, &AuthenticatorManager::timeOutTimerFired)

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
@@ -28,8 +28,10 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include "CcidService.h"
 #include "HidService.h"
 #include "LocalService.h"
+#include "MockCcidService.h"
 #include "MockHidService.h"
 #include "MockLocalService.h"
 #include "MockNfcService.h"
@@ -47,6 +49,8 @@ UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::create(W
         return makeUniqueRef<HidService>(observer);
     case WebCore::AuthenticatorTransport::Nfc:
         return makeUniqueRef<NfcService>(observer);
+    case WebCore::AuthenticatorTransport::SmartCard:
+        return makeUniqueRef<CcidService>(observer);
     default:
         ASSERT_NOT_REACHED();
         return makeUniqueRef<LocalService>(observer);
@@ -62,6 +66,8 @@ UniqueRef<AuthenticatorTransportService> AuthenticatorTransportService::createMo
         return makeUniqueRef<MockHidService>(observer, configuration);
     case WebCore::AuthenticatorTransport::Nfc:
         return makeUniqueRef<MockNfcService>(observer, configuration);
+    case WebCore::AuthenticatorTransport::SmartCard:
+        return makeUniqueRef<MockCcidService>(observer, configuration);
     default:
         ASSERT_NOT_REACHED();
         return makeUniqueRef<MockLocalService>(observer, configuration);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CcidConnection.h"
+
+#if ENABLE(WEB_AUTHN)
+#import "CcidService.h"
+#import <CryptoTokenKit/TKSmartCard.h>
+#import <WebCore/FidoConstants.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+namespace WebKit {
+using namespace fido;
+
+namespace {
+inline bool compareVersion(NSData *data, const uint8_t version[], size_t versionSize)
+{
+    if (!data)
+        return false;
+    if (data.length != versionSize)
+        return false;
+    return !memcmp(data.bytes, version, versionSize);
+}
+
+} // namespace
+
+Ref<CcidConnection> CcidConnection::create(RetainPtr<TKSmartCard>&& smartCard, CcidService& service)
+{
+    return adoptRef(*new CcidConnection(WTFMove(smartCard), service));
+}
+
+CcidConnection::CcidConnection(RetainPtr<TKSmartCard>&& smartCard, CcidService& service)
+    : m_smartCard(WTFMove(smartCard))
+    , m_service(service)
+    , m_retryTimer(RunLoop::main(), this, &CcidConnection::startPolling)
+{
+    startPolling();
+}
+
+CcidConnection::~CcidConnection()
+{
+    stop();
+}
+
+const uint8_t kGetUidCommand[] = {
+    0xFF, 0xCA, 0x00, 0x00, 0x00
+};
+
+void CcidConnection::detectContactless()
+{
+    [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:kGetUidCommand length:sizeof(kGetUidCommand)]).get() reply:makeBlockPtr([this](NSData * _Nullable versionData, NSError * _Nullable error) {
+        // Only contactless smart cards have uid, check for longer length than apdu status
+        if (versionData && [versionData length] > 2) {
+            callOnMainRunLoop([this] () mutable {
+                m_contactless = true;
+            });
+        }
+    }).get()];
+}
+
+void CcidConnection::trySelectFidoApplet()
+{
+    [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:kCtapNfcAppletSelectionCommand length:sizeof(kCtapNfcAppletSelectionCommand)]).get() reply:makeBlockPtr([this](NSData * _Nullable versionData, NSError * _Nullable error) {
+        if (compareVersion(versionData, kCtapNfcAppletSelectionU2f, sizeof(kCtapNfcAppletSelectionU2f))
+            || compareVersion(versionData, kCtapNfcAppletSelectionCtap, sizeof(kCtapNfcAppletSelectionCtap))) {
+            callOnMainRunLoop([this] () mutable {
+                if (m_service)
+                    m_service->didConnectTag();
+            });
+            return;
+        }
+            [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:kCtapNfcU2fVersionCommand length:sizeof(kCtapNfcU2fVersionCommand)]).get() reply:makeBlockPtr([this](NSData * _Nullable versionData, NSError * _Nullable error) {
+                if (compareVersion(versionData, kCtapNfcAppletSelectionU2f, sizeof(kCtapNfcAppletSelectionU2f))) {
+                    callOnMainRunLoop([this] () mutable {
+                        if (m_service)
+                            m_service->didConnectTag();
+                    });
+                    return;
+                }
+            }).get()];
+    }).get()];
+}
+
+void CcidConnection::transact(Vector<uint8_t>&& data, DataReceivedCallback&& callback) const
+{
+    [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
+        auto response = vectorFromNSData(nsResponse);
+        callOnMainRunLoop([this, response = WTFMove(response), callback = WTFMove(callback)] () mutable {
+            callback(WTFMove(response));
+            (void)this;
+        });
+    }).get()];
+}
+
+
+void CcidConnection::stop() const
+{
+}
+
+// NearField polling is a one shot polling. It halts after tags are detected.
+// Therefore, a restart process is needed to resume polling after error.
+void CcidConnection::restartPolling()
+{
+    m_retryTimer.startOneShot(1_s); // Magic number to give users enough time for reactions.
+}
+
+void CcidConnection::startPolling()
+{
+    [m_smartCard beginSessionWithReply:makeBlockPtr([this] (BOOL success, NSError *error) mutable {
+        detectContactless();
+        trySelectFidoApplet();
+    }).get()];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CcidService.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#import "CcidConnection.h"
+#import "CtapCcidDriver.h"
+#import <CryptoTokenKit/TKSmartCard.h>
+#import <WebCore/AuthenticatorTransport.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RunLoop.h>
+
+@interface _WKSmartCardSlotObserver : NSObject {
+    WeakPtr<WebKit::CcidService> m_service;
+}
+
+- (instancetype)initWithService:(WeakPtr<WebKit::CcidService>&&)service;
+- (void)observeValueForKeyPath:(id)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
+@end
+
+@interface _WKSmartCardSlotStateObserver : NSObject {
+    WeakPtr<WebKit::CcidService> m_service;
+    RetainPtr<TKSmartCardSlot> m_slot;
+}
+
+- (instancetype)initWithService:(WeakPtr<WebKit::CcidService>&&)service slot:(RetainPtr<TKSmartCardSlot>&&)slot;
+- (void)observeValueForKeyPath:(id)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context;
+@end
+
+namespace WebKit {
+
+CcidService::CcidService(Observer& observer)
+    : FidoService(observer)
+    , m_restartTimer(RunLoop::main(), this, &CcidService::platformStartDiscovery)
+{
+}
+
+CcidService::~CcidService()
+{
+}
+
+void CcidService::didConnectTag()
+{
+    auto connection = m_connection;
+    getInfo(WTF::makeUnique<CtapCcidDriver>(connection.releaseNonNull(), m_connection->contactless() ? WebCore::AuthenticatorTransport::Nfc : WebCore::AuthenticatorTransport::SmartCard));
+}
+
+void CcidService::startDiscoveryInternal()
+{
+    platformStartDiscovery();
+}
+
+void CcidService::restartDiscoveryInternal()
+{
+    m_restartTimer.startOneShot(1_s); // Magic number to give users enough time for reactions.
+}
+
+void CcidService::platformStartDiscovery()
+{
+    [[TKSmartCardSlotManager defaultManager] addObserver:[[_WKSmartCardSlotObserver alloc] initWithService:this] forKeyPath:@"slotNames" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:nil];
+}
+
+void CcidService::onValidCard(RetainPtr<TKSmartCard>&& smartCard)
+{
+    m_connection = WebKit::CcidConnection::create(WTFMove(smartCard), *this);
+}
+
+void CcidService::updateSlots(NSArray *slots)
+{
+    HashSet<String> slotsSet;
+    for (NSString *nsName : slots) {
+        auto name = String(nsName);
+        slotsSet.add(name);
+        auto it = m_slotNames.find(name);
+        if (it == m_slotNames.end()) {
+            m_slotNames.add(name);
+            [[TKSmartCardSlotManager defaultManager] getSlotWithName:nsName reply:makeBlockPtr([this](TKSmartCardSlot * _Nullable slot) mutable {
+                [slot addObserver:[[_WKSmartCardSlotStateObserver alloc] initWithService:this slot:WTFMove(slot)] forKeyPath:@"state" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:nil];
+            }).get()];
+        }
+    }
+    HashSet<String> staleSlots;
+    for (const String& slot : m_slotNames) {
+        if (!slotsSet.contains(slot))
+            staleSlots.add(slot);
+    }
+    for (const String& slot : staleSlots)
+        m_slotNames.remove(slot);
+}
+
+} // namespace WebKit
+
+@implementation _WKSmartCardSlotObserver
+- (instancetype)initWithService:(WeakPtr<WebKit::CcidService>&&)service
+{
+    if (!(self = [super init]))
+        return nil;
+
+    m_service = WTFMove(service);
+
+    return self;
+}
+
+- (void)observeValueForKeyPath:(id)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    UNUSED_PARAM(object);
+    UNUSED_PARAM(change);
+    UNUSED_PARAM(context);
+
+    callOnMainRunLoop([service = m_service, change = retainPtr(change)] () mutable {
+        if (!service)
+            return;
+        service->updateSlots(change.get()[NSKeyValueChangeNewKey]);
+    });
+}
+@end
+
+@implementation _WKSmartCardSlotStateObserver
+- (instancetype)initWithService:(WeakPtr<WebKit::CcidService>&&)service slot:(RetainPtr<TKSmartCardSlot>&&)slot
+{
+    if (!(self = [super init]))
+        return nil;
+
+    m_service = WTFMove(service);
+    m_slot = WTFMove(slot);
+
+    return self;
+}
+
+- (void)observeValueForKeyPath:(id)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    UNUSED_PARAM(object);
+    UNUSED_PARAM(change);
+    UNUSED_PARAM(context);
+
+    if (!m_service)
+        return;
+    switch ([change[NSKeyValueChangeNewKey] intValue]) {
+    case TKSmartCardSlotStateMissing:
+        m_slot.clear();
+        return;
+    case TKSmartCardSlotStateValidCard: {
+        auto* smartCard = [object makeSmartCard];
+        callOnMainRunLoop([service = m_service, smartCard = retainPtr(smartCard)] () mutable {
+            if (!service)
+                return;
+            service->onValidCard(WTFMove(smartCard));
+        });
+        break;
+    }
+    default:
+        break;
+    }
+}
+@end
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -163,6 +163,9 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
             case AuthenticatorTransport::Hybrid:
                 transportString = @"hybrid";
                 break;
+            case AuthenticatorTransport::SmartCard:
+                transportString = @"smart-card";
+                break;
             }
 
             if (transportString)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
@@ -56,6 +56,8 @@ void MockAuthenticatorManager::filterTransports(TransportSet& transports) const
         transports.remove(WebCore::AuthenticatorTransport::Nfc);
     if (!m_testConfiguration.local)
         transports.remove(WebCore::AuthenticatorTransport::Internal);
+    if (!m_testConfiguration.ccid)
+        transports.remove(WebCore::AuthenticatorTransport::SmartCard);
     transports.remove(WebCore::AuthenticatorTransport::Ble);
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,42 +27,23 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#include <optional>
-#include <wtf/Forward.h>
+#include "CcidService.h"
+#include <WebCore/MockWebAuthenticationConfiguration.h>
 
-namespace WebCore {
+namespace WebKit {
 
-enum class AuthenticatorTransport {
-    Usb,
-    Nfc,
-    Ble,
-    Internal,
-    Cable,
-    Hybrid,
-    SmartCard
+class MockCcidService final : public CcidService {
+public:
+    MockCcidService(Observer&, const WebCore::MockWebAuthenticationConfiguration&);
+
+    RetainPtr<NSData> nextReply();
+
+private:
+    void platformStartDiscovery() final;
+
+    WebCore::MockWebAuthenticationConfiguration m_configuration;
 };
 
-WEBCORE_EXPORT std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport);
-
-WEBCORE_EXPORT String toString(AuthenticatorTransport);
-
-} // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AuthenticatorTransport> {
-    using values = EnumValues<
-        WebCore::AuthenticatorTransport,
-        WebCore::AuthenticatorTransport::Usb,
-        WebCore::AuthenticatorTransport::Nfc,
-        WebCore::AuthenticatorTransport::Ble,
-        WebCore::AuthenticatorTransport::Internal,
-        WebCore::AuthenticatorTransport::Cable,
-        WebCore::AuthenticatorTransport::Hybrid,
-        WebCore::AuthenticatorTransport::SmartCard
-    >;
-};
-
-} // namespace WTF
+} // namespace WebKit
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MockCcidService.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#import <CryptoTokenKit/TKSmartCard.h>
+#include <wtf/RunLoop.h>
+
+@interface _WKMockTKSmartCard : TKSmartCard
+- (instancetype)initWithService:(WeakPtr<WebKit::MockCcidService>&&)service;
+@end
+
+@implementation _WKMockTKSmartCard {
+    WeakPtr<WebKit::MockCcidService> m_service;
+}
+
+- (instancetype)initWithService:(WeakPtr<WebKit::MockCcidService>&&)service
+{
+    if (!(self = [super init]))
+        return nil;
+
+    m_service = WTFMove(service);
+
+    return self;
+}
+
+- (void)beginSessionWithReply:(void(^)(BOOL success, NSError * error))reply
+{
+    reply(TRUE, nil);
+}
+
+- (void)transmitRequest:(NSData *)request reply:(void(^)(NSData * response, NSError * error))reply
+{
+    reply(m_service->nextReply().get(), nil);
+}
+
+@end
+
+namespace WebKit {
+
+MockCcidService::MockCcidService(Observer& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
+    : CcidService(observer)
+    , m_configuration(configuration)
+{
+}
+
+void MockCcidService::platformStartDiscovery()
+{
+    if (!!m_configuration.ccid) {
+        auto card = adoptNS([[_WKMockTKSmartCard alloc] initWithService:this]);
+        onValidCard(WTFMove(card));
+        return;
+    }
+    LOG_ERROR("No ccid authenticators is available.");
+}
+
+RetainPtr<NSData> MockCcidService::nextReply()
+{
+    if (m_configuration.ccid->payloadBase64.isEmpty())
+        return nil;
+
+    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.ccid->payloadBase64[0] options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    m_configuration.ccid->payloadBase64.remove(0);
+    return result;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CtapCcidDriver.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include <WebCore/ApduCommand.h>
+#include <WebCore/ApduResponse.h>
+#include <wtf/RunLoop.h>
+
+namespace WebKit {
+using namespace apdu;
+using namespace fido;
+
+CtapCcidDriver::CtapCcidDriver(Ref<CcidConnection>&& connection, WebCore::AuthenticatorTransport transport)
+    : CtapDriver(transport)
+    , m_connection(WTFMove(connection))
+{
+}
+
+void CtapCcidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callback)
+{
+    // For CTAP2, commands follow:
+    // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc-command-framing
+    if (protocol() == ProtocolVersion::kCtap) {
+        ApduCommand command;
+        command.setCla(kCtapNfcApduCla);
+        command.setIns(kCtapNfcApduIns);
+        command.setData(WTFMove(data));
+        command.setResponseLength(ApduCommand::kApduMaxResponseLength);
+        auto ncallback = [callback = WTFMove(callback), this](Vector<uint8_t>&& resp) mutable {
+            auto apduResponse = ApduResponse::createFromMessage(resp);
+            if (!apduResponse) {
+                respondAsync(WTFMove(callback), { });
+                return;
+            }
+            if (apduResponse->status() == ApduResponse::Status::SW_INS_NOT_SUPPORTED) {
+                // Return kCtap1ErrInvalidCommand instead of an empty response to signal FidoService to create a U2F authenticator
+                // for the getInfo stage.
+                respondAsync(WTFMove(callback), { static_cast<uint8_t>(CtapDeviceResponseCode::kCtap1ErrInvalidCommand) });
+                return;
+            }
+            if (apduResponse->status() != ApduResponse::Status::SW_NO_ERROR) {
+                respondAsync(WTFMove(callback), { });
+                return;
+            }
+
+            respondAsync(WTFMove(callback), WTFMove(apduResponse->data()));
+            return;
+        };
+        m_connection->transact(command.getEncodedCommand(), WTFMove(ncallback));
+        return;
+    }
+
+    // For U2F, U2fAuthenticator would handle the APDU encoding.
+    // https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-nfc-protocol-v1.2-ps-20170411.html#framing
+    m_connection->transact(WTFMove(data), WTFMove(callback));
+}
+
+void CtapCcidDriver::respondAsync(ResponseCallback&& callback, Vector<uint8_t>&& response) const
+{
+    RunLoop::main().dispatch([callback = WTFMove(callback), response = WTFMove(response)] () mutable {
+        callback(WTFMove(response));
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,42 +27,26 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#include <optional>
-#include <wtf/Forward.h>
+#include "CcidConnection.h"
+#include "CtapDriver.h"
+#include <wtf/UniqueRef.h>
 
-namespace WebCore {
+namespace WebKit {
 
-enum class AuthenticatorTransport {
-    Usb,
-    Nfc,
-    Ble,
-    Internal,
-    Cable,
-    Hybrid,
-    SmartCard
+// The following implements the CTAP NFC protocol:
+// https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#nfc
+class CtapCcidDriver : public CtapDriver {
+public:
+    explicit CtapCcidDriver(Ref<CcidConnection>&&, WebCore::AuthenticatorTransport);
+
+    void transact(Vector<uint8_t>&& data, ResponseCallback&&) final;
+
+private:
+    void respondAsync(ResponseCallback&&, Vector<uint8_t>&& response) const;
+
+    Ref<CcidConnection> m_connection;
 };
 
-WEBCORE_EXPORT std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport);
-
-WEBCORE_EXPORT String toString(AuthenticatorTransport);
-
-} // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::AuthenticatorTransport> {
-    using values = EnumValues<
-        WebCore::AuthenticatorTransport,
-        WebCore::AuthenticatorTransport::Usb,
-        WebCore::AuthenticatorTransport::Nfc,
-        WebCore::AuthenticatorTransport::Ble,
-        WebCore::AuthenticatorTransport::Internal,
-        WebCore::AuthenticatorTransport::Cable,
-        WebCore::AuthenticatorTransport::Hybrid,
-        WebCore::AuthenticatorTransport::SmartCard
-    >;
-};
-
-} // namespace WTF
+} // namespace WebKit
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
@@ -33,6 +33,7 @@
 #import "WKMouseDeviceObserver.h"
 #import "WKStylusDeviceObserver.h"
 #import "WebProcessMessages.h"
+#import "WebProcessPool.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1068,8 +1068,11 @@
 		5252A51927E048740094BEB9 /* VirtualHidConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5252A51727E048740094BEB9 /* VirtualHidConnection.h */; };
 		5252A51A27E048740094BEB9 /* VirtualHidConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5252A51827E048740094BEB9 /* VirtualHidConnection.cpp */; };
 		52688AB427D7CE40003577A2 /* _WKResidentKeyRequirement.h in Headers */ = {isa = PBXBuildFile; fileRef = 52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		526C5722284ADCBC00E08955 /* CtapCcidDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 526C5720284ADCBC00E08955 /* CtapCcidDriver.h */; };
+		526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526C5721284ADCBC00E08955 /* CtapCcidDriver.cpp */; };
 		5272D4C91E735F0900EB4290 /* WKProtectionSpaceNS.h in Headers */ = {isa = PBXBuildFile; fileRef = 5272D4C71E735F0900EB4290 /* WKProtectionSpaceNS.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		528C37C1195CBB1A00D8B9CC /* WKBackForwardListPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9F28101958F478008CAC72 /* WKBackForwardListPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		52A69BEA286CFFAC00893E8F /* CryptoTokenKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A69BE9286CFFAC00893E8F /* CryptoTokenKit.framework */; };
 		52C3C26528651F860005BE6E /* WKBrowsingContextHandlePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52CDC5C42731DA0D00A3E3EB /* VirtualAuthenticatorConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 52CDC5BD2731DA0C00A3E3EB /* VirtualAuthenticatorConfiguration.h */; };
 		52CDC5C52731DA0D00A3E3EB /* VirtualService.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52CDC5BE2731DA0C00A3E3EB /* VirtualService.mm */; };
@@ -4915,8 +4918,17 @@
 		5252A51727E048740094BEB9 /* VirtualHidConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirtualHidConnection.h; sourceTree = "<group>"; };
 		5252A51827E048740094BEB9 /* VirtualHidConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VirtualHidConnection.cpp; sourceTree = "<group>"; };
 		52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = _WKResidentKeyRequirement.h; path = UIProcess/API/Cocoa/_WKResidentKeyRequirement.h; sourceTree = "<group>"; };
+		526C5718284AD09500E08955 /* CcidConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CcidConnection.h; sourceTree = "<group>"; };
+		526C5719284AD09500E08955 /* CcidConnection.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = CcidConnection.mm; sourceTree = "<group>"; };
+		526C571C284AD0C000E08955 /* CcidService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CcidService.h; sourceTree = "<group>"; };
+		526C571D284AD0C000E08955 /* CcidService.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = CcidService.mm; sourceTree = "<group>"; };
+		526C5720284ADCBC00E08955 /* CtapCcidDriver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CtapCcidDriver.h; sourceTree = "<group>"; };
+		526C5721284ADCBC00E08955 /* CtapCcidDriver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CtapCcidDriver.cpp; sourceTree = "<group>"; };
 		5272D4C71E735F0900EB4290 /* WKProtectionSpaceNS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKProtectionSpaceNS.h; path = mac/WKProtectionSpaceNS.h; sourceTree = "<group>"; };
 		5272D4C81E735F0900EB4290 /* WKProtectionSpaceNS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKProtectionSpaceNS.mm; path = mac/WKProtectionSpaceNS.mm; sourceTree = "<group>"; };
+		52A69BE9286CFFAC00893E8F /* CryptoTokenKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoTokenKit.framework; path = System/Library/Frameworks/CryptoTokenKit.framework; sourceTree = SDKROOT; };
+		52C05BA72874996C00D80C59 /* MockCcidService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockCcidService.h; sourceTree = "<group>"; };
+		52C05BA82874996C00D80C59 /* MockCcidService.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MockCcidService.mm; sourceTree = "<group>"; };
 		52C3C26428651F860005BE6E /* WKBrowsingContextHandlePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextHandlePrivate.h; sourceTree = "<group>"; };
 		52CDC5BD2731DA0C00A3E3EB /* VirtualAuthenticatorConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualAuthenticatorConfiguration.h; sourceTree = "<group>"; };
 		52CDC5BE2731DA0C00A3E3EB /* VirtualService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualService.mm; sourceTree = "<group>"; };
@@ -7256,6 +7268,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52A69BEA286CFFAC00893E8F /* CryptoTokenKit.framework in Frameworks */,
 				3766F9EE189A1241003CF19B /* JavaScriptCore.framework in Frameworks */,
 				3766F9F1189A1254003CF19B /* libicucore.dylib in Frameworks */,
 				3766F9EF189A1244003CF19B /* QuartzCore.framework in Frameworks */,
@@ -10489,6 +10502,7 @@
 			isa = PBXGroup;
 			children = (
 				DDAB377528234B2100890546 /* AuthenticationServicesCore.framework */,
+				52A69BE9286CFFAC00893E8F /* CryptoTokenKit.framework */,
 				E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */,
 				E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */,
 				DDE992F4278D06D900F60D26 /* libWebKitAdditions.a */,
@@ -10505,6 +10519,8 @@
 			children = (
 				57597EBC2181848F0037F924 /* CtapAuthenticator.cpp */,
 				57597EBB2181848F0037F924 /* CtapAuthenticator.h */,
+				526C5721284ADCBC00E08955 /* CtapCcidDriver.cpp */,
+				526C5720284ADCBC00E08955 /* CtapCcidDriver.h */,
 				570B73CF230236DD00FAEC53 /* CtapDriver.h */,
 				57597EC021818BE20037F924 /* CtapHidDriver.cpp */,
 				57597EB721811D9A0037F924 /* CtapHidDriver.h */,
@@ -10573,6 +10589,10 @@
 				57FABB112581827C0059DC95 /* AuthenticationServicesCoreSoftLink.mm */,
 				5777398F258037430059348B /* AuthenticatorPresenterCoordinator.h */,
 				57773990258037430059348B /* AuthenticatorPresenterCoordinator.mm */,
+				526C5718284AD09500E08955 /* CcidConnection.h */,
+				526C5719284AD09500E08955 /* CcidConnection.mm */,
+				526C571C284AD0C000E08955 /* CcidService.h */,
+				526C571D284AD0C000E08955 /* CcidService.mm */,
 				57AC8F4E217FEED90055438C /* HidConnection.h */,
 				57AC8F4F217FEED90055438C /* HidConnection.mm */,
 				5772F204217DBD6A0056BF2C /* HidService.h */,
@@ -10607,6 +10627,8 @@
 			children = (
 				57DCEDCD214F51680016B847 /* MockAuthenticatorManager.cpp */,
 				57DCEDC9214F4E420016B847 /* MockAuthenticatorManager.h */,
+				52C05BA72874996C00D80C59 /* MockCcidService.h */,
+				52C05BA82874996C00D80C59 /* MockCcidService.mm */,
 				5756DD77218D14A200D4EE6A /* MockHidConnection.cpp */,
 				5756DD76218D14A200D4EE6A /* MockHidConnection.h */,
 				5756DD75218D104900D4EE6A /* MockHidService.cpp */,
@@ -13931,6 +13953,7 @@
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,
 				B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */,
 				57597EBD218184900037F924 /* CtapAuthenticator.h in Headers */,
+				526C5722284ADCBC00E08955 /* CtapCcidDriver.h in Headers */,
 				57597EB921811D9A0037F924 /* CtapHidDriver.h in Headers */,
 				570DAACA230385FD00E8FC04 /* CtapNfcDriver.h in Headers */,
 				5C1579EF27172A8B00ED5280 /* DaemonDecoder.h in Headers */,
@@ -16718,6 +16741,7 @@
 				517CF0E3163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp in Sources */,
 				BCE579A72634836700F5C5E9 /* CGDisplayListImageBufferBackend.cpp in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
+				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,
 				2D0C56FE229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm in Sources */,
 				1AB7D6191288B9D900CFD08C /* DownloadProxyMessageReceiver.cpp in Sources */,
 				1A64229912DD029200CAAE2C /* DrawingAreaMessageReceiver.cpp in Sources */,


### PR DESCRIPTION
#### c0f5fc64aac387a18a1ec9f54e013847964b4067
<pre>
[WebAuthn] Add support for authenticators over CCID
<a href="https://bugs.webkit.org/show_bug.cgi?id=242365">https://bugs.webkit.org/show_bug.cgi?id=242365</a>
rdar://82529212

Reviewed by Brent Fulgham.

This patch adds support for authenticators over CCID. This allows use of credentials
on smart cards. The transport used is determined by how the card responds to the
&quot;Get Data Command,&quot; which returns a uid with contactless cards.

Added layout tests and tested manually with a smart card (contact and contactless), as well
as a Yubikey 5c over NFC.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https-expected.txt: Added.
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html: Added.
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https-expected.txt: Added.
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html: Added.
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/AuthenticatorTransport.h:
* Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl:
* Source/WebCore/Modules/webauthn/WebAuthenticationConstants.h:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::toString):
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::convertStringToAuthenticatorTransport):
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
(WebCore::MockWebAuthenticationConfiguration::CcidConfiguration::encode const):
(WebCore::MockWebAuthenticationConfiguration::CcidConfiguration::decode):
(WebCore::MockWebAuthenticationConfiguration::encode const):
(WebCore::MockWebAuthenticationConfiguration::decode):
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::WebCore::collectTransports):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.cpp:
(WebKit::AuthenticatorTransportService::create):
(WebKit::AuthenticatorTransportService::createMock):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h: Copied from Source/WebCore/Modules/webauthn/AuthenticatorTransport.h.
(WebKit::CcidConnection::contactless const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm: Added.
(WebKit::fido::compareVersion):
(WebKit::CcidConnection::create):
(WebKit::CcidConnection::CcidConnection):
(WebKit::CcidConnection::~CcidConnection):
(WebKit::CcidConnection::detectContactless):
(WebKit::CcidConnection::trySelectFidoApplet):
(WebKit::CcidConnection::transact const):
(WebKit::CcidConnection::stop const):
(WebKit::CcidConnection::restartPolling):
(WebKit::CcidConnection::startPolling):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h: Copied from Source/WebCore/Modules/webauthn/AuthenticatorTransport.h.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm: Added.
(WebKit::CcidService::CcidService):
(WebKit::CcidService::~CcidService):
(WebKit::CcidService::didConnectTag):
(WebKit::CcidService::startDiscoveryInternal):
(WebKit::CcidService::restartDiscoveryInternal):
(WebKit::CcidService::platformStartDiscovery):
(WebKit::CcidService::onValidCard):
(WebKit::CcidService::updateSlots):
(-[_WKSmartCardSlotObserver initWithService:]):
(-[_WKSmartCardSlotObserver observeValueForKeyPath:ofObject:change:context:]):
(-[_WKSmartCardSlotStateObserver initWithService:slot:]):
(-[_WKSmartCardSlotStateObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toASCDescriptor):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp:
(WebKit::MockAuthenticatorManager::filterTransports const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h: Copied from Source/WebCore/Modules/webauthn/AuthenticatorTransport.idl.
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm: Added.
(-[_WKMockTKSmartCard initWithService:]):
(-[_WKMockTKSmartCard beginSessionWithReply:]):
(-[_WKMockTKSmartCard transmitRequest:reply:]):
(WebKit::MockCcidService::MockCcidService):
(WebKit::MockCcidService::platformStartDiscovery):
(WebKit::MockCcidService::nextReply):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp: Added.
(WebKit::CtapCcidDriver::CtapCcidDriver):
(WebKit::CtapCcidDriver::transact):
(WebKit::CtapCcidDriver::respondAsync const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h: Copied from Source/WebCore/Modules/webauthn/AuthenticatorTransport.h.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/252425@main">https://commits.webkit.org/252425@main</a>
</pre>
