### PR TITLE
[iOS] Fix thread safety issues when printing on a background thread

### DIFF
--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
@@ -30,6 +30,8 @@
 
 #import "WKWebViewInternal.h"
 #import "_WKFrameHandle.h"
+#import <wtf/Condition.h>
+#import <wtf/Locker.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SetForScope.h>
 
@@ -40,8 +42,11 @@
 
 @implementation _WKWebViewPrintFormatter {
     RetainPtr<_WKFrameHandle> _frameToPrint;
-    RetainPtr<CGPDFDocumentRef> _printedDocument;
     BOOL _suppressPageCountRecalc;
+
+    Lock _printLock;
+    Condition _printCompletionCondition;
+    RetainPtr<CGPDFDocumentRef> _printedDocument;
 }
 
 - (BOOL)requiresMainThread
@@ -66,6 +71,33 @@
     return static_cast<WKWebView *>(view);
 }
 
+- (CGPDFDocumentRef)_printedDocument
+{
+    if (self.requiresMainThread)
+        return _printedDocument.get();
+
+    Locker locker { _printLock };
+    return _printedDocument.get();
+}
+
+- (void)_setPrintedDocument:(CGPDFDocumentRef)printedDocument
+{
+    if (self.requiresMainThread) {
+        _printedDocument = printedDocument;
+        return;
+    }
+
+    Locker locker { _printLock };
+    _printedDocument = printedDocument;
+    _printCompletionCondition.notifyOne();
+}
+
+- (void)_waitForPrintedDocument
+{
+    Locker locker { _printLock };
+    _printCompletionCondition.wait(_printLock);
+}
+
 - (void)_setSnapshotPaperRect:(CGRect)paperRect
 {
     SetForScope suppressPageCountRecalc(_suppressPageCountRecalc, YES);
@@ -76,7 +108,7 @@
 
 - (NSInteger)_recalcPageCount
 {
-    _printedDocument = nullptr;
+    [self _setPrintedDocument:nullptr];
     NSUInteger pageCount = [self._webView._printProvider _wk_pageCountForPrintFormatter:self];
     return std::min<NSUInteger>(pageCount, NSIntegerMax);
 }
@@ -96,9 +128,11 @@
 
 - (void)drawInRect:(CGRect)rect forPageAtIndex:(NSInteger)pageIndex
 {
-    if (!_printedDocument) {
-        _printedDocument = self._webView._printProvider._wk_printedDocument;
-        if (!_printedDocument)
+    RetainPtr<CGPDFDocumentRef> printedDocument = [self _printedDocument];
+    if (!printedDocument) {
+        [self._webView._printProvider _wk_requestDocumentForPrintFormatter:self];
+        printedDocument = [self _printedDocument];
+        if (!printedDocument)
             return;
     }
 
@@ -106,7 +140,7 @@
     if (offsetFromStartPage < 0)
         return;
 
-    CGPDFPageRef page = CGPDFDocumentGetPage(_printedDocument.get(), offsetFromStartPage + 1);
+    CGPDFPageRef page = CGPDFDocumentGetPage(printedDocument.get(), offsetFromStartPage + 1);
     if (!page)
         return;
 

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h
@@ -34,12 +34,15 @@
 
 @interface _WKWebViewPrintFormatter ()
 - (void)_setSnapshotPaperRect:(CGRect)paperRect;
+- (void)_setPrintedDocument:(CGPDFDocumentRef)printedDocument;
+
+- (void)_waitForPrintedDocument;
 @end
 
 @protocol _WKWebViewPrintProvider <NSObject>
 - (NSUInteger)_wk_pageCountForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter;
+- (void)_wk_requestDocumentForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter;
 @property (nonatomic, readonly) BOOL _wk_printFormatterRequiresMainThread;
-@property (nonatomic, readonly) CGPDFDocumentRef _wk_printedDocument;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -790,9 +790,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return pageCount;
 }
 
-- (CGPDFDocumentRef)_wk_printedDocument
+- (void)_wk_requestDocumentForPrintFormatter:(_WKWebViewPrintFormatter *)printFormatter
 {
-    return [self _ensureDocumentForPrinting];
+    [printFormatter _setPrintedDocument:[self _ensureDocumentForPrinting]];
 }
 
 @end


### PR DESCRIPTION
#### 7ab1a7bb64d82336e8fd6f64c49e00b85ba97302
<pre>
[iOS] Fix thread safety issues when printing on a background thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=242693">https://bugs.webkit.org/show_bug.cgi?id=242693</a>
rdar://93749291

Reviewed by Chris Dumez and Devin Rousso.

In iOS 16, UIKit added support for performing printing on a background thread
when using a UIPrintInteractionController. WebKit opts-in to background thread
printing when printing a web page, in order to avoid blocking the UI process.

Printing on a background thread means that the page count computation and drawing
are done off main thread. UIViewPrintFormatters must still be used on a single thread.

However, the existing logic has a couple of notable thread-safety issues:

1. Unsafe use of WebPageProxy in WKContentView (_WKWebViewPrintFormatter):

To fix this issue, all uses of `_page` are now performed on the main thread,
using `callOnMainRunLoop` and `ensureOnMainRunLoop`.

2. Unsynchronized, shared state representing the current print job on WKContentView:

WKContentView currently maintains a single printed document and a single
completion semaphore, even though multiple print jobs can be ongoing. There is
no synchronization between print jobs, which can result in multiple threads
reading and writing to the same variables representing the printing state.

Multiple background print jobs can be triggered using SPI, while a print job
on the main thread and a single background thread can be triggered using API.
In order to address the current thread-safety issues in this scenario, print
state is now maintained per-_WKWebViewPrintFormatter.

WKContentView maintains a set of waiting print formatters, in order to unblock
them should the web process get terminated.

* Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm:
(-[_WKWebViewPrintFormatter _printedDocument]):

Add a wrapper method to retrieve the printed document, ensuring the lock is
held.

(-[_WKWebViewPrintFormatter _setPrintedDocument:]):

Notify the waiting thread once the printed document has been retrieved.

(-[_WKWebViewPrintFormatter _waitForPrintedDocument]):
(-[_WKWebViewPrintFormatter _recalcPageCount]):
(-[_WKWebViewPrintFormatter drawInRect:forPageAtIndex:]):
* Source/WebKit/UIProcess/_WKWebViewPrintFormatterInternal.h:

Change `_wk_printedDocument` into `_wk_requestDocumentForPrintFormatter` as the
print formatter now contains state necessary for waiting.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _resetPrintingState]):

