### PR TITLE
[ macOS ] TestWebKitAPI.WebKit.DeleteEmptyOriginDirectoryWhenOriginIsGone is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -1241,7 +1241,7 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://apple.com"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     kill(pid, SIGKILL);
-    while ([fileManager fileExistsAtPath:originDirectory.path])
+    while ([fileManager fileExistsAtPath:topOriginDirectory.path])
         TestWebKitAPI::Util::spinRunLoop();
     EXPECT_FALSE([fileManager fileExistsAtPath:topOriginDirectory.path]);
 }


### PR DESCRIPTION
#### de016a084220b9d02666afacf46e0f7fb43e58c7
<pre>
[ macOS ] TestWebKitAPI.WebKit.DeleteEmptyOriginDirectoryWhenOriginIsGone is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242723">https://bugs.webkit.org/show_bug.cgi?id=242723</a>

Reviewed by Chris Dumez.

That origin directory is removed does not mean top origin directory is already removed, because top origin directory is
removed after origin directory. So let&apos;s make the test wait until top origin directory is removed.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/252457@main">https://commits.webkit.org/252457@main</a>
</pre>
