### PR TITLE
High memory use (jetsam) with scaled-down tiled layers

### DIFF
--- a/LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale-expected.txt
+++ b/LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale-expected.txt
@@ -1,0 +1,35 @@
+Layer with backing store
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 10243.00)
+  (visible rect 0.00, 0.00 785.00 x 600.00)
+  (coverage rect 0.00, 0.00 785.00 x 600.00)
+  (intersects coverage rect 1)
+  (contentsScale 1.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 10243.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 785.00 x 600.00)
+      (coverage rect 0.00, 0.00 785.00 x 600.00)
+      (intersects coverage rect 1)
+      (contentsScale 1.00)
+      (children 1
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (anchor 0.00 0.00)
+          (bounds 10220.00 10220.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (transform [0.05 0.00 0.00 0.00] [0.00 0.05 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+          (visible rect 0.00, 0.00 10220.00 x 10220.00)
+          (coverage rect -360.00, -200.00 15700.00 x 12000.00)
+          (intersects coverage rect 1)
+          (contentsScale 0.65)
+          (contentsScale limiting factor 0.65)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale.html
+++ b/LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <style>
+        #pageContainer {
+            position: relative;
+            z-index: 0;
+            margin: 10px;
+            height: 10000px;
+            width: 10000px;
+            border: 10px solid black;
+            padding: 100px;
+            transform-origin: left top;
+            transform: scale3d(0.05, 0.05, 1);
+            font-size: 200pt;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText(true);
+        
+        function dumpLayers()
+        {
+            if (window.internals)
+                document.getElementById('layers').innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS);
+        }
+        window.addEventListener('load', dumpLayers, false);
+    </script>
+</head>
+<body>
+    <div id="pageContainer">Layer with backing store</div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/compositing/tiling/tiled-layers-limit-contents-scale-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/tiling/tiled-layers-limit-contents-scale-expected.txt
@@ -1,0 +1,35 @@
+Layer with backing store
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 10243.00)
+  (visible rect 0.00, 0.00 800.00 x 600.00)
+  (coverage rect 0.00, 0.00 800.00 x 600.00)
+  (intersects coverage rect 1)
+  (contentsScale 2.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 10243.00)
+      (contentsOpaque 1)
+      (visible rect 0.00, 0.00 800.00 x 600.00)
+      (coverage rect 0.00, 0.00 800.00 x 600.00)
+      (intersects coverage rect 1)
+      (contentsScale 2.00)
+      (children 1
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (anchor 0.00 0.00)
+          (bounds 10220.00 10220.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (transform [0.05 0.00 0.00 0.00] [0.00 0.05 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+          (visible rect 0.00, 0.00 10220.00 x 10220.00)
+          (coverage rect -360.00, -200.00 16000.00 x 12000.00)
+          (intersects coverage rect 1)
+          (contentsScale 0.60)
+          (contentsScale limiting factor 0.30)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -340,7 +340,10 @@ private:
     const FloatRect& coverageRect() const { return m_coverageRect; }
 
     void setVisibleAndCoverageRects(const VisibleAndCoverageRects&);
-    
+
+    void adjustContentsScaleLimitingFactor();
+    void setContentsScaleLimitingFactor(float);
+
     bool recursiveVisibleRectChangeRequiresFlush(const CommitState&, const TransformState&) const;
 
     bool isTiledBackingLayer() const { return type() == Type::TiledBacking; }
@@ -654,6 +657,8 @@ private:
     Vector<FloatRect> m_dirtyRects;
 
     std::unique_ptr<DisplayList::InMemoryDisplayList> m_displayList;
+
+    float m_contentsScaleLimitingFactor { 1 };
 
     ContentsLayerPurpose m_contentsLayerPurpose { ContentsLayerPurpose::None };
     bool m_isCommittingChanges { false };

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -103,14 +103,16 @@ void TileController::setNeedsDisplayInRect(const IntRect& rect)
     updateTileCoverageMap();
 }
 
-void TileController::setContentsScale(float scale)
+void TileController::setContentsScale(float contentsScale)
 {
     ASSERT(owningGraphicsLayer()->isCommittingChanges());
 
     float deviceScaleFactor = owningGraphicsLayer()->platformCALayerDeviceScaleFactor();
     // The scale we get is the product of the page scale factor and device scale factor.
     // Divide by the device scale factor so we'll get the page scale factor.
-    scale /= deviceScaleFactor;
+    float scale = contentsScale / deviceScaleFactor;
+    
+    LOG_WITH_STREAM(Tiling, stream << "TileController " << this << " setContentsScale " << contentsScale << " computed scale " << scale << " (deviceScaleFactor " << deviceScaleFactor << ")");
 
     if (tileGrid().scale() == scale && m_deviceScaleFactor == deviceScaleFactor && !m_hasTilesWithTemporaryScaleFactor)
         return;
@@ -416,7 +418,7 @@ FloatRect TileController::adjustTileCoverageForDesktopPageScrolling(const FloatR
     };
 
     FloatRect coverage = expandRectWithinRect(visibleRect, coverageSize, coverageBounds);
-    LOG_WITH_STREAM(Tiling, stream << "TileController::adjustTileCoverageForDesktopPageScrolling newSize=" << newSize << " mode " << m_tileCoverage << " expanded to " << coverageSize << " bounds with margin " << coverageBounds << " coverage " << coverage);
+    LOG_WITH_STREAM(Tiling, stream << "TileController " << this << " adjustTileCoverageForDesktopPageScrolling newSize=" << newSize << " mode " << m_tileCoverage << " expanded to " << coverageSize << " bounds with margin " << coverageBounds << " coverage " << coverage);
     return unionRect(coverageRect, coverage);
 }
 #endif
@@ -618,6 +620,8 @@ void TileController::tileRevalidationTimerFired()
 void TileController::didRevalidateTiles()
 {
     m_boundsAtLastRevalidate = bounds();
+
+    LOG_WITH_STREAM(Tiling, stream << "TileController " << this << " (bounds " << bounds() << ") didRevalidateTiles - tileCoverageRect " << tileCoverageRect() << " grid extent " << tileGridExtent() << " memory use " << (retainedTileBackingStoreMemory() / (1024 * 1024)) << "MB");
 
     updateTileCoverageMap();
 }


### PR DESCRIPTION
#### ae4b128c8c00089c79fed1e17b80e6279d7fa7a7
<pre>
High memory use (jetsam) with scaled-down tiled layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242675">https://bugs.webkit.org/show_bug.cgi?id=242675</a>
&lt;rdar://96303961&gt;

Reviewed by Tim Horton.

The site in question had some large composting layers with a scale(0.05) transform; this
triggers the creation of many visible tiles, causing jetsam. This got worse after
249828@main which triggered compositing for some negative z-index cases.

To fix this, impose a per-layer memory limit of 156MB (this is enough to cover a large display
with a 4-byte per pixel texture format) for tiled layers. For layers above this limit, adjust
the contents scale with factor between 0.05 and 1 which reduce the contents scale; this
may cause some blurriness, but that&apos;s preferable to triggering jetsam.

setContentsScaleLimitingFactor() is called in two places; first, when we swap to/from
tiled layers, and second when the exposed area of a tiled layer changes.

* LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale-expected.txt: Added.
* LayoutTests/compositing/tiling/tiled-layers-limit-contents-scale.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::adjustContentsScaleLimitingFactor):
(WebCore::GraphicsLayerCA::setContentsScaleLimitingFactor):
(WebCore::GraphicsLayerCA::setVisibleAndCoverageRects):
(WebCore::GraphicsLayerCA::updateContentsScale):
(WebCore::GraphicsLayerCA::dumpAdditionalProperties const):
(WebCore::GraphicsLayerCA::changeLayerTypeTo):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setContentsScale):
(WebCore::TileController::adjustTileCoverageForDesktopPageScrolling const):
(WebCore::TileController::didRevalidateTiles):

Canonical link: <a href="https://commits.webkit.org/252437@main">https://commits.webkit.org/252437@main</a>
</pre>
