### PR TITLE
[git-webkit] Log errors for failed bitbucket PR update

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.0',
+    version='5.3.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 0)
+version = Version(5, 3, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -216,6 +216,8 @@ class BitBucket(Scm):
 
             response = requests.put(pr_url, json=data)
             if response.status_code // 100 != 2:
+                for error in response.json().get('errors', []):
+                    sys.stderr.write('{}: {}\n'.format(error.get('context'), error.get('message')))
                 return None
             data = response.json()
 


### PR DESCRIPTION
#### 4bd246f6647d4da7859611cd2e278d9b57d6c426
<pre>
[git-webkit] Log errors for failed bitbucket PR update
<a href="https://bugs.webkit.org/show_bug.cgi?id=242703">https://bugs.webkit.org/show_bug.cgi?id=242703</a>
&lt;rdar://problem/96962440&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.update):

Canonical link: <a href="https://commits.webkit.org/252608@main">https://commits.webkit.org/252608@main</a>
</pre>
