### PR TITLE
[GStreamer][VideoCapture] VideoTrackPrivateGStreamer: Only enqueueTask in callbacks when not on MainThread

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -53,14 +53,20 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivat
     }
 
     g_signal_connect_swapped(m_stream, "notify::caps", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
-        track->m_taskQueue.enqueueTask([track]() {
+        if (isMainThread())
             track->updateConfigurationFromCaps();
-        });
+        else
+            track->m_taskQueue.enqueueTask([track]() {
+                track->updateConfigurationFromCaps();
+            });
     }), this);
     g_signal_connect_swapped(m_stream, "notify::tags", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
-        track->m_taskQueue.enqueueTask([track]() {
+        if (isMainThread())
             track->updateConfigurationFromTags();
-        });
+        else
+            track->m_taskQueue.enqueueTask([track]() {
+                track->updateConfigurationFromTags();
+            });
     }), this);
 
     updateConfigurationFromCaps();


### PR DESCRIPTION
#### 033de5eb1bec2d1b2d5bc4715801fa0a6a8ac83d
<pre>
[GStreamer][VideoCapture] VideoTrackPrivateGStreamer: Only enqueueTask in callbacks when not on MainThread
<a href="https://bugs.webkit.org/show_bug.cgi?id=242644">https://bugs.webkit.org/show_bug.cgi?id=242644</a>

Reviewed by NOBODY (OOPS!).

If we receive a callback while isMainThread() is already true we
should execute the callback function directly as AbortableTaskQueue
expects isMainThread() to be false.

