### PR TITLE
Automatically engage live-ish resize when available

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -110,6 +110,17 @@ AsyncOverflowScrollingEnabled:
     WebCore:
       default: false
 
+AutomaticLiveResizeEnabled:
+  type: bool
+  humanReadableName: "Enable Automatic Live Resize"
+  humanReadableDescription: "Automatically synchronize web view resize with painting"
+  webcoreBinding: none
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      "HAVE(UIKIT_WEBKIT_INTERNALS)": true
+      default: false
+
 BlockIOKitInWebContentSandbox:
   type: bool
   humanReadableName: "IOKit blocking in the WebContent sandbox"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -223,6 +223,7 @@ class ViewGestureController;
         CGPoint initialScrollPosition;
     };
     std::optional<LiveResizeParameters> _liveResizeParameters;
+    RetainPtr<id> _endLiveResizeNotificationObserver;
 
     BOOL _commitDidRestoreScrollPosition;
     std::optional<WebCore::FloatPoint> _scrollOffsetToRestore;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -156,6 +156,9 @@ enum class TapHandlingResult : uint8_t;
 - (BOOL)_effectiveAppearanceIsDark;
 - (BOOL)_effectiveUserInterfaceLevelIsElevated;
 
+- (void)_beginLiveResize;
+- (void)_endLiveResize;
+
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 - (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion;
 #endif


### PR DESCRIPTION
#### 202b4697ed2f7d0866688cb7439619110414e53a
<pre>
Automatically engage live-ish resize when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=242534">https://bugs.webkit.org/show_bug.cgi?id=242534</a>

Reviewed by Wenson Hsieh.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
Add a preference for automatically beginning and ending live resize based
on system notifications.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _restorePageScrollPosition:scrollOrigin:previousObscuredInset:scale:]):
(-[WKWebView _restorePageStateToUnobscuredCenter:scale:]):
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]):
(-[WKWebView _shouldDeferGeometryUpdates]):
(-[WKWebView _updateVisibleContentRects]):
(-[WKWebView _setAvoidsUnsafeArea:]):
(-[WKWebView _setViewLayoutSizeOverride:]):
(-[WKWebView _setMinimumUnobscuredSizeOverride:]):
(-[WKWebView _setMaximumUnobscuredSizeOverride:]):
(-[WKWebView _setInterfaceOrientationOverride:]):
(-[WKWebView _snapshotRectAfterScreenUpdates:rectInViewCoordinates:intoImageOfWidth:completionHandler:]):
Factor `_dynamicViewportUpdateMode` checks out of callers, and into `_shouldDeferGeometryUpdates`.
Also defer geometry updates when we&apos;re in a live-ish resize, not just animated resize.

(-[WKWebView _beginAutomaticLiveResizeIfNeeded]):
Try to infer when we&apos;re in a live resize (currently in a somewhat roundabout way;
to be improved as better mechanisms become avilable), and call _beginLiveResize
and _endLiveResize automatically.

(-[WKWebView didMoveToWindow]):
(-[WKWebView _destroyEndLiveResizeObserver]):
Tear down any active live resize and end-observer when we move between
windows (or out of the window).

(-[WKWebView _frameOrBoundsChanged]):
(-[WKWebView _didCompleteAnimatedResize]):
(-[WKWebView _didStopDeferringGeometryUpdates]):
Factor `_didStopDeferringGeometryUpdates`, which sends all of the &quot;I stopped deferring
geometry updates, so now send the current state&quot; messages, out of _didCompleteAnimatedResize,
and call it from _endLiveResize, so that we always end up at the correct final state.

(-[WKWebView _beginLiveResize]):
(-[WKWebView _endLiveResize]):
Move these down to the internal category. Add some guards so we&apos;ll never start
an animated resize during live resize, or vice versa. Adopt `_didStopDeferringGeometryUpdates`
instead of randomly calling just `_frameOrBoundsChanged`.

(-[WKWebView _beginAnimatedResizeWithUpdates:]):

Canonical link: <a href="https://commits.webkit.org/252307@main">https://commits.webkit.org/252307@main</a>
</pre>
