### PR TITLE
Optimize AtomStringImpl::remove by skipping unnecessary string equality checks

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -62,14 +62,13 @@
 #include <wtf/Forward.h>
 #include <wtf/Gigacage.h>
 #include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueArray.h>
+#include <wtf/text/SymbolImpl.h>
 #include <wtf/text/SymbolRegistry.h>
-#include <wtf/text/WTFString.h>
 
 #if ENABLE(REGEXP_TRACING)
 #include <wtf/ListHashSet.h>


### PR DESCRIPTION
#### d781022ac569fbff5cbec9409e542088f3602e9b
<pre>
Optimize AtomStringImpl::remove by skipping unnecessary string equality checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=242624">https://bugs.webkit.org/show_bug.cgi?id=242624</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/VM.h: Adjusted includes after changes to SymbolRegistry.h.

* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringTableRemovalHashTranslator): Added. This does a pointer comparison rather than
a string equality comparison.
(WTF::AtomStringImpl::remove): Use AtomStringTableRemovalHashTranslator.

* Source/WTF/wtf/text/SymbolRegistry.cpp:
(WTF::SymbolRegistry::~SymbolRegistry): Updated since m_table is now a HashSet&lt;RefPtr&lt;StringImpl&gt;&gt;.
(WTF::SymbolRegistry::symbolForKey): Ditto.
(WTF::SymbolRegistryTableRemovalHashTranslator): Added. This does a pointer comparison rather
than a string equality comparison.
(WTF::SymbolRegistry::remove): Use SymbolRegistryTableRemovalHashTranslator.

* Source/WTF/wtf/text/SymbolRegistry.h: Deleted SymbolRegistryKey and the hash table traits
that went with it, since we no longer have the special hashing considerations for symbols
that originally required it.

Canonical link: <a href="https://commits.webkit.org/252379@main">https://commits.webkit.org/252379@main</a>
</pre>
