### PR TITLE
[LBSE] Cleanup RenderSVGRoot code

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-04-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-04-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (-5,-10) size 84x62 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGContainer {g} at (-1,-2) size 85x64
 layer at (8,1) size 66x9

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-05-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-05-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (-5,-10) size 80x62 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGContainer {g} at (-1,-2) size 81x64
 layer at (8,1) size 66x9

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-06-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-06-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (-5,-10) size 84x62 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGContainer {g} at (-1,-2) size 85x64
 layer at (7,1) size 66x9

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-07-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/animate-elem-07-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (-5,-10) size 84x62 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGContainer {g} at (-1,-2) size 85x64
 layer at (7,1) size 66x9

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/filters-blend-01-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/filters-blend-01-b-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 160x120
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (5,10) size 145x88
   RenderSVGContainer {g} at (0,0) size 145x88
 layer at (30,10) size 120x10

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/interact-zoom-01-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/interact-zoom-01-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (5,2) size 65x41
   RenderSVGContainer {g} at (0,0) size 66x41
 layer at (5,2) size 65x41

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-02-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-02-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (100,100) size 100x100
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (100,100) size 100x100
   RenderSVGContainer {g} at (0,0) size 100x100
 layer at (100,100) size 50x50

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-03-t-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-03-t-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (83,100) size 134x100
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (100,100) size 100x100
   RenderSVGContainer {g} at (0,0) size 100x100
 layer at (100,100) size 50x50

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/text-spacing-01-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/text-spacing-01-b-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 80x60
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (3,1) size 74x51
   RenderSVGContainer {g} at (0,0) size 74x50
 layer at (3,1) size 74x50

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/text-text-01-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/text-text-01-b-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
-  RenderSVGRoot {svg} at (0,0) size 160x120
+  RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (3,1) size 156x46
   RenderSVGContainer {g} at (0,0) size 156x111
 layer at (14,1) size 108x11

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -244,6 +244,13 @@ void RenderLayerModelObject::suspendAnimations(MonotonicTime time)
     layer()->backing()->suspendAnimations(time);
 }
 
+TransformationMatrix* RenderLayerModelObject::layerTransform() const
+{
+    if (hasLayer())
+        return layer()->transform();
+    return nullptr;
+}
+
 void RenderLayerModelObject::updateLayerTransform()
 {
     // Transform-origin depends on box size, so we need to update the layer transform after layout.

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -85,8 +85,9 @@ public:
     virtual void setCurrentSVGLayoutLocation(const LayoutPoint&) { ASSERT_NOT_REACHED(); }
 #endif
 
-    void updateLayerTransform();
+    TransformationMatrix* layerTransform() const;
 
+    virtual void updateLayerTransform();
     virtual void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> = RenderStyle::allTransformOperations) const = 0;
 
 protected:

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2020, 2021 Igalia S.L.
+ * Copyright (C) 2020, 2021, 2022 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -47,6 +47,7 @@
 #include "SVGContainerLayout.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
+#include "SVGLayerTransformUpdater.h"
 #include "SVGRenderingContext.h"
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
@@ -156,6 +157,14 @@ LayoutUnit RenderSVGRoot::computeReplacedLogicalHeight(std::optional<LayoutUnit>
     return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth);
 }
 
