### PR TITLE
TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptions test gardening

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -650,7 +650,6 @@ static WebCore::PublicKeyCredentialCreationOptions::RpEntity publicKeyCredential
     WebCore::PublicKeyCredentialCreationOptions::RpEntity result;
     result.name = rpEntity.name;
     result.icon = rpEntity.icon;
-    ASSERT(rpEntity.identifier);
     result.id = rpEntity.identifier;
 
     return result;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1475,7 +1475,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 
 #endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
 
-TEST(WebAuthenticationPanel, DISABLED_PublicKeyCredentialCreationOptionsMinimun)
+TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 {
     uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
     NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
@@ -1510,7 +1510,7 @@ TEST(WebAuthenticationPanel, DISABLED_PublicKeyCredentialCreationOptionsMinimun)
     EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
 
-TEST(WebAuthenticationPanel, DISABLED_PublicKeyCredentialCreationOptionsMaximumDefault)
+TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 {
     uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
     NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];


### PR DESCRIPTION
#### e54af3fce340054b8233826636c32d8b506cc6ec
<pre>
TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptions test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=242509">https://bugs.webkit.org/show_bug.cgi?id=242509</a>
rdar://problem/96674140

Unreviewed, gardening

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(publicKeyCredentialRpEntity):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/252280@main">https://commits.webkit.org/252280@main</a>
</pre>
