### PR TITLE
[iOS] Image context menu presentation should only be gated on text recognition results

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
@@ -272,7 +272,7 @@ static void addToReadingList(NSURL *targetURL, NSString *title)
     }
 }
 
-static UIActionIdentifier elementActionTypeToUIActionIdentifier(_WKElementActionType actionType)
+UIActionIdentifier elementActionTypeToUIActionIdentifier(_WKElementActionType actionType)
 {
     switch (actionType) {
     case _WKElementActionTypeCustom:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h
@@ -30,6 +30,8 @@
 @class WKActionSheetAssistant;
 @class WKContentView;
 
+UIActionIdentifier elementActionTypeToUIActionIdentifier(_WKElementActionType);
+
 @interface _WKElementAction ()
 
 + (instancetype)_elementActionWithType:(_WKElementActionType)type info:(_WKActivatedElementInfo *)info assistant:(WKActionSheetAssistant *)assistant;

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -551,10 +551,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (elementInfo.type == _WKActivatedElementTypeImage || elementInfo._isImage) {
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-        if ([_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self]) {
-            // FIXME (rdar://88834304): This should be additionally gated on the relevant VisionKit SPI.
+        if ([_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self])
             [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopyCroppedImage info:elementInfo assistant:self]];
-        }
 #endif
 #if ENABLE(IMAGE_ANALYSIS)
         if ([_delegate respondsToSelector:@selector(actionSheetAssistant:shouldIncludeShowTextActionForElement:)] && [_delegate actionSheetAssistant:self shouldIncludeShowTextActionForElement:elementInfo])

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -34,6 +34,7 @@
 #import "GestureRecognizerConsistencyEnforcer.h"
 #import "GestureTypes.h"
 #import "IdentifierTypes.h"
+#import "ImageAnalysisUtilities.h"
 #import "InteractionInformationAtPosition.h"
 #import "PasteboardAccessIntent.h"
 #import "SyntheticEditingCommandType.h"
@@ -261,6 +262,13 @@ enum class ProceedWithTextSelectionInImage : bool {
 
 enum ImageAnalysisRequestIdentifierType { };
 using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIdentifierType>;
+
+struct ImageAnalysisContextMenuActionData {
+    bool hasSelectableText { false };
+    bool hasVisualSearchResults { false };
+    RetainPtr<CGImageRef> copySubjectResult;
+    RetainPtr<UIMenu> machineReadableCodeMenu;
+};
 
 }
 
@@ -522,22 +530,19 @@ using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIden
     std::optional<WebCore::ElementContext> _elementPendingImageAnalysis;
     Vector<BlockPtr<void(WebKit::ProceedWithTextSelectionInImage)>> _actionsToPerformAfterPendingImageAnalysis;
 #if USE(UICONTEXTMENU)
-#if ENABLE(IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
-    RetainPtr<UIMenu> _contextMenuForMachineReadableCode;
-#endif // ENABLE(IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
     BOOL _contextMenuWasTriggeredByImageAnalysisTimeout;
 #endif // USE(UICONTEXTMENU)
     BOOL _isProceedingWithTextSelectionInImage;
-    RetainPtr<id> _imageAnalyzer;
+    RetainPtr<CocoaImageAnalyzer> _imageAnalyzer;
 #if USE(QUICK_LOOK)
     RetainPtr<QLPreviewController> _visualSearchPreviewController;
     RetainPtr<UIImage> _visualSearchPreviewImage;
     RetainPtr<NSURL> _visualSearchPreviewImageURL;
     RetainPtr<NSString> _visualSearchPreviewTitle;
     CGRect _visualSearchPreviewImageBounds;
-    BOOL _hasSelectableTextInImage;
-    BOOL _hasVisualSearchResults;
 #endif // USE(QUICK_LOOK)
+    BOOL _canUpdateVisibleContextMenuWithImageAnalysisActions;
+    std::optional<WebKit::ImageAnalysisContextMenuActionData> _imageAnalysisContextMenuActionData;
 #endif // ENABLE(IMAGE_ANALYSIS)
     uint32_t _fullscreenVideoImageAnalysisRequestIdentifier;
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
@@ -545,7 +550,6 @@ using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIden
     RetainPtr<NSMutableSet<UIButton *>> _imageAnalysisActionButtons;
     WebCore::FloatRect _imageAnalysisInteractionBounds;
     std::optional<WebKit::RemoveBackgroundData> _removeBackgroundData;
-    RetainPtr<CGImageRef> _copySubjectResult;
 #endif
 }
 


### PR DESCRIPTION
#### a8666b738a4541517d50a52afa73d5efc9f85e5b
<pre>
[iOS] Image context menu presentation should only be gated on text recognition results
<a href="https://bugs.webkit.org/show_bug.cgi?id=242490">https://bugs.webkit.org/show_bug.cgi?id=242490</a>
rdar://94488144

Reviewed by Tim Horton and Devin Rousso.

When long pressing images on iOS 15+, context menu presentation is gated behind image analysis
results for two reasons:

1.  If the user long presses text that appears inside of an image element, we perform text selection
    instead of showing a context menu.

2.  If the image doesn&apos;t contain text at the touch location, we still wait for visual search,
    machine-readable code detection and (new in iOS 16) object lifting to finish before showing the
    context menu, in order to determine whether or not we should include &quot;Look Up&quot;, the entire QR
    code submenu, as well as &quot;Copy Subject&quot;.

With the inclusion of &quot;Copy Subject&quot; on iOS 16, this means that it can take an unexpectedly long
time for the context menu to show up when long pressing images. To mitigate this problem, we adjust
our gating logic so that the context menu may appear immediately after step (1), if the user isn&apos;t
long pressing text inside of an image.

As the context menu is showing, we simultaneously run image analysis (visual look up, MRC and object
lifting); if analysis finishes before the context menu has finished presenting, we show the context
menu with all of the image analysis actions up front; otherwise, use `-updateVisibleMenuWithBlock:`
to dynamically insert the new image analysis context menu items, as long as the WebKit client hasn&apos;t
overridden default context menu items.

* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm:
(elementActionTypeToUIActionIdentifier):
* Source/WebKit/UIProcess/API/Cocoa/_WKElementActionInternal.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant defaultActionsForLinkSheet:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Pull out all image-analysis-related context menu data (e.g. whether to include &quot;Show Text&quot; or &quot;Look
Up&quot;) into a separate struct, rather than as separate members. This allows us to more easily
accumulate results as each of the analyses finish, and also makes it easier to entirely reset this
state when beginning or ending context menu presentation.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView hasSelectableTextForImageContextMenu]):
(-[WKContentView hasVisualSearchResultsForImageContextMenu]):
(-[WKContentView copySubjectResultForImageContextMenu]):
(-[WKContentView machineReadableCodeSubMenuForImageContextMenu]):

