### PR TITLE
[Gardening]: 4X http/tests/media/modern-media-controls/time-control (layout-tests) are very flakily crashing

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2293,3 +2293,5 @@ webkit.org/b/242249 [ BigSur+ ] webanimations/accelerated-animation-after-forwar
 webkit.org/b/242481 fast/css/direct-adjacent-style-sharing-3.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242484 fast/css/display-contents-all.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass Crash ]


### PR DESCRIPTION
#### 29784aacc48127d49427621faa627c7f296ebb44
<pre>
[Gardening]: 4X http/tests/media/modern-media-controls/time-control (layout-tests) are very flakily crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=242226">https://bugs.webkit.org/show_bug.cgi?id=242226</a>

Unreviewed test gardening.

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252471@main">https://commits.webkit.org/252471@main</a>
</pre>
