### PR TITLE
Teach run-webkit-tests how to run WPT crash tests

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -112,13 +112,21 @@ class LayoutTestFinder(object):
                 test_file,
                 is_http_test=self.http_subdir in test_file,
                 is_websocket_test=self.websocket_subdir in test_file or (self.http_subdir in test_file and 'websocket' in test_file),
-                is_wpt_test=(
-                    self.web_platform_test_subdir in test_file
-                    or self.webkit_specific_web_platform_test_subdir in test_file
-                ),
+                is_wpt_test=self._is_wpt_test(test_file),
+                is_wpt_crash_test=self._is_wpt_crash_test(test_file),
             )
             for test_file in self._real_tests(expanded_paths)
         ]
+
+    def _is_wpt_test(self, test_file):
+        return self.web_platform_test_subdir in test_file or self.webkit_specific_web_platform_test_subdir in test_file
+
+    def _is_wpt_crash_test(self, test_file):
+        if not self._is_wpt_test(test_file):
+            return False
+        filename, _ = self._filesystem.splitext(test_file)
+        crashtests_dirname = self._port.TEST_PATH_SEPARATOR + 'crashtests' + self._port.TEST_PATH_SEPARATOR
+        return filename.endswith('-crash') or crashtests_dirname in test_file
 
     def _expanded_paths(self, paths, device_type=None):
         expanded_paths = []

--- a/Tools/Scripts/webkitpy/layout_tests/models/test.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test.py
@@ -44,6 +44,7 @@ class Test(object):
     is_http_test = attr.ib(default=None, type=bool)
     is_websocket_test = attr.ib(default=None, type=bool)
     is_wpt_test = attr.ib(default=None, type=bool)
+    is_wpt_crash_test = attr.ib(default=None, type=bool)
 
     @property
     def needs_http_server(self):


### PR DESCRIPTION
#### b3ec691a75db640d7a32cc4c5505bd5e6d95edf2
<pre>
Teach run-webkit-tests how to run WPT crash tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=242633">https://bugs.webkit.org/show_bug.cgi?id=242633</a>

Reviewed by Youenn Fablet.

This patch adds the support for WPT crash tests whereby which the output of the test is ignored.
Instead, run-webkit-tests will check that the test didn&apos;t result in a crash or a timeout.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.find_tests_by_path): Specify is_wpt_crash_test on a new Test object.
(LayoutTestFinder._is_wpt_test): Extracted.
(LayoutTestFinder._is_wpt_crash_test): Added.
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner.run):
(SingleTestRunner._run_wpt_crash_test): Added. This method implements the core logic for running
a WPT crash test.
* Tools/Scripts/webkitpy/layout_tests/models/test.py:
(Test): Added a new field, is_wpt_crash_test, to indicate whether this is a WPT crash test or not.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.serial_test_basic):
(RunTest.test_wpt_tests): Added.
(RunTest.test_wpt_tests_rebaseline): Added.
* Tools/Scripts/webkitpy/port/test.py:
(TestInstance.__init__):

Canonical link: <a href="https://commits.webkit.org/252469@main">https://commits.webkit.org/252469@main</a>
</pre>
