### PR TITLE
Optimize some array operations by bypassing Identifier creation/destruction

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -174,7 +174,7 @@ static ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject*
         return result;
 
     // Don't return undefined if the property is not found.
-    return object->getIfPropertyExists(globalObject, Identifier::from(globalObject->vm(), index));
+    return object->getIfPropertyExists(globalObject, index);
 }
 
 static ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj, uint64_t value)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -338,8 +338,7 @@ bool JSGenericTypedArrayView<Adaptor>::set(
                 return false;
         }
         for (size_t i = safeLength; i < length; ++i) {
-            Identifier ident = Identifier::from(vm, static_cast<uint64_t>(i + objectOffset));
-            JSValue value = object->get(globalObject, ident);
+            JSValue value = object->get(globalObject, static_cast<uint64_t>(i + objectOffset));
             RETURN_IF_EXCEPTION(scope, false);
             bool success = setIndex(globalObject, offset + i, value);
             EXCEPTION_ASSERT(!scope.exception() || !success);

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -164,7 +164,7 @@ public:
     template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const;
     template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
 
-    JSValue getIfPropertyExists(JSGlobalObject*, PropertyName);
+    template<typename PropertyNameType> JSValue getIfPropertyExists(JSGlobalObject*, const PropertyNameType&);
     bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
 
 private:

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -188,7 +188,7 @@ inline bool JSObject::getOwnPropertySlotInline(JSGlobalObject* globalObject, Pro
     return JSObject::getOwnPropertySlot(this, globalObject, propertyName, slot);
 }
 
-inline JSValue JSObject::getIfPropertyExists(JSGlobalObject* globalObject, PropertyName propertyName)
+template<typename PropertyNameType> inline JSValue JSObject::getIfPropertyExists(JSGlobalObject* globalObject, const PropertyNameType& propertyName)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);


### PR DESCRIPTION
#### 0e5b5facb6445ca7a1feb46cee6322189df5282c
<pre>
Optimize some array operations by bypassing Identifier creation/destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=242631">https://bugs.webkit.org/show_bug.cgi?id=242631</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::getProperty): Pass the index to getIfPropertyExists rather than creating an
Identifier from it here.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::set): Use the JSObject::get function that takes
a 64-bit integer rather than creating an identifier from it here.

* Source/JavaScriptCore/runtime/JSObject.h: Change getIfPropertyExists into a template
so it can work with all three types of property name (PropertyName, uint32_t, uint64_t).

* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getIfPropertyExists): Turned this into a template.

Canonical link: <a href="https://commits.webkit.org/252380@main">https://commits.webkit.org/252380@main</a>
</pre>
