### PR TITLE
Unreviewed, fix two paths in GitHub CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,12 +79,12 @@
 /Source/WebCore/editing @rniwa
 /LayoutTests/editing @rniwa
 
-/Source/WebCore/Modules/apple-pay @dcrousso
+/Source/WebCore/Modules/applepay @dcrousso
 /Source/WebCore/Modules/paymentrequest @dcrousso
 /LayoutTests/http/tests/paymentrequest @dcrousso
 /LayoutTests/http/tests/ssl/applepay @dcrousso
 
-/Source/WebCore/Modules/apple-pay-ams-ui @dcrousso
+/Source/WebCore/Modules/applepay-ams-ui @dcrousso
 /LayoutTests/http/tests/ssl/applepay-ams-ui @dcrousso
 
 /Source/WebCore/Modules/mediacontrols @dcrousso


### PR DESCRIPTION
#### 7f52a37c80dfad2e1b667e852917afd08b092506
<pre>
Unreviewed, fix two paths in GitHub CODEOWNERS

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/252463@main">https://commits.webkit.org/252463@main</a>
</pre>