Add helper methods to consult whether or not each of the image-analysis-related context menu actions
should be available. Use these in place of checking the individual ivars when determining whether or
not we should show these menu items.

(-[WKContentView presentVisualSearchPreviewControllerForImage:imageURL:title:imageBounds:appearanceActions:]):
(-[WKContentView actionSheetAssistant:shouldIncludeShowTextActionForElement:]):
(-[WKContentView actionSheetAssistant:shouldIncludeLookUpImageActionForElement:]):
(-[WKContentView _setUpImageAnalysis]):
(-[WKContentView _tearDownImageAnalysis]):
(-[WKContentView updateImageAnalysisForContextMenuPresentation:]):
(-[WKContentView imageAnalysisGestureDidBegin:]):
(-[WKContentView _completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:]):

This is the bulk of the change; we now call `-_invokeAllActionsToPerformAfterPendingImageAnalysis:`
up front, and accumulate the results in a `ImageAnalysisContextMenuActionData`. When all of the
analysis types have completed, we then set `_imageAnalysisContextMenuActionData` and update the
context menu with the corresponding items if needed.

(-[WKContentView imageAnalysisGestureDidTimeOut:]):
(-[WKContentView actionSheetAssistantShouldIncludeCopySubjectAction:]):
(-[WKContentView actionSheetAssistant:copySubject:sourceMIMEType:]):
(-[WKContentView continueContextMenuInteraction:]):

Unset the `_canUpdateVisibleContextMenuWithImageAnalysisActions` flag, if the WebKit client has
specified its own context menu configuration. Later on, if image analysis completes and this flag is
`NO`, we&apos;ll skip updating the visible menu to contain image analysis actions.

(-[WKContentView contextMenuInteraction:willEndForConfiguration:animator:]):
(-[WKContentView _updateContextMenuForMachineReadableCodeForImageAnalysis:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/252307@main">https://commits.webkit.org/252307@main</a>
</pre>
