### PR TITLE
Crash under WebCore::ShadowData::~ShadowData

### DIFF
--- a/LayoutTests/fast/css/shadow-box-recursion-depth-expected.txt
+++ b/LayoutTests/fast/css/shadow-box-recursion-depth-expected.txt
@@ -1,0 +1,9 @@
+This test passes if it doesn't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/shadow-box-recursion-depth.html
+++ b/LayoutTests/fast/css/shadow-box-recursion-depth.html
@@ -1,0 +1,29 @@
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="testDiv"></div>
+<script>
+description("This test passes if it doesn't crash.");
+jsTestIsAsync = true;
+
+onload = () => {
+    if (location.search.indexOf("reloaded=") != -1) {
+        finishJSTest();
+        return;
+    }
+
+    let div = document.getElementById("testDiv");
+    let styleString = "box-shadow:";
+    for (let i=0; i<300000; i++) {
+        if (i)
+            styleString += ", ";
+        styleString += "rgba(0, 0, 0, 0.2) -15px -15px inset";
+    }
+    styleString += ", rgba(0, 0, 127, 0.6) 5px 5px 5px inset;";
+    div.setAttribute("style", styleString);
+    document.body.offsetLeft; // Force style recalc
+    setTimeout(() => {
+        location.href += "?reloaded=1";
+    }, 0);
+}
+</script>
+</body>

--- a/Source/WebCore/rendering/style/ShadowData.h
+++ b/Source/WebCore/rendering/style/ShadowData.h
@@ -51,6 +51,8 @@ public:
     {
     }
 
+    ~ShadowData();
+
     ShadowData(const ShadowData&);
     static std::optional<ShadowData> clone(const ShadowData*);
 
@@ -89,6 +91,8 @@ public:
     void adjustRectForShadow(FloatRect&, int additionalOutlineSize = 0) const;
 
 private:
+    void deleteNextLinkedListWithoutRecursion();
+
     LengthPoint m_location;
     Length m_spread;
     Length m_radius; // This is the "blur radius", or twice the standard deviation of the Gaussian blur.
@@ -97,6 +101,12 @@ private:
     bool m_isWebkitBoxShadow { false };
     std::unique_ptr<ShadowData> m_next;
 };
+
+inline ShadowData::~ShadowData()
+{
+    if (m_next)
+        deleteNextLinkedListWithoutRecursion();
+}
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ShadowData&);
 


### PR DESCRIPTION
#### d5d562272a83aad433001065b6e2186acc97049d
<pre>
Crash under WebCore::ShadowData::~ShadowData
<a href="https://bugs.webkit.org/show_bug.cgi?id=242609">https://bugs.webkit.org/show_bug.cgi?id=242609</a>
&lt;rdar://96588555&gt;

Reviewed by Geoffrey Garen.

We see some crashes under ~ShadowData in the wild, due to reaching the
maximum recursion depth.

The ShadowData destructor indeed destroys a whole linked list recursively
via the ShadowData::m_next data member. The length of the linked list is
under the control of the Web content so we could theoretically reach the
recursion limit (though likely due to a bug or bad content).

Without knowing exactly under what circumstances and with which content
we hit this crash, my proposal is to stop relying on recursion to destroy
this linked list.

I am also fixing operator==() as it also traverses this linked list
recursively and we see similar crashes there &lt;rdar://problem/96588560&gt;.

Test: fast/css/shadow-box-recursion-depth.html

* Source/WebCore/rendering/style/ShadowData.cpp:
(WebCore::ShadowData::deleteNextLinkedListWithoutRecursion):
* Source/WebCore/rendering/style/ShadowData.h:
(WebCore::ShadowData::~ShadowData):

Canonical link: <a href="https://commits.webkit.org/252367@main">https://commits.webkit.org/252367@main</a>
</pre>
