### PR TITLE
Block ability to open IOKit services

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -960,6 +960,7 @@
     (preference-domain "com.apple.WebKit.WebContent.BlockIOKitInWebContentSandbox"))
 
 (with-filter (state-flag "BlockIOKitInWebContentSandbox")
+    (deny iokit-open-service)
     (deny iokit-open (with telemetry-backtrace)
         (require-all
             (require-not (extension "com.apple.webkit.extension.iokit"))


### PR DESCRIPTION
#### 73035815bfbbdb8cfca0fcb1e0bdf3587a5f4151
<pre>
Block ability to open IOKit services
<a href="https://bugs.webkit.org/show_bug.cgi?id=242696">https://bugs.webkit.org/show_bug.cgi?id=242696</a>
&lt;rdar://problem/96957606&gt;

Reviewed by Chris Dumez.

When all IOKit user clients are blocked in the WebContent process, there is no need to allow opening of IOKit services.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/252419@main">https://commits.webkit.org/252419@main</a>
</pre>
