### PR TITLE
WebVTT: Add missing default css style for text and backgound colors.

### DIFF
--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -177,6 +177,70 @@ video::cue {
     background-color: rgba(0, 0, 0, 0.8);
 }
 
+video::cue(.white) {
+    color: rgb(255, 255, 255);
+}
+
+video::cue(.lime) {
+    color: rgb(0, 255, 0);
+}
+
+video::cue(.cyan) {
+    color: rgb(0, 255, 255);
+}
+
+video::cue(.red) {
+    color: rgb(255, 0, 0);
+}
+
+video::cue(.yellow) {
+    color: rgb(255, 255, 0);
+}
+
+video::cue(.magenta) {
+    color: rgb(255, 0, 255);
+}
+
+video::cue(.blue) {
+    color: rgb(0, 0, 255);
+}
+
+video::cue(.black) {
+    color: rgb(0, 0, 0);
+}
+
+video::cue(.bg_white) {
+    background-color: rgb(255, 255, 255);
+}
+
+video::cue(.bg_lime) {
+    background-color: rgb(0, 255, 0);
+}
+
+video::cue(.bg_cyan) {
+    background-color: rgb(0, 255, 255);
+}
+
+video::cue(.bg_red) {
+    background-color: rgb(255, 0, 0);
+}
+
+video::cue(.bg_yellow) {
+    background-color: rgb(255, 255, 0);
+}
+
+video::cue(.bg_magenta) {
+    background-color: rgb(255, 0, 255);
+}
+
+video::cue(.bg_blue) {
+    background-color: rgb(0, 0, 255);
+}
+
+video::cue(.bg_black) {
+    background-color: rgb(0, 0, 0);
+}
+
 video::-webkit-media-text-track-region {
     position: absolute;
     line-height: 5.33vh;


### PR DESCRIPTION
#### df2ca59a2ba44f9edc76105314c544b0933f3365
<pre>
WebVTT: Add missing default css style for text and backgound colors.
<a href="https://bugs.webkit.org/show_bug.cgi?id=238540">https://bugs.webkit.org/show_bug.cgi?id=238540</a>

Base on specification from:
<a href="https://www.w3.org/TR/webvtt1/#default-text-color">https://www.w3.org/TR/webvtt1/#default-text-color</a>
<a href="https://www.w3.org/TR/webvtt1/#default-text-background">https://www.w3.org/TR/webvtt1/#default-text-background</a>

I added new default css classes with proper values for cues.
This change fixes problem with ignored color of subtitles
(and its background) delivered as WebVTT.

Reviewed by Eric Carlson.

* Source/WebCore/css/mediaControls.css:
(video::cue(.white)):
(video::cue(.lime)):
(video::cue(.cyan)):
(video::cue(.red)):
(video::cue(.yellow)):
(video::cue(.magenta)):
(video::cue(.blue)):
(video::cue(.black)):
(video::cue(.bg_white)):
(video::cue(.bg_lime)):
(video::cue(.bg_cyan)):
(video::cue(.bg_red)):
(video::cue(.bg_yellow)):
(video::cue(.bg_magenta)):
(video::cue(.bg_blue)):
(video::cue(.bg_black)):

Canonical link: <a href="https://commits.webkit.org/252464@main">https://commits.webkit.org/252464@main</a>
</pre>
