### PR TITLE
[GTK][WPE] Build fails with ORIENTATION_EVENTS enabled

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1469,6 +1469,14 @@ void WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess(Frame& frame, 
 }
 #endif
 
+#if ENABLE(ORIENTATION_EVENTS) && !PLATFORM(IOS_FAMILY)
+int WebChromeClient::deviceOrientation() const
+{
+    notImplemented();
+    return 0;
+}
+#endif
+
 void WebChromeClient::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)
 {
     m_page.configureLoggingChannel(channelName, state, level);


### PR DESCRIPTION
#### 2510901a9a26f1f11daf5e9ae29382dce1fe7f0c
<pre>
[GTK][WPE] Build fails with ORIENTATION_EVENTS enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=242637">https://bugs.webkit.org/show_bug.cgi?id=242637</a>

Reviewed by Michael Catanzaro.

The function WebChromeClient::deviceOrientation() is only
defined for the iOS build. Fix the build failure for other
platforms by defining a skeleton function.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::deviceOrientation const):

Canonical link: <a href="https://commits.webkit.org/252385@main">https://commits.webkit.org/252385@main</a>
</pre>
