### PR TITLE
Check for missing DecomposedGlyphs resource correctly in RemoteDisplayListRecorder::drawDecomposedGlyphsWithQualifiedIdentifiers

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -273,7 +273,7 @@ void RemoteDisplayListRecorder::drawDecomposedGlyphsWithQualifiedIdentifiers(Qua
     }
 
     RefPtr decomposedGlyphs = resourceCache().cachedDecomposedGlyphs(decomposedGlyphsIdentifier);
-    if (!decomposedGlyphsIdentifier) {
+    if (!decomposedGlyphs) {
         ASSERT_NOT_REACHED();
         return;
     }


### PR DESCRIPTION
#### 459ef027e4e8e1cabb990f037f20573387fa859c
<pre>
Check for missing DecomposedGlyphs resource correctly in RemoteDisplayListRecorder::drawDecomposedGlyphsWithQualifiedIdentifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242626">https://bugs.webkit.org/show_bug.cgi?id=242626</a>
rdar://96429605

Reviewed by Said Abou-Hallawa.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawDecomposedGlyphsWithQualifiedIdentifiers):

Canonical link: <a href="https://commits.webkit.org/252392@main">https://commits.webkit.org/252392@main</a>
</pre>
