### PR TITLE
[git-webkit] Correct bug-reopen on revert

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.5',
+    version='5.2.6',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 5)
+version = Version(5, 2, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -260,11 +260,10 @@ class PullRequest(Command):
 
         log.info('Adding comment for reverted commits...')
         for line in commit.message.split():
-            tracker = Tracker.from_string(line)
-            if tracker:
-                tracker.add_comment('Reverted by {}'.format(pr.url))
-                tracker.set(opened=True)
-                continue
+            issue = Tracker.from_string(line)
+            if issue:
+                issue.open(why='Reverted by {}'.format(pr.url))
+                break
         return 0
 
     @classmethod


### PR DESCRIPTION
#### 19aaed1f34a512cae8fc4651f5a11081cf94ac4d
<pre>
[git-webkit] Correct bug-reopen on revert
<a href="https://bugs.webkit.org/show_bug.cgi?id=242508">https://bugs.webkit.org/show_bug.cgi?id=242508</a>
&lt;rdar://problem/96672520&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.add_comment_to_reverted_commit_bug_tracker): Use issue.open() instead of tracker.set.

Canonical link: <a href="https://commits.webkit.org/252281@main">https://commits.webkit.org/252281@main</a>
</pre>
