### PR TITLE
[commits.webkit.org] Don't map commit by revision if revision undefined

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 0)
+version = Version(0, 7, 1)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
@@ -206,7 +206,8 @@ class CheckoutRoute(AuthedBlueprint):
 
         encoded = json.dumps(commit, cls=Commit.Encoder)
         self.database.set(commit.hash, encoded)
-        self.database.set('r{}'.format(commit.revision), encoded)
+        if commit.revision:
+            self.database.set('r{}'.format(commit.revision), encoded)
         self.database.set(str(commit), encoded)
 
         return commit

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.0',
+    version='0.7.1',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 0b5d0feb07ea508cb7ea199b3946d7a053ae8d6f
<pre>
[commits.webkit.org] Don&apos;t map commit by revision if revision undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=242594">https://bugs.webkit.org/show_bug.cgi?id=242594</a>
&lt;rdar://problem/96828195&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/setup.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(CheckoutRoute.commit):

Canonical link: <a href="https://commits.webkit.org/252355@main">https://commits.webkit.org/252355@main</a>
</pre>
