### PR TITLE
[GStreamer][WebRTC] Support for VP9 Profile 2 (10-bit color) encoding

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -968,7 +968,6 @@ webkit.org/b/235885 webrtc/video-mute.html [ Timeout ]
 webkit.org/b/235885 webrtc/video-replace-track-to-null.html [ Failure ]
 webkit.org/b/235885 webrtc/video-replace-track.html [ Failure ]
 webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
-webkit.org/b/235885 webrtc/video-vp8-videorange.html [ Timeout ]
 webkit.org/b/235885 webrtc/video.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
 webkit.org/b/235885 webrtc/vp9-svc.html [ Failure ]
@@ -1513,6 +1512,7 @@ webkit.org/b/193641 webkit.org/b/235885 webrtc/video-setDirection.html [ Failure
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
 [ Debug ] webrtc/video-h264.html [ Slow ]
+webrtc/vp9-profile2.html [ Slow ]
 
 webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Crash Timeout ]
 # h264-high.html is marked as slow in the root expectation
@@ -1522,8 +1522,6 @@ webkit.org/b/215007 [ Debug ] webrtc/h264-high.html [ Slow Failure ]
 webkit.org/b/216538 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Slow Failure ]
 
 webkit.org/b/216763 webkit.org/b/235885 webrtc/captureCanvas-webrtc-software-h264-high.html [ Crash Failure Timeout ]
-
-webkit.org/b/218221 webrtc/vp9-profile2.html [ Timeout Failure ]
 
 webkit.org/b/224074 webrtc/concurrentVideoPlayback.html [ Timeout Pass ]
 
@@ -2356,7 +2354,6 @@ webkit.org/b/186100 fast/hidpi/filters-turbulence.html [ ImageOnlyFailure ]
 webkit.org/b/187044 webanimations/opacity-animation-yields-compositing-span.html [ Failure ]
 
 webkit.org/b/187064 webrtc/video-addTrack.html [ Failure ]
-webkit.org/b/187064 webkit.org/b/235885 webrtc/video-replace-muted-track.html [ Timeout Failure ]
 webkit.org/b/187064 webkit.org/b/235885 webrtc/video-disabled-black.html [ Crash Timeout ]
 webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Crash Failure ]
 webkit.org/b/187064 webrtc/video-rotation.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -93,6 +93,10 @@ static RTCRtpCapabilities gstreamerRtpCapatiblities(const String& kind)
             .clockRate = 90000,
             .channels = std::nullopt,
             .sdpFmtpLine = "profile-id=1"_s });
+        capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP9"_s,
+            .clockRate = 90000,
+            .channels = std::nullopt,
+            .sdpFmtpLine = "profile-id=2"_s });
         capabilities.codecs.uncheckedAppend({ .mimeType = "video/H264"_s,
             .clockRate = 90000,
             .channels = std::nullopt,

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -66,12 +66,15 @@ protected:
     GRefPtr<GstElement> m_postEncoderQueue;
     GRefPtr<GstElement> m_capsFilter;
     GRefPtr<GstCaps> m_allowedCaps;
+    GRefPtr<GstWebRTCRTPTransceiver> m_transceiver;
     GRefPtr<GstWebRTCRTPSender> m_sender;
     GRefPtr<GstPad> m_webrtcSinkPad;
 
 private:
     void sourceMutedChanged();
     void sourceEnabledChanged();
+
+    virtual void codecPreferencesChanged(const GRefPtr<GstCaps>&) { }
 
     // MediaStreamTrackPrivate::Observer API
     void trackMutedChanged(MediaStreamTrackPrivate&) override { sourceMutedChanged(); }

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -39,6 +39,8 @@ protected:
     bool m_shouldApplyRotation { false };
 
 private:
+    void codecPreferencesChanged(const GRefPtr<GstCaps>&) final;
+
     GRefPtr<GstElement> m_videoConvert;
     GRefPtr<GstElement> m_videoFlip;
 };


### PR DESCRIPTION
#### d3c0cebbf427e3c8898281615fc34b1d25f71ed9
<pre>
[GStreamer][WebRTC] Support for VP9 Profile 2 (10-bit color) encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=218221">https://bugs.webkit.org/show_bug.cgi?id=218221</a>

Reviewed by Xabier Rodriguez-Calvar.

Transceiver codec preferences are now passed down to the WebRTC video encoder, which is able to
dynamically switch to a different platform encoder. VP9 profile 2 requiring a 10-bit pixel input
format, the WebRTC video encoder now wraps a videoconvert element and an additional capsfilter in
order to handler optional video conversion upfront of the encoder.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::gstreamerRtpCapatiblities):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::setCodecPreferences):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp:
(webrtcVideoEncoderSetEncoder):
(webrtcVideoEncoderSetFormat):
(webkit_webrtc_video_encoder_class_init):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setSinkPad):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::codecPreferencesChanged):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::codecPreferencesChanged):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/252497@main">https://commits.webkit.org/252497@main</a>
</pre>
