### PR TITLE
Unreviewed build fix.

### DIFF
--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -119,8 +119,10 @@ static CFType typeFromCFTypeRef(CFTypeRef type)
     if (typeID == SecCertificateGetTypeID())
         return CFType::SecCertificate;
 #if HAVE(SEC_KEYCHAIN)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (typeID == SecKeychainItemGetTypeID())
         return CFType::SecKeychainItem;
+ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 #if HAVE(SEC_ACCESS_CONTROL)
     if (typeID == SecAccessControlGetTypeID())
@@ -848,11 +850,13 @@ void ArgumentCoder<SecKeychainItemRef>::encode(Encoder& encoder, SecKeychainItem
 {
     RELEASE_ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessCredentials));
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CFDataRef data;
     if (SecKeychainItemCreatePersistentReference(keychainItem, &data) == errSecSuccess) {
         encoder << data;
         CFRelease(data);
     }
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 template void ArgumentCoder<SecKeychainItemRef>::encode<Encoder>(Encoder&, SecKeychainItemRef);
@@ -872,10 +876,12 @@ std::optional<RetainPtr<SecKeychainItemRef>> ArgumentCoder<RetainPtr<SecKeychain
     if (!CFDataGetLength(dref))
         return std::nullopt;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     SecKeychainItemRef item;
     if (SecKeychainItemCopyFromPersistentReference(dref, &item) != errSecSuccess || !item)
         return std::nullopt;
-    
+ALLOW_DEPRECATED_DECLARATIONS_END
+
     return adoptCF(item);
 }
 #endif


### PR DESCRIPTION
#### 2c28b28a6839c30b024956a2b2241872223249dd
<pre>
Unreviewed build fix.

* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::typeFromCFTypeRef):
Add ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END around
SecKeychainItemGetTypeID call.
(IPC::ArgumentCoder&lt;SecKeychainItemRef&gt;::encode):
Add ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END around
SecKeychainItemCreatePersistentReference call.
(IPC::ArgumentCoder&lt;RetainPtr&lt;SecKeychainItemRef&gt;&gt;::decode):
Add ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END around
SecKeychainItemCreatePersistentReference call.

Canonical link: <a href="https://commits.webkit.org/252448@main">https://commits.webkit.org/252448@main</a>
</pre>
