### PR TITLE
[GPU Process] Under memory pressure WebPage should release its cached shared NativeImages

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -143,18 +143,22 @@ public:
         return remove<WebCore::DecomposedGlyphs>(renderingResourceIdentifier, m_decomposedGlyphsCount);
     }
 
-    void deleteAllFonts()
+    void releaseAllResources()
     {
         checkInvariants();
 
-        if (!m_fontCount)
+        if (!m_nativeImageCount && !m_fontCount && !m_decomposedGlyphsCount)
             return;
 
         m_resources.removeIf([] (const auto& resource) {
-            return std::holds_alternative<Ref<WebCore::Font>>(resource.value);
+            return std::holds_alternative<Ref<WebCore::NativeImage>>(resource.value)
+                || std::holds_alternative<Ref<WebCore::Font>>(resource.value)
+                || std::holds_alternative<Ref<WebCore::DecomposedGlyphs>>(resource.value);
         });
 
+        m_nativeImageCount = 0;
         m_fontCount = 0;
+        m_decomposedGlyphsCount = 0;
 
         checkInvariants();
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -349,20 +349,20 @@ void RemoteRenderingBackend::cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<De
     m_remoteResourceCache.cacheDecomposedGlyphs(WTFMove(decomposedGlyphs), decomposedGlyphsIdentifier);
 }
 
-void RemoteRenderingBackend::deleteAllFonts()
+void RemoteRenderingBackend::releaseAllResources()
 {
     ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.deleteAllFonts();
+    m_remoteResourceCache.releaseAllResources();
 }
 
