### PR TITLE
Add a logging channel for ResizeObserver

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8289,6 +8289,7 @@ bool Document::hasResizeObservers()
 
 size_t Document::gatherResizeObservations(size_t deeperThan)
 {
+    LOG_WITH_STREAM(ResizeObserver, stream << "Document " << *this << " gatherResizeObservations");
     size_t minDepth = ResizeObserver::maxElementDepth();
     for (const auto& observer : m_resizeObservers) {
         if (!observer->hasObservations())
@@ -8301,6 +8302,7 @@ size_t Document::gatherResizeObservations(size_t deeperThan)
 
 void Document::deliverResizeObservations()
 {
+    LOG_WITH_STREAM(ResizeObserver, stream << "Document " << *this << " deliverResizeObservations");
     auto observersToNotify = m_resizeObservers;
     for (const auto& observer : observersToNotify) {
         if (!observer || !observer->hasActiveObservations())

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -105,6 +105,8 @@ std::optional<ResizeObservation::BoxSizes> ResizeObservation::elementSizeChanged
 {
     auto currentSizes = computeObservedSizes();
 
+    LOG_WITH_STREAM(ResizeObserver, stream << "ResizeObservation " << this << " elementSizeChanged - new content box " << currentSizes.contentBoxSize);
+
     switch (m_observedBox) {
     case ResizeObserverBoxOptions::BorderBox:
         if (m_lastObservationSizes.borderBoxLogicalSize != currentSizes.borderBoxLogicalSize)
@@ -128,6 +130,15 @@ size_t ResizeObservation::targetElementDepth() const
     }
 
     return depth;
+}
+
+TextStream& operator<<(TextStream& ts, const ResizeObservation& observation)
+{
+    ts.dumpProperty("target", ValueOrNull(observation.target()));
+    ts.dumpProperty("border box", observation.borderBoxSize());
+    ts.dumpProperty("content box", observation.contentBoxSize());
+    ts.dumpProperty("snapped content box", observation.snappedContentBoxSize());
+    return ts;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -32,6 +32,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class Element;
@@ -71,5 +75,7 @@ private:
     BoxSizes m_lastObservationSizes;
     ResizeObserverBoxOptions m_observedBox;
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const ResizeObservation&);
 
 } // namespace WebCore

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -31,10 +31,12 @@
 #include "Element.h"
 #include "InspectorInstrumentation.h"
 #include "JSNodeCustom.h"
+#include "Logging.h"
 #include "ResizeObserverEntry.h"
 #include "ResizeObserverOptions.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -115,6 +117,9 @@ size_t ResizeObserver::gatherObservations(size_t deeperThan)
             size_t depth = observation->targetElementDepth();
             if (depth > deeperThan) {
                 observation->updateObservationSize(*currentSizes);
+
+                LOG_WITH_STREAM(ResizeObserver, stream << "ResizeObserver " << this << " gatherObservations - recording observation " << observation.get());
+
                 m_activeObservations.append(observation.get());
                 m_activeObservationTargets.append(*observation->target());
                 minObservedDepth = std::min(depth, minObservedDepth);
@@ -127,6 +132,8 @@ size_t ResizeObserver::gatherObservations(size_t deeperThan)
 
 void ResizeObserver::deliverObservations()
 {
+    LOG_WITH_STREAM(ResizeObserver, stream << "ResizeObserver " << this << " deliverObservations");
+
     auto entries = m_activeObservations.map([](auto& observation) {
         ASSERT(observation->target());
         return ResizeObserverEntry::create(observation->target(), observation->computeContentRect(), observation->borderBoxSize(), observation->contentBoxSize());

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -99,6 +99,7 @@ namespace WebCore {
     M(Push) \
     M(RemoteInspector) \
     M(RequestAnimationFrame) \
+    M(ResizeObserver) \
     M(ResourceLoading) \
     M(ResourceLoadObserver) \
     M(ResourceLoadStatistics) \


### PR DESCRIPTION
#### 79a1a5cf03b2a29fcc33fcb60aca5fcdd1d8df6e
<pre>
Add a logging channel for ResizeObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=242535">https://bugs.webkit.org/show_bug.cgi?id=242535</a>

Reviewed by Chris Dumez.

Add some basic logging for ResizeObserver via a log channel.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::gatherResizeObservations):
(WebCore::Document::deliverResizeObservations):
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::elementSizeChanged const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::gatherObservations):
(WebCore::ResizeObserver::deliverObservations):
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/252320@main">https://commits.webkit.org/252320@main</a>
</pre>
