### PR TITLE
Continual resizeobserver-driven flashing on Jupyter notebook page

### DIFF
--- a/LayoutTests/fast/frames/iframe-resize-removes-scrollbar-expected.html
+++ b/LayoutTests/fast/frames/iframe-resize-removes-scrollbar-expected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+ <head>
+ <style>
+     #container {
+         width: 200px;
+         height: 300px;
+     }
+
+     #container.changed {
+         width: 400px;
+     }
+
+     iframe {
+         height: 100%;
+         width: 100%;
+         border: 1px solid black;
+     }
+ </style>
+ <script>
+     window.addEventListener('load', () => {
+         // Work around webkit.org/b/242550 to eliminate the initial vertical scrollbar.
+         const container = document.getElementById('container');
+         container.getBoundingClientRect();
+         container.classList.remove('changed');
+     }, false);
+ </script>
+</head>
+ <body>
+     <p>The iframe should not gain a vertical scrollbar when the height decreases but remains large enough to show all of the contents.</p>
+     <p>The third line of the iframe contents will wrap if a vertical scrollbar is visible. This test is only valid with non-overlay scrollbars.</p>
+     <div id="container" class="changed">
+         <iframe srcdoc="
+<style>
+    html {
+         font-size: 20px;
+         line-height: 20px;
+    }
+</style>
+<body>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xxxxxxxxxxxxxxxxx z</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>x</div>
+</body>
+    "></iframe>
+     </div>
+ </body>

--- a/LayoutTests/fast/frames/iframe-resize-removes-scrollbar.html
+++ b/LayoutTests/fast/frames/iframe-resize-removes-scrollbar.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+ <head>
+ <style>
+     #container {
+         width: 200px;
+         height: 320px;
+     }
+
+     iframe {
+         height: 100%;
+         width: 100%;
+         border: 1px solid black;
+     }
+ </style>
+ <script>
+     if (window.testRunner)
+         testRunner.waitUntilDone();
+
+     window.addEventListener('load', () => {
+         setTimeout(() => {
+             const container = document.getElementById('container');
+             container.style.height = '300px';
+             if (window.testRunner)
+                 testRunner.notifyDone();
+         }, 0);
+
+     }, false);
+ </script>
+ </head>
+ <body>
+     <p>The iframe should not gain a vertical scrollbar when the height decreases but remains large enough to show all of the contents.</p>
+     <p>The third line of the iframe contents will wrap if a vertical scrollbar is visible. This test is only valid with non-overlay scrollbars.</p>
+     <div id="container">
+         <iframe srcdoc="
+<style>
+    html {
+         font-size: 20px;
+         line-height: 20px;
+    }
+</style>
+<body>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xxxxxxxxxxxxxxxxx z</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>x</div>
+</body>
+    "></iframe>
+     </div>
+ </body>

