### PR TITLE
REGRESSION (251077@main): fast/events/touch/ios/content-observation/visibility-change-with-image-content.html is a constant timeout

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -790,12 +790,17 @@ bool HTMLImageElement::childShouldCreateRenderer(const Node& child) const
 
 #if PLATFORM(IOS_FAMILY)
 // FIXME: We should find a better place for the touch callout logic. See rdar://problem/48937767.
-bool HTMLImageElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
+bool HTMLImageElement::willRespondToMouseClickEventsWithEditability(Editability editability, IgnoreTouchCallout ignoreTouchCallout) const
 {
     auto renderer = this->renderer();
-    if (!renderer || renderer->style().touchCalloutEnabled())
+    if (ignoreTouchCallout == IgnoreTouchCallout::No && (!renderer || renderer->style().touchCalloutEnabled()))
         return true;
     return HTMLElement::willRespondToMouseClickEventsWithEditability(editability);
+}
+
+bool HTMLImageElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
+{
+    return willRespondToMouseClickEventsWithEditability(editability, IgnoreTouchCallout::No);
 }
 #endif
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -102,6 +102,9 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     bool willRespondToMouseClickEventsWithEditability(Editability) const override;
+
+    enum class IgnoreTouchCallout { No, Yes };
+    bool willRespondToMouseClickEventsWithEditability(Editability, IgnoreTouchCallout) const;
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -146,9 +146,9 @@ bool ContentChangeObserver::isConsideredActionableContent(const Element& candida
         if (is<HTMLIFrameElement>(element))
             return true;
 
-        if (is<HTMLImageElement>(element)) {
+        if (auto imageElement = dynamicDowncast<HTMLImageElement>(element)) {
             // This is required to avoid HTMLImageElement's touch callout override logic. See rdar://problem/48937767.
-            return element.Element::willRespondToMouseClickEvents();
+            return imageElement->willRespondToMouseClickEventsWithEditability(imageElement->computeEditabilityForMouseClickEvents(), HTMLImageElement::IgnoreTouchCallout::Yes);
         }
         bool hasRenderer = element.renderer();
         auto willRespondToMouseClickEvents = element.willRespondToMouseClickEvents();


### PR DESCRIPTION
#### e94f950ce43bb281ae67395d2e9ad8692e6874dd
<pre>
REGRESSION (251077@main): fast/events/touch/ios/content-observation/visibility-change-with-image-content.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=242613">https://bugs.webkit.org/show_bug.cgi?id=242613</a>
rdar://95417026

Reviewed by Wenson Hsieh.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::willRespondToMouseClickEventsWithEditability const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::isConsideredActionableContent const):
Previously, ContentChangeObserver skipped to Element&apos;s implementation of
willRespondToMouseClickEvents in order to avoid HTMLImageElement&apos;s touch-callout
logic. This no longer works because I changed which method subclasses
override in 251077@main.

Instead, make the &quot;I don&apos;t want the touch-callout logic&quot; desire specific,
by introducing a new bit on an override of HTMLImageElement&apos;s implementation
of `willRespondToMouseClickEventsWithEditability`, and adopting in ContentChangeObserver.

Canonical link: <a href="https://commits.webkit.org/252381@main">https://commits.webkit.org/252381@main</a>
</pre>
