### PR TITLE
Should be able to copy editable strong password on iOS

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -40,6 +40,7 @@ void EditorState::encode(IPC::Encoder& encoder) const
     encoder << selectionIsNone;
     encoder << selectionIsRange;
     encoder << selectionIsRangeInsideImageOverlay;
+    encoder << selectionIsRangeInAutoFilledAndViewableField;
     encoder << isContentEditable;
     encoder << isContentRichlyEditable;
     encoder << isInPasswordField;
@@ -72,6 +73,9 @@ bool EditorState::decode(IPC::Decoder& decoder, EditorState& result)
         return false;
 
     if (!decoder.decode(result.selectionIsRangeInsideImageOverlay))
+        return false;
+
+    if (!decoder.decode(result.selectionIsRangeInAutoFilledAndViewableField))
         return false;
 
     if (!decoder.decode(result.isContentEditable))

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -77,6 +77,7 @@ struct EditorState {
     bool selectionIsNone { true }; // This will be false when there is a caret selection.
     bool selectionIsRange { false };
     bool selectionIsRangeInsideImageOverlay { false };
+    bool selectionIsRangeInAutoFilledAndViewableField { false };
     bool isContentEditable { false };
     bool isContentRichlyEditable { false };
     bool isInPasswordField { false };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3978,7 +3978,7 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
     }
 
     if (action == @selector(copy:)) {
-        if (editorState.isInPasswordField)
+        if (editorState.isInPasswordField && !editorState.selectionIsRangeInAutoFilledAndViewableField)
             return NO;
         return editorState.selectionIsRange;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1251,6 +1251,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     if (result.selectionIsRange) {
         auto selectionRange = selection.range();
         result.selectionIsRangeInsideImageOverlay = selectionRange && ImageOverlay::isInsideOverlay(*selectionRange);
+        result.selectionIsRangeInAutoFilledAndViewableField = selection.isInAutoFilledAndViewableField();
     }
 
     m_lastEditorStateWasContentEditable = result.isContentEditable ? EditorStateIsContentEditable::Yes : EditorStateIsContentEditable::No;

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2423,6 +2423,15 @@
    },
    {
       "emails" : [
+         "eryn_wells@apple.com"
+      ],
+      "name" : "Eryn Wells",
+      "nicks" : [
+         "erynofwales"
+      ]
+   },
+   {
+      "emails" : [
          "eustas@chromium.org"
       ],
       "name" : "Eugene Klyuchnikov",


### PR DESCRIPTION
#### f07a52b9573be1d5b638c719cbf84b5eaed88c5f
<pre>
Should be able to copy editable strong password on iOS

<a href="https://bugs.webkit.org/show_bug.cgi?id=242544">https://bugs.webkit.org/show_bug.cgi?id=242544</a>

rdar://96259620

Reviewed by Tim Horton and Wenson Hsieh.

Add a flag to EditorState to track when selection is in an autofilled and
viewable field. Consult this flag in WKContentView when we&apos;re deciding what
editing actions to allow.

Test: WebKit.CopyInAutoFilledAndViewablePasswordField

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::encode const):
(WebKit::EditorState::decode):
    Implement transmitting the new flag over the IPC interface

* Source/WebKit/Shared/EditorState.h:
    Add selectionIsInAutoFilledAndViewableField to EditorState
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
    Check the new flag when deciding whether to add the Copy item to the list of
    available actions

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
    Set the new flag based on whether the selection is in an AutoFilled and
    Viewable field

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm:
    Add a new API test to exercise this fix.

* metadata/contributors.json:
    Add myself to the contributors file

Canonical link: <a href="https://commits.webkit.org/252351@main">https://commits.webkit.org/252351@main</a>
</pre>
