### PR TITLE
[WebGPU] Move getPreferredFormat() from GPUCanvasContext to GPU to align with spec

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -63,4 +63,9 @@ void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options,
     });
 }
 
+GPUTextureFormat GPU::getPreferredCanvasFormat()
+{
+    return GPUTextureFormat::Rgba8unorm;
+}
+
 }

--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -27,6 +27,7 @@
 
 #include "GPUAdapter.h"
 #include "GPURequestAdapterOptions.h"
+#include "GPUTextureFormat.h"
 #include "JSDOMPromiseDeferred.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPU.h>
@@ -45,6 +46,8 @@ public:
 
     using RequestAdapterPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<GPUAdapter>>>;
     void requestAdapter(const std::optional<GPURequestAdapterOptions>&, RequestAdapterPromise&&);
+
+    GPUTextureFormat getPreferredCanvasFormat();
 
     void setBacking(PAL::WebGPU::GPU&);
 

--- a/Source/WebCore/Modules/WebGPU/GPU.idl
+++ b/Source/WebCore/Modules/WebGPU/GPU.idl
@@ -32,4 +32,5 @@
 ]
 interface GPU {
     Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options);
+    GPUTextureFormat getPreferredCanvasFormat();
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasContext.cpp
@@ -45,11 +45,6 @@ void GPUCanvasContext::unconfigure()
 {
 }
 
-GPUTextureFormat GPUCanvasContext::getPreferredFormat(const GPUAdapter&)
-{
-    return GPUTextureFormat::Rgba8unorm;
-}
-
 RefPtr<GPUTexture> GPUCanvasContext::getCurrentTexture()
 {
     return nullptr;

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasContext.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "GPUTexture.h"
-#include "GPUTextureFormat.h"
 #include "HTMLCanvasElement.h"
 #include "OffscreenCanvas.h"
 #include <variant>
@@ -57,7 +56,6 @@ public:
     void configure(const GPUCanvasConfiguration&);
     void unconfigure();
 
-    GPUTextureFormat getPreferredFormat(const GPUAdapter&);
     RefPtr<GPUTexture> getCurrentTexture();
 
 private:

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl
@@ -40,6 +40,5 @@ interface GPUCanvasContext {
     undefined configure(GPUCanvasConfiguration configuration);
     undefined unconfigure();
 
-    GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
     GPUTexture getCurrentTexture();
 };


### PR DESCRIPTION
#### 1e3ea2a7462c8e91954dd17a7e25129c992c86bd
<pre>
[WebGPU] Move getPreferredFormat() from GPUCanvasContext to GPU to align with spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=242648">https://bugs.webkit.org/show_bug.cgi?id=242648</a>

Reviewed by Myles C. Maxfield.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::getPreferredCanvasFormat):
* Source/WebCore/Modules/WebGPU/GPU.h:
* Source/WebCore/Modules/WebGPU/GPU.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.cpp:
(WebCore::GPUCanvasContext::getPreferredFormat): Deleted.
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.h:
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl:

Canonical link: <a href="https://commits.webkit.org/252658@main">https://commits.webkit.org/252658@main</a>
</pre>
