### PR TITLE
[Make] Can't set GCC_PREPROCESSOR_ADDITIONS since 252143@main

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -1,7 +1,7 @@
 SCRIPTS_PATH ?= ../Tools/Scripts
 
 XCODE_OPTIONS = `perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_OPTIONS)` $(ARGS)
-XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_DEFINITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_DEFINITIONS)')
+XCODE_OPTIONS += $(if $(GCC_PREPROCESSOR_ADDITIONS),GCC_PREPROCESSOR_DEFINITIONS='$(GCC_PREPROCESSOR_ADDITIONS) $$(inherited)')
 ifeq (ON,$(ENABLE_LLVM_PROFILE_GENERATION))
 	XCODE_OPTIONS += ENABLE_LLVM_PROFILE_GENERATION=ENABLE_LLVM_PROFILE_GENERATION
 endif
@@ -140,7 +140,7 @@ release r: force
 release+assert ra: force
 	@$(call set_webkit_configuration,--release)
 	@$(call invoke_xcode,,,)
-release+assert ra: override GCC_PREPROCESSOR_DEFINITIONS += ASSERT_ENABLED=1
+release+assert ra: override GCC_PREPROCESSOR_ADDITIONS += ASSERT_ENABLED=1
 
 testing t: force
 	@$(call set_webkit_configuration,--debug --force-optimization-level=O3)


### PR DESCRIPTION
#### ab59fcd01122e2a99779f041d8f006e1fc37d40d
<pre>
[Make] Can&apos;t set GCC_PREPROCESSOR_ADDITIONS since 252143@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242597">https://bugs.webkit.org/show_bug.cgi?id=242597</a>

Reviewed by Mark Lam.

Fix a Makefile typo which prevented build-jsc and others from being able
to add to GCC_PREPROCESSOR_DEFINITIONS using GCC_PREPROCESSOR_ADDITIONS.

* Makefile.shared:

Canonical link: <a href="https://commits.webkit.org/252348@main">https://commits.webkit.org/252348@main</a>
</pre>
