### PR TITLE
macOS - add 'notifyutil -p com.apple.WebKit.showPaintOrderTree' command

### DIFF
--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -60,6 +60,7 @@ void Page::platformInitialize()
         PAL::registerNotifyCallback("com.apple.WebKit.showRenderTree"_s, printRenderTreeForLiveDocuments);
         PAL::registerNotifyCallback("com.apple.WebKit.showLayerTree"_s, printLayerTreeForLiveDocuments);
         PAL::registerNotifyCallback("com.apple.WebKit.showGraphicsLayerTree"_s, printGraphicsLayerTreeForLiveDocuments);
+        PAL::registerNotifyCallback("com.apple.WebKit.showPaintOrderTree"_s, printPaintOrderTreeForLiveDocuments);
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
         PAL::registerNotifyCallback("com.apple.WebKit.showLayoutTree"_s, Layout::printLayoutTreeForLiveDocuments);
 #endif

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6114,4 +6114,11 @@ void showPaintOrderTree(const WebCore::RenderLayer* layer)
     WTFLogAlways("%s", stream.release().utf8().data());
 }
 
+void showPaintOrderTree(const WebCore::RenderObject* renderer)
+{
+    if (!renderer)
+        return;
+    showPaintOrderTree(renderer->enclosingLayer());
+}
+
 #endif

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1316,7 +1316,8 @@ WTF::TextStream& operator<<(WTF::TextStream&, PaintBehavior);
 #if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from lldb.
 void showLayerTree(const WebCore::RenderLayer*);
-void showPaintOrderTree(const WebCore::RenderLayer*);
 void showLayerTree(const WebCore::RenderObject*);
+void showPaintOrderTree(const WebCore::RenderLayer*);
+void showPaintOrderTree(const WebCore::RenderObject*);
 #endif
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2571,6 +2571,18 @@ TextStream& operator<<(TextStream& ts, const RenderObject& renderer)
 
 #if ENABLE(TREE_DEBUGGING)
 
+void printPaintOrderTreeForLiveDocuments()
+{
+    for (const auto* document : Document::allDocuments()) {
+        if (!document->renderView())
+            continue;
+        if (document->frame() && document->frame()->isMainFrame())
+            fprintf(stderr, "----------------------main frame--------------------------\n");
+        fprintf(stderr, "%s", document->url().string().utf8().data());
+        showPaintOrderTree(document->renderView());
+    }
+}
+
 void printRenderTreeForLiveDocuments()
 {
     for (const auto* document : Document::allDocuments()) {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1239,6 +1239,7 @@ inline bool RenderObject::hasPotentiallyScrollableOverflow() const
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject&);
 
 #if ENABLE(TREE_DEBUGGING)
+void printPaintOrderTreeForLiveDocuments();
 void printRenderTreeForLiveDocuments();
 void printLayerTreeForLiveDocuments();
 void printGraphicsLayerTreeForLiveDocuments();


### PR DESCRIPTION
#### f836278a1403c99dfab938fcd243f2c28e7d7191
<pre>
macOS - add &apos;notifyutil -p com.apple.WebKit.showPaintOrderTree&apos; command
<a href="https://bugs.webkit.org/show_bug.cgi?id=242680">https://bugs.webkit.org/show_bug.cgi?id=242680</a>

Reviewed by Simon Fraser.

Add new macOS specific &apos;notify callback&apos; to dump the paint order tree.
Helpful to investigate in stacking/z-index issues, etc.

* Source/WebCore/page/mac/PageMac.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::showPaintOrderTree):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::printPaintOrderTreeForLiveDocuments):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/252447@main">https://commits.webkit.org/252447@main</a>
</pre>
