### PR TITLE
[LBSE] Begin stub implementation of RenderSVGViewportContainer

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2516,15 +2516,16 @@ rendering/style/StyleVisualData.cpp
 rendering/style/TextSizeAdjustment.cpp
 rendering/style/WillChangeData.cpp
 rendering/svg/LegacyRenderSVGContainer.cpp
+rendering/svg/LegacyRenderSVGEllipse.cpp
 rendering/svg/LegacyRenderSVGModelObject.cpp
 rendering/svg/LegacyRenderSVGPath.cpp
 rendering/svg/LegacyRenderSVGRect.cpp
 rendering/svg/LegacyRenderSVGRoot.cpp
 rendering/svg/LegacyRenderSVGShape.cpp
 rendering/svg/LegacyRenderSVGTransformableContainer.cpp
+rendering/svg/LegacyRenderSVGViewportContainer.cpp
 rendering/svg/RenderSVGBlock.cpp
 rendering/svg/RenderSVGContainer.cpp
-rendering/svg/LegacyRenderSVGEllipse.cpp
 rendering/svg/RenderSVGEllipse.cpp
 rendering/svg/RenderSVGForeignObject.cpp
 rendering/svg/RenderSVGGradientStop.cpp

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -332,6 +332,7 @@ public:
     virtual bool isSVGTransformableContainer() const { return false; }
     virtual bool isLegacySVGTransformableContainer() const { return false; }
     virtual bool isSVGViewportContainer() const { return false; }
+    virtual bool isLegacySVGViewportContainer() const { return false; }
     virtual bool isSVGGradientStop() const { return false; }
     virtual bool isSVGHiddenContainer() const { return false; }
     virtual bool isLegacySVGPath() const { return false; }

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp
@@ -59,13 +59,13 @@ void LegacyRenderSVGContainer::layout()
 
     LayoutRepainter repainter(*this, SVGRenderSupport::checkForSVGRepaintDuringLayout(*this) || selfWillPaint(), RepaintOutlineBounds::No);
 
-    // Allow RenderSVGViewportContainer to update its viewport.
+    // Allow LegacyRenderSVGViewportContainer to update its viewport.
     calcViewport();
 
     // Allow LegacyRenderSVGTransformableContainer to update its transform.
     bool updatedTransform = calculateLocalTransform();
 
-    // RenderSVGViewportContainer needs to set the 'layout size changed' flag.
+    // LegacyRenderSVGViewportContainer needs to set the 'layout size changed' flag.
     determineIfLayoutSizeChanged();
 
     SVGRenderSupport::layoutChildren(*this, selfNeedsLayout() || SVGRenderSupport::filtersForceContainerLayout(*this));
