### PR TITLE
Remove figma.com from simulated mouse events quirk

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -406,8 +406,6 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
 
         if ((host == "desmos.com"_s || host.endsWith(".desmos.com"_s)) && startsWithLettersIgnoringASCIICase(url.path(), "/calculator/"_s))
             return ShouldDispatchSimulatedMouseEvents::Yes;
-        if (host == "figma.com"_s || host.endsWith(".figma.com"_s))
-            return ShouldDispatchSimulatedMouseEvents::Yes;
         if (host == "trello.com"_s || host.endsWith(".trello.com"_s))
             return ShouldDispatchSimulatedMouseEvents::Yes;
         if (host == "airtable.com"_s || host.endsWith(".airtable.com"_s))


### PR DESCRIPTION
#### 54155e10cd9ee3510f400397e39dca2d35abbb53
<pre>
Remove figma.com from simulated mouse events quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=241515">https://bugs.webkit.org/show_bug.cgi?id=241515</a>

Reviewed by Tim Horton.

Don&apos;t make touch events simulate mouse events on figma.com anymore.

In 2019, this quirk was added in
<a href="https://bugs.webkit.org/show_bug.cgi?id=196830.">https://bugs.webkit.org/show_bug.cgi?id=196830.</a>

In 2022, figma.com supports all iPad interactions (touch, mouse/
trackpad, and Apple Pencil) by using the web pointer event API, which
isn&apos;t affected by this quirk.  Also, the Figma iPad app loads the same
content in a WKWebView with isSiteSpecificQuirksModeEnabled = false, so
it&apos;s a known and supported path.

At this point, simulated mouse events just create more problems and
confusion, since they diverge from the web event spec.
(The extra simulated mouse events can&apos;t be prevented by calling
preventDefault or stopPropagation on the original touch events,
they can&apos;t be distinguished from real mouse events, and they aren&apos;t easy
to ignore because they&apos;re delivered with different timing than the touch
events.)

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const): Deleted
check for figma.com.

Canonical link: <a href="https://commits.webkit.org/252429@main">https://commits.webkit.org/252429@main</a>
</pre>
