### PR TITLE
shadow-dom/nested-slot-remove-crash.html and other -crash tests are listed in resource-files.json

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -300,6 +300,7 @@ class TestImporter(object):
             total_tests = 0
             reftests = 0
             jstests = 0
+            crashtests = 0
 
             copy_list = []
 
@@ -361,6 +362,10 @@ class TestImporter(object):
                     jstests += 1
                     total_tests += 1
                     copy_list.append({'src': fullpath, 'dest': filename})
+                elif 'crashtest' in test_info.keys():
+                    crashtests += 1
+                    total_tests += 1
+                    copy_list.append({'src': fullpath, 'dest': filename})
                 else:
                     total_tests += 1
                     copy_list.append({'src': fullpath, 'dest': filename})
@@ -368,7 +373,7 @@ class TestImporter(object):
             if copy_list:
                 # Only add this directory to the list if there's something to import
                 self.import_list.append({'dirname': root, 'copy_list': copy_list,
-                    'reftests': reftests, 'jstests': jstests, 'total_tests': total_tests})
+                    'reftests': reftests, 'jstests': jstests, 'crashtests': crashtests, 'total_tests': total_tests})
 
     def should_convert_test_harness_links(self, test):
         if self._importing_downloaded_tests:
@@ -460,6 +465,7 @@ class TestImporter(object):
         total_imported_tests = 0
         total_imported_reftests = 0
         total_imported_jstests = 0
+        total_imported_crashtests = 0
         total_prefixed_properties = {}
         total_prefixed_property_values = {}
 
@@ -473,6 +479,7 @@ class TestImporter(object):
             total_imported_tests += dir_to_copy['total_tests']
             total_imported_reftests += dir_to_copy['reftests']
             total_imported_jstests += dir_to_copy['jstests']
+            total_imported_crashtests += dir_to_copy['crashtests']
 
             prefixed_properties = []
             prefixed_property_values = []
@@ -576,6 +583,7 @@ class TestImporter(object):
         _log.info('IMPORTED %d TOTAL TESTS', total_imported_tests)
         _log.info('Imported %d reftests', total_imported_reftests)
         _log.info('Imported %d JS tests', total_imported_jstests)
+        _log.info('Imported %d Crash tests', total_imported_crashtests)
         _log.info('Imported %d pixel/manual tests', total_imported_tests - total_imported_jstests - total_imported_reftests)
         if len(failed_conversion_files):
             _log.warn('Failed converting %d files (files copied without being converted)', len(failed_conversion_files))

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -347,6 +347,27 @@ class TestImporterTest(unittest.TestCase):
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/new-manual.html'))
         self.assertEqual(tests_options, fs.read_text_file('/mock-checkout/LayoutTests/tests-options.json'))
 
+    def test_crash_test_with_resource_file(self):
+        FAKE_FILES = {
+            '/home/user/wpt/css/css-images/test-crash.html': '<!DOCTYPE html>',
+            '/home/user/wpt/css/css-images/some-file.html': '<!DOCTYPE html>',
+            '/home/user/wpt/css/css-images/resources/some-file.html': '<!DOCTYPE html>',
+            '/mock-checkout/LayoutTests/imported/w3c/resources/resource-files.json': '{"directories": [], "files": []}',
+        }
+        FAKE_FILES.update(FAKE_REPOSITORIES)
+
+        fs = self.import_directory(['-s', '/home/user/wpt', '-d', '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests'], FAKE_FILES, 'css/css-images')
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/css/css-images/test-crash.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/css/css-images/some-file.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/css/css-images/resources/some-file.html'))
+
+        self.assertEqual(fs.read_text_file('/mock-checkout/LayoutTests/imported/w3c/resources/resource-files.json'), """{
+    "directories": [],
+    "files": [
+        "css/css-images/some-file.html"
+    ]
+}""")
+
     def test_webkit_test_runner_options(self):
         FAKE_FILES = {
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/t/test.html': '<!doctype html><script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script>',

--- a/Tools/Scripts/webkitpy/w3c/test_parser.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser.py
@@ -121,7 +121,8 @@ class TestParser(object):
                 if len(reference_support_files) > 0:
                     reference_relpath = self.filesystem.relpath(self.filesystem.dirname(self.filename), self.filesystem.dirname(ref_file)) + self.filesystem.sep
                     test_info['reference_support_info'] = {'reference_relpath': reference_relpath, 'files': reference_support_files}
-
+        elif self.is_wpt_crashtest():
+            test_info = {'test': self.filename, 'crashtest': True}
         elif self.is_jstest():
             test_info = {'test': self.filename, 'jstest': True}
         elif self.is_reference_filename():
@@ -162,6 +163,9 @@ class TestParser(object):
                 return True
 
         return False
+
+    def is_wpt_crashtest(self):
+        return self.filename.find('-crash.') != -1
 
     def is_reference_filename(self):
         # From tools/manifest/sourcefile.py in WPT repository

--- a/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
@@ -218,7 +218,6 @@ class TestParserTest(unittest.TestCase):
         test_info = parser.analyze_test(test_contents=test_html)
         self.assertTrue(test_info['manualtest'], 'test_info is manual')
 
-
     def test_analyze_css_manual_test(self):
         """ Tests analyze_test() using a css manual test """
 
@@ -243,6 +242,21 @@ class TestParserTest(unittest.TestCase):
 """ % flag
             test_info = parser.analyze_test(test_contents=test_html)
             self.assertTrue(test_info['manualtest'], 'test with CSS flag %s should be manual' % flag)
+
+    def test_analyze_crash_test(self):
+        test_html = """<body></body>
+"""
+        test_path = os.path.join(os.path.sep, 'some', 'madeup', 'path')
+        parser = TestParser(options, os.path.join(test_path, 'somefile-crash.html'))
+        test_info = parser.analyze_test(test_contents=test_html)
+
+        self.assertNotEqual(test_info, None)
+        self.assertTrue('test' in test_info.keys())
+        self.assertTrue('crashtest' in test_info.keys())
+        self.assertFalse('reference' in test_info.keys())
+        self.assertFalse('type' in test_info.keys())
+        self.assertFalse('refsupport' in test_info.keys())
+        self.assertFalse('jstest' in test_info.keys())
 
     def test_analyze_pixel_test_all_true(self):
         """ Tests analyze_test() using a test that is neither a reftest or jstest with all=False """


### PR DESCRIPTION
#### 23adab4c9570e7b928e01727b0abb9de24bc9985
<pre>
shadow-dom/nested-slot-remove-crash.html and other -crash tests are listed in resource-files.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=242586">https://bugs.webkit.org/show_bug.cgi?id=242586</a>

Reviewed by Jonathan Bedard and Chris Dumez.

The bug was caused by find_importable_tests classifying a crash test as a potential resource file
since TestParser.analyze_test doesn&apos;t recognize a crash test. Fixed the bug by adding an explicit
check for a crash test in TestParser.analyze_test, and importing this category of tests as such.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.find_importable_tests): Count crash tests as a separate category.
(TestImporter.import_tests): Ditto.
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(test_crash_test_with_resource_file): Added.
* Tools/Scripts/webkitpy/w3c/test_parser.py:
(TestParser.analyze_test):
(TestParser.is_wpt_crashtest): Added.
* Tools/Scripts/webkitpy/w3c/test_parser_unittest.py:
(test_analyze_crash_test): Added.

Canonical link: <a href="https://commits.webkit.org/252348@main">https://commits.webkit.org/252348@main</a>
</pre>
