### PR TITLE
:focus-within pseudo class doesn't get invalidated when frame loses focus

### DIFF
--- a/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin-expected.html
+++ b/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+#host {
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div id="host"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html
+++ b/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+#parent {
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+#parent:focus-within {
+    width: 50px;
+    height: 50px;
+}
+#host {
+    width: 50px;
+    height: 50px;
+    outline: none;
+}
+</style>
+<div id="parent"><div id="host"></div></div>
+<div></div>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+const shadowRoot = host.attachShadow({mode: 'closed', delegatesFocus: true});
+shadowRoot.innerHTML = `<div tabindex="0"></div>
+<style>
+div { width: 50px; height: 50px; }
+</style>`;
+
+onload = runTest;
+
+async function runTest() {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+
+    eventSender.mouseMoveTo(host.offsetLeft + 5, host.offsetTop + 5);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+
+    await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    await UIHelper.resignFirstResponder();
+
+    await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    testRunner.notifyDone();
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling-expected.html
+++ b/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+#host {
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div id="host"></div>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling.html
+++ b/LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+#host:focus {
+    width: 50px;
+    height: 50px;
+    background: green;
+    overflow: hidden;
+}
+#host + div {
+    width: 100px;
+    height: 50px;
+    background: green;
+}
+#host:focus + div {
+    width: 50px;
+    height: 50px;
+}
+</style>
+<div id="host"></div>
+<div></div>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+const shadowRoot = host.attachShadow({mode: 'closed', delegatesFocus: true});
+shadowRoot.innerHTML = `<div tabindex="0"></div>
+<style>
+div { width: 100px; height: 50px; background: green; }
+</style>`;
+const foucsableElement = shadowRoot.querySelector('div');
+
+onload = runTest;
+
+async function runTest() {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+
+    eventSender.mouseMoveTo(host.offsetLeft + 5, host.offsetTop + 5);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+
+    await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    await UIHelper.resignFirstResponder();
+
+    await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
+    testRunner.notifyDone();
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -911,7 +911,9 @@ webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-codecs.htm
 webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Skip ]
 
 # resignFirstResponder is not implemented on GTK+
-fast/shadow-dom/focus-ring-on-shadow-host.html
+fast/shadow-dom/focus-ring-on-shadow-host.html [ Skip ]
+fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html [ Skip ]
+fast/shadow-dom/focus-ring-on-shadow-host-sibling.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Expected failures.

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -989,7 +989,9 @@ webkit.org/b/77568 fast/text/locale-shaping-complex.html [ ImageOnlyFailure ]
 fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
 
 # resignFirstResponder is not implemented on Windows
-fast/shadow-dom/focus-ring-on-shadow-host.html
+fast/shadow-dom/focus-ring-on-shadow-host.html [ Skip ]
+fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html [ Skip ]
+fast/shadow-dom/focus-ring-on-shadow-host-sibling.html [ Skip ]
 
 ################################################################################
 ###########    End Missing Functionality Prevents Testing         ##############

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -991,7 +991,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         case CSSSelector::PseudoClassFocusVisible:
             return matchesFocusVisiblePseudoClass(element);
         case CSSSelector::PseudoClassFocusWithin:
-            return element.hasFocusWithin();
+            return matchesFocusWithinPseudoClass(element);
         case CSSSelector::PseudoClassHover:
             if (m_strictParsing || element.isLink() || canMatchHoverOrActiveInQuirksMode(context)) {
                 // See the comment in generateElementIsHovered() in SelectorCompiler.

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -349,6 +349,7 @@ private:
     bool m_caretPaint : 1;
     bool m_isCaretBlinkingSuspended : 1;
     bool m_focused : 1;
+    bool m_isActive : 1;
     bool m_shouldShowBlockCursor : 1;
     bool m_pendingSelectionUpdate : 1;
     bool m_alwaysAlignCursorOnScrollWhenRevealingSelection : 1;


### PR DESCRIPTION
#### ac8282feee7f212d45261661d82051c83d344cc2
<pre>
:focus-within pseudo class doesn&apos;t get invalidated when frame loses focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=242526">https://bugs.webkit.org/show_bug.cgi?id=242526</a>

Reviewed by Antti Koivisto and Darin Adler.

This patch fixes the bug that :focus-within pseudo fails to start applying or stop applying upon frame
gaining or losing focus, and makes pseudo class invalidation more precise.

A new boolean flag FrameSelection::m_isActive, which mirrors the value of FocusController::isActive()
while the frame associated with FrameSelection is focused, is introduced and used in FrameSelection&apos;s
isFocusedAndActive on behalf of FocusController::isActive(). It&apos;s used to compute the value of :focus,
:focus-visible, :focus-within and pseudo classes. Most notably, FrameSelection::pageActivationChanged
and FrameSelection::setFocused use it to flip the flag with Style::PseudoClassChangeInvalidation.

Note that the value of FrameSelection::m_isActive could be stale when the frame associated with
FrameSelection is no longer focused. This isn&apos;t an issue in practice since it means isFocusedAndActive
would always return false in such cases (since m_focused check fails).

* LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin-expected.html: Added.
* LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-focuswithin.html: Added.
* LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling-expected.html: Added.
* LayoutTests/fast/shadow-dom/focus-ring-on-shadow-host-sibling.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const): Fixed a bug that this was checking hasFocusWithin
without isFrameFocused.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::isPageActive): Added.
(WebCore::FrameSelection::FrameSelection): Initialize newly introduced m_isActive.
(WebCore::FrameSelection::focusedOrActiveStateChanged): Moved the logic to invalidate elements to
callers of this function: FrameSelection::pageActivationChanged and FrameSelection::setFocused.
(WebCore::invalidateFocusedElementAndShadowIncludingAncestors): Added.
(WebCore::FrameSelection::pageActivationChanged):
(WebCore::FrameSelection::setFocused):
(WebCore::FrameSelection::isFocusedAndActive const):
* Source/WebCore/editing/FrameSelection.h:

Canonical link: <a href="https://commits.webkit.org/252324@main">https://commits.webkit.org/252324@main</a>
</pre>