--- a/LayoutTests/resize-observer/resize-observer-iframe-scrollbar-expected.txt
+++ b/LayoutTests/resize-observer/resize-observer-iframe-scrollbar-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Got 3 rAF callbacks without Resize Observer firing
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/resize-observer/resize-observer-iframe-scrollbar.html
+++ b/LayoutTests/resize-observer/resize-observer-iframe-scrollbar.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<head>
+<style>
+    #container {
+        width: 200px;
+        height: 300px;
+    }
+
+    iframe {
+        height: 100%;
+        width: 100%;
+        border: 1px solid black;
+    }
+</style>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+    jsTestIsAsync = true;
+
+    const maxRAFsWithoutResizeObserver = 3;
+    const maxRAFsOnFailure = 10;
+
+    let rAFFireCount = 0;
+    let rAFsWithoutResizeObserverCount = 0;
+
+    function animationFrame()
+    {
+        ++rAFsWithoutResizeObserverCount;
+        ++rAFFireCount;
+        if (rAFsWithoutResizeObserverCount == maxRAFsWithoutResizeObserver) {
+            testPassed(`Got ${rAFsWithoutResizeObserverCount} rAF callbacks without Resize Observer firing`);
+            finishJSTest();
+            return;
+        }
+
+        if (rAFFireCount == maxRAFsOnFailure) {
+            testFailed(`Got ${rAFFireCount} rAF callbacks and the Resize Observer is still firing`);
+            finishJSTest();
+            return;
+        }
+
+        requestAnimationFrame(animationFrame)
+    }
+
+    let resizeObserverCount = 0;
+    window.addEventListener("message", (event) => {
+        if (!resizeObserverCount)
+            requestAnimationFrame(animationFrame)
+
+            ++resizeObserverCount;
+        rAFsWithoutResizeObserverCount = 0;
+        const container = document.getElementById("container");
+        container.style.height = event.data.height + "px";
+
+    }, false);
+</script>
+</head>
+<body>
+    <div id="container">
+        <iframe srcdoc="
+<style>
+    html {
+        font-size: 20px;
+        line-height: 20px;
+    }
+</style>
+<body>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xxxxxxxxxxxxxxxxx z</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>xx</div>
+    <div>x</div>
+<script>
+    const ro = new ResizeObserver(entries => {
+        for (let entry of entries) {
+            const cr = entry.contentRect;
+            const message = {
+                width: cr.width,
+                height: cr.height
+            };
+            window.parent.postMessage(message, '*');
+        }
+    });
+    ro.observe(document.documentElement);
+</script>
+</body>
+    "></iframe>
+    </div>
+    <div id="console"></div>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -812,6 +812,8 @@ private:
     bool mockScrollbarsControllerEnabled() const final;
     void logMockScrollbarsControllerMessage(const String&) const final;
 
+    bool canShowNonOverlayScrollbars() const final;
+
     bool styleHidesScrollbarWithOrientation(ScrollbarOrientation) const;
     bool horizontalScrollbarHiddenByStyle() const final;
     bool verticalScrollbarHiddenByStyle() const final;

--- a/Source/WebCore/page/FrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/FrameViewLayoutContext.cpp
@@ -423,7 +423,7 @@ void FrameViewLayoutContext::unscheduleLayout()
 
 #if !LOG_DISABLED
     if (!frame().document()->ownerElement())
-        LOG(Layout, "FrameView %p layout timer unscheduled at %.3fs", this, frame().document()->timeSinceDocumentCreation().value());
+        LOG_WITH_STREAM(Layout, stream << "FrameViewLayoutContext for FrameView " << frame().view() << " layout timer unscheduled at " << frame().document()->timeSinceDocumentCreation().value());
 #endif
 
     m_layoutTimer.stop();
@@ -487,7 +487,7 @@ void FrameViewLayoutContext::layoutTimerFired()
 {
 #if !LOG_DISABLED
     if (!frame().document()->ownerElement())
-        LOG(Layout, "FrameView %p layout timer fired at %.3fs", this, frame().document()->timeSinceDocumentCreation().value());
+        LOG_WITH_STREAM(Layout, stream << "FrameViewLayoutContext for FrameView " << frame().view() << " layout timer fired at " << frame().document()->timeSinceDocumentCreation().value());
 #endif
     layout();
 }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -358,6 +358,11 @@ bool ScrollableArea::hasOverlayScrollbars() const
         || (horizontalScrollbar() && horizontalScrollbar()->isOverlayScrollbar());
 }
 
+bool ScrollableArea::canShowNonOverlayScrollbars() const
+{
+    return canHaveScrollbars() && !ScrollbarTheme::theme().usesOverlayScrollbars();
+}
+
 void ScrollableArea::setScrollbarOverlayStyle(ScrollbarOverlayStyle overlayStyle)
 {
     m_scrollbarOverlayStyle = overlayStyle;

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -170,7 +170,12 @@ public:
     };
     WEBCORE_EXPORT virtual void availableContentSizeChanged(AvailableSizeChangeReason);
 
+    // This returns information about existing scrollbars, not scrollbars that may be created in future.
     bool hasOverlayScrollbars() const;
