### PR TITLE
Add some tests for SVG resource invalidation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5221,6 +5221,9 @@ imported/w3c/web-platform-tests/workers/shared-worker-name-via-options.html [ Du
 # Display list logging is only available in debug
 [ Release ] fast/text/glyph-display-lists [ Skip ]
 
+webkit.org/b/242498 svg/resource-invalidation/filter-resource-invalidation.html [ ImageOnlyFailure ]
+webkit.org/b/242498 svg/resource-invalidation/mask-resource-invalidation.html [ ImageOnlyFailure ]
+
 # Plugins
 # FIXME: Remove these tests.
 plugins/ [ Skip ]

--- a/LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<svg width="450" height="250">
+    <defs>
+        <clipPath id="c1" x="0" y="0" width="100%" height="100%" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c2a" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c2b" clipPathUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.5" y="0.5" width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c3" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c4" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c5" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c6" clipPathUnits="objectBoundingBox">
+            <rect width="175" height="175"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c7" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c8" clipPathUnits="objectBoundingBox">
+            <rect width="1" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" clip-path="url(#c1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" clip-path="url(#c2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" clip-path="url(#c4)" fill="blue"/>
+    <rect id="r5" x="50" y="150" width="75" height="50" clip-path="url(#c5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" clip-path="url(#c6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" clip-path="url(#c7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" clip-path="url(#c8)"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<body onload="run();">
+<svg width="450" height="250">
+    <defs>
+        <clipPath id="c1" x="0" y="0" width="100%" height="100%" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c2a" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c2b" clipPathUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.5" y="0.5" width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c3" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c4" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c5" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c6" clipPathUnits="userSpaceOnUse">
+            <rect width="175" height="175"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c7" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" visibility="hidden"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+        <clipPath id="c8" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+            <rect x="0.75" y="0.75" width="0.25" height="0.25"/>
+        </clipPath>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" clip-path="url(#c2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" clip-path="url(#c3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" clip-path="url(#c4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" clip-path="url(#c5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" clip-path="url(#c6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" clip-path="url(#c7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" clip-path="url(#c8)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("clip-path", "url(#c1)"); // change from no clipPath to some clipPath
+            r2.setAttribute("clip-path", "url(#c2b)"); // change from one clipPath to another
+            r3.removeAttribute("clip-path"); // change from a clipPath to no clipPath
+            r4.setAttribute("fill", "blue"); // change style of clipPath resource client
+            r5.setAttribute("width", "75"); // change layout of clipPath resource client
+            c6.setAttribute("clipPathUnits", "objectBoundingBox"); // change clipPath attribute
+            c7.firstElementChild.setAttribute("visibility", "visible"); // change style of clipPath contents
+            c8.firstElementChild.setAttribute("width", "1"); // change other attribute of clipPath contents
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>

--- a/LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<svg width="450" height="250">
+    <defs>
+        <clipPath id="c1" x="0" y="0" width="100%" height="100%" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c2a" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c2b" clipPathUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c3" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c4" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c5" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c6" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c6" clipPathUnits="objectBoundingBox">
+            <rect width="175" height="175"/>
+        </clipPath>
+        <clipPath id="c7" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c8" clipPathUnits="objectBoundingBox">
+            <rect width="1" height="0.5"/>
+        </clipPath>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" clip-path="url(#c1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" clip-path="url(#c2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" clip-path="url(#c4)" fill="blue"/>
+    <rect id="r5" x="50" y="150" width="75" height="50" clip-path="url(#c5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" clip-path="url(#c6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" clip-path="url(#c7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" clip-path="url(#c8)"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<body onload="run();">
+<svg width="450" height="250">
+    <defs>
+        <clipPath id="c1" x="0" y="0" width="100%" height="100%" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c2a" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c2b" clipPathUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c3" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c4" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c5" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+        <clipPath id="c6" clipPathUnits="userSpaceOnUse">
+            <rect width="175" height="175"/>
+        </clipPath>
+        <clipPath id="c7" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" visibility="hidden"/>
+        </clipPath>
+        <clipPath id="c8" clipPathUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" clip-path="url(#c2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" clip-path="url(#c3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" clip-path="url(#c4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" clip-path="url(#c5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" clip-path="url(#c6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" clip-path="url(#c7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" clip-path="url(#c8)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("clip-path", "url(#c1)"); // change from no clipPath to some clipPath
+            r2.setAttribute("clip-path", "url(#c2b)"); // change from one clipPath to another
+            r3.removeAttribute("clip-path"); // change from a clipPath to no clipPath
+            r4.setAttribute("fill", "blue"); // change style of clipPath resource client
+            r5.setAttribute("width", "75"); // change layout of clipPath resource client
+            c6.setAttribute("clipPathUnits", "objectBoundingBox"); // change clipPath attribute
+            c7.firstElementChild.setAttribute("visibility", "visible"); // change style of clipPath contents
+            c8.firstElementChild.setAttribute("width", "1"); // change other attribute of clipPath contents
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>

--- a/LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<svg width="450" height="350">
+    <defs>
+        <filter id="f1">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f2a">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f2b">
+            <feColorMatrix type="hueRotate" values="240"/>
+        </filter>
+        <filter id="f3">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f4">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f5">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f6" x="50%">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f7">
+            <feFlood flood-color="green"/>
+        </filter>
+        <filter id="f8">
+            <feColorMatrix type="hueRotate" values="240"/>
+        </filter>
+        <filter id="f9a" width="50%"/>
+        <filter id="f9b" xlink:href="#f9a">
+            <feFlood flood-color="blue"/>
+        </filter>
+        <filter id="f10a"/>
+        <filter id="f10b" width="50%"/>
+        <filter id="f10c" xlink:href="#f10b">
+            <feFlood flood-color="blue"/>
+        </filter>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" fill="purple" filter="url(#f1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="purple" filter="url(#f2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" fill="purple"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="red" filter="url(#f4)"/>
+    <rect id="r5" x="50" y="150" width="75" height="50" fill="purple" filter="url(#f5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="purple" filter="url(#f6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="purple" filter="url(#f7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="purple" filter="url(#f8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="purple" filter="url(#f9b)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="purple" filter="url(#f10c)"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<body onload="run();">
+<svg width="450" height="350">
+    <defs>
+        <filter id="f1">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f2a">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f2b">
+            <feColorMatrix type="hueRotate" values="240"/>
+        </filter>
+        <filter id="f3">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f4">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f5">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f6">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f7">
+            <feFlood flood-color="red"/>
+        </filter>
+        <filter id="f8">
+            <feColorMatrix type="hueRotate" values="120"/>
+        </filter>
+        <filter id="f9a"/>
+        <filter id="f9b" xlink:href="#f9a">
+            <feFlood flood-color="blue"/>
+        </filter>
+        <filter id="f10a"/>
+        <filter id="f10b" width="50%"/>
+        <filter id="f10c" xlink:href="#f10a">
+            <feFlood flood-color="blue"/>
+        </filter>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" fill="purple"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="purple" filter="url(#f2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" fill="purple" filter="url(#f3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="purple" filter="url(#f4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" fill="purple" filter="url(#f5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="purple" filter="url(#f6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="purple" filter="url(#f7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="purple" filter="url(#f8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="purple" filter="url(#f9b)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="purple" filter="url(#f10c)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("filter", "url(#f1)"); // change from no filter to some filter
+            r2.setAttribute("filter", "url(#f2b)"); // change from one filter to another
+            r3.removeAttribute("filter"); // change from a filter to no filter
+            r4.setAttribute("fill", "red"); // change style of filter resource client
+            r5.setAttribute("width", "75"); // change layout of filter resource client
+            f6.setAttribute("x", "50%"); // change filter attribute
+            f7.firstElementChild.setAttribute("flood-color", "green"); // change style of filter contents
+            f8.firstElementChild.setAttribute("values", "240"); // change other attribute of filter contents
+            f9a.setAttribute("x", "50%"); // change linked filter resource attribute
+            f10c.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", "#f10b"); // change xlink:href of filter resource
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>

--- a/LayoutTests/svg/resource-invalidation/gradient-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/gradient-resource-invalidation-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ColorFilterEnabled=true ] -->
+<body onload="run();">
+<svg width="450" height="350">
+    <defs>
+        <linearGradient id="g1">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g2a">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g2b">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g3">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g4">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g5">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g6" x2="0.5">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g7">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g8">
+            <stop offset="0.5" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g9">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g10">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g11">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" fill="url(#g1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="url(#g2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="url(#g4)" fill-opacity="0.5"/>
+    <rect id="r5" x="50" y="150" width="75" height="50" fill="url(#g5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="url(#g6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="url(#g7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="url(#g8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="url(#g9)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="url(#g10)"/>
+    <rect id="r11" x="250" y="250" width="50" height="50" fill="url(#g11)" style="-apple-color-filter: grayscale();"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/gradient-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/gradient-resource-invalidation.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ColorFilterEnabled=true ] -->
+<body onload="run();">
+<svg width="450" height="350">
+    <defs>
+        <linearGradient id="g1">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g2a">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g2b">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g3">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g4">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g5">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g6">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g7">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g8">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g9a">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g9b" xlink:href="#g9a"/>
+        <linearGradient id="g10a">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g10b">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+        <linearGradient id="g10c" xlink:href="#g10a"/>
+        <linearGradient id="g11">
+            <stop offset="0" stop-color="blue"/>
+            <stop offset="1" stop-color="yellow"/>
+        </linearGradient>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="url(#g2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" fill="url(#g3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="url(#g4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" fill="url(#g5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="url(#g6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="url(#g7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="url(#g8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="url(#g9b)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="url(#g10c)"/>
+    <rect id="r11" x="250" y="250" width="50" height="50" fill="url(#g11)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("fill", "url(#g1)"); // change from no gradient to some gradient
+            r2.setAttribute("fill", "url(#g2b)"); // change from one gradient to another
+            r3.removeAttribute("fill"); // change from a gradient to no gradient
+            r4.setAttribute("fill-opacity", "0.5"); // change style of gradient resource client
+            r5.setAttribute("width", "75"); // change layout of gradient resource client
+            g6.setAttribute("x2", "0.5"); // change gradient attribute
+            g7.firstElementChild.setAttribute("stop-color", "blue"); // change style of gradient contents
+            g8.firstElementChild.setAttribute("offset", "0.5"); // change other attribute of gradient contents
+            g9a.firstElementChild.setAttribute("stop-color", "blue"); // change style of linked gradient resource contents
+            g10c.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", "#g10b"); // change xlink:href of gradient resource
+            r11.style = "-apple-color-filter: grayscale();"; // change style of gradient resource client
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>

--- a/LayoutTests/svg/resource-invalidation/mask-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/mask-resource-invalidation-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<svg width="400" height="250">
+    <defs>
+        <mask id="m1" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m2a" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m2b" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m3" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m4" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m5" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m6" x="0.5" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m7" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="#808080"/>
+        </mask>
+        <mask id="m8" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect x="0.5" width="0.5" height="0.5" fill="white"/>
+        </mask>
+    </defs>
+    <rect id="r1" x="50" y="50" width="50" height="50" mask="url(#m1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" mask="url(#m2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" mask="url(#m4)" fill="blue"/>
+    <rect id="r5" x="50" y="150" width="50" height="75" mask="url(#m5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" mask="url(#m6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" mask="url(#m7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" mask="url(#m8)"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/mask-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/mask-resource-invalidation.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<body onload="run();">
+<svg width="450" height="250">
+    <defs>
+        <mask id="m1" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m2a" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m2b" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m3" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect x="0.5" y="0.5" width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m4" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m5" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m6" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m7" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+        <mask id="m8" x="0" y="0" width="1" height="1" maskContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.5" fill="white"/>
+        </mask>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" mask="url(#m2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" mask="url(#m3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" mask="url(#m4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" mask="url(#m5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" mask="url(#m6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" mask="url(#m7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" mask="url(#m8)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("mask", "url(#m1)"); // change from no mask to some mask
+            r2.setAttribute("mask", "url(#m2b)"); // change from one mask to another
+            r3.removeAttribute("mask"); // change from a mask to no mask
+            r4.setAttribute("fill", "blue"); // change style of mask resource client
+            r5.setAttribute("height", "75"); // change layout of mask resource client
+            m6.setAttribute("x", "0.5"); // change mask attribute
+            m7.firstElementChild.setAttribute("fill", "#808080"); // change style of mask contents
+            m8.firstElementChild.setAttribute("x", "0.5"); // change layout of mask contents
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>

--- a/LayoutTests/svg/resource-invalidation/pattern-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/pattern-resource-invalidation-expected.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<svg width="450" height="350">
+    <defs>
+        <pattern id="p1" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p2a" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p2b" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p3" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p4" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p5" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p6" x="0" y="0" width="0.25" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p7" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25" fill="blue"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p8" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.5" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p9a" x="0" y="0" width="0.25" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p9b" xlink:href="#p9a">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p10a" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p10b" x="0" y="0" width="0.25" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p10c" xlink:href="#p10b">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50" fill="url(#p1)"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="url(#p2b)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="url(#p4)" fill-opacity="0.5"/>
+    <rect id="r5" x="50" y="150" width="75" height="50" fill="url(#p5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="url(#p6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="url(#p7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="url(#p8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="url(#p9b)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="url(#p10c)"/>
+</svg>

--- a/LayoutTests/svg/resource-invalidation/pattern-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/pattern-resource-invalidation.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<body onload="run();">
+<svg width="450" height="350">
+    <defs>
+        <pattern id="p1" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p2a" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p2b" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p3" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p4" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p5" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p6" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p7" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p8" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p9a" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p9b" xlink:href="#p9a">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+        <pattern id="p10a" x="0" y="0" width="0.5" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p10b" x="0" y="0" width="0.25" height="0.5" patternUnits="objectBoundingBox" patternContentUnits="objectBoundingBox"/>
+        <pattern id="p10c" xlink:href="#p10a">
+            <rect width="0.25" height="0.25"/>
+            <rect x="0.25" y="0.25" width="0.25" height="0.25"/>
+        </pattern>
+    </defs>
+
+    <rect id="r1" x="50" y="50" width="50" height="50"/>
+    <rect id="r2" x="150" y="50" width="50" height="50" fill="url(#p2a)"/>
+    <rect id="r3" x="250" y="50" width="50" height="50" fill="url(#p3)"/>
+    <rect id="r4" x="350" y="50" width="50" height="50" fill="url(#p4)"/>
+    <rect id="r5" x="50" y="150" width="50" height="50" fill="url(#p5)"/>
+    <rect id="r6" x="150" y="150" width="50" height="50" fill="url(#p6)"/>
+    <rect id="r7" x="250" y="150" width="50" height="50" fill="url(#p7)"/>
+    <rect id="r8" x="350" y="150" width="50" height="50" fill="url(#p8)"/>
+    <rect id="r9" x="50" y="250" width="50" height="50" fill="url(#p9b)"/>
+    <rect id="r10" x="150" y="250" width="50" height="50" fill="url(#p10c)"/>
+</svg>
+<script>
+function run() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        requestAnimationFrame(function() {
+            r1.setAttribute("fill", "url(#p1)"); // change from no pattern to some pattern
+            r2.setAttribute("fill", "url(#p2b)"); // change from one pattern to another
+            r3.removeAttribute("fill"); // change from a pattern to no pattern
+            r4.setAttribute("fill-opacity", "0.5"); // change style of pattern resource client
+            r5.setAttribute("width", "75"); // change layout of pattern resource client
+            p6.setAttribute("width", "0.25"); // change pattern attribute
+            p7.firstElementChild.setAttribute("fill", "blue"); // change style of pattern contents
+            p8.firstElementChild.setAttribute("width", "0.5"); // change other attribute of pattern contents
+            p9a.setAttribute("width", "0.25"); // change attribute on linked pattern
+            p10c.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", "#p10b"); // change xlink:href on pattern
+            testRunner.notifyDone();
+        });
+    }
+}
+</script>


### PR DESCRIPTION
#### f22c7781ad7df4488303c83980ae1ae4c5391cfc
<pre>
Add some tests for SVG resource invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242497">https://bugs.webkit.org/show_bug.cgi?id=242497</a>

Reviewed by Nikolas Zimmermann.

The filter and mask tests are currently failing in their second
sub-tests, where the URL reference is changed from one resource to
another, but no update happens.

* LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/clip-path-complex-resource-invalidation.html: Added.
* LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/clip-path-resource-invalidation.html: Added.
* LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html: Added.
* LayoutTests/svg/resource-invalidation/gradient-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/gradient-resource-invalidation.html: Added.
* LayoutTests/svg/resource-invalidation/mask-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/mask-resource-invalidation.html: Added.
* LayoutTests/svg/resource-invalidation/pattern-resource-invalidation-expected.html: Added.
* LayoutTests/svg/resource-invalidation/pattern-resource-invalidation.html: Added.

Canonical link: <a href="https://commits.webkit.org/252476@main">https://commits.webkit.org/252476@main</a>
</pre>
