### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -207,13 +207,14 @@ inline void AtomHTMLToken::initializeAttributes(const HTMLToken::AttributeList& 
     addedAttributes.reserveInitialCapacity(size);
     m_attributes.reserveInitialCapacity(size);
     for (auto& attribute : attributes) {
-        if (attribute.name.isEmpty())
+        auto name = attribute.name();
+        if (!name.size())
             continue;
 
-        auto qualifiedName = HTMLNameCache::makeAttributeQualifiedName(attribute.name);
+        auto qualifiedName = HTMLNameCache::makeAttributeQualifiedName(name);
 
         if (addedAttributes.add(qualifiedName.localName()).isNewEntry)
-            m_attributes.uncheckedAppend(Attribute(WTFMove(qualifiedName), HTMLNameCache::makeAttributeValue(attribute.value)));
+            m_attributes.uncheckedAppend(Attribute(WTFMove(qualifiedName), HTMLNameCache::makeAttributeValue(attribute.value())));
         else
             m_hasDuplicateAttribute = true;
     }

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
@@ -46,8 +46,7 @@ public:
     const PAL::TextEncoding& encoding() { return m_encoding; }
 
     // The returned encoding might not be valid.
-    typedef Vector<std::pair<AtomString, AtomString>> AttributeList;
-    static PAL::TextEncoding encodingFromMetaAttributes(const AttributeList&);
+    static PAL::TextEncoding encodingFromMetaAttributes(Span<const Attribute>);
 
 private:
     bool processMeta(HTMLToken&);

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -74,12 +74,12 @@ static bool isCharsetSpecifyingNode(const Node& node)
     const HTMLElement& element = downcast<HTMLElement>(node);
     if (!element.hasTagName(HTMLNames::metaTag))
         return false;
-    HTMLMetaCharsetParser::AttributeList attributes;
+
+    Vector<Attribute> attributes;
     if (element.hasAttributes()) {
-        for (const Attribute& attribute : element.attributesIterator()) {
-            // FIXME: We should deal appropriately with the attribute if they have a namespace.
-            attributes.append({ attribute.name().toAtomString(), attribute.value() });
-        }
+        attributes.reserveInitialCapacity(element.attributeCount());
+        for (auto& attribute : element.attributesIterator())
+            attributes.uncheckedAppend(attribute);
     }
     return HTMLMetaCharsetParser::encodingFromMetaAttributes(attributes).isValid();
 }


### PR DESCRIPTION
#### f85e0acabccfb2deaea0732156ff5157503f4e4c
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter.asm:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/LowLevelInterpreter.js:
* PerformanceTests/JetStream2/RexBench/OfflineAssembler/expected.js:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter.asm:
* PerformanceTests/RexBench/OfflineAssembler/LowLevelInterpreter.js:
* PerformanceTests/RexBench/OfflineAssembler/expected.js:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::privateCompileMainPass):
(JSC::JIT::privateCompileSlowCases):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_op_less):
(JSC::JIT::emit_op_lesseq):
(JSC::JIT::emit_op_greater):
(JSC::JIT::emit_op_greatereq):
(JSC::JIT::emit_op_jless):
(JSC::JIT::emit_op_jgreatereq):
(JSC::JIT::emitSlow_op_less):
(JSC::JIT::emitSlow_op_lesseq):
(JSC::JIT::emitSlow_op_greater):
(JSC::JIT::emitSlow_op_greatereq):
(JSC::JIT::emit_compare):
(JSC::JIT::emit_compareImpl):
(JSC::JIT::emit_compareSlow):
(JSC::JIT::emit_compareSlowImpl):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
</pre>