### PR TITLE
[Gardening]: [ EWS macOS wk1 ] imported/w3c/web-platform-tests/web-locks/lock-attributes.tentative.https.any.sharedworker.html is a constant failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1847,3 +1847,5 @@ webkit.org/b/241266 compositing/video/video-border-radius.html [ Pass Timeout ]
 webkit.org/b/241376 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242546 media/video-canvas-createPattern.html [ Pass Failure ]
+
+webkit.org/b/242602 imported/w3c/web-platform-tests/web-locks/lock-attributes.tentative.https.any.sharedworker.html [ Failure ]


### PR DESCRIPTION
#### 811b22c0a8a4328fc8c713eedc8ed5e24e5d1bf9
<pre>
[Gardening]: [ EWS macOS wk1 ] imported/w3c/web-platform-tests/web-locks/lock-attributes.tentative.https.any.sharedworker.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242602">https://bugs.webkit.org/show_bug.cgi?id=242602</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252351@main">https://commits.webkit.org/252351@main</a>
</pre>
