### PR TITLE
Crash under getNetworkProcessConnection()

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -403,6 +403,7 @@ private:
     Client& m_client;
     UniqueID m_uniqueID;
     bool m_isServer;
+    bool m_didInvalidationOnMainThread { false }; // Main thread only.
     std::atomic<bool> m_isValid { true };
 
     bool m_onlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage { false };

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1150,7 +1150,7 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
         return IPC::Connection::identifierIsValid(connectionInfo.identifier());
     };
 
-    static constexpr unsigned maxFailedAttempts = 10;
+    static constexpr unsigned maxFailedAttempts = 30;
     unsigned failedAttempts = 0;
     while (!requestConnection()) {
         if (++failedAttempts >= maxFailedAttempts)


### PR DESCRIPTION
#### d8327a389be8fe72b4cd808e358904cb47c4c105
<pre>
Crash under getNetworkProcessConnection()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242766">https://bugs.webkit.org/show_bug.cgi?id=242766</a>
&lt;rdar://92432654&gt;

Reviewed by Geoffrey Garen.

We see quite a few crashes under getNetworkProcessConnection() in the wild so
I am making the following changes to try and mitigate this:
1. Retry more times to establish the network process connection (for up the
   3 seconds instead of 1)
2. requestConnection() would keep checking if the connection is still valid,
   in case the reason the connection establishment failed because the UIProcess
   severed the connection. However, because getNetworkProcessConnection() hangs
   the main thread and because Connection::m_isValid was only getting updated
   on the main thread, it wouldn&apos;t actually be possible for isValid() to start
   returning false, even if the IPC connection was severed. To address this
   issue, we now update m_isValid on a background thread, as soon as the
   IPC connection closes.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::invalidate):
(IPC::Connection::connectionDidClose):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::getNetworkProcessConnection):

Canonical link: <a href="https://commits.webkit.org/252520@main">https://commits.webkit.org/252520@main</a>
</pre>
