### PR TITLE
[GStreamer][VideoCapture] GLVideoSinkGStreamer fix GstContext resource leak

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -151,16 +151,16 @@ std::optional<GRefPtr<GstContext>> requestGLContext(const char* contextType)
         return std::nullopt;
 
     if (!g_strcmp0(contextType, GST_GL_DISPLAY_CONTEXT_TYPE)) {
-        GstContext* displayContext = gst_context_new(GST_GL_DISPLAY_CONTEXT_TYPE, TRUE);
-        gst_context_set_gl_display(displayContext, gstGLDisplay);
-        return adoptGRef(displayContext);
+        GRefPtr<GstContext> displayContext = adoptGRef(gst_context_new(GST_GL_DISPLAY_CONTEXT_TYPE, TRUE));
+        gst_context_set_gl_display(displayContext.get(), gstGLDisplay);
+        return displayContext;
     }
 
     if (!g_strcmp0(contextType, "gst.gl.app_context")) {
-        GstContext* appContext = gst_context_new("gst.gl.app_context", TRUE);
-        GstStructure* structure = gst_context_writable_structure(appContext);
+        GRefPtr<GstContext> appContext = adoptGRef(gst_context_new("gst.gl.app_context", TRUE));
+        GstStructure* structure = gst_context_writable_structure(appContext.get());
         gst_structure_set(structure, "context", GST_TYPE_GL_CONTEXT, gstGLContext, nullptr);
-        return adoptGRef(appContext);
+        return appContext;
     }
 
     return std::nullopt;
