### PR TITLE
Refine C++ coroutine use

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -59,7 +59,7 @@ struct Task {
     struct promise_type {
         Task get_return_object() { return { std::experimental::coroutine_handle<promise_type>::from_promise(*this) }; }
         std::experimental::suspend_never initial_suspend() { return { }; }
-        std::experimental::suspend_never final_suspend() noexcept { return { }; }
+        std::experimental::suspend_always final_suspend() noexcept { return { }; }
         void unhandled_exception() { }
         void return_void() { }
     };
@@ -132,7 +132,7 @@ private:
     RetainPtr<nw_connection_t> m_connection;
 };
 
-class ReceiveOperation : public std::experimental::suspend_never {
+class ReceiveOperation {
 public:
     ReceiveOperation(const Connection& connection)
         : m_connection(connection) { }
@@ -144,13 +144,14 @@ private:
     Vector<char> m_result;
 };
 
-class SendOperation : public std::experimental::suspend_never {
+class SendOperation {
 public:
     SendOperation(RetainPtr<dispatch_data_t>&& data, const Connection& connection)
         : m_data(WTFMove(data))
         , m_connection(connection) { }
     bool await_ready() { return false; }
     void await_suspend(std::experimental::coroutine_handle<>);
+    void await_resume() { }
 private:
     RetainPtr<dispatch_data_t> m_data;
     Connection m_connection;


### PR DESCRIPTION
#### 270e5776c43a008a0d33939cfc337ad8168cd1a5
<pre>
Refine C++ coroutine use
<a href="https://bugs.webkit.org/show_bug.cgi?id=242598">https://bugs.webkit.org/show_bug.cgi?id=242598</a>

Reviewed by Darin Adler.

Task::promise_type::final_suspend() needs to return a std::experimental::suspend_always instead of a std::experimental::suspend_never, otherwise it crashes if we ever use co_return.  We don&apos;t yet, but we probably will.

ReceiveOperation and SendOperation inherit from std::experimental::suspend_never but override await_ready with an implementation more like std::experimental::suspend_always, and an await_suspend that actually does something interesting.  Instead of inheriting from std::experimental::suspend_never, just write out everything it does, which just requires adding an await_resume that returns void.

* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
(TestWebKitAPI::SendOperation::await_resume):

Canonical link: <a href="https://commits.webkit.org/252430@main">https://commits.webkit.org/252430@main</a>
</pre>
