### PR TITLE
[media-controls] allow for the fullscreen and picture-in-picture buttons to not show in fullscreen

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -183,6 +183,18 @@ AllowsAirPlayForMediaPlayback:
     WebCore:
       default: true
 
+AllowsFullscreenButtonsOverrideWithMediaControls:
+  type: bool
+  condition: PLATFORM(IOS_FAMILY)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "HAVE(UIKIT_WEBKIT_INTERNALS)": true
+      default: false
+    WebCore:
+      default: false
+
 AllowsInlineMediaPlayback:
   type: bool
   webKitLegacyPreferenceKey: WebKitMediaPlaybackAllowsInline

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -98,6 +98,7 @@ public:
     virtual double volume() const = 0;
     virtual bool isPictureInPictureSupported() const = 0;
     virtual bool isPictureInPictureActive() const = 0;
+    virtual bool hasControls() const = 0;
 };
 
 class PlaybackSessionModelClient {

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -103,6 +103,7 @@ public:
     double volume() const final;
     bool isPictureInPictureSupported() const final;
     bool isPictureInPictureActive() const final;
+    bool hasControls() const final;
 
 private:
     WEBCORE_EXPORT PlaybackSessionModelMediaElement();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -634,6 +634,11 @@ bool PlaybackSessionModelMediaElement::isPictureInPictureActive() const
     return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
 }
 
+bool PlaybackSessionModelMediaElement::hasControls() const
+{
+    return m_mediaElement ? m_mediaElement->controls() : false;
+}
+
 }
 
 #endif

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -223,6 +223,7 @@ private:
     void failedToEnterPictureInPicture() final;
     void willExitPictureInPicture() final;
     void didExitPictureInPicture() final;
+    bool hasControls() const override;
 
     HashSet<PlaybackSessionModelClient*> m_playbackClients;
     HashSet<VideoFullscreenModelClient*> m_fullscreenClients;
@@ -702,6 +703,11 @@ FloatSize VideoFullscreenControllerContext::videoDimensions() const
 {
     ASSERT(isUIThread());
     return m_fullscreenModel ? m_fullscreenModel->videoDimensions() : FloatSize();
+}
+
+bool VideoFullscreenControllerContext::hasControls() const
+{
+    return false;
 }
 
 #pragma mark - PlaybackSessionModel

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -147,6 +147,7 @@ private:
     double volume() const final { return m_volume; }
     bool isPictureInPictureSupported() const final { return m_pictureInPictureSupported; }
     bool isPictureInPictureActive() const final { return m_pictureInPictureActive; }
+    bool hasControls() const final { return m_hasControls; }
 
     PlaybackSessionManagerProxy* m_manager;
     PlaybackSessionContextIdentifier m_contextId;
@@ -176,6 +177,7 @@ private:
     double m_volume { 0 };
     bool m_pictureInPictureSupported { false };
     bool m_pictureInPictureActive { false };
+    bool m_hasControls { false };
 };
 
 class PlaybackSessionManagerProxy : public RefCounted<PlaybackSessionManagerProxy>, private IPC::MessageReceiver {

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -236,7 +236,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto page = [self._webView _page])
         isPiPEnabled = page->preferences().pictureInPictureAPIEnabled() && page->preferences().allowsPictureInPictureMediaPlayback();
     bool isPiPSupported = playbackSessionModel && playbackSessionModel->isPictureInPictureSupported();
-    [_pipButton setHidden:!isPiPEnabled || !isPiPSupported];
+    bool controlsShouldHideButtons = page->preferences().allowsFullscreenButtonsOverrideWithMediaControls() && playbackSessionModel && playbackSessionModel->hasControls();
+    [_pipButton setHidden:!isPiPEnabled || !isPiPSupported || controlsShouldHideButtons];
+    [_cancelButton setHidden:controlsShouldHideButtons];
 }
 
 - (void)setAnimatingViewAlpha:(CGFloat)alpha


### PR DESCRIPTION
#### 3462d3bc320f7edb964bd4a7ba5d21165c6df5cb
<pre>
[media-controls] allow for the fullscreen and picture-in-picture buttons to not show in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=242507">https://bugs.webkit.org/show_bug.cgi?id=242507</a>
rdar://96618439

Reviewed by NOBODY (OOPS!).

The fullscreen media controls provided by WebKit when the `controls` attribute is set on the
media element may provide their own buttons to exit fullscreen or enter picture-in-picture.
So we need a way for the buttons shown by WKFullScreenViewController to be hidden in this
situation.

We add a new preference to control whether this behavior is enabled and add a new member to
PlaybackSessionModel to indicate whether the `controls` attribute is set.

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::hasControls const):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::hasControls const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController videoControlsManagerDidChange]):
</pre>