### PR TITLE
Use requested depth-stencil renderbuffer formats

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -778,7 +778,6 @@ void WebGL2RenderingContext::framebufferTextureLayer(GCGLenum target, GCGLenum a
         return;
     }
     framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, texTarget, texture, level, layer);
-    applyStencilTest();
 }
 
 WebGLAny WebGL2RenderingContext::getInternalformatParameter(GCGLenum target, GCGLenum internalformat, GCGLenum pname)
@@ -866,7 +865,6 @@ void WebGL2RenderingContext::renderbufferStorageMultisample(GCGLenum target, GCG
     if (!validateSize(functionName, width, height))
         return;
     renderbufferStorageImpl(target, samples, internalformat, width, height, functionName);
-    applyStencilTest();
 }
 
 WebGLAny WebGL2RenderingContext::getTexParameter(GCGLenum target, GCGLenum pname)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -2442,8 +2442,10 @@ void WebGLRenderingContextBase::disable(GCGLenum cap)
         return;
     if (cap == GraphicsContextGL::STENCIL_TEST) {
         m_stencilEnabled = false;
+#if !USE(ANGLE)
         applyStencilTest();
         return;
+#endif
     }
     if (cap == GraphicsContextGL::SCISSOR_TEST)
         m_scissorEnabled = false;
@@ -2925,8 +2927,10 @@ void WebGLRenderingContextBase::enable(GCGLenum cap)
         return;
     if (cap == GraphicsContextGL::STENCIL_TEST) {
         m_stencilEnabled = true;
+#if !USE(ANGLE)
         applyStencilTest();
         return;
+#endif
     }
     if (cap == GraphicsContextGL::SCISSOR_TEST)
         m_scissorEnabled = true;
@@ -2993,7 +2997,9 @@ void WebGLRenderingContextBase::framebufferRenderbuffer(GCGLenum target, GCGLenu
 #endif
 
     framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, buffer);
+#if !USE(ANGLE)
     applyStencilTest();
+#endif
 }
 
 void WebGLRenderingContextBase::framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum textarget, WebGLTexture* texture, GCGLint level)
@@ -3023,7 +3029,9 @@ void WebGLRenderingContextBase::framebufferTexture2D(GCGLenum target, GCGLenum a
 #endif
 
     framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, textarget, texture, level, 0);
+#if !USE(ANGLE)
     applyStencilTest();
+#endif
 }
 
 void WebGLRenderingContextBase::frontFace(GCGLenum mode)
@@ -4709,7 +4717,9 @@ void WebGLRenderingContextBase::renderbufferStorage(GCGLenum target, GCGLenum in
     if (!validateSize(functionName, width, height))
         return;
     renderbufferStorageImpl(target, 0, internalformat, width, height, functionName);
+#if !USE(ANGLE)
     applyStencilTest();
+#endif
 }
 
 void WebGLRenderingContextBase::renderbufferStorageImpl(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, const char* functionName)
@@ -8059,6 +8069,7 @@ void WebGLRenderingContextBase::synthesizeLostContextGLError(GCGLenum error, con
     m_contextLostState->errors.add(error);
 }
 
+#if !USE(ANGLE)
 void WebGLRenderingContextBase::applyStencilTest()
 {
     bool haveStencilBuffer = false;
@@ -8072,6 +8083,7 @@ void WebGLRenderingContextBase::applyStencilTest()
     }
     enableOrDisable(GraphicsContextGL::STENCIL_TEST, m_stencilEnabled && haveStencilBuffer);
 }
+#endif
 
 void WebGLRenderingContextBase::enableOrDisable(GCGLenum capability, bool enable)
 {
@@ -8121,7 +8133,9 @@ void WebGLRenderingContextBase::setFramebuffer(const AbstractLocker&, GCGLenum t
 
     if (target == GraphicsContextGL::FRAMEBUFFER || target == GraphicsContextGL::DRAW_FRAMEBUFFER) {
         m_framebufferBinding = buffer;
+#if !USE(ANGLE)
         applyStencilTest();
+#endif
     }
     m_context->bindFramebuffer(target, objectOrZero(buffer));
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1156,8 +1156,10 @@ protected:
 
     String ensureNotNull(const String&) const;
 
+#if !USE(ANGLE)
     // Enable or disable stencil test based on user setting and whether the current FBO has a stencil buffer.
     void applyStencilTest();
+#endif
 
     // Helper for enabling or disabling a capability.
     void enableOrDisable(GCGLenum capability, bool enable);


### PR DESCRIPTION
#### 50d25492e4fe331a5e9f432c153bec5fc88cfa14
<pre>
Use requested depth-stencil renderbuffer formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=242657">https://bugs.webkit.org/show_bug.cgi?id=242657</a>

Reviewed by Kenneth Russell.

Create a depth, stencil, or combined depth-stencil
renderbuffer depending on the context creation options.

Using only the requested renderbuffer features reduces
memory footprint because D24S8 may be emulated as D32FS8.

Removed applyStencilTest workaround when ANGLE is used.

Fixes (ANGLE-only):
* conformance/context/context-attributes-alpha-depth-stencil-antialias.html

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::framebufferTextureLayer):
(WebCore::WebGL2RenderingContext::renderbufferStorageMultisample):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::disable):
(WebCore::WebGLRenderingContextBase::enable):
(WebCore::WebGLRenderingContextBase::framebufferRenderbuffer):
(WebCore::WebGLRenderingContextBase::framebufferTexture2D):
(WebCore::WebGLRenderingContextBase::renderbufferStorage):
(WebCore::WebGLRenderingContextBase::setFramebuffer):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::validateAttributes):
(WebCore::GraphicsContextGLANGLE::reshapeFBOs):
(WebCore::GraphicsContextGLANGLE::attachDepthAndStencilBufferIfNeeded):
(WebCore::GraphicsContextGLANGLE::validateDepthStencil):

Canonical link: <a href="https://commits.webkit.org/252900@main">https://commits.webkit.org/252900@main</a>
</pre>
