### PR TITLE
[JSC] JSRemoteFunction's m_nameMayBeNull must be non-rope String

### DIFF
--- a/JSTests/stress/remote-function-should-have-resolved-name-string.js
+++ b/JSTests/stress/remote-function-should-have-resolved-name-string.js
@@ -1,0 +1,3 @@
+let s = new ShadowRealm();
+let z = s.evaluate(`(function foo() {}).bind()`);
+z.toString();

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -221,8 +221,13 @@ void JSRemoteFunction::copyNameAndLength(JSGlobalObject* globalObject)
 
     JSValue targetName = m_targetFunction->get(globalObject, vm.propertyNames->name);
     RETURN_IF_EXCEPTION(scope, void());
-    if (targetName.isString())
-        m_nameMayBeNull.set(vm, this, asString(targetName));
+    if (targetName.isString()) {
+        auto* targetString = asString(targetName);
+        targetString->value(globalObject); // Resolving rope.
+        RETURN_IF_EXCEPTION(scope, void());
+        m_nameMayBeNull.set(vm, this, targetString);
+    }
+    ASSERT(!m_nameMayBeNull || !m_nameMayBeNull->isRope());
 }
 
 void JSRemoteFunction::finishCreation(JSGlobalObject* globalObject, VM& vm)


### PR DESCRIPTION
#### a497adcf6b4b58098d7c9edafa08dcd224acccdc
<pre>
[JSC] JSRemoteFunction&apos;s m_nameMayBeNull must be non-rope String
<a href="https://bugs.webkit.org/show_bug.cgi?id=242521">https://bugs.webkit.org/show_bug.cgi?id=242521</a>
rdar://96666984

Reviewed by Alexey Shvayka.

As the same to JSBoundFunction, JSRemoteFunction&apos;s m_nameMayBeNull must be non-rope String.
We add the assertion used in JSBoundFunction to JSRemoteFunction. And we ensure that we resolve
rope before setting it to JSRemoteFunction&apos;s m_nameMayBeNull.

* JSTests/stress/remote-function-should-have-resolved-name-string.js: Added.
(let.z.s.evaluate.foo):
* Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:
(JSC::JSRemoteFunction::copyNameAndLength):

Canonical link: <a href="https://commits.webkit.org/252288@main">https://commits.webkit.org/252288@main</a>
</pre>
