### PR TITLE
WebKit::ThreadedCompositor::targetRefreshRateDidChange don't refresh unless !RunLoop::isMain()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -465,7 +465,7 @@ void DrawingAreaCoordinatedGraphics::targetRefreshRateDidChange(unsigned rate)
 {
     UNUSED_PARAM(rate);
 #if !USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
-    if (m_layerTreeHost)
+    if (m_layerTreeHost && !RunLoop::isMain())
         m_layerTreeHost->targetRefreshRateDidChange(rate);
 #endif
 }


### PR DESCRIPTION
#### bd728299696f293aea30b563675ffc089a538e06
<pre>
WebKit::ThreadedCompositor::targetRefreshRateDidChange don&apos;t refresh unless !RunLoop::isMain()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242575">https://bugs.webkit.org/show_bug.cgi?id=242575</a>

Reviewed by NOBODY (OOPS!).

Appears to fix:
[-&gt; Web 74 receiver 0x374e6460] DrawingArea_TargetRefreshRateDidChange (rate 60000)
ASSERTION FAILED: !RunLoop::isMain()
/app/webkit/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp(315) : void WebKit::ThreadedCompositor::targetRefreshRateDidChange(unsigned int)
[-&gt; UI 17 receiver 0x3c1c3110] WebPageProxy_DidUpdateRenderingAfterCommittingLoad
[-&gt; UI 17 receiver 0x1fc3b140] DrawingAreaProxy_DidUpdateBackingStoreState (backingStoreStateID 1) (updateInfo ...) (context ...)

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::targetRefreshRateDidChange):
</pre>