### PR TITLE
[Gardening]: [ iOS15 wk2 Release arm64 ] compositing/reflections/mask-and-reflection.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2220,3 +2220,5 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the
 imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/image-orientation/drawImage-from-element.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html [ ImageOnlyFailure ]
+
+webkit.org/b/242515 [ arm64 ] compositing/reflections/mask-and-reflection.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### e2167a1a28c25a6be3fc68f559d7e660c67800d9
<pre>
[Gardening]: [ iOS15 wk2 Release arm64 ] compositing/reflections/mask-and-reflection.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242515">https://bugs.webkit.org/show_bug.cgi?id=242515</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252278@main">https://commits.webkit.org/252278@main</a>
</pre>
