### PR TITLE
Revert patches are not using fast-cq path anymore since migration to identifiers

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1217,7 +1217,7 @@ class BugzillaMixin(AddToLogMixin):
     addURLs = False
     bug_open_statuses = ['UNCONFIRMED', 'NEW', 'ASSIGNED', 'REOPENED']
     bug_closed_statuses = ['RESOLVED', 'VERIFIED', 'CLOSED']
-    fast_cq_preambles = ('revert of r', 'fast-cq', '[fast-cq]')
+    fast_cq_preambles = ('revert of ', 'fast-cq', '[fast-cq]')
 
     def fetch_data_from_url_with_authentication_bugzilla(self, url):
         response = None

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -5053,7 +5053,7 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         return rc
 
     def test_fast_cq_patches_trigger_fast_cq_mode(self):
-        fast_cq_patch_titles = ('REVERT OF r1234', 'revert of r1234', '[fast-cq]Patch', '[FAST-cq] patch', 'fast-cq-patch', 'FAST-CQ Patch')
+        fast_cq_patch_titles = ('REVERT OF r1234', 'revert of r1234', 'REVERT of 123456@main', '[fast-cq]Patch', '[FAST-cq] patch', 'fast-cq-patch', 'FAST-CQ Patch')
         for fast_cq_patch_title in fast_cq_patch_titles:
             self.setupStep(ValidateChange(verifyBugClosed=False))
             ValidateChange.get_patch_json = lambda x, patch_id: self.get_patch(title=fast_cq_patch_title)


### PR DESCRIPTION
#### fbeafa9b5676762f9890af2d2d6672dddb309b99
<pre>
Revert patches are not using fast-cq path anymore since migration to identifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242754">https://bugs.webkit.org/show_bug.cgi?id=242754</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/steps.py:
(BugzillaMixin):

Canonical link: <a href="https://commits.webkit.org/252461@main">https://commits.webkit.org/252461@main</a>
</pre>
