### PR TITLE
Assert that scripts don't execute in UA shadow tree updates during style resolution

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2043,23 +2043,16 @@ void Document::resolveStyle(ResolveStyleType type)
 
     RenderView::RepaintRegionAccumulator repaintRegionAccumulator(renderView());
 
-    // FIXME: Do this user agent shadow tree update per tree scope.
-
-    // We can't clear m_elementsWithPendingUserAgentShadowTreeUpdates here
-    // because SVGUseElement::updateUserAgentShadowTree may end up executing
-    // arbitrary scripts which may insert new SVG use elements or remove
-    // existing ones inside sync IPC via ImageLoader::updateFromElement.
-    //
-    // Instead, it is the responsibility of updateUserAgentShadowTree to
-    // remove the element.
-    for (auto& element : copyToVectorOf<Ref<Element>>(m_elementsWithPendingUserAgentShadowTreeUpdates))
-        element->updateUserAgentShadowTree();
-
     // FIXME: We should update style on our ancestor chain before proceeding, however doing so at
     // the time this comment was originally written caused several tests to crash.
 
     {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+
+        // FIXME: Do this user agent shadow tree update per tree scope.
+        for (auto& element : copyToVectorOf<Ref<Element>>(m_elementsWithPendingUserAgentShadowTreeUpdates))
+            element->updateUserAgentShadowTree();
+
         styleScope().flushPendingUpdate();
         frameView.willRecalcStyle();
     }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -578,6 +578,7 @@ Ref<Node> Element::cloneNodeInternal(Document& targetDocument, CloningOperation 
 Ref<Element> Element::cloneElementWithChildren(Document& targetDocument)
 {
     Ref<Element> clone = cloneElementWithoutChildren(targetDocument);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
     cloneChildNodes(clone);
     return clone;
 }

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -49,6 +49,7 @@
 #include "KeyboardEvent.h"
 #include "Page.h"
 #include "PlatformLocale.h"
+#include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
@@ -313,6 +314,8 @@ void BaseDateAndTimeInputType::createShadowSubtree()
 
     auto& element = *this->element();
     auto& document = element.document();
+
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element.userAgentShadowRoot() };
 
     if (document.settings().dateTimeInputsEditableComponentsEnabled()) {
         m_dateTimeEditElement = DateTimeEditElement::create(document, *this);

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -49,6 +49,7 @@
 #include "InputTypeNames.h"
 #include "RenderView.h"
 #include "ScopedEventQueue.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "UserGestureIndicator.h"
@@ -145,11 +146,14 @@ void ColorInputType::createShadowSubtree()
 
     Document& document = element()->document();
     auto wrapperElement = HTMLDivElement::create(document);
-    wrapperElement->setPseudo(ShadowPseudoIds::webkitColorSwatchWrapper());
     auto colorSwatch = HTMLDivElement::create(document);
-    colorSwatch->setPseudo(ShadowPseudoIds::webkitColorSwatch());
-    wrapperElement->appendChild(ContainerNode::ChildChange::Source::Parser, colorSwatch);
+
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
     element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, wrapperElement);
+
+    wrapperElement->appendChild(ContainerNode::ChildChange::Source::Parser, colorSwatch);
+    wrapperElement->setPseudo(ShadowPseudoIds::webkitColorSwatchWrapper());
+    colorSwatch->setPseudo(ShadowPseudoIds::webkitColorSwatch());
 
     updateColorSwatch();
 }

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -41,6 +41,7 @@
 #include "LocalizedStrings.h"
 #include "MIMETypeRegistry.h"
 #include "RenderFileUploadControl.h"
