### PR TITLE
[Gardening]: [ iOS15 wk2 arm64 Release ] css3/color-filters/svg/color-filter-inline-svg.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios-simulator-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-simulator-wk2/TestExpectations
@@ -177,3 +177,5 @@ webkit.org/b/236926 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-b
 webkit.org/b/236926 webrtc/vp9-profile2.html [ Timeout Pass ]
 # This passes only on the arm64 host
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/adopt-from-image-document.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/242748 [ Release arm64 ] css3/color-filters/svg/color-filter-inline-svg.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### b61d0cc6a87426e77512fdce1b4d96f222ae95be
<pre>
[Gardening]: [ iOS15 wk2 arm64 Release ] css3/color-filters/svg/color-filter-inline-svg.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242748">https://bugs.webkit.org/show_bug.cgi?id=242748</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-simulator-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252458@main">https://commits.webkit.org/252458@main</a>
</pre>
