### PR TITLE
REGRESSION (PHP to Python): http/tests/media/hls/hls-hdr-switch.html is a constant timeout

### DIFF
--- a/LayoutTests/http/tests/media/resources/hls/test-live.py
+++ b/LayoutTests/http/tests/media/resources/hls/test-live.py
@@ -21,15 +21,15 @@ sys.stdout.write(
 
 chunk_duration = 6.0272
 if 'duration' in query.keys():
-    chunk_duration = float(query.get('duration'))
+    chunk_duration = float(query.get('duration')[0])
 
 chunk_count = 4
 if 'count' in query.keys():
-    chunk_count = int(query.get('count'))
+    chunk_count = int(query.get('count')[0])
 
 chunk_url = 'test.ts'
 if 'url' in query.keys():
-    chunk_url = query.get('url')
+    chunk_url = query.get('url')[0]
 
 sys.stdout.write(
     '#EXTM3U\n'

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1887,8 +1887,8 @@ webkit.org/b/186045 imported/w3c/web-platform-tests/html/rendering/replaced-elem
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/extend-20.html [ Slow ]
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/extend-00.html [ Slow ]
 
-# This test requires API only availble on BigSur and later
-webkit.org/b/222425 [ BigSur+ ] http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
+# rdar://96780622
+[ Monterey+ ] http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
 
 # rdar://69347249
 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/realtime-conv.html [ Failure ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -209,9 +209,9 @@ http/tests/download/inherited-encoding.html
 http/tests/images/loading-image-border.html
 http/tests/images/loading-image-no-border.html
 
-# webkit.org/b/221694
-http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
-http/tests/media/hls/hls-progress.html [ Failure ]
+webkit.org/b/223280 http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
+
+http/tests/media/hls/hls-progress.html [ Pass Crash Failure ]
 
 # webkit.org/b/221685
 media/modern-media-controls/media-controller/media-controller-fullscreen-change.html [ Failure Pass ]


### PR DESCRIPTION
#### ba207c023cfed1e0f9e94966d53ae782ba8b108e
<pre>
REGRESSION (PHP to Python): http/tests/media/hls/hls-hdr-switch.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242559">https://bugs.webkit.org/show_bug.cgi?id=242559</a>
rdar://96780676

Reviewed by Jonathan Bedard.

* LayoutTests/http/tests/media/resources/hls/test-live.py: Fix the bug by only looking at the first value for each key,
not the whole list returned by parse_qs.
* LayoutTests/platform/mac/TestExpectations: Adjusted WebKit1 expectations, as this test passes on Big Sur, and
a different bug tracks problems on newer OSes.
* LayoutTests/platform/wk2/TestExpectations: Updated expectations to point to the right bug, and also separated
expectations for unrelated test hls-progress.html which is a flaky failure/crash.

Canonical link: <a href="https://commits.webkit.org/252342@main">https://commits.webkit.org/252342@main</a>
</pre>
