### PR TITLE
[Gardening]: [ macOS ] http/tests/media/user-gesture-preserved-across-xmlhttprequest.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2174,7 +2174,7 @@ webkit.org/b/231463 fast/css/accent-color/range.html [ ImageOnlyFailure ]
 
 webkit.org/b/229521 pointer-lock/lock-already-locked.html [ Pass Failure ]
 
-[ Debug ] http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Slow ]
+webkit.org/b/242658 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Slow Pass Failure ]
 
 webkit.org/b/228176 [ BigSur Monterey ] fast/text/variable-system-font-2.html [ Pass ]
 


### PR DESCRIPTION
#### 9c8e21dda821f5d90857e1823b029d0f1da4bca5
<pre>
[Gardening]: [ macOS ] http/tests/media/user-gesture-preserved-across-xmlhttprequest.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242658">https://bugs.webkit.org/show_bug.cgi?id=242658</a>

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252394@main">https://commits.webkit.org/252394@main</a>
</pre>
