### PR TITLE
[git-webkit] base-commit for PRs should control remote

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.2.8',
+    version='5.2.9',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 2, 8)
+version = Version(5, 2, 9)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -504,6 +504,19 @@ class Git(Scm):
 
         return None
 
+    def source_remotes(self, cached=None):
+        candidates = [self.default_remote]
+        config = self.config(cached=cached)
+        for candidate in config.keys():
+            if not candidate.startswith('webkitscmpy.remotes'):
+                continue
+            candidate = candidate.split('.')[-1]
+            if candidate in candidates:
+                continue
+            if config.get('remote.{}.url'.format(candidate)):
+                candidates.append(candidate)
+        return candidates
+
     def _commit_count(self, native_parameter):
         revision_count = run(
             [self.executable(), 'rev-list', '--count', '--no-merges', native_parameter],

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -517,6 +517,40 @@ CommitDate: {time_c}
             mocked.staged['added.txt'] = 'added'
             self.assertEqual(local.Git(self.path).pull(), 128)
 
+    def test_source_remotes_default(self):
+        with mocks.local.Git(self.path), OutputCapture():
+            self.assertEqual(local.Git(self.path).source_remotes(), ['origin'])
+
+    def test_source_remotes_single(self):
+        with mocks.local.Git(self.path, remotes={
+            'origin': 'git@github.example.com:WebKit/WebKit.git',
+            'fork': 'git@github.example.com:Contributor/WebKit.git',
+        }), OutputCapture():
+            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
+            os.mkdir(os.path.dirname(project_config))
+            with open(project_config, 'w') as f:
+                f.write('[webkitscmpy "remotes"]\n')
+                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+
+            self.assertEqual(local.Git(self.path).source_remotes(), ['origin'])
+
+    def test_source_remotes_multiple(self):
+        with mocks.local.Git(self.path, remotes={
+            'origin': 'git@github.example.com:WebKit/WebKit.git',
+            'fork': 'git@github.example.com:Contributor/WebKit.git',
+            'security': 'git@github.example.com:WebKit/WebKit-security.git',
+            'fork-security': 'git@github.example.com:Contributor/WebKit-security.git',
+        }), OutputCapture():
+            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
+            os.mkdir(os.path.dirname(project_config))
+            with open(project_config, 'w') as f:
+                f.write('[webkitscmpy "remotes"]\n')
+                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+
+            self.assertEqual(local.Git(self.path).source_remotes(), ['origin', 'security'])
+
 
 class TestGitHub(testing.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'


### PR DESCRIPTION
#### c85ae4314641181e32bd6c83d0a41dc36991d885
<pre>
[git-webkit] base-commit for PRs should control remote
<a href="https://bugs.webkit.org/show_bug.cgi?id=242662">https://bugs.webkit.org/show_bug.cgi?id=242662</a>
&lt;rdar://96914116&gt;

Reviewed by David Kilzer.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.source_remotes): Return a list of source remotes, which are distinct from individual&apos;s
forked remotes.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.pull_request_branch_point): If no remote is defined, use the branch_point and
project source_remotes to determine which remote to use.
(PullRequest.add_comment_to_reverted_commit_bug_tracker): Use default_remote instead of &apos;origin&apos;.
(PullRequest.create_pull_request): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:

Canonical link: <a href="https://commits.webkit.org/252475@main">https://commits.webkit.org/252475@main</a>
</pre>
