### PR TITLE
Active transform feedback must affect useProgram

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2285,6 +2285,11 @@ void WebGL2RenderingContext::resumeTransformFeedback()
     m_context->resumeTransformFeedback();
 }
 
+bool WebGL2RenderingContext::isTransformFeedbackActiveAndNotPaused()
+{
+    return m_boundTransformFeedback->isActive() && !m_boundTransformFeedback->isPaused();
+}
+
 bool WebGL2RenderingContext::setIndexedBufferBinding(const char *functionName, GCGLenum target, GCGLuint index, WebGLBuffer* buffer)
 {
     Locker locker { objectGraphLock() };

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -264,6 +264,8 @@ public:
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) override;
 
+    bool isTransformFeedbackActiveAndNotPaused();
+
 private:
     WebGL2RenderingContext(CanvasBase&, GraphicsContextGLAttributes);
     WebGL2RenderingContext(CanvasBase&, Ref<GraphicsContextGL>&&, GraphicsContextGLAttributes);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -6421,6 +6421,19 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "useProgram", "program not valid");
         return;
     }
+
+#if ENABLE(WEBGL2)
+    // Extend the base useProgram method instead of overriding it in
+    // WebGL2RenderingContext to keep the preceding validations in the same order.
+    if (isWebGL2()) {
+        ASSERT(is<WebGL2RenderingContext>(*this));
+        if (downcast<WebGL2RenderingContext>(*this).isTransformFeedbackActiveAndNotPaused()) {
+            synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "useProgram", "transform feedback is active and not paused");
+            return;
+        }
+    }
+#endif
+
     if (m_currentProgram != program) {
         if (m_currentProgram)
             m_currentProgram->onDetached(locker, graphicsContextGL());


### PR DESCRIPTION
#### f1fd6ea39943fbd147877d7e5ea9bc359d9a4911
<pre>
Active transform feedback must affect useProgram
<a href="https://bugs.webkit.org/show_bug.cgi?id=242632">https://bugs.webkit.org/show_bug.cgi?id=242632</a>

Reviewed by Kenneth Russell.

Extended WebGLRenderingContextBase::useProgram flow
to check for an active and not paused transform feedback.

Added a helper function to WebGL2RenderingContext.

Fixes forthcoming strengthened conformance test in
<a href="https://github.com/KhronosGroup/WebGL/pull/3462">https://github.com/KhronosGroup/WebGL/pull/3462</a>

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::isTransformFeedbackActiveAndUnpaused):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::useProgram):

Canonical link: <a href="https://commits.webkit.org/252432@main">https://commits.webkit.org/252432@main</a>
</pre>
