### PR TITLE
Web Inspector: Sources Tab: paused icon needs a title explaining it

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -865,6 +865,7 @@ localizedStrings["JavaScript"] = "JavaScript";
 localizedStrings["JavaScript & Events"] = "JavaScript & Events";
 localizedStrings["JavaScript Allocations"] = "JavaScript Allocations";
 localizedStrings["JavaScript Context"] = "JavaScript Context";
+localizedStrings["JavaScript execution is paused"] = "JavaScript execution is paused";
 localizedStrings["Jump to Definition"] = "Jump to Definition";
 localizedStrings["Key"] = "Key";
 localizedStrings["Key Path"] = "Key Path";

--- a/Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js
@@ -47,6 +47,7 @@ WI.SourcesTabContentView = class SourcesTabContentView extends WI.ContentBrowser
         return {
             identifier: SourcesTabContentView.Type,
             image: WI.debuggerManager.paused ? "Images/SourcesPaused.svg" : "Images/Sources.svg",
+            title: WI.debuggerManager.paused ? WI.UIString("JavaScript execution is paused") : "",
             displayName: WI.UIString("Sources", "Sources Tab Name", "Name of Sources Tab"),
         };
     }
@@ -120,11 +121,13 @@ WI.SourcesTabContentView = class SourcesTabContentView extends WI.ContentBrowser
     _handleDebuggerPaused(event)
     {
         this.tabBarItem.image = "Images/SourcesPaused.svg";
+        this.tabBarItem.title = WI.UIString("JavaScript execution is paused");
     }
 
     _handleDebuggerResumed(event)
     {
         this.tabBarItem.image = "Images/Sources.svg";
+        this.tabBarItem.title = "";
     }
 };
 


### PR DESCRIPTION
#### eed2a5d6ad16e3e186335799f3dcce57200b556d
<pre>
Web Inspector: Sources Tab: paused icon needs a title explaining it
<a href="https://bugs.webkit.org/show_bug.cgi?id=242702">https://bugs.webkit.org/show_bug.cgi?id=242702</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/SourcesTabContentView.js:
(WI.SourcesTabContentView.tabInfo):
(WI.SourcesTabContentView.prototype._handleDebuggerPaused):
(WI.SourcesTabContentView.prototype._handleDebuggerResumed):

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/252421@main">https://commits.webkit.org/252421@main</a>
</pre>