@@ -168,7 +168,7 @@ std::optional<GRefPtr<GstContext>> requestGLContext(const char* contextType)
 
 static bool setGLContext(GstElement* elementSink, const char* contextType)
 {
-    GRefPtr<GstContext> oldContext = gst_element_get_context(elementSink, contextType);
+    GRefPtr<GstContext> oldContext = adoptGRef(gst_element_get_context(elementSink, contextType));
     if (!oldContext) {
         auto newContext = requestGLContext(contextType);
         if (!newContext)


### PR DESCRIPTION
#### 5cdbff32ce95017103b937ecb557380c382ecbdf
<pre>
[GStreamer][VideoCapture] GLVideoSinkGStreamer fix GstContext resource leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=242576">https://bugs.webkit.org/show_bug.cgi?id=242576</a>

Reviewed by Xabier Rodriguez-Calvar.

Refactor ref counting for GstContext in GLVideoSinkGStreamer to
prevent a resource leak.

Fixes:
==196== 401 (296 direct, 105 indirect) bytes in 1 blocks are definitely lost in loss record 58,280 of 62,411
==196==    at 0x4845A83: calloc (vg_replace_malloc.c:1328)
==196==    by 0x15F58780: g_malloc0 (gmem.c:136)
==196==    by 0x161C8CBB: gst_structure_new_id_empty_with_size (gststructure.c:281)
==196==    by 0x161C8CBB: gst_structure_new_id_empty (gststructure.c:312)
==196==    by 0x161716CF: gst_context_new (gstcontext.c:178)
==196==    by 0x1122BB85: requestGLContext(char const*) (GLVideoSinkGStreamer.cpp:154)
==196==    by 0x1122BD12: setGLContext(_GstElement*, char const*) (GLVideoSinkGStreamer.cpp:173)
==196==    by 0x1122BE39: webKitGLVideoSinkChangeState(_GstElement*, GstStateChange) (GLVideoSinkGStreamer.cpp:189)
==196==    by 0x1617FA11: gst_element_change_state (gstelement.c:3083)
==196==    by 0x16180154: gst_element_set_state_func (gstelement.c:3037)
==196==    by 0x40651CE6: activate_sink (gstplaybin3.c:3805)
==196==    by 0x40651CE6: activate_sink.constprop.0 (gstplaybin3.c:3780)
==196==    by 0x40652B3E: activate_group (gstplaybin3.c:4539)
==196==    by 0x40652B3E: setup_next_source (gstplaybin3.c:4801)
==196==    by 0x406542A7: gst_play_bin3_change_state (gstplaybin3.c:5031)
==196==    by 0x1617FA11: gst_element_change_state (gstelement.c:3083)
==196==    by 0x1617FA5A: gst_element_change_state (gstelement.c:3122)
==196==    by 0x16180154: gst_element_set_state_func (gstelement.c:3037)
==196==    by 0x11257BC9: WebCore::MediaPlayerPrivateGStreamer::changePipelineState(GstState) (MediaPlayerPrivateGStreamer.cpp:924)
==196==    by 0x11258D8B: WebCore::MediaPlayerPrivateGStreamer::commitLoad() (MediaPlayerPrivateGStreamer.cpp:1184)
==196==    by 0x1125420B: WebCore::MediaPlayerPrivateGStreamer::load(WTF::String const&amp;) (MediaPlayerPrivateGStreamer.cpp:354)
==196==    by 0x112542F4: WebCore::MediaPlayerPrivateGStreamer::load(WebCore::MediaStreamPrivate&amp;) (MediaPlayerPrivateGStreamer.cpp:370)
==196==    by 0x148CF508: WebCore::MediaPlayer::loadWithNextMediaEngine(WebCore::MediaPlayerFactory const*) (MediaPlayer.cpp:646)
==196==    by 0x148CED64: WebCore::MediaPlayer::load(WebCore::MediaStreamPrivate&amp;) (MediaPlayer.cpp:549)
==196==    by 0x13CF7047: WebCore::HTMLMediaElement::loadResource(WTF::URL const&amp;, WebCore::ContentType&amp;, WTF::String const&amp;) (HTMLMediaElement.cpp:1599)
==196==    by 0x13CF5D70: WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}::operator()() const (HTMLMediaElement.cpp:1413)
==196==    by 0x13D291BD: WTF::Detail::CallableWrapper&lt;WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x131C31E7: WTF::CancellableTask::operator()() (CancellableTask.h:86)
==196==    by 0x13D2D2DD: WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}::operator()() (ActiveDOMObject.h:119)
==196==    by 0x13D5C88F: WTF::Detail::CallableWrapper&lt;WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x1399229B: WebCore::EventLoopFunctionDispatchTask::execute() (EventLoop.cpp:159)
==196==    by 0x13987D3A: WebCore::EventLoop::run() (EventLoop.cpp:123)
==196==    by 0x13ABF15D: WebCore::WindowEventLoop::didReachTimeToRun() (WindowEventLoop.cpp:121)
==196==    by 0x13AD46FB: void std::__invoke_impl&lt;void, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:74)
==196==    by 0x13AD4666: std::__invoke_result&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;::type std::__invoke&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:96)
==196==    by 0x13AD45DC: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==196==    by 0x13AD456E: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==196==    by 0x13AD4537: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0xE23D137: WebCore::Timer::fired() (Timer.h:135)
==196==    by 0x146E59EF: WebCore::ThreadTimers::sharedTimerFiredInternal() (ThreadTimers.cpp:127)
==196==    by 0x146E52E4: WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}::operator()() const (ThreadTimers.cpp:67)
==196==    by 0x146E8407: WTF::Detail::CallableWrapper&lt;WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x14698311: WebCore::MainThreadSharedTimer::fired() (MainThreadSharedTimer.cpp:83)
==196==    by 0x146A2E9D: void std::__invoke_impl&lt;void, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:74)
==196==    by 0x146A2E16: std::__invoke_result&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;::type std::__invoke&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:96)
==196==    by 0x146A2D8C: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==196==    by 0x146A2D1E: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==196==    by 0x146A2CC7: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x146A2CE7: WTF::RunLoop::Timer&lt;WebCore::MainThreadSharedTimer&gt;::fired() (RunLoop.h:188)
==196==    by 0x110196A8: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:177)
==196==    by 0x110196E8: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:181)
==196==    by 0x11018BFA: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==196==    by 0x11018C48: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==196==    by 0x15F52293: g_main_dispatch (gmain.c:3381)
==196==    by 0x15F52293: g_main_context_dispatch (gmain.c:4099)
==196==    by 0x15F52637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==196==    by 0x15F52942: g_main_loop_run (gmain.c:4373)
==196==    by 0x110192B3: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==196==    by 0xEFB8674: WebKit::AuxiliaryProcessMainBase&lt;WebKit::WebProcess, true&gt;::run(int, char**) (AuxiliaryProcessMain.h:70)
==196==    by 0xEFB5D26: int WebKit::AuxiliaryProcessMain&lt;WebKit::WebProcessMainWPE&gt;(int, char**) (AuxiliaryProcessMain.h:96)
==196==    by 0xEFB227E: WebKit::WebProcessMain(int, char**) (WebProcessMainWPE.cpp:75)
==196==    by 0x109908: main (WebProcessMain.cpp:31)
==196==

