### PR TITLE
Disable GlyphDisplayListCache tests on WK1

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1845,6 +1845,9 @@ webkit.org/b/240081 [ Debug ]  webaudio/AudioBuffer/huge-buffer.html [ Pass Slow
 # This test has been timing out on WK1 since IntersectionObserver was enabled.
 intersection-observer/observe-then-disconnect-target.html [ Skip ]
 
+# These tests rely on painting during the test, which DRT doesn't do.
+fast/text/glyph-display-lists [ Skip ]
+
 # rdar://82399990 ([ Catalina EWS ] webgl/2.0.0/* tests are flaky crashing ASSERTION FAILED: !needsLayout() (229580)) Disable webgl tests for mac-wk1
 webgl [ Skip ]
 


### PR DESCRIPTION
#### cbec770dec08b1e7717fefa90db5cdb7817e47fb
<pre>
Disable GlyphDisplayListCache tests on WK1
<a href="https://bugs.webkit.org/show_bug.cgi?id=242722">https://bugs.webkit.org/show_bug.cgi?id=242722</a>
rdar://96954416

Unreviewed test gardening.

These tests rely on repainting during the test, which DRT doesn&apos;t do.

* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252427@main">https://commits.webkit.org/252427@main</a>
</pre>
