### PR TITLE
[Gardening]: REGRESSION(252190?): [ EWS macOS iOS ] imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html is a constant failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5339,3 +5339,5 @@ imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqu
 imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.worker.html [ Skip ]
 streams/readable-byte-stream-controller.html [ Skip ]
 streams/readable-byte-stream-controller-worker.html [ Skip ]
+
+webkit.org/b/242532 imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html [ Failure ]


### PR DESCRIPTION
#### 931f747fad23202144dc39e0412ca26052855759
<pre>
[Gardening]: REGRESSION(252190?): [ EWS macOS iOS ] imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242532">https://bugs.webkit.org/show_bug.cgi?id=242532</a>

Unreviewed test gardening.

* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252295@main">https://commits.webkit.org/252295@main</a>
</pre>
