### PR TITLE
[TextureMapper] WebCore::MediaPlayerPrivateGStreamer initialize m_textureMapperFlags

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -356,7 +356,7 @@ protected:
     bool m_areVolumeAndMuteInitialized { false };
 
 #if USE(TEXTURE_MAPPER_GL)
-    TextureMapperGL::Flags m_textureMapperFlags;
+    TextureMapperGL::Flags m_textureMapperFlags { TextureMapperGL::NoFlag };
 #endif
 
     GRefPtr<GstStreamVolume> m_volumeElement;


### PR DESCRIPTION
#### 7a8322c163697373f3ab27cf0014a1f6ce218d7b
<pre>
[TextureMapper] WebCore::MediaPlayerPrivateGStreamer initialize m_textureMapperFlags
<a href="https://bugs.webkit.org/show_bug.cgi?id=242561">https://bugs.webkit.org/show_bug.cgi?id=242561</a>

Reviewed by Xabier Rodriguez-Calvar.

Fixes:
==195== Conditional jump or move depends on uninitialised value(s)
==195==    at 0x11429778: WebCore::TextureMapperPlatformLayerBuffer::paintToTextureMapper(WebCore::TextureMapper&amp;, WebCore::FloatRect const&amp;, WebCore::TransformationMatrix const&amp;, float) (TextureMapperPlatformLayerBuffer.cpp:112)
==195==    by 0x11403DDD: WebCore::TextureMapperLayer::paintSelf(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:202)
==195==    by 0x114042D4: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:255)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x114046C9: WebCore::TextureMapperLayer::paintSelfAndChildren(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:283)
==195==    by 0x114049D4: WebCore::TextureMapperLayer::paintSelfAndChildrenWithReplica(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:319)
==195==    by 0x1140683D: WebCore::TextureMapperLayer::paintSelfChildrenReplicaFilterAndMask(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:563)
==195==    by 0x11406903: WebCore::TextureMapperLayer::paintRecursive(WebCore::TextureMapperPaintOptions&amp;) (TextureMapperLayer.cpp:576)
==195==    by 0x11403586: WebCore::TextureMapperLayer::paint(WebCore::TextureMapper&amp;) (TextureMapperLayer.cpp:145)
==195==    by 0xE6C2F6B: WebKit::CoordinatedGraphicsScene::paintToCurrentGLContext(WebCore::TransformationMatrix const&amp;, WebCore::FloatRect const&amp;, unsigned int) (CoordinatedGraphicsScene.cpp:78)
==195==    by 0xE6E47A2: WebKit::ThreadedCompositor::renderLayerTree() (ThreadedCompositor.cpp:240)
==195==    by 0xE6E3762: WebKit::ThreadedCompositor::ThreadedCompositor(WebKit::ThreadedCompositor::Client&amp;, WebKit::ThreadedDisplayRefreshMonitor::Client&amp;, unsigned int, WebCore::IntSize const&amp;, float, unsigned int)::{lambda()#1}::operator()() const (ThreadedCompositor.cpp:58)
==195==    by 0xE6E83FD: WTF::Detail::CallableWrapper&lt;WebKit::ThreadedCompositor::ThreadedCompositor(WebKit::ThreadedCompositor::Client&amp;, WebKit::ThreadedDisplayRefreshMonitor::Client&amp;, unsigned int, WebCore::IntSize const&amp;, float, unsigned int)::{lambda()#1}, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0xE6C660B: WebKit::CompositingRunLoop::updateTimerFired() (CompositingRunLoop.cpp:188)
==195==    by 0xE6E33EF: void std::__invoke_impl&lt;void, void (WebKit::CompositingRunLoop::*&amp;)(), WebKit::CompositingRunLoop*&amp;&gt;(std::__invoke_memfun_deref, void (WebKit::CompositingRunLoop::*&amp;)(), WebKit::CompositingRunLoop*&amp;) (invoke.h:74)
==195==    by 0xE6E3368: std::__invoke_result&lt;void (WebKit::CompositingRunLoop::*&amp;)(), WebKit::CompositingRunLoop*&amp;&gt;::type std::__invoke&lt;void (WebKit::CompositingRunLoop::*&amp;)(), WebKit::CompositingRunLoop*&amp;&gt;(void (WebKit::CompositingRunLoop::*&amp;)(), WebKit::CompositingRunLoop*&amp;) (invoke.h:96)
==195==    by 0xE6E32DE: void std::_Bind&lt;void (WebKit::CompositingRunLoop::*(WebKit::CompositingRunLoop*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==195==    by 0xE6E3270: void std::_Bind&lt;void (WebKit::CompositingRunLoop::*(WebKit::CompositingRunLoop*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==195==    by 0xE6E3219: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebKit::CompositingRunLoop::*(WebKit::CompositingRunLoop*))()&gt;, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0xE6E3239: WTF::RunLoop::Timer&lt;WebKit::CompositingRunLoop&gt;::fired() (RunLoop.h:188)
==195==    by 0x1108296A: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:177)
==195==    by 0x110829AA: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:181)
==195==    by 0x11081EBC: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==195==    by 0x11081F0A: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==195==    by 0x15FB8293: g_main_dispatch (gmain.c:3381)
==195==    by 0x15FB8293: g_main_context_dispatch (gmain.c:4099)
==195==    by 0x15FB8637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==195==    by 0x15FB8942: g_main_loop_run (gmain.c:4373)
==195==    by 0x11082575: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==195==    by 0xE6C5CB2: WebKit::createRunLoop()::{lambda()#1}::operator()() const (CompositingRunLoop.cpp:49)
==195==    by 0xE6CADE5: WTF::Detail::CallableWrapper&lt;WebKit::createRunLoop()::{lambda()#1}, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0x10FDF034: WTF::Thread::entryPoint(WTF::Thread::NewThreadContext*) (Threading.cpp:236)
==195==    by 0x1108F1BC: WTF::wtfThreadEntryPoint(void*) (ThreadingPOSIX.cpp:242)
==195==    by 0x18A463B9: start_thread (pthread_create.c:481)
==195==    by 0x16782952: clone (clone.S:95)
==195==  Uninitialised value was created by a heap allocation
==195==    at 0x4840899: malloc (vg_replace_malloc.c:381)
==195==    by 0x10F92F47: WTF::fastMalloc(unsigned long) (FastMalloc.cpp:232)
==195==    by 0x112E0165: WebCore::MediaPlayerPrivateGStreamer::operator new(unsigned long) (MediaPlayerPrivateGStreamer.h:128)
==195==    by 0x112E5BB3: std::_MakeUniq&lt;WebCore::MediaPlayerPrivateGStreamer&gt;::__single_object std::make_unique&lt;WebCore::MediaPlayerPrivateGStreamer, WebCore::MediaPlayer*&amp;&gt;(WebCore::MediaPlayer*&amp;) (unique_ptr.h:962)
==195==    by 0x112E24B9: decltype(auto) WTF::makeUnique&lt;WebCore::MediaPlayerPrivateGStreamer, WebCore::MediaPlayer*&amp;&gt;(WebCore::MediaPlayer*&amp;) (StdLibExtras.h:540)
==195==    by 0x112E2509: WebCore::MediaPlayerFactoryGStreamer::createMediaEnginePlayer(WebCore::MediaPlayer*) const (MediaPlayerPrivateGStreamer.cpp:288)
==195==    by 0x149351A3: WebCore::MediaPlayer::loadWithNextMediaEngine(WebCore::MediaPlayerFactory const*) (MediaPlayer.cpp:625)
==195==    by 0x14934C7E: WebCore::MediaPlayer::load(WebCore::MediaStreamPrivate&amp;) (MediaPlayer.cpp:549)
==195==    by 0x13D5FCA5: WebCore::HTMLMediaElement::loadResource(WTF::URL const&amp;, WebCore::ContentType&amp;, WTF::String const&amp;) (HTMLMediaElement.cpp:1599)
==195==    by 0x13D5E9CE: WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}::operator()() const (HTMLMediaElement.cpp:1413)
==195==    by 0x13D91E1B: WTF::Detail::CallableWrapper&lt;WebCore::HTMLMediaElement::selectMediaResource()::{lambda()#1}, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0x1322C265: WTF::CancellableTask::operator()() (CancellableTask.h:86)
==195==    by 0x13D95F3B: WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}::operator()() (ActiveDOMObject.h:119)
==195==    by 0x13DC54ED: WTF::Detail::CallableWrapper&lt;WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive&lt;WebCore::HTMLMediaElement&gt;(WebCore::HTMLMediaElement&amp;, WebCore::TaskSource, WTF::TaskCancellationGroup&amp;, WTF::Function&lt;void ()&gt;&amp;&amp;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0x139FB2B1: WebCore::EventLoopFunctionDispatchTask::execute() (EventLoop.cpp:159)
==195==    by 0x139F0D50: WebCore::EventLoop::run() (EventLoop.cpp:123)
==195==    by 0x13B2815F: WebCore::WindowEventLoop::didReachTimeToRun() (WindowEventLoop.cpp:121)
==195==    by 0x13B3D6FD: void std::__invoke_impl&lt;void, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:74)
==195==    by 0x13B3D668: std::__invoke_result&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;::type std::__invoke&lt;void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;&gt;(void (WebCore::WindowEventLoop::*&amp;)(), WebCore::WindowEventLoop*&amp;) (invoke.h:96)
==195==    by 0x13B3D5DE: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==195==    by 0x13B3D570: void std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==195==    by 0x13B3D539: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::WindowEventLoop::*(WebCore::WindowEventLoop*))()&gt;, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0xE2769FD: WebCore::Timer::fired() (Timer.h:135)
==195==    by 0x1474B909: WebCore::ThreadTimers::sharedTimerFiredInternal() (ThreadTimers.cpp:127)
==195==    by 0x1474B1FE: WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}::operator()() const (ThreadTimers.cpp:67)
==195==    by 0x1474E321: WTF::Detail::CallableWrapper&lt;WebCore::ThreadTimers::setSharedTimer(WebCore::SharedTimer*)::{lambda()#1}, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0x146FE25D: WebCore::MainThreadSharedTimer::fired() (MainThreadSharedTimer.cpp:83)
==195==    by 0x14708DE9: void std::__invoke_impl&lt;void, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(std::__invoke_memfun_deref, void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:74)
==195==    by 0x14708D62: std::__invoke_result&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;::type std::__invoke&lt;void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;&gt;(void (WebCore::MainThreadSharedTimer::*&amp;)(), WebCore::MainThreadSharedTimer*&amp;) (invoke.h:96)
==195==    by 0x14708CD8: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::__call&lt;void, , 0ul&gt;(std::tuple&lt;&gt;&amp;&amp;, std::_Index_tuple&lt;0ul&gt;) (functional:420)
==195==    by 0x14708C6A: void std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;::operator()&lt;, void&gt;() (functional:503)
==195==    by 0x14708C13: WTF::Detail::CallableWrapper&lt;std::_Bind&lt;void (WebCore::MainThreadSharedTimer::*(WebCore::MainThreadSharedTimer*))()&gt;, void&gt;::call() (Function.h:53)
==195==    by 0xD9D7F1C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==195==    by 0x14708C33: WTF::RunLoop::Timer&lt;WebCore::MainThreadSharedTimer&gt;::fired() (RunLoop.h:188)
==195==    by 0x1108296A: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:177)
==195==    by 0x110829AA: WTF::RunLoop::TimerBase::TimerBase(WTF::RunLoop&amp;)::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:181)
==195==    by 0x11081EBC: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==195==    by 0x11081F0A: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==195==    by 0x15FB8293: g_main_dispatch (gmain.c:3381)
==195==    by 0x15FB8293: g_main_context_dispatch (gmain.c:4099)
==195==    by 0x15FB8637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==195==    by 0x15FB8942: g_main_loop_run (gmain.c:4373)
==195==    by 0x11082575: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==195==    by 0xF024098: WebKit::AuxiliaryProcessMainBase&lt;WebKit::WebProcess, true&gt;::run(int, char**) (AuxiliaryProcessMain.h:70)
==195==    by 0xF02174A: int WebKit::AuxiliaryProcessMain&lt;WebKit::WebProcessMainWPE&gt;(int, char**) (AuxiliaryProcessMain.h:96)
==195==    by 0xF01DCA2: WebKit::WebProcessMain(int, char**) (WebProcessMainWPE.cpp:75)
==195==    by 0x109918: main (WebProcessMain.cpp:31)
==195==

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/252393@main">https://commits.webkit.org/252393@main</a>
</pre>