+bool RenderSVGRoot::updateLayoutSizeIfNeeded()
+{
+    auto previousSize = size();
+    updateLogicalWidth();
+    updateLogicalHeight();
+    return selfNeedsLayout() || (svgSVGElement().hasRelativeLengths() && previousSize != size());
+}
+
 void RenderSVGRoot::layout()
 {
     SetForScope change(m_inLayout, true);
@@ -167,41 +176,46 @@ void RenderSVGRoot::layout()
     // Arbitrary affine transforms are incompatible with RenderLayoutState.
     LayoutStateDisabler layoutStateDisabler(view().frameView().layoutContext());
 
-    bool needsLayout = selfNeedsLayout();
     LayoutRepainter repainter(*this, checkForRepaintDuringLayout());
 
-    auto previousLogicalSize = size();
-    updateLogicalWidth();
-    updateLogicalHeight();
-    m_isLayoutSizeChanged = needsLayout || (svgSVGElement().hasRelativeLengths() && previousLogicalSize != size());
-
-    auto oldTransform = m_supplementalLocalToParentTransform;
-    computeTransformationMatrices();
-
-    if (oldTransform != m_supplementalLocalToParentTransform)
-        m_didTransformToRootUpdate = true;
-    else if (previousLogicalSize != size())
-        m_didTransformToRootUpdate = true;
-
-    // FIXME: [LBSE] Upstream SVGLengthContext changes
-    // svgSVGElement().updateLengthContext();
-
-    // FIXME: [LBSE] Upstream SVGLayerTransformUpdater
-    // SVGLayerTransformUpdater transformUpdater(*this);
-    updateLayerInformation();
-
+    // Update layer transform before laying out children (SVG needs access to the transform matrices during layout for on-screen text font-size calculations).
+    // Eventually re-update if the transform reference box, relevant for transform-origin, has changed during layout.
+    //
+    // FIXME: LBSE should not repeat the same mistake -- remove the on-screen text font-size hacks that predate the modern solutions to this.
     {
-        SVGContainerLayout containerLayout(*this);
-        containerLayout.layoutChildren(needsLayout || SVGRenderSupport::filtersForceContainerLayout(*this));
+        ASSERT(!m_isLayoutSizeChanged);
+        SetForScope trackLayoutSizeChanges(m_isLayoutSizeChanged, updateLayoutSizeIfNeeded());
 
-        SVGBoundingBoxComputation boundingBoxComputation(*this);
-        m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration);
-
-        constexpr auto objectBoundingBoxDecorationWithoutTransformations = SVGBoundingBoxComputation::objectBoundingBoxDecoration | SVGBoundingBoxComputation::DecorationOption::IgnoreTransformations;
-        m_objectBoundingBoxWithoutTransformations = boundingBoxComputation.computeDecoratedBoundingBox(objectBoundingBoxDecorationWithoutTransformations);
-
-        m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
+        ASSERT(!m_didTransformToRootUpdate);
+        SVGLayerTransformUpdater transformUpdater(*this);
+        SetForScope trackTransformChanges(m_didTransformToRootUpdate, transformUpdater.layerTransformChanged());
+        layoutChildren();
     }
+
+    clearOverflow();
+    if (!shouldApplyViewportClip()) {
+        addVisualOverflow(visualOverflowRectEquivalent());
+        addVisualEffectOverflow();
+    }
+
+    invalidateBackgroundObscurationStatus();
+
+    repainter.repaintAfterLayout();
+    clearNeedsLayout();
+}
+
+void RenderSVGRoot::layoutChildren()
+{
+    SVGContainerLayout containerLayout(*this);
+    containerLayout.layoutChildren(selfNeedsLayout() || SVGRenderSupport::filtersForceContainerLayout(*this));
+
+    SVGBoundingBoxComputation boundingBoxComputation(*this);
+    m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration);
+
+    constexpr auto objectBoundingBoxDecorationWithoutTransformations = SVGBoundingBoxComputation::objectBoundingBoxDecoration | SVGBoundingBoxComputation::DecorationOption::IgnoreTransformations;
+    m_objectBoundingBoxWithoutTransformations = boundingBoxComputation.computeDecoratedBoundingBox(objectBoundingBoxDecorationWithoutTransformations);
+
+    m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
 
     if (!m_resourcesNeedingToInvalidateClients.isEmpty()) {
         // Invalidate resource clients, which may mark some nodes for layout.
@@ -210,26 +224,9 @@ void RenderSVGRoot::layout()
             SVGResourcesCache::clientStyleChanged(*resource, StyleDifference::Layout, resource->style());
         }
 
-        m_isLayoutSizeChanged = false;
-
-        SVGContainerLayout containerLayout(*this);
+        SetForScope clearLayoutSizeChanged(m_isLayoutSizeChanged, false);
         containerLayout.layoutChildren(false);
     }
