### PR TITLE
Fix various compiler warnings

### DIFF
--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -138,102 +138,10 @@ void AXObjectCache::postPlatformNotification(AXCoreObject* coreObject, AXNotific
         if (auto* descendant = coreObject->activeDescendant())
             platformHandleFocusedUIElementChanged(nullptr, descendant->node());
         break;
-    case AXAriaRoleChanged:
-        break;
-    case AXAutocorrectionOccured:
-        break;
     case AXChildrenChanged:
         coreObject->updateChildrenIfNecessary();
         break;
-    case AXFocusedUIElementChanged:
-        break;
-    case AXFrameLoadComplete:
-        break;
-    case AXIdAttributeChanged:
-        break;
-    case AXImageOverlayChanged:
-        break;
-    case AXLanguageChanged:
-        break;
-    case AXLayoutComplete:
-        break;
-    case AXLoadComplete:
-        break;
-    case AXNewDocumentLoadComplete:
-        break;
-    case AXPageScrolled:
-        break;
-    case AXSelectedTextChanged:
-        break;
-    case AXScrolledToAnchor:
-        break;
-    case AXLiveRegionCreated:
-        break;
-    case AXLiveRegionChanged:
-        break;
-    case AXMenuClosed:
-        break;
-    case AXMenuOpened:
-        break;
-    case AXRowCountChanged:
-        break;
-    case AXPressDidSucceed:
-        break;
-    case AXPressDidFail:
-        break;
-    case AXSortDirectionChanged:
-        break;
-    case AXTextChanged:
-        break;
-    case AXDraggingStarted:
-        break;
-    case AXDraggingEnded:
-        break;
-    case AXDraggingEnteredDropZone:
-        break;
-    case AXDraggingDropped:
-        break;
-    case AXDraggingExitedDropZone:
-        break;
-    case AXGrabbedStateChanged:
-        break;
-    case AXPositionInSetChanged:
-        break;
-    case AXDescribedByChanged:
-        break;
-    case AXHasPopupChanged:
-        break;
-    case AXSetSizeChanged:
-        break;
-    case AXLevelChanged:
-        break;
-    case AXMaximumValueChanged:
-        break;
-    case AXMinimumValueChanged:
-        break;
-    case AXMultiSelectableStateChanged:
-        break;
-    case AXIsAtomicChanged:
-        break;
-    case AXLiveRegionRelevantChanged:
-        break;
-    case AXLiveRegionStatusChanged:
-        break;
-    case AXOrientationChanged:
-        break;
-    case AXPlaceholderChanged:
-        break;
-    case AXColumnCountChanged:
-        break;
-    case AXColumnIndexChanged:
-        break;
-    case AXColumnSpanChanged:
-        break;
-    case AXRowIndexChanged:
-        break;
-    case AXRowSpanChanged:
-        break;
-    case AXDropEffectChanged:
+    default:
         break;
     }
 }

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -248,6 +248,8 @@ bool InputType::isValidValue(const String& value) const
 #endif
     case Type::Text:
         return validateInputType(downcast<TextInputType>(*this), value);
+    default:
+        break;
     }
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5404,6 +5404,18 @@ void WebGLRenderingContextBase::texImage3DBase(GCGLenum target, GCGLint level, G
     byteLength = std::min(byteLength, (GCGLsizei) bytesRequired);
     m_context->texImage3D(target, level, internalFormat, width, height, depth, border, format, type, makeGCGLSpan(pixels, byteLength));
 #else
+    UNUSED_PARAM(target);
+    UNUSED_PARAM(level);
+    UNUSED_PARAM(internalFormat);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    UNUSED_PARAM(depth);
+    UNUSED_PARAM(border);
+    UNUSED_PARAM(format);
+    UNUSED_PARAM(type);
+    UNUSED_PARAM(byteLength);
+    UNUSED_PARAM(pixels);
+    
     ASSERT_NOT_REACHED();
 #endif // USE(ANGLE)
 }
@@ -5459,6 +5471,20 @@ void WebGLRenderingContextBase::texSubImage3DBase(GCGLenum target, GCGLint level
     byteLength = std::min(byteLength, (GCGLsizei) bytesRequired);
     m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, makeGCGLSpan(pixels, byteLength));
 #else
+    UNUSED_PARAM(target);
+    UNUSED_PARAM(level);
+    UNUSED_PARAM(xoffset);
+    UNUSED_PARAM(yoffset);
+    UNUSED_PARAM(zoffset);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    UNUSED_PARAM(depth);
+    UNUSED_PARAM(internalFormat);
+    UNUSED_PARAM(format);
+    UNUSED_PARAM(type);
+    UNUSED_PARAM(byteLength);
+    UNUSED_PARAM(pixels);
+
     ASSERT_NOT_REACHED();
 #endif
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -322,7 +322,7 @@ void ImageBuffer::drawPattern(GraphicsContext& destContext, const FloatRect& des
     FloatRect adjustedSrcRect = srcRect;
     adjustedSrcRect.scale(resolutionScale());
 
-    if (auto* backend = ensureBackendCreated()) {
+    if (ensureBackendCreated()) {
         if (auto image = copyImage(&destContext == &context() ? CopyBackingStore : DontCopyBackingStore))
             image->drawPattern(destContext, destRect, adjustedSrcRect, patternTransform, phase, spacing, options);
     }


### PR DESCRIPTION
#### 8f811dbdfb4eca44f17ceff99db6cbce3a965300
<pre>
Fix various compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=242711">https://bugs.webkit.org/show_bug.cgi?id=242711</a>

Reviewed by Carlos Garcia Campos.

In particular, it&apos;s time to stop warning about new values of
AXNotification. These would be useful if they indicated a need to
implement something, but in practice all we wind up doing is ignoring
each one individually, which is not useful.

* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::postPlatformNotification):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::isValidValue const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImage3DBase):
(WebCore::WebGLRenderingContextBase::texSubImage3DBase):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::drawPattern):

Canonical link: <a href="https://commits.webkit.org/252451@main">https://commits.webkit.org/252451@main</a>
</pre>
