### PR TITLE
[JSC] Use memchr for integer TypedArray indexOf and includes

### DIFF
--- a/JSTests/microbenchmarks/int8-array-index-of-large.js
+++ b/JSTests/microbenchmarks/int8-array-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int8-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/int8-array-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/int8-array-index-of-small.js
+++ b/JSTests/microbenchmarks/int8-array-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Int8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-index-of-large.js
+++ b/JSTests/microbenchmarks/uint8-array-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint8-array-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-array-index-of-small.js
+++ b/JSTests/microbenchmarks/uint8-array-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint8Array(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-index-of-large.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-index-of-large.js
@@ -1,0 +1,14 @@
+let size = 20 << 20;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e2; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-index-of-medium.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-index-of-medium.js
@@ -1,0 +1,14 @@
+let size = 4096;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/microbenchmarks/uint8-clamped-array-index-of-small.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-index-of-small.js
@@ -1,0 +1,14 @@
+let size = 16;
+let array = new Uint8ClampedArray(size);
+for (let i = 0; i < size; ++i)
+    array[i] = 1;
+array[size - 1] = 42;
+
+function test(array) {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += array.indexOf(42);
+    return result;
+}
+noInline(test);
+test(array);

--- a/JSTests/stress/non-suitable-typed-array-index-of.js
+++ b/JSTests/stress/non-suitable-typed-array-index-of.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let array = new Uint8Array([0, 1, 2, 3, 0xff]);
+    shouldBe(array.indexOf(-1), -1);
+    shouldBe(array.indexOf(0xff), 4);
+    shouldBe(array.indexOf(0xffff), -1);
+    shouldBe(array.includes(-1), false);
+    shouldBe(array.includes(0xff), true);
+    shouldBe(array.includes(0xffff), false);
+}
+{
+    let array = new Uint8ClampedArray([0, 1, 2, 3, 0xff]);
+    shouldBe(array.indexOf(-1), -1);
+    shouldBe(array.indexOf(0xff), 4);
+    shouldBe(array.indexOf(0xffff), -1);
+    shouldBe(array.includes(-1), false);
+    shouldBe(array.includes(0xff), true);
+    shouldBe(array.includes(0xffff), false);
+}
+{
+    let array = new Int8Array([0, 1, 2, 3, -1]);
+    shouldBe(array.indexOf(-1), 4);
+    shouldBe(array.indexOf(0xff), -1);
+    shouldBe(array.indexOf(0xffff), -1);
+    shouldBe(array.includes(-1), true);
+    shouldBe(array.includes(0xff), false);
+    shouldBe(array.includes(0xffff), false);
+}

--- a/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
@@ -46,6 +46,9 @@ struct IntegralTypedArrayAdaptor {
     static constexpr TypeArg maxValue = std::numeric_limits<TypeArg>::max();
     static constexpr bool canConvertToJSQuickly = true;
     static constexpr TypedArrayContentType contentType = JSC::contentType(typeValue);
+    static constexpr bool isInteger = true;
+    static constexpr bool isFloat = false;
+    static constexpr bool isBigInt = false;
 
     static JSValue toJSValue(JSGlobalObject*, Type value)
     {
@@ -119,6 +122,9 @@ struct FloatTypedArrayAdaptor {
     static constexpr TypeArg maxValue = std::numeric_limits<TypeArg>::max();
     static constexpr bool canConvertToJSQuickly = true;
     static constexpr TypedArrayContentType contentType = JSC::contentType(typeValue);
+    static constexpr bool isInteger = false;
+    static constexpr bool isFloat = true;
+    static constexpr bool isBigInt = false;
 
     static JSValue toJSValue(JSGlobalObject*, Type value)
     {
@@ -180,6 +186,9 @@ struct BigIntTypedArrayAdaptor {
     static constexpr TypeArg maxValue = std::numeric_limits<TypeArg>::max();
     static constexpr bool canConvertToJSQuickly = false;
     static constexpr TypedArrayContentType contentType = JSC::contentType(typeValue);
+    static constexpr bool isInteger = true;
+    static constexpr bool isFloat = false;
+    static constexpr bool isBigInt = true;
 
     static JSValue toJSValue(JSGlobalObject* globalObject, Type value)
     {
@@ -242,6 +251,9 @@ struct Uint8ClampedAdaptor {
     static constexpr uint8_t maxValue = std::numeric_limits<uint8_t>::max();
     static constexpr bool canConvertToJSQuickly = true;
     static constexpr TypedArrayContentType contentType = JSC::contentType(typeValue);
+    static constexpr bool isInteger = true;
+    static constexpr bool isFloat = false;
+    static constexpr bool isBigInt = false;
 
     static JSValue toJSValue(JSGlobalObject*, uint8_t value)
     {


### PR DESCRIPTION
#### 5ba7d3c8466d733bbff0ad2a0de6582b90084404
<pre>
[JSC] Use memchr for integer TypedArray indexOf and includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=242548">https://bugs.webkit.org/show_bug.cgi?id=242548</a>

Reviewed by Darin Adler.

This patch adds `memchr` fast path in indexOf and includes for TypedArrays having 1byte elements, Uint8Array, Int8Array, and Uint8ClampedArray.

                                                    ToT                     Patched

    uint8-clamped-array-index-of-large       882.1838+-0.9972     ^     56.5419+-0.2234        ^ definitely 15.6023x faster
    uint8-clamped-array-index-of-small         0.4704+-0.0176     ^      0.3334+-0.0073        ^ definitely 1.4109x faster
    int8-array-index-of-small                  0.5072+-0.0160     ^      0.3467+-0.0123        ^ definitely 1.4627x faster
    uint8-array-index-of-large               884.6808+-2.2707     ^     56.5313+-0.1798        ^ definitely 15.6494x faster
    uint8-array-index-of-small                 0.4886+-0.0187     ^      0.3367+-0.0092        ^ definitely 1.4513x faster
    int8-array-index-of-large                882.0187+-2.3905     ^     56.5979+-0.2482        ^ definitely 15.5840x faster
    uint8-clamped-array-index-of-medium       17.5590+-0.0534     ^      1.5236+-0.0149        ^ definitely 11.5245x faster
    int8-array-index-of-medium                17.4599+-0.0406     ^      1.4924+-0.0110        ^ definitely 11.6994x faster
    uint8-array-index-of-medium               18.0687+-0.0512     ^      1.5281+-0.0172        ^ definitely 11.8239x faster

    &lt;geometric&gt;                               19.6620+-0.1418     ^      3.0706+-0.0135        ^ definitely 6.4033x faster

* JSTests/microbenchmarks/int8-array-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/int8-array-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/int8-array-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint8-array-index-of-small.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-index-of-large.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-index-of-medium.js: Added.
(test):
* JSTests/microbenchmarks/uint8-clamped-array-index-of-small.js: Added.
(test):
* JSTests/stress/non-suitable-typed-array-index-of.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncIncludes):
(JSC::genericTypedArrayViewProtoFuncIndexOf):
(JSC::genericTypedArrayViewProtoFuncLastIndexOf):
* Source/JavaScriptCore/runtime/TypedArrayAdaptors.h:

Canonical link: <a href="https://commits.webkit.org/252314@main">https://commits.webkit.org/252314@main</a>
</pre>
