### PR TITLE
Crash under XPCServiceEventHandler when calling CFBundleGetFunctionPointerForName()

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -109,6 +109,10 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             }
 
             CFBundleRef webKitBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebKit"));
+            if (!webKitBundle) {
+                RELEASE_LOG_FAULT(IPC, "XPCServiceEventHandler: Couldn't load bundle with using 'com.apple.WebKit' identifier");
+                return;
+            }
             typedef void (*InitializerFunction)(xpc_connection_t, xpc_object_t, xpc_object_t);
             InitializerFunction initializerFunctionPtr = reinterpret_cast<InitializerFunction>(CFBundleGetFunctionPointerForName(webKitBundle, entryPointFunctionName));
             if (!initializerFunctionPtr) {


### PR DESCRIPTION
#### 5341c9977573023e815c5c626f20e870b0e650d5
<pre>
Crash under XPCServiceEventHandler when calling CFBundleGetFunctionPointerForName()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242755">https://bugs.webkit.org/show_bug.cgi?id=242755</a>
&lt;rdar://97002400&gt;

Reviewed by NOBODY (OOPS!).

CFBundleGetFunctionPointerForName() crashes when passed in a null bundle pointer so we
need to make sure we deal with CFBundleGetBundleWithIdentifier() potentially returning
null.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
</pre>