### PR TITLE
[LBSE] Cleanup RenderSVGContainer related code

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -37,7 +37,10 @@ public:
     virtual ~RenderSVGContainer();
 
     void paint(PaintInfo&, const LayoutPoint&) override;
+
     bool isObjectBoundingBoxValid() const { return m_objectBoundingBoxValid; }
+    bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
+    bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
@@ -51,15 +54,17 @@ protected:
     bool canHaveChildren() const final { return true; }
 
     void layout() override;
+
     virtual void layoutChildren();
-    bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
-
-    virtual void calculateViewport();
     virtual bool pointIsInsideViewportClip(const FloatPoint&) { return true; }
+    virtual bool updateLayoutSizeIfNeeded() { return false; }
 
+    bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     bool selfWillPaint();
 
     bool m_objectBoundingBoxValid { false };
+    bool m_isLayoutSizeChanged { false };
+    bool m_didTransformToRootUpdate { false };
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     FloatRect m_strokeBoundingBox;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -34,24 +34,20 @@ public:
     RenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
 
     bool isSVGTransformableContainer() const final { return true; }
-    void setHadTransformUpdate(bool value = true) { m_hadTransformUpdate = value; }
-    bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }
 
 private:
-    SVGGraphicsElement& graphicsElement() const;
+    // FIXME: Change renderName() for consistency in a follow-up commit
+    // ASCIILiteral renderName() const override { return "RenderSVGTransformableContainer"_s; }
 
     void element() const = delete;
+    SVGGraphicsElement& graphicsElement() const;
 
-    void layoutChildren() final;
-    void calculateViewport() final;
-    FloatPoint additionalContainerTranslation() const;
+    FloatSize additionalContainerTranslation() const;
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> = RenderStyle::allTransformOperations) const final;
-    void styleWillChange(StyleDifference, const RenderStyle& newStyle) final;
+    void updateLayerTransform() final;
     void updateFromStyle() final;
 
-    AffineTransform m_supplementalLocalToParentTransform;
-    bool m_didTransformToRootUpdate { false };
-    bool m_hadTransformUpdate { false };
+    AffineTransform m_supplementalLayerTransform;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0113dff599ec80b55049327eee2e378abd1da1c8
<pre>
[LBSE] Cleanup RenderSVGContainer related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=242718">https://bugs.webkit.org/show_bug.cgi?id=242718</a>

Reviewed by Rob Buis.

This unifies the main pieces of the container child layout logic in
RenderSVGContainer::layout(), in such a way that the logic is more
straightforward to follow (not having critical pieces of the logic
sprinkled across RenderSVG(Transformable|Viewport)Container) and to
assure that sensitive flags like &apos;m_didTransformToRootUpdate&apos; and
&apos;m_isLayoutSizeChanged&apos; are computed and stored in one place
instead of one per container renderer.

Use SetScope&lt;&gt; instead of manual updates of these flags to avoid any
undefined states.

The RenderSVGContainer layout logic now looks almost identical to
RenderSVGRoot - the LBSE variants are clean &amp; small compared to their
LegacyRenderSVG* counterparts.

Covered by existing tests, that were broken under LBSE before.
(No progressions as the affected tests are still broken compared
to legacy, due to other reasons, e.g. missing &lt;image&gt; support).

* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::layout):
(WebCore::RenderSVGContainer::calculateViewport): Deleted.
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
(WebCore::RenderSVGContainer::isLayoutSizeChanged const):
(WebCore::RenderSVGContainer::didTransformToRootUpdate const):
(WebCore::RenderSVGContainer::updateLayoutSizeIfNeeded):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::graphicsElement const):
(WebCore::RenderSVGTransformableContainer::additionalContainerTranslation const):
(WebCore::RenderSVGTransformableContainer::updateFromStyle):
(WebCore::RenderSVGTransformableContainer::updateLayerTransform):
(WebCore::RenderSVGTransformableContainer::applyTransform const):
(WebCore::RenderSVGTransformableContainer::calculateViewport): Deleted.
(WebCore::RenderSVGTransformableContainer::layoutChildren): Deleted.
(WebCore::RenderSVGTransformableContainer::styleWillChange): Deleted.
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:

Canonical link: <a href="https://commits.webkit.org/252466@main">https://commits.webkit.org/252466@main</a>
</pre>
