### PR TITLE
Avoid unnecessary autorelease in NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded()

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -122,7 +122,7 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
     if (!boundInterfaceIdentifier.isNull())
         [mutableRequest setBoundInterfaceIdentifier:boundInterfaceIdentifier];
 
-    nsRequest = mutableRequest.autorelease();
+    nsRequest = WTFMove(mutableRequest);
 }
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)


### PR DESCRIPTION
#### 46d3bd9d59069dcfebba8b9c180aaf00e326bcdb
<pre>
Avoid unnecessary autorelease in NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242700">https://bugs.webkit.org/show_bug.cgi?id=242700</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):

Canonical link: <a href="https://commits.webkit.org/252420@main">https://commits.webkit.org/252420@main</a>
</pre>
