### PR TITLE
[Web share] canShare() validation returns incorrect result when sharing valid files but invalid URL

### DIFF
--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt
@@ -3,6 +3,6 @@ PASS canShare() empty and default dictionary
 PASS canShare() url member
 PASS canShare() title member
 PASS canShare() text member
-FAIL canShare() files member assert_false: invalid URL invalidates the share expected false got true
+PASS canShare() files member
 PASS canShare() multiple members
 

--- a/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt
+++ b/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt
@@ -3,6 +3,6 @@ PASS canShare() empty and default dictionary
 PASS canShare() url member
 PASS canShare() title member
 PASS canShare() text member
-FAIL canShare() files member assert_false: invalid URL invalidates the share expected false got true
+PASS canShare() files member
 PASS canShare() multiple members
 

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -137,15 +137,16 @@ bool Navigator::canShare(Document& document, const ShareData& data)
     if (!document.isFullyActive() || !validateWebSharePolicy(document))
         return false;
 
-    bool hasShareableTitleOrText = !data.title.isNull() || !data.text.isNull();
-    bool hasShareableURL = !!shareableURLForShareData(document, data);
 #if ENABLE(FILE_SHARE)
     bool hasShareableFiles = document.settings().webShareFileAPIEnabled() && !data.files.isEmpty();
 #else
     bool hasShareableFiles = false;
 #endif
 
-    return hasShareableTitleOrText || hasShareableURL || hasShareableFiles;
+    if (data.title.isNull() && data.text.isNull() && data.url.isNull() && !hasShareableFiles)
+        return false;
+
+    return data.url.isNull() || shareableURLForShareData(document, data);
 }
 
 void Navigator::share(Document& document, const ShareData& data, Ref<DeferredPromise>&& promise)


### PR DESCRIPTION
#### 44186059d58ae7dfeb5baefbca62a757d7e58fdd
<pre>
[Web share] canShare() validation returns incorrect result when sharing valid files but invalid URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=242502">https://bugs.webkit.org/show_bug.cgi?id=242502</a>

Reviewed by Youenn Fablet.

* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt:
* LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/web-share/canShare.https-expected.txt:
* Source/WebCore/page/Navigator.cpp:
(WebCore::shareableURLForShareData):
(WebCore::Navigator::canShare):

Canonical link: <a href="https://commits.webkit.org/252403@main">https://commits.webkit.org/252403@main</a>
</pre>