-void RemoteRenderingBackend::releaseRemoteResource(RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackend::releaseResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
     // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    releaseRemoteResourceWithQualifiedIdentifier({ renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
+    releaseResourceWithQualifiedIdentifier({ renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
 }
 
-void RemoteRenderingBackend::releaseRemoteResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     ASSERT(!RunLoop::isMain());
     {
@@ -370,7 +370,7 @@ void RemoteRenderingBackend::releaseRemoteResourceWithQualifiedIdentifier(Qualif
         if (auto remoteDisplayList = m_remoteDisplayLists.take(renderingResourceIdentifier))
             remoteDisplayList->clearImageBufferReference();
     }
-    auto success = m_remoteResourceCache.releaseRemoteResource(renderingResourceIdentifier);
+    auto success = m_remoteResourceCache.releaseResource(renderingResourceIdentifier);
     MESSAGE_CHECK(success, "Resource is being released before being cached.");
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -119,8 +119,8 @@ private:
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheFont(Ref<WebCore::Font>&&);
-    void deleteAllFonts();
-    void releaseRemoteResource(WebCore::RenderingResourceIdentifier);
+    void releaseAllResources();
+    void releaseResource(WebCore::RenderingResourceIdentifier);
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>&);
     void prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(const Vector<PrepareBackingStoreBuffersOutputData>&)>&&);
@@ -130,7 +130,7 @@ private:
     void getShareableBitmapForImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImageWithQualifiedIdentifier(const ShareableBitmap::Handle&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
-    void releaseRemoteResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
+    void releaseResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
 
     void prepareLayerBuffersForDisplay(const PrepareBackingStoreBuffersInputData&, PrepareBackingStoreBuffersOutputData&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -33,8 +33,8 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheNativeImage(WebKit::ShareableBitmap::Handle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheFont(Ref<WebCore::Font> font) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
-    DeleteAllFonts()
-    ReleaseRemoteResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    ReleaseAllResources()
+    ReleaseResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 
     PrepareBuffersForDisplay(Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodable NotStreamEncodableReply
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -85,12 +85,12 @@ DecomposedGlyphs* RemoteResourceCache::cachedDecomposedGlyphs(QualifiedRendering
     return m_resourceHeap.getDecomposedGlyphs(renderingResourceIdentifier);
 }
 
-void RemoteResourceCache::deleteAllFonts()
+void RemoteResourceCache::releaseAllResources()
 {
-    m_resourceHeap.deleteAllFonts();
+    m_resourceHeap.releaseAllResources();
 }
 
-bool RemoteResourceCache::releaseRemoteResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+bool RemoteResourceCache::releaseResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (m_resourceHeap.removeImageBuffer(renderingResourceIdentifier)
         || m_resourceHeap.removeNativeImage(renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -51,8 +51,8 @@ public:
 
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;
 
-    void deleteAllFonts();
-    bool releaseRemoteResource(QualifiedRenderingResourceIdentifier);
+    void releaseAllResources();
+    bool releaseResource(QualifiedRenderingResourceIdentifier);
 
 private:
     QualifiedResourceHeap m_resourceHeap;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -253,14 +253,14 @@ void RemoteRenderingBackendProxy::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& 
     sendToStream(Messages::RemoteRenderingBackend::CacheDecomposedGlyphs(WTFMove(decomposedGlyphs)));
 }
 
-void RemoteRenderingBackendProxy::deleteAllFonts()
+void RemoteRenderingBackendProxy::releaseAllRemoteResources()
 {
-    sendToStream(Messages::RemoteRenderingBackend::DeleteAllFonts());
+    sendToStream(Messages::RemoteRenderingBackend::ReleaseAllResources());
 }
 
 void RemoteRenderingBackendProxy::releaseRemoteResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    sendToStream(Messages::RemoteRenderingBackend::ReleaseRemoteResource(renderingResourceIdentifier));
+    sendToStream(Messages::RemoteRenderingBackend::ReleaseResource(renderingResourceIdentifier));
 }
 
 auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPrepareBuffersData>& prepareBuffersInput) -> Vector<SwapBuffersResult>

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -92,7 +92,7 @@ public:
     void cacheNativeImage(const ShareableBitmap::Handle&, WebCore::RenderingResourceIdentifier);
     void cacheFont(Ref<WebCore::Font>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
-    void deleteAllFonts();
+    void releaseAllRemoteResources();
     void releaseRemoteResource(WebCore::RenderingResourceIdentifier);
     void markSurfacesVolatile(Vector<WebCore::RenderingResourceIdentifier>&&, CompletionHandler<void(bool madeAllVolatile)>&&);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -154,8 +154,8 @@ void RemoteResourceCacheProxy::releaseNativeImage(RenderingResourceIdentifier re
 
 void RemoteResourceCacheProxy::clearNativeImageMap()
 {
-    for (auto& nativeImageState : m_nativeImages.values())
-        nativeImageState->removeObserver(*this);
+    for (auto& nativeImage : m_nativeImages.values())
+        nativeImage->removeObserver(*this);
     m_nativeImages.clear();
 }
 
@@ -169,12 +169,6 @@ void RemoteResourceCacheProxy::releaseDecomposedGlyphs(RenderingResourceIdentifi
     bool removed = m_decomposedGlyphs.remove(renderingResourceIdentifier);
     RELEASE_ASSERT(removed);
     m_remoteRenderingBackendProxy.releaseRemoteResource(renderingResourceIdentifier);
-}
-
-void RemoteResourceCacheProxy::releaseAllRemoteFonts()
-{
-    for (auto& fontState : m_fonts)
-        m_remoteRenderingBackendProxy.releaseRemoteResource(fontState.key);
 }
 
 void RemoteResourceCacheProxy::clearFontMap()
@@ -246,9 +240,10 @@ void RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed()
 
 void RemoteResourceCacheProxy::releaseMemory()
 {
-    releaseAllRemoteFonts();
+    clearNativeImageMap();
     clearFontMap();
-    m_remoteRenderingBackendProxy.deleteAllFonts();
+    clearDecomposedGlyphsMap();
+    m_remoteRenderingBackendProxy.releaseAllRemoteResources();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -59,7 +59,6 @@ public:
     void finalizeRenderingUpdate();
 
     void remoteResourceCacheWasDestroyed();
-    void releaseAllRemoteFonts();
     void releaseMemory();
     
     unsigned imagesCount() const { return m_nativeImages.size(); }


### PR DESCRIPTION
#### cb94fff59e923cd040a30f1c75bce390e94cfdbd
<pre>
[GPU Process] Under memory pressure WebPage should release its cached shared NativeImages
<a href="https://bugs.webkit.org/show_bug.cgi?id=242499">https://bugs.webkit.org/show_bug.cgi?id=242499</a>
rdar://96656391

Reviewed by Cameron McCormack.

RemoteResourceCacheProxy::releaseMemory() is called under memory pressure to
release its allocated memory. But it does not release the cached shared
NativeImages or the cached shared DecomposedGlyphs.

RemoteResourceCacheProxy should be a good citizen by releasing its NativeImages
and DecomposedGlyphs. WebCore will regenerate them first they are needed.

* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::clearNativeImageMap):
(WebKit::RemoteResourceCacheProxy::releaseAllNativeImages):
(WebKit::RemoteResourceCacheProxy::releaseAllFonts):
(WebKit::RemoteResourceCacheProxy::releaseAllDecomposedGlyphs):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::releaseAllRemoteFonts): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/252285@main">https://commits.webkit.org/252285@main</a>
</pre>
