### PR TITLE
Check for strict-dynamic when checking host sources for CSP

### DIFF
--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -246,7 +246,7 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
     if (checkHashes(operativeDirective, hashes)
         || checkNonParserInsertedScripts(operativeDirective, parserInserted)
         || checkNonce(operativeDirective, nonce)
-        || checkSource(operativeDirective, url)
+        || (checkSource(operativeDirective, url) && !strictDynamicIncluded())
         || (url.isEmpty() && checkInline(operativeDirective)))
         return nullptr;
     return operativeDirective;
@@ -413,7 +413,7 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
     if (!operativeDirective
         || operativeDirective->containsAllHashes(subResourceIntegrityDigests)
         || checkNonce(operativeDirective, nonce)
-        || checkSource(operativeDirective, url, didReceiveRedirectResponse))
+        || (checkSource(operativeDirective, url, didReceiveRedirectResponse) && !strictDynamicIncluded()))
         return nullptr;
 
     return operativeDirective;
@@ -663,7 +663,7 @@ void ContentSecurityPolicyDirectiveList::addDirective(ParsedDirective&& directiv
         m_policy.reportUnsupportedDirective(WTFMove(directive.name));
 }
 
-bool ContentSecurityPolicyDirectiveList::strictDynamicIncluded()
+bool ContentSecurityPolicyDirectiveList::strictDynamicIncluded() const
 {
     ContentSecurityPolicySourceListDirective* directive = this->operativeDirectiveScript(m_scriptSrcElem.get(), ContentSecurityPolicyDirectiveNames::scriptSrc);
     return directive && directive->allowNonParserInsertedScripts();

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -89,7 +89,7 @@ public:
     // FIXME: Remove this once we teach ContentSecurityPolicyDirectiveList how to log an arbitrary console message.
     const ContentSecurityPolicy& policy() const { return m_policy; }
 
-    bool strictDynamicIncluded();
+    bool strictDynamicIncluded() const;
 
 private:
     void parse(const String&, ContentSecurityPolicy::PolicyFrom);

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -302,7 +302,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     if (skipExactlyIgnoringASCIICase(buffer, "'strict-dynamic'"_s)
         && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)
         && (m_directiveName == ContentSecurityPolicyDirectiveNames::scriptSrc
-            || m_directiveName == ContentSecurityPolicyDirectiveNames::scriptSrcElem)) {
+            || m_directiveName == ContentSecurityPolicyDirectiveNames::scriptSrcElem || m_directiveName == ContentSecurityPolicyDirectiveNames::defaultSrc)) {
         m_allowNonParserInsertedScripts = true;
         m_allowSelf = false;
         m_allowInline = false;


### PR DESCRIPTION
#### 71153b04b44b218da962bf681bb3c30e01ccd319
<pre>
Check for strict-dynamic when checking host sources for CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=242752">https://bugs.webkit.org/show_bug.cgi?id=242752</a>
&lt;rdar://95774298&gt;

Reviewed by Chris Dumez.

According to the CSP specification, if &quot;strict-dynamic&quot; is used inside
of a script-src or default-src directive, it should have two main effects:

1.) host-source and scheme-source expressions, as well as the
&quot;unsafe-inline&quot; and &quot;self&quot; keyword-sources will be ignored when
loading script.

2.) Script requests which are triggered by non-&quot;parser-inserted&quot;
script elements are allowed.

This patch addresses the specific case where host-source was not
being ignored. Before we were incorrectly using the result of
checkSource if &quot;strict-dynamic&quot; was being used. By adding the call to
!strictDynamicIncluded(), we will only check the source if
&quot;strict-dynamic&quot; is not included. If it is included, we will
not use any of the sources.

Each of the tests address both points 1 and 2 for the script-src
scenario and default-src scenario. Each of the tests have the same
content, but test to make sure the policies are followed in each
directive. The script with src &quot;resources/alert-fail.js&quot; makes sure that
self is being ignored properly. The localhost script makes sure that the
host lookups are being ignored properly. The inline script makes sure
that unsafe-inline is being ignored properly. Finally, the script being
generated through JavaScript makes sure that non parser-inserted
scripts still execute.

* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::violatedDirectiveForNonParserInsertedScripts):
(WebCore::ContentSecurityPolicyDirectiveList::violatedDirectiveForScript):
(WebCore::ContentSecurityPolicyDirectiveList::strictDynamicIncluded):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
(WebCore::ContentSecurityPolicyDirectiveList::strictDynamicIncluded):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseSource):
We need to make sure that &quot;strict-dynamic&quot; is also being mapped to the
default-src directive.

Canonical link: <a href="https://commits.webkit.org/252465@main">https://commits.webkit.org/252465@main</a>
</pre>
