### PR TITLE
[WKTR] REGRESSION(252335@main): _setOverrideLanguagesForTesting needs to be called before the web view is created

### DIFF
--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -205,6 +205,12 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
         [copiedConfiguration _setApplicationManifest:[_WKApplicationManifest applicationManifestFromJSON:text manifestURL:nil documentURL:nil]];
     }
 
+    auto overrideLanguages = options.overrideLanguages();
+    NSMutableArray<NSString *> *overrideLanguagesForAPI = [NSMutableArray arrayWithCapacity:overrideLanguages.size()];
+    for (auto& language : overrideLanguages)
+        [overrideLanguagesForAPI addObject:[NSString stringWithUTF8String:language.c_str()]];
+    [TestRunnerWKWebView _setOverrideLanguagesForTesting:overrideLanguagesForAPI];
+
     m_mainWebView = makeUnique<PlatformWebView>(copiedConfiguration.get(), options);
     finishCreatingPlatformWebView(m_mainWebView.get(), options);
 
@@ -329,12 +335,6 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
     [globalWebsiteDataStoreDelegateClient() setAllowRaisingQuota:YES];
 
     WebCoreTestSupport::setAdditionalSupportedImageTypesForTesting(String::fromLatin1(options.additionalSupportedImageTypes().c_str()));
-
-    auto overrideLanguages = options.overrideLanguages();
-    NSMutableArray<NSString *> *overrideLanguagesForAPI = [NSMutableArray arrayWithCapacity:overrideLanguages.size()];
-    for (auto& language : overrideLanguages)
-        [overrideLanguagesForAPI addObject:[NSString stringWithUTF8String:language.c_str()]];
-    [TestRunnerWKWebView _setOverrideLanguagesForTesting:overrideLanguagesForAPI];
 }
 
 void TestController::platformWillRunTest(const TestInvocation& testInvocation)


### PR DESCRIPTION
#### 174a41524e74c3b3883944fc2497332851841558
<pre>
[WKTR] REGRESSION(252335@main): _setOverrideLanguagesForTesting needs to be called before the web view is created
<a href="https://bugs.webkit.org/show_bug.cgi?id=242676">https://bugs.webkit.org/show_bug.cgi?id=242676</a>
&lt;rdar://problem/96888848&gt;

Unreviewed test gardening.

The title says it all.

* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):
(WTR::TestController::cocoaResetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/252406@main">https://commits.webkit.org/252406@main</a>
</pre>
