### PR TITLE
[AArch32][Aarch64] ASSERTION FAILED variant.intrinsic() == NoIntrinsic in void JSC::DFG::ByteCodeParser::handleGetById

### DIFF
--- a/JSTests/stress/bigint-array-byte-offset.js
+++ b/JSTests/stress/bigint-array-byte-offset.js
@@ -1,0 +1,4 @@
+function __f_2(__v_23) { __v_23.byteOffset }
+noInline(__f_2);
+for (var i = 0; i < 1e5; ++i)
+    __f_2(new BigInt64Array)

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4785,8 +4785,6 @@ void ByteCodeParser::handleGetById(
         return;
     }
 
-    ASSERT(variant.intrinsic() == NoIntrinsic);
-
     // Make a call. We don't try to get fancy with using the smallest operand number because
     // the stack layout phase should compress the stack anyway.
     


### PR DESCRIPTION
#### 1f3e8b70b99967df7ff1fd267763c21361461244
<pre>
[AArch32][Aarch64] ASSERTION FAILED variant.intrinsic() == NoIntrinsic in void JSC::DFG::ByteCodeParser::handleGetById
<a href="https://bugs.webkit.org/show_bug.cgi?id=242599">https://bugs.webkit.org/show_bug.cgi?id=242599</a>
&lt;rdar://96836847&gt;

Reviewed by Mark Lam.

Previously all intrinsic getters are handled. So at this point, it should be NoIntrinsic.
But after introducing 4GB TypedArray and BigInt64Array, this handling can fail.

However, in this case, we should just continue using this generic path: invoking a getter.
Thus, the current code is correct, and this assertion is stale.

This patch removes this stale assertion.

* JSTests/stress/bigint-array-byte-offset.js: Added.
(__f_2):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleGetById):

Canonical link: <a href="https://commits.webkit.org/252391@main">https://commits.webkit.org/252391@main</a>
</pre>
