### PR TITLE
[JSC][ARMv7] ARMv7 WasmMemory::growShared is incorrect

### DIFF
--- a/JSTests/wasm/stress/shared-memory-grow-non-crash.js
+++ b/JSTests/wasm/stress/shared-memory-grow-non-crash.js
@@ -1,0 +1,4 @@
+try {
+    new WebAssembly.Memory({initial : 0, maximum : 1, shared : true}).grow(1)
+} catch {
+}

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -494,14 +494,15 @@ bool Memory::addressIsInGrowableOrFastMemory(void* address)
 
 Expected<PageCount, Memory::GrowFailReason> Memory::growShared(PageCount delta)
 {
-#if CPU(ARM)
-    // Shared memory requires signaling memory which is not available on ARMv7
+#if !ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    // Shared memory requires signaling memory which is not available on ARMv7 or others
     // yet. In order to get more of the test suite to run, we can still use
     // a shared mmeory by using bounds checking, but we cannot grow it safely
     // in case it's used by multiple threads. Once the signal handler are
     // available, this can be relaxed.
-    RELEASE_ASSERT_NOT_REACHED();
+    return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
 #endif
+
     Wasm::PageCount oldPageCount;
     Wasm::PageCount newPageCount;
     auto result = ([&]() -> Expected<PageCount, Memory::GrowFailReason> {

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -127,6 +127,7 @@ public:
         InvalidGrowSize,
         WouldExceedMaximum,
         OutOfMemory,
+        GrowSharedUnavailable,
     };
     Expected<PageCount, GrowFailReason> grow(PageCount);
     bool fill(uint32_t, uint8_t, uint32_t);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -661,6 +661,7 @@ JSC_DEFINE_JIT_OPERATION(operationGrowMemory, int32_t, (void* callFrame, Instanc
         case Memory::GrowFailReason::InvalidGrowSize:
         case Memory::GrowFailReason::WouldExceedMaximum:
         case Memory::GrowFailReason::OutOfMemory:
+        case Memory::GrowFailReason::GrowSharedUnavailable:
             return -1;
         }
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -139,6 +139,9 @@ Wasm::PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, 
         case Wasm::Memory::GrowFailReason::OutOfMemory:
             throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));
             break;
+        case Wasm::Memory::GrowFailReason::GrowSharedUnavailable:
+            throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory.grow for shared memory is unavailable"_s));
+            break;
         }
         return Wasm::PageCount();
     }


### PR DESCRIPTION
#### 12ed8dc6d02049db08d5bfef98402418f3759c27
<pre>
[JSC][ARMv7] ARMv7 WasmMemory::growShared is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=242600">https://bugs.webkit.org/show_bug.cgi?id=242600</a>
&lt;rdar://96836953&gt;

Reviewed by Mark Lam.

ARMv7 does not implement signaling memory, but it does not fully disable the implementation.
But in this case, we should throw an error instead of crashing since this is exposed function.

* JSTests/wasm/stress/shared-memory-grow-non-crash.js: Added.
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::growShared):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::grow):

Canonical link: <a href="https://commits.webkit.org/252395@main">https://commits.webkit.org/252395@main</a>
</pre>
