### PR TITLE
[Make] Select the workspace to build with set-webkit-configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ifeq ($(USE_WORKSPACE),YES)
 
 SCHEME = All Modules
 SCRIPTS_PATH = Tools/Scripts
+WORKSPACE_PATH = WebKit.xcworkspace
 include Makefile.shared
 
 else

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -1,21 +1,27 @@
 SCRIPTS_PATH ?= ../Tools/Scripts
 
-XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
-XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
-ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
-	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION
-endif
-
 ifeq ($(USE_WORKSPACE),YES)
 SCHEME ?= $(notdir $(CURDIR))
-WORKSPACE_PATH ?= $(dir $(lastword $(MAKEFILE_LIST)))WebKit.xcworkspace
-XCODE_TARGET = -workspace $(WORKSPACE_PATH) -scheme "$(SCHEME)"
+XCODE_TARGET = -scheme "$(SCHEME)"
+
+ifneq (,$(WORKSPACE_PATH))
+CONFIG_OPTIONS += --workspace=$(WORKSPACE_PATH)
+endif
+
 # FIXME: Move this setting to xcconfigs once all local Xcode builds of WebKit
 # happen in the workspace. When this is only passed on the command line, it
 # invalidates build results made in the IDE (rdar://88135402).
 #XCODE_OPTIONS += WK_VALIDATE_DEPENDENCIES=YES_ERROR
 else
 USE_WORKSPACE =
