### PR TITLE
Use constexpr DoubleToStringConverter singletons in EcmaScriptConverter() and CSSConverter().

### DIFF
--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -46,24 +46,14 @@ namespace WTF {
 namespace double_conversion {
 
 const DoubleToStringConverter& DoubleToStringConverter::EcmaScriptConverter() {
-  int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN;
-  static DoubleToStringConverter converter(flags,
-                                           "Infinity",
-                                           "NaN",
-                                           'e',
-                                           -6, 21,
-                                           6, 0);
+  constexpr int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN;
+  static constexpr DoubleToStringConverter converter(flags, "Infinity", "NaN", 'e', -6, 21, 6, 0);
   return converter;
 }
 
 const DoubleToStringConverter& DoubleToStringConverter::CSSConverter() {
-  int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN;
-  static DoubleToStringConverter converter(flags,
-                                           "infinity",
-                                           "NaN",
-                                           'e',
-                                           -6, 21,
-                                           6, 0);
+  constexpr int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN;
+  static constexpr DoubleToStringConverter converter(flags, "infinity", "NaN", 'e', -6, 21, 6, 0);
   return converter;
 }
 

--- a/Source/WTF/wtf/dtoa/double-conversion.h
+++ b/Source/WTF/wtf/dtoa/double-conversion.h
@@ -105,7 +105,7 @@ class DoubleToStringConverter {
   //   ToPrecision(230.0, 2) -> "230"
   //   ToPrecision(230.0, 2) -> "230."  with EMIT_TRAILING_DECIMAL_POINT.
   //   ToPrecision(230.0, 2) -> "2.3e2" with EMIT_TRAILING_ZERO_AFTER_POINT.
-  DoubleToStringConverter(int flags,
+  constexpr DoubleToStringConverter(int flags,
                           const char* infinity_symbol,
                           const char* nan_symbol,
                           char exponent_character,
@@ -125,7 +125,7 @@ class DoubleToStringConverter {
             max_trailing_padding_zeroes_in_precision_mode) {
     // When 'trailing zero after the point' is set, then 'trailing point'
     // must be set too.
-    ASSERT(((flags & EMIT_TRAILING_DECIMAL_POINT) != 0) ||
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(((flags & EMIT_TRAILING_DECIMAL_POINT) != 0) ||
         !((flags & EMIT_TRAILING_ZERO_AFTER_POINT) != 0));
   }
 


### PR DESCRIPTION
#### 89e322db73e37f879711ec37d0432248058b164c
<pre>
Use constexpr DoubleToStringConverter singletons in EcmaScriptConverter() and CSSConverter().
<a href="https://bugs.webkit.org/show_bug.cgi?id=242555">https://bugs.webkit.org/show_bug.cgi?id=242555</a>

Reviewed by Darin Adler and Yusuke Suzuki.

Previously, the DoubleToStringConverter singletons were initialized at runtime.  By making
them constexpr, they can be initialize at compile and link time rather than at runtime.

* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/dtoa/double-conversion.h:
(WTF::double_conversion::DoubleToStringConverter::DoubleToStringConverter):

Canonical link: <a href="https://commits.webkit.org/252321@main">https://commits.webkit.org/252321@main</a>
</pre>
