### PR TITLE
Web Inspector: capture async stack traces for `queueMicrotask`

### DIFF
--- a/LayoutTests/inspector/debugger/async-stack-trace-basic-expected.txt
+++ b/LayoutTests/inspector/debugger/async-stack-trace-basic-expected.txt
@@ -2,6 +2,26 @@ Tests for checking that async stack traces exist when pausing in asynchronous ca
 
 
 == Running test suite: AsyncStackTrace.Basic
+-- Running test case: AsyncStackTrace.Basic.Microtask
+PAUSED
+CALL STACK:
+0: [F] handleMicrotask
+ASYNC CALL STACK:
+1: --- queueMicrotask ---
+2: [F] triggerMicrotask
+3: [P] Global Code
+
+-- Running test case: AsyncStackTrace.Basic.NestedMicrotask
+PAUSED
+CALL STACK:
+0: [F] handleMicrotask2
+ASYNC CALL STACK:
+1: --- queueMicrotask ---
+2: [F] handleMicrotask1
+3: --- queueMicrotask ---
+4: [F] triggerNestedMicrotask
+5: [P] Global Code
+
 -- Running test case: AsyncStackTrace.Basic.RequestAnimationFrame
 PAUSED
 CALL STACK:
@@ -78,6 +98,33 @@ PAUSED
 CALL STACK:
 0: [F] handleMessage
 ASYNC CALL STACK:
-1: --- postMessage ---
-2: [P] Global Code
+1: --- addEventListener ---
+2: [F] triggerPostMessage
+3: [P] Global Code
+
+-- Running test case: AsyncStackTrace.Basic.Combined
+PAUSED
+CALL STACK:
+0: [F] handleMessage
+ASYNC CALL STACK:
+1: --- addEventListener ---
+2: [F] triggerPostMessage
+3: [F]
+4: [F] handleInterval
+5: --- setInterval ---
+6: [F] triggerSetInterval
+7: [F]
+8: [F] handleTimeout
+9: --- setTimeout ---
+10: [F] triggerSetTimeout
+11: [F]
+12: [F] handleAnimationFrame
+13: --- requestAnimationFrame ---
+14: [F] triggerRequestAnimationFrame
+15: [F]
+16: [F] handleMicrotask
+17: --- queueMicrotask ---
+18: [F] triggerMicrotask
+19: [F] triggerCombined
+20: [P] Global Code
 

--- a/LayoutTests/inspector/debugger/async-stack-trace-basic.html
+++ b/LayoutTests/inspector/debugger/async-stack-trace-basic.html
@@ -5,9 +5,29 @@
 <script src="resources/async-stack-trace-test.js"></script>
 <script>
 
-function triggerRequestAnimationFrame() {
+function triggerMicrotask(completion) {
+    queueMicrotask(function handleMicrotask() {
+        if (completion)
+            completion();
+        else
+            debugger;
+    });
+}
+
+function triggerNestedMicrotask() {
+    queueMicrotask(function handleMicrotask1() {
+        queueMicrotask(function handleMicrotask2() {
+            debugger;
+        });
+    });
+}
+
+function triggerRequestAnimationFrame(completion) {
     requestAnimationFrame(function handleAnimationFrame() {
-        debugger;
+        if (completion)
+            completion();
+        else
+            debugger;
     });
 }
 
@@ -19,9 +39,12 @@ function triggerNestedRequestAnimationFrame() {
     });
 }
 
-function triggerSetTimeout() {
+function triggerSetTimeout(completion) {
     setTimeout(function handleTimeout() {
-        debugger;
+        if (completion)
+            completion();
+        else
+            debugger;
     });
 }
 
@@ -33,10 +56,13 @@ function triggerNestedSetTimeout() {
     });
 }
 
-function triggerSetInterval() {
+function triggerSetInterval(completion) {
     let timer = setInterval(function handleInterval() {
         clearInterval(timer);
-        debugger;
+        if (completion)
+            completion();
+        else
+            debugger;
     });
 }
 
@@ -50,14 +76,29 @@ function triggerNestedSetInterval() {
     });
 }
 
