### PR TITLE
Fix a typo in fast/shadow-dom/attach-shadow-to-elements.html

### DIFF
--- a/LayoutTests/fast/shadow-dom/attach-shadow-to-elements-expected.txt
+++ b/LayoutTests/fast/shadow-dom/attach-shadow-to-elements-expected.txt
@@ -218,8 +218,8 @@ PASS document.createElement("section").attachShadow({mode: "open"}) instanceof S
 PASS document.createElement("section").attachShadow({mode: "closed"}) instanceof ShadowRoot is true
 PASS document.createElement("select").attachShadow({mode: "open"}) threw exception NotSupportedError: The operation is not supported..
 PASS document.createElement("select").attachShadow({mode: "closed"}) threw exception NotSupportedError: The operation is not supported..
-FAIL document.createElement("slot ").attachShadow({mode: "open"}) should throw a NotSupportedError. Threw a InvalidCharacterError.
-FAIL document.createElement("slot ").attachShadow({mode: "closed"}) should throw a NotSupportedError. Threw a InvalidCharacterError.
+PASS document.createElement("slot").attachShadow({mode: "open"}) threw exception NotSupportedError: The operation is not supported..
+PASS document.createElement("slot").attachShadow({mode: "closed"}) threw exception NotSupportedError: The operation is not supported..
 PASS document.createElement("small").attachShadow({mode: "open"}) threw exception NotSupportedError: The operation is not supported..
 PASS document.createElement("small").attachShadow({mode: "closed"}) threw exception NotSupportedError: The operation is not supported..
 PASS document.createElement("source").attachShadow({mode: "open"}) threw exception NotSupportedError: The operation is not supported..
@@ -279,7 +279,6 @@ PASS document.createElement("xmp").attachShadow({mode: "closed"}) threw exceptio
 PASS document.createElement("noscript").attachShadow({mode: "open"}) threw exception NotSupportedError: The operation is not supported..
 PASS document.createElement("noscript").attachShadow({mode: "closed"}) threw exception NotSupportedError: The operation is not supported..
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/shadow-dom/attach-shadow-to-elements.html
+++ b/LayoutTests/fast/shadow-dom/attach-shadow-to-elements.html
@@ -12,7 +12,7 @@ const elements = ['a', 'abbr', 'acronym', 'address', 'applet', 'area', 'article'
     'kbd', 'keygen', 'label', 'layer', 'legend', 'li', 'link', 'listing', 'main', 'map', 'mark', 'marquee', 'menu', 'menuitem', 'meta', 'meter',
     'nav', 'nobr', 'noembed', 'noframes', 'nolayer', 'object', 'ol', 'optgroup', 'option', 'output',
     'p', 'param', 'picture', 'plaintext', 'pre', 'progress', 'q', 'rb', 'rp', 'rt', 'rtc', 'ruby',
-    's', 'samp', 'script', 'section', 'select', 'slot ', 'small', 'source', 'span', 'strike', 'strong', 'style', 'sub', 'summary', 'sup',
+    's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strike', 'strong', 'style', 'sub', 'summary', 'sup',
     'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'tt',
     'u', 'ul', 'var', 'video', 'wbr', 'xmp', 'noscript'];
 


### PR DESCRIPTION
#### e826a8a00605979f677750db66c18b77236878ad
<pre>
Fix a typo in fast/shadow-dom/attach-shadow-to-elements.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=242562">https://bugs.webkit.org/show_bug.cgi?id=242562</a>

Reviewed by Alan Bujtas.

Remove the superfluous whitespace in the test.

* LayoutTests/fast/shadow-dom/attach-shadow-to-elements-expected.txt:
* LayoutTests/fast/shadow-dom/attach-shadow-to-elements.html:

Canonical link: <a href="https://commits.webkit.org/252323@main">https://commits.webkit.org/252323@main</a>
</pre>