+#include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
@@ -95,6 +96,7 @@ Ref<UploadButtonElement> UploadButtonElement::createForMultiple(Document& docume
 Ref<UploadButtonElement> UploadButtonElement::createInternal(Document& document, const String& value)
 {
     auto button = adoptRef(*new UploadButtonElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { button };
     button->setType(HTMLNames::buttonTag->localName());
     button->setPseudo(ShadowPseudoIds::fileSelectorButton());
     button->setValue(value);
@@ -264,6 +266,7 @@ void FileInputType::createShadowSubtree()
     ASSERT(element()->shadowRoot());
 
     auto button = element()->multiple() ? UploadButtonElement::createForMultiple(element()->document()) : UploadButtonElement::create(element()->document());
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
     element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, button);
     disabledStateChanged();
 }

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -47,6 +47,7 @@
 #include "PlatformMouseEvent.h"
 #include "RenderSlider.h"
 #include "ScopedEventQueue.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "SliderThumbElement.h"
@@ -259,12 +260,16 @@ void RangeInputType::createShadowSubtree()
     ASSERT(element()->userAgentShadowRoot());
 
     Document& document = element()->document();
+
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
+
     auto track = HTMLDivElement::create(document);
+    auto container = SliderContainerElement::create(document);
+    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, container);
+    container->appendChild(ContainerNode::ChildChange::Source::Parser, track);
+
     track->setPseudo(ShadowPseudoIds::webkitSliderRunnableTrack());
     track->appendChild(ContainerNode::ChildChange::Source::Parser, SliderThumbElement::create(document));
-    auto container = SliderContainerElement::create(document);
-    container->appendChild(ContainerNode::ChildChange::Source::Parser, track);
-    element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, container);
 }
 
 HTMLElement* RangeInputType::sliderTrackElement() const

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -38,6 +38,7 @@
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "RenderSearchField.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "TextControlInnerElements.h"
@@ -111,13 +112,14 @@ void SearchInputType::createShadowSubtree()
     TextFieldInputType::createShadowSubtree();
     RefPtr<HTMLElement> container = containerElement();
     RefPtr<HTMLElement> textWrapper = innerBlockElement();
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *container };
     ASSERT(container);
     ASSERT(textWrapper);
 
     ASSERT(element());
     m_resultsButton = SearchFieldResultsButtonElement::create(element()->document());
-    updateResultButtonPseudoType(*m_resultsButton, element()->maxResults());
     container->insertBefore(*m_resultsButton, textWrapper.get());
+    updateResultButtonPseudoType(*m_resultsButton, element()->maxResults());
 
     m_cancelButton = SearchFieldCancelButtonElement::create(element()->document());
     container->insertBefore(*m_cancelButton, textWrapper->nextSibling());

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -355,6 +355,7 @@ void TextFieldInputType::createShadowSubtree()
 
     m_innerText = TextControlInnerTextElement::create(document, element()->isInnerTextElementEditable());
 
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *element()->userAgentShadowRoot() };
     if (!createsContainer) {
         element()->userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, *m_innerText);
         updatePlaceholderText();
@@ -371,12 +372,12 @@ void TextFieldInputType::createShadowSubtree()
 
     if (shouldHaveCapsLockIndicator) {
         m_capsLockIndicator = HTMLDivElement::create(document);
+        m_container->appendChild(ContainerNode::ChildChange::Source::Parser, *m_capsLockIndicator);
+
         m_capsLockIndicator->setPseudo(ShadowPseudoIds::webkitCapsLockIndicator());
 
         bool shouldDrawCapsLockIndicator = this->shouldDrawCapsLockIndicator();
         m_capsLockIndicator->setInlineStyleProperty(CSSPropertyDisplay, shouldDrawCapsLockIndicator ? CSSValueBlock : CSSValueNone, true);
-
-        m_container->appendChild(ContainerNode::ChildChange::Source::Parser, *m_capsLockIndicator);
     }
 
     updateAutoFillButton();
