### PR TITLE
REGRESSION (252177@main?): [ iOS ] TestWebKitAPI.WebProcessCache.ReusedCrashedCachedWebProcess is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -8469,8 +8469,10 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-// FIXME: Re-enable after webkit.org/b/242527 is resolved
-TEST(WebProcessCache, DISABLED_ReusedCrashedCachedWebProcess)
+// The WebProcess cache cannot be enabled on devices with too little RAM so we need to disable
+// tests relying on it on iOS. The WebProcess cache is disabled by default on iOS anyway.
+#if !PLATFORM(IOS_FAMILY)
+TEST(WebProcessCache, ReusedCrashedCachedWebProcess)
 {
     auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;
@@ -8524,6 +8526,7 @@ TEST(WebProcessCache, DISABLED_ReusedCrashedCachedWebProcess)
 
     EXPECT_EQ(crashCount, 1u);
 }
+#endif
 
 TEST(WebProcessCache, ReusedCrashedBackForwardSuspendedWebProcess)
 {


### PR DESCRIPTION
#### 6619c73818d5bdc101dd1a65c17f4339009ce8f0
<pre>
REGRESSION (252177@main?): [ iOS ] TestWebKitAPI.WebProcessCache.ReusedCrashedCachedWebProcess is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242527">https://bugs.webkit.org/show_bug.cgi?id=242527</a>
&lt;rdar://96686099&gt;

Unreviewed, only disable the test on iOS and not on all platforms.
The test is expected to fail on iOS because the WebProcess cache is
disabled on this platform and cannot be enabled due to RAM restrictions.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/252357@main">https://commits.webkit.org/252357@main</a>
</pre>
