### PR TITLE
[git-webkit] Rebase on target remote in pull-request

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.7',
+    version='5.2.8',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 7)
+version = Version(5, 2, 8)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -281,7 +281,7 @@ class PullRequest(Command):
 
         if rebasing:
             log.info("Rebasing '{}' on '{}'...".format(repository.branch, branch_point.branch))
-            if repository.pull(rebase=True, branch=branch_point.branch):
+            if repository.pull(rebase=True, branch=branch_point.branch, remote=source_remote):
                 sys.stderr.write("Failed to rebase '{}' on '{},' please resolve conflicts\n".format(repository.branch, branch_point.branch))
                 return 1
             log.info("Rebased '{}' on '{}!'".format(repository.branch, branch_point.branch))


### PR DESCRIPTION
#### c286bc3a89ffa02811713f38d08bc34c914aeb33
<pre>
[git-webkit] Rebase on target remote in pull-request
<a href="https://bugs.webkit.org/show_bug.cgi?id=242617">https://bugs.webkit.org/show_bug.cgi?id=242617</a>
&lt;rdar://problem/96851195&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request):

Canonical link: <a href="https://commits.webkit.org/252390@main">https://commits.webkit.org/252390@main</a>
</pre>
