### PR TITLE
Crash under IPC::StreamConnectionBuffer::decode

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -88,7 +88,7 @@ std::optional<StreamConnectionBuffer> StreamConnectionBuffer::decode(Decoder& de
     if (dataSize > headerSize() + maximumSize())
         return std::nullopt;
     auto sharedMemory = WebKit::SharedMemory::map(ipcHandle->handle, WebKit::SharedMemory::Protection::ReadWrite);
-    if (sharedMemory->size() < dataSize)
+    if (!sharedMemory || sharedMemory->size() < dataSize)
         return std::nullopt;
     return StreamConnectionBuffer { sharedMemory.releaseNonNull(), dataSize };
 }


### PR DESCRIPTION
#### f41b1ddcfb592f657aa0bc5fd135e25c69ed378d
<pre>
Crash under IPC::StreamConnectionBuffer::decode
<a href="https://bugs.webkit.org/show_bug.cgi?id=242750">https://bugs.webkit.org/show_bug.cgi?id=242750</a>
&lt;rdar://94805403&gt;

Reviewed by Wenson Hsieh.

SharedMemory::map() can return null but we were failing to null check
before dereferencing the returned value.

* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::decode):

Canonical link: <a href="https://commits.webkit.org/252462@main">https://commits.webkit.org/252462@main</a>
</pre>
