### PR TITLE
Add my GitHub name (HerculesH) to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2939,6 +2939,14 @@
    },
    {
       "emails" : [
+         "hhjalmarsson@apple.com"
+      ],
+      "github" : "HerculesH",
+      "name" : "Hercules Hjalmarsson",
+      "status" : "committer"
+   },
+   {
+      "emails" : [
          "hclam@google.com",
          "hclam@chromium.org"
       ],


### PR DESCRIPTION
#### 7a7d494a4d8765d01232384ebd85e9cfb1b72c68
<pre>
Add my GitHub name (HerculesH) to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=242610">https://bugs.webkit.org/show_bug.cgi?id=242610</a>

Reviewed by Jonathan Bedard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252361@main">https://commits.webkit.org/252361@main</a>
</pre>
