### PR TITLE
Fix various issues with Document::shouldMaskURLForBindings and Element::getAttributeForBindings.

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -27,6 +27,7 @@
 #include "WebCoreJSClientData.h"
 
 #include "DOMGCOutputConstraint.h"
+#include "DocumentInlines.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "JSAudioWorkletGlobalScope.h"

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -718,11 +718,10 @@ public:
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
     URL completeURL(const String&, const URL& baseURLOverride, ForceUTF8 = ForceUTF8::No) const;
 
-    bool shouldMaskURLForBindings(const URL&) const;
-    bool hasURLsToMaskForBindings() const;
-    const URL& maskedURLForBindingsIfNeeded(const URL&) const;
-    const AtomString& maskedURLStringForBindings() const;
-    const URL& maskedURLForBindings() const;
+    inline bool shouldMaskURLForBindings(const URL&) const;
+    inline const URL& maskedURLForBindingsIfNeeded(const URL&) const;
+    static const AtomString& maskedURLStringForBindings();
+    static const URL& maskedURLForBindings();
 
     String userAgent(const URL&) const final;
 
@@ -1780,6 +1779,8 @@ private:
 
     HttpEquivPolicy httpEquivPolicy() const;
     AXObjectCache* existingAXObjectCacheSlow() const;
+
+    bool shouldMaskURLForBindingsInternal(const URL&) const;
 
     // DOM Cookies caching.
     const String& cachedDOMCookies() const { return m_cachedDOMCookies; }

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -80,6 +80,19 @@ inline bool Document::hasMutationObserversOfType(MutationObserverOptionType type
 
 inline bool Document::isSameOriginAsTopDocument() const { return securityOrigin().isSameOriginAs(topOrigin()); }
 
+inline bool Document::shouldMaskURLForBindings(const URL& urlToMask) const
+{
+    if (LIKELY(urlToMask.protocolIsInHTTPFamily()))
+        return false;
+    return shouldMaskURLForBindingsInternal(urlToMask);
+}
+
+inline const URL& Document::maskedURLForBindingsIfNeeded(const URL& url) const
+{
+    if (UNLIKELY(shouldMaskURLForBindings(url)))
+        return maskedURLForBindings();
+    return url;
+}
 
 // These functions are here because they require the Document class definition and we want to inline them.
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -718,21 +718,20 @@ AtomString Element::getAttributeForBindings(const QualifiedName& name, ResolveUR
     if (!attribute)
         return nullAtom();
 
+    if (!attributeContainsURL(*attribute))
+        return attribute->value();
+
     switch (resolveURLs) {
     case ResolveURLs::Yes:
     case ResolveURLs::YesExcludingURLsForPrivacy:
+    case ResolveURLs::NoExcludingURLsForPrivacy:
         return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
 
-    case ResolveURLs::NoExcludingURLsForPrivacy:
-        if (document().hasURLsToMaskForBindings())
-            return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
-        break;
-
     case ResolveURLs::No:
-        break;
+        return attribute->value();
     }
 
-    return attribute->value();
+    ASSERT_NOT_REACHED();
 }
 
 Vector<String> Element::getAttributeNames() const
@@ -1819,21 +1818,20 @@ AtomString Element::getAttributeForBindings(const AtomString& qualifiedName, Res
     if (!attribute)
         return nullAtom();
 
+    if (!attributeContainsURL(*attribute))
+        return attribute->value();
+
     switch (resolveURLs) {
     case ResolveURLs::Yes:
     case ResolveURLs::YesExcludingURLsForPrivacy:
+    case ResolveURLs::NoExcludingURLsForPrivacy:
         return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
 
-    case ResolveURLs::NoExcludingURLsForPrivacy:
-        if (document().hasURLsToMaskForBindings())
-            return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
-        break;
-
     case ResolveURLs::No:
-        break;
+        return attribute->value();
     }
 
-    return attribute->value();
+    ASSERT_NOT_REACHED();
 }
 
 const AtomString& Element::getAttributeNS(const AtomString& namespaceURI, const AtomString& localName) const

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "ElementData.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3757,13 +3757,6 @@ bool Page::shouldDisableCorsForRequestTo(const URL& url) const
     });
 }
 
-bool Page::shouldMaskURLForBindings(const URL& url) const
-{
-    if (m_maskedURLSchemes.isEmpty())
-        return false;
-    return m_maskedURLSchemes.contains<StringViewHashTranslator>(url.protocol());
-}
-
 void Page::revealCurrentSelection()
 {
     CheckedRef(focusController())->focusedOrMainFrame().selection().revealSelection(SelectionRevealMode::Reveal, ScrollAlignment::alignCenterIfNeeded);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -920,8 +920,7 @@ public:
     void forEachFrame(const Function<void(Frame&)>&);
 
     bool shouldDisableCorsForRequestTo(const URL&) const;
-    bool shouldMaskURLForBindings(const URL&) const;
-    bool hasURLsToMaskForBindings() const { return !m_maskedURLSchemes.isEmpty(); }
+    const HashSet<String>& maskedURLSchemes() const { return m_maskedURLSchemes; }
 
     WEBCORE_EXPORT void injectUserStyleSheet(UserStyleSheet&);
     WEBCORE_EXPORT void removeInjectedUserStyleSheet(UserStyleSheet&);


### PR DESCRIPTION
#### eec128ed1111c3b92a2edac67cdeca122ffae129
<pre>
Fix various issues with Document::shouldMaskURLForBindings and Element::getAttributeForBindings.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242611">https://bugs.webkit.org/show_bug.cgi?id=242611</a>
rdar://81991245

Reviewed by Yusuke Suzuki.

Simplified implementation of the URL masking to be contained in Document and not split between Document and Page.
Added an inline fast path for the two hot functions that return quickly for HTTP family URLs, which are never masked.
Fixed a functionality regression in Safari by never masking URLs that have the same protocol as the main document.
Fixed a performance regression on Speedometer&apos;s AngularJS-TodoMVC and some other subtests that are attribute heavy.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::shouldMaskURLForBindingsInternal const): Moved logic from Page::shouldMaskURLForBindings().
Added additional check for document&apos;s protocol, this fixes a functionality regression in Safari.
(WebCore::Document::maskedURLStringForBindings const): Made static, and dropped const.
(WebCore::Document::maskedURLForBindings const): Ditto.
(WebCore::Document::shouldMaskURLForBindings const): Deleted. Made inline in DocumentInlines.h.
(WebCore::Document::hasURLsToMaskForBindings const): Deleted.
(WebCore::Document::maskedURLForBindingsIfNeeded const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::shouldMaskURLForBindings const): Added.
(WebCore::Document::maskedURLForBindingsIfNeeded const): Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getAttributeForBindings const): Check attributeContainsURL() before calling completeURLsInAttributeValue().
This fixes the performance regression on Speedometer.
* Source/WebCore/dom/ElementInlines.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::completeURLsInAttributeValue const): Don&apos;t generate a string if there are no URLs to mask.
This keeps attribute value of srcset intact when nothing needs masked. This is needed to pass some srcset WPTs.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::shouldMaskURLForBindings const): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::maskedURLSchemes const): Added.
(WebCore::Page::hasURLsToMaskForBindings const): Deleted.

Canonical link: <a href="https://commits.webkit.org/252418@main">https://commits.webkit.org/252418@main</a>
</pre>
