### PR TITLE
[Alternate WebM Player] Remove unused resource loader options from load function

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -161,22 +161,6 @@ void MediaPlayerPrivateWebM::load(const String& url)
     request.setAllowCookies(true);
     request.setFirstPartyForCookies(URL(url));
 
-    ResourceLoaderOptions loaderOptions(
-        SendCallbackPolicy::SendCallbacks,
-        ContentSniffingPolicy::DoNotSniffContent,
-        DataBufferingPolicy::BufferData,
-        StoredCredentialsPolicy::DoNotUse,
-        ClientCredentialPolicy::CannotAskClientForCredentials,
-        FetchOptions::Credentials::Omit,
-        SecurityCheckPolicy::DoSecurityCheck,
-        FetchOptions::Mode::NoCors,
-        CertificateInfoPolicy::DoNotIncludeCertificateInfo,
-        ContentSecurityPolicyImposition::DoPolicyCheck,
-        DefersLoadingPolicy::AllowDefersLoading,
-        CachingPolicy::DisallowCaching
-    );
-    loaderOptions.destination = FetchOptions::Destination::Video;
-
     auto loader = m_player->createResourceLoader();
     m_resourceClient = WebMResourceClient::create(*this, *loader, WTFMove(request));
     


### PR DESCRIPTION
#### 05bf576d2798feaeb1be5a5f70299acd0caaae9f
<pre>
[Alternate WebM Player] Remove unused resource loader options from load function
<a href="https://bugs.webkit.org/show_bug.cgi?id=242760">https://bugs.webkit.org/show_bug.cgi?id=242760</a>

Reviewed by Tim Horton.

The MediaPlayerPrivateWebM::load function had unused resource loader options
from during the initial prototype of the engine. They are no longer passed
on to the resource loader and instead handled by the MediaResourceLoader class.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):

Canonical link: <a href="https://commits.webkit.org/252474@main">https://commits.webkit.org/252474@main</a>
</pre>
