### PR TITLE
[iOS 16] Web content process sometimes crashes under WebPage::preemptivelySendAutocorrectionContext()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6246,14 +6246,15 @@ void WebPage::didChangeSelection(Frame& frame)
     didChangeSelectionOrOverflowScrollPosition();
 
 #if PLATFORM(IOS_FAMILY)
-    if (!m_sendAutocorrectionContextAfterFocusingElement)
+    if (!std::exchange(m_sendAutocorrectionContextAfterFocusingElement, false))
         return;
 
-    if (UNLIKELY(!frame.document() || !frame.document()->hasLivingRenderTree() || frame.selection().isNone()))
-        return;
+    callOnMainRunLoop([protectedThis = Ref { *this }, frame = Ref { frame }] {
+        if (UNLIKELY(!frame->document() || !frame->document()->hasLivingRenderTree() || frame->selection().isNone()))
+            return;
 
-    m_sendAutocorrectionContextAfterFocusingElement = false;
-    preemptivelySendAutocorrectionContext();
+        protectedThis->preemptivelySendAutocorrectionContext();
+    });
 #endif // PLATFORM(IOS_FAMILY)
 }
 


### PR DESCRIPTION
#### 99b2ade90b007352d85bd59acaee5cd62f688302
<pre>
[iOS 16] Web content process sometimes crashes under WebPage::preemptivelySendAutocorrectionContext()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242753">https://bugs.webkit.org/show_bug.cgi?id=242753</a>
rdar://94622926

Reviewed by Devin Rousso.

248034@main introduced a mechanism to preemptively send autocorrection context to the UI process in
the case where element focus would (by default) cause the software keyboard to appear; this is
because we know, a priori, that UIKit will begin syncwaiting (in the UI process) for autocorrection
context data soon after the `ElementDidFocus` IPC message is received in the UI process anyways;
computing and sending this information eagerly greatly reduces the window of oppportunity where the
web process might simultaneously begin waiting for its own sync IPC to the UI process and back,
which may result in deadlock.

However, in some circumstances, `didChangeSelection()` may be invoked underneath a scope where
script execution (and importantly, layout) is disabled -- for instance, inside of
`ContainerNode::removeChildren()`, due to changing the `textContent` of a `textarea` element. This
causes us to crash, since computing autocorrection context requires layout to be up-to-date (and
will trigger layout if it&apos;s not).

To mitigate this, we defer the preemptive send by scheduling on the main runloop instead of
computing it synchronously.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChangeSelection):

Canonical link: <a href="https://commits.webkit.org/252481@main">https://commits.webkit.org/252481@main</a>
</pre>
