### PR TITLE
[Make] Update build-jsc and build-webgpu to use workspace builds

### DIFF
--- a/Tools/Scripts/build-jsc
+++ b/Tools/Scripts/build-jsc
@@ -32,9 +32,7 @@ use lib $FindBin::Bin;
 use webkitperl::FeatureList qw(getFeatureOptionList);
 use webkitperl::BuildSubproject;
 
-buildMyProject("Source/bmalloc", "bmalloc");
-buildMyProject("Source/WTF", "WTF");
-buildMyProject("Source/JavaScriptCore", "JavaScriptCore");
+buildUpToProject("Source/JavaScriptCore", "JavaScriptCore");
 if (isAppleCocoaWebKit()) {
     writeCongrats("JavaScriptCore");
 }

--- a/Tools/Scripts/build-webgpu
+++ b/Tools/Scripts/build-webgpu
@@ -32,8 +32,5 @@ use lib $FindBin::Bin;
 use webkitperl::FeatureList qw(getFeatureOptionList);
 use webkitperl::BuildSubproject;
 
-buildMyProject("Source/bmalloc", "bmalloc");
-buildMyProject("Source/WTF", "WTF");
-buildMyProject("Source/JavaScriptCore", "JavaScriptCore");
-buildMyProject("Source/WebGPU", "WebGPU");
+buildUpToProject("Source/WebGPU", "WebGPU");
 writeCongrats("WebGPU");

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -110,7 +110,7 @@ if (isAppleCocoaWebKit() && !isCMakeBuild()) {
 }
 
 if (checkForArgumentAndRemoveFromARGV("--reset")) {
-    for my $fileName (qw(Architecture ASan Configuration Coverage ForceOptimizationLevel LTO TSan UBSan)) {
+    for my $fileName (qw(Architecture ASan Configuration Coverage ForceOptimizationLevel LTO TSan UBSan Workspace)) {
         unlink File::Spec->catfile($baseProductDir, $fileName);
     }
     printCurrentSettings();

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -214,12 +214,15 @@ if (isAppleCocoaWebKit()) {
     }
 }
 
-sub buildMyProject
+sub buildUpToProject
 {
     my ($projectDirectory, $projectName) = @_;
     my $result;
     chdir $projectDirectory or die "Can't find $projectName directory to build from";
     if (isAppleCocoaWebKit()) {
+        if (!configuredXcodeWorkspace()) {
+            system("$FindBin::Bin/set-webkit-configuration", "--workspace=" . sourceDir() . "/WebKit.xcworkspace") == 0 or die;
+        }
         my $compilerFlags = 'GCC_PREPROCESSOR_ADDITIONS="';
         if ($forceCLoop) {
             $compilerFlags .= "ENABLE_JIT=0 ENABLE_C_LOOP=1";
@@ -238,7 +241,7 @@ sub buildMyProject
             $extraCommands .= " " . $arg;
         }
 
-        my $command = "make " . (lc configuration()) . " " . $compilerFlags . " " . $extraCommands;
+        my $command = "make USE_WORKSPACE=YES " . (lc configuration()) . " " . $compilerFlags . " " . $extraCommands;
 
         print "\n";
         print "building ", $projectName, "\n";


### PR DESCRIPTION
#### 03af7beefb55c6e846ba3dc640fb7a0868977881
<pre>
[Make] Update build-jsc and build-webgpu to use workspace builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=242616">https://bugs.webkit.org/show_bug.cgi?id=242616</a>

Reviewed by Alexey Proskuryakov.

Improve build performance by making workspace builds of JSC and WebGPU
in their respective build scripts.

This closely mirrors the pending switch to workspace builds by default,
except that build-jsc and build-webgpu will default to building out of
WebKit.xcworkspace, whereas manually running `make` out of
Source/JavaScriptCore or Source/WebGPU has no default workspace -- it&apos;ll
use the previously selected workspace path, or none at all.

The default is necessary here to ensure that these script always produce
a valid workspace build.

* Tools/Scripts/build-jsc:
* Tools/Scripts/build-webgpu:
* Tools/Scripts/set-webkit-configuration: Reset `Workspace` along with
  all other configuration settings. Accidentally left out of
  <a href="https://commits.webkit.org/252363@main.">https://commits.webkit.org/252363@main.</a>
* Tools/Scripts/webkitperl/BuildSubproject.pm:
(buildUpToProject): Renamed from buildMyProject.

Canonical link: <a href="https://commits.webkit.org/252809@main">https://commits.webkit.org/252809@main</a>
</pre>
