### PR TITLE
REGRESSION (252308@main): ImageAnalysisTests.AvoidRedundantTextRecognitionRequests crashes with an unrecognized selector

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
@@ -113,6 +113,7 @@
 @interface TestVKImageAnalysis : NSObject
 - (instancetype)initWithLines:(NSArray<VKWKLineInfo *> *)lines;
 #if HAVE(VK_IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
+@property (nonatomic, readonly) UIMenu *mrcMenu;
 @property (nonatomic, weak) UIViewController *presentingViewControllerForMrcAction;
 #endif
 @end


### PR DESCRIPTION
#### 086c880d7266d9e1c4e1772f5f97b50c8b2bdb17
<pre>
REGRESSION (252308@main): ImageAnalysisTests.AvoidRedundantTextRecognitionRequests crashes with an unrecognized selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=242578">https://bugs.webkit.org/show_bug.cgi?id=242578</a>
rdar://94488144

Reviewed by Devin Rousso.

Quick followup fix after 252308@main -- define a `mrcMenu` property on the simulated
`TestVKImageAnalysis`, to avoid calling an unrecognized selector.

* Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm:

Canonical link: <a href="https://commits.webkit.org/252344@main">https://commits.webkit.org/252344@main</a>
</pre>
