### PR TITLE
[JSC] The fast path for JSONP should handle TDZ

### DIFF
--- a/JSTests/stress/function-name-too-long-to-reify.js
+++ b/JSTests/stress/function-name-too-long-to-reify.js
@@ -1,0 +1,65 @@
+//@ skip if $memoryLimited
+//@ runDefault
+var prop = "".padEnd(2 ** 31 - 1, "a");
+
+function shouldBe(actual, expected) {
+    if (String(actual) !== expected)
+        throw new Error('Actual Value:' + actual + 'Expected Value:' + expected);
+    return true;
+}
+
+function shouldThrow(func, expectedError) {
+    var errorThrown = false;
+    var ActualError = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        ActualError = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (!shouldBe(ActualError, expectedError))
+        throw new Error(`bad error: ${String(ActualError)}`);
+}
+
+function classSetter() {
+    class A {
+        set [prop](_) {
+        }
+    }
+}
+
+function objectSetter() {
+    let obj = {
+        set [prop](_) {
+        }
+    };
+}
+
+function classGetter() {
+    class A {
+        get [prop]() {
+        }
+    }
+}
+
+function objectGetter() {
+    let obj = {
+        get [prop]() {
+        }
+    };
+}
+
+setterExpectedError = "RangeError: Out of memory: Setter name is too long";
+getterExpectedError = "RangeError: Out of memory: Getter name is too long";
+
+shouldThrow(classSetter, setterExpectedError);
+shouldThrow(classSetter, setterExpectedError); // Make sure it should still throw.
+shouldThrow(classGetter, getterExpectedError);
+shouldThrow(classGetter, getterExpectedError); // Make sure it should still throw.
+
+shouldThrow(objectSetter, setterExpectedError);
+shouldThrow(objectSetter, setterExpectedError); // Make sure it should still throw.
+shouldThrow(objectGetter, getterExpectedError);
+shouldThrow(objectGetter, getterExpectedError); // Make sure it should still throw.

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -203,8 +203,8 @@ private:
     bool hasReifiedLength() const;
     bool hasReifiedName() const;
     void reifyLength(VM&);
-    void reifyName(VM&, JSGlobalObject*);
-    void reifyName(VM&, JSGlobalObject*, String name);
+    PropertyStatus reifyName(VM&, JSGlobalObject*);
+    PropertyStatus reifyName(VM&, JSGlobalObject*, String name);
 
     static bool isLazy(PropertyStatus property) { return property == PropertyStatus::Lazy || property == PropertyStatus::Reified; }
     static bool isReified(PropertyStatus property) { return property == PropertyStatus::Reified; }


### PR DESCRIPTION
#### 0f6d9985ade696e37ec5653318935961e3f73056
<pre>
[JSC] The fast path for JSONP should handle TDZ
<a href="https://bugs.webkit.org/show_bug.cgi?id=243578">https://bugs.webkit.org/show_bug.cgi?id=243578</a>
rdar://98106247

Reviewed by NOBODY (OOPS!).

All the fast paths for JSONP should throw exceptions for handling TDZ.

* JSTests/stress/jsonp-program-evaluate-path-must-consider-global-lexical-environment.js:
* JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js: Added.
(shouldThrow):
(test1):
(test2):
(test3):
(test4):
(test5):
(test6):
(test7):
(test8):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
</pre>