### PR TITLE
Add scrolling options to PDFJS context menus.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1701,3 +1701,13 @@
 
 /* Lockdown Mode alert message */
 "Certain experiences and features may not function as expected. You can turn off Lockdown Mode for this app in Settings." = "Certain experiences and features may not function as expected. You can turn off Lockdown Mode for this app in Settings.";
+
+/* PDFJS strings */
+"Single Page" = "Single Page";
+
+"Single Page Continuous" = "Single Page Continuous";
+
+"Two Pages" = "Two Pages";
+
+"Two Pages Continuous" = "Two Pages Continuous";
+

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -197,6 +197,9 @@ bool isValidContextMenuAction(ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemPDFZoomOut:
     case ContextMenuAction::ContextMenuItemPDFAutoSize:
     case ContextMenuAction::ContextMenuItemPDFSinglePage:
+    case ContextMenuAction::ContextMenuItemPDFSinglePageContinuous:
+    case ContextMenuAction::ContextMenuItemPDFTwoPages:
+    case ContextMenuAction::ContextMenuItemPDFTwoPagesContinuous:
     case ContextMenuAction::ContextMenuItemPDFFacingPages:
     case ContextMenuAction::ContextMenuItemPDFContinuous:
     case ContextMenuAction::ContextMenuItemPDFNextPage:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -150,7 +150,10 @@ enum ContextMenuAction {
     ContextMenuItemTagLookUpImage,
     ContextMenuItemTagTranslate,
     ContextMenuItemTagCopySubject,
-    ContextMenuItemLastNonCustomTag = ContextMenuItemTagCopySubject,
+    ContextMenuItemPDFSinglePageContinuous,
+    ContextMenuItemPDFTwoPages,
+    ContextMenuItemPDFTwoPagesContinuous,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemPDFTwoPagesContinuous,
     ContextMenuItemBaseCustomTag = 5000,
     ContextMenuItemLastCustomTag = 5999,
     ContextMenuItemBaseApplicationTag = 10000

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -487,6 +487,28 @@ String contextMenuItemTagInspectElement()
     return WEB_UI_STRING_WITH_MNEMONIC("Inspect Element", "Inspect _Element", "Inspect Element context menu item");
 }
 
+#if ENABLE(PDFJS)
+String contextMenuItemPDFSinglePage()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Single Page", "_Single Page", "Single Page context menu item");
+}
+
+String contextMenuItemPDFSinglePageContinuous()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Single Page Continuous", "_Single Page Continuous", "Single Page Continuous context menu item");
+}
+
+String contextMenuItemPDFTwoPages()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Two Pages", "_Two Pages", "Two Pages context menu item");
+}
+
+String contextMenuItemPDFTwoPagesContinuous()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Two Pages Continuous", "_Two Pages Continuous", "Two Pages Continuous context menu item");
+}
+#endif
+
 #if !PLATFORM(COCOA)
 String contextMenuItemTagSearchWeb()
 {

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -161,6 +161,13 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemTagInspectElement();
 #endif // ENABLE(CONTEXT_MENUS)
 
+#if ENABLE(PDFJS)
+WEBCORE_EXPORT String contextMenuItemPDFSinglePage();
+WEBCORE_EXPORT String contextMenuItemPDFSinglePageContinuous();
+WEBCORE_EXPORT String contextMenuItemPDFTwoPages();
+WEBCORE_EXPORT String contextMenuItemPDFTwoPagesContinuous();
+#endif
+
 #if !PLATFORM(IOS_FAMILY)
     String searchMenuNoRecentSearchesText();
     String searchMenuRecentSearchesText();

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -601,6 +601,9 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagTranslate;
     case ContextMenuItemTagCopySubject:
     case ContextMenuItemTagLookUpImage:
+    case ContextMenuItemPDFSinglePageContinuous:
+    case ContextMenuItemPDFTwoPages:
+    case ContextMenuItemPDFTwoPagesContinuous:
         return std::nullopt;
 
     case ContextMenuItemBaseCustomTag ... ContextMenuItemLastCustomTag:


### PR DESCRIPTION
#### d50f30c80ffad3e9a1fe97e3eb367a696a622683
<pre>
Add scrolling options to PDFJS context menus.
<a href="https://bugs.webkit.org/show_bug.cgi?id=237059">https://bugs.webkit.org/show_bug.cgi?id=237059</a>
rdar://89315125

Reviewed by Aditya Keerthi.

This patch adds scrolling options to the context menu when right
clicking on a PDF that is being rendered in PDFJS. It is important to
note that this patch only adds the options to the context menu in
appearance only. Linking the options to the actual implementation in
PDFJS will be done in another patch.

By taking advantage of the current context menu code, such as in
ContextMenuController, we can try to keep the PDF code as close to the
rest of the context menu code. For example, we would have have to go
through WebPageProxy::showPDFContextMenu inside WebPageProxyMac, which
the current PDFPlugin code does.

The only special consideration that needs to be made is within
ContextMenuController::populate. We need to be able to determine that
the PDF context menu items must be added to the context menu. We can
do this by determining that the current frame is an iframe
(!frame-&gt;isMainFrame) and that the owning document is a PDFDocument
(frame-&gt;ownerElement()-&gt;document().isPDFDocument()). Similarly, in
already existing cases where the code checks for frame-&gt;page(), we must
add an extra condition that the owning document is NOT a PDFDocument so
that we do not add any extra context menu items to PDF context menus and
remain consistent with the current PDF context menu.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
(WebCore::ContextMenuController::populate):
Goes through and determines where to add the PDF context menu items. We
need to make sure that the normal context menu remain the same (when
not viewing a PDF) and also to make sure that the PDF context menu
remains consistent with the current implementation.

* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
Adds the new context menu scrolling items to the ContextMenuAction
enum.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFSinglePage):
(WebCore::contextMenuItemPDFSinglePageContinuous):
(WebCore::contextMenuItemPDFTwoPages):
(WebCore::contextMenuItemPDFTwoPagesContinuous):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):

Canonical link: <a href="https://commits.webkit.org/253130@main">https://commits.webkit.org/253130@main</a>
</pre>