+
+    // Returns true if any scrollbars that might be created would be non-overlay scrollbars.
+    WEBCORE_EXPORT virtual bool canShowNonOverlayScrollbars() const;
+
     WEBCORE_EXPORT virtual void setScrollbarOverlayStyle(ScrollbarOverlayStyle);
     ScrollbarOverlayStyle scrollbarOverlayStyle() const { return m_scrollbarOverlayStyle; }
     void invalidateScrollbars();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -819,6 +819,11 @@ bool RenderLayerScrollableArea::verticalScrollbarHiddenByStyle() const
     return scrollbarHiddenByStyle(verticalScrollbar());
 }
 
+bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
+{
+    return canHaveScrollbars() && !(m_layer.renderBox() && m_layer.renderBox()->canUseOverlayScrollbars());
+}
+
 static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& renderer)
 {
     if (Element* element = renderer.element()) {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -139,6 +139,8 @@ public:
     bool horizontalScrollbarHiddenByStyle() const final;
     bool verticalScrollbarHiddenByStyle() const final;
 
+    bool canShowNonOverlayScrollbars() const final;
+
     ScrollPosition scrollPosition() const final { return m_scrollPosition; }
 
     Scrollbar* horizontalScrollbar() const final { return m_hBar.get(); }


### PR DESCRIPTION
#### 912b33473fa3567ab5b1207a2b1230246ffa02ec
<pre>
Continual resizeobserver-driven flashing on Jupyter notebook page
<a href="https://bugs.webkit.org/show_bug.cgi?id=236346">https://bugs.webkit.org/show_bug.cgi?id=236346</a>
&lt;rdar://88399120&gt;

Reviewed by Alan Bujtas.

Based on a patch by Cathie Chen (cathiechen@igalia.com)

The page in question has a Resize Observer inside an `&lt;iframe&gt;` observing the `&lt;html&gt;` size, and
messages the enclosing document which attempts to size the iframe to its content. Line wrapping in
the iframe caused a vertical scrollbar to appear and disappear, triggering a continual flicker
between two states (when scrollbars are always visible).

The primary issue is that shrinking an iframe vertically would always trigger a vertical scrollbar,
even when the content could fit without one. This was a combination of two factors. First,
`ScrollView::setFrameRect()` updated scrollbars before forcing layout on the available content size
change, so `updateScrollbars()` saw a stale (too tall) document size and decided that a vertical
scrollbar was needed.

Second, `ScrollView::updateScrollbars()` would sometimes fail to trigger the layout that was
supposed to happen inside `updateContentsSize()`. This happened when there were no scrollbars. The
logic was attempting to avoid work for overlay scrollbars, but really needs to run if there&apos;s the
potential for a space-taking scrollbar to appear. For this, we add the virtual
`canShowNonOverlayScrollbars()` on ScrollableArea, and override on `FrameView` and
`RenderLayerScrollableArea`. Implementations determine if there can be any scrollbars, and if so
whether there is custom scrollbar style, or the theme specifies overlay scrollbars.

Finally, `ScrollView::setFrameRect()` only needs to call `updateScrollbars()` if it didn&apos;t call
`availableContentSizeChanged()`, since `updateScrollbars()` is called inside
`availableContentSizeChanged()`.

Other minor changes include use of SetForScope&lt;&gt;, and improvements to Layout logging.

* LayoutTests/fast/frames/iframe-resize-removes-scrollbar-expected.html: Added.
* LayoutTests/fast/frames/iframe-resize-removes-scrollbar.html: Added.
* LayoutTests/resize-observer/resize-observer-iframe-scrollbar-expected.txt: Added.
* LayoutTests/resize-observer/resize-observer-iframe-scrollbar.html: Added.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::adjustScrollbarsForLayout):
(WebCore::FrameView::willDoLayout):
(WebCore::FrameView::canShowNonOverlayScrollbars const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/FrameViewLayoutContext.cpp:
(WebCore::FrameViewLayoutContext::unscheduleLayout):
(WebCore::FrameViewLayoutContext::layoutTimerFired):
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::updateScrollbars):
(WebCore::ScrollView::setFrameRect):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::canShowNonOverlayScrollbars const):
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::canShowNonOverlayScrollbars const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/252440@main">https://commits.webkit.org/252440@main</a>
</pre>
