### PR TITLE
Crash if IOHIDDeviceCopyMatchingElements returns null (again)

### DIFF
--- a/Source/WebCore/platform/mac/HIDDevice.cpp
+++ b/Source/WebCore/platform/mac/HIDDevice.cpp
@@ -77,7 +77,7 @@ Vector<HIDElement> HIDDevice::uniqueInputElementsInDeviceTreeOrder() const
 
     RetainPtr<CFArrayRef> elements = adoptCF(IOHIDDeviceCopyMatchingElements(m_rawDevice.get(), NULL, kIOHIDOptionsTypeNone));
     CFIndex count = elements ? CFArrayGetCount(elements.get()) : 0;
-    for (CFIndex i = 0; count; ++i)
+    for (CFIndex i = 0; i < count; ++i)
         elementQueue.append(checked_cf_cast<IOHIDElementRef>(CFArrayGetValueAtIndex(elements.get(), i)));
 
     Vector<HIDElement> result;


### PR DESCRIPTION
#### 5f10be336ff3df673905768405ac215ab7894eb5
<pre>
Crash if IOHIDDeviceCopyMatchingElements returns null (again)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242721">https://bugs.webkit.org/show_bug.cgi?id=242721</a>

Reviewed by Tim Horton.

* Source/WebCore/platform/mac/HIDDevice.cpp:
(WebCore::HIDDevice::uniqueInputElementsInDeviceTreeOrder const): Null check the CFArray

Canonical link: <a href="https://commits.webkit.org/252431@main">https://commits.webkit.org/252431@main</a>
</pre>
