### PR TITLE
Crash if IOHIDDeviceCopyMatchingElements returns null

### DIFF
--- a/Source/WebCore/platform/mac/HIDDevice.cpp
+++ b/Source/WebCore/platform/mac/HIDDevice.cpp
@@ -76,7 +76,8 @@ Vector<HIDElement> HIDDevice::uniqueInputElementsInDeviceTreeOrder() const
     Deque<IOHIDElementRef> elementQueue;
 
     RetainPtr<CFArrayRef> elements = adoptCF(IOHIDDeviceCopyMatchingElements(m_rawDevice.get(), NULL, kIOHIDOptionsTypeNone));
-    for (CFIndex i = 0; i < CFArrayGetCount(elements.get()); ++i)
+    CFIndex count = elements ? CFArrayGetCount(elements.get()) : 0;
+    for (CFIndex i = 0; count; ++i)
         elementQueue.append(checked_cf_cast<IOHIDElementRef>(CFArrayGetValueAtIndex(elements.get(), i)));
 
     Vector<HIDElement> result;


### PR DESCRIPTION
#### f0fbb371107ffb52fa6c6622d7918045ca4e92fa
<pre>
Crash if IOHIDDeviceCopyMatchingElements returns null
<a href="https://bugs.webkit.org/show_bug.cgi?id=242721">https://bugs.webkit.org/show_bug.cgi?id=242721</a>
&lt;rdar://70867237&gt;

Reviewed by Tim Horton.

* Source/WebCore/platform/mac/HIDDevice.cpp:
(WebCore::HIDDevice::uniqueInputElementsInDeviceTreeOrder const): Null check the returned elements array.

Canonical link: <a href="https://commits.webkit.org/252428@main">https://commits.webkit.org/252428@main</a>
</pre>
