### PR TITLE
Using CGDisplayListImageBufferBackend in a bifurcated context often results in the CTM getting out of sync

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -66,8 +66,6 @@
 {
     if (!_displayListDataForTesting)
         return;
-    CGContextScaleCTM(context, 1, -1);
-    CGContextTranslateCTM(context, 0, -self.bounds.size.height);
     WKCGContextDrawCGCommandsEncodedData(context, _displayListDataForTesting.get(), nullptr);
 }
 


### PR DESCRIPTION
#### df10db33ccfed3e0b96d06668978b109f5c6606e
<pre>
Using CGDisplayListImageBufferBackend in a bifurcated context often results in the CTM getting out of sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=242667">https://bugs.webkit.org/show_bug.cgi?id=242667</a>
&lt;rdar://96467183&gt;

Reviewed by Dean Jackson.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.cpp:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
(WebKit::CGDisplayListImageBufferBackend::create):
As in 243661@main, we need both sides of a bifurcated context to have the same
effective CTM (as exposed through GraphicsContext), because BifurcatedGraphicsContext&apos;s
implementation of getCTM reads from the primary context, and the result of
that is sometimes set back onto *both* contexts via setCTM. So they need to have
the same effective CTM.

This was previously achieved as a side effect of a workaround that applied an
actual flip to the context, which was removed in 251833@main due to changes
below WebKit.

Now that that has been removed, we still need to keep the effective CTM the
same between the two contexts, so we need to tuck it into the fake transform
introduced in 243661@main.

* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer drawInContext:]):
Drive-by remove the extraneous flip from our debugging code now that it is
handled beneath WebKit. This should have been a part of 251833@main.

Canonical link: <a href="https://commits.webkit.org/252402@main">https://commits.webkit.org/252402@main</a>
</pre>