-
-    m_isLayoutSizeChanged = false;
-    m_didTransformToRootUpdate = false;
-
-    clearOverflow();
-    if (!shouldApplyViewportClip()) {
-        auto visualOverflowRect = enclosingLayoutRect(m_viewBoxTransform.mapRect(visualOverflowRectEquivalent()));
-        addVisualOverflow(visualOverflowRect);
-        addVisualEffectOverflow();
-    }
-    invalidateBackgroundObscurationStatus();
-
-    repainter.repaintAfterLayout();
-
-    clearNeedsLayout();
 }
 
 bool RenderSVGRoot::shouldApplyViewportClip() const
@@ -388,23 +385,24 @@ void RenderSVGRoot::styleDidChange(StyleDifference diff, const RenderStyle* oldS
     SVGResourcesCache::clientStyleChanged(*this, diff, style());
 }
 
-void RenderSVGRoot::updateLayerInformation()
-{
-    /* FIXME: [LBSE] Upstream SVGRenderSupport changes
-    if (SVGRenderSupport::isRenderingDisabledDueToEmptySVGViewBox(*this))
-        layer()->dirtyAncestorChainVisibleDescendantStatus();
-     */
-}
-
 void RenderSVGRoot::updateFromStyle()
 {
     RenderReplaced::updateFromStyle();
 
-    setHasSVGTransform();
-    setHasTransformRelatedProperty();
-
     if (shouldApplyViewportClip())
         setHasNonVisibleOverflow();
+}
+
+void RenderSVGRoot::updateLayerTransform()
+{
+    RenderReplaced::updateLayerTransform();
+
+    if (!hasLayer())
+        return;
+
+    // An empty viewBox disables the rendering -- dirty the visible descendant status!
+    if (svgSVGElement().hasAttribute(SVGNames::viewBoxAttr) && svgSVGElement().hasEmptyViewBox())
+        layer()->dirtyVisibleContentStatus();
 }
 
 LayoutRect RenderSVGRoot::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext context) const
@@ -412,29 +410,7 @@ LayoutRect RenderSVGRoot::clippedOverflowRect(const RenderLayerModelObject* repa
     if (isInsideEntirelyHiddenLayer())
         return { };
 
-    auto repaintRect = LayoutRect(valueOrDefault(m_viewBoxTransform.inverse()).mapRect(borderBoxRect()));
-    return computeRect(repaintRect, repaintContainer, context);
-}
-
-void RenderSVGRoot::computeTransformationMatrices()
-{
-    // Compute SVG viewBox transformation against unscaled viewport.
-    auto viewportSize = currentViewportSize();
-    auto zoom = style().effectiveZoom();
-    if (zoom != 1)
-        viewportSize.scale(1.0 / zoom);
-    m_viewBoxTransform = svgSVGElement().viewBoxToViewTransform(viewportSize.width(), viewportSize.height());
-
-    // Compute total transformation matrix, taking border / padding (for child renderers that don't follow the CSS box model object!) + panning into account.
-    auto panning = svgSVGElement().currentTranslateValue();
-    auto contentLocation = contentBoxLocation();
-
-    m_supplementalLocalToParentTransform.makeIdentity();
-    m_supplementalLocalToParentTransform.translate(panning.x() + contentLocation.x(), panning.y() + contentLocation.y());
-    m_supplementalLocalToParentTransform.scale(zoom);
-
-    if (!m_viewBoxTransform.isIdentity())
-        m_supplementalLocalToParentTransform.multiply(m_viewBoxTransform);
+    return computeRect(borderBoxRect(), repaintContainer, context);
 }
 
 bool RenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)
@@ -487,7 +463,7 @@ void RenderSVGRoot::addResourceForClientInvalidation(RenderSVGResourceContainer*
     */
 }
 
