### PR TITLE
Unreviewed. [GTK] Fix make dist

### DIFF
--- a/Tools/gtk/manifest.txt.in
+++ b/Tools/gtk/manifest.txt.in
@@ -94,7 +94,6 @@ exclude Tools/gtk/ycm_extra_conf.py
 file Tools/glib/common.py
 file Tools/glib/generate-inspector-gresource-manifest.py
 
-directory Tools/gtkdoc
 directory Tools/MiniBrowser
 directory Tools/TestWebKitAPI
 


### PR DESCRIPTION
#### 2bd1d79f4988da0429e0046254e065bc154c1a4a
<pre>
Unreviewed. [GTK] Fix make dist

Remove reference to gtkdoc directory that no longer exists.

* Tools/gtk/manifest.txt.in:

Canonical link: <a href="https://commits.webkit.org/252339@main">https://commits.webkit.org/252339@main</a>
</pre>
