### PR TITLE
[GPUP] The system language in the Web Process needs to match the system language in the GPU Process

### DIFF
--- a/LayoutTests/fast/text/international/system-language/han-text-style-expected.html
+++ b/LayoutTests/fast/text/international/system-language/han-text-style-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><!-- webkit-test-runner [ language=zh-Hans,en-US ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+This test makes sure that the correct glyphs are drawn for text-style fonts when app-specific languages are specified.
+The test passes if this text you're reading right now is the only text on this page.
+</body>
+</html>

--- a/LayoutTests/fast/text/international/system-language/han-text-style.html
+++ b/LayoutTests/fast/text/international/system-language/han-text-style.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ language=zh-Hans,en-US ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+This test makes sure that the correct glyphs are drawn for text-style fonts when app-specific languages are specified.
+The test passes if this text you're reading right now is the only text on this page.
+<div style="position: relative;">
+<div style="font: -apple-system-tall-body; font-size: 48px;"><span id="target">[][][]</target></div>
+<div id="overlay" style="position: absolute; top: 0px; left: 0px; width: 100px; height: 100px; background: white;"></div>
+</div>
+<script>
+let target = document.getElementById("target");
+let overlay = document.getElementById("overlay");
+overlay.style.width = target.offsetWidth + "px";
+overlay.style.height = (target.offsetHeight * 2) + "px";
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,6 +184,9 @@ protected:
 private:
     virtual void connectionWillOpen(IPC::Connection&);
     virtual void processWillShutDown(IPC::Connection&) = 0;
+
+    void populateOverrideLanguagesLaunchOptions(ProcessLauncher::LaunchOptions&) const;
+    Vector<String> platformOverrideLanguages() const;
 
     ResponsivenessTimer m_responsivenessTimer;
     Vector<PendingMessage> m_pendingMessages;

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -26,9 +26,9 @@
 #import "config.h"
 #import "AuxiliaryProcessProxy.h"
 
-#if PLATFORM(COCOA)
-
 #import <WebCore/WebMAudioUtilitiesCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
 #import <pal/cf/AudioToolboxSoftLink.h>
 
 namespace WebKit {
@@ -53,6 +53,10 @@ RefPtr<WebCore::SharedBuffer> AuxiliaryProcessProxy::fetchAudioComponentServerRe
 }
 #endif
 
-} // namespace WebKit
+Vector<String> AuxiliaryProcessProxy::platformOverrideLanguages() const
+{
+    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>([[NSUserDefaults standardUserDefaults] valueForKey:@"AppleLanguages"]);
+    return overrideLanguages;
+}
 
-#endif // PLATFORM(COCOA)
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -252,12 +252,6 @@ void WebProcessProxy::unblockAccessibilityServerIfNeeded()
 
     send(Messages::WebProcess::UnblockServicesRequiredByAccessibility(handleArray), 0);
     m_hasSentMessageToUnblockAccessibilityServer = true;
-}
-
-Vector<String> WebProcessProxy::platformOverrideLanguages() const
-{
-    static const NeverDestroyed<Vector<String>> overrideLanguages = makeVector<String>([[NSUserDefaults standardUserDefaults] valueForKey:@"AppleLanguages"]);
-    return overrideLanguages;
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -35,7 +35,6 @@
 #include "Logging.h"
 #include "NetworkProcessConnectionInfo.h"
 #include "NotificationManagerMessageHandlerMessages.h"
-#include "OverrideLanguages.h"
 #include "ProvisionalPageProxy.h"
 #include "RemoteWorkerType.h"
 #include "ServiceWorkerNotificationHandler.h"
@@ -417,24 +416,6 @@ void WebProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& launchOpt
     if (WebKit::isInspectorProcessPool(processPool()))
         launchOptions.extraInitializationData.add<HashTranslatorASCIILiteral>("inspector-process"_s, "1"_s);
 
-    LOG(Language, "WebProcessProxy is getting launch options.");
-    auto overrideLanguages = WebKit::overrideLanguages();
-    if (overrideLanguages.isEmpty()) {
-        LOG(Language, "overrideLanguages() reports empty. Calling platformOverrideLanguages()");
-        overrideLanguages = platformOverrideLanguages();
-    }
-    if (!overrideLanguages.isEmpty()) {
-        StringBuilder languageString;
-        for (size_t i = 0; i < overrideLanguages.size(); ++i) {
-            if (i)
-                languageString.append(',');
-            languageString.append(overrideLanguages[i]);
-        }
-        LOG_WITH_STREAM(Language, stream << "Setting WebProcess's launch OverrideLanguages to " << languageString);
-        launchOptions.extraInitializationData.add<HashTranslatorASCIILiteral>("OverrideLanguages"_s, languageString.toString());
-    } else
-        LOG(Language, "overrideLanguages is still empty. Not setting WebProcess's launch OverrideLanguages.");
-
     launchOptions.nonValidInjectedCodeAllowed = shouldAllowNonValidInjectedCode();
 
     if (isPrewarmed())
@@ -774,11 +755,6 @@ bool WebProcessProxy::checkURLReceivedFromWebProcess(const URL& url, CheckBackFo
 bool WebProcessProxy::fullKeyboardAccessEnabled()
 {
     return false;
-}
-
-Vector<String> WebProcessProxy::platformOverrideLanguages() const
-{
-    return { };
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -524,7 +524,6 @@ private:
     void logDiagnosticMessageForResourceLimitTermination(const String& limitKey);
     
     void updateRegistrationWithDataStore();
-    Vector<String> platformOverrideLanguages() const;
 
     void maybeShutDown();
 


### PR DESCRIPTION
#### 50f8feea3d4e1a756d156a56519d1c33a8fdad92
<pre>
[GPUP] The system language in the Web Process needs to match the system language in the GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242581">https://bugs.webkit.org/show_bug.cgi?id=242581</a>
&lt;rdar://problem/94135218&gt;

Reviewed by Chris Dumez.

If the Web Process and the GPU process disagree about the system language, we can&apos;t IPC
system fonts correctly.

This patch simply moves the code that sets the web process&apos;s system language from WebProcessProxy
to AuxiliaryProcessProxy, so all processes get it, so all WebKit processes agree on the system language.

Test: fast/text/international/system-language/han-text-style.html

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::populateOverrideLanguagesLaunchOptions):
(WebKit::AuxiliaryProcessProxy::getLaunchOptions):
(WebKit::AuxiliaryProcessProxy::platformOverrideLanguages const):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformOverrideLanguages const):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::platformOverrideLanguages const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::getLaunchOptions):
(WebKit::WebProcessProxy::fullKeyboardAccessEnabled):
(WebKit::WebProcessProxy::platformOverrideLanguages const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/252347@main">https://commits.webkit.org/252347@main</a>
</pre>
