### PR TITLE
[Cocoa][MSE] Fix SourceBufferParserWebM logging

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -189,6 +189,7 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(const ui
     MediaTime duration;
     RefPtr<AudioTrackPrivateWebM> track;
     Vector<Ref<MediaSampleAVFObjC>> samples;
+    parser->setLogger(m_logger, m_logIdentifier);
     parser->setDidEncounterErrorDuringParsingCallback([&](uint64_t) {
         error = true;
     });

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -89,6 +89,9 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateAVFObjC::addSourceBuffer(const C
     auto parser = SourceBufferParser::create(contentType, webMParserEnabled);
     if (!parser)
         return AddStatus::NotSupported;
+#if !RELEASE_LOG_DISABLED
+    parser->setLogger(m_logger, m_logIdentifier);
+#endif
 
     auto newSourceBuffer = SourceBufferPrivateAVFObjC::create(this, parser.releaseNonNull());
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -27,8 +27,10 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "Logging.h"
 #include "SourceBufferParser.h"
 #include <wtf/Box.h>
+#include <wtf/LoggerHelper.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -43,7 +45,10 @@ typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 
 namespace WebCore {
 
-class SourceBufferParserAVFObjC final : public SourceBufferParser, public CanMakeWeakPtr<SourceBufferParserAVFObjC> {
+class SourceBufferParserAVFObjC final
+    : public SourceBufferParser
+    , public CanMakeWeakPtr<SourceBufferParserAVFObjC>
+    , private LoggerHelper {
 public:
     static MediaPlayerEnums::SupportsType isContentTypeSupported(const ContentType&);
 
@@ -73,7 +78,10 @@ public:
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const { return m_logger.get(); }
-    const void* logIdentifier() const { return m_logIdentifier; }
+    const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
+    const void* logIdentifier() const final { return m_logIdentifier; }
+    const char* logClassName() const final { return "SourceBufferParserAVFObjC"; }
+    WTFLogChannel& logChannel() const final { return LogMedia; }
 #endif
 
     RetainPtr<AVStreamDataParser> m_parser;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -42,7 +42,6 @@
 #include "WebMAudioUtilitiesCocoa.h"
 #include <webm/webm_parser.h>
 #include <wtf/Algorithms.h>
-#include <wtf/LoggerHelper.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/StdList.h>
 #include <wtf/darwin/WeakLinking.h>
@@ -232,9 +231,6 @@ template<> struct LogArgument<webm::Id> {
 } // namespace WTF
 
 namespace WebCore {
-
-static WTFLogChannel& logChannel() { return LogMedia; }
-static const char* logClassName() { return "SourceBufferParserWebM"; }
 
 // FIXME: Remove this once kCMVideoCodecType_VP9 is added to CMFormatDescription.h
 constexpr CMVideoCodecType kCMVideoCodecType_VP9 { 'vp09' };
@@ -536,7 +532,10 @@ WebMParser::WebMParser(Callback& callback)
 {
 }
 
-WebMParser::~WebMParser() = default;
+WebMParser::~WebMParser()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+}
 
 void WebMParser::resetState()
 {
@@ -554,6 +553,7 @@ void WebMParser::resetState()
 
 void WebMParser::reset()
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_reader->reset();
     m_parser->DidSeek();
 }
@@ -607,14 +607,21 @@ ExceptionOr<int> WebMParser::parse(SourceBufferParser::Segment&& segment)
     return m_status.code;
 }
 
-void WebMParser::setLogger(const Logger& logger, const void* logIdentifier)
+void WebMParser::setLogger(const Logger& newLogger, const void* newLogIdentifier)
 {
-    m_logger = &logger;
-    m_logIdentifier = logIdentifier;
+    m_logger = &newLogger;
+    m_logIdentifier = newLogIdentifier;
+    ALWAYS_LOG(LOGIDENTIFIER);
+}
+
+WTFLogChannel& WebMParser::logChannel() const
+{
+    return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, Media);
 }
 
 void WebMParser::invalidate()
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_parser = nullptr;
     m_tracks.clear();
     m_initializationSegment = nullptr;
@@ -1267,6 +1274,11 @@ SourceBufferParserWebM::SourceBufferParserWebM()
 {
 }
 
+SourceBufferParserWebM::~SourceBufferParserWebM()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+}
+
 bool SourceBufferParserWebM::isWebMFormatReaderAvailable()
 {
     return PlatformMediaSessionManager::webMFormatReaderEnabled() && canLoadFormatReader() && isWebmParserAvailable();
@@ -1515,13 +1527,23 @@ void SourceBufferParserWebM::invalidate()
     m_parser.invalidate();
 }
 
-void SourceBufferParserWebM::setLogger(const Logger& logger, const void* logIdentifier)
+void SourceBufferParserWebM::setLogger(const Logger& newLogger, const void* newLogIdentifier)
 {
-    m_parser.setLogger(logger, logIdentifier);
+    m_logger = &newLogger;
+    m_logIdentifier = newLogIdentifier;
+    ALWAYS_LOG(LOGIDENTIFIER);
+    
+    m_parser.setLogger(newLogger, newLogIdentifier);
+}
+
+WTFLogChannel& SourceBufferParserWebM::logChannel() const
+{
+    return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, Media);
 }
 
 void SourceBufferParserWebM::setMinimumAudioSampleDuration(float duration)
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, duration);
     m_minimumAudioSampleDuration = MediaTime::createWithFloat(duration);
 }
 

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
@@ -53,19 +53,6 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static const void* nextLogIdentifier()
-{
-    static uint64_t logIdentifier = cryptographicallyRandomNumber();
-    return reinterpret_cast<const void*>(++logIdentifier);
-}
-
-static WTFLogChannel& logChannel()
-{
-    return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, Media);
-}
-
-static const char* logClassName() { return "MediaFormatReader"; }
-
 class AbortAction {
 public:
     AbortAction(Condition& condition)
@@ -305,6 +292,17 @@ OSStatus MediaFormatReader::copyTrackArray(CFArrayRef* trackArrayCopy)
 const void* MediaFormatReader::nextTrackReaderLogIdentifier(uint64_t trackID) const
 {
     return LoggerHelper::childLogIdentifier(m_logIdentifier, trackID);
+}
+
+const void* MediaFormatReader::nextLogIdentifier()
+{
+    static uint64_t logIdentifier = cryptographicallyRandomNumber();
+    return reinterpret_cast<const void*>(++logIdentifier);
+}
+
+WTFLogChannel& MediaFormatReader::logChannel()
+{
+    return JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, Media);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
@@ -83,6 +83,9 @@ private:
     // WrapperClass
     OSStatus copyTrackArray(CFArrayRef*);
     
+    static const void* nextLogIdentifier();
+    static WTFLogChannel& logChannel();
+    static const char* logClassName() { return "MediaFormatReader"; }
     const void* logIdentifier() const { return m_logIdentifier; }
 
     RetainPtr<MTPluginByteSourceRef> m_byteSource WTF_GUARDED_BY_LOCK(m_parseTracksLock);


### PR DESCRIPTION
#### d6399ef829dd61ecf3b9f3058437e65ff78067b1
<pre>
[Cocoa][MSE] Fix SourceBufferParserWebM logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=242720">https://bugs.webkit.org/show_bug.cgi?id=242720</a>

Reviewed by Jean-Yves Avenard.

Currently, the logger for SourceBufferParsers are not being set within
MediaSourcePrivateAVFObjC. Futhermore, the setLogger function within
SourceBufferParserWebM never sets its own logger and log identifier, leading
to no logs ever being outputted.

* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::~SourceBufferParserAVFObjC):
(WebCore::SourceBufferParserAVFObjC::appendData):
(WebCore::SourceBufferParserAVFObjC::flushPendingMediaData):
(WebCore::SourceBufferParserAVFObjC::setShouldProvideMediaDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::shouldProvideMediadataForTrackID):
(WebCore::SourceBufferParserAVFObjC::resetParserState):
(WebCore::SourceBufferParserAVFObjC::invalidate):
(WebCore::SourceBufferParserAVFObjC::setLogger):
(WebCore::SourceBufferParserAVFObjC::didParseStreamDataAsAsset):
(WebCore::SourceBufferParserAVFObjC::didFailToParseStreamDataWithError):
(WebCore::SourceBufferParserAVFObjC::didProvideMediaDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferParserAVFObjC::didProvideContentKeyRequestSpecifierForTrackID):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::~WebMParser):
(WebCore::WebMParser::reset):
(WebCore::WebMParser::setLogger):
(WebCore::WebMParser::logChannel const):
(WebCore::WebMParser::invalidate):
(WebCore::SourceBufferParserWebM::~SourceBufferParserWebM):
(WebCore::SourceBufferParserWebM::setLogger):
(WebCore::SourceBufferParserWebM::setMinimumAudioSampleDuration):
(WebCore::SourceBufferParserWebM::logChannel const):
(WebCore::logChannel): Deleted.
(WebCore::logClassName): Deleted.
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::TrackData::logChannel const):
(WebCore::WebMParser::VideoTrackData::logClassName const):
(WebCore::WebMParser::AudioTrackData::logClassName const):
(WebCore::WebMParser::VideoTrackData::logChannel const): Deleted.
(WebCore::WebMParser::AudioTrackData::logChannel const): Deleted.
(WebCore::WebMParser::loggerPtr const):
(WebCore::SourceBufferParserWebM::loggerPtr const):
(WebCore::WebMParser::logIdentifier const): Deleted.
(WebCore::SourceBufferParserWebM::logIdentifier const): Deleted.
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp:
(WebKit::MediaFormatReader::nextLogIdentifier):
(WebKit::MediaFormatReader::logChannel):
(WebKit::nextLogIdentifier): Deleted.
(WebKit::logChannel): Deleted.
(WebKit::logClassName): Deleted.
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h:

Canonical link: <a href="https://commits.webkit.org/252482@main">https://commits.webkit.org/252482@main</a>
</pre>
