### PR TITLE
[iPadOS] Google Docs font picker is sometimes dismissed upon first click with trackpad

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10038,7 +10038,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
     if (!_page->hasRunningProcess())
         return;
 
-    auto event = gestureRecognizer.lastMouseEvent;
+    auto event = gestureRecognizer.takeLastMouseEvent;
     if (!event)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.h
@@ -35,7 +35,7 @@
 #endif
 
 - (std::optional<CGPoint>)lastMouseLocation;
-- (WebKit::NativeWebMouseEvent *)lastMouseEvent;
+- (std::unique_ptr<WebKit::NativeWebMouseEvent>)takeLastMouseEvent;
 
 - (UITouch *)mouseTouch;
 

--- a/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm
@@ -90,9 +90,9 @@ static String pointerTypeForUITouchType(UITouchType)
     return touch == _currentTouch && touch._isPointerTouch;
 }
 
-- (WebKit::NativeWebMouseEvent *)lastMouseEvent
+- (std::unique_ptr<WebKit::NativeWebMouseEvent>)takeLastMouseEvent
 {
-    return _lastEvent.get();
+    return std::exchange(_lastEvent, nullptr);
 }
 
 - (std::optional<CGPoint>)lastMouseLocation


### PR DESCRIPTION
#### 0e244717e96a87a202301283de267755faafb192
<pre>
[iPadOS] Google Docs font picker is sometimes dismissed upon first click with trackpad
<a href="https://bugs.webkit.org/show_bug.cgi?id=242520">https://bugs.webkit.org/show_bug.cgi?id=242520</a>
rdar://94527350

Reviewed by Devin Rousso.

When clicking with a trackpad on iPad, we currently dispatch mouse events in the gesture
recognizer&apos;s target action (in this case, `-[WKContentView mouseGestureRecognizerChanged:]`).
However, this action selector is invoked when UIKit routes both `UITouchesEvent` and `UIHoverEvent`
through the application (and the window containing the web view). These events are propagated from
backboard in the form of HID events, and may come in either order when clicking; in the case where
the `UIHoverEvent` precedes the `UITouchesEvent`, we end up with a &quot;mousemove&quot; followed by
&quot;mousedown&quot;. However, in the case where the `UITouchesEvent` precedes `UIHoverEvent`, the last mouse
event (of `MouseDown` type) gets created underneath `-touchesBegan:withEvent:` and is dispatched
twice.

This duplicate &quot;mousedown&quot; event results in Google Docs toggling some of its clickable menus twice
when clicking, which results in these menus opening and immediately closing (or vice versa). To
avoid this, we rename `-lastMouseEvent` to `-takeLastMouseEvent` and adjust it so that it clears out
the `_lastEvent`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView mouseGestureRecognizerChanged:]):
* Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm:
(-[WKMouseGestureRecognizer takeLastMouseEvent]):
(-[WKMouseGestureRecognizer lastMouseEvent]): Deleted.

Canonical link: <a href="https://commits.webkit.org/252290@main">https://commits.webkit.org/252290@main</a>
</pre>
