### PR TITLE
[JSC] Adjust ArrayBuffer size tracking only when full GC happens

### DIFF
--- a/Source/JavaScriptCore/heap/GCIncomingRefCountedSet.h
+++ b/Source/JavaScriptCore/heap/GCIncomingRefCountedSet.h
@@ -41,7 +41,7 @@ public:
     // Returns true if the native object is new to this set.
     bool addReference(JSCell*, T*);
     
-    void sweep(VM&);
+    void sweep(VM&, CollectionScope);
     
     size_t size() const { return m_bytes; };
     

--- a/Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h
+++ b/Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h
@@ -59,19 +59,22 @@ bool GCIncomingRefCountedSet<T>::addReference(JSCell* cell, T* object)
 }
 
 template<typename T>
-void GCIncomingRefCountedSet<T>::sweep(VM& vm)
+void GCIncomingRefCountedSet<T>::sweep(VM& vm, CollectionScope collectionScope)
 {
-    m_bytes = 0;
+    size_t preciseBytes = 0;
     m_vector.removeAllMatching([&](T* object) {
         size_t size = object->gcSizeEstimateInBytes();
         ASSERT(object->isDeferred());
         ASSERT(object->numberOfIncomingReferences());
         if (!object->filterIncomingReferences([&] (JSCell* cell) { return vm.heap.isMarked(cell); })) {
-            m_bytes += size;
+            preciseBytes += size;
             return false;
         }
         return true;
     });
+    // Update m_bytes to the precise value when Full-GC happens since Eden-GC only expects that Eden region is collected.
+    if (collectionScope == CollectionScope::Full)
+        m_bytes = preciseBytes;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2282,7 +2282,7 @@ void Heap::pruneStaleEntriesFromWeakGCHashTables()
 
 void Heap::sweepArrayBuffers()
 {
-    m_arrayBuffers.sweep(vm());
+    m_arrayBuffers.sweep(vm(), collectionScope().value_or(CollectionScope::Eden));
 }
 
 void Heap::snapshotUnswept()


### PR DESCRIPTION
#### 8136ad12111fb4e589c0aa38201f1f30601f7e15
<pre>
[JSC] Adjust ArrayBuffer size tracking only when full GC happens
<a href="https://bugs.webkit.org/show_bug.cgi?id=242630">https://bugs.webkit.org/show_bug.cgi?id=242630</a>
rdar://problem/96850434

Reviewed by Mark Lam.

This patch fixes it so that we adjust ArrayBuffer size tracking only when full GC happens.
This is because right now our GC expects that Eden GC only collects newly allocated Eden memory.
And it is not expecting that we can reduce extra-memory. We can enhance it in the future, but for now,
only adjust it at full GC time

* Source/JavaScriptCore/heap/GCIncomingRefCountedSet.h:
* Source/JavaScriptCore/heap/GCIncomingRefCountedSetInlines.h:
(JSC::GCIncomingRefCountedSet&lt;T&gt;::sweep):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::sweepArrayBuffers):

Canonical link: <a href="https://commits.webkit.org/252368@main">https://commits.webkit.org/252368@main</a>
</pre>
