### PR TITLE
[Linux] Web Inspector: missing memory measurements in memory timeline

### DIFF
--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -312,6 +312,10 @@ void ResourceUsageThread::platformCollectMemoryData(JSC::VM* vm, ResourceUsageDa
     data.categories[MemoryCategory::GCHeap].dirtySize = currentGCHeapCapacity;
     data.categories[MemoryCategory::GCOwned].dirtySize = currentGCOwnedExtra - currentGCOwnedExternal;
     data.categories[MemoryCategory::GCOwned].externalSize = currentGCOwnedExternal;
+    size_t categoriesTotalSize = 0;
+    for (auto& category : data.categories)
+        categoriesTotalSize += category.totalSize();
+    data.categories[MemoryCategory::Other].dirtySize = data.totalDirtySize - categoriesTotalSize;
 
     data.totalExternalSize = currentGCOwnedExternal;
 

--- a/Source/WebInspectorUI/UserInterface/Models/MemoryTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/MemoryTimelineRecord.js
@@ -78,12 +78,16 @@ WI.MemoryTimelineRecord = class MemoryTimelineRecord extends WI.TimelineRecord
             }
         }
 
-        return [
-            {type: WI.MemoryCategory.Type.JavaScript, size: javascriptSize},
-            {type: WI.MemoryCategory.Type.Images, size: imagesSize},
-            {type: WI.MemoryCategory.Type.Layers, size: layersSize},
-            {type: WI.MemoryCategory.Type.Page, size: pageSize},
-        ];
+        let memoryCategories = [];
+        if (javascriptSize)
+            memoryCategories.push({type: WI.MemoryCategory.Type.JavaScript, size: javascriptSize});
+        if (imagesSize)
+            memoryCategories.push({type: WI.MemoryCategory.Type.Images, size: imagesSize});
+        if (layersSize)
+            memoryCategories.push({type: WI.MemoryCategory.Type.Layers, size: layersSize});
+        if (pageSize)
+            memoryCategories.push({type: WI.MemoryCategory.Type.Page, size: pageSize});
+        return memoryCategories;
     }
 
     // Import / Export


### PR DESCRIPTION
#### ec374dbfec091ed210b7534dd447e6e9e5262d1a
<pre>
[Linux] Web Inspector: missing memory measurements in memory timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=242500">https://bugs.webkit.org/show_bug.cgi?id=242500</a>

Reviewed by Adrian Perez de Castro and Patrick Angle.

In linux we don&apos;t show memory information for image, layers and page
categories. I don&apos;t think we can get image and layers, but at least we
can add others category with the memory not in javascript categories. We
can also not show the categories for which the memory is 0, because it&apos;s
confusing.

* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::ResourceUsageThread::platformCollectMemoryData): Set memory
for category other.
* Source/WebInspectorUI/UserInterface/Models/MemoryTimelineRecord.js:
(WI.MemoryTimelineRecord.memoryCategoriesFromProtocol): Do not show
categories for which the memory reported is 0.

Canonical link: <a href="https://commits.webkit.org/252496@main">https://commits.webkit.org/252496@main</a>
</pre>
