### PR TITLE
Unreviewed build fix.

### DIFF
--- a/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
@@ -48,7 +48,9 @@
 
 #if USE(KEYCHAIN_ACCESS_CONTROL_LISTS)
 #import <wtf/cf/TypeCastsCF.h>
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 WTF_DECLARE_CF_TYPE_TRAIT(SecACL);
+ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 namespace WebCore {
@@ -98,14 +100,18 @@ static std::optional<Vector<uint8_t>> createAndStoreMasterKey()
 
 #if USE(KEYCHAIN_ACCESS_CONTROL_LISTS)
     SecAccessRef accessRef;
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     status = SecAccessCreate((__bridge CFStringRef)localizedItemName, nullptr, &accessRef);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (status) {
         WTFLogAlways("Cannot create a security access object for storing WebCrypto master key, error %d", (int)status);
         return std::nullopt;
     }
     RetainPtr<SecAccessRef> access = adoptCF(accessRef);
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<CFArrayRef> acls = adoptCF(SecAccessCopyMatchingACLList(accessRef, kSecACLAuthorizationExportClear));
+ALLOW_DEPRECATED_DECLARATIONS_END
     SecACLRef acl = checked_cf_cast<SecACLRef>(CFArrayGetValueAtIndex(acls.get(), 0));
 
     SecTrustedApplicationRef trustedAppRef;
@@ -118,7 +124,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
     RetainPtr<SecTrustedApplicationRef> trustedApp = adoptCF(trustedAppRef);
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     status = SecACLSetContents(acl, (__bridge CFArrayRef)@[ (__bridge id)trustedApp.get() ], (__bridge CFStringRef)localizedItemName, kSecKeychainPromptRequirePassphase);
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (status) {
         WTFLogAlways("Cannot set ACL for WebCrypto master key, error %d", (int)status);
         return std::nullopt;

--- a/Source/WebCore/platform/mac/SSLKeyGeneratorMac.mm
+++ b/Source/WebCore/platform/mac/SSLKeyGeneratorMac.mm
@@ -40,7 +40,9 @@
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/Base64.h>
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 WTF_DECLARE_CF_TYPE_TRAIT(SecACL);
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 namespace WebCore {
 


### PR DESCRIPTION
#### c5cae63ef35bfad7faf2f647f7845549e6b9a3d5
<pre>
Unreviewed build fix.

* Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm:
(WebCore::createAndStoreMasterKey):
Add ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END around SecACL and SecAccessCreate,
SecAccessCopyMatchingACLList and SecACLSetContents calls.
* Source/WebCore/platform/mac/SSLKeyGeneratorMac.mm:
Add ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END around SecACL.

Canonical link: <a href="https://commits.webkit.org/252439@main">https://commits.webkit.org/252439@main</a>
</pre>
