### PR TITLE
Web Inspector: Improve DataGridItem performance when adding a large number of items to a data grid at once

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGridNode.js
@@ -673,12 +673,12 @@ WI.DataGridNode = class DataGridNode extends WI.Object
         let insertionIndex = -1;
 
         if (!this.isPlaceholderNode) {
-            var previousGridNode = this.traversePreviousNode(true, true);
-            insertionIndex = this.dataGrid._rows.indexOf(previousGridNode);
-            if (insertionIndex === -1)
+            let previousGridNode = this.traversePreviousNode(true, true);
+            if (previousGridNode) {
+                // If the previousGridNode isn't in the list, we'll increment the not found value of `-1` to `0`.
+                insertionIndex = this.dataGrid._rows.lastIndexOf(previousGridNode) + 1;
+            } else
                 insertionIndex = 0;
-            else
-                insertionIndex++;
         }
 
         if (insertionIndex === -1)


### PR DESCRIPTION
#### 8f75ae36260cdc7aff28822500d04e423e1b2c73
<pre>
Web Inspector: Improve DataGridItem performance when adding a large number of items to a data grid at once
<a href="https://bugs.webkit.org/show_bug.cgi?id=242729">https://bugs.webkit.org/show_bug.cgi?id=242729</a>
rdar://96892753

Reviewed by Devin Rousso.

When adding a data grid item to a DataGrid, it is very likely the previous item is closer to the end than the beginning
of the collection of rows, so we should use `lastIndexOf` instead of `indexOf` to find the index of that item, otherwise
for grids with tens of thousands of items (like a timeline recording, for example) we will have to traverse down every
row for each item we add, even though we are adding the items sequentially in bulk. For a tested very large timeline
recording with ~180,000 Layout/Rendering records, this improved view presentation time from ~10 seconds locally to under
a second.

To preserve the performance of inserting an item at the start of the list, we check if the previous item is null, and
skip checking the entire array of rows.

* Source/WebInspectorUI/UserInterface/Views/DataGridNode.js:
(WI.DataGridNode.prototype._attach):

Canonical link: <a href="https://commits.webkit.org/252529@main">https://commits.webkit.org/252529@main</a>
</pre>
