### PR TITLE
[Gardening]: REGRESSION (252177@main?): [ iOS ] TestWebKitAPI.WebProcessCache.ReusedCrashedCachedWebProcess is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -8469,7 +8469,8 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-TEST(WebProcessCache, ReusedCrashedCachedWebProcess)
+// FIXME: Re-enable after webkit.org/b/242527 is resolved
+TEST(WebProcessCache, DISABLED_ReusedCrashedCachedWebProcess)
 {
     auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;


### PR DESCRIPTION
#### 204d3358560ca3c14699b09fa08f318f94697e17
<pre>
[Gardening]: REGRESSION (252177@main?): [ iOS ] TestWebKitAPI.WebProcessCache.ReusedCrashedCachedWebProcess is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242527">https://bugs.webkit.org/show_bug.cgi?id=242527</a>
&lt;rdar://96686099&gt;

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/252287@main">https://commits.webkit.org/252287@main</a>
</pre>
