### PR TITLE
[Modern Media Controls] [iOS] the semi-transparent black background should not be shown until the full controls are loaded

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
@@ -86,6 +86,7 @@ class InlineMediaControls extends MediaControls
             return;
 
         this._showsStartButton = flag;
+        this.element.classList.toggle("shows-start-button", flag);
         this.layout();
     }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
@@ -3,9 +3,10 @@
 
 .media-controls.inline.ios:not(.audio) {
     background-color: rgba(0, 0, 0, 0.55);
+    border-radius: inherit;
 }
 
-.media-controls.inline.ios:not(.audio):is(:empty, .faded) {
+.media-controls.inline.ios:not(.audio):is(:empty, .shows-start-button, .faded) {
     background-color: transparent;
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -57,6 +57,7 @@
     -webkit-cursor-visibility: inherit;
     position: relative;
     will-change: z-index;
+    border-radius: inherit;
 }
 
 .media-controls-container,


### PR DESCRIPTION
#### e9db9bafdb8fa6733be89b8d1f732a3af7721251
<pre>
[Modern Media Controls] [iOS] the semi-transparent black background should not be shown until the full controls are loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=242606">https://bugs.webkit.org/show_bug.cgi?id=242606</a>
&lt;rdar://problem/89927908&gt;

Reviewed by Wenson Hsieh.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(.media-controls-container):
* Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css:
(.media-controls.inline.ios:not(.audio)):
(.media-controls.inline.ios:not(.audio):is(:empty, .shows-start-button, .faded)): Renamed from `.media-controls.inline.ios:not(.audio):is(:empty, .faded)`.
Make sure to inherit the `border-radius` so that the semi-transparent black background doesn&apos;t &quot;leak&quot;
outside of the `&lt;video controls&gt;`.

* Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js:
(InlineMediaControls.prototype.set showsStartButton):
Set a CSS class so that the CSS can know if the user has interacted with the `&lt;video&gt;` yet.

Canonical link: <a href="https://commits.webkit.org/252362@main">https://commits.webkit.org/252362@main</a>
</pre>
