### PR TITLE
[WPE][CMake] Build the Cog external project using Meson

### DIFF
--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -150,8 +150,8 @@ class WPEPort(Port):
         configuration['platform'] = 'WPE'
         return configuration
 
-    def cog_path_to(self, file_or_directory):
-        return self._build_path('Tools', 'cog-prefix', 'src', 'cog-build', file_or_directory)
+    def cog_path_to(self, *components):
+        return self._build_path('Tools', 'cog-prefix', 'src', 'cog-build', *components)
 
     def browser_name(self):
         """Returns the lower case name of the browser to be used (Cog or MiniBrowser)
@@ -165,7 +165,7 @@ class WPEPort(Port):
         if browser:
             print("Unknown browser {}. Defaulting to Cog and MiniBrowser selection".format(browser))
 
-        if self._filesystem.isfile(self.cog_path_to('cog')):
+        if self._filesystem.isfile(self.cog_path_to('launcher', 'cog')):
             return "cog"
         return "minibrowser"
 
@@ -174,7 +174,7 @@ class WPEPort(Port):
 
         if self.browser_name() == "cog":
             env.update({'WEBKIT_EXEC_PATH': self._build_path('bin'),
-                        'COG_MODULEDIR': self.cog_path_to('modules'),
+                        'COG_MODULEDIR': self.cog_path_to('platform'),
                         'WEBKIT_INJECTED_BUNDLE_PATH': self._build_path('lib')})
 
         return env
@@ -184,7 +184,7 @@ class WPEPort(Port):
         miniBrowser = None
 
         if self.browser_name() == "cog":
-            miniBrowser = self.cog_path_to('cog')
+            miniBrowser = self.cog_path_to('launcher', 'cog')
             if not self._filesystem.isfile(miniBrowser):
                 print("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to good old MiniBrowser")
                 miniBrowser = None

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -86,7 +86,7 @@ class WPEPortTest(port_testcase.PortTestCase):
         with patch('os.environ', {'WPE_BROWSER': ''}):
             port = self.make_port()
             port._filesystem = MockFileSystem({
-                "/mock-build/Tools/cog-prefix/src/cog-build/cog": "",
+                "/mock-build/Tools/cog-prefix/src/cog-build/launcher/cog": "",
             })
             self.assertEqual(port.browser_name(), "cog")
 


### PR DESCRIPTION
#### f8bee700b064f7df5e34e2a35cd232035e7ea96b
<pre>
[WPE][CMake] Build the Cog external project using Meson
<a href="https://bugs.webkit.org/show_bug.cgi?id=242639">https://bugs.webkit.org/show_bug.cgi?id=242639</a>

Reviewed by Philippe Normand.

* Tools/PlatformWPE.cmake: Change the parameters passed to ExternalProject_Add()
to use CONFIGURE_COMMAND and BUILD_COMMAND instead of CMAKE_ARGS, explicitly
specifying build/source directories, and arranging to pass Meson build
options derived from CMake ones.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.cog_path_to): Modify to accept a variable number of arguments,
which are forwarded to _build_path().
(WPEPort.browser_name): Adapt path to the &quot;cog&quot; program to accommodate changes
introduced by the Meson build system.
(WPEPort.browser_env): Adapt path to build directory containing the Cog
platform plug-ins to accommodate changes introduced by the meson build
system.
(WPEPort.run_minibrowser): Adapt path to the &quot;cog&quot; program, to
accommodate changes introduced by the Meson build system.
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_browser_name_with_cog_built): Adapt test.

Canonical link: <a href="https://commits.webkit.org/252411@main">https://commits.webkit.org/252411@main</a>
</pre>