-FloatSize RenderSVGRoot::currentViewportSize() const
+FloatSize RenderSVGRoot::computeViewportSize() const
 {
     FloatSize result = contentBoxRect().size();
     result.setWidth(result.width() + verticalScrollbarWidth());
@@ -612,8 +588,7 @@ LayoutRect RenderSVGRoot::overflowClipRect(const LayoutPoint& location, RenderFr
 
 void RenderSVGRoot::absoluteRects(Vector<IntRect>& rects, const LayoutPoint& accumulatedOffset) const
 {
-    auto localRect = LayoutRect(valueOrDefault(m_supplementalLocalToParentTransform.inverse()).mapRect(borderBoxRect()));
-    rects.append(snappedIntRect(accumulatedOffset, localRect.size()));
+    rects.append(snappedIntRect(accumulatedOffset, borderBoxRect().size()));
 }
 
 void RenderSVGRoot::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
@@ -622,7 +597,7 @@ void RenderSVGRoot::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) cons
     if (fragmentedFlow && fragmentedFlow->absoluteQuadsForBox(quads, wasFixed, this))
         return;
 
-    auto localRect = FloatRect(valueOrDefault(m_supplementalLocalToParentTransform.inverse()).mapRect(borderBoxRect()));
+    FloatRect localRect = borderBoxRect();
     quads.append(localToAbsoluteQuad(localRect, UseTransforms, wasFixed));
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2009 Google, Inc.  All rights reserved.
  * Copyright (C) 2009 Apple Inc. All rights reserved.
- * Copyright (C) 2020, 2021 Igalia S.L.
+ * Copyright (C) 2020, 2021, 2022 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -41,15 +41,12 @@ public:
     virtual ~RenderSVGRoot();
 
     SVGSVGElement& svgSVGElement() const;
-    FloatSize currentViewportSize() const;
-
-    const AffineTransform& viewBoxTransform() const { return m_viewBoxTransform; }
-    const AffineTransform& supplementalLocalToParentTransform() const { return m_supplementalLocalToParentTransform; }
+    FloatSize computeViewportSize() const;
 
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
 
-    void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, double& intrinsicRatio) const override;
+    void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, double& intrinsicRatio) const final;
 
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
     bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }
@@ -58,7 +55,7 @@ public:
     IntSize containerSize() const { return m_containerSize; }
     void setContainerSize(const IntSize& containerSize) { m_containerSize = containerSize; }
 
-    bool hasRelativeDimensions() const override;
+    bool hasRelativeDimensions() const final;
 
     // The flag is cleared at the beginning of each layout() pass. Elements then call this
     // method during layout when they are invalidated by a filter.
@@ -76,47 +73,44 @@ public:
 private:
     void element() const = delete;
 
-    bool isSVGRoot() const override { return true; }
-    ASCIILiteral renderName() const override { return "RenderSVGRoot"_s; }
-    bool requiresLayer() const override { return true; }
+    bool isSVGRoot() const final { return true; }
+    ASCIILiteral renderName() const final { return "RenderSVGRoot"_s; }
+    bool requiresLayer() const final { return true; }
+
+    bool updateLayoutSizeIfNeeded();
 
     // To prevent certain legacy code paths to hit assertions in debug builds, when switching off LBSE (during the teardown of the LBSE tree).
     std::optional<FloatRect> computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject*, VisibleRectContext) const final { return std::nullopt; }
 
-    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ComputeActual) const override;
-    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
-    void layout() override;
-    void paint(PaintInfo&, const LayoutPoint&) override;
-    void paintObject(PaintInfo&, const LayoutPoint&) override;
+    LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ComputeActual) const final;
+    LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const final;
+    void layout() final;
+    void layoutChildren();
+    void paint(PaintInfo&, const LayoutPoint&) final;
+    void paintObject(PaintInfo&, const LayoutPoint&) final;
     void paintContents(PaintInfo&, const LayoutPoint&);
 
-    void willBeDestroyed() override;
+    void willBeDestroyed() final;
 
-    void insertedIntoTree(IsInternalMove) override;
-    void willBeRemovedFromTree(IsInternalMove) override;
+    void insertedIntoTree(IsInternalMove) final;
+    void willBeRemovedFromTree(IsInternalMove) final;
 
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
-    void updateLayerInformation();
-    void updateFromStyle() override;
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
+    void updateFromStyle() final;
+    void updateLayerTransform() final;
 
-    bool fillContains(const FloatPoint&) const;
-    bool strokeContains(const FloatPoint&) const;
-    bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
-
-    void computeTransformationMatrices();
+    bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     LayoutRect overflowClipRect(const LayoutPoint& location, RenderFragmentContainer* = nullptr, OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const final;
-    LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext) const override;
+    LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext) const final;
 
