### PR TITLE
[macOS Ventura] Build fails when using public SDK

### DIFF
--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -888,7 +888,9 @@ ExceptionOr<void> ApplePayPaymentHandler::retry(PaymentValidationErrors&& valida
     if (errors.isEmpty())
         errors.append(ApplePayError::create(ApplePayErrorCode::Unknown, std::nullopt, nullString()));
 
-    ApplePayPaymentAuthorizationResult authorizationResult { ApplePayPaymentAuthorizationResult::Failure, WTFMove(errors) };
+    ApplePayPaymentAuthorizationResult authorizationResult;
+    authorizationResult.status = ApplePayPaymentAuthorizationResult::Failure;
+    authorizationResult.errors = WTFMove(errors);
     ASSERT(!authorizationResult.isFinalState());
     paymentCoordinator().completePaymentSession(WTFMove(authorizationResult));
     return { };

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -409,6 +409,7 @@ extern CGDataProviderRef CGDataProviderCreateMultiRangeDirectAccess(
 #if HAVE(LOCKDOWN_MODE_PDF_ADDITIONS)
 CG_EXTERN void CGEnterLockdownModeForPDF();
 CG_LOCAL bool CGIsInLockdownModeForPDF();
+CG_EXTERN void CGEnterLockdownModeForFonts();
 #endif
 
 WTF_EXTERN_C_END

--- a/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSInteger, NSSharingServicePickerStyle) {
 - (NSMenu *)menu;
 - (void)getMenuWithCompletion:(void(^)(NSMenu *))completion;
 - (void)hide;
+- (void)showPopoverRelativeToRect:(NSRect)rect ofView:(NSView *)view preferredEdge:(NSRectEdge)preferredEdge completion:(void (^)(NSSharingService *))completion;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -121,6 +121,7 @@
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/cocoa/NSTouchBarSPI.h>
+#import <pal/spi/cocoa/VisionKitCoreSPI.h>
 #import <pal/spi/mac/LookupSPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -35,6 +35,7 @@
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFullscreenDelegate.h>
+#import <pal/spi/cocoa/VisionKitCoreSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
 


### PR DESCRIPTION
#### 16213795b52db0b2171464a228870d8fb84627c9
<pre>
[macOS Ventura] Build fails when using public SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=242429">https://bugs.webkit.org/show_bug.cgi?id=242429</a>

Reviewed by Tim Horton.

These changes should be enough to get the Mac build succeeding with the
latest Xcode 14 beta and macOS Venture SDK.

Unless otherwise noted, all changes are declaring and updating SPI.

* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::retry): ApplePayAuthorizationResult
  may not have an orderDetails member. Avoid designated initialization
  to simplify the use site.
* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h: Import public request
  status API for PASSKIT_PAYMENT_ORDER_DETAILS feature, along with
  declaring new SPI. Additionally, begin importing the
  &lt;PassKit/PassKit.h&gt; umbrella header on macOS, and clean up SPI
  declarations that have become API since Big Sur.
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h:
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.h:
* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:

Canonical link: <a href="https://commits.webkit.org/253305@main">https://commits.webkit.org/253305@main</a>
</pre>
