### PR TITLE
[JSC] for-await-of loop should annotate UseAwait

### DIFF
--- a/JSTests/modules/top-level-for-await.js
+++ b/JSTests/modules/top-level-for-await.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+
+function countUp(count) {
+    let value = 0;
+
+    const q = {
+        async next() {
+            if (value === count) {
+                return {
+                    done: true,
+                    value: undefined,
+                };
+            }
+
+            value++;
+
+            return {
+                done: false,
+                value,
+            };
+        },
+    };
+
+    return {
+        [Symbol.asyncIterator]: () => q,
+    };
+}
+
+let count = 0;
+for await (const i of countUp(10)) {
+    count += i;
+}
+shouldBe(count, 55);

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -635,6 +635,8 @@ public:
         ForOfNode* result = new (m_parserArena) ForOfNode(isForAwait, location, lhs, iter, statements, WTFMove(lexicalVariables));
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         setExceptionLocation(result, eStart, eDivot, eEnd);
+        if (isForAwait)
+            usesAwait();
         return result;
     }
     


### PR DESCRIPTION
#### a4091cbee66cd7bbf72175574cb845a16c8113d4
<pre>
[JSC] for-await-of loop should annotate UseAwait
<a href="https://bugs.webkit.org/show_bug.cgi?id=242670">https://bugs.webkit.org/show_bug.cgi?id=242670</a>

Reviewed by Mark Lam.

While `await` expression annotates UseAwait flag, for-await-of does not.
We need to annotate it so that top-level-await on the module only including
for-await-of should work.

* JSTests/modules/top-level-for-await.js: Added.
(shouldBe):
(countUp.const.q.async next):
(countUp):
(await.const.i.of.countUp):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createForOfLoop):

Canonical link: <a href="https://commits.webkit.org/252405@main">https://commits.webkit.org/252405@main</a>
</pre>
