### PR TITLE
[iOS] Support dynamically inserted image analysis context menu items when long pressing image links

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -118,7 +118,7 @@ UIContextMenuInteractionDelegate>
 - (void)interactionDidStartWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)information;
 - (void)handleElementActionWithType:(_WKElementActionType)type element:(_WKActivatedElementInfo *)element needsInteraction:(BOOL)needsInteraction;
 #if USE(UICONTEXTMENU)
-- (NSArray<UIMenuElement *> *)suggestedActionsForContextMenuWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)positionInformation;
+- (NSMutableArray<UIMenuElement *> *)suggestedActionsForContextMenuWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)positionInformation;
 #endif
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -585,10 +585,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopy info:elementInfo assistant:self]];
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    if ([_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self]) {
-        // FIXME (rdar://88834304): This should be additionally gated on the relevant VisionKit SPI.
+    if ([_delegate respondsToSelector:@selector(actionSheetAssistantShouldIncludeCopySubjectAction:)] && [_delegate actionSheetAssistantShouldIncludeCopySubjectAction:self])
         [defaultActions addObject:[_WKElementAction _elementActionWithType:_WKElementActionTypeCopyCroppedImage info:elementInfo assistant:self]];
-    }
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -856,7 +854,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
-static NSArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr<NSArray> defaultElementActions, RetainPtr<_WKActivatedElementInfo> elementInfo)
+static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr<NSArray> defaultElementActions, RetainPtr<_WKActivatedElementInfo> elementInfo)
 {
     if (![defaultElementActions count])
         return nil;
@@ -868,7 +866,7 @@ static NSArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr<NSArra
     return actions;
 }
 
-- (NSArray<UIMenuElement *> *)suggestedActionsForContextMenuWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)positionInformation
+- (NSMutableArray<UIMenuElement *> *)suggestedActionsForContextMenuWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)positionInformation
 {
     auto elementInfo = adoptNS([[_WKActivatedElementInfo alloc] _initWithInteractionInformationAtPosition:positionInformation userInfo:nil]);
     RetainPtr<NSArray<_WKElementAction *>> defaultActionsFromAssistant = positionInformation.isLink ? [self defaultActionsForLinkSheet:elementInfo.get()] : [self defaultActionsForImageSheet:elementInfo.get()];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -541,7 +541,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<NSString> _visualSearchPreviewTitle;
     CGRect _visualSearchPreviewImageBounds;
 #endif // USE(QUICK_LOOK)
-    BOOL _canUpdateVisibleContextMenuWithImageAnalysisActions;
+    BOOL _waitingForDynamicImageAnalysisContextMenuActions;
     std::optional<WebKit::ImageAnalysisContextMenuActionData> _imageAnalysisContextMenuActionData;
 #endif // ENABLE(IMAGE_ANALYSIS)
     uint32_t _fullscreenVideoImageAnalysisRequestIdentifier;


### PR DESCRIPTION
#### 24deb829fd303882281b3ef52fa266af13a5e701
<pre>
[iOS] Support dynamically inserted image analysis context menu items when long pressing image links
<a href="https://bugs.webkit.org/show_bug.cgi?id=242577">https://bugs.webkit.org/show_bug.cgi?id=242577</a>
rdar://96800769

Reviewed by Tim Horton.

After 252308@main, when long pressing images inside links in Safari, the contextual image analysis
actions (&quot;Show Text&quot;, &quot;Look Up&quot;, &quot;Copy Subject&quot; and the machine-readable-code submenu) don&apos;t appear
if image analysis takes longer than the context menu appearance animation. This is because we
currently prevent appending these image analysis items in the case where the UI delegate has
supplied its own menu configuration (i.e. the `_canUpdateVisibleContextMenuWithImageAnalysisActions`
flag is set). However, Safari uses this delegate method for image links, and we need to presesrve
the ability for the user to perform these image analysis actions on these links.

To mitigate this, we refactor how this visible menu update codepath works, such that:

1.  If we&apos;re still waiting for image analysis to complete when the context menu shows up, we now
    insert a hidden `UIAction` that represents the list of image analysis items that may potentially
    be inserted once image analysis finishes.

2.  In `-_completeImageAnalysisRequestForContextMenu:`, if this hidden placeholder item is still
    present (in other words, the UI delegate hasn&apos;t explicitly removed it when determining which
    items to present), then swap out this hidden placeholder with the final list of actions.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant defaultActionsForImageSheet:]):
(-[WKActionSheetAssistant suggestedActionsForContextMenuWithPositionInformation:]):

Make this return an NSMutableArray, so that the content view can append an extra placeholder item
to represent the pending image analysis actions. See below for more details.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Replace `_canUpdateVisibleContextMenuWithImageAnalysisActions` with another flag
(`_waitingForDynamicImageAnalysisContextMenuActions`) that indicates whether or not we&apos;re waiting for
image analysis to complete, in order to determine whether the image analysis context menu items
should appear in the long press context menu.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setUpImageAnalysis]):
(-[WKContentView _tearDownImageAnalysis]):
(-[WKContentView imageAnalysisGestureDidBegin:]):
(-[WKContentView _completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:]):

Refactor this to search for and replace the placeholder image analysis action with a list of image
analysis items, after analysis has completed. Also, make a minor adjustment to only insert the
&quot;Copy Subject&quot; item if the &quot;Copy&quot; item is also present. Currently, Mail explicitly avoids adding the
&quot;Copy&quot; menu item when long pressing images in managed emails; this tweak allows us to automatically
match that behavior for &quot;Copy Subject&quot;.

(-[WKContentView placeholderForDynamicallyInsertedImageAnalysisActions]):

Add a helper method to create a hidden `UIAction` to append to the recommended list of context menu
actions when long pressing images (by setting the `UIMenuElementAttributesHidden` item attribute).

(-[WKContentView continueContextMenuInteraction:]):
(-[WKContentView _contextMenuInteraction:overrideSuggestedActionsForConfiguration:]):

Canonical link: <a href="https://commits.webkit.org/252356@main">https://commits.webkit.org/252356@main</a>
</pre>