@@ -848,11 +849,12 @@ void TextFieldInputType::createAutoFillButton(AutoFillButtonType autoFillButtonT
 
     ASSERT(element());
     m_autoFillButton = AutoFillButtonElement::create(element()->document(), *this);
+    m_container->appendChild(*m_autoFillButton);
+
     m_autoFillButton->setPseudo(autoFillButtonTypeToAutoFillButtonPseudoClassName(autoFillButtonType));
     m_autoFillButton->setAttributeWithoutSynchronization(roleAttr, HTMLNames::buttonTag->localName());
     m_autoFillButton->setAttributeWithoutSynchronization(aria_labelAttr, AtomString { autoFillButtonTypeToAccessibilityLabel(autoFillButtonType) });
     m_autoFillButton->setTextContent(autoFillButtonTypeToAutoFillButtonText(autoFillButtonType));
-    m_container->appendChild(*m_autoFillButton);
 }
 
 void TextFieldInputType::updateAutoFillButton()

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -38,6 +38,7 @@
 #include "Event.h"
 #include "HTMLNames.h"
 #include "PlatformLocale.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "Text.h"
 #include <wtf/IsoMallocInlines.h>
@@ -172,6 +173,7 @@ void DateTimeEditBuilder::visitLiteral(String&& text)
     ASSERT(text.length());
 
     auto element = HTMLDivElement::create(m_editElement.document());
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitDatetimeEditText());
 
     // If the literal begins/ends with a space, the gap between two fields will appear
@@ -236,6 +238,7 @@ DateTimeFieldElement* DateTimeEditElement::focusedFieldElement() const
 Ref<DateTimeEditElement> DateTimeEditElement::create(Document& document, EditControlOwner& editControlOwner)
 {
     auto element = adoptRef(*new DateTimeEditElement(document, editControlOwner));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitDatetimeEdit());
     return element;
 }
