### PR TITLE
Remove deleted account rancored-mongoose

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -4765,7 +4765,6 @@
       "emails" : [
          "jlewis3@apple.com"
       ],
-      "github" : "rancored-mongoose",
       "name" : "Matt Lewis",
       "nicks" : [
          "mattlewis"


### PR DESCRIPTION
#### fff6c1d628aae003eec832b5901828a221335220
<pre>
Remove deleted account rancored-mongoose

Unreviewed contributor maintence.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252384@main">https://commits.webkit.org/252384@main</a>
</pre>
