### PR TITLE
[macOS][WP] Fix syscall sandbox violation

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2062,10 +2062,9 @@
     (allow syscall-unix (syscall-number SYS_gettid))) ;; Needed for base system, see <rdar://problem/48651255>
 
 #if HAVE(SANDBOX_STATE_FLAGS)
-(if (not (equal? (param "CPU") "arm64"))
-    (with-filter (require-not (state-flag "WebContentProcessLaunched"))
-        (allow syscall-unix
-            (syscall-number SYS_quotactl))))
+(with-filter (require-not (state-flag "WebContentProcessLaunched"))
+    (allow syscall-unix
+        (syscall-number SYS_quotactl)))
 #endif
 
 #if HAVE(ADDITIONAL_APPLE_CAMERA_SERVICE)


### PR DESCRIPTION
#### 5646eaffcda13de25b60d471748813b2a715961d
<pre>
[macOS][WP] Fix syscall sandbox violation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242545">https://bugs.webkit.org/show_bug.cgi?id=242545</a>
&lt;rdar://96695359&gt;

Reviewed by Chris Dumez.

We currently allow the sys call quotactl during startup of the WebContent process on Intel. We also need to allow it for AS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252304@main">https://commits.webkit.org/252304@main</a>
</pre>