-function triggerPostMessage() {
+function triggerPostMessage(completion) {
     let frame = document.createElement("iframe");
     frame.srcdoc = `<script>window.parent.postMessage(42, "*");<\/script>`;
     document.body.appendChild(frame);
 
     window.addEventListener("message", function handleMessage() {
         window.removeEventListener("message", handleMessage);
-        debugger;
+        if (completion)
+            completion();
+        else
+            debugger;
+    });
+}
+
+function triggerCombined() {
+    triggerMicrotask(() => {
+        triggerRequestAnimationFrame(() => {
+            triggerSetTimeout(() => {
+                triggerSetInterval(() => {
+                    triggerPostMessage();
+                });
+            });
+        });
     });
 }
 
@@ -66,43 +107,58 @@ function test()
     let suite = InspectorTest.createAsyncSuite("AsyncStackTrace.Basic");
 
     addAsyncStackTraceTestCase(suite, {
+        name: "AsyncStackTrace.Basic.Microtask",
+        expression: `triggerMicrotask()`,
+    });
+
+    addAsyncStackTraceTestCase(suite, {
+        name: "AsyncStackTrace.Basic.NestedMicrotask",
+        expression: `triggerNestedMicrotask()`,
+    });
+
+    addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.RequestAnimationFrame",
-        expression: "triggerRequestAnimationFrame()",
+        expression: `triggerRequestAnimationFrame()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.NestedRequestAnimationFrame",
-        expression: "triggerNestedRequestAnimationFrame()",
+        expression: `triggerNestedRequestAnimationFrame()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.SetTimeout",
-        expression: "triggerSetTimeout()",
+        expression: `triggerSetTimeout()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.NestedSetTimeout",
-        expression: "triggerNestedSetTimeout()",
+        expression: `triggerNestedSetTimeout()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.SetInterval",
-        expression: "triggerSetInterval()",
+        expression: `triggerSetInterval()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.NestedSetInterval",
-        expression: "triggerNestedSetInterval()",
+        expression: `triggerNestedSetInterval()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.NestedSetInterval",
-        expression: "triggerNestedSetInterval()",
+        expression: `triggerNestedSetInterval()`,
     });
 
     addAsyncStackTraceTestCase(suite, {
         name: "AsyncStackTrace.Basic.PostMessage",
-        expression: "triggerPostMessage()",
+        expression: `triggerPostMessage()`,
+    });
+
+    addAsyncStackTraceTestCase(suite, {
+        name: "AsyncStackTrace.Basic.Combined",
+        expression: `triggerCombined()`,
     });
 
     suite.runTestCasesAndFinish();

--- a/LayoutTests/inspector/debugger/resources/async-stack-trace-test.js
+++ b/LayoutTests/inspector/debugger/resources/async-stack-trace-test.js
@@ -66,21 +66,22 @@ TestPage.registerInitializer(() => {
             description,
             setup,
             teardown,
-            async test(resolve, reject) {
-                let result = WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Paused)
-                .then(() => {
+            test(resolve, reject) {
+                WI.debuggerManager.singleFireEventListener(WI.DebuggerManager.Event.Paused, () => {
                     InspectorTest.log("PAUSED");
                     logAsyncStackTrace();
 
                     if (pausedHandler)
                         pausedHandler(getAsyncStackTrace());
 
+                    WI.debuggerManager.singleFireEventListener(WI.DebuggerManager.Event.Resumed, () => {
+                        resolve();
+                    });
+
                     WI.debuggerManager.resume();
-                })
-                .then(() => WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed));
+                });
 
                 InspectorTest.evaluateInPage(expression);
-                await result;
             }
         });
     };

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -28,6 +28,7 @@
 #include "HeapIterationScope.h"
 #include "JSCInlines.h"
 #include "MarkedSpaceInlines.h"
+#include "Microtask.h"
 #include "VMEntryScope.h"
 #include "VMTrapsInlines.h"
 #include <wtf/HashMap.h>
@@ -1248,17 +1249,24 @@ void Debugger::didReachDebuggerStatement(CallFrame* callFrame)
     updateCallFrame(lexicalGlobalObjectForCallFrame(m_vm, callFrame), callFrame, AttemptPause);
 }
 
