### PR TITLE
Web Inspector: Network Tab: shift key should highlight initiator/initiated resources

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -87,6 +87,26 @@
     cursor: pointer;
 }
 
+body.shift-key-pressed .network-table > .table:hover li:not(:hover, .selected, .initiated) .cell {
+    color: var(--text-color-transparent);
+}
+
+body.shift-key-pressed .network-table > .table:hover li:not(:hover, .selected, .initiated) .cell > * {
+    color: var(--text-color);
+    opacity: 0.4;
+}
+
+body.shift-key-pressed .network-table > .table:hover li.initiated .cell.name::after {
+    display: inline-block;
+    float: right;
+    width: 4px;
+    height: 4px;
+    margin-top: 8px;
+    content: "";
+    background-color: var(--glyph-color-active);
+    border-radius: 50%;
+}
+
 .network-table > .table .cell.dom-node.name .icon {
     content: url(../Images/TypeIcons.svg#DOMElement-light);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -35,6 +35,8 @@
     --foreground-lightness: 0%;
 
     --text-color: black;
+    --text-color-transparent: hsla(0, 0%, 0%, 0.4);
+
     --text-color-active: black;
 
     --text-color-secondary: hsl(0, 0%, 50%);
@@ -232,6 +234,7 @@ body.window-inactive {
 
 body:is(.mac-platform.monterey, .mac-platform.big-sur) {
     --text-color: hsl(0, 0%, 15%);
+    --text-color-transparent: hsla(0, 0%, 15%, 0.4);
 
     --background-color-intermediate: hsl(0, 0%, 98.5%);
 
@@ -263,6 +266,8 @@ body:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
         --foreground-lightness: 100%;
 
         --text-color: hsl(0, 0%, 88%);
+        --text-color-transparent: hsla(0, 0%, 88%, 0.4);
+
         --text-color-active: white;
         --text-color-secondary: hsl(0, 0%, 65%);
 
@@ -396,6 +401,7 @@ body:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
 
     body:is(.mac-platform.monterey, .mac-platform.big-sur) {
         --text-color: hsl(0, 0%, 85%);
+        --text-color-transparent: hsla(0, 0%, 85%, 0.4);
 
         --background-color: hsl(0, 0%, 20%);
         --background-color-secondary: hsl(0, 0%, 23%);


### PR DESCRIPTION
#### 56748b5465db4056faa2977d298337252dcfb548
<pre>
Web Inspector: Network Tab: shift key should highlight initiator/initiated resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=242714">https://bugs.webkit.org/show_bug.cgi?id=242714</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView):
(WI.NetworkTableContentView.prototype.attached): Added.
(WI.NetworkTableContentView.prototype.detached):
(WI.NetworkTableContentView.prototype.tableRowHovered): Added.
(WI.NetworkTableContentView.prototype.tableRowClassNames): Added.
(WI.NetworkTableContentView.prototype._highlightRelatedResourcesForHoveredResource): Added.
(WI.NetworkTableContentView.prototype._entryForResource):
(WI.NetworkTableContentView.prototype._entryForDOMNode):
(WI.NetworkTableContentView.prototype._handleGlobalModifierKeysDidChange): Added.
Save `rowClassNames` for each entry in the table, adding items based on if the shift key is pressed
and if the entry was loaded (i.e. initiated) by the hovered entry.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(body.shift-key-pressed .network-table &gt; .table:hover li:not(:hover, .selected, .initiated) .cell):
(body.shift-key-pressed .network-table &gt; .table:hover li:not(:hover, .selected, .initiated) .cell &gt; *):
(body.shift-key-pressed .network-table &gt; .table:hover li.initiated .cell.name::after):
Indiciated initiated resources by drawing a small blue (or whatever the system accent color is) dot.

* Source/WebInspectorUI/UserInterface/Views/Table.js:
(WI.Table.prototype.restyleRow): Added.
(WI.Table.prototype._getOrCreateRow):
(WI.Table.prototype._styleRow):
(WI.Table.prototype._handleRowMouseEnter): Added.
(WI.Table.prototype._handleRowMouseLeave): Added.
Add delegate methods for `tableRowHovered` and `tableRowClassNames` to allow clients to further
customize the appearance of rows in a `WI.Table` whenever needed.
Also add a way to force calling these new delegate methods for a given row (index).

* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
(body:is(.mac-platform.monterey, .mac-platform.big-sur)):
(@media (prefers-color-scheme: dark) :root):
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur)):
Add a new `--text-color-transparent` that&apos;s used instead of `opacity` to change the color of cells
for initiated resources. This is necessary because we don&apos;t want to affect the `background-color`.

Canonical link: <a href="https://commits.webkit.org/252489@main">https://commits.webkit.org/252489@main</a>
</pre>
