### PR TITLE
remove getRGBAImageData refs

### DIFF
--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -47,19 +47,6 @@ void VideoFrame::initializeCharacteristics(MediaTime presentationTime, bool isMi
     const_cast<bool&>(m_isMirrored) = isMirrored;
     const_cast<Rotation&>(m_rotation) = rotation;
 }
-
-#if !PLATFORM(COCOA)
-RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
-{
-#if USE(GSTREAMER)
-    if (isGStreamer())
-        return static_cast<const VideoFrameGStreamer*>(this)->computeRGBAImageData();
-#endif
-    // FIXME: Add support.
-    return nullptr;
-}
-#endif
-
 }
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -60,7 +60,6 @@ public:
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
     WEBCORE_EXPORT RefPtr<VideoFrameCV> asVideoFrameCV();
 #endif
-    WEBCORE_EXPORT RefPtr<JSC::Uint8ClampedArray> getRGBAImageData() const;
 
     virtual FloatSize presentationSize() const = 0;
     virtual uint32_t pixelFormat() const = 0;

--- a/Source/WebCore/platform/VideoFrame.mm
+++ b/Source/WebCore/platform/VideoFrame.mm
@@ -37,25 +37,6 @@
 
 namespace WebCore {
 
-RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
-{
-    PixelBufferConformerCV pixelBufferConformer((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32RGBA) });
-
-    auto pixelBuffer = this->pixelBuffer();
-    auto rgbaPixelBuffer = pixelBufferConformer.convert(pixelBuffer);
-    auto status = CVPixelBufferLockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-    ASSERT_UNUSED(status, status == noErr);
-
-    void* data = CVPixelBufferGetBaseAddressOfPlane(rgbaPixelBuffer.get(), 0);
-    size_t byteLength = CVPixelBufferGetHeight(pixelBuffer) * CVPixelBufferGetWidth(pixelBuffer) * 4;
-    auto result = JSC::Uint8ClampedArray::tryCreate(JSC::ArrayBuffer::create(data, byteLength), 0, byteLength);
-
-    status = CVPixelBufferUnlockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-    ASSERT(status == noErr);
-
-    return result;
-}
-
 #if USE(AVFOUNDATION)
 RefPtr<VideoFrameCV> VideoFrame::asVideoFrameCV()
 {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -249,6 +249,11 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringToIntegerConversion.h>
+#include "PixelBufferConformerCV.h"
+#include "VideoFrameCV.h"
+#include <JavaScriptCore/TypedArrayInlines.h>
+#include <pal/cf/CoreMediaSoftLink.h>
+#include "CoreVideoSoftLink.h"
 
 #if USE(CG)
 #include "PDFDocumentImage.h"
@@ -5616,11 +5621,45 @@ void Internals::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetada
         if (!videoSettings.width() || !videoSettings.height())
             return;
 
-        auto rgba = videoFrame->getRGBAImageData();
-        if (!rgba)
+        #if PLATFORM(COCOA) && ENABLE(VIDEO)
+        const OSType imageFormat = kCVPixelFormatType_32RGBA;
+        RetainPtr<CFNumberRef> imageFormatNumber = adoptCF(CFNumberCreate(nullptr,  kCFNumberIntType,  &imageFormat));
+
+        RetainPtr<CFMutableDictionaryRef> conformerOptions = adoptCF(CFDictionaryCreateMutable(0, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        CFDictionarySetValue(conformerOptions.get(), kCVPixelBufferPixelFormatTypeKey, imageFormatNumber.get());
+        PixelBufferConformerCV pixelBufferConformer(conformerOptions.get());
+
+        auto pixelBuffer = videoFrame->pixelBuffer();
+        auto rgbaPixelBuffer = pixelBufferConformer.convert(pixelBuffer);
+        auto status = CVPixelBufferLockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+        ASSERT_UNUSED(status, status == noErr);
+
+        void* data = CVPixelBufferGetBaseAddressOfPlane(rgbaPixelBuffer.get(), 0);
+        size_t byteLength = CVPixelBufferGetHeight(pixelBuffer) * CVPixelBufferGetWidth(pixelBuffer) * 4;
+        auto result = JSC::Uint8ClampedArray::tryCreate(JSC::ArrayBuffer::create(data, byteLength), 0, byteLength);
+
+        status = CVPixelBufferUnlockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
+        ASSERT(status == noErr);
+        #endif
+        #if !PLATFORM(COCOA)
+        RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
+        {
+        #if USE(GSTREAMER)
+            JSC::Uint8ClampedArray result = nullptr;
+            if (isGStreamer())
+                result = static_cast<const VideoFrameGStreamer*>(this)->computeRGBAImageData();
+        #endif
+            // FIXME: Add support.
+            JSC::Uint8ClampedArray result = nullptr;
+        }
+        #endif
+        // auto rgba = videoFrame->getRGBAImageData();
+        if (!result)
             return;
 
-        auto imageData = ImageData::create(rgba.releaseNonNull(), videoSettings.width(), videoSettings.height(), { { PredefinedColorSpace::SRGB } });
+        // return result;
+
+        auto imageData = ImageData::create(result.releaseNonNull(), videoSettings.width(), videoSettings.height(), { { PredefinedColorSpace::SRGB } });
         if (!imageData.hasException())
             m_nextTrackFramePromise->resolve(imageData.releaseReturnValue());
         else


### PR DESCRIPTION
#### 5ceba47572e5da6d8f73d7bc9ab2be46e4ad0f18
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::initializeCharacteristics):
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/VideoFrame.mm:
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::videoFrameAvailable):

This commit include:

refactor: move function to Internals.cpp

Remove VideoFrame::getRGBAImageData()
<a href="https://bugs.webkit.org/show_bug.cgi?id=240115">https://bugs.webkit.org/show_bug.cgi?id=240115</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::initializeCharacteristics):
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/VideoFrame.mm:
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::videoFrameAvailable):

This patch deletes references to VideoFrame::getRGBAImageData() and refactors existing code to use other overloads.
</pre>