### PR TITLE
Allow WebVTT tracks to be loaded in Captive Portal mode

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1325,7 +1325,7 @@ MediaContainerTypesAllowedInCaptivePortalMode:
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
-      default: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2"'
+      default: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2,text/vtt"'
 
 MediaContentTypesRequiringHardwareSupport:
   type: String


### PR DESCRIPTION
#### 2ad072eee4c9415f4d1c798a12d62c22f0516ecf
<pre>
Allow WebVTT tracks to be loaded in Captive Portal mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=242530">https://bugs.webkit.org/show_bug.cgi?id=242530</a>
&lt;rdar://95815568&gt;

Reviewed by Eric Carlson.

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/252310@main">https://commits.webkit.org/252310@main</a>
</pre>
