### PR TITLE
PROGRESSION (252224@main): [ iOS Debug ][ macOS Debug ] Two TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptions tests are a consistent crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1475,7 +1475,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 
 #endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
 
-TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimun)
+TEST(WebAuthenticationPanel, DISABLED_PublicKeyCredentialCreationOptionsMinimun)
 {
     uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
     NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
@@ -1510,7 +1510,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimun)
     EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
 
-TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
+TEST(WebAuthenticationPanel, DISABLED_PublicKeyCredentialCreationOptionsMaximumDefault)
 {
     uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
     NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];


### PR DESCRIPTION
#### 0832284c78b8eb4538262db4c6a2bb7670273ff4
<pre>
PROGRESSION (252224@main): [ iOS Debug ][ macOS Debug ] Two TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptions tests are a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=242509">https://bugs.webkit.org/show_bug.cgi?id=242509</a>
&lt;rdar://96674140&gt;

Unreviewed, gardening

* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252274@main">https://commits.webkit.org/252274@main</a>
</pre>
