### PR TITLE
Tidy VM.h and the VM constructor a bit

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -210,33 +210,17 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , heap(*this, heapType)
     , clientHeap(heap)
     , vmType(vmType)
-    , clientData(nullptr)
-    , topEntryFrame(nullptr)
     , topCallFrame(CallFrame::noCaller())
     , deferredWorkTimer(DeferredWorkTimer::create(*this))
     , m_atomStringTable(vmType == Default ? Thread::current().atomStringTable() : new AtomStringTable)
-    , m_privateSymbolRegistry(WTF::SymbolRegistry::Type::PrivateSymbol)
-    , propertyNames(nullptr)
     , emptyList(new ArgList)
     , machineCodeBytesPerBytecodeWordForBaselineJIT(makeUnique<SimpleStats>())
     , symbolImplToSymbolMap(*this)
-    , interpreter(nullptr)
-    , entryScope(nullptr)
     , m_regExpCache(new RegExpCache(this))
-    , m_compactVariableMap(adoptRef(*(new CompactTDZEnvironmentMap)))
-#if ENABLE(REGEXP_TRACING)
-    , m_rtTraceList(new RTTraceList())
-#endif
-#if ENABLE(GC_VALIDATION)
-    , m_initializingObjectClass(0)
-#endif
-    , m_stackPointerAtVMEntry(nullptr)
+    , m_compactVariableMap(adoptRef(*new CompactTDZEnvironmentMap))
     , m_codeCache(makeUnique<CodeCache>())
     , m_intlCache(makeUnique<IntlCache>())
     , m_builtinExecutables(makeUnique<BuiltinExecutables>(*this))
-    , m_typeProfilerEnabledCount(0)
-    , m_primitiveGigacageEnabled(IsWatched)
-    , m_controlFlowProfilerEnabledCount(0)
 {
     if (UNLIKELY(vmCreationShouldCrash))
         CRASH_WITH_INFO(0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
@@ -336,8 +320,6 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
         pathOut.print("JSCProfile-", getCurrentProcessID(), "-", m_perBytecodeProfiler->databaseID(), ".json");
         m_perBytecodeProfiler->registerToSaveAtExit(pathOut.toCString().data());
     }
-
-    callFrameForCatch = nullptr;
 
     // Initialize this last, as a free way of asserting that VM initialization itself
     // won't use this.
@@ -476,10 +458,6 @@ VM::~VM()
 
     delete clientData;
     delete m_regExpCache;
-
-#if ENABLE(REGEXP_TRACING)
-    delete m_rtTraceList;
-#endif
 
 #if ENABLE(DFG_JIT)
     for (unsigned i = 0; i < m_scratchBuffers.size(); ++i)
@@ -1091,6 +1069,7 @@ static void logSanitizeStack(VM& vm)
 }
 
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
+
 char* VM::acquireRegExpPatternContexBuffer()
 {
     m_regExpPatternContextLock.lock();
@@ -1106,21 +1085,23 @@ void VM::releaseRegExpPatternContexBuffer()
 
     m_regExpPatternContextLock.unlock();
 }
+
 #endif
 
 #if ENABLE(REGEXP_TRACING)
