### PR TITLE
Adjust WebGL2RenderingContext::deleteTransformFeedback validation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3807,6 +3807,7 @@ webgl/2.0.y/conformance/extensions/webgl-multi-draw.html [ Pass Slow ]
 webgl/2.0.y/conformance/programs/program-test.html [ Pass ]
 webgl/2.0.y/conformance2/context/constants-and-properties-2.html [ Pass ]
 webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html [ Pass ]
+webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html [ Pass ]
 webgl/1.0.x/conformance/extensions/oes-vertex-array-object.html [ Pass ]
 
 # Explicitly turn on conformance test until all of webgl/2.0.y is enabled

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2085,11 +2085,20 @@ void WebGL2RenderingContext::deleteTransformFeedback(WebGLTransformFeedback* fee
 
     // We have to short-circuit the deletion process if the transform feedback is
     // active. This requires duplication of some validation logic.
-    if (isContextLostOrPending() && feedbackObject && feedbackObject->validate(contextGroup(), *this)) {
-        if (feedbackObject->isActive()) {
-            synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "deleteTransformFeedback", "attempt to delete an active transform feedback object");
-            return;
-        }
+    if (isContextLostOrPending() || !feedbackObject)
+        return;
+
+    if (!feedbackObject->validate(contextGroup(), *this)) {
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "delete", "object does not belong to this context");
+        return;
+    }
+
+    if (feedbackObject->isDeleted())
+        return;
+
+    if (feedbackObject->isActive()) {
+        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "deleteTransformFeedback", "attempt to delete an active transform feedback object");
+        return;
     }
 
     ASSERT(feedbackObject != m_defaultTransformFeedback);


### PR DESCRIPTION
#### d8119af7ac88f5cd86917520af6ce50343787f3f
<pre>
Adjust WebGL2RenderingContext::deleteTransformFeedback validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=223359">https://bugs.webkit.org/show_bug.cgi?id=223359</a>

Reviewed by Kenneth Russell.

Some checks were bypassed because of
the incorrect context loss condition.

Added an error message when the passed
object belongs to another context.

* LayoutTests/TestExpectations:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::deleteTransformFeedback):

Canonical link: <a href="https://commits.webkit.org/252372@main">https://commits.webkit.org/252372@main</a>
</pre>
