### PR TITLE
Fix cloop build after 252338@main

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -837,6 +837,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/remote/RemoteInspector.h
 
     interpreter/AbstractPC.h
+    interpreter/CLoopStack.h
     interpreter/CallFrame.h
     interpreter/CallFrameInlines.h
     interpreter/CalleeBits.h


### PR DESCRIPTION
#### 40e49bb53218a986b4d6569f3fc2730cc4b71472
<pre>
Fix cloop build after 252338@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242579">https://bugs.webkit.org/show_bug.cgi?id=242579</a>

Reviewed by Mark Lam.

* Source/JavaScriptCore/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/252400@main">https://commits.webkit.org/252400@main</a>
</pre>
