### PR TITLE
SEED: 21G5063a/MacBookPro11,4: Google Maps rendering (graphic distortion rendered against a black view where Maps should be)

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -108,6 +108,10 @@ static bool platformSupportsMetal()
         // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL via Metal.
         // This check can be removed once they are no longer supported.
         return [device supportsFamily:MTLGPUFamilyApple3];
+#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
+        // This check can be removed once they are no longer supported.
+        return [device supportsFamily:MTLGPUFamilyMac2];
 #endif
         return true;
     }

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -191,16 +191,21 @@ bool Internals::platformSupportsMetal(bool isWebGL2)
 {
     auto device = adoptNS(MTLCreateSystemDefaultDevice());
 
+    UNUSED_PARAM(isWebGL2);
+
     if (device) {
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
         // A8 devices (iPad Mini 4, iPad Air 2) cannot use WebGL2 via Metal.
         // This check can be removed once they are no longer supported.
         if (isWebGL2)
             return [device supportsFamily:MTLGPUFamilyApple3];
+#elif PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
+        // This check can be removed once they are no longer supported.
+        return [device supportsFamily:MTLGPUFamilyMac2];
 #else
-        UNUSED_PARAM(isWebGL2);
-#endif
         return true;
+#endif
     }
 
     return false;


### PR DESCRIPTION
#### 8d2a69e734f034df7d5c79782eba867dcf63f348
<pre>
SEED: 21G5063a/MacBookPro11,4: Google Maps rendering (graphic distortion rendered against a black view where Maps should be)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242764">https://bugs.webkit.org/show_bug.cgi?id=242764</a>
rdar://96780550

Reviewed by Kenneth Russell.

With the latest ANGLE Metal, older devices are seeing some issues. e.g. MacBook
Pros from 2015. They are no longer supported in Ventura, so this isn&apos;t an issue
there, but they are supported on Monterey. This fix forces them into using the
OpenGL backend for ANGLE.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::platformSupportsMetal): Return false if the device doesn&apos;t support MTLGPUFamilyMac2.
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::platformSupportsMetal):

Canonical link: <a href="https://commits.webkit.org/252480@main">https://commits.webkit.org/252480@main</a>
</pre>
