### PR TITLE
Add missing MIG routine to sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2164,6 +2164,7 @@
                     io_service_open_extended
                     mach_exception_raise
                     mach_memory_entry_ownership
+                    mach_port_extract_right
                     mach_port_get_context_from_user
                     mach_port_get_refs
                     mach_port_request_notification


### PR DESCRIPTION
#### e24c79d8b07a732b1c64cd74de5d4ae16e49a224
<pre>
Add missing MIG routine to sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=242765">https://bugs.webkit.org/show_bug.cgi?id=242765</a>
&lt;rdar://96919857&gt;

Reviewed by Geoffrey Garen.

Add missing MIG routine to the WebContent sandbox on macOS.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252479@main">https://commits.webkit.org/252479@main</a>
</pre>
