### PR TITLE
[GTK][WebRTC] webrtc/video-h264.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1512,8 +1512,7 @@ webkit.org/b/193641 webkit.org/b/235885 webrtc/video-setDirection.html [ Failure
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
-webkit.org/b/201267 [ Release ] webrtc/video-h264.html [ Timeout Failure ]
-webkit.org/b/222585 webkit.org/b/235885 [ Debug ] webrtc/video-h264.html [ Crash Failure ]
+[ Debug ] webrtc/video-h264.html [ Slow ]
 
 webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Crash Timeout ]
 # h264-high.html is marked as slow in the root expectation
@@ -1526,10 +1525,6 @@ webkit.org/b/216763 webkit.org/b/235885 webrtc/captureCanvas-webrtc-software-h26
 
 webkit.org/b/218221 webrtc/vp9-profile2.html [ Timeout Failure ]
 
-# Release timing out.
-webkit.org/b/219825 [ Release ] webrtc/sframe-keys.html [ Skip ]
-webkit.org/b/219825 [ Debug ] webrtc/sframe-keys.html [ Failure ]
-
 webkit.org/b/224074 webrtc/concurrentVideoPlayback.html [ Timeout Pass ]
 
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Crash Failure Timeout ]
@@ -1537,8 +1532,6 @@ webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaSt
 webkit.org/b/210385 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-firstframe.https.html [ Failure Crash Pass ]
 
 webkit.org/b/227987 http/tests/media/media-stream/get-display-media-prompt.html [ Timeout Pass ]
-
-webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs
@@ -2040,6 +2033,8 @@ webrtc/audio-sframe.html [ Skip ]
 webrtc/sframe-test-vectors.html [ Skip ]
 webrtc/sframe-transform-buffer-source.html [ Skip ]
 webrtc/video-sframe.html [ Skip ]
+webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
+webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -80,7 +80,7 @@ static RTCRtpCapabilities gstreamerRtpCapatiblities(const String& kind)
             .sdpFmtpLine = emptyString() });
     } else {
         capabilities.headerExtensions.append({ "urn:3gpp:video-orientation"_s });
-        capabilities.codecs.reserveCapacity(4);
+        capabilities.codecs.reserveCapacity(6);
         capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP8"_s,
             .clockRate = 90000,
             .channels = std::nullopt,
@@ -96,7 +96,11 @@ static RTCRtpCapabilities gstreamerRtpCapatiblities(const String& kind)
         capabilities.codecs.uncheckedAppend({ .mimeType = "video/H264"_s,
             .clockRate = 90000,
             .channels = std::nullopt,
-            .sdpFmtpLine = "packetization-mode=1;profile-level-id=42e01f"_s });
+            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"_s });
+        capabilities.codecs.uncheckedAppend({ .mimeType = "video/H264"_s,
+            .clockRate = 90000,
+            .channels = std::nullopt,
+            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f"_s });
     }
     return capabilities;
 }


### PR DESCRIPTION
#### 906621c54f03203bc747337e9af1b08f17f96e05
<pre>
[GTK][WebRTC] webrtc/video-h264.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=201267">https://bugs.webkit.org/show_bug.cgi?id=201267</a>

Reviewed by Carlos Garcia Campos.

Advertise constrained-baseline and high H.264 profiles in the GstWebRTC capabilities.

Drive-by: Refactor sframe test expectations in a single section.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::gstreamerRtpCapatiblities):

Canonical link: <a href="https://commits.webkit.org/252409@main">https://commits.webkit.org/252409@main</a>
</pre>
