### PR TITLE
update-webkit fails while doing git svn rebase

### DIFF
--- a/Tools/Scripts/VCSUtils.pm
+++ b/Tools/Scripts/VCSUtils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2007-2018 Apple Inc.  All rights reserved.
+# Copyright (C) 2007-2022 Apple Inc.  All rights reserved.
 # Copyright (C) 2009, 2010 Chris Jerdonek (chris.jerdonek@gmail.com)
 # Copyright (C) 2010, 2011 Research In Motion Limited. All rights reserved.
 # Copyright (C) 2012 Daniel Bates (dbates@intudata.com)
@@ -71,8 +71,6 @@ BEGIN {
         &isGit
         &isGitBranchBuild
         &isGitDirectory
-        &isGitSVN
-        &isGitSVNDirectory
         &isSVN
         &isSVNDirectory
         &isSVNVersion16OrNewer
@@ -111,7 +109,6 @@ our @EXPORT_OK;
 
 my $gitRoot;
 my $isGit;
-my $isGitSVN;
 my $isGitBranchBuild;
 my $isSVN;
 my $svnVersion;
@@ -235,26 +232,6 @@ sub isGit()
 
     $isGit = isGitDirectory(".");
     return $isGit;
-}
-
-sub isGitSVNDirectory($)
-{
-    my ($directory) = @_;
-
-    # There doesn't seem to be an officially documented way to determine
-    # if you're in a git-svn checkout. The best suggestions seen so far
-    # all use something like the following:
-    my $output = `git -C \"$directory\" config --get svn-remote.svn.fetch 2>&1`;
-    $isGitSVN = exitStatus($?) == 0 && $output ne "";
-    return $isGitSVN;
-}
-
-sub isGitSVN()
-{
-    return $isGitSVN if defined $isGitSVN;
-
-    $isGitSVN = isGitSVNDirectory(".");
-    return $isGitSVN;
 }
 
 sub gitDirectory()

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2005-2022 Apple Inc. All rights reserved.
 # Copyright (C) 2009 Google Inc. All rights reserved.
 # Copyright (C) 2011 Research In Motion Limited. All rights reserved.
 # Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
@@ -3324,16 +3324,9 @@ sub runSvnUpdateAndResolveChangeLogs(@)
 
 sub runGitUpdate()
 {
-    # Doing a git fetch first allows setups with svn-remote.svn.fetch = trunk:refs/remotes/origin/master
-    # to perform the rebase much much faster.
-    system("git", "fetch");
-    if (isGitSVNDirectory(".")) {
-        system("git", "svn", "rebase") == 0 or die;
-    } else {
-        # This will die if branch.$BRANCHNAME.merge isn't set, which is
-        # almost certainly what we want.
-        system("git", "pull") == 0 or die;
-    }
+    # This will die if branch.$BRANCHNAME.merge isn't set, which is
+    # almost certainly what we want.
+    system("git", "pull") == 0 or die;
 }
 
 1;


### PR DESCRIPTION
#### 59c9e255e1f17d7c8834c68db78b0e9819f0b90e
<pre>
update-webkit fails while doing git svn rebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=242652">https://bugs.webkit.org/show_bug.cgi?id=242652</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/VCSUtils.pm:
(isGitSVNDirectory): Deleted.
(isGitSVN): Deleted.
* Tools/Scripts/webkitdirs.pm:
(runGitUpdate):

Canonical link: <a href="https://commits.webkit.org/252410@main">https://commits.webkit.org/252410@main</a>
</pre>
