### PR TITLE
[JSC] GCIncomingRefSet gets wrong size when array-buffer is transferred

### DIFF
--- a/JSTests/stress/gc-invocation-with-transfer.js
+++ b/JSTests/stress/gc-invocation-with-transfer.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (let i = 0; i < 1e3; i++) {
+    transferArrayBuffer(new Uint8Array(2 ** 21).buffer);
+}
+fullGC();
+shouldBe($vm.heapExtraMemorySize() < (2 ** 20 * 1e3), true);

--- a/Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h
+++ b/Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h
@@ -61,17 +61,17 @@ bool GCIncomingRefCountedSet<T>::addReference(JSCell* cell, T* object)
 template<typename T>
 void GCIncomingRefCountedSet<T>::sweep(VM& vm)
 {
-    for (size_t i = 0; i < m_vector.size(); ++i) {
-        T* object = m_vector[i];
+    m_bytes = 0;
+    m_vector.removeAllMatching([&](T* object) {
         size_t size = object->gcSizeEstimateInBytes();
         ASSERT(object->isDeferred());
         ASSERT(object->numberOfIncomingReferences());
-        if (!object->filterIncomingReferences([&] (JSCell* cell) { return vm.heap.isMarked(cell); }))
-            continue;
-        m_bytes -= size;
-        m_vector[i--] = m_vector.last();
-        m_vector.removeLast();
-    }
+        if (!object->filterIncomingReferences([&] (JSCell* cell) { return vm.heap.isMarked(cell); })) {
+            m_bytes += size;
+            return false;
+        }
+        return true;
+    });
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2200,6 +2200,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionDumpAndResetPasDebugSpectrum);
 static JSC_DECLARE_HOST_FUNCTION(functionMonotonicTimeNow);
 static JSC_DECLARE_HOST_FUNCTION(functionWallTimeNow);
 static JSC_DECLARE_HOST_FUNCTION(functionApproximateTimeNow);
+static JSC_DECLARE_HOST_FUNCTION(functionHeapExtraMemorySize);
 #if ENABLE(JIT)
 static JSC_DECLARE_HOST_FUNCTION(functionJITSizeStatistics);
 static JSC_DECLARE_HOST_FUNCTION(functionDumpJITSizeStatistics);
@@ -3865,6 +3866,12 @@ JSC_DEFINE_HOST_FUNCTION(functionApproximateTimeNow, (JSGlobalObject*, CallFrame
     return JSValue::encode(jsNumber(ApproximateTime::now().secondsSinceEpoch().milliseconds()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionHeapExtraMemorySize, (JSGlobalObject* globalObject, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsNumber(globalObject->vm().heap.extraMemorySize()));
+}
+
 #if ENABLE(JIT)
 JSC_DEFINE_HOST_FUNCTION(functionJITSizeStatistics, (JSGlobalObject* globalObject, CallFrame*))
 {
@@ -4100,6 +4107,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "monotonicTimeNow"_s, functionMonotonicTimeNow, 0);
     addFunction(vm, "wallTimeNow"_s, functionWallTimeNow, 0);
     addFunction(vm, "approximateTimeNow"_s, functionApproximateTimeNow, 0);
+
+    addFunction(vm, "heapExtraMemorySize"_s, functionHeapExtraMemorySize, 0);
 
 #if ENABLE(JIT)
     addFunction(vm, "jitSizeStatistics"_s, functionJITSizeStatistics, 0);


### PR DESCRIPTION
#### 29c071afdfe66761a42da5df37f6ae9180a0785b
<pre>
[JSC] GCIncomingRefSet gets wrong size when array-buffer is transferred
<a href="https://bugs.webkit.org/show_bug.cgi?id=242494">https://bugs.webkit.org/show_bug.cgi?id=242494</a>

Reviewed by Mark Lam.

GCIncomingRefCountedSet is used for tracking ArrayBuffers and their size. This number is used
to drive GC scheduling and threshold to the next GC invocation.
GCIncomingRefCountedSet::sweep is called in GC end phase, and it cleans up already dead references
from GC and adjust m_bytes (Note that this m_bytes can be reduced only in sweep since this needs
to be monotonically increasing until GC end phase to use it as a part of the number for GC invocation request).
In GCIncomingRefCountedSet::sweep, we decrease m_bytes, but it is problematic if ArrayBuffer content
is transferred to different VM. In that case, this object&apos;s gcSizeEstimateInBytes is already reduced compared
to the original gcSizeEstimateInBytes which is added to m_bytes when calling GCIncomingRefCountedSet::addReference.
This confuses the computation of this m_bytes, keeping the number high since decreased value is significantly small,
and makes GC invocation broken.
Since we are scanning all references at sweep anyway, this patch makes it so that we recompute m_bytes by
adding gcSizeEstimateInBytes from live ArrayBuffers.

* JSTests/stress/gc-invocation-with-transfer.js: Added.
(shouldBe):
* Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h:
(JSC::GCIncomingRefCountedSet&lt;T&gt;::sweep):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/252262@main">https://commits.webkit.org/252262@main</a>
</pre>
