### PR TITLE
Fix following 252298@main

### DIFF
--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
@@ -47,16 +47,18 @@ std::optional<ResidentKeyRequirement> PublicKeyCredentialCreationOptions::Authen
         return ResidentKeyRequirement::Required;
     if (residentKeyString == "discouraged"_s)
         return ResidentKeyRequirement::Discouraged;
-    return ResidentKeyRequirement::Preferred;
+    if (residentKeyString == "preferred"_s)
+        return ResidentKeyRequirement::Preferred;
+    return std::nullopt;
 }
 
 UserVerificationRequirement PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::userVerification() const
 {
     if (userVerificationString == "required"_s)
         return UserVerificationRequirement::Required;
-    if (userVerificationString == "preferred"_s)
-        return UserVerificationRequirement::Preferred;
-    return UserVerificationRequirement::Discouraged;
+    if (userVerificationString == "discouraged"_s)
+        return UserVerificationRequirement::Discouraged;
+    return UserVerificationRequirement::Preferred;
 }
 
 std::optional<AuthenticatorAttachment> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::authenticatorAttachment() const


### PR DESCRIPTION
#### 4ecbd466dba2329a1445996a1a518dd717713527
<pre>
Fix following 252298@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242549">https://bugs.webkit.org/show_bug.cgi?id=242549</a>

Unreviewed, follow up fix to 252298@main.

* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp:
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::residentKey const):
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::userVerification const):

Canonical link: <a href="https://commits.webkit.org/252313@main">https://commits.webkit.org/252313@main</a>
</pre>
