### PR TITLE
[Flatpak SDK] xdg-dbus-proxy a11y process goes zombie in local projects runtime

### DIFF
--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -744,6 +744,11 @@ class WebkitFlatpak:
         return command and "build-jsc" in os.path.basename(command)
 
     def setup_a11y_proxy(self):
+        # This method might be called more than once, in case of local projects setups for instance.
+        # Overriding the xdg-dbus-proxy process actually leads to process leaks. Ensure the process
+        # is created at most one time.
+        if self.dbus_proxy_process:
+            return []
         try:
             output = subprocess.check_output(("gdbus", "call", "-e", "-d", "org.a11y.Bus", "-o", "/org/a11y/bus", "-m", "org.a11y.Bus.GetAddress"))
             a11y_bus_address = re.findall(br"'([^']+)", output)[0]  # Extract string from output from: ('unix:abstract=0000f',)


### PR DESCRIPTION
#### 355134e5e9814536b58831aad5774f85b762ffb5
<pre>
[Flatpak SDK] xdg-dbus-proxy a11y process goes zombie in local projects runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=242572">https://bugs.webkit.org/show_bug.cgi?id=242572</a>

Reviewed by Jonathan Bedard.

Setup the a11y proxy only one time at runtime, to avoid zombies.

* Tools/flatpak/flatpakutils.py:
(WebkitFlatpak.setup_a11y_proxy):

Canonical link: <a href="https://commits.webkit.org/252358@main">https://commits.webkit.org/252358@main</a>
</pre>
