### PR TITLE
[Gardening]: [ macOS wk1 ] media/video-canvas-createPattern.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1846,3 +1846,5 @@ webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/w
 webkit.org/b/241266 compositing/video/video-border-radius.html [ Pass Timeout ]
 
 webkit.org/b/241376 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/242546 media/video-canvas-createPattern.html [ Pass Failure ]


### PR DESCRIPTION
#### 881e36db26e651b4f2494d8df6ba673ee060a18f
<pre>
[Gardening]: [ macOS wk1 ] media/video-canvas-createPattern.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242546">https://bugs.webkit.org/show_bug.cgi?id=242546</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252309@main">https://commits.webkit.org/252309@main</a>
</pre>