-void Debugger::willRunMicrotask()
+void Debugger::didQueueMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
 {
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.willRunMicrotask();
+        observer.didQueueMicrotask(globalObject, microtask);
     });
 }
 
-void Debugger::didRunMicrotask()
+void Debugger::willRunMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
 {
     dispatchFunctionToObservers([&] (Observer& observer) {
-        observer.didRunMicrotask();
+        observer.willRunMicrotask(globalObject, microtask);
+    });
+}
+
+void Debugger::didRunMicrotask(JSGlobalObject* globalObject, const Microtask& microtask)
+{
+    dispatchFunctionToObservers([&] (Observer& observer) {
+        observer.didRunMicrotask(globalObject, microtask);
     });
 }
 

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -36,6 +36,7 @@ class CallFrame;
 class CodeBlock;
 class Exception;
 class JSGlobalObject;
+class Microtask;
 class SourceProvider;
 class VM;
 
@@ -137,8 +138,9 @@ public:
     void didExecuteProgram(CallFrame*);
     void didReachDebuggerStatement(CallFrame*);
 
-    JS_EXPORT_PRIVATE void willRunMicrotask();
-    JS_EXPORT_PRIVATE void didRunMicrotask();
+    JS_EXPORT_PRIVATE void didQueueMicrotask(JSGlobalObject*, const Microtask&);
+    JS_EXPORT_PRIVATE void willRunMicrotask(JSGlobalObject*, const Microtask&);
+    JS_EXPORT_PRIVATE void didRunMicrotask(JSGlobalObject*, const Microtask&);
 
     void registerCodeBlock(CodeBlock*);
 
@@ -174,8 +176,9 @@ public:
         virtual void didParseSource(SourceID, const Debugger::Script&) { }
         virtual void failedToParseSource(const String& /* url */, const String& /* data */, int /* firstLine */, int /* errorLine */, const String& /* errorMessage */) { }
 
-        virtual void willRunMicrotask() { }
-        virtual void didRunMicrotask() { }
+        virtual void didQueueMicrotask(JSGlobalObject*, const Microtask&) { }
+        virtual void willRunMicrotask(JSGlobalObject*, const Microtask&) { }
+        virtual void didRunMicrotask(JSGlobalObject*, const Microtask&) { }
 
         virtual void didPause(JSGlobalObject*, DebuggerCallFrame&, JSValue /* exceptionOrCaughtValue */) { }
         virtual void didContinue() { }

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -101,8 +101,9 @@ public:
     // JSC::Debugger::Observer
     void didParseSource(JSC::SourceID, const JSC::Debugger::Script&) final;
     void failedToParseSource(const String& url, const String& data, int firstLine, int errorLine, const String& errorMessage) final;
-    void willRunMicrotask() final;
-    void didRunMicrotask() final;
+    void didQueueMicrotask(JSC::JSGlobalObject*, const JSC::Microtask&) final;
+    void willRunMicrotask(JSC::JSGlobalObject*, const JSC::Microtask&) final;
+    void didRunMicrotask(JSC::JSGlobalObject*, const JSC::Microtask&) final;
     void didPause(JSC::JSGlobalObject*, JSC::DebuggerCallFrame&, JSC::JSValue exceptionOrCaughtValue) final;
     void didContinue() final;
     void breakpointActionSound(JSC::BreakpointActionID) final;
@@ -121,6 +122,7 @@ public:
         EventListener,
         PostMessage,
         RequestAnimationFrame,
+        Microtask,
     };
 
     void didScheduleAsyncCall(JSC::JSGlobalObject*, AsyncCallType, int callbackId, bool singleShot);
@@ -165,7 +167,7 @@ protected:
     virtual String sourceMapURLForScript(const JSC::Debugger::Script&);
 
     void didClearGlobalObject();
-    virtual void didClearAsyncStackTraceData() { }
+    virtual void didClearAsyncStackTraceData();
 
 private:
     bool shouldBlackboxURL(const String&) const;
@@ -272,8 +274,11 @@ private:
     RefPtr<JSON::Object> m_preBlackboxPauseData;
 
     HashMap<AsyncCallIdentifier, RefPtr<AsyncStackTrace>> m_pendingAsyncCalls;