@@ -244,8 +247,8 @@ void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
 {
     if (!firstChild()) {
         auto element = HTMLDivElement::create(document());
-        element->setPseudo(ShadowPseudoIds::webkitDatetimeEditFieldsWrapper());
         appendChild(element);
+        element->setPseudo(ShadowPseudoIds::webkitDatetimeEditFieldsWrapper());
     }
 
     Element& fieldsWrapper = fieldsWrapperElement();

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
@@ -31,6 +31,7 @@
 
 #include "DateComponents.h"
 #include "DateTimeFieldsState.h"
+#include "ScriptDisallowedScope.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ Ref<DateTimeDayFieldElement> DateTimeDayFieldElement::create(Document& document,
 {
     auto element = adoptRef(*new DateTimeDayFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> dayPseudoId("-webkit-datetime-edit-day-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(dayPseudoId);
     return element;
 }
@@ -72,6 +74,7 @@ Ref<DateTimeHourFieldElement> DateTimeHourFieldElement::create(Document& documen
 {
     auto element = adoptRef(*new DateTimeHourFieldElement(document, fieldOwner, minimum, maximum));
     static MainThreadNeverDestroyed<const AtomString> hourPseudoId("-webkit-datetime-edit-hour-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(hourPseudoId);
     return element;
 }
@@ -137,6 +140,7 @@ Ref<DateTimeMeridiemFieldElement> DateTimeMeridiemFieldElement::create(Document&
 {
     auto element = adoptRef(*new DateTimeMeridiemFieldElement(document, fieldOwner, labels));
     static MainThreadNeverDestroyed<const AtomString> meridiemPseudoId("-webkit-datetime-edit-meridiem-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(meridiemPseudoId);
     return element;
 }
@@ -163,6 +167,7 @@ Ref<DateTimeMillisecondFieldElement> DateTimeMillisecondFieldElement::create(Doc
 {
     auto element = adoptRef(*new DateTimeMillisecondFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> millisecondPseudoId("-webkit-datetime-edit-millisecond-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(millisecondPseudoId);
     return element;
 }
@@ -189,6 +194,7 @@ Ref<DateTimeMinuteFieldElement> DateTimeMinuteFieldElement::create(Document& doc
 {
     auto element = adoptRef(*new DateTimeMinuteFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> minutePseudoId("-webkit-datetime-edit-minute-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(minutePseudoId);
     return element;
 }
@@ -215,6 +221,7 @@ Ref<DateTimeMonthFieldElement> DateTimeMonthFieldElement::create(Document& docum
 {
     auto element = adoptRef(*new DateTimeMonthFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(monthPseudoId);
     return element;
 }
@@ -242,6 +249,7 @@ Ref<DateTimeSecondFieldElement> DateTimeSecondFieldElement::create(Document& doc
 {
     auto element = adoptRef(*new DateTimeSecondFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> secondPseudoId("-webkit-datetime-edit-second-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(secondPseudoId);
     return element;
 }
@@ -268,6 +276,7 @@ Ref<DateTimeSymbolicMonthFieldElement> DateTimeSymbolicMonthFieldElement::create
 {
     auto element = adoptRef(*new DateTimeSymbolicMonthFieldElement(document, fieldOwner, labels));
     static MainThreadNeverDestroyed<const AtomString> monthPseudoId("-webkit-datetime-edit-month-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(monthPseudoId);
     return element;
 }
@@ -294,6 +303,7 @@ Ref<DateTimeYearFieldElement> DateTimeYearFieldElement::create(Document& documen
 {
     auto element = adoptRef(*new DateTimeYearFieldElement(document, fieldOwner));
     static MainThreadNeverDestroyed<const AtomString> yearPseudoId("-webkit-datetime-edit-year-field"_s);
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->initialize(yearPseudoId);
     return element;
 }

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -45,6 +45,7 @@
 #include "RenderFlexibleBox.h"
 #include "RenderSlider.h"
 #include "RenderTheme.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "StepRange.h"
@@ -173,6 +174,7 @@ void RenderSliderContainer::layout()
 Ref<SliderThumbElement> SliderThumbElement::create(Document& document)
 {
     auto element = adoptRef(*new SliderThumbElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitSliderThumb());
     return element;
 }
@@ -586,6 +588,7 @@ inline SliderContainerElement::SliderContainerElement(Document& document)
 Ref<SliderContainerElement> SliderContainerElement::create(Document& document)
 {
     auto element = adoptRef(*new SliderContainerElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitSliderContainer());
     return element;
 }

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -36,6 +36,7 @@
 #include "Page.h"
 #include "RenderBox.h"
 #include "RenderTheme.h"
+#include "ScriptDisallowedScope.h"
 #include "ScrollbarTheme.h"
 #include "ShadowPseudoIds.h"
 #include "WheelEvent.h"
@@ -62,6 +63,7 @@ inline SpinButtonElement::SpinButtonElement(Document& document, SpinButtonOwner&
 Ref<SpinButtonElement> SpinButtonElement::create(Document& document, SpinButtonOwner& spinButtonOwner)
 {
     auto element = adoptRef(*new SpinButtonElement(document, spinButtonOwner));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitInnerSpinButton());
     return element;
 }

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -42,6 +42,7 @@
 #include "RenderTextControl.h"
 #include "RenderView.h"
 #include "ScriptController.h"
+#include "ScriptDisallowedScope.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "StyleResolver.h"
@@ -145,6 +146,7 @@ Ref<TextControlInnerTextElement> TextControlInnerTextElement::create(Document& d
 {
     auto result = adoptRef(*new TextControlInnerTextElement(document));
     constexpr bool initialization = true;
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { result };
     result->updateInnerTextElementEditabilityImpl(isEditable, initialization);
     return result;
 }
@@ -204,6 +206,7 @@ inline TextControlPlaceholderElement::TextControlPlaceholderElement(Document& do
 Ref<TextControlPlaceholderElement> TextControlPlaceholderElement::create(Document& document)
 {
     auto element = adoptRef(*new TextControlPlaceholderElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::placeholder());
     return element;
 }
@@ -296,6 +299,7 @@ Ref<SearchFieldCancelButtonElement> SearchFieldCancelButtonElement::create(Docum
 {
     auto element = adoptRef(*new SearchFieldCancelButtonElement(document));
 
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
     element->setPseudo(ShadowPseudoIds::webkitSearchCancelButton());
 #if !PLATFORM(IOS_FAMILY)
     element->setAttributeWithoutSynchronization(aria_labelAttr, AtomString { AXSearchFieldCancelButtonText() });

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -237,6 +237,7 @@ void SVGUseElement::updateUserAgentShadowTree()
     RELEASE_ASSERT(!isDescendantOf(target));
     {
         auto& shadowRoot = ensureUserAgentShadowRoot();
+        ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
         cloneTarget(shadowRoot, *target);
         expandUseElementsInShadowTree();
         expandSymbolElementsInShadowTree();
@@ -436,6 +437,7 @@ SVGElement* SVGUseElement::findTarget(AtomString* targetID) const
 void SVGUseElement::cloneTarget(ContainerNode& container, SVGElement& target) const
 {
     Ref<SVGElement> targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(document()).get());
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { targetClone };
     associateClonesWithOriginals(targetClone.get(), target);
     removeDisallowedElementsFromSubtree(targetClone.get());
     removeSymbolElementsFromSubtree(targetClone.get());
@@ -468,6 +470,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
         // 'use' element except for x, y, width, height and xlink:href are transferred to the generated 'g' element.
 
         auto replacementClone = SVGGElement::create(document());
+        ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
 
@@ -503,6 +506,8 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
         // 'svg' element will use values of 100% for these attributes.
 
         auto replacementClone = SVGSVGElement::create(document());
+        ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
+
         cloneDataAndChildren(replacementClone.get(), originalClone);
 
         originalClone.parentNode()->replaceChild(replacementClone, originalClone);


### PR DESCRIPTION
#### b10818115c0fc3bd523d064f26b16293f4167bb2
<pre>
Assert that scripts don&apos;t execute in UA shadow tree updates during style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=242348">https://bugs.webkit.org/show_bug.cgi?id=242348</a>

Reviewed by Alan Bujtas.

This patch adds a new release assertion that no author scripts are executed while updating
the user agent shadow roots of from and SVG use elements.

Most of this patch instantiates ScriptDisallowedScope::EventAllowedScope and reorders code
so that DOM mutation happen after a node got inserted into a tree with EventAllowedScope.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle): This is the main change.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneElementWithChildren):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::createShadowSubtree):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::createShadowSubtree):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::UploadButtonElement::createInternal):
(WebCore::FileInputType::createShadowSubtree):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::createShadowSubtree):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::createShadowSubtree):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createShadowSubtree):
(WebCore::TextFieldInputType::createAutoFillButton):
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditBuilder::visitLiteral):
(WebCore::DateTimeEditElement::create):
(WebCore::DateTimeEditElement::layout):
* Source/WebCore/html/shadow/DateTimeFieldElements.cpp:
(WebCore::DateTimeDayFieldElement::create):
(WebCore::DateTimeHourFieldElement::create):
(WebCore::DateTimeMeridiemFieldElement::create):
(WebCore::DateTimeMillisecondFieldElement::create):
(WebCore::DateTimeMinuteFieldElement::create):
(WebCore::DateTimeMonthFieldElement::create):
(WebCore::DateTimeSecondFieldElement::create):
(WebCore::DateTimeSymbolicMonthFieldElement::create):
(WebCore::DateTimeYearFieldElement::create):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::create):
(WebCore::SliderContainerElement::create):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::create):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerTextElement::create):
(WebCore::TextControlPlaceholderElement::create):
(WebCore::SearchFieldCancelButtonElement::create):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::updateUserAgentShadowTree):
(WebCore::SVGUseElement::cloneTarget const):
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):

Canonical link: <a href="https://commits.webkit.org/252551@main">https://commits.webkit.org/252551@main</a>
</pre>
