### PR TITLE
[Rebaseline]: REGRESSION(252190@main): [ EWS macOS iOS ] imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html is a constant failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5339,5 +5339,3 @@ imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqu
 imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.worker.html [ Skip ]
 streams/readable-byte-stream-controller.html [ Skip ]
 streams/readable-byte-stream-controller-worker.html [ Skip ]
-
-webkit.org/b/242532 imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window-expected.txt
@@ -1,8 +1,6 @@
 
 PASS document.open should throw an InvalidStateError with XML document even if it is cross-origin
-FAIL document.open should throw an InvalidStateError when the throw-on-dynamic-markup-insertion counter is incremented even if the document is cross-origin assert_throws_dom: opening a document when the throw-on-dynamic-markup-insertion counter is incremented should throw an InvalidStateError function "() => {
-          iframe.contentDocument.open();
-        }" threw object "SecurityError: The operation is insecure." that is not a DOMException InvalidStateError: property "code" is equal to 18, expected 11
+PASS document.open should throw an InvalidStateError when the throw-on-dynamic-markup-insertion counter is incremented even if the document is cross-origin
 PASS document.open should throw a SecurityError with cross-origin document even when there is an active parser executing script
 PASS document.open should throw a SecurityError with cross-origin document even when the ignore-opens-during-unload counter is greater than 0 (during beforeunload event)
 PASS document.open should throw a SecurityError with cross-origin document even when the ignore-opens-during-unload counter is greater than 0 (during pagehide event)


### PR DESCRIPTION
#### aeb67b9f713b48245099098696757478f711567b
<pre>
[Rebaseline]: REGRESSION(252190@main): [ EWS macOS iOS ] imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242532">https://bugs.webkit.org/show_bug.cgi?id=242532</a>

Unreviewed test gardening.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window-expected.txt:

Canonical link: <a href="https://commits.webkit.org/252299@main">https://commits.webkit.org/252299@main</a>
</pre>
