### PR TITLE
Update rtp_sender RestoreEncodingLayers function

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
@@ -74,7 +74,7 @@ RtpParameters RestoreEncodingLayers(
     const RtpParameters& parameters,
     const std::vector<std::string>& removed_rids,
     const std::vector<RtpEncodingParameters>& all_layers) {
-  RTC_DCHECK_EQ(parameters.encodings.size() + removed_rids.size(),
+  RTC_CHECK_EQ(parameters.encodings.size() + removed_rids.size(),
                 all_layers.size());
   RtpParameters result(parameters);
   result.encodings.clear();


### PR DESCRIPTION
#### 4cfca4164256be24710084f6c5be7fea47451737
<pre>
Update rtp_sender RestoreEncodingLayers function
<a href="https://bugs.webkit.org/show_bug.cgi?id=242506">https://bugs.webkit.org/show_bug.cgi?id=242506</a>
rdar://96590018

Reviewed by Eric Carlson.

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc:

Canonical link: <a href="https://commits.webkit.org/252302@main">https://commits.webkit.org/252302@main</a>
</pre>
