### PR TITLE
Revert 252218@main; caused assertion failures on platforms with no GPUProcess

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -33,7 +33,6 @@
 #include "IOSurfacePool.h"
 #include "IntRect.h"
 #include "PixelBuffer.h"
-#include "RuntimeApplicationChecks.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/IsoMallocInlines.h>
@@ -219,13 +218,6 @@ void ImageBufferIOSurfaceBackend::releaseGraphicsContext()
 
 bool ImageBufferIOSurfaceBackend::setVolatile()
 {
-    ASSERT(isInGPUProcess());
-
-    // Volatility of a surface is managed by the GPU process via a single Backend object.
-    // We can safely cache the state and avoid IOKit calls.
-    if (m_volatilityState == VolatilityState::Volatile)
-        return true;
-
     if (m_surface->isInUse())
         return false;
 
@@ -236,16 +228,8 @@ bool ImageBufferIOSurfaceBackend::setVolatile()
 
 SetNonVolatileResult ImageBufferIOSurfaceBackend::setNonVolatile()
 {
-    ASSERT(isInGPUProcess());
-
-    // Volatility of a surface is managed by the GPU process via a single Backend object.
-    // We can safely cache the state and avoid IOKit calls.
-    if (m_volatilityState == VolatilityState::NonVolatile)
-        return m_setNonVolatileResult;
-
     setVolatilityState(VolatilityState::NonVolatile);
-    m_setNonVolatileResult = m_surface->setVolatile(false);
-    return m_setNonVolatileResult;
+    return m_surface->setVolatile(false);
 }
 
 VolatilityState ImageBufferIOSurfaceBackend::volatilityState() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -86,7 +86,6 @@ protected:
     mutable bool m_mayHaveOutstandingBackingStoreReferences { false };
     mutable bool m_needsSetupContext { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };
-    SetNonVolatileResult m_setNonVolatileResult { SetNonVolatileResult::Valid };
 
     RefPtr<IOSurfacePool> m_ioSurfacePool;
 };


### PR DESCRIPTION
#### 949632ce677e4ef1ef058107959d5a9083ae554e
<pre>
Revert 252218@main; caused assertion failures on platforms with no GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=242646">https://bugs.webkit.org/show_bug.cgi?id=242646</a>

Unreviewed, revert.

This reverts commit 1c1fc9cf94efdaf9b545bf8886206a4eeb64062d.

Canonical link: <a href="https://commits.webkit.org/252389@main">https://commits.webkit.org/252389@main</a>
</pre>