-    void mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState&, OptionSet<MapCoordinatesMode>, bool* wasFixed) const override;
+    void mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState&, OptionSet<MapCoordinatesMode>, bool* wasFixed) const final;
 
-    void absoluteRects(Vector<IntRect>&, const LayoutPoint& accumulatedOffset) const override;
-    void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;
+    void absoluteRects(Vector<IntRect>&, const LayoutPoint& accumulatedOffset) const final;
+    void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const final;
 
-    bool canBeSelectionLeaf() const override { return false; }
-    bool canHaveChildren() const override { return true; }
-
-    void buildViewportTransform();
+    bool canBeSelectionLeaf() const final { return false; }
+    bool canHaveChildren() const final { return true; }
 
     bool m_inLayout { false };
     bool m_didTransformToRootUpdate { false };
@@ -126,8 +120,6 @@ private:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     FloatRect m_strokeBoundingBox;
-    AffineTransform m_viewBoxTransform;
-    AffineTransform m_supplementalLocalToParentTransform;
     HashSet<RenderSVGResourceContainer*> m_resourcesNeedingToInvalidateClients;
 };
 

--- a/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h
@@ -34,6 +34,8 @@ public:
             return;
 
         m_transformReferenceBox = m_renderer.transformReferenceBoxRect();
+        m_layerTransform = m_renderer.layerTransform();
+
         m_renderer.updateLayerTransform();
     }
 
@@ -47,9 +49,22 @@ public:
         m_renderer.updateLayerTransform();
     }
 
+    bool layerTransformChanged() const
+    {
+        auto* layerTransform = m_renderer.layerTransform();
+
+        bool hasTransform = !!layerTransform;
+        bool hadTransform = !!m_layerTransform;
+        if (hasTransform != hadTransform)
+            return true;
+
+        return hasTransform && (*layerTransform != *m_layerTransform);
+    }
+
 private:
     RenderLayerModelObject& m_renderer;
     FloatRect m_transformReferenceBox;
+    TransformationMatrix* m_layerTransform { nullptr };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c4a9f53874d4654a144b84c21cc25ca661af42a3
<pre>
[LBSE] Cleanup RenderSVGRoot code
<a href="https://bugs.webkit.org/show_bug.cgi?id=242715">https://bugs.webkit.org/show_bug.cgi?id=242715</a>

Reviewed by Rob Buis.

Cleanup the convoluted RenderSVGRoot code, get rid of the
viewBox transformations, which are going to be replaced
soon by a proper implementation, that only uses CSS Transforms
to realize viewBox.

For now get rid of the half-baked implementation, and report
correct metrics again for RenderSVGRoot (invariant under viewBox).

Update existing LBSE text expectations. Rendering is not affected
since there is no viewBox support during painting yet.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::layerTransform const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::updateLayoutSizeIfNeeded):
(WebCore::RenderSVGRoot::layout):
(WebCore::RenderSVGRoot::layoutChildren):
(WebCore::RenderSVGRoot::updateFromStyle):
(WebCore::RenderSVGRoot::updateLayerTransform):
(WebCore::RenderSVGRoot::clippedOverflowRect const):
(WebCore::RenderSVGRoot::computeViewportSize const):
(WebCore::RenderSVGRoot::overflowClipRect const):
(WebCore::RenderSVGRoot::absoluteRects const):
(WebCore::RenderSVGRoot::absoluteQuads const):
(WebCore::RenderSVGRoot::updateLayerInformation): Deleted.
(WebCore::RenderSVGRoot::computeTransformationMatrices): Deleted.
(WebCore::RenderSVGRoot::currentViewportSize const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/SVGLayerTransformUpdater.h:
(WebCore::SVGLayerTransformUpdater::SVGLayerTransformUpdater):
(WebCore::SVGLayerTransformUpdater::layerTransformChanged const):

Canonical link: <a href="https://commits.webkit.org/252450@main">https://commits.webkit.org/252450@main</a>
</pre>
