### PR TITLE
Fix IPC::Connection::sendOutputMessage(IPC::UnixMessage&) Syscall param sendmsg(msg.msg_iov[2]) points to uninitialised byte(s)

### DIFF
--- a/Source/WebKit/Shared/UpdateInfo.h
+++ b/Source/WebKit/Shared/UpdateInfo.h
@@ -52,7 +52,7 @@ public:
 
     // The size of the web view.
     WebCore::IntSize viewSize;
-    float deviceScaleFactor;
+    float deviceScaleFactor { 0 };
 
     // The rect and delta to be scrolled.
     WebCore::IntRect scrollRect;
@@ -65,7 +65,7 @@ public:
     Vector<WebCore::IntRect> updateRects;
 
     // The page scale factor used to render this update.
-    float updateScaleFactor;
+    float updateScaleFactor { 0 };
 
     // The handle of the shareable bitmap containing the updates. Will be null if there are no updates.
     ShareableBitmap::Handle bitmapHandle;


### PR DESCRIPTION
#### f4367f2cffe45c4514079c73232cf425757ab44e
<pre>
Fix IPC::Connection::sendOutputMessage(IPC::UnixMessage&amp;) Syscall param sendmsg(msg.msg_iov[2]) points to uninitialised byte(s)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242518">https://bugs.webkit.org/show_bug.cgi?id=242518</a>

Reviewed by Fujii Hironori.

Initialize deviceScaleFactor and updateScaleFactor so that we don&apos;t try
to encode uninitialized memory.

* Source/WebKit/Shared/UpdateInfo.h:

Canonical link: <a href="https://commits.webkit.org/252330@main">https://commits.webkit.org/252330@main</a>
</pre>