-    std::optional<AsyncCallIdentifier> m_currentAsyncCallIdentifier;
+    Vector<AsyncCallIdentifier> m_currentAsyncCallIdentifierStack;
     int m_asyncStackTraceDepth { 0 };
+
+    HashMap<const JSC::Microtask*, int> m_identifierForMicrotask;
+    int m_nextMicrotaskIdentifier { 1 };
 
     RefPtr<JSC::Breakpoint> m_pauseOnAssertionsBreakpoint;
     RefPtr<JSC::Breakpoint> m_pauseOnMicrotasksBreakpoint;

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -78,13 +78,13 @@ void JSMicrotask::run(JSGlobalObject* globalObject)
         return;
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->willRunMicrotask();
+        globalObject->debugger()->willRunMicrotask(globalObject, *this);
 
     profiledCall(globalObject, ProfilingReason::Microtask, m_job.get(), handlerCallData, jsUndefined(), handlerArguments);
     scope.clearException();
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->didRunMicrotask();
+        globalObject->debugger()->didRunMicrotask(globalObject, *this);
 }
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMicrotask.cpp
@@ -68,7 +68,7 @@ void JSDOMMicrotask::run(JSGlobalObject* globalObject)
     ASSERT(callData.type != CallData::Type::None);
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->willRunMicrotask();
+        globalObject->debugger()->willRunMicrotask(globalObject, *this);
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
     JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, jsUndefined(), ArgList(), returnedException);
@@ -76,7 +76,7 @@ void JSDOMMicrotask::run(JSGlobalObject* globalObject)
         reportException(lexicalGlobalObject, returnedException);
 
     if (UNLIKELY(globalObject->hasDebugger()))
-        globalObject->debugger()->didRunMicrotask();
+        globalObject->debugger()->didRunMicrotask(globalObject, *this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -171,6 +171,8 @@ void WebDebuggerAgent::didDispatchPostMessage(int postMessageIdentifier)
 
 void WebDebuggerAgent::didClearAsyncStackTraceData()
 {
+    InspectorDebuggerAgent::didClearAsyncStackTraceData();
+
     m_registeredEventListeners.clear();
     m_postMessageTasks.clear();
     m_nextEventListenerIdentifier = 1;


### PR DESCRIPTION
#### 6545a6f6c7c37f384f4da9af7995cd7e2eea33d4
<pre>
Web Inspector: capture async stack traces for `queueMicrotask`
<a href="https://bugs.webkit.org/show_bug.cgi?id=242749">https://bugs.webkit.org/show_bug.cgi?id=242749</a>

Reviewed by Patrick Angle.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::queueMicrotask):
Add a `Debugger` instrumentation hook.

* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::JSMicrotask::run):
* Source/WebCore/bindings/js/JSDOMMicrotask.cpp:
(WebCore::JSDOMMicrotask::run):
Pass along the `JSC::Microtask` to use (the pointer of) in a `HashMap` that holds a identifier for
that async task.

* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::didQueueMicrotask): Added.
(JSC::Debugger::willRunMicrotask):
(JSC::Debugger::didRunMicrotask):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::didScheduleAsyncCall):
(Inspector::InspectorDebuggerAgent::willDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didQueueMicrotask): Added.
(Inspector::InspectorDebuggerAgent::willRunMicrotask):
(Inspector::InspectorDebuggerAgent::didRunMicrotask):
(Inspector::InspectorDebuggerAgent::didPause):
(Inspector::InspectorDebuggerAgent::didClearAsyncStackTraceData): Added.
Call the existing `didScheduleAsyncCall`, `willDispatchAsyncCall`, and `didDispatchAsyncCall`. Also
allow multiple async calls to be tracked at the same time.

* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::didClearAsyncStackTraceData):
Don&apos;t forget to call the base class method too.

* LayoutTests/inspector/debugger/async-stack-trace-basic.html:
* LayoutTests/inspector/debugger/async-stack-trace-basic-expected.txt:

* LayoutTests/inspector/debugger/resources/async-stack-trace-test.js:
(addAsyncStackTraceTestCase):
Drive-by: Adjust the test to make sure listeners are added before relevant events are dispatched.

Canonical link: <a href="https://commits.webkit.org/252543@main">https://commits.webkit.org/252543@main</a>
</pre>