@@ -111,7 +111,7 @@ void LegacyRenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint&)
     {
         GraphicsContextStateSaver stateSaver(childPaintInfo.context());
 
-        // Let the RenderSVGViewportContainer subclass clip if necessary
+        // Let the LegacyRenderSVGViewportContainer subclass clip if necessary
         applyViewportClip(childPaintInfo);
 
         childPaintInfo.applyTransform(localToParentTransform());
@@ -157,7 +157,7 @@ void LegacyRenderSVGContainer::updateCachedBoundaries()
 
 bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)
 {
-    // Give RenderSVGViewportContainer a chance to apply its viewport clip
+    // Give LegacyRenderSVGViewportContainer a chance to apply its viewport clip
     if (!pointIsInsideViewportClip(pointInParent))
         return false;
 

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
+ * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
+ * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
+ * Copyright (C) 2009 Google, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "LegacyRenderSVGViewportContainer.h"
+
+#include "GraphicsContext.h"
+#include "RenderView.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGSVGElement.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGViewportContainer);
+
+LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement& element, RenderStyle&& style)
+    : LegacyRenderSVGContainer(element, WTFMove(style))
+    , m_didTransformToRootUpdate(false)
+    , m_isLayoutSizeChanged(false)
+    , m_needsTransformUpdate(true)
+{
+}
+
+SVGSVGElement& LegacyRenderSVGViewportContainer::svgSVGElement() const
+{
+    return downcast<SVGSVGElement>(LegacyRenderSVGContainer::element());
+}
+
+void LegacyRenderSVGViewportContainer::determineIfLayoutSizeChanged()
+{
+    m_isLayoutSizeChanged = svgSVGElement().hasRelativeLengths() && selfNeedsLayout();
+}
+
+void LegacyRenderSVGViewportContainer::applyViewportClip(PaintInfo& paintInfo)
+{
+    if (SVGRenderSupport::isOverflowHidden(*this))
+        paintInfo.context().clip(m_viewport);
+}
+
+void LegacyRenderSVGViewportContainer::calcViewport()
+{
+    SVGSVGElement& element = svgSVGElement();
+    SVGLengthContext lengthContext(&element);
+    FloatRect newViewport(element.x().value(lengthContext), element.y().value(lengthContext), element.width().value(lengthContext), element.height().value(lengthContext));
+
+    if (m_viewport == newViewport)
+        return;
+
+    m_viewport = newViewport;
+
+    setNeedsBoundariesUpdate();
+    setNeedsTransformUpdate();
+}
+
+bool LegacyRenderSVGViewportContainer::calculateLocalTransform()
+{
+    m_didTransformToRootUpdate = m_needsTransformUpdate || SVGRenderSupport::transformToRootChanged(parent());
+    if (!m_needsTransformUpdate)
+        return false;
+
+    m_localToParentTransform = AffineTransform::makeTranslation(toFloatSize(m_viewport.location())) * viewportTransform();
+    m_needsTransformUpdate = false;
+    return true;
+}
+
+AffineTransform LegacyRenderSVGViewportContainer::viewportTransform() const
+{
+    return svgSVGElement().viewBoxToViewTransform(m_viewport.width(), m_viewport.height());
+}
+
+bool LegacyRenderSVGViewportContainer::pointIsInsideViewportClip(const FloatPoint& pointInParent)
+{
+    // Respect the viewport clip (which is in parent coords)
+    if (!SVGRenderSupport::isOverflowHidden(*this))
+        return true;
+
+    return m_viewport.contains(pointInParent);
+}
+
+void LegacyRenderSVGViewportContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
+    // An empty viewBox disables rendering.
+    if (svgSVGElement().hasEmptyViewBox())
+        return;
+
+    LegacyRenderSVGContainer::paint(paintInfo, paintOffset);
+}
+
+}

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
+ * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
+ * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "LegacyRenderSVGContainer.h"
+
+namespace WebCore {
+
+// This is used for non-root <svg> elements and <marker> elements, neither of which are SVGTransformable
+// thus we inherit from LegacyRenderSVGContainer instead of LegacyRenderSVGTransformableContainer
+class LegacyRenderSVGViewportContainer final : public LegacyRenderSVGContainer {
+    WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGViewportContainer);
+public:
+    LegacyRenderSVGViewportContainer(SVGSVGElement&, RenderStyle&&);
+
+    SVGSVGElement& svgSVGElement() const;
+
+    FloatRect viewport() const { return m_viewport; }
+
+    bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
+    bool didTransformToRootUpdate() override { return m_didTransformToRootUpdate; }
+
+    void determineIfLayoutSizeChanged() override;
+    void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
+
+    void paint(PaintInfo&, const LayoutPoint&) override;
+
+private:
+    void element() const = delete;
+
+    bool isLegacySVGViewportContainer() const override { return true; }
+    ASCIILiteral renderName() const override { return "RenderSVGViewportContainer"_s; }
+
+    AffineTransform viewportTransform() const;
+    const AffineTransform& localToParentTransform() const override { return m_localToParentTransform; }
+
+    void calcViewport() override;
+    bool calculateLocalTransform() override;
+
+    void applyViewportClip(PaintInfo&) override;
+    bool pointIsInsideViewportClip(const FloatPoint& pointInParent) override;
+
+    bool m_didTransformToRootUpdate : 1;
+    bool m_isLayoutSizeChanged : 1;
+    bool m_needsTransformUpdate : 1;
+
+    FloatRect m_viewport;
+    mutable AffineTransform m_localToParentTransform;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGViewportContainer, isLegacySVGViewportContainer())

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -31,6 +31,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGShape.h"
 #include "LegacyRenderSVGTransformableContainer.h"
+#include "LegacyRenderSVGViewportContainer.h"
 #include "NodeRenderStyle.h"
 #include "RenderChildIterator.h"
 #include "RenderElement.h"
@@ -45,7 +46,6 @@
 #include "RenderSVGRoot.h"
 #include "RenderSVGShape.h"
 #include "RenderSVGText.h"
-#include "RenderSVGViewportContainer.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGGeometryElement.h"
 #include "SVGResources.h"
@@ -207,17 +207,13 @@ static inline void invalidateResourcesOfChildren(RenderElement& renderer)
 static inline bool layoutSizeOfNearestViewportChanged(const RenderElement& renderer)
 {
     const RenderElement* start = &renderer;
-    while (start && !start->isSVGRootOrLegacySVGRoot() && !is<RenderSVGViewportContainer>(*start))
+    while (start && !is<LegacyRenderSVGRoot>(*start) && !is<LegacyRenderSVGViewportContainer>(*start))
         start = start->parent();
 
     ASSERT(start);
-    if (is<RenderSVGViewportContainer>(*start))
-        return downcast<RenderSVGViewportContainer>(*start).isLayoutSizeChanged();
+    if (is<LegacyRenderSVGViewportContainer>(*start))
+        return downcast<LegacyRenderSVGViewportContainer>(*start).isLayoutSizeChanged();
 
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGRoot>(*start))
-        return downcast<RenderSVGRoot>(*start).isLayoutSizeChanged();
-#endif
     return downcast<LegacyRenderSVGRoot>(*start).isLayoutSizeChanged();
 }
 
