### PR TITLE
Build Fix after 93085945

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -40,6 +40,7 @@
 #import "WebProcess.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/BifurcatedGraphicsContext.h>
+#import <WebCore/ConcreteImageBuffer.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurfacePool.h>
 #import <WebCore/ImageBuffer.h>
@@ -367,7 +368,7 @@ void RemoteLayerBackingStore::ensureFrontBuffer()
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     if (m_includeDisplayList == IncludeDisplayList::Yes)
-        m_frontBuffer.displayListImageBuffer = ConcreteImageBuffer<CGDisplayListImageBufferBackend>::create(m_size, m_scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, { });
+        m_frontBuffer.displayListImageBuffer = ConcreteImageBuffer::create<CGDisplayListImageBufferBackend>(m_size, m_scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, { });
 #endif
 }
 


### PR DESCRIPTION
#### 5b1b31499637446fd581eb9e86143b5fcd97f0c0
<pre>
Build Fix after 93085945
<a href="https://bugs.webkit.org/show_bug.cgi?id=242533">https://bugs.webkit.org/show_bug.cgi?id=242533</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::ensureFrontBuffer):

Canonical link: <a href="https://commits.webkit.org/252296@main">https://commits.webkit.org/252296@main</a>
</pre>
