### PR TITLE
Unexpose event.relatedTarget when shadow tree state has changed

### DIFF
--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -45,8 +45,8 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     event.setTarget(m_target.get());
     event.setCurrentTarget(m_currentTarget.get(), m_currentTargetIsInShadowTree);
 
-    if (m_relatedTarget) {
-        ASSERT(m_type == Type::MouseOrFocus);
+    if (m_relatedTargetIsSet) {
+        ASSERT(!m_relatedTarget || m_type == Type::MouseOrFocus);
         event.setRelatedTarget(m_relatedTarget.get());
     }
 

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -91,6 +91,7 @@ private:
     int m_closedShadowDepth { 0 };
     bool m_currentTargetIsInShadowTree { false };
     bool m_contextNodeIsFormElement { false };
+    bool m_relatedTargetIsSet { false };
     Type m_type { Type::Normal };
 };
 
@@ -128,6 +129,7 @@ inline void EventContext::setRelatedTarget(Node* relatedTarget)
 {
     ASSERT(!isUnreachableNode(relatedTarget));
     m_relatedTarget = relatedTarget;
+    m_relatedTargetIsSet = true;
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -299,7 +299,8 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Node& relatedNode, Node& target)
     if (LIKELY(currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode.isConnected()))
         return;
 
-    if (&currentTreeScope->documentScope() != &targetTreeScope.documentScope()) {
+    if (&currentTreeScope->documentScope() != &targetTreeScope.documentScope()
+        || (relatedNode.hasBeenInUserAgentShadowTree() && !relatedNode.isConnected())) {
         m_hasDifferentTreeRoot = true;
         m_retargetedRelatedNode = nullptr;
         return;

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2027,11 +2027,14 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
 
     Document& oldDocument = oldScope.documentScope();
     Document& newDocument = newScope.documentScope();
+    bool newScopeIsUAShadowTree = newScope.rootNode().hasBeenInUserAgentShadowTree();
     if (&oldDocument != &newDocument) {
         oldDocument.incrementReferencingNodeCount();
         traverseSubtreeToUpdateTreeScope(root, [&](Node& node) {
             ASSERT(!node.isTreeScope());
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&node.treeScope() == &oldScope);
+            if (newScopeIsUAShadowTree)
+                node.setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
             node.setTreeScope(newScope);
             node.moveNodeToNewDocument(oldDocument, newDocument);
         }, [&](ShadowRoot& shadowRoot) {
@@ -2045,6 +2048,8 @@ void Node::moveTreeToNewScope(Node& root, TreeScope& oldScope, TreeScope& newSco
         traverseSubtreeToUpdateTreeScope(root, [&](Node& node) {
             ASSERT(!node.isTreeScope());
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&node.treeScope() == &oldScope);
+            if (newScopeIsUAShadowTree)
+                node.setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
             node.setTreeScope(newScope);
             if (UNLIKELY(!node.hasRareData()))
                 return;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -387,6 +387,7 @@ public:
     bool isInUserAgentShadowTree() const;
     bool isInShadowTree() const { return hasNodeFlag(NodeFlag::IsInShadowTree); }
     bool isInTreeScope() const { return hasNodeFlag(NodeFlag::IsConnected) || hasNodeFlag(NodeFlag::IsInShadowTree); }
+    bool hasBeenInUserAgentShadowTree() const { return hasNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree); }
 
     // https://dom.spec.whatwg.org/#in-a-document-tree
     bool isInDocumentTree() const { return isConnected() && !isInShadowTree(); }
@@ -584,8 +585,9 @@ protected:
         IsInTopLayer = 1 << 27,
         NeedsSVGRendererUpdate = 1 << 28,
         NeedsUpdateQueryContainerDependentStyle = 1 << 29,
+        HasBeenInUserAgentShadowTree = 1 << 30,
 
-        // Bits 30-31 are free.
+        // Bit 31 is free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -72,6 +72,8 @@ ShadowRoot::ShadowRoot(Document& document, ShadowRootMode type, DelegatesFocus d
     , m_type(type)
     , m_styleScope(makeUnique<Style::Scope>(*this))
 {
+    if (type == ShadowRootMode::UserAgent)
+        setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
 }
 
 
@@ -82,6 +84,7 @@ ShadowRoot::ShadowRoot(Document& document, std::unique_ptr<SlotAssignment>&& slo
     , m_styleScope(makeUnique<Style::Scope>(*this))
     , m_slotAssignment(WTFMove(slotAssignment))
 {
+    setNodeFlag(NodeFlag::HasBeenInUserAgentShadowTree);
 }
 
 


### PR DESCRIPTION
#### 73d8160d105b0b8e5e62d397e6e4f67956b6a984
<pre>
Unexpose event.relatedTarget when shadow tree state has changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=242671">https://bugs.webkit.org/show_bug.cgi?id=242671</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::setRelatedTarget):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::moveTreeToNewScope):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasBeenInUserAgentShadowTree const):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):

Canonical link: <a href="https://commits.webkit.org/252631@main">https://commits.webkit.org/252631@main</a>
</pre>
