### PR TITLE
Set application information for the GPU process in the Network process

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -41,7 +41,7 @@
 "%@ Forced (text track)" = "%@ Forced";
 
 /* visible name of the GPU process. The argument is the application name. */
-"%@ Graphics and Media" = "%@ Graphics and Media";
+"%s Graphics and Media" = "%s Graphics and Media";
 
 /* Metadata text track display name format that includes the language and/or locale (e.g. 'English Metadata'). */
 "%@ Metadata (text track)" = "%@ Metadata";

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -31,7 +31,6 @@
 #import "GPUProcessCreationParameters.h"
 #import "SandboxInitializationParameters.h"
 #import "WKFoundation.h"
-#import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ScreenProperties.h>
 #import <WebCore/WebMAudioUtilitiesCocoa.h>
@@ -62,10 +61,6 @@ void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
 
 void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
-#if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)parameters.uiProcessName];
-    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
-#endif
 }
 
 void GPUProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -382,6 +382,8 @@ public:
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, URL&&, CompletionHandler<void(bool)>&&);
 
+    void setApplicationName(const String& applicationName, audit_token_t);
+    
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -214,4 +214,6 @@ messages -> NetworkProcess LegacyReceiver {
     DeletePushAndNotificationRegistration(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin) -> (String errorMessage)
     GetOriginsWithPushAndNotificationPermissions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
     HasPushSubscriptionForTesting(PAL::SessionID sessionID, URL scopeURL) -> (bool hasSubscription)
+
+    SetApplicationName(String applicationName, audit_token_t auditToken)
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -42,6 +42,7 @@
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/SocketStreamHandleImpl.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
+#import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/FileSystem.h>
@@ -254,6 +255,12 @@ const String& NetworkProcess::uiProcessBundleIdentifier() const
         m_uiProcessBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
 
     return m_uiProcessBundleIdentifier;
+}
+
+void NetworkProcess::setApplicationName(const String& applicationName, audit_token_t auditToken)
+{
+    auto asn = adoptCF(_LSCopyLSASNForAuditToken(kLSDefaultSessionID, auditToken));
+    _LSSetApplicationInformationItem(kLSDefaultSessionID, asn.get(), _kLSDisplayNameKey, applicationName.createCFString().get(), nullptr);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -45,6 +45,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include "WebProcessProxyMessages.h"
+#include <WebCore/LocalizedStrings.h>
 #include <WebCore/LogInitialization.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/RuntimeApplicationChecks.h>
@@ -475,8 +476,13 @@ void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif
 
 #if PLATFORM(COCOA)
-    if (auto networkProcess = NetworkProcessProxy::defaultNetworkProcess())
+    if (auto networkProcess = NetworkProcessProxy::defaultNetworkProcess()) {
         networkProcess->sendXPCEndpointToProcess(*this);
+        String uiProcessName;
+        auto displayName = makeString(WEB_UI_STRING("%s Graphics and Media", "visible name of the GPU process. The argument is the application name."), uiProcessName);
+        auto auditToken = connection()->getAuditToken();
+        networkProcess->send(Messages::NetworkProcess::SetApplicationName(displayName, *auditToken), 0);
+    }
 #endif
 
     beginResponsivenessChecks();


### PR DESCRIPTION
#### d971aaab9fce79a733b14ee6de3db67d9d9d349b
<pre>
Set application information for the GPU process in the Network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242512">https://bugs.webkit.org/show_bug.cgi?id=242512</a>
&lt;rdar://problem/96674540&gt;

Reviewed by NOBODY (OOPS!).

Since the GPU process is not allowed to talk to Launch Services, the application information can be set in the Network process instead.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeProcessName):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::setApplicationName):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didFinishLaunching):
</pre>