### PR TITLE
[macOS][GPUP] Allow reading Audio related IOKit property

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -465,6 +465,10 @@
         (iokit-property "acoustic-id") ;; <rdar://problem/65290967>
     ))
 
+(with-filter (iokit-registry-entry-class "IOService")
+    (allow iokit-get-properties
+        (iokit-property "supports-advanced-vp-chatflavor")))
+
 (if (equal? (param "CPU") "arm64")
     (with-filter (iokit-registry-entry-class "IOService")
         (allow iokit-get-properties


### PR DESCRIPTION
#### 88cbbc8b34ed9ee00b7749bd4686924b171c57f0
<pre>
[macOS][GPUP] Allow reading Audio related IOKit property
<a href="https://bugs.webkit.org/show_bug.cgi?id=242541">https://bugs.webkit.org/show_bug.cgi?id=242541</a>
&lt;rdar://94298216&gt;

Reviewed by Brent Fulgham.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252300@main">https://commits.webkit.org/252300@main</a>
</pre>
