### PR TITLE
Fix the build warning below from 252277@main

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js
@@ -28,7 +28,7 @@ WI.SourceCodeSearchMatchObject = class SourceCodeSearchMatchObject
     constructor(sourceCode, lineText, searchTerm, textRange)
     {
         console.assert(sourceCode instanceof WI.SourceCode);
-        console.assert(textRange instanceof WI.TextRange, textRange)
+        console.assert(textRange instanceof WI.TextRange, textRange);
 
         this._sourceCode = sourceCode;
         this._lineText = lineText;


### PR DESCRIPTION
#### d7903e73fd92e1e091f668cf6658625471ad9a4d
<pre>
Fix the build warning below from 252277@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242591">https://bugs.webkit.org/show_bug.cgi?id=242591</a>

Unreviewed. This patch fixes the build warning occurs in SourceCodeSearchMatchObject.js.

WARNING: console.assert missing trailing semicolon on line 39741:
console.assert(textRange instanceof WI.TextRange, textRange)

* Source/WebInspectorUI/UserInterface/Models/SourceCodeSearchMatchObject.js:
(WI.SourceCodeSearchMatchObject):

Canonical link: <a href="https://commits.webkit.org/252336@main">https://commits.webkit.org/252336@main</a>
</pre>
