### PR TITLE
Web Inspector: nodes that aren't visible should be visually distinguished in the DOM tree

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html
+++ b/LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html
@@ -51,10 +51,10 @@ function test()
         description: "Change a `grid` to a non-grid.",
         selector: "#gridToNonGrid",
         async domNodeHandler(domNode) {
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Grid, "Layout context should be `grid`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Grid, "Layout context should be `grid`.");
 
             await Promise.all([
-                domNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("gridToNonGrid", "block"),
             ]);
 
@@ -70,11 +70,11 @@ function test()
             InspectorTest.expectEqual(domNode.layoutContextType, null, "Layout context should be `null`.");
 
             await Promise.all([
-                domNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("nonGridToGrid", "grid"),
             ]);
 
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Grid, "Layout context should now be `grid`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Grid, "Layout context should now be `grid`.");
         }
     });
 
@@ -83,10 +83,10 @@ function test()
         description: "Change a flex container to a non-flex container.",
         selector: "#flexToNonFlex",
         async domNodeHandler(domNode) {
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Flex, "Layout context should be `flex`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Flex, "Layout context should be `flex`.");
 
             await Promise.all([
-                domNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("flexToNonFlex", "block"),
             ]);
 
@@ -102,11 +102,11 @@ function test()
             InspectorTest.expectEqual(domNode.layoutContextType, null, "Layout context should be `null`.");
 
             await Promise.all([
-                domNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("nonFlexToFlex", "flex"),
             ]);
 
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Flex, "Layout context should now be `flex`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Flex, "Layout context should now be `flex`.");
         }
     });
 
