### PR TITLE
Unable to set application information in the GPU process

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -40,9 +40,6 @@
 /* Forced text track display name format that includes the language and/or locale (e.g. 'English Forced'). */
 "%@ Forced (text track)" = "%@ Forced";
 
-/* visible name of the GPU process. The argument is the application name. */
-"%@ Graphics and Media" = "%@ Graphics and Media";
-
 /* Metadata text track display name format that includes the language and/or locale (e.g. 'English Metadata'). */
 "%@ Metadata (text track)" = "%@ Metadata";
 

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -31,7 +31,6 @@
 #import "GPUProcessCreationParameters.h"
 #import "SandboxInitializationParameters.h"
 #import "WKFoundation.h"
-#import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ScreenProperties.h>
 #import <WebCore/WebMAudioUtilitiesCocoa.h>
@@ -62,10 +61,6 @@ void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
 
 void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
-#if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)parameters.uiProcessName];
-    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
-#endif
 }
 
 void GPUProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)


### PR DESCRIPTION
#### e74263bee4a3ffde7708b47d63ab2e2b9b1d39ba
<pre>
Unable to set application information in the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242519">https://bugs.webkit.org/show_bug.cgi?id=242519</a>
&lt;rdar://problem/96678011&gt;

Reviewed by NOBODY (OOPS!).

Setting application information in the GPU process is currently failing, since access to Launch Services is not permitted in the GPU process.
A potential fix for this is to check in with Launch Services while holding a temporary sandbox extension in the GPU process, and then use the
Network process to set the application information on behalf of the GPU process. However, since the GPU process is not an application in the
normal sense, it may not make sense to register with Launch Services, since that will also allow Launch Services to change the priority of
the GPU process. I suggest we remove the code which sets the application information now, since that is blocked by the sandbox. Since the
aforementioned alternative is a more complex change, we can potentially look into that at a later point.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeProcessName):
</pre>