### PR TITLE
[iOS] -requestAutocorrectionContextWithCompletionHandler: deadlocks when launching the GPU Process

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2087,7 +2087,7 @@ public:
     void setCocoaView(WKWebView *);
 #endif
 
-    bool isRunningModalJavaScriptDialog() const { return m_isRunningModalJavaScriptDialog; }
+    bool shouldAvoidSynchronouslyWaitingToPreventDeadlock() const;
 
 #if ENABLE(IMAGE_ANALYSIS) && PLATFORM(MAC)
     WKQuickLookPreviewController *quickLookPreviewController() const { return m_quickLookPreviewController.get(); }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5015,7 +5015,7 @@ static void selectionChangedWithTouch(WKContentView *view, const WebCore::IntPoi
     }
 
     bool respondWithLastKnownAutocorrectionContext = ([&] {
-        if (_page->isRunningModalJavaScriptDialog())
+        if (_page->shouldAvoidSynchronouslyWaitingToPreventDeadlock())
             return true;
 
         if (_domPasteRequestHandler)


### PR DESCRIPTION
#### b85a7ac966f5cfda942a7c5922c41468d85adbd8
<pre>
[iOS] -requestAutocorrectionContextWithCompletionHandler: deadlocks when launching the GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=242732">https://bugs.webkit.org/show_bug.cgi?id=242732</a>
rdar://94233518

Reviewed by Chris Dumez.

On iOS, `-[WKContentView requestAutocorrectionContextWithCompletionHandler:]` synchronously waits
for a `WebPageProxy::HandleAutocorrectionContext` IPC message from the web process. It&apos;s possible
for the web process to try and launch the GPU process at the same time by sending the async
`WebProcessProxy::CreateGPUProcessConnection` message to the UI process, and then syncwaiting for
`RemoteRenderingBackendProxy::DidInitialize` once the GPU process has finished launching and has
created a remote rendering backend for the page.

While similar at first glance to existing synchronous IPC deadlocks (which we already resolve by
dispatching incoming messages immediately), this technique isn&apos;t sufficient to address these
failures. This is because, even if the incoming IPC is handled in the UI process during syncwait,
the GPU process may not have finished launching yet -- this means that the outgoing messages from
the UI process to the GPU process to tell it to actually initialize (e.g.
`GPUProcess::InitializeGPUProcess`) will be added to `m_pendingMessages` on `AuxiliaryProcessProxy`.
These pending messages are dispatched once the process has finished initializing; however, since
this work is dispatched asynchronously onto the main thread (see `ProcessLauncher::launchProcess`),
it never ends up running due to the fact that we&apos;re still syncwaiting in the UI process.

We could feasibly deal with the above issue by dispatching XPC bootstrap message receipt on a
background thread, and then create an `IPC::Connection` and dispatch pending messages to the GPU
process off of the main thread. Unfortunately, this approach is likely too risky to be viable in the
short term.

Instead, simply fall back to the last cached autocorrection context in the case where the GPU
process hasn&apos;t been initialized, yet DOM rendering for GPU process is enabled.

Test:   AutocorrectionTests.AvoidDeadlockWithGPUProcessCreationInEmptyView
        AutocorrectionTests.AutocorrectionContextBeforeAndAfterEditing

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock const):

Add a helper method on WebPageProxy that returns `false` only if it&apos;s currently unsafe to begin
syncwaiting. This covers two common, known circumstances:

1.  When the page is running a modal dialog, and is therefore blocked from processing incoming IPC
    messages anyways.

2.  DOM rendering using GPU process is enabled, yet the GPU process hasn&apos;t been initialized yet
    (which may lead to the 3-way deadlock detailed above).

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):

In the case where the above `WebPageProxy` helper returns `false`, just fall back to the last known
autocorrection context instead of trying to send another sync IPC message.

* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:

In investigating this issue, I also realized that the reason why we kept on deadlocking in
`AutocorrectionTests.AutocorrectionContextBeforeAndAfterEditing` is that the web view is empty (i.e.
the size is 0 by 0). This causes us to delay GPU process initialization until the next layer tree
transaction, which (in this API test) happens to often coincide with when we directly request a
autocorrection context via UIKit SPI, immediately after navigation finishes. I suspect that many of
the hangs observed in iOS telemetry are triggered in a similar way (i.e. autocorrection contexts
being requested very early on during the initialization of an empty web view, or after an idle GPU
process exit).

At any rate, this patch reenables a flaky test (`AutocorrectionContextBeforeAndAfterEditing`) that
was disabled due to frequently triggering this deadlock, by giving the web view nonzero bounds.
Additionally, we add a dedicated test that uses SPI to disable the sync IPC message timeout, and
verify that calling `-requestAutocorrectionContextWithCompletionHandler:` in this case doesn&apos;t
trigger a hang.

Canonical link: <a href="https://commits.webkit.org/252568@main">https://commits.webkit.org/252568@main</a>
</pre>