@@ -115,14 +115,14 @@ function test()
         description: "Change a non-flex container to a flex container.",
         selector: "#gridToFlex",
         async domNodeHandler(domNode) {
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Grid, "Layout context should now be `grid`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Grid, "Layout context should now be `grid`.");
 
             await Promise.all([
-                domNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("gridToFlex", "flex"),
             ]);
 
-            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutContextType.Flex, "Layout context should now be `flex`.");
+            InspectorTest.expectEqual(domNode.layoutContextType, WI.DOMNode.LayoutFlag.Flex, "Layout context should now be `flex`.");
         }
     });
 

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered-expected.txt
@@ -1,0 +1,48 @@
+Tests for the CSS.nodeLayoutFlagsChanged event with the Rendered enum.
+
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.Rendered
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Existing.Direct.Display.None
+PASS: Should not render existing nodes with `display: none`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Existing.Direct.Display.Block
+PASS: Should render existing nodes with `display: block`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Existing.Parent.Display.None
+PASS: Should not render existing nodes that have a parent with `display: none`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Existing.Parent.Display.Block
+PASS: Should render existing nodes that have a parent with `display: block`.
+
+-- Running test setup.
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.None
+PASS: Should not render new nodes with `display: none`.
+
+-- Running test setup.
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.Block
+PASS: Should render new nodes with `display: block`.
+
+-- Running test setup.
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.None
+PASS: Should not render new nodes that have a parent with `display: none`.
+
+-- Running test setup.
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.Block
+PASS: Should render new nodes that have a parent with `display: block`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Change.Direct.Display.None
+Changing to `display: none`...
+PASS: Should not render nodes changed to `display: none`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Change.Direct.Display.Block
+Changing to `display: block`...
+PASS: Should render nodes changed to `display: block`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Change.Parent.Display.None
+Changing to `display: none`...
+PASS: Should not render nodes that have a parent changed to `display: none`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Rendered.Change.Parent.Display.Block
+Changing to `display: block`...
+PASS: Should render nodes that have a parent changed to `display: block`.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let documentNode;
+
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.Rendered");
+
+    function addTestCase({name, description, selector, setup, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            setup,
+            async test() {
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+                await domNodeHandler(domNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Existing.Direct.Display.None",
+        description: "Test that existing nodes with `display: none` are not rendered.",
+        selector: "#direct-display-none",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render existing nodes with `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Existing.Direct.Display.Block",
+        description: "Test that existing nodes with `display: block` are rendered.",
+        selector: "#direct-display-block",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render existing nodes with `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Existing.Parent.Display.None",
+        description: "Test that existing nodes that have a parent with `display: none` are not rendered.",
+        selector: "#parent-display-none",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render existing nodes that have a parent with `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Existing.Parent.Display.Block",
+        description: "Test that existing nodes that have a parent with with `display: block` are rendered.",
+        selector: "#parent-display-block",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render existing nodes that have a parent with `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.None",
+        description: "Test that new nodes with `display: none` are not rendered.",
+        selector: "#new-direct-display-none",
+        async setup() {
+            await InspectorTest.evaluateInPage(`document.body.insertAdjacentHTML("beforeend", "<div id='new-direct-display-none' style='display: none'></div>")`);
+        },
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render new nodes with `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.Block",
+        description: "Test that new nodes with `display: block` are rendered.",
+        selector: "#new-direct-display-block",
+        async setup() {
+            await InspectorTest.evaluateInPage(`document.body.insertAdjacentHTML("beforeend", "<div id='new-direct-display-block' style='display: block'></div>")`);
+        },
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render new nodes with `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.None",
+        description: "Test that new nodes that have a parent with `display: none` are not rendered.",
+        selector: "#new-direct-display-none",
+        async setup() {
+            await InspectorTest.evaluateInPage(`document.body.insertAdjacentHTML("beforeend", "<div style='display: none'><div id='new-direct-display-none'></div></div>")`);
+        },
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render new nodes that have a parent with `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.New.Direct.Display.Block",
+        description: "Test that new nodes that have a parent with `display: block` are rendered.",
+        selector: "#new-direct-display-block",
+        async setup() {
+            await InspectorTest.evaluateInPage(`document.body.insertAdjacentHTML("beforeend", "<div style='display: block'><div id='new-direct-display-block'></div></div>")`);
+        },
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render new nodes that have a parent with `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Change.Direct.Display.None",
+        description: "Test that nodes changed to `display: block` are rendered.",
+        selector: "#direct-display-block",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render existing nodes with `display: block`.");
+
+            InspectorTest.log("Changing to `display: none`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "display: none"),
+            ]);
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render nodes changed to `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Change.Direct.Display.Block",
+        description: "Test that nodes changed to `display: none` are not rendered.",
+        selector: "#direct-display-none",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render existing nodes with `display: none`.");
+
+            InspectorTest.log("Changing to `display: block`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "display: block"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render nodes changed to `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Change.Parent.Display.None",
+        description: "Test that nodes that have a parent changed to `display: block` are rendered.",
+        selector: "#parent-display-block",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render existing nodes that have a parent with `display: block`.");
+
+            InspectorTest.log("Changing to `display: none`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.parentNode.setAttributeValue("style", "display: none"),
+            ]);
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render nodes that have a parent changed to `display: none`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Rendered.Change.Parent.Display.Block",
+        description: "Test that nodes that have a parent changed to `display: none` are not rendered.",
+        selector: "#parent-display-none",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should not render existing nodes that have a parent with `display: none`.");
+
+            InspectorTest.log("Changing to `display: block`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.parentNode.setAttributeValue("style", "display: block"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render nodes that have a parent changed to `display: block`.");
+        },
+    });
+
+    WI.domManager.requestDocument().then((doc) => {
+        documentNode = doc;
+        suite.runTestCasesAndFinish();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.nodeLayoutFlagsChanged event with the Rendered enum.</p>
+
+    <div id="direct-display-none" style="display: none"></div>
+    <div id="direct-display-block" style="display: block"></div>
+
+    <div style="display: none"><div id="parent-display-none"></div></div>
+    <div style="display: block"><div id="parent-display-block"></div></div>
+</body>
+</html>

--- a/LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html
+++ b/LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html
@@ -31,41 +31,41 @@ function test()
         name: "CSS.setLayoutContextTypeChangedMode.queryGrid",
         description: "Test that the expected number of grids are instrumented without chagning the LayoutContextTypeChangedMode.",
         async test() {
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 0, "0 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 0, "0 grid nodes should be instrumented.");
 
             // Query for the node, sending it to the frontend.
             InspectorTest.log("Querying document for selector `#queryGrid`...");
             let documentNode = await WI.domManager.requestDocument();
             let queryNode = WI.domManager.nodeForId(await documentNode.querySelector("#queryGrid"));
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 1, "1 grid node should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
 
             InspectorTest.log("Changing `#queryGrid` to `display: block;`...");
             await Promise.all([
-                queryNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                queryNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("queryGrid", "block"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 0, "0 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 0, "0 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#queryGrid` to `display: grid;`...");
             await Promise.all([
-                queryNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                queryNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("queryGrid", "grid"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 1, "1 grid node should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
 
             InspectorTest.log("Changing `#queryGrid` to `display: block;`...");
             await Promise.all([
-                queryNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                queryNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("queryGrid", "block"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 0, "0 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 0, "0 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#queryGrid` to `display: inline-grid;`...");
             await Promise.all([
-                queryNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                queryNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("queryGrid", "inline-grid"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 1, "1 grid node should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
         }
     });
 
@@ -75,7 +75,7 @@ function test()
         async test() {
             await WI.domManager.requestDocument();
 
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 1, "1 grid node should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
 
             // Grid layout contexts are sent to the frontend when the mode is changed to all.
             InspectorTest.log("Changing `layoutContextTypeChangedMode` to `All`...");
@@ -83,26 +83,26 @@ function test()
                 WI.domManager.awaitEvent(WI.DOMManager.Event.NodeInserted),
                 setLayoutContextTypeChangeMode(WI.CSSManager.LayoutContextTypeChangedMode.All),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             // Once a node has been observed, it will always be kept up-to-date.
             InspectorTest.log("Changing `layoutContextTypeChangedMode` to `Observed`...");
             await setLayoutContextTypeChangeMode(WI.CSSManager.LayoutContextTypeChangedMode.Observed),
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#normalGrid` to `display: block;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("normalGrid", "block"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 1, "1 grid node should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 1, "1 grid node should be instrumented.");
 
             InspectorTest.log("Changing `#normalGrid` to `display: grid;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("normalGrid", "grid"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
         }
     });
 
@@ -112,36 +112,36 @@ function test()
         async test() {
             await WI.domManager.requestDocument();
 
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             // Changes to unobserved nodes should not change the grid count.
             InspectorTest.log("Changing `#normalNonGrid` to `display: grid;`...");
             await changeElementDisplayValue("normalNonGrid", "grid");
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#normalNonGrid` to `display: block;`...");
             await changeElementDisplayValue("normalNonGrid", "block");
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             // Enabling `All` mode should not change the grid count.
             InspectorTest.log("Changing `layoutContextTypeChangedMode` to `All`...");
             await setLayoutContextTypeChangeMode(WI.CSSManager.LayoutContextTypeChangedMode.All),
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
 
             // Changing a node to a grid after enabling `All` mode will increase the count.
             InspectorTest.log("Changing `#normalNonGrid` to `display: grid;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("normalNonGrid", "grid"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 3, "3 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 3, "3 grid nodes should be instrumented.");
 
             InspectorTest.log("Changing `#normalNonGrid` to `display: block;`...");
             await Promise.all([
-                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutContextTypeChanged),
+                WI.DOMNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
                 changeElementDisplayValue("normalNonGrid", "block"),
             ]);
-            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutContextType.Grid).length, 2, "2 grid nodes should be instrumented.");
+            InspectorTest.expectEqual(nodesWithLayoutContextType(WI.DOMNode.LayoutFlag.Grid).length, 2, "2 grid nodes should be instrumented.");
         }
     });
 

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -269,10 +269,14 @@
             ]
         },
         {
-            "id": "LayoutContextType",
+            "id": "LayoutFlag",
             "type": "string",
-            "enum": ["flex", "grid"],
-            "description": "The layout context type of a node."
+            "enum": [
+                "rendered",
+                "flex",
+                "grid"
+            ],
+            "description": "Relevant layout information about the node. Things not in this list are not important to Web Inspector."
         },
         {
             "id": "LayoutContextTypeChangedMode",
@@ -479,12 +483,12 @@
             ]
         },
         {
-            "name": "nodeLayoutContextTypeChanged",
-            "description": "Called when a node's layout context type has changed.",
+            "name": "nodeLayoutFlagsChanged",
+            "description": "Called when the layout of a node changes in a way that is important to Web Inspector.",
             "targetTypes": ["page"],
             "parameters": [
-                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node whose layout context type changed." },
-                { "name": "layoutContextType", "$ref": "LayoutContextType", "optional": true, "description": "The new layout context type of the node. When not provided, the <code>LayoutContextType</code> of the node is not a context for which Web Inspector has specific functionality." }
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node whose layout changed." },
+                { "name": "layoutFlags", "type": "array", "items": { "type": "string", "description": "CSS.LayoutFlag" }, "optional": true, "description": "Relevant information about the layout of the node. When not provided, the layout of the node is not important to Web Inspector." }
             ]
         }
     ]

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -67,7 +67,7 @@
                 { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements" },
                 { "name": "pseudoElements", "type": "array", "items": { "$ref": "Node" }, "optional": true, "description": "Pseudo elements associated with this node." },
                 { "name": "contentSecurityPolicyHash", "type": "string", "optional": true, "description": "Computed SHA-256 Content Security Policy hash source for given element." },
-                { "name": "layoutContextType", "$ref": "CSS.LayoutContextType", "optional": true, "description": "The layout context type of the node. When not provided, the <code>LayoutContextType</code> of the node is not a context for which Web Inspector has specific functionality." }
+                { "name": "layoutFlags", "type": "array", "items": { "type": "string", "description": "CSS.LayoutFlag" }, "optional": true, "description": "Relevant information about the layout of the node. When not provided, the layout of the node is not important to Web Inspector." }
             ]
         },
         {

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2667,6 +2667,11 @@ WebCoreOpaqueRoot Node::traverseToOpaqueRoot() const
     return WebCoreOpaqueRoot { const_cast<Node*>(node) };
 }
 
+void Node::notifyInspectorOfRendererChange()
+{
+    InspectorInstrumentation::didChangeRendererForDOMNode(*this);
+}
+
 template<> ContainerNode* parent<Tree>(const Node& node)
 {
     return node.parentNode();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -734,6 +734,8 @@ private:
     static void moveShadowTreeToNewDocument(ShadowRoot&, Document& oldDocument, Document& newDocument);
     static void moveTreeToNewScope(Node&, TreeScope& oldScope, TreeScope& newScope);
     void moveNodeToNewDocument(Document& oldDocument, Document& newDocument);
+
+    WEBCORE_EXPORT void notifyInspectorOfRendererChange();
     
     struct NodeRareDataDeleter {
         void operator()(NodeRareData*) const;

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -179,10 +179,10 @@ void InspectorInstrumentation::willDestroyDOMNodeImpl(InstrumentingAgents& instr
         domAgent->willDestroyDOMNode(node);
 }
 
-void InspectorInstrumentation::nodeLayoutContextChangedImpl(InstrumentingAgents& instrumentingAgents, Node& node, RenderObject* newRenderer)
+void InspectorInstrumentation::didChangeRendererForDOMNodeImpl(InstrumentingAgents& instrumentingAgents, Node& node)
 {
     if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
-        cssAgent->nodeLayoutContextTypeChanged(node, newRenderer);
+        cssAgent->didChangeRendererForDOMNode(node);
 }
 
 void InspectorInstrumentation::willModifyDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -123,7 +123,7 @@ public:
     static void willRemoveDOMNode(Document&, Node&);
     static void didRemoveDOMNode(Document&, Node&);
     static void willDestroyDOMNode(Node&);
-    static void nodeLayoutContextChanged(Node&, RenderObject*);
+    static void didChangeRendererForDOMNode(Node&);
     static void willModifyDOMAttr(Document&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttr(Document&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttr(Document&, Element&, const AtomString& name);
@@ -345,7 +345,7 @@ private:
     static void willRemoveDOMNodeImpl(InstrumentingAgents&, Node&);
     static void didRemoveDOMNodeImpl(InstrumentingAgents&, Node&);
     static void willDestroyDOMNodeImpl(InstrumentingAgents&, Node&);
-    static void nodeLayoutContextChangedImpl(InstrumentingAgents&, Node&, RenderObject*);
+    static void didChangeRendererForDOMNodeImpl(InstrumentingAgents&, Node&);
     static void willModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name);
@@ -598,11 +598,11 @@ inline void InspectorInstrumentation::willDestroyDOMNode(Node& node)
         willDestroyDOMNodeImpl(*agents, node);
 }
 
-inline void InspectorInstrumentation::nodeLayoutContextChanged(Node& node, RenderObject* newRenderer)
+inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
 {
-    FAST_RETURN_IF_NO_FRONTENDS(void());
+    ASSERT(InspectorInstrumentationPublic::hasFrontends());
     if (auto* agents = instrumentingAgents(node.document()))
-        nodeLayoutContextChangedImpl(*agents, node, newRenderer);
+        didChangeRendererForDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1842,8 +1842,8 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
             value->setChildren(WTFMove(children));
     }
     
-    if (auto layoutContextType = InspectorCSSAgent::layoutContextTypeForRenderer(node->renderer()))
-        value->setLayoutContextType(layoutContextType.value());
+    if (auto layoutFlags = InspectorCSSAgent::layoutFlagsForNode(*node))
+        value->setLayoutFlags(layoutFlags.releaseNonNull());
 
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (pageAgent) {

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -75,8 +75,6 @@ RenderFlexibleBox::RenderFlexibleBox(Element& element, RenderStyle&& style)
     : RenderBlock(element, WTFMove(style), 0)
 {
     setChildrenInline(false); // All of our children must be block-level.
-
-    InspectorInstrumentation::nodeLayoutContextChanged(element, this);
 }
 
 RenderFlexibleBox::RenderFlexibleBox(Document& document, RenderStyle&& style)
@@ -85,11 +83,7 @@ RenderFlexibleBox::RenderFlexibleBox(Document& document, RenderStyle&& style)
     setChildrenInline(false); // All of our children must be block-level.
 }
 
-RenderFlexibleBox::~RenderFlexibleBox()
-{
-    if (!isAnonymous())
-        InspectorInstrumentation::nodeLayoutContextChanged(nodeForNonAnonymous(), nullptr);
-}
+RenderFlexibleBox::~RenderFlexibleBox() = default;
 
 ASCIILiteral RenderFlexibleBox::renderName() const
 {

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -31,7 +31,6 @@
 #include "GridLayoutFunctions.h"
 #include "GridPositionsResolver.h"
 #include "GridTrackSizingAlgorithm.h"
-#include "InspectorInstrumentation.h"
 #include "LayoutRepainter.h"
 #include "RenderChildIterator.h"
 #include "RenderLayer.h"
@@ -57,14 +56,9 @@ RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
 {
     // All of our children must be block level.
     setChildrenInline(false);
-
-    InspectorInstrumentation::nodeLayoutContextChanged(element, this);
 }
 
-RenderGrid::~RenderGrid()
-{
-    InspectorInstrumentation::nodeLayoutContextChanged(element(), nullptr);
-}
+RenderGrid::~RenderGrid() = default;
 
 StyleSelfAlignmentData RenderGrid::selfAlignmentForChild(GridAxis axis, const RenderBox& child, const RenderStyle* gridStyle) const
 {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -31,6 +31,7 @@
 #include "Frame.h"
 #include "FrameDestructionObserverInlines.h"
 #include "HTMLNames.h"
+#include "InspectorInstrumentationPublic.h"
 #include "LayoutRect.h"
 #include "Page.h"
 #include "RenderObjectEnums.h"
@@ -1204,6 +1205,9 @@ inline RenderObject::SetLayoutNeededForbiddenScope::SetLayoutNeededForbiddenScop
 inline void Node::setRenderer(RenderObject* renderer)
 {
     m_rendererWithStyleFlags.setPointer(renderer);
+
+    if (UNLIKELY(InspectorInstrumentationPublic::hasFrontends()))
+        notifyInspectorOfRendererChange();
 }
 
 inline RenderObject* RenderObject::previousInFlowSibling() const

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -34,7 +34,6 @@
 #include "FullscreenManager.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLSlotElement.h"
-#include "InspectorInstrumentation.h"
 #include "NodeRenderStyle.h"
 #include "PseudoElement.h"
 #include "RenderDescendantIterator.h"

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -273,14 +273,16 @@ WI.DOMManager = class DOMManager extends WI.Object
         node.powerEfficientPlaybackStateChanged(timestamp, isPowerEfficient);
     }
 
-    nodeLayoutContextTypeChanged(nodeId, layoutContextType)
+    // CSSObserver
+
+    nodeLayoutFlagsChanged(nodeId, layoutFlags)
     {
         let domNode = this._idToDOMNode[nodeId];
         console.assert(domNode instanceof WI.DOMNode, domNode, nodeId);
         if (!domNode)
             return;
 
-        domNode.layoutContextType = layoutContextType;
+        domNode.layoutFlags = layoutFlags;
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -52,7 +52,8 @@ WI.DOMNode = class DOMNode extends WI.Object
         this._shadowRootType = payload.shadowRootType;
         this._computedRole = null;
         this._contentSecurityPolicyHash = payload.contentSecurityPolicyHash;
-        this._layoutContextType = null;
+
+        this._layoutFlags = [];
         this._layoutOverlayShowing = false;
         this._layoutOverlayColorSetting = null;
 
@@ -157,8 +158,14 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this.isMediaElement())
             WI.DOMNode.addEventListener(WI.DOMNode.Event.DidFireEvent, this._handleDOMNodeDidFireEvent, this);
 
-        // Setting layoutContextType to anything other than null will dispatch an event.
-        this.layoutContextType = payload.layoutContextType;
+        // COMPATIBILITY (iOS 16): CSS.LayoutContextType was renamed/expanded to CSS.LayoutFlag.
+        if (!InspectorBackend.Enum.CSS.LayoutFlag) {
+            let layoutFlags = [WI.DOMNode.LayoutFlag.Rendered];
+            if (payload.layoutContextType)
+                layoutFlags.append(payload.layoutContextType);
+            this.layoutFlags = layoutFlags;
+        } else
+            this.layoutFlags = payload.layoutFlags;
     }
 
     // Static
@@ -256,21 +263,26 @@ WI.DOMNode = class DOMNode extends WI.Object
         this._childNodeCount = count;
     }
 
-    get layoutContextType()
+    get layoutFlags()
     {
-        return this._layoutContextType;
+        return this._layoutFlags;
     }
 
-    set layoutContextType(layoutContextType)
+    set layoutFlags(layoutFlags)
     {
-        layoutContextType ||= null;
-        if (layoutContextType === this._layoutContextType)
+        layoutFlags ||= [];
+        console.assert(Array.isArray(layoutFlags), layoutFlags);
+        console.assert(layoutFlags.every((layoutFlag) => Object.values(WI.DOMNode.LayoutFlag).includes(layoutFlag)), layoutFlags);
+        console.assert(layoutFlags.filter((layoutFlag) => WI.DOMNode._LayoutContextTypes.includes(layoutFlag)).length <= 1, this._layoutFlags);
+
+        if (Array.shallowEqual(layoutFlags, this._layoutFlags))
             return;
 
-        let oldLayoutContextType = this._layoutContextType;
-        this._layoutContextType = layoutContextType;
+        let oldLayoutContextType = this.layoutContextType;
 
-        this.dispatchEventToListeners(WI.DOMNode.Event.LayoutContextTypeChanged);
+        this._layoutFlags = layoutFlags;
+
+        this.dispatchEventToListeners(WI.DOMNode.Event.LayoutFlagsChanged);
 
         if (!this._layoutOverlayShowing)
             return;
@@ -279,11 +291,11 @@ WI.DOMNode = class DOMNode extends WI.Object
         this.dispatchEventToListeners(WI.DOMNode.Event.LayoutOverlayHidden);
 
         switch (oldLayoutContextType) {
-        case WI.DOMNode.LayoutContextType.Flex:
+        case WI.DOMNode.LayoutFlag.Flex:
             WI.settings.flexOverlayShowOrderNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             break;
 
-        case WI.DOMNode.LayoutContextType.Grid:
+        case WI.DOMNode.LayoutFlag.Grid:
             WI.settings.gridOverlayShowExtendedGridLines.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
@@ -293,12 +305,17 @@ WI.DOMNode = class DOMNode extends WI.Object
         }
     }
 
+    get layoutContextType()
+    {
+        return this._layoutFlags.find((layoutFlag) => WI.DOMNode._LayoutContextTypes.includes(layoutFlag)) || null;
+    }
+
     markDestroyed()
     {
         console.assert(!this._destroyed, this);
         this._destroyed = true;
 
-        this.layoutContextType = null;
+        this.layoutFlags = [];
     }
 
     computedRole()
@@ -489,11 +506,21 @@ WI.DOMNode = class DOMNode extends WI.Object
     {
         console.assert(!this._destroyed, this);
         if (this._destroyed) {
+            if (!callback)
+                return Promise.reject("ERROR: node is destroyed");
+
             callback("ERROR: node is destroyed");
             return;
         }
 
         let target = WI.assumingMainTarget();
+
+        if (!callback) {
+            return target.DOMAgent.setAttributeValue(this.id, name, value).then(() => {
+                this._markUndoableState();
+            });
+        }
+
         target.DOMAgent.setAttributeValue(this.id, name, value, this._makeUndoableCallback(callback));
     }
 
@@ -612,7 +639,7 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
 
-        console.assert(Object.values(WI.DOMNode.LayoutContextType).includes(this._layoutContextType), this);
+        console.assert(Object.values(WI.DOMNode._LayoutContextTypes).includes(this.layoutContextType), this);
 
         console.assert(!color || color instanceof WI.Color, color);
         color ||= this.layoutOverlayColor;
@@ -621,8 +648,8 @@ WI.DOMNode = class DOMNode extends WI.Object
         let agentCommandFunction = null;
         let agentCommandArguments = {nodeId: this.id};
 
-        switch (this._layoutContextType) {
-        case WI.DOMNode.LayoutContextType.Grid:
+        switch (this.layoutContextType) {
+        case WI.DOMNode.LayoutFlag.Grid:
             agentCommandArguments.gridColor = color.toProtocol();
             agentCommandArguments.showLineNames = WI.settings.gridOverlayShowLineNames.value;
             agentCommandArguments.showLineNumbers = WI.settings.gridOverlayShowLineNumbers.value;
@@ -640,7 +667,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             }
             break;
 
-        case WI.DOMNode.LayoutContextType.Flex:
+        case WI.DOMNode.LayoutFlag.Flex:
             agentCommandArguments.flexColor = color.toProtocol();
             agentCommandArguments.showOrderNumbers = WI.settings.flexOverlayShowOrderNumbers.value;
             agentCommandFunction = target.DOMAgent.showFlexOverlay;
@@ -664,14 +691,14 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
 
-        console.assert(Object.values(WI.DOMNode.LayoutContextType).includes(this._layoutContextType), this);
+        console.assert(Object.values(WI.DOMNode._LayoutContextTypes).includes(this.layoutContextType), this);
 
         let target = WI.assumingMainTarget();
         let agentCommandFunction;
         let agentCommandArguments = {nodeId: this.id};
 
-        switch (this._layoutContextType) {
-        case WI.DOMNode.LayoutContextType.Grid:
+        switch (this.layoutContextType) {
+        case WI.DOMNode.LayoutFlag.Grid:
             WI.settings.gridOverlayShowExtendedGridLines.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNames.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
             WI.settings.gridOverlayShowLineNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
@@ -681,7 +708,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             agentCommandFunction = target.DOMAgent.hideGridOverlay;
             break;
 
-        case WI.DOMNode.LayoutContextType.Flex:
+        case WI.DOMNode.LayoutFlag.Flex:
             WI.settings.flexOverlayShowOrderNumbers.removeEventListener(WI.Setting.Event.Changed, this._handleLayoutOverlaySettingChanged, this);
 
             agentCommandFunction = target.DOMAgent.hideFlexOverlay;
@@ -1196,14 +1223,18 @@ WI.DOMNode = class DOMNode extends WI.Object
         target.CSSAgent.forcePseudoState(this.id, pseudoClasses, changed.bind(this));
     }
 
+    _markUndoableState()
+    {
+        let target = WI.assumingMainTarget();
+        if (target.hasCommand("DOM.markUndoableState"))
+            target.DOMAgent.markUndoableState();
+    }
+
     _makeUndoableCallback(callback)
     {
         return (...args) => {
-            if (!args[0]) { // error
-                let target = WI.assumingMainTarget();
-                if (target.hasCommand("DOM.markUndoableState"))
-                    target.DOMAgent.markUndoableState();
-            }
+            if (!args[0]) // error
+                this._markUndoableState();
 
             if (callback)
                 callback.apply(null, args);
@@ -1257,13 +1288,13 @@ WI.DOMNode = class DOMNode extends WI.Object
         let url = this.ownerDocument.documentURL || WI.networkManager.mainFrame.url;
 
         let nextColorIndex;
-        switch (this._layoutContextType) {
-        case WI.DOMNode.LayoutContextType.Grid:
+        switch (this.layoutContextType) {
+        case WI.DOMNode.LayoutFlag.Grid:
             nextColorIndex = defaultConfiguration.nextGridColorIndex;
             defaultConfiguration.nextGridColorIndex = (nextColorIndex + 1) % defaultConfiguration.colors.length;
             break;
 
-        case WI.DOMNode.LayoutContextType.Flex:
+        case WI.DOMNode.LayoutFlag.Flex:
             nextColorIndex = defaultConfiguration.nextFlexColorIndex;
             defaultConfiguration.nextFlexColorIndex = (nextColorIndex + 1) % defaultConfiguration.colors.length;
             break;
@@ -1298,7 +1329,7 @@ WI.DOMNode.Event = {
     EventListenersChanged: "dom-node-event-listeners-changed",
     DidFireEvent: "dom-node-did-fire-event",
     PowerEfficientPlaybackStateChanged: "dom-node-power-efficient-playback-state-changed",
-    LayoutContextTypeChanged: "dom-node-layout-context-type-changed",
+    LayoutFlagsChanged: "dom-node-layout-flags-changed",
     LayoutOverlayShown: "dom-node-layout-overlay-shown",
     LayoutOverlayHidden: "dom-node-layout-overlay-hidden",
 };
@@ -1321,8 +1352,16 @@ WI.DOMNode.CustomElementState = {
     Failed: "failed",
 };
 
-// Corresponds to `CSS.LayoutContextType`.
-WI.DOMNode.LayoutContextType = {
+// Corresponds to `CSS.LayoutFlag`.
+WI.DOMNode.LayoutFlag = {
+    Rendered: "rendered",
+
+    // These are mutually exclusive.
     Flex: "flex",
     Grid: "grid",
 };
+
+WI.DOMNode._LayoutContextTypes = [
+    WI.DOMNode.LayoutFlag.Flex,
+    WI.DOMNode.LayoutFlag.Grid,
+];

--- a/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
@@ -47,9 +47,15 @@ WI.CSSObserver = class CSSObserver extends InspectorBackend.Dispatcher
         WI.cssManager.styleSheetRemoved(id);
     }
 
+    nodeLayoutFlagsChanged(nodeId, layoutFlags)
+    {
+        WI.domManager.nodeLayoutFlagsChanged(nodeId, layoutFlags);
+    }
+
     nodeLayoutContextTypeChanged(nodeId, layoutContextType)
     {
-        WI.domManager.nodeLayoutContextTypeChanged(nodeId, layoutContextType);
+        // COMPATIBILITY (iOS 16): CSS.nodeLayoutContextTypeChanged was renamed/expanded to CSS.nodeLayoutFlagsChanged.
+        WI.domManager.nodeLayoutFlagsChanged(nodeId, [WI.DOMNode.LayoutFlag.Rendered, layoutContextType]);
     }
 
     namedFlowCreated(namedFlow)

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -444,22 +444,19 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             this.listItemElement.addEventListener("dragstart", this);
         }
 
-        if (this.representedObject.layoutContextType) {
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
-        }
-        this.representedObject.addEventListener(WI.DOMNode.Event.LayoutContextTypeChanged, this._handleLayoutContextTypeChanged, this);
+        this.representedObject.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
+        this._handleLayoutFlagsChanged();
 
         this._updateLayoutBadge();
     }
 
     ondetach()
     {
-        if (this.representedObject.layoutContextType === WI.DOMNode.LayoutContextType.Grid) {
+        if (this.representedObject.layoutContextType && !this._elementCloseTag) {
             this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
             this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
         }
-        this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutContextTypeChanged, this._handleLayoutContextTypeChanged, this);
+        this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
     }
 
     onpopulate()
@@ -2027,11 +2024,11 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         this._layoutBadgeElement.className = "layout-badge";
 
         switch (this.representedObject.layoutContextType) {
-        case WI.DOMNode.LayoutContextType.Grid:
+        case WI.DOMNode.LayoutFlag.Grid:
             this._layoutBadgeElement.textContent = WI.unlocalizedString("grid");
             break;
 
-        case WI.DOMNode.LayoutContextType.Flex:
+        case WI.DOMNode.LayoutFlag.Flex:
             this._layoutBadgeElement.textContent = WI.unlocalizedString("flex");
             break;
 
@@ -2083,13 +2080,17 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             this._layoutBadgeElement.removeAttribute("style");
     }
 
-    _handleLayoutContextTypeChanged(event)
+    _handleLayoutFlagsChanged(event)
     {
-        let domNode = event.target;
-        if (domNode.layoutContextType && !this._layoutBadgeElement) {
+        this.listItemElement?.classList.toggle("rendered", this.representedObject.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered));
+
+        if (this._elementCloseTag)
+            return;
+
+        if (this.representedObject.layoutContextType && !this._layoutBadgeElement) {
             this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
             this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
-        } else if (!domNode.layoutContextType && this._layoutBadgeElement) {
+        } else if (!this.representedObject.layoutContextType && this._layoutBadgeElement) {
             this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
             this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
         }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -87,6 +87,16 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
     color: var(--selected-secondary-text-color);
 }
 
+.tree-outline.dom li:not(.rendered) > span > *:not(.html-comment) {
+    filter: grayscale();
+}
+
+.tree-outline.dom li:not(.rendered, .selected) > span > *:not(.html-comment),
+.tree-outline.dom:not(:focus-within) li.selected:not(.rendered) > span > *:not(.html-comment),
+body:is(.window-inactive, .window-docked-inactive) .tree-outline.dom li.selected:not(.rendered) > span > *:not(.html-comment) {
+    opacity: 0.7;
+}
+
 .tree-outline.dom ol {
     list-style-type: none;
     margin: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js
@@ -43,7 +43,7 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         WI.domManager.addEventListener(WI.DOMManager.Event.NodeInserted, this._handleNodeInserted, this);
         WI.domManager.addEventListener(WI.DOMManager.Event.NodeRemoved, this._handleNodeRemoved, this);
 
-        WI.DOMNode.addEventListener(WI.DOMNode.Event.LayoutContextTypeChanged, this._handleLayoutContextTypeChanged, this);
+        WI.DOMNode.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
 
         WI.cssManager.layoutContextTypeChangedMode = WI.CSSManager.LayoutContextTypeChangedMode.All;
@@ -58,7 +58,7 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         WI.domManager.removeEventListener(WI.DOMManager.Event.NodeInserted, this._handleNodeInserted, this);
         WI.domManager.removeEventListener(WI.DOMManager.Event.NodeRemoved, this._handleNodeRemoved, this);
 
-        WI.DOMNode.removeEventListener(WI.DOMNode.Event.LayoutContextTypeChanged, this._handleLayoutContextTypeChanged, this);
+        WI.DOMNode.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
         WI.Frame.removeEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
 
         super.detached();
@@ -133,7 +133,7 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
         this.needsLayout();
     }
 
-    _handleLayoutContextTypeChanged(event)
+    _handleLayoutFlagsChanged(event)
     {
         let domNode = event.target;
         if (domNode.layoutContextType)
@@ -171,16 +171,16 @@ WI.LayoutDetailsSidebarPanel = class LayoutDetailsSidebarPanel extends WI.DOMDet
 
         for (let node of WI.domManager.attachedNodes({filter: (node) => node.layoutContextType})) {
             switch (node.layoutContextType) {
-            case WI.DOMNode.LayoutContextType.Grid:
+            case WI.DOMNode.LayoutFlag.Grid:
                 this._gridNodeSet.add(node);
                 break;
 
-            case WI.DOMNode.LayoutContextType.Flex:
+            case WI.DOMNode.LayoutFlag.Flex:
                 this._flexNodeSet.add(node);
                 break;
 
             default:
-                console.assert(false, "Unknown layout context type.", node, node.type);
+                console.assert(false, this.representedObject.layoutContextType);
                 break;
             }
         }


### PR DESCRIPTION
#### 7c836fc5a6c43742684b3f495cdc43f572b98ced
<pre>
Web Inspector: nodes that aren&apos;t visible should be visually distinguished in the DOM tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=17219">https://bugs.webkit.org/show_bug.cgi?id=17219</a>
&lt;rdar://problem/5732820&gt;

Reviewed by Patrick Angle.

This will help developers more quickly identify whether a particular node in the Elements Tab is
something they care about (e.g. if they&apos;re adjusting layout, a `&lt;script&gt;` is probably irrelevant).

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeRendererForDOMNode): Renamed from `nodeLayoutContextChanged`.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeRendererForDOMNodeImpl): Renamed from `nodeLayoutContextChangedImpl`.
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::InspectorCSSAgent):
(WebCore::InspectorCSSAgent::reset):
(WebCore::layoutFlagContextTypeForRenderer): Renamed from `InspectorCSSAgent::layoutContextTypeForRenderer`.
(WebCore::InspectorCSSAgent::layoutFlagsForNode): Added.
(WebCore::pushChildrenNodesToFrontendIfLayoutFlagIsRelevant) Renamed from `pushChildrenNodesToFrontendIfLayoutContextTypePresent`.
(WebCore::InspectorCSSAgent::didChangeRendererForDOMNode): Renamed from `nodeLayoutContextTypeChanged`.
(WebCore::InspectorCSSAgent::nodesWithPendingLayoutFlagChangesTimerFired): Renamed from `layoutContextTypeChangedTimerFired`.
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.nodeLayoutFlagsChanged): Renamed from `nodeLayoutContextTypeChanged`.
* Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js:
(WI.CSSObserver.prototype.nodeLayoutFlagsChanged): Renamed from `nodeLayoutContextTypeChanged`.
(WI.CSSObserver.prototype.nodeLayoutContextTypeChanged):
Expand `CSS.LayoutContextType` to be `CSS.LayoutFlag` (which is used in an array instead of as a
singular value), allowing for other layout information to be sent at the same time as layout context
type changes (currently the only other value is `Rendered`, which indicates whether the node has a
corresponding `WebCore::RenderObject` and is therefore rendered). Share the same instrumentation
point for layout context type changes and renderer changes, as both are closely related and can
therefore share the same timer (for coalescing rapid changes).
Drive-by: Move the logic for getting the `nodeId` into `nodesWithPendingLayoutFlagChangesTimerFired`
          so that we avoid extra work in this potentially hot code (i.e. before it was multiple
          branches/hashes and now it&apos;s just a single hash with all the other work deferred/coalesced).

* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::notifyInspectorOfRendererChange): Added.
* Source/WebCore/rendering/RenderObject.h:
(WebCore::Node::setRenderer):
Add instrumentation inside `Node::setRenderer`. We can&apos;t use `InspectorInstrumentation` directly as
that causes linker problems, so instead we check `hasFrontends` to determine whether another
function is called, which then calls `InspectorInstrumentation` in the implementation.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::RenderFlexibleBox):
(WebCore::RenderFlexibleBox::~RenderFlexibleBox): Deleted.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
(WebCore::RenderGrid::~RenderGrid): Deleted.
These instrumentation points are now handled by the above.

* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode):
(WI.DOMNode.prototype.get layoutFlags): Renamed from `get layoutContextType`.
(WI.DOMNode.prototype.set layoutFlags): Renamed from `set layoutContextType`.
(WI.DOMNode.prototype.get layoutContextType):
(WI.DOMNode.prototype.markDestroyed):
(WI.DOMNode.prototype.setAttributeValue):
(WI.DOMNode.prototype.showLayoutOverlay):
(WI.DOMNode.prototype.hideLayoutOverlay):
(WI.DOMNode.prototype._markUndoableState): Added.
(WI.DOMNode.prototype._makeUndoableCallback):
(WI.DOMNode.prototype._createLayoutOverlayColorSettingIfNeeded):
Replace the existing `layoutContextType` with the new `layoutFlags` when creating a `DOM.Node`.
Drive-by: Promisify `setAttributeValue` for use in tests.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.onattach):
(WI.DOMTreeElement.prototype.ondetach):
(WI.DOMTreeElement.prototype._updateLayoutBadge):
(WI.DOMTreeElement.prototype._handleLayoutFlagsChanged): Renamed from `_handleLayoutContextTypeChanged`.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.tree-outline.dom li:not(.rendered) &gt; span &gt; *:not(.html-comment)):
(.tree-outline.dom li:not(.rendered, .selected) &gt; span &gt; *:not(.html-comment), .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment), body:is(.window-inactive, .window-docked-inactive) .tree-outline.dom li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment)): Added.
Visually distinguish non-rendered nodes by making them greyscale.

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered.html: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Rendered-expected.txt: Added.

* Source/WebInspectorUI/UserInterface/Views/LayoutDetailsSidebarPanel.js:
(WI.LayoutDetailsSidebarPanel.prototype.attached):
(WI.LayoutDetailsSidebarPanel.prototype.detached):
(WI.LayoutDetailsSidebarPanel.prototype._handleLayoutFlagsChanged): Renamed from `_handleLayoutContextTypeChanged`.
(WI.LayoutDetailsSidebarPanel.prototype._refreshNodeSets):
* LayoutTests/inspector/css/nodeLayoutContextTypeChanged.html:
* LayoutTests/inspector/css/setLayoutContextTypeChangedMode.html:
Use the renamed `WI.DOMNode.LayoutFlag` and `WI.DOMNode.Event.LayoutFlagsChanged`.

Canonical link: <a href="https://commits.webkit.org/252653@main">https://commits.webkit.org/252653@main</a>
</pre>
