### PR TITLE
[GPUP] 252096@main caused fast/text/isolate-ignore.html to stop crashing

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3635,8 +3635,6 @@ platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html
 swipe/main-frame-pinning-requirement.html
 
 
-webkit.org/b/240659 fast/text/isolate-ignore.html [ Crash ]
-
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
 
 webkit.org/b/231266 fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html [ Pass Failure ]


### PR DESCRIPTION
#### fe990e312c6abfbcb95a873f991adc7db35d1ff1
<pre>
[GPUP] 252096@main caused fast/text/isolate-ignore.html to stop crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=242621">https://bugs.webkit.org/show_bug.cgi?id=242621</a>
&lt;rdar://problem/91052074&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252366@main">https://commits.webkit.org/252366@main</a>
</pre>
