### PR TITLE
WebCore::GlobalWindowIdentifier Initialize processIdentifier

### DIFF
--- a/Source/WebCore/page/GlobalWindowIdentifier.h
+++ b/Source/WebCore/page/GlobalWindowIdentifier.h
@@ -89,7 +89,11 @@ struct GlobalWindowIdentifierHash {
 template<> struct HashTraits<WebCore::GlobalWindowIdentifier> : GenericHashTraits<WebCore::GlobalWindowIdentifier> {
     static WebCore::GlobalWindowIdentifier emptyValue() { return { }; }
 
-    static void constructDeletedValue(WebCore::GlobalWindowIdentifier& slot) { new (NotNull, &slot.windowIdentifier) WebCore::WindowIdentifier(WTF::HashTableDeletedValue); }
+    static void constructDeletedValue(WebCore::GlobalWindowIdentifier& slot)
+    {
+        new (NotNull, &slot.processIdentifier) WebCore::ProcessIdentifier(WTF::HashTableDeletedValue);
+        new (NotNull, &slot.windowIdentifier) WebCore::WindowIdentifier(WTF::HashTableDeletedValue);
+    }
     static bool isDeletedValue(const WebCore::GlobalWindowIdentifier& slot) { return slot.windowIdentifier.isHashTableDeletedValue(); }
 };
 


### PR DESCRIPTION
#### ca0950a5bebc48b166c3c9199f0e3a938e0ff126
<pre>
WebCore::GlobalWindowIdentifier Initialize processIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=242517">https://bugs.webkit.org/show_bug.cgi?id=242517</a>

Reviewed by Darin Adler.

We need to initialize processIdentifier as it is accessed by the
equality operator for GlobalWindowIdentifier.

Fixes the following valgrind error:
==137== Conditional jump or move depends on uninitialised value(s)
==137==    at 0x144770C4: WebCore::operator==(WebCore::GlobalWindowIdentifier const&amp;, WebCore::GlobalWindowIdentifier const&amp;) (GlobalWindowIdentifier.h:49)
==137==    by 0x1447715D: WTF::GlobalWindowIdentifierHash::equal(WebCore::GlobalWindowIdentifier const&amp;, WebCore::GlobalWindowIdentifier const&amp;) (GlobalWindowIdentifier.h:85)
==137==    by 0x1447ACBA: bool WTF::HashMapTranslator&lt;WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt; &gt;::equal&lt;WebCore::GlobalWindowIdentifier, WebCore::GlobalWindowIdentifier&gt;(WebCore::GlobalWindowIdentifier const&amp;, WebCore::GlobalWindowIdentifier const&amp;) (HashMap.h:229)
==137==    by 0x1447AAEB: void WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;::checkKey&lt;WTF::HashMapTranslator&lt;WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier&gt;(WebCore::GlobalWindowIdentifier const&amp;) (HashTable.h:664)
==137==    by 0x14479888: WTF::HashTableAddResult&lt;WTF::HashTableIterator&lt;WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt; &gt; WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;::add&lt;WTF::HashMapTranslator&lt;WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier const&amp;, WebCore::AbstractDOMWindow*&gt;(WebCore::GlobalWindowIdentifier const&amp;, WebCore::AbstractDOMWindow*&amp;&amp;) (HashTable.h:932)
==137==    by 0x1447895D: WTF::HashTableAddResult&lt;WTF::HashTableIterator&lt;WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt; &gt; WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::inlineAdd&lt;WebCore::GlobalWindowIdentifier const&amp;, WebCore::AbstractDOMWindow*&gt;(WebCore::GlobalWindowIdentifier const&amp;, WebCore::AbstractDOMWindow*&amp;&amp;) (HashMap.h:382)
==137==    by 0x1447795B: WTF::HashTableAddResult&lt;WTF::HashTableIterator&lt;WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt; &gt; WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::add&lt;WebCore::AbstractDOMWindow*&gt;(WebCore::GlobalWindowIdentifier const&amp;, WebCore::AbstractDOMWindow*&amp;&amp;) (HashMap.h:417)
==137==    by 0x144705B3: WebCore::AbstractDOMWindow::AbstractDOMWindow(WebCore::GlobalWindowIdentifier&amp;&amp;) (AbstractDOMWindow.cpp:48)
==137==    by 0x1448AA3C: WebCore::DOMWindow::DOMWindow(WebCore::Document&amp;) (DOMWindow.cpp:405)
==137==    by 0x1392F767: WebCore::DOMWindow::create(WebCore::Document&amp;) (DOMWindow.h:124)
==137==    by 0x139026F1: WebCore::Document::createDOMWindow() (Document.cpp:5119)
==137==    by 0x142DD1B7: WebCore::DocumentWriter::begin(WTF::URL const&amp;, bool, WebCore::Document*, WebCore::ProcessQualified&lt;WTF::UUID&gt;)::{lambda()#1}::operator()() const (DocumentWriter.cpp:165)
==137==    by 0x142E61DB: WTF::Detail::CallableWrapper&lt;WebCore::DocumentWriter::begin(WTF::URL const&amp;, bool, WebCore::Document*, WebCore::ProcessQualified&lt;WTF::UUID&gt;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==137==    by 0xD9D5E94: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==137==    by 0x1431A333: WebCore::FrameLoader::clear(WTF::RefPtr&lt;WebCore::Document, WTF::RawPtrTraits&lt;WebCore::Document&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Document&gt; &gt;&amp;&amp;, bool, bool, bool, WTF::Function&lt;void ()&gt;&amp;&amp;) (FrameLoader.cpp:646)
==137==    by 0x142DD5B1: WebCore::DocumentWriter::begin(WTF::URL const&amp;, bool, WebCore::Document*, WebCore::ProcessQualified&lt;WTF::UUID&gt;) (DocumentWriter.cpp:168)
==137==    by 0x142D05BB: WebCore::DocumentLoader::commitData(WebCore::SharedBuffer const&amp;) (DocumentLoader.cpp:1235)
==137==    by 0x142CAE8C: WebCore::DocumentLoader::finishedLoading() (DocumentLoader.cpp:493)
==137==    by 0x142D44AA: WebCore::DocumentLoader::maybeLoadEmpty() (DocumentLoader.cpp:2038)
==137==    by 0x142D4D93: WebCore::DocumentLoader::startLoadingMainResource() (DocumentLoader.cpp:2065)
==137==    by 0x143188E2: WebCore::FrameLoader::init() (FrameLoader.cpp:351)
==137==    by 0x144DB8BF: WebCore::Frame::init() (Frame.cpp:192)
==137==    by 0xEFD71C5: WebKit::WebFrame::initWithCoreMainFrame(WebKit::WebPage&amp;, WebCore::Frame&amp;) (WebFrame.cpp:115)
==137==    by 0xEF7CECD: WebKit::WebPage::WebPage(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;) (WebPage.cpp:721)
==137==    by 0xEF7B307: WebKit::WebPage::create(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;) (WebPage.cpp:461)
==137==    by 0xECA85C2: WebKit::WebProcess::createWebPage(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;) (WebProcess.cpp:837)
==137==    by 0xDEB4991: void IPC::callMemberFunctionImpl&lt;WebKit::WebProcess, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;), std::tuple&lt;WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&gt;, 0ul, 1ul&gt;(WebKit::WebProcess*, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;), std::tuple&lt;WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&gt;&amp;&amp;, std::integer_sequence&lt;unsigned long, 0ul, 1ul&gt;) (HandleMessage.h:131)
==137==    by 0xDEB1B6F: void IPC::callMemberFunction&lt;WebKit::WebProcess, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;), std::tuple&lt;WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&gt;, std::integer_sequence&lt;unsigned long, 0ul, 1ul&gt; &gt;(std::tuple&lt;WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&gt;&amp;&amp;, WebKit::WebProcess*, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;)) (HandleMessage.h:137)
==137==    by 0xDEACC26: void IPC::handleMessage&lt;Messages::WebProcess::CreateWebPage, WebKit::WebProcess, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;)&gt;(IPC::Connection&amp;, IPC::Decoder&amp;, WebKit::WebProcess*, void (WebKit::WebProcess::*)(WTF::ObjectIdentifier&lt;WebCore::PageIdentifierType&gt;, WebKit::WebPageCreationParameters&amp;&amp;)) (HandleMessage.h:259)
==137==    by 0xDEAA311: WebKit::WebProcess::didReceiveWebProcessMessage(IPC::Connection&amp;, IPC::Decoder&amp;) (WebProcessMessageReceiver.cpp:280)
==137==    by 0xECA8AA3: WebKit::WebProcess::didReceiveMessage(IPC::Connection&amp;, IPC::Decoder&amp;) (WebProcess.cpp:916)
==137==    by 0xE58AFE3: IPC::Connection::dispatchMessage(IPC::Decoder&amp;) (Connection.cpp:1108)
==137==    by 0xE58B27A: IPC::Connection::dispatchMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;) (Connection.cpp:1153)
==137==    by 0xE58B821: IPC::Connection::dispatchOneIncomingMessage() (Connection.cpp:1222)
==137==    by 0xE58ACF3: IPC::Connection::enqueueIncomingMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;)::{lambda()#1}::operator()() (Connection.cpp:1072)
==137==    by 0xE591DD7: WTF::Detail::CallableWrapper&lt;IPC::Connection::enqueueIncomingMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==137==    by 0xD9D5E94: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==137==    by 0x10FD4BEE: WTF::RunLoop::performWork() (RunLoop.cpp:133)
==137==    by 0x110803FD: WTF::RunLoop::RunLoop()::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:80)
==137==    by 0x11080421: WTF::RunLoop::RunLoop()::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:82)
==137==    by 0x11080390: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==137==    by 0x110803DE: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==137==    by 0x15FB4293: g_main_dispatch (gmain.c:3381)
==137==    by 0x15FB4293: g_main_context_dispatch (gmain.c:4099)
==137==    by 0x15FB4637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==137==    by 0x15FB4942: g_main_loop_run (gmain.c:4373)
==137==    by 0x11080A49: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==137==    by 0xF022010: WebKit::AuxiliaryProcessMainBase&lt;WebKit::WebProcess, true&gt;::run(int, char**) (AuxiliaryProcessMain.h:70)
==137==    by 0xF01F6C2: int WebKit::AuxiliaryProcessMain&lt;WebKit::WebProcessMainWPE&gt;(int, char**) (AuxiliaryProcessMain.h:96)
==137==    by 0xF01BC1A: WebKit::WebProcessMain(int, char**) (WebProcessMainWPE.cpp:75)
==137==    by 0x109918: main (WebProcessMain.cpp:31)
==137==  Uninitialised value was created by a stack allocation
==137==    at 0x1447AA1A: void WTF::HashTable&lt;WebCore::GlobalWindowIdentifier, WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt;, WTF::KeyValuePairKeyExtractor&lt;WTF::KeyValuePair&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*&gt; &gt;, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt; &gt;::checkKey&lt;WTF::HashMapTranslator&lt;WTF::HashMap&lt;WebCore::GlobalWindowIdentifier, WebCore::AbstractDOMWindow*, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;, WTF::HashTraits&lt;WebCore::AbstractDOMWindow*&gt;, WTF::HashTableTraits&gt;::KeyValuePairTraits, WTF::DefaultHash&lt;WebCore::GlobalWindowIdentifier&gt; &gt;, WebCore::GlobalWindowIdentifier&gt;(WebCore::GlobalWindowIdentifier const&amp;) (HashTable.h:655)
==137==

* Source/WebCore/page/GlobalWindowIdentifier.h:
(WTF::HashTraits&lt;WebCore::GlobalWindowIdentifier&gt;::constructDeletedValue):

Canonical link: <a href="https://commits.webkit.org/252473@main">https://commits.webkit.org/252473@main</a>
</pre>
