### PR TITLE
Add message check to WebPageProxy::requestAttachmentIcon

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10432,6 +10432,8 @@ void WebPageProxy::writePromisedAttachmentToPasteboard(WebCore::PromisedAttachme
 
 void WebPageProxy::requestAttachmentIcon(const String& identifier, const String& contentType, const String& fileName, const String& title, const FloatSize& requestedSize)
 {
+    MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
+
     FloatSize size = requestedSize;
     ShareableBitmap::Handle handle;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 334993de44eed1ed8223454bc537a4124325e207
<pre>
Add message check to WebPageProxy::requestAttachmentIcon
<a href="https://bugs.webkit.org/show_bug.cgi?id=242694">https://bugs.webkit.org/show_bug.cgi?id=242694</a>
&lt;rdar://96832034&gt;

Reviewed by Chris Dumez.

WebPageProxy::requestAttachmentIcon should only be called if the attachment element is enabled. Also, passing a full pathname
when creating the icon for the attachment is not needed, it is sufficient to create a dummy filename with the same extension.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):

Canonical link: <a href="https://commits.webkit.org/252533@main">https://commits.webkit.org/252533@main</a>
</pre>