+BUILD_WEBKIT_OPTIONS += --no-use-workspace
+endif
+
+
+XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
+XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
+ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
+	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION
 endif
 
 ifneq (,$(SDKROOT))

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -226,6 +226,12 @@ if ((isAppleWebKit() || isWinCairo() || isPlayStation() || isFTW()) && !-d "WebK
 my @options = ();
 
 if (isAppleCocoaWebKit()) {
+    # Ignore any workspace set by set-webkit-configuration
+    if (!$useWorkspace) {
+        overrideConfiguredXcodeWorkspace("");
+    } else {
+        overrideConfiguredXcodeWorkspace("WebKit.xcworkspace");
+    }
     push @options, XcodeOptions();
 
     sub option($$)
@@ -246,6 +252,7 @@ if (isAppleCocoaWebKit()) {
         "deprecated.\nIf you have a workflow requirement that depends " .
         "on building targets in manual order, please document it in " .
         "https://bugs.webkit.org/show_bug.cgi?id=241295.\n";
+        
         # ANGLE and libwebrtc must come before WebCore
         splice @projects, 0, 0, ("Source/ThirdParty/ANGLE");
         # if (not $archs32bit and (portName() eq Mac or portName() eq iOS or portName() eq watchOS)) {
@@ -361,7 +368,7 @@ if (isAppleWinWebKit() || isWinCairo() || isPlayStation() || isFTW()) {
     # Build, and abort if the build fails.
     if ($useWorkspace) {
         my $scheme = $onlyWebKitProject ? "WebKitLegacy" : "All Modules";
-        $result = buildXCodeWorkspace("WebKit.xcworkspace", $scheme, $clean, @local_options, @ARGV);
+        $result = buildXcodeScheme($scheme, $clean, @local_options, @ARGV);
         if (exitStatus($result)) {
             exit exitStatus($result);
         }

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -28,6 +28,7 @@
 
 use strict;
 use warnings;
+use Cwd qw(realpath);
 use File::Path qw(make_path);
 use File::Spec;
 use FindBin;
@@ -47,6 +48,7 @@ Usage: $programName [options]
   --lto-mode=<mode>                  Set LTO mode: full, thin, or none
   --debug                            Set the default configuration to debug
   --release                          Set the default configuration to release
+  --workspace=<workspace>            Set the default Xcode workspace to build from
   --reset                            Reset configurations
   -h, --help                         Show this message and exit
 EOF
@@ -74,6 +76,10 @@ if (!checkForArgumentAndRemoveFromARGVGettingValue("--force-optimization-level",
     && !checkForArgumentAndRemoveFromARGVGettingValue("--force-opt", \$forceOptimizationLevel)) {
     $forceOptimizationLevel="";
 }
+my $workspace;
+if (!checkForArgumentAndRemoveFromARGVGettingValue("--workspace", \$workspace)) {
+    $workspace="";
+}
 
 if (checkForArgumentAndRemoveFromARGV("-h") || checkForArgumentAndRemoveFromARGV("--help")) {
     printUsage();
@@ -94,6 +100,11 @@ if (!$architecture) {
 my $baseProductDir = baseProductDir();
 if (isAppleCocoaWebKit() && !isCMakeBuild()) {
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();
+    if ($workspace) {
+        open WORKSPACE, ">", "$baseProductDir/Workspace";
+        print WORKSPACE realpath($workspace);
+        close WORKSPACE;
+    }
 } else {
     make_path($baseProductDir);
 }
@@ -180,6 +191,7 @@ sub printCurrentSettings()
     $result .= " Coverage" if coverageIsEnabled();
     $result .= " LTOMode:" . ltoMode() if ltoMode();
     $result .= " ForceOptimizationLevel:O" . forceOptimizationLevel() if forceOptimizationLevel();
+    $result .= " Workspace:" . configuredXcodeWorkspace() if configuredXcodeWorkspace();
 
     print STDERR $result, "\n";
 }


### PR DESCRIPTION
#### b5a89116d0839fc05400fbf81f50e82a9a8ed433
<pre>
[Make] Select the workspace to build with set-webkit-configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=242542">https://bugs.webkit.org/show_bug.cgi?id=242542</a>
rdar://96686845

Reviewed by Alexey Proskuryakov.

A common command-line workflow for Safari+WebKit engineers is to build
the whole stack once using Make:

    # In the Internal repo
    make debug

...and then iterate on the specific project they are working on by
changing to its directory:

    cd Source/WebCore
    make debug

In recursive-Make builds, the latter command is purely a subset of what
the former command runs. In workspace builds, it’s a completely
different invocation, with Make determining what scheme and workspace to
use. If the workspace used for the full-stack build is different from
the workspace used for the specific project, Xcode invalidates the build
result, and the specific-project build is done from scratch. This is
unacceptable since it breaks a commonly-used incremental build workflow.

To address this, add &quot;current workspace&quot; as a piece of state managed by
set-webkit-configuration. Top-level Make builds (i.e. from the root of
the repo), call `set-webkit-configuration --workspace=/path/to/workspace`.
Subproject or single-project Make builds do not set the workspace; they
use whatever workspace is currently set. (If none, xcodebuild defaults
to using the project in the current directory.)

The result is that a top-level Make build will &quot;reset&quot; the workspace
being used, and subsequent builds of individual projects will continue
to use that workspace. This should build the &quot;right thing&quot; for most
engineers in most cases, while being reasonably upfront about the
added statefulness. (After all, engineers who build with specific
configurations or sanitizers already have to know about
set-webkit-configuration.)

* Makefile: Set the WORKSPACE_PATH here to indicate that a top-level
  build should set WebKit.xcworkspace as the workspace.
* Makefile.shared: Don&apos;t set WORKSPACE_PATH by default. If it _is_ set,
  pass it through to set-webkit-configuration.
* Tools/Scripts/set-webkit-configuration:
(printCurrentSettings):
* Tools/Scripts/webkitdirs.pm:
(determineConfiguredXcodeWorkspace):
(configuredXcodeWorkspace):
(overrideConfiguredXcodeWorkspace): Used by build-webkit to opt out of
this behavior, as it should always build like the open-source project
does.
(XcodeOptions): Set the actual -workspace flag corresponding to the
configured workspace.
(buildXcodeScheme): Renamed from buildXCodeWorkspace.

Canonical link: <a href="https://commits.webkit.org/252363@main">https://commits.webkit.org/252363@main</a>
</pre>
