### PR TITLE
run-benchmark script should launch app bundle with absolute path.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -45,6 +45,7 @@ class OSXSafariDriver(OSXBrowserDriver):
                 raise Exception('Could not find any framework "{}"'.format(browser_build_path))
 
         elif browser_path:
+            browser_path = os.path.abspath(browser_path)
             safari_binary_path = os.path.join(browser_path, 'Contents/MacOS/Safari')
             if os.path.exists(safari_binary_path):
                 safari_app_path = browser_path


### PR DESCRIPTION
#### 0b0682d7ce80c21acfa5cd119cb1b9bc2c20cd73
<pre>
run-benchmark script should launch app bundle with absolute path.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242727">https://bugs.webkit.org/show_bug.cgi?id=242727</a>
rdar://96978464

Reviewed by Jonathan Bedard and Justin Michaud.

Fix a bug in run-benchmark that `--browser-path` is not correctly interpreted while
loading a url from a launched Safari.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver.launch_url):

Canonical link: <a href="https://commits.webkit.org/252441@main">https://commits.webkit.org/252441@main</a>
</pre>
