### PR TITLE
Fix typo in RenderObject 'hasTransformOrPespective' accessor

### DIFF
--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -150,7 +150,7 @@ static bool canMapBetweenRenderersViaLayers(const RenderLayerModelObject& render
         if (current->isFixedPositioned() || style.isFlippedBlocksWritingMode())
             return false;
 
-        if (current->hasTransformOrPespective())
+        if (current->hasTransformOrPerspective())
             return false;
         
         if (current->isRenderFragmentedFlow())

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -474,7 +474,7 @@ public:
 
     bool hasTransformRelatedProperty() const { return m_bitfields.hasTransformRelatedProperty(); } // Transform, perspective or transform-style: preserve-3d.
     bool hasTransform() const { return hasTransformRelatedProperty() && (style().hasTransform() || style().translate() || style().scale() || style().rotate() || hasSVGTransform()); }
-    bool hasTransformOrPespective() const { return hasTransformRelatedProperty() && (hasTransform() || style().hasPerspective()); }
+    bool hasTransformOrPerspective() const { return hasTransformRelatedProperty() && (hasTransform() || style().hasPerspective()); }
 
     inline bool preservesNewline() const;
 


### PR DESCRIPTION
#### 7ec7522cd63a3c74cd891b0ac60e9e949c2360ff
<pre>
Fix typo in RenderObject &apos;hasTransformOrPespective&apos; accessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=242713">https://bugs.webkit.org/show_bug.cgi?id=242713</a>

Reviewed by Manuel Rego Casasnovas.

s/Pespective/Perspective/

No change in behavior, covered by existing tests.

* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::canMapBetweenRenderersViaLayers):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::hasTransformOrPerspective const):
(WebCore::RenderObject::hasTransformOrPespective const): Deleted.

Canonical link: <a href="https://commits.webkit.org/252446@main">https://commits.webkit.org/252446@main</a>
</pre>