Fixes the following assert:
ASSERTION FAILED: !isMainThread()
/app/webkit/Source/WebCore/platform/AbortableTaskQueue.h(124) : void WebCore::AbortableTaskQueue::enqueueTask(WTF::Function&lt;void()&gt;&amp;&amp;)
1   0x10f16c73 WTFCrash
2   0xd923126 /app/webkit/WebKitBuild/Debug/lib/libWPEWebKit-1.1.so.0(+0x90d0126) [0xd923126]
3   0x1122626e /app/webkit/WebKitBuild/Debug/lib/libWPEWebKit-1.1.so.0(+0xc9d326e) [0x1122626e]
4   0x112a7b79 /app/webkit/WebKitBuild/Debug/lib/libWPEWebKit-1.1.so.0(+0xca54b79) [0x112a7b79]
5   0x112a7bbd /app/webkit/WebKitBuild/Debug/lib/libWPEWebKit-1.1.so.0(+0xca54bbd) [0x112a7bbd]
6   0x19839fef g_closure_invoke
7   0x1984cf16 /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x28f16) [0x1984cf16]
8   0x19853c0c g_signal_emit_valist
9   0x19853d63 g_signal_emit
10  0x1983ed84 /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0(+0x1ad84) [0x1983ed84]
11  0x16150c08 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x44c08) [0x16150c08]
12  0x19840f1a g_object_notify_by_pspec
13  0x4063c688 /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstplayback.so(+0x43688) [0x4063c688]
14  0x1619a126 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x8e126) [0x1619a126]
15  0x15f41896 g_hook_list_marshal
16  0x16199895 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x8d895) [0x16199895]
17  0x1619c68d /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x9068d) [0x1619c68d]
18  0x1619d26e /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x9126e) [0x1619d26e]
19  0x1619d728 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x91728) [0x1619d728]
20  0x1619b000 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x8f000) [0x1619b000]
21  0x161a6780 gst_pad_push_event
22  0x1619cbec /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x90bec) [0x1619cbec]
23  0x1619d26e /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x9126e) [0x1619d26e]
24  0x1619d728 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x91728) [0x1619d728]
25  0x1619b000 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x8f000) [0x1619b000]
26  0x161a6780 gst_pad_push_event
27  0x161a6d62 /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x9ad62) [0x161a6d62]
28  0x161a2d6e gst_pad_forward
29  0x161a2eb5 gst_pad_event_default
30  0x1619cbec /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x90bec) [0x1619cbec]
31  0x1619d26e /usr/lib/x86_64-linux-gnu/libgstreamer-1.0.so.0(+0x9126e) [0x1619d26e]
==74== Invalid write of size 4
==74==    at 0x10F16C78: WTFCrash (Assertions.cpp:328)
==74==    by 0xD923125: WTFCrashWithInfo(int, char const*, char const*, int) (Assertions.h:754)
==74==    by 0x1122626D: WebCore::AbortableTaskQueue::enqueueTask(WTF::Function&lt;void ()&gt;&amp;&amp;) (AbortableTaskQueue.h:124)
==74==    by 0x112A7B78: WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WTF::WeakPtr&lt;WebCore::MediaPlayerPrivateGStreamer, WTF::EmptyCounter&gt;, unsigned int, _GstStream*)::{lambda(WebCore::VideoTrackPrivateGStreamer*)#2}::operator()(WebCore::VideoTrackPrivateGStreamer*) const (VideoTrackPrivateGStreamer.cpp:60)
==74==    by 0x112A7BBC: WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WTF::WeakPtr&lt;WebCore::MediaPlayerPrivateGStreamer, WTF::EmptyCounter&gt;, unsigned int, _GstStream*)::{lambda(WebCore::VideoTrackPrivateGStreamer*)#2}::_FUN(WebCore::VideoTrackPrivateGStreamer*) (VideoTrackPrivateGStreamer.cpp:60)
==74==    by 0x19839FEE: g_closure_invoke (gclosure.c:830)
==74==    by 0x1984CF15: signal_emit_unlocked_R (gsignal.c:3742)
==74==    by 0x19853C0B: g_signal_emit_valist (gsignal.c:3497)
==74==    by 0x19853D62: g_signal_emit (gsignal.c:3553)
==74==    by 0x1983ED83: g_object_dispatch_properties_changed (gobject.c:1212)
==74==    by 0x16150C07: gst_object_dispatch_properties_changed (gstobject.c:455)
==74==    by 0x19840F19: g_object_notify_by_spec_internal (gobject.c:1305)
==74==    by 0x19840F19: g_object_notify_by_pspec (gobject.c:1415)
==74==    by 0x4063C687: gst_parse_pad_update_tags (gstparsebin.c:3961)
==74==    by 0x4063C687: gst_parse_pad_event (gstparsebin.c:4060)
==74==    by 0x1619A125: probe_hook_marshal (gstpad.c:3664)
==74==    by 0x15F41895: g_hook_list_marshal (ghook.c:672)
==74==    by 0x16199894: do_probe_callbacks (gstpad.c:3848)
==74==    by 0x1619C68C: gst_pad_send_event_unchecked (gstpad.c:5872)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x1619CBEB: gst_pad_send_event_unchecked (gstpad.c:5900)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x161A6D61: event_forward_func (gstpad.c:3125)
==74==    by 0x161A2D6D: gst_pad_forward (gstpad.c:3079)
==74==    by 0x161A2EB4: gst_pad_event_default (gstpad.c:3176)
==74==    by 0x1619CBEB: gst_pad_send_event_unchecked (gstpad.c:5900)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x161A6D61: event_forward_func (gstpad.c:3125)
==74==    by 0x161A2D6D: gst_pad_forward (gstpad.c:3079)
==74==    by 0x161A2EB4: gst_pad_event_default (gstpad.c:3176)
==74==    by 0x1619CBEB: gst_pad_send_event_unchecked (gstpad.c:5900)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x161A6D61: event_forward_func (gstpad.c:3125)
==74==    by 0x161A2D6D: gst_pad_forward (gstpad.c:3079)
==74==    by 0x161A2EB4: gst_pad_event_default (gstpad.c:3176)
==74==    by 0x1619CBEB: gst_pad_send_event_unchecked (gstpad.c:5900)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x1619CBEB: gst_pad_send_event_unchecked (gstpad.c:5900)
==74==    by 0x1619D26D: gst_pad_push_event_unchecked (gstpad.c:5544)
==74==    by 0x1619D727: push_sticky (gstpad.c:4047)
==74==    by 0x1619AFFF: events_foreach (gstpad.c:608)
==74==    by 0x161A677F: check_sticky (gstpad.c:4106)
==74==    by 0x161A677F: gst_pad_push_event (gstpad.c:5675)
==74==    by 0x11310D74: webkitMediaStreamSrcTrackEnded(_WebKitMediaStreamSrc*, InternalSource&amp;) (GStreamerMediaStreamSource.cpp:791)
==74==    by 0x11310F79: InternalSource::trackEnded(WebCore::MediaStreamTrackPrivate&amp;) (GStreamerMediaStreamSource.cpp:812)
==74==    by 0x14A385B6: auto WebCore::MediaStreamTrackPrivate::endTrack()::{lambda(auto:1&amp;)#1}::operator()&lt;WebCore::MediaStreamTrackPrivate::Observer&gt;(WebCore::MediaStreamTrackPrivate::Observer&amp;) const (MediaStreamTrackPrivate.cpp:155)
==74==    by 0x14A385E9: WTF::Detail::CallableWrapper&lt;WebCore::MediaStreamTrackPrivate::endTrack()::{lambda(auto:1&amp;)#1}, void, WebCore::MediaStreamTrackPrivate::Observer&amp;&gt;::call(WebCore::MediaStreamTrackPrivate::Observer&amp;) (Function.h:53)
==74==    by 0x14A3EFE4: WTF::Function&lt;void (WebCore::MediaStreamTrackPrivate::Observer&amp;)&gt;::operator()(WebCore::MediaStreamTrackPrivate::Observer&amp;) const (Function.h:82)
==74==    by 0x14A3C417: WTF::WeakHashSet&lt;WebCore::MediaStreamTrackPrivate::Observer, WTF::EmptyCounter, (WTF::EnableWeakPtrThreadingAssertions)1&gt;::forEach(WTF::Function&lt;void (WebCore::MediaStreamTrackPrivate::Observer&amp;)&gt; const&amp;) (WeakHashSet.h:147)
==74==    by 0x14A2E45A: WebCore::MediaStreamTrackPrivate::forEachObserver(WTF::Function&lt;void (WebCore::MediaStreamTrackPrivate::Observer&amp;)&gt; const&amp;) (MediaStreamTrackPrivate.cpp:89)
==74==    by 0x14A2E898: WebCore::MediaStreamTrackPrivate::endTrack() (MediaStreamTrackPrivate.cpp:154)
==74==    by 0x12D950F7: WebCore::MediaStreamTrack::stopTrack(WebCore::MediaStreamTrack::StopMode) (MediaStreamTrack.cpp:244)
==74==    by 0x12D97482: WebCore::MediaStreamTrack::suspend(WebCore::ReasonForSuspension) (MediaStreamTrack.cpp:653)
==74==    by 0x13A576A8: auto WebCore::ScriptExecutionContext::suspendActiveDOMObjects(WebCore::ReasonForSuspension)::{lambda(auto:1&amp;)#1}::operator()&lt;WebCore::ActiveDOMObject&gt;(WebCore::ActiveDOMObject&amp;) const (ScriptExecutionContext.cpp:302)
==74==    by 0x13A576DF: WTF::Detail::CallableWrapper&lt;WebCore::ScriptExecutionContext::suspendActiveDOMObjects(WebCore::ReasonForSuspension)::{lambda(auto:1&amp;)#1}, WebCore::ScriptExecutionContext::ShouldContinue, WebCore::ActiveDOMObject&amp;&gt;::call(WebCore::ActiveDOMObject&amp;) (Function.h:53)
==74==    by 0x13A5AA4E: WTF::Function&lt;WebCore::ScriptExecutionContext::ShouldContinue (WebCore::ActiveDOMObject&amp;)&gt;::operator()(WebCore::ActiveDOMObject&amp;) const (Function.h:82)
==74==    by 0x13A4EFE5: WebCore::ScriptExecutionContext::forEachActiveDOMObject(WTF::Function&lt;WebCore::ScriptExecutionContext::ShouldContinue (WebCore::ActiveDOMObject&amp;)&gt; const&amp;) const (ScriptExecutionContext.cpp:273)
==74==    by 0x13A4F157: WebCore::ScriptExecutionContext::suspendActiveDOMObjects(WebCore::ReasonForSuspension) (ScriptExecutionContext.cpp:301)
==74==    by 0x1388F5B8: WebCore::Document::suspendActiveDOMObjects(WebCore::ReasonForSuspension) (Document.cpp:2824)
==74==    by 0x138A3FEB: WebCore::Document::suspendScheduledTasks(WebCore::ReasonForSuspension) (Document.cpp:6788)
==74==    by 0x1389EDEB: WebCore::Document::suspend(WebCore::ReasonForSuspension) (Document.cpp:5774)
==74==    by 0x13C36554: WebCore::CachedFrame::CachedFrame(WebCore::Frame&amp;) (CachedFrame.cpp:169)
==74==    by 0x13C3CC95: std::_MakeUniq&lt;WebCore::CachedFrame&gt;::__single_object std::make_unique&lt;WebCore::CachedFrame, WebCore::Frame&amp;&gt;(WebCore::Frame&amp;) (unique_ptr.h:962)
==74==    by 0x13C3B58B: decltype(auto) WTF::makeUnique&lt;WebCore::CachedFrame, WebCore::Frame&amp;&gt;(WebCore::Frame&amp;) (StdLibExtras.h:540)
==74==    by 0x13C37214: WebCore::CachedPage::CachedPage(WebCore::Page&amp;) (CachedPage.cpp:61)
==74==    by 0x13C3BF15: std::_MakeUniq&lt;WebCore::CachedPage&gt;::__single_object std::make_unique&lt;WebCore::CachedPage, WebCore::Page&amp;&gt;(WebCore::Page&amp;) (unique_ptr.h:962)
==74==    by 0x13C3B305: decltype(auto) WTF::makeUnique&lt;WebCore::CachedPage, WebCore::Page&amp;&gt;(WebCore::Page&amp;) (StdLibExtras.h:540)
==74==    by 0x13C34450: WebCore::BackForwardCache::trySuspendPage(WebCore::Page&amp;, WebCore::BackForwardCache::ForceSuspension) (BackForwardCache.cpp:460)
==74==    by 0x13C344EE: WebCore::BackForwardCache::addIfCacheable(WebCore::HistoryItem&amp;, WebCore::Page*) (BackForwardCache.cpp:471)
==74==    by 0x142BFF6C: WebCore::FrameLoader::commitProvisionalLoad() (FrameLoader.cpp:2040)
==74==    by 0x142665F2: WebCore::DocumentLoader::commitIfReady() (DocumentLoader.cpp:412)
==74==    by 0x1426C200: WebCore::DocumentLoader::commitLoad(WebCore::SharedBuffer const&amp;) (DocumentLoader.cpp:1178)
==74==    by 0x1426D388: WebCore::DocumentLoader::dataReceived(WebCore::SharedBuffer const&amp;) (DocumentLoader.cpp:1373)
==74==    by 0x1426D0E7: WebCore::DocumentLoader::dataReceived(WebCore::CachedResource&amp;, WebCore::SharedBuffer const&amp;) (DocumentLoader.cpp:1347)
==74==    by 0x143A2A52: WebCore::CachedRawResource::notifyClientsDataWasReceived(WebCore::SharedBuffer const&amp;) (CachedRawResource.cpp:145)
==74==    by 0x143A252A: WebCore::CachedRawResource::updateBuffer(WebCore::FragmentedSharedBuffer const&amp;) (CachedRawResource.cpp:81)
==74==    by 0x1433945C: WebCore::SubresourceLoader::didReceiveBuffer(WebCore::FragmentedSharedBuffer const&amp;, long long, WebCore::DataPayloadType) (SubresourceLoader.cpp:559)
==74==    by 0x14323A3F: WebCore::ResourceLoader::didReceiveData(WebCore::SharedBuffer const&amp;, long long, WebCore::DataPayloadType) (ResourceLoader.cpp:560)
==74==    by 0xED59FD9: WebKit::WebResourceLoader::didReceiveData(IPC::SharedBufferReference&amp;&amp;, long) (WebResourceLoader.cpp:243)
==74==    by 0xDF022C8: void IPC::callMemberFunctionImpl&lt;WebKit::WebResourceLoader, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long), std::tuple&lt;IPC::SharedBufferReference, long&gt;, 0ul, 1ul&gt;(WebKit::WebResourceLoader*, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long), std::tuple&lt;IPC::SharedBufferReference, long&gt;&amp;&amp;, std::integer_sequence&lt;unsigned long, 0ul, 1ul&gt;) (HandleMessage.h:131)
==74==    by 0xDF01053: void IPC::callMemberFunction&lt;WebKit::WebResourceLoader, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long), std::tuple&lt;IPC::SharedBufferReference, long&gt;, std::integer_sequence&lt;unsigned long, 0ul, 1ul&gt; &gt;(std::tuple&lt;IPC::SharedBufferReference, long&gt;&amp;&amp;, WebKit::WebResourceLoader*, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long)) (HandleMessage.h:137)
==74==    by 0xDF00255: void IPC::handleMessage&lt;Messages::WebResourceLoader::DidReceiveData, WebKit::WebResourceLoader, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long)&gt;(IPC::Connection&amp;, IPC::Decoder&amp;, WebKit::WebResourceLoader*, void (WebKit::WebResourceLoader::*)(IPC::SharedBufferReference&amp;&amp;, long)) (HandleMessage.h:259)
==74==    by 0xDEFF838: WebKit::WebResourceLoader::didReceiveWebResourceLoaderMessage(IPC::Connection&amp;, IPC::Decoder&amp;) (WebResourceLoaderMessageReceiver.cpp:76)
==74==    by 0xED50A06: WebKit::NetworkProcessConnection::didReceiveMessage(IPC::Connection&amp;, IPC::Decoder&amp;) (NetworkProcessConnection.cpp:102)
==74==    by 0xE5537A5: IPC::Connection::dispatchMessage(IPC::Decoder&amp;) (Connection.cpp:1108)
==74==    by 0xE553A3C: IPC::Connection::dispatchMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;) (Connection.cpp:1153)
==74==    by 0xE553FE3: IPC::Connection::dispatchOneIncomingMessage() (Connection.cpp:1222)
==74==    by 0xE5534B5: IPC::Connection::enqueueIncomingMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;)::{lambda()#1}::operator()() (Connection.cpp:1072)
==74==    by 0xE55A599: WTF::Detail::CallableWrapper&lt;IPC::Connection::enqueueIncomingMessage(std::unique_ptr&lt;IPC::Decoder, std::default_delete&lt;IPC::Decoder&gt; &gt;)::{lambda()#1}, void&gt;::call() (Function.h:53)
==74==    by 0xD99E63C: WTF::Function&lt;void ()&gt;::operator()() const (Function.h:82)
==74==    by 0x10F6D6C2: WTF::RunLoop::performWork() (RunLoop.cpp:133)
==74==    by 0x11018C67: WTF::RunLoop::RunLoop()::{lambda(void*)#1}::operator()(void*) const (RunLoopGLib.cpp:80)
==74==    by 0x11018C8B: WTF::RunLoop::RunLoop()::{lambda(void*)#1}::_FUN(void*) (RunLoopGLib.cpp:82)
==74==    by 0x11018BFA: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::operator()(_GSource*, int (*)(void*), void*) const (RunLoopGLib.cpp:53)
==74==    by 0x11018C48: WTF::RunLoop::{lambda(_GSource*, int (*)(void*), void*)#1}::_FUN(_GSource*, int (*)(void*), void*) (RunLoopGLib.cpp:56)
==74==    by 0x15F52293: g_main_dispatch (gmain.c:3381)
==74==    by 0x15F52293: g_main_context_dispatch (gmain.c:4099)
==74==    by 0x15F52637: g_main_context_iterate.constprop.0 (gmain.c:4175)
==74==    by 0x15F52942: g_main_loop_run (gmain.c:4373)
==74==    by 0x110192B3: WTF::RunLoop::run() (RunLoopGLib.cpp:108)
==74==    by 0xEFB8674: WebKit::AuxiliaryProcessMainBase&lt;WebKit::WebProcess, true&gt;::run(int, char**) (AuxiliaryProcessMain.h:70)
==74==    by 0xEFB5D26: int WebKit::AuxiliaryProcessMain&lt;WebKit::WebProcessMainWPE&gt;(int, char**) (AuxiliaryProcessMain.h:96)
==74==    by 0xEFB227E: WebKit::WebProcessMain(int, char**) (WebProcessMainWPE.cpp:75)
==74==    by 0x109908: main (WebProcessMain.cpp:31)
==74==  Address 0xbbadbeef is not stack&apos;d, malloc&apos;d or (recently) free&apos;d
==74==

* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
</pre>