### PR TITLE
[GPUP] Chinese text in language selector in Google News is invisible

### DIFF
--- a/LayoutTests/fast/text/fallback-not-supported-expected-mismatch.html
+++ b/LayoutTests/fast/text/fallback-not-supported-expected-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+This test makes sure that fallback fonts, when the primary font is a web font that doesn't support the requested character, are visible when rendered by the GPU process. The test passes if you see something visually below.
+</body>
+</html>

--- a/LayoutTests/fast/text/fallback-not-supported.html
+++ b/LayoutTests/fast/text/fallback-not-supported.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/ahem.woff2") format("woff2");
+}
+</style>
+</head>
+<body>
+This test makes sure that fallback fonts, when the primary font is a web font that doesn't support the requested character, are visible when rendered by the GPU process. The test passes if you see something visually below.
+<div style="font: 48px 'WebFont';">中</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -1565,7 +1565,10 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
 
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont, description, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
 
-    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), platformData.creationData());
+    const FontPlatformData::CreationData* creationData = nullptr;
+    if (safeCFEqual(platformData.font(), substituteFont))
+        creationData = platformData.creationData();
+    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), creationData);
 
     return fontForPlatformData(alternateFont);
 }


### PR DESCRIPTION
#### 457dbbe185b3f5d84132411a86cb4f368189312c
<pre>
[GPUP] Chinese text in language selector in Google News is invisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=242674">https://bugs.webkit.org/show_bug.cgi?id=242674</a>
&lt;rdar://problem/96903146&gt;

Reviewed by Cameron McCormack.

When falling off the end of the font-family list, the browser needs to pick some font which
can render the requested character. Font selection routines accept a &quot;hint&quot; font, which it
tries to match as stylistically closely as possible. The hint font itself may actually be
selected - if it is, we have to make sure the fallback font takes the CreationData from the
hint font. However, if the hint font is not selected, then the fallback font will be
guaranteed to be an installed font, which means that no CreationData should be specified.
252096@main had some of this logic, but not all of it.

* LayoutTests/fast/text/fallback-not-supported-expected-mismatch.html: Added.
* LayoutTests/fast/text/fallback-not-supported.html: Added.
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::systemFallbackForCharacters):

Canonical link: <a href="https://commits.webkit.org/252407@main">https://commits.webkit.org/252407@main</a>
</pre>