@@ -226,8 +222,8 @@ bool SVGRenderSupport::transformToRootChanged(RenderElement* ancestor)
     while (ancestor && !ancestor->isSVGRootOrLegacySVGRoot()) {
         if (is<LegacyRenderSVGTransformableContainer>(*ancestor))
             return downcast<LegacyRenderSVGTransformableContainer>(*ancestor).didTransformToRootUpdate();
-        if (is<RenderSVGViewportContainer>(*ancestor))
-            return downcast<RenderSVGViewportContainer>(*ancestor).didTransformToRootUpdate();
+        if (is<LegacyRenderSVGViewportContainer>(*ancestor))
+            return downcast<LegacyRenderSVGViewportContainer>(*ancestor).didTransformToRootUpdate();
         ancestor = ancestor->parent();
     }
 

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -29,7 +29,6 @@
 #include "Frame.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LengthFunctions.h"
-#include "RenderSVGViewportContainer.h"
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGSVGElement.h"

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -31,9 +31,9 @@
 #include "Frame.h"
 #include "FrameSelection.h"
 #include "LegacyRenderSVGRoot.h"
+#include "LegacyRenderSVGViewportContainer.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGRoot.h"
-#include "RenderSVGViewportContainer.h"
 #include "RenderView.h"
 #include "SMILTimeContainer.h"
 #include "SVGAngle.h"
@@ -411,7 +411,9 @@ RenderPtr<RenderElement> SVGSVGElement::createElementRenderer(RenderStyle&& styl
 #endif
         return createRenderer<LegacyRenderSVGRoot>(*this, WTFMove(style));
     }
-    return createRenderer<RenderSVGViewportContainer>(*this, WTFMove(style));
+
+    // FIXME: [LBSE] Enable creation of inner <svg> element renderers.
+    return createRenderer<LegacyRenderSVGViewportContainer>(*this, WTFMove(style));
 }
 
 Node::InsertedIntoAncestorResult SVGSVGElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
@@ -526,7 +528,7 @@ FloatSize SVGSVGElement::currentViewportSize() const
             viewportSize = root.contentBoxRect().size() / root.style().effectiveZoom();
 #endif
         } else
-            viewportSize = downcast<RenderSVGViewportContainer>(*renderer()).viewport().size();
+            viewportSize = downcast<LegacyRenderSVGViewportContainer>(*renderer()).viewport().size();
     }
 
     if (!viewportSize.isEmpty())


### PR DESCRIPTION
#### 273d610500568994a594191403c869ffe26098e2
<pre>
[LBSE] Begin stub implementation of RenderSVGViewportContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=242701">https://bugs.webkit.org/show_bug.cgi?id=242701</a>

Reviewed by Rob Buis.

Rename LegacyRenderSVGViewportContainer -&gt; RenderSVGViewportContainer and adapt all call sites.
Introduce layer-aware RenderSVGViewportContainer at the same time as stub implementation.

Follow-up patches will bring support for inner &lt;svg&gt; elements.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isLegacySVGViewportContainer const):
* Source/WebCore/rendering/svg/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::layout):
(WebCore::LegacyRenderSVGContainer::paint):
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.cpp: Copied from Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp.
(WebCore::LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer):
(WebCore::LegacyRenderSVGViewportContainer::svgSVGElement const):
(WebCore::LegacyRenderSVGViewportContainer::determineIfLayoutSizeChanged):
(WebCore::LegacyRenderSVGViewportContainer::applyViewportClip):
(WebCore::LegacyRenderSVGViewportContainer::calcViewport):
(WebCore::LegacyRenderSVGViewportContainer::calculateLocalTransform):
(WebCore::LegacyRenderSVGViewportContainer::viewportTransform const):
(WebCore::LegacyRenderSVGViewportContainer::pointIsInsideViewportClip):
(WebCore::LegacyRenderSVGViewportContainer::paint):
* Source/WebCore/rendering/svg/LegacyRenderSVGViewportContainer.h: Copied from Source/WebCore/rendering/svg/RenderSVGViewportContainer.h.
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::RenderSVGViewportContainer):
(WebCore::RenderSVGViewportContainer::svgSVGElement const):
(WebCore::RenderSVGViewportContainer::computeViewport const):
(WebCore::RenderSVGViewportContainer::updateLayerTransform):
(WebCore::RenderSVGViewportContainer::applyTransform const):
(WebCore::RenderSVGViewportContainer::determineIfLayoutSizeChanged): Deleted.
(WebCore::RenderSVGViewportContainer::applyViewportClip): Deleted.
(WebCore::RenderSVGViewportContainer::calcViewport): Deleted.
(WebCore::RenderSVGViewportContainer::calculateLocalTransform): Deleted.
(WebCore::RenderSVGViewportContainer::viewportTransform const): Deleted.
(WebCore::RenderSVGViewportContainer::pointIsInsideViewportClip): Deleted.
(WebCore::RenderSVGViewportContainer::paint): Deleted.
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::layoutSizeOfNearestViewportChanged):
(WebCore::SVGRenderSupport::transformToRootChanged):
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::createElementRenderer):
(WebCore::SVGSVGElement::currentViewportSize const):

Canonical link: <a href="https://commits.webkit.org/252500@main">https://commits.webkit.org/252500@main</a>
</pre>