==196== 403 (88 direct, 315 indirect) bytes in 1 blocks are definitely lost in loss record 58,282 of 62,411
==196==    at 0x4840899: malloc (vg_replace_malloc.c:381)
==196==    by 0x15F58728: g_malloc (gmem.c:106)
==196==    by 0x15F710B4: g_slice_alloc (gslice.c:1072)
==196==    by 0x16171683: gst_context_new (gstcontext.c:174)
==196==    by 0x1122BC0A: requestGLContext(char const*) (GLVideoSinkGStreamer.cpp:160)
==196==    by 0x1122BD12: setGLContext(_GstElement*, char const*) (GLVideoSinkGStreamer.cpp:173)
==196==    by 0x1122BE5D: webKitGLVideoSinkChangeState(_GstElement*, GstStateChange) (GLVideoSinkGStreamer.cpp:191)
==196==    by 0x1617FA11: gst_element_change_state (gstelement.c:3083)
==196==    by 0x16180154: gst_element_set_state_func (gstelement.c:3037)
==196==    by 0x40651CE6: activate_sink (gstplaybin3.c:3805)
==196==    by 0x40651CE6: activate_sink.constprop.0 (gstplaybin3.c:3780)
==196==    by 0x40652B3E: activate_group (gstplaybin3.c:4539)
==196==    by 0x40652B3E: setup_next_source (gstplaybin3.c:4801)
==196==    by 0x406542A7: gst_play_bin3_change_state (gstplaybin3.c:5031)
==196==    by 0x1617FA11: gst_element_change_state (gstelement.c:3083)
==196==    by 0x1617FA5A: gst_element_change_state (gstelement.c:3122)
==196==    by 0x16180154: gst_element_set_state_func (gstelement.c:3037)
==196==    by 0x11257BC9: WebCore::MediaPlayerPrivateGStreamer::changePipelineState(GstState) (MediaPlayerPrivateGStreamer.cpp:924)
==196==    by 0x11258D8B: WebCore::MediaPlayerPrivateGStreamer::commitLoad() (MediaPlayerPrivateGStreamer.cpp:1184)
==196==    by 0x1125420B: WebCore::MediaPlayerPrivateGStreamer::load(WTF::String const&amp;) (MediaPlayerPrivateGStreamer.cpp:354)
==196==    by 0x112542F4: WebCore::MediaPlayerPrivateGStreamer::load(WebCore::MediaStreamPrivate&amp;) (MediaPlayerPrivateGStreamer.cpp:370)
==196==    by 0x148CF508: WebCore::MediaPlayer::loadWithNextMediaEngine(WebCore::MediaPlayerFactory const*) (MediaPlayer.cpp:646)
==196==    by 0x148CED64: WebCore::MediaPlayer::load(WebCore::MediaStreamPrivate&amp;) (MediaPlayer.cpp:549)
==196==    by 0x13CF7047: WebCore::HTMLMediaElement::loadResource(WTF::URL const&amp;, WebCore::ContentType&amp;, WTF::String const&amp;) (HTMLMediaElement.cpp:1599)
==196==    by 0x13CF5D70: WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}::operator()() const (HTMLMediaElement.cpp:1413)
==196==    by 0x13D291BD: WTF::Detail::CallableWrapper&lt;WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x131C31E7: WTF::CancellableTask::operator()() (CancellableTask.h:86)
==196==    by 0x13D2D2DD: WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}::operator()() (ActiveDOMObject.h:119)
==196==    by 0x13D5C88F: WTF::Detail::CallableWrapper&lt;WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x1399229B: WebCore::EventLoopFunctionDispatchTask::execute() (EventLoop.cpp:159)
==196==    by 0x13987D3A: WebCore::EventLoop::run() (EventLoop.cpp:123)
==196==    by 0x13ABF15D: WebCore::WindowEventLoop::didReachTimeToRun() (WindowEventLoop.cpp:121)
==196==    by 0x13AD46FB: void std::__invoke_impl&lt;void, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:74)
==196==    by 0x13AD4666: std::__invoke_result&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;::type std::__invoke&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:96)
==196==    by 0x13AD45DC: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==196==    by 0x13AD456E: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==196==    by 0x13AD4537: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0xE23D137: WebCore::Timer::fired() (Timer.h:135)
==196==    by 0x146E59EF: WebCore::ThreadTimers::sharedTimerFiredInternal() (ThreadTimers.cpp:127)
==196==    by 0x146E52E4: WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}::operator()() const (ThreadTimers.cpp:67)
==196==    by 0x146E8407: WTF::Detail::CallableWrapper&lt;WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x14698311: WebCore::MainThreadSharedTimer::fired() (MainThreadSharedTimer.cpp:83)
==196==    by 0x146A2E9D: void std::__invoke_impl&lt;void, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:74)
==196==    by 0x146A2E16: std::__invoke_result&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;::type std::__invoke&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:96)
==196==    by 0x146A2D8C: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==196==    by 0x146A2D1E: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==196==    by 0x146A2CC7: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;, void&gt;::call() (Function.h:53)
==196==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==196==    by 0x146A2CE7: WTF::RunLoop::Timer&lt;WebCore::MainThreadSharedTimer&gt;::fired() (RunLoop.h:188)
==196==    by 0x110196A8: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:177)
==196==    by 0x110196E8: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:181)
==196==    by 0x11018BFA: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==196==    by 0x11018C48: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==196==    by 0x15F52293: g_main_dispatch (gmain.c:3381)
==196==    by 0x15F52293: g_main_context_dispatch (gmain.c:4099)
==196==    by 0x15F52637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==196==    by 0x15F52942: g_main_loop_run (gmain.c:4373)
==196==    by 0x110192B3: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==196==    by 0xEFB8674: WebKit::AuxiliaryProcessMainBase&lt;WebKit::WebProcess, true&gt;::run(int, char**) (AuxiliaryProcessMain.h:70)
==196==    by 0xEFB5D26: int WebKit::AuxiliaryProcessMain&lt;WebKit::WebProcessMainWPE&gt;(int, char**) (AuxiliaryProcessMain.h:96)
==196==    by 0xEFB227E: WebKit::WebProcessMain(int, char**) (WebProcessMainWPE.cpp:75)
==196==    by 0x109908: main (WebProcessMain.cpp:31)
==196==

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(requestGLContext):
(setGLContext):

Canonical link: <a href="https://commits.webkit.org/252340@main">https://commits.webkit.org/252340@main</a>
</pre>
