### PR TITLE
Fix canPlayType for WebM VP8 on older Macs without VP9

### DIFF
--- a/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9-expected.txt
+++ b/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9-expected.txt
@@ -1,0 +1,11 @@
+
+Test that WebM VP8 is supported when the VP9 decoder is not available.
+
+These tests may be expected to fail if the WebKit port does not support the format.
+
+Forcing VP9 decoder to be enabled.
+EXPECTED (MediaSource.isTypeSupported('video/webm; codecs=vp8') == 'true') OK
+Forcing VP9 decoder to be disabled.
+EXPECTED (MediaSource.isTypeSupported('video/webm; codecs=vp8.0') == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
+++ b/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../video-test.js"></script>
+        <script>
+            function start() {
+                if (!window.internals) {
+                    failTest('This test requires window.internals.');
+                    return;
+                }
+
+                consoleWrite('Forcing VP9 decoder to be enabled.')
+                internals.setVP9DecoderDisabledForTesting(false);
+                testExpected("MediaSource.isTypeSupported('video/webm; codecs=vp8')", true);
+
+                consoleWrite('Forcing VP9 decoder to be disabled.')
+                internals.setVP9DecoderDisabledForTesting(true);
+                // vp8.0 is used since isTypeSupported caches results
+                testExpected("MediaSource.isTypeSupported('video/webm; codecs=vp8.0')", true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="start()">
+        <video controls></video>
+        <p>Test that WebM VP8 is supported when the VP9 decoder is not available.</p>
+        <p>These tests may be expected to fail if the WebKit port does not support the format.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1310,6 +1310,7 @@ MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(co
     bool isAnyCodecAvailable = isAnyAudioCodecAvailable;
 #if ENABLE(VP9)
     isAnyCodecAvailable |= isVP9DecoderAvailable();
+    isAnyCodecAvailable |= isVP8DecoderAvailable();
 #endif
 
     if (!isAnyCodecAvailable)
@@ -1321,14 +1322,13 @@ MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(co
 
     for (auto& codec : codecs) {
 #if ENABLE(VP9)
-        if (codec.startsWith("vp09"_s)
-            || codec.startsWith("vp08"_s)
-            || equal(codec, "vp8"_s)
-            || equal(codec, "vp9"_s)
-            || equal(codec, "vp8.0"_s)
-            || equal(codec, "vp9.0"_s)) {
+        bool isVP9 = codec.startsWith("vp09"_s) || equal(codec, "vp9"_s) || equal(codec, "vp9.0"_s);
+        bool isVP8 = codec.startsWith("vp08"_s) || equal(codec, "vp8"_s) || equal(codec, "vp8.0"_s);
+        if (isVP9 || isVP8) {
 
-            if (!isVP9DecoderAvailable())
+            if (isVP9 && !isVP9DecoderAvailable())
+                return MediaPlayerEnums::SupportsType::IsNotSupported;
+            if (isVP8 && !isVP8DecoderAvailable())
                 return MediaPlayerEnums::SupportsType::IsNotSupported;
 
             auto codecParameters = parseVPCodecParameters(codec);

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -75,6 +75,9 @@ public:
 
     void setHardwareDecoderDisabled(std::optional<bool>&&);
     std::optional<bool> hardwareDecoderDisabled() { return m_hardwareDecoderDisabled; }
+    
+    void setVP9DecoderDisabled(std::optional<bool>&&);
+    std::optional<bool> vp9DecoderDisabled() { return m_vp9DecoderDisabled; }
 
     void setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&&);
     std::optional<ScreenDataOverrides> vp9ScreenSizeAndScale()  { return m_screenSizeAndScale; }
@@ -83,6 +86,7 @@ public:
 
 private:
     std::optional<bool> m_hardwareDecoderDisabled;
+    std::optional<bool> m_vp9DecoderDisabled;
     std::optional<ScreenDataOverrides> m_screenSizeAndScale;
     Function<void()> m_configurationChangedCallback;
 };

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -63,6 +63,13 @@ void VP9TestingOverrides::setHardwareDecoderDisabled(std::optional<bool>&& disab
         m_configurationChangedCallback();
 }
 
+void VP9TestingOverrides::setVP9DecoderDisabled(std::optional<bool>&& disabled)
+{
+    m_vp9DecoderDisabled = WTFMove(disabled);
+    if (m_configurationChangedCallback)
+        m_configurationChangedCallback();
+}
+
 void VP9TestingOverrides::setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&& overrides)
 {
     m_screenSizeAndScale = WTFMove(overrides);
@@ -124,6 +131,9 @@ void registerSupplementalVP9Decoder()
 
 bool isVP9DecoderAvailable()
 {
+    if (auto disabledForTesting = VP9TestingOverrides::singleton().vp9DecoderDisabled())
+        return !*disabledForTesting;
+
 #if PLATFORM(IOS)
     return canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9);
 #else

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -706,6 +706,7 @@ Internals::Internals(Document& document)
 
 #if ENABLE(VP9) && PLATFORM(COCOA)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(std::nullopt);
+    VP9TestingOverrides::singleton().setVP9DecoderDisabled(std::nullopt);
     VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(std::nullopt);
 #endif
 }
@@ -6413,6 +6414,15 @@ void Internals::setHardwareVP9DecoderDisabledForTesting(bool disabled)
 {
 #if ENABLE(VP9) && PLATFORM(COCOA)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(disabled);
+#else
+    UNUSED_PARAM(disabled);
+#endif
+}
+
+void Internals::setVP9DecoderDisabledForTesting(bool disabled)
+{
+#if ENABLE(VP9) && PLATFORM(COCOA)
+    VP9TestingOverrides::singleton().setVP9DecoderDisabled(disabled);
 #else
     UNUSED_PARAM(disabled);
 #endif

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1237,6 +1237,7 @@ public:
     void setSystemHasACForTesting(bool);
 
     void setHardwareVP9DecoderDisabledForTesting(bool);
+    void setVP9DecoderDisabledForTesting(bool);
     void setVP9ScreenSizeAndScaleForTesting(double, double, double);
 
     int readPreferenceInteger(const String& domain, const String& key);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1107,6 +1107,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setSystemHasACForTesting(boolean hasAC);
 
     undefined setHardwareVP9DecoderDisabledForTesting(boolean disabled);
+    undefined setVP9DecoderDisabledForTesting(boolean disabled);
     undefined setVP9ScreenSizeAndScaleForTesting(double width, double height, double scale);
 
     long readPreferenceInteger(DOMString domain, DOMString key);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -710,6 +710,7 @@ void GPUConnectionToWebProcess::setMediaOverridesForTesting(MediaOverridesForTes
 {
 #if ENABLE(VP9) && PLATFORM(COCOA)
     VP9TestingOverrides::singleton().setHardwareDecoderDisabled(WTFMove(overrides.vp9HardwareDecoderDisabled));
+    VP9TestingOverrides::singleton().setVP9DecoderDisabled(WTFMove(overrides.vp9DecoderDisabled));
     VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(WTFMove(overrides.vp9ScreenSizeAndScale));
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -400,7 +400,9 @@ void GPUProcessConnection::updateMediaConfiguration()
         settingsChanged = true;
 
 #if ENABLE(VP9)
-    if (m_mediaOverridesForTesting.vp9HardwareDecoderDisabled != VP9TestingOverrides::singleton().hardwareDecoderDisabled() || m_mediaOverridesForTesting.vp9ScreenSizeAndScale != VP9TestingOverrides::singleton().vp9ScreenSizeAndScale())
+    if (m_mediaOverridesForTesting.vp9HardwareDecoderDisabled != VP9TestingOverrides::singleton().hardwareDecoderDisabled()
+        || m_mediaOverridesForTesting.vp9DecoderDisabled != VP9TestingOverrides::singleton().vp9DecoderDisabled()
+        || m_mediaOverridesForTesting.vp9ScreenSizeAndScale != VP9TestingOverrides::singleton().vp9ScreenSizeAndScale())
         settingsChanged = true;
 #endif
 
@@ -413,6 +415,7 @@ void GPUProcessConnection::updateMediaConfiguration()
 
 #if ENABLE(VP9)
         .vp9HardwareDecoderDisabled = VP9TestingOverrides::singleton().hardwareDecoderDisabled(),
+        .vp9DecoderDisabled = VP9TestingOverrides::singleton().vp9DecoderDisabled(),
         .vp9ScreenSizeAndScale = VP9TestingOverrides::singleton().vp9ScreenSizeAndScale(),
 #endif
     };

--- a/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h
@@ -36,6 +36,7 @@ struct MediaOverridesForTesting {
     std::optional<bool> systemHasBattery;
 
     std::optional<bool> vp9HardwareDecoderDisabled;
+    std::optional<bool> vp9DecoderDisabled;
     std::optional<WebCore::ScreenDataOverrides> vp9ScreenSizeAndScale;
 
     template<class Encoder>
@@ -44,6 +45,7 @@ struct MediaOverridesForTesting {
         encoder << systemHasAC;
         encoder << systemHasBattery;
         encoder << vp9HardwareDecoderDisabled;
+        encoder << vp9DecoderDisabled;
         encoder << vp9ScreenSizeAndScale;
     }
 
@@ -64,6 +66,11 @@ struct MediaOverridesForTesting {
         decoder >> vp9HardwareDecoderDisabled;
         if (!vp9HardwareDecoderDisabled)
             return std::nullopt;
+        
+        std::optional<std::optional<bool>> vp9DecoderDisabled;
+        decoder >> vp9DecoderDisabled;
+        if (!vp9DecoderDisabled)
+            return std::nullopt;
 
         std::optional<std::optional<WebCore::ScreenDataOverrides>> vp9ScreenSizeAndScale;
         decoder >> vp9ScreenSizeAndScale;
@@ -74,6 +81,7 @@ struct MediaOverridesForTesting {
             *systemHasAC,
             *systemHasBattery,
             *vp9HardwareDecoderDisabled,
+            *vp9DecoderDisabled,
             *vp9ScreenSizeAndScale,
         }};
     }


### PR DESCRIPTION
#### 5706f1c79429a78d8dadf72c0a9293cf8bb0fa29
<pre>
Fix canPlayType for WebM VP8 on older Macs without VP9
<a href="https://bugs.webkit.org/show_bug.cgi?id=241920">https://bugs.webkit.org/show_bug.cgi?id=241920</a>

Reviewed by Eric Carlson and Jean-Yves Avenard.
Original patch by: Brion Vibber &lt;brion@pobox.com&gt;
Patch amended by: Youssef Soliman &lt;y_soliman@apple.com&gt;

SourceBufferParserWebM::isContentTypeSupported called
isVP9DecoderAvailable for both VP9 and VP8 codecs, which caused
some older Macs to misreport a failure of VP8 support in
HTMLMediaElement.canPlayType, MediaSource.isTypeSupported, and
the filtering of video sources based on codec lists.

Example of failing hardware is an early-2015 13&quot; MacBook Pro,
whose integrated GPU supports VP8 but not VP9. A test case
is not included as I was unable to replicate the failing
conditions at runtime by adding disable-for-testing options
successfully.

* platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(SourceBufferParserWebM::isContentTypeSupported): Included
calls to isVP8DecoderAvailable as appropriate.
* LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9-expected.txt: Added.
* LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html: Added.
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::VP9TestingOverrides::setVP9DecoderDisabled):
(WebCore::isVP9DecoderAvailable):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::Internals):
(WebCore::Internals::setVP9DecoderDisabledForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::setMediaOverridesForTesting):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::updateMediaConfiguration):
* Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h:
(WebKit::MediaOverridesForTesting::encode const):
(WebKit::MediaOverridesForTesting::decode):

Canonical link: <a href="https://commits.webkit.org/254013@main">https://commits.webkit.org/254013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/139cbaf34e58bfc95f4304fbed3b8447dd90581c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87742 "failed 1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96943 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/150752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30189 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/26282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91689 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24389 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74489 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79346 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/79517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27880 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27859 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14353 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2821 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37265 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33629 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->