### PR TITLE
[WIP] Support disassembly comments.

### DIFF
--- a/JSTests/stress/poc2.js
+++ b/JSTests/stress/poc2.js
@@ -1,0 +1,22 @@
+const limit = 3;
+let depth;
+let a = {
+  get length() {
+    new foo();
+  }
+};
+
+function foo() {
+  if (depth >= limit) {
+    OSRExit();
+    return;
+  }
+  ++depth;
+  foo.apply(undefined, a);
+  gc();
+}
+
+for (let i = 0; i < 100000; ++i) {
+  depth = 0;
+  foo.apply(undefined, a);
+}

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -53,6 +53,9 @@ typedef void (*V_DebugOperation_EPP)(CallFrame*, void*, void*);
 
 class AssemblyHelpers : public MacroAssembler {
 public:
+    static const char* DISASSEMBLER_COMMENT;
+    static constexpr uint64_t DISASSEMBLER_COMMENT_MASK = 0xFFFFFF;
+
     AssemblyHelpers(CodeBlock* codeBlock)
         : m_codeBlock(codeBlock)
         , m_baselineCodeBlock(codeBlock ? codeBlock->baselineAlternative() : nullptr)
@@ -1352,6 +1355,7 @@ public:
     void jitAssertArgumentCountSane();
     inline void jitAssertNoException(VM& vm) { jitReleaseAssertNoException(vm); }
     void jitAssertCodeBlockOnCallFrameWithType(GPRReg scratchGPR, JITType);
+    void jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(GPRReg scratchGPR, GPRReg scratchGPR2, bool isConstructor);
     void jitAssertCodeBlockOnCallFrameIsOptimizingJIT(GPRReg scratchGPR);
 #else
     void jitAssertIsInt32(GPRReg) { }
@@ -1940,6 +1944,8 @@ public:
         return branchPtr(cond, left, right);
 #endif
     }
+
+    void comment(const char* const &);
 
 #if USE(JSVALUE64)
     void wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch);


### PR DESCRIPTION
#### 55bc94033532a18fd937e9a5f7746bb5f39ad143
<pre>
[WIP] Support disassembly comments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242531">https://bugs.webkit.org/show_bug.cgi?id=242531</a>

Reviewed by NOBODY (OOPS!).

* JSTests/stress/poc2.js: Added.
(let.a.get length):
(foo):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64OpcodeExceptionGeneration::format):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::comment):
(JSC::AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
</pre>