### PR TITLE
SVGDocument getElementById returns null when svg element is disconnected from documents

### DIFF
--- a/LayoutTests/svg/dom/getElementsById-in-disconnected-svg-expected.txt
+++ b/LayoutTests/svg/dom/getElementsById-in-disconnected-svg-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVGSVGElement.prototype.getElementById must return the first element in tree order, within the 'svg' element's descendants, whose ID is elementId, or null if there is no such element
+

--- a/LayoutTests/svg/dom/getElementsById-in-disconnected-svg.html
+++ b/LayoutTests/svg/dom/getElementsById-in-disconnected-svg.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://www.w3.org/TR/SVG2/struct.html#__svg__SVGSVGElement__getElementById">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="test">
+    <svg xmlns="http://www.w3.org/2000/svg">
+        <g id="test"></g>
+        <g id="test"></g>
+    </svg>
+</div>
+<script>
+
+test(() => {
+    const div = document.querySelector('div');
+    const firstG = document.querySelector('g');
+    div.remove();
+    assert_equals(div.querySelector('svg').getElementById('test'), firstG);
+}, "SVGSVGElement.prototype.getElementById must return the first element in tree order,"
+    + " within the 'svg' element's descendants, whose ID is elementId, or null if there is no such element");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -48,6 +48,7 @@
 #include "SVGViewElement.h"
 #include "SVGViewSpec.h"
 #include "StaticNodeList.h"
+#include "TypedElementDescendantIterator.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -714,6 +715,14 @@ Element* SVGSVGElement::getElementById(const AtomString& id)
     if (id.isNull())
         return nullptr;
 
+    if (UNLIKELY(!isInTreeScope())) {
+        for (auto& element : descendantsOfType<Element>(*this)) {
+            if (element.getIdAttribute() == id)
+                return &element;
+        }
+        return nullptr;
+    }
+
     RefPtr element = treeScope().getElementById(id);
     if (element && element->isDescendantOf(*this))
         return element.get();
@@ -723,6 +732,7 @@ Element* SVGSVGElement::getElementById(const AtomString& id)
                 return element;
         }
     }
+
     return nullptr;
 }
 


### PR DESCRIPTION
#### 71e97d661b45a984d7b8a777aedb552461d353b8
<pre>
SVGDocument getElementById returns null when svg element is disconnected from documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=151969">https://bugs.webkit.org/show_bug.cgi?id=151969</a>

Reviewed by Chris Dumez.

Fixed the bug that SVGSVGElement.prototype.getElementById could not find an element of
a given ID if its subtree is disconnected from documents. New behavior matches the spec
as well as the behaviors of Gecko &amp; Blink:
<a href="https://www.w3.org/TR/SVG2/struct.html#__svg__SVGSVGElement__getElementById">https://www.w3.org/TR/SVG2/struct.html#__svg__SVGSVGElement__getElementById</a>

* LayoutTests/svg/dom/getElementsById-in-disconnected-svg-expected.txt: Added.
* LayoutTests/svg/dom/getElementsById-in-disconnected-svg.html: Added.
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getElementById): Fixed the bug.

Canonical link: <a href="https://commits.webkit.org/252478@main">https://commits.webkit.org/252478@main</a>
</pre>
