### PR TITLE
[Alternate WebM Player] Assertion when playing file when player is enabled.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -632,13 +632,14 @@ bool MediaPlayerPrivateWebM::shouldEnsureLayer() const
 
 void MediaPlayerPrivateWebM::playerContentBoxRectChanged(const LayoutRect& newRect)
 {
-    if (!m_displayLayer && !newRect.isEmpty())
+    if (m_hasVideo && !m_displayLayer && !newRect.isEmpty())
         updateDisplayLayerAndDecompressionSession();
 }
 
 void MediaPlayerPrivateWebM::acceleratedRenderingStateChanged()
 {
-    updateDisplayLayerAndDecompressionSession();
+    if (m_hasVideo)
+        updateDisplayLayerAndDecompressionSession();
 }
 
 void MediaPlayerPrivateWebM::updateDisplayLayerAndDecompressionSession()


### PR DESCRIPTION
#### b4d9eee5f23a28c1aff9e3e2ccec77b130af6453
<pre>
[Alternate WebM Player] Assertion when playing file when player is enabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242677">https://bugs.webkit.org/show_bug.cgi?id=242677</a>
&lt;rdar://96935749&gt;

Reviewed by Eric Carlson.

An assertion in MediaPlayerPrivateWebM::provideMediaData was being hit
due to an invalid trackId being passed in from MediaPlayerPrivateWebM::ensureLayer.
A layer should not be created if no video is available within the WebM.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateWebM::acceleratedRenderingStateChanged):

Canonical link: <a href="https://commits.webkit.org/252424@main">https://commits.webkit.org/252424@main</a>
</pre>
