### PR TITLE
Adding achan00 github account to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -53,6 +53,7 @@
          "adachan@apple.com"
       ],
       "expertise" : "WebKit on Windows",
+      "github" : "achan00",
       "name" : "Ada Chan",
       "nicks" : [
          "chanada"


### PR DESCRIPTION
#### 1bf7fe84989fed963b714fc44ed5d1178aed8cc5
<pre>
Adding achan00 github account to contributors.json

Reviewed by Jonathan Bedard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252396@main">https://commits.webkit.org/252396@main</a>
</pre>