Wake up blocked print formatting threads as necessary.

(-[WKContentView _processDidExit]):
(-[WKContentView _frameIdentifierForPrintFormatter:]):

Factor out frame identifier retrieval into a common method to ensure it is
done on the main thread.

(-[WKContentView _wk_pageCountForPrintFormatter:]):

Move the frame identifier retrieval next to the page count computation and
perform the logic on the main thread.

`_page` can (incorrectly) be used off the main thread. To fix this, use
`ensureOnMainRunLoop` prior to calling WebPageProxy::drawToPDFiOS. Once the
PDF is retrieved, the background thread is woken up.

If printing on a background thread, add the print formatter to the pending set.

(-[WKContentView _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:]):

Use the callback ID when printing on the main thread. On background threads,
consult the set of pending print formatters and wait as necessary.

(-[WKContentView _wk_requestDocumentForPrintFormatter:]):
(-[WKContentView _waitForDrawToPDFCallbackIfNeeded]): Deleted.
(-[WKContentView _wk_printedDocument]): Deleted.
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView _wk_requestDocumentForPrintFormatter:]):
(-[WKPDFView _wk_printedDocument]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewPrintFormatter.mm:
(TEST):

Added new tests to exercise the multiple background threads scenario, and the
main thread and single background thread scenario.

Canonical link: <a href="https://commits.webkit.org/252602@main">https://commits.webkit.org/252602@main</a>
</pre>
