### PR TITLE
Delete dead code WebProcessPool::setOverrideLanguages()

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -363,18 +363,6 @@ void WebProcessPool::setCustomWebContentServiceBundleIdentifier(const String& cu
     m_configuration->setCustomWebContentServiceBundleIdentifier(customWebContentServiceBundleIdentifier);
 }
 
-void WebProcessPool::setOverrideLanguages(Vector<String>&& languages)
-{
-    m_configuration->setOverrideLanguages(WTFMove(languages));
-
-    LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
-    sendToAllProcesses(Messages::WebProcess::UserPreferredLanguagesChanged(m_configuration->overrideLanguages()));
-#if USE(SOUP)
-    for (auto networkProcess : NetworkProcessProxy::allNetworkProcesses())
-        networkProcess->send(Messages::NetworkProcess::UserPreferredLanguagesChanged(m_configuration->overrideLanguages()), 0);
-#endif
-}
-
 void WebProcessPool::fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled)
 {
     sendToAllProcesses(Messages::WebProcess::FullKeyboardAccessModeChanged(fullKeyboardAccessEnabled));

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -492,8 +492,6 @@ public:
     void setJavaScriptConfigurationDirectory(String&& directory) { m_javaScriptConfigurationDirectory = directory; }
     const String& javaScriptConfigurationDirectory() const { return m_javaScriptConfigurationDirectory; }
 
-    void setOverrideLanguages(Vector<String>&&);
-
     WebProcessDataStoreParameters webProcessDataStoreParameters(WebProcessProxy&, WebsiteDataStore&);
     
     static void setUseSeparateServiceWorkerProcess(bool);


### PR DESCRIPTION
#### 580050ef828abbe5203981153baf2ccce2122294
<pre>
Delete dead code WebProcessPool::setOverrideLanguages()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242582">https://bugs.webkit.org/show_bug.cgi?id=242582</a>

Reviewed by NOBODY (OOPS!).

Nobody calls it.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::setOverrideLanguages): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
</pre>