### PR TITLE
[commits.webkit.org] Strip commit details from non-origin commits

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 1)
+version = Version(0, 7, 2)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
@@ -124,7 +124,8 @@ class CheckoutRouteUnittest(testing.PathTestCase):
                 redirectors=[Redirector('https://trac.webkit.org')],
             ))
             reference = Commit.Encoder().default(repo.commits['main'][3])
-            reference['message'] = reference['message'].rstrip()
+            del reference['author']
+            del reference['message']
 
             response = client.get('4@main/json')
             self.assertEqual(response.status_code, 200)

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.1',
+    version='0.7.2',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 43087b9a16932993cc34a352f14325cbfd207006
<pre>
[commits.webkit.org] Strip commit details from non-origin commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=242595">https://bugs.webkit.org/show_bug.cgi?id=242595</a>
&lt;rdar://problem/96829118&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/reporelaypy/setup.py: Bumpv version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(CheckoutRoute.commit): Check if commit is on an origin branch.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py:
(CheckoutRouteUnittest.test_json):

Canonical link: <a href="https://commits.webkit.org/252433@main">https://commits.webkit.org/252433@main</a>
</pre>
