### PR TITLE
Add push subscriptions to apsd ignore list if necessary

### DIFF
--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -210,6 +210,7 @@ void xpc_dictionary_set_value(xpc_object_t, const char* key, xpc_object_t value)
 xpc_type_t xpc_get_type(xpc_object_t);
 const char* xpc_type_get_name(xpc_type_t);
 void xpc_main(xpc_connection_handler_t);
+xpc_object_t xpc_string_create(const char *string);
 const char* xpc_string_get_string_ptr(xpc_object_t);
 os_transaction_t os_transaction_create(const char *description);
 void xpc_transaction_exit_clean(void);

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -69,6 +69,14 @@ struct RemovedPushRecord {
     WEBCORE_EXPORT RemovedPushRecord isolatedCopy() &&;
 };
 
+struct PushTopics {
+    Vector<String> enabledTopics;
+    Vector<String> ignoredTopics;
+
+    WEBCORE_EXPORT PushTopics isolatedCopy() const &;
+    WEBCORE_EXPORT PushTopics isolatedCopy() &&;
+};
+
 class PushDatabase {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -86,17 +94,21 @@ public:
     WEBCORE_EXPORT void getRecordByTopic(const String& topic, CompletionHandler<void(std::optional<PushRecord>&&)>&&);
     WEBCORE_EXPORT void getRecordByBundleIdentifierAndScope(const String& bundleID, const String& scope, CompletionHandler<void(std::optional<PushRecord>&&)>&&);
     WEBCORE_EXPORT void getIdentifiers(CompletionHandler<void(HashSet<PushSubscriptionIdentifier>&&)>&&);
-    WEBCORE_EXPORT void getTopics(CompletionHandler<void(Vector<String>&&)>&&);
+    WEBCORE_EXPORT void getTopics(CompletionHandler<void(PushTopics&&)>&&);
 
     WEBCORE_EXPORT void incrementSilentPushCount(const String& bundleID, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
     WEBCORE_EXPORT void removeRecordsByBundleIdentifier(const String& bundleID, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
     WEBCORE_EXPORT void removeRecordsByBundleIdentifierAndSecurityOrigin(const String& bundleID, const String& securityOrigin, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);
 
+    WEBCORE_EXPORT void setPushesEnabledForOrigin(const String& bundleID, const String& securityOrigin, bool, CompletionHandler<void(bool recordsChanged)>&&);
+
 private:
     PushDatabase(Ref<WorkQueue>&&, UniqueRef<WebCore::SQLiteDatabase>&&);
     WebCore::SQLiteStatementAutoResetScope cachedStatementOnQueue(ASCIILiteral query);
     void dispatchOnWorkQueue(Function<void()>&&);
+
+    enum class SubscriptionSetState { Enabled, Ignored };
 
     Ref<WorkQueue> m_queue;
     UniqueRef<WebCore::SQLiteDatabase> m_db;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2372,6 +2372,17 @@ void NetworkProcess::processPushMessage(PAL::SessionID, WebPushMessage&&, PushPe
 #endif // ENABLE(BUILT_IN_NOTIFICATIONS)
 #endif // ENABLE(SERVICE_WORKER)
 
+void NetworkProcess::setPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& callback)
+{
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    if (auto* session = networkSession(sessionID)) {
+        session->notificationManager().setPushAndNotificationsEnabledForOrigin(origin, enabled, WTFMove(callback));
+        return;
+    }
+#endif
+    callback();
+}
+
 void NetworkProcess::deletePushAndNotificationRegistration(PAL::SessionID sessionID, const SecurityOriginData& origin, CompletionHandler<void(const String&)>&& callback)
 {
 #if ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -378,6 +378,7 @@ public:
     void processNotificationEvent(WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
 #endif
 
+    void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, URL&&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -211,6 +211,7 @@ messages -> NetworkProcess LegacyReceiver {
     ProcessPushMessage(PAL::SessionID sessionID, struct WebKit::WebPushMessage pushMessage, enum:uint8_t WebCore::PushPermissionState pushPermissionState) -> (bool didSucceed)
     ProcessNotificationEvent(struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType eventType) -> (bool didSucceed)
 #endif
+    SetPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin, bool enabled) -> ()
     DeletePushAndNotificationRegistration(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin) -> (String errorMessage)
     GetOriginsWithPushAndNotificationPermissions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
     HasPushSubscriptionForTesting(PAL::SessionID sessionID, URL scopeURL) -> (bool hasSubscription)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -63,6 +63,16 @@ void NetworkNotificationManager::requestSystemNotificationPermission(const Strin
     sendMessageWithReply<WebPushD::MessageType::RequestSystemNotificationPermission>(WTFMove(completionHandler), originString);
 }
 
+void NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin(const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& completionHandler)
+{
+    if (!m_connection) {
+        completionHandler();
+        return;
+    }
+
+    sendMessageWithReply<WebPushD::MessageType::SetPushAndNotificationsEnabledForOrigin>(WTFMove(completionHandler), origin.toString(), enabled);
+}
+
 void NetworkNotificationManager::deletePushAndNotificationRegistration(const SecurityOriginData& origin, CompletionHandler<void(const String&)>&& completionHandler)
 {
     if (!m_connection) {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -54,6 +54,7 @@ class NetworkNotificationManager : public NotificationManagerMessageHandler {
 public:
     NetworkSession& networkSession() const { return m_networkSession; }
 
+    void setPushAndNotificationsEnabledForOrigin(const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&&);

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -38,6 +38,7 @@ constexpr const char* protocolDebugMessageKey { "debug message" };
 constexpr const char* protocolDebugMessageLevelKey { "debug message level" };
 
 constexpr const char* protocolMessageTypeKey { "message type" };
+
 enum class MessageType : uint8_t {
     EchoTwice = 1,
     RequestSystemNotificationPermission,
@@ -56,6 +57,11 @@ enum class MessageType : uint8_t {
     RemoveAllPushSubscriptions,
     RemovePushSubscriptionsForOrigin,
     SetPublicTokenForTesting,
+    SetPushAndNotificationsEnabledForOrigin,
+};
+
+enum class RawXPCMessageType : uint8_t {
+    GetPushTopicsForTesting = 192,
 };
 
 inline bool messageTypeSendsReply(MessageType messageType)
@@ -76,6 +82,7 @@ inline bool messageTypeSendsReply(MessageType messageType)
     case MessageType::RemoveAllPushSubscriptions:
     case MessageType::RemovePushSubscriptionsForOrigin:
     case MessageType::SetPublicTokenForTesting:
+    case MessageType::SetPushAndNotificationsEnabledForOrigin:
         return true;
     case MessageType::SetDebugModeIsEnabled:
     case MessageType::UpdateConnectionConfiguration:

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1766,6 +1766,11 @@ void NetworkProcessProxy::processNotificationEvent(const NotificationData& data,
 }
 #endif // ENABLE(SERVICE_WORKER)
 
+void NetworkProcessProxy::setPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::SetPushAndNotificationsEnabledForOrigin { sessionID, origin, enabled }, WTFMove(callback));
+}
+
 void NetworkProcessProxy::deletePushAndNotificationRegistration(PAL::SessionID sessionID, const SecurityOriginData& origin, CompletionHandler<void(const String&)>&& callback)
 {
     sendWithAsyncReply(Messages::NetworkProcess::DeletePushAndNotificationRegistration { sessionID, origin }, WTFMove(callback));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -283,6 +283,7 @@ public:
     void processNotificationEvent(const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool wasProcessed)>&&);
 #endif
 
+    void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, const URL&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -277,35 +277,33 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
     }
 }
 
-void WebNotificationManagerProxy::providerDidUpdateNotificationPolicy(const API::SecurityOrigin* origin, bool allowed)
+static RefPtr<WebsiteDataStore> persistentDataStoreIfExists()
 {
-    LOG(Notifications, "Provider did update notification policy for origin %s to %i", origin->securityOrigin().toString().utf8().data(), allowed);
+    RefPtr<WebsiteDataStore> result;
+    WebsiteDataStore::forEachWebsiteDataStore([&result](WebsiteDataStore& dataStore) {
+        if (dataStore.isPersistent())
+            result = &dataStore;
+    });
+    return result;
+}
 
-    WebProcessPool::sendToAllRemoteWorkerProcesses(Messages::WebNotificationManager::DidUpdateNotificationDecision(origin->securityOrigin().toString(), allowed));
-
-    if (!processPool())
+static void setPushesAndNotificationsEnabledForOrigin(const WebCore::SecurityOriginData& origin, bool enabled)
+{
+    auto dataStore = persistentDataStoreIfExists();
+    if (!dataStore)
         return;
 
-    processPool()->sendToAllProcesses(Messages::WebNotificationManager::DidUpdateNotificationDecision(origin->securityOrigin().toString(), allowed));
+    dataStore->networkProcess().setPushAndNotificationsEnabledForOrigin(dataStore->sessionID(), origin, enabled, []() { });
 }
 
 static void removePushSubscriptionsForOrigins(const Vector<WebCore::SecurityOriginData>& origins)
 {
-    RefPtr<NetworkProcessProxy> networkProcess;
-    auto sessionID = PAL::SessionID::defaultSessionID();
-
-    WebsiteDataStore::forEachWebsiteDataStore([&networkProcess, &sessionID](WebsiteDataStore& dataStore) {
-        if (!networkProcess && dataStore.isPersistent()) {
-            networkProcess = &dataStore.networkProcess();
-            sessionID = dataStore.sessionID();
-        }
-    });
-
-    if (!networkProcess)
+    auto dataStore = persistentDataStoreIfExists();
+    if (!dataStore)
         return;
 
     for (auto& origin : origins)
-        networkProcess->deletePushAndNotificationRegistration(sessionID, origin, [originString = origin.toString()](auto&&) { });
+        dataStore->networkProcess().deletePushAndNotificationRegistration(dataStore->sessionID(), origin, [originString = origin.toString()](auto&&) { });
 }
 
 static Vector<WebCore::SecurityOriginData> apiArrayToSecurityOrigins(API::Array* origins)
@@ -336,6 +334,20 @@ static Vector<String> apiArrayToSecurityOriginStrings(API::Array* origins)
         originStrings.uncheckedAppend(origins->at<API::SecurityOrigin>(i)->securityOrigin().toString());
 
     return originStrings;
+}
+
+void WebNotificationManagerProxy::providerDidUpdateNotificationPolicy(const API::SecurityOrigin* origin, bool enabled)
+{
+    RELEASE_LOG(Notifications, "Provider did update notification policy for origin %" PRIVATE_LOG_STRING " to %d", origin->securityOrigin().toString().utf8().data(), enabled);
+
+    if (this == &sharedServiceWorkerManager()) {
+        setPushesAndNotificationsEnabledForOrigin(origin->securityOrigin(), enabled);
+        WebProcessPool::sendToAllRemoteWorkerProcesses(Messages::WebNotificationManager::DidUpdateNotificationDecision(origin->securityOrigin().toString(), enabled));
+        return;
+    }
+
+    if (processPool())
+        processPool()->sendToAllProcesses(Messages::WebNotificationManager::DidUpdateNotificationDecision(origin->securityOrigin().toString(), enabled));
 }
 
 void WebNotificationManagerProxy::providerDidRemoveNotificationPolicies(API::Array* origins)

--- a/Source/WebKit/webpushd/MockPushServiceConnection.h
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.h
@@ -39,19 +39,25 @@ public:
     void subscribe(const String& topic, const Vector<uint8_t>& vapidPublicKey, SubscribeHandler&&) override;
     void unsubscribe(const String& topic, const Vector<uint8_t>& vapidPublicKey, UnsubscribeHandler&&) override;
 
-    Vector<String> enabledTopics() override;
-    Vector<String> ignoredTopics() override;
-    Vector<String> opportunisticTopics() override;
-    Vector<String> nonWakingTopics() override;
+    Vector<String> enabledTopics() override { return m_enabledTopics; }
+    Vector<String> ignoredTopics() override { return m_ignoredTopics; }
+    Vector<String> opportunisticTopics() override { return m_opportunisticTopics; }
+    Vector<String> nonWakingTopics() override { return m_nonWakingTopics; }
 
-    void setEnabledTopics(Vector<String>&&) override;
-    void setIgnoredTopics(Vector<String>&&) override;
-    void setOpportunisticTopics(Vector<String>&&) override;
-    void setNonWakingTopics(Vector<String>&&) override;
+    void setEnabledTopics(Vector<String>&& enabledTopics) override { m_enabledTopics = enabledTopics; }
+    void setIgnoredTopics(Vector<String>&& ignoredTopics) override { m_ignoredTopics = ignoredTopics; }
+    void setOpportunisticTopics(Vector<String>&& opportunisticTopics) override { m_opportunisticTopics = opportunisticTopics; }
+    void setNonWakingTopics(Vector<String>&& nonWakingTopics) override { m_nonWakingTopics = nonWakingTopics; }
 
     void setTopicLists(TopicLists&&) override;
 
     void setPublicTokenForTesting(Vector<uint8_t>&&) override;
+
+private:
+    Vector<String> m_enabledTopics;
+    Vector<String> m_ignoredTopics;
+    Vector<String> m_opportunisticTopics;
+    Vector<String> m_nonWakingTopics;
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/MockPushServiceConnection.mm
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.mm
@@ -65,44 +65,12 @@ void MockPushServiceConnection::unsubscribe(const String&, const Vector<uint8_t>
     handler(true, nil);
 }
 
-Vector<String> MockPushServiceConnection::enabledTopics()
+void MockPushServiceConnection::setTopicLists(TopicLists&& topics)
 {
-    return { };
-}
-
-Vector<String> MockPushServiceConnection::ignoredTopics()
-{
-    return { };
-}
-
-Vector<String> MockPushServiceConnection::opportunisticTopics()
-{
-    return { };
-}
-
-Vector<String> MockPushServiceConnection::nonWakingTopics()
-{
-    return { };
-}
-
-void MockPushServiceConnection::setEnabledTopics(Vector<String>&& topics)
-{
-}
-
-void MockPushServiceConnection::setIgnoredTopics(Vector<String>&& topics)
-{
-}
-
-void MockPushServiceConnection::setOpportunisticTopics(Vector<String>&& topics)
-{
-}
-
-void MockPushServiceConnection::setNonWakingTopics(Vector<String>&& topics)
-{
-}
-
-void MockPushServiceConnection::setTopicLists(TopicLists&& topicLists)
-{
+    setEnabledTopics(WTFMove(topics.enabledTopics));
+    setIgnoredTopics(WTFMove(topics.ignoredTopics));
+    setOpportunisticTopics(WTFMove(topics.opportunisticTopics));
+    setNonWakingTopics(WTFMove(topics.nonWakingTopics));
 }
 
 void MockPushServiceConnection::setPublicTokenForTesting(Vector<uint8_t>&& token)

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -57,9 +57,14 @@ public:
     PushServiceConnection& connection() { return m_connection; }
     WebCore::PushDatabase& database() { return m_database; }
 
+    Vector<String> enabledTopics() { return m_connection->enabledTopics(); }
+    Vector<String> ignoredTopics() { return m_connection->ignoredTopics(); }
+
     void getSubscription(const String& bundleIdentifier, const String& scope, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&&);
     void subscribe(const String& bundleIdentifier, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);
     void unsubscribe(const String& bundleIdentifier, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
+
+    void setPushesEnabledForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, bool, CompletionHandler<void()>&&);
 
     void removeRecordsForBundleIdentifier(const String& bundleIdentifier, CompletionHandler<void(unsigned)>&&);
     void removeRecordsForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -75,6 +75,7 @@ public:
     void echoTwice(ClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
     void requestSystemNotificationPermission(ClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
     void getOriginsWithPushAndNotificationPermissions(ClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
+    void setPushAndNotificationsEnabledForOrigin(ClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
     void deletePushRegistration(const String&, const String&, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(ClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);
     void setDebugModeIsEnabled(ClientConnection*, bool);
@@ -82,6 +83,7 @@ public:
     void injectPushMessageForTesting(ClientConnection*, const PushMessageForTesting&, CompletionHandler<void(bool)>&&);
     void injectEncryptedPushMessageForTesting(ClientConnection*, const String&, CompletionHandler<void(bool)>&&);
     void getPendingPushMessages(ClientConnection*, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
+    void getPushTopicsForTesting(OSObjectPtr<xpc_object_t>&&);
     void subscribeToPushService(ClientConnection*, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
     void unsubscribeFromPushService(ClientConnection*, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
     void getPushSubscription(ClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
@@ -98,6 +100,7 @@ private:
     Daemon();
 
     CompletionHandler<void(EncodedMessage&&)> createReplySender(WebKit::WebPushD::MessageType, OSObjectPtr<xpc_object_t>&& request);
+    void decodeAndHandleRawXPCMessage(WebKit::WebPushD::RawXPCMessageType, OSObjectPtr<xpc_object_t>&&);
     void decodeAndHandleMessage(xpc_connection_t, WebKit::WebPushD::MessageType, Span<const uint8_t> encodedMessage, CompletionHandler<void(EncodedMessage&&)>&&);
 
     bool canRegisterForNotifications(ClientConnection&);


### PR DESCRIPTION
#### 94e15b227a3ceda11fadfb31f3bde8e9d40d5ae8
<pre>
Add push subscriptions to apsd ignore list if necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=242719">https://bugs.webkit.org/show_bug.cgi?id=242719</a>
&lt;rdar://problem/91586206&gt;

Reviewed by Chris Dumez.

Currently, if a user changes the notification permission for an origin from Allow to Deny in the
browser settings pane, we don&apos;t communicate this change to apsd. This means that pushes from this
origin can continue to wake the device and induce battery drain even though the push will always be
useless, as we bail out of running push event handlers early when we detect that an origin is
missing the notification permission.

To fix this, we now add or remove push topics from the apsd ignore list when the user denies or
allows push permissions for an origin (in the call to providerDidUpdateNotificationPolicy).

Note that moving a topic to the ignore list does not delete the associated PushSubscription. It&apos;s
more like putting the subscription in a paused state that can be re-enabled later by adding the
topic back to the enabled list. This matches the behavior of native app push subscriptions when the
notification preference is toggled for native apps.

* Source/WebCore/Modules/push-api/PushDatabase.cpp: Update schema to add a state column that tracks enabled/ignored state.
(WebCore::PushTopics::isolatedCopy const):
(WebCore::PushTopics::isolatedCopy):
(WebCore::PushDatabase::insertRecord):
(WebCore::PushDatabase::getTopics):
(WebCore::PushDatabase::setPushesEnabledForOrigin):
* Source/WebCore/Modules/push-api/PushDatabase.h:

* Source/WebKit/NetworkProcess/NetworkProcess.cpp: Forward the setPushAndNotificationsEnabledForOrigin message to webpushd.
(WebKit::NetworkProcess::setPushAndNotificationsEnabledForOrigin):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::messageTypeSendsReply):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::setPushAndNotificationsEnabledForOrigin):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:

* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp: Call setPushAndNotificationsEnabledForOrigin when the user changes the notification permissions from Allow to Deny or vice-versa.
(WebKit::persistentDataStoreIfExists):
(WebKit::setPushesAndNotificationsEnabledForOrigin):
(WebKit::removePushSubscriptionsForOrigins):
(WebKit::WebNotificationManagerProxy::providerDidUpdateNotificationPolicy):
* Source/WebKit/webpushd/MockPushServiceConnection.h:
* Source/WebKit/webpushd/MockPushServiceConnection.mm:
* Source/WebKit/webpushd/PushService.h:
(WebPushD::PushService::enabledTopics):
(WebPushD::PushService::ignoredTopics):

* Source/WebKit/webpushd/PushService.mm: Move topics to the enabled or ignored list as necessary when the database state changes.
(WebPushD::updateTopicLists):
(WebPushD::PushService::setPushesEnabledForBundleIdentifierAndOrigin):

* Source/WebKit/webpushd/WebPushDaemon.h: Add a new raw XPC message type that can be used for sending messages from integration tests directly to webpushd without going through NetworkProcess.
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::Daemon::connectionEventHandler):
(WebPushD::Daemon::decodeAndHandleRawXPCMessage):
(WebPushD::Daemon::decodeAndHandleMessage):
(WebPushD::Daemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::toXPCArray):
(WebPushD::Daemon::getPushTopicsForTesting):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::getTopicsSync):
(TestWebKitAPI::PushDatabaseTest::getTopics):
(TestWebKitAPI::PushDatabaseTest::setPushesEnabledForOrigin):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::addMessageTypeHeaders):
(TestWebKitAPI::createMessageDictionary):
(TestWebKitAPI::toStringVector):

Canonical link: <a href="https://commits.webkit.org/252434@main">https://commits.webkit.org/252434@main</a>
</pre>