+
 void VM::addRegExpToTrace(RegExp* regExp)
 {
     gcProtect(regExp);
-    m_rtTraceList->add(regExp);
+    m_rtTraceList.add(regExp);
 }
 
 void VM::dumpRegExpTrace()
 {
-    // The first RegExp object is ignored.  It is create by the RegExpPrototype ctor and not used.
-    RTTraceList::iterator iter = ++m_rtTraceList->begin();
+    // The first RegExp object is ignored. It is created by the RegExpPrototype ctor and not used.
+    RTTraceList::iterator iter = ++m_rtTraceList.begin();
     
-    if (iter != m_rtTraceList->end()) {
+    if (iter != m_rtTraceList.end()) {
         dataLogF("\nRegExp Tracing\n");
         dataLogF("Regular Expression                              8 Bit          16 Bit        match()    Matches    Average\n");
         dataLogF(" <Match only / Match>                         JIT Addr      JIT Address       calls      found   String len\n");
@@ -1128,7 +1109,7 @@ void VM::dumpRegExpTrace()
     
         unsigned reCount = 0;
     
-        for (; iter != m_rtTraceList->end(); ++iter, ++reCount) {
+        for (; iter != m_rtTraceList.end(); ++iter, ++reCount) {
             (*iter)->printTraceData();
             gcUnprotect(*iter);
         }
@@ -1136,12 +1117,9 @@ void VM::dumpRegExpTrace()
         dataLogF("%d Regular Expressions\n", reCount);
     }
     
-    m_rtTraceList->clear();
+    m_rtTraceList.clear();
 }
-#else
-void VM::dumpRegExpTrace()
-{
-}
+
 #endif
 
 WatchpointSet* VM::ensureWatchpointSetForImpureProperty(UniquedStringImpl* propertyName)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -70,6 +70,7 @@
 #include <wtf/UniqueArray.h>
 #include <wtf/text/SymbolRegistry.h>
 #include <wtf/text/WTFString.h>
+
 #if ENABLE(REGEXP_TRACING)
 #include <wtf/ListHashSet.h>
 #endif
@@ -394,7 +395,7 @@ public:
     ALWAYS_INLINE GCClient::IsoSubspace& unlinkedFunctionExecutableSpace() { return clientHeap.unlinkedFunctionExecutableSpace; }
 
     VMType vmType;
-    ClientData* clientData;
+    ClientData* clientData { nullptr };
     EntryFrame* topEntryFrame { nullptr };
     // NOTE: When throwing an exception while rolling back the call frame, this may be equal to
     // topEntryFrame.
@@ -462,13 +463,13 @@ public:
 
     Ref<DeferredWorkTimer> deferredWorkTimer;
 
-    JSCell* currentlyDestructingCallbackObject;
+    JSCell* currentlyDestructingCallbackObject { nullptr };
     const ClassInfo* currentlyDestructingCallbackObjectClassInfo { nullptr };
 
     AtomStringTable* m_atomStringTable;
     WTF::SymbolRegistry m_symbolRegistry;
-    WTF::SymbolRegistry m_privateSymbolRegistry;
-    CommonIdentifiers* propertyNames;
+    WTF::SymbolRegistry m_privateSymbolRegistry { WTF::SymbolRegistry::Type::PrivateSymbol };
+    CommonIdentifiers* propertyNames { nullptr };
     const ArgList* emptyList;
     SmallStrings smallStrings;
     NumericStrings numericStrings;
@@ -557,13 +558,12 @@ public:
 
     typedef HashMap<RefPtr<SourceProvider>, RefPtr<SourceProviderCache>> SourceProviderCacheMap;
     SourceProviderCacheMap sourceProviderCacheMap;
-    Interpreter* interpreter;
+    Interpreter* interpreter { nullptr };
 #if ENABLE(JIT)
     std::unique_ptr<JITThunks> jitStubs;
     MacroAssemblerCodeRef<JITThunkPtrTag> getCTIStub(ThunkGenerator);
     std::unique_ptr<SharedJITStubSet> m_sharedJITStubs;
-
-#endif // ENABLE(JIT)
+#endif
 #if ENABLE(FTL_JIT)
     std::unique_ptr<FTL::Thunks> ftlThunks;
 #endif
@@ -674,7 +674,7 @@ public:
     EncodedJSValue encodedHostCallReturnValue { };
     unsigned varargsLength;
     CallFrame* newCallFrameReturnValue;
-    CallFrame* callFrameForCatch;
+    CallFrame* callFrameForCatch { nullptr };
     CalleeBits calleeForWasmCatch;
     void* targetMachinePCForThrow;
     JSOrWasmInstruction targetInterpreterPCForThrow;
@@ -708,7 +708,7 @@ public:
     void scanSideState(ConservativeRoots&) const;
 
     unsigned disallowVMEntryCount { 0 };
-    VMEntryScope* entryScope;
+    VMEntryScope* entryScope { nullptr };
 
     JSObject* stringRecursionCheckFirstObject { nullptr };
     HashSet<JSObject*> stringRecursionCheckVisitedObjects;
@@ -738,17 +738,14 @@ public:
     HasOwnPropertyCache* ensureHasOwnPropertyCache();
 
 #if ENABLE(REGEXP_TRACING)
-    typedef ListHashSet<RegExp*> RTTraceList;
-    RTTraceList* m_rtTraceList;
+    ListHashSet<RegExp*> m_rtTraceList;
+    void addRegExpToTrace(RegExp*);
+    JS_EXPORT_PRIVATE void dumpRegExpTrace();
 #endif
 
     void resetDateCacheIfNecessary() { dateCache.resetIfNecessary(); }
 
     RegExpCache* regExpCache() { return m_regExpCache; }
-#if ENABLE(REGEXP_TRACING)
-    void addRegExpToTrace(RegExp*);
-#endif
-    JS_EXPORT_PRIVATE void dumpRegExpTrace();
 
     bool isCollectorBusyOnCurrentThread() { return heap.currentThreadIsDoingGCWork(); }
 
@@ -910,10 +907,10 @@ private:
     void didExhaustMicrotaskQueue();
 
 #if ENABLE(GC_VALIDATION)
-    const ClassInfo* m_initializingObjectClass;
+    const ClassInfo* m_initializingObjectClass { nullptr };
 #endif
 
-    void* m_stackPointerAtVMEntry;
+    void* m_stackPointerAtVMEntry { nullptr };
     size_t m_currentSoftReservedZoneSize;
     void* m_stackLimit { nullptr };
     void* m_softStackLimit { nullptr };
@@ -949,17 +946,17 @@ private:
     HashMap<RefPtr<UniquedStringImpl>, RefPtr<WatchpointSet>> m_impurePropertyWatchpointSets;
     std::unique_ptr<TypeProfiler> m_typeProfiler;
     std::unique_ptr<TypeProfilerLog> m_typeProfilerLog;
-    unsigned m_typeProfilerEnabledCount;
+    unsigned m_typeProfilerEnabledCount { 0 };
     bool m_needToFirePrimitiveGigacageEnabled { false };
     bool m_isInService { false };
     Lock m_scratchBufferLock;
     Vector<ScratchBuffer*> m_scratchBuffers;
     size_t m_sizeOfLastScratchBuffer { 0 };
     Vector<std::unique_ptr<CheckpointOSRExitSideState>, expectedMaxActiveSideStateCount> m_checkpointSideState;
-    InlineWatchpointSet m_primitiveGigacageEnabled;
+    InlineWatchpointSet m_primitiveGigacageEnabled { IsWatched };
     FunctionHasExecutedCache m_functionHasExecutedCache;
     std::unique_ptr<ControlFlowProfiler> m_controlFlowProfiler;
-    unsigned m_controlFlowProfilerEnabledCount;
+    unsigned m_controlFlowProfilerEnabledCount { 0 };
     Deque<std::unique_ptr<QueuedTask>> m_microtaskQueue;
     MallocPtr<EncodedJSValue, VMMalloc> m_exceptionFuzzBuffer;
     VMTraps m_traps;


### PR DESCRIPTION
#### deb752b9da0a684017973ca133e98a6527199f43
<pre>
Tidy VM.h and the VM constructor a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=242574">https://bugs.webkit.org/show_bug.cgi?id=242574</a>

Reviewed by Mark Lam.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM): Move initialization of clientData, topEntryFrame, m_privateSymbolRegistry
propertyNames, interpreter, entryScope, m_rtTraceList, m_initializingObjectClass,
m_stackPointerAtVMEntry, m_typeProfilerEnabledCount, m_primitiveGigacageEnabled,
m_controlFlowProfilerEnabledCount, and callFrameForCatch to the header file.
(JSC::VM::~VM): Removed deletion of m_rtTraceList since it&apos;s no longer a pointer.
(JSC::VM::addRegExpToTrace): Update since m_rtTraceList is no longer a pointer.
(JSC::VM::dumpRegExpTrace): Ditto. Also remove the unused non-ENABLE(REGEXP_TRACING)
version of this function.

* Source/JavaScriptCore/runtime/VM.h: Initialize the data members mentioned above
here in the header rather than in the constructor. Changed m_rtTraceList from
a ListHashSet* to just a ListHashSet. ListHashSet and the other similar collections
are already pointer-like, the size of a pointer, with an initial empty set represented
by a null pointer, so there is no reason to use a pointer. Also removed the RTTTraceList
type and moved the dumpRegExpTrace declaration inside ENABLE(REGEXP_TRACING) since all
callers were already conditionalized.

Canonical link: <a href="https://commits.webkit.org/252327@main">https://commits.webkit.org/252327@main</a>
</pre>
