### PR TITLE
Send events async in textfield-outline.

### DIFF
--- a/LayoutTests/fast/forms/textfield-outline.html
+++ b/LayoutTests/fast/forms/textfield-outline.html
@@ -1,14 +1,15 @@
 <html>
     <head>
+        <script type="text/javascript" src="../../resources/ui-helper.js"></script>
         <script>
-        function test()
+        async function test()
         {
             var tf = document.getElementById('tf');
             tf.focus();
             if (window.testRunner) {
-                eventSender.keyDown("a");
-                eventSender.keyDown("b");
-                eventSender.keyDown("c");
+                await UIHelper.keyDown("a");
+                await UIHelper.keyDown("b");
+                await UIHelper.keyDown("c");
             }
         }
         </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3650,8 +3650,6 @@ webkit.org/b/240929 [ Debug ]  resize-observer/resize-observer-with-zoom.html [ 
 webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Failure ] 
 webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Failure ] 
 
-webkit.org/b/241205 fast/forms/textfield-outline.html [ Pass Failure ]
-
 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 # Accessibility bold only exists on iOS.


### PR DESCRIPTION
#### 2e8bcf908a7d6c7cca495e1f4cd89f9ad538d8f3
<pre>
Send events async in textfield-outline.
<a href="https://bugs.webkit.org/show_bug.cgi?id=241205">https://bugs.webkit.org/show_bug.cgi?id=241205</a>

Reviewed by Simon Fraser.

fast/forms/textfield-outline should send keyDown events asynchronously
due to the recent change to make style updates to non user-initiated focus in a form
asynchronous. The UIHelper helpfully preserves behavior of the old test
for macOS and other non-ios platforms.

* LayoutTests/fast/forms/textfield-outline.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252417@main">https://commits.webkit.org/252417@main</a>
</pre>
