### PR TITLE
Web Inspector: REGRESSION(251279@main): text editors don't highlight revealed lines

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -1460,7 +1460,7 @@ WI.showLocalResourceOverride = function(localResourceOverride, options = {})
 {
     console.assert(localResourceOverride instanceof WI.LocalResourceOverride);
 
-    let cookie = {};
+    let cookie = {preventHighlight: true};
 
     switch (localResourceOverride.type) {
     case WI.LocalResourceOverride.InterceptType.Response:

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -316,6 +316,7 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
     {
         this.revealPosition(new WI.SourceCodePosition(lineNumber - 1, 0), {
             textRangeToSelect: new WI.TextRange(lineNumber - 1, 0, lineNumber, 0),
+            preventHighlight: true,
         });
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/TextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TextEditor.js
@@ -503,7 +503,7 @@ WI.TextEditor = class TextEditor extends WI.View
         delete this._pendingPositionToReveal;
         delete this._pendingRevealPositionOptions;
 
-        let {textRangeToSelect, scrollOffset, forceUnformatted} = options;
+        let {textRangeToSelect, scrollOffset, forceUnformatted, preventHighlight} = options;
 
         console.assert(!textRangeToSelect || textRangeToSelect instanceof WI.TextRange, textRangeToSelect);
         console.assert(!scrollOffset || scrollOffset instanceof WI.Point, scrollOffset);
@@ -546,7 +546,7 @@ WI.TextEditor = class TextEditor extends WI.View
             if (!this.readOnly)
                 this.focus();
 
-            if (textRangeToSelect)
+            if (preventHighlight)
                 return;
 
             // Avoid highlighting the execution line while debugging.


### PR DESCRIPTION
#### e063281ea53d07e93237d19708f1d245f456b98e
<pre>
Web Inspector: REGRESSION(251279@main): text editors don&apos;t highlight revealed lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=242524">https://bugs.webkit.org/show_bug.cgi?id=242524</a>
&lt;rdar://problem/96639468&gt;

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/TextEditor.js:
(WI.TextEditor.prototype.revealPosition.revealAndHighlightLine):
We can&apos;t only check for `textRangeToSelect` when deciding to bail because it&apos;s guaranteed to exist
based on an `if` right before this function is called. Instead, do as it was done before 251279@main
by having a separate option for preventing the highlight (though it was called `noHighlight` before).

* Source/WebInspectorUI/UserInterface/Base/Main.js:
(WI.showLocalResourceOverride):
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor.prototype.dialogWasDismissedWithRepresentedObject):
(Re)Adopt the `preventHighlight` (previously `noHighlight`) argument.

Canonical link: <a href="https://commits.webkit.org/252283@main">https://commits.webkit.org/252283@main</a>
</pre>
