### PR TITLE
[LBSE] Move the SVGLayerTransformUpdater class in its own file

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -35,6 +35,7 @@
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
 #include "SVGContainerLayout.h"
+#include "SVGLayerTransformUpdater.h"
 #include "SVGRenderingContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
@@ -51,36 +52,6 @@ RenderSVGContainer::RenderSVGContainer(SVGElement& element, RenderStyle&& style)
 }
 
 RenderSVGContainer::~RenderSVGContainer() = default;
-
-// Helper class, move to its own file once utilized in more than one place.
-class SVGLayerTransformUpdater {
-    WTF_MAKE_NONCOPYABLE(SVGLayerTransformUpdater);
-public:
-    SVGLayerTransformUpdater(RenderLayerModelObject& renderer)
-        : m_renderer(renderer)
-    {
-        if (!m_renderer.hasLayer())
-            return;
-
-        m_transformReferenceBox = m_renderer.transformReferenceBoxRect();
-        m_renderer.updateLayerTransform();
-    }
-
-
-    ~SVGLayerTransformUpdater()
-    {
-        if (!m_renderer.hasLayer())
-            return;
-        if (m_renderer.transformReferenceBoxRect() == m_transformReferenceBox)
-            return;
-
-        m_renderer.updateLayerTransform();
-    }
-
-private:
-    RenderLayerModelObject& m_renderer;
-    FloatRect m_transformReferenceBox;
-};
 
 void RenderSVGContainer::layout()
 {

--- a/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020, 2021, 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+#include "RenderLayerModelObject.h"
+
+namespace WebCore {
+
+class SVGLayerTransformUpdater {
+    WTF_MAKE_NONCOPYABLE(SVGLayerTransformUpdater);
+public:
+    SVGLayerTransformUpdater(RenderLayerModelObject& renderer)
+        : m_renderer(renderer)
+    {
+        if (!m_renderer.hasLayer())
+            return;
+
+        m_transformReferenceBox = m_renderer.transformReferenceBoxRect();
+        m_renderer.updateLayerTransform();
+    }
+
+    ~SVGLayerTransformUpdater()
+    {
+        if (!m_renderer.hasLayer())
+            return;
+        if (m_renderer.transformReferenceBoxRect() == m_transformReferenceBox)
+            return;
+
+        m_renderer.updateLayerTransform();
+    }
+
+private:
+    RenderLayerModelObject& m_renderer;
+    FloatRect m_transformReferenceBox;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(LAYER_BASED_SVG_ENGINE)


### PR DESCRIPTION
#### 82b4ea6a8a38a0a2f2dfdcc876400cdf5ec9c2eb
<pre>
[LBSE] Move the SVGLayerTransformUpdater class in its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=242682">https://bugs.webkit.org/show_bug.cgi?id=242682</a>

Reviewed by Adrian Perez de Castro.

RenderSVGRoot needs to use SVGLayerTransformUpdater as well in future,
so move the class in its own file.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::SVGLayerTransformUpdater::SVGLayerTransformUpdater): Deleted.
(WebCore::SVGLayerTransformUpdater::~SVGLayerTransformUpdater): Deleted.
* Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h: Added.
(WebCore::SVGLayerTransformUpdater::SVGLayerTransformUpdater):
(WebCore::SVGLayerTransformUpdater::~SVGLayerTransformUpdater):

Canonical link: <a href="https://commits.webkit.org/252449@main">https://commits.webkit.org/252449@main</a>
</pre>
