### PR TITLE
Web Inspector: REGRESSION(?): Sources Tab: async stack trace divider line is not vertically centered

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.css
@@ -79,8 +79,7 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:focus-within .
     content: "";
     display: inline-block;
     height: 0;
-    margin-top: 2px;
-    vertical-align: middle;
+    margin-bottom: 4px;
     border-bottom: solid 0.5px var(--border-color);
 }
 


### PR DESCRIPTION
#### 0dda86696f7db131ac2d3b51e91610c1282baf22
<pre>
Web Inspector: REGRESSION(?): Sources Tab: async stack trace divider line is not vertically centered
<a href="https://bugs.webkit.org/show_bug.cgi?id=242751">https://bugs.webkit.org/show_bug.cgi?id=242751</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.css:
(.tree-outline .item.call-frame.async-boundary::before,):

Canonical link: <a href="https://commits.webkit.org/252468@main">https://commits.webkit.org/252468@main</a>
</pre>
