### PR TITLE
[commits.webkit.org] prune when fetching

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 3)
+version = Version(0, 7, 4)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
@@ -253,7 +253,7 @@ class Checkout(object):
 
     def fetch(self, remote=REMOTE):
         return not run(
-            [self.repository.executable(), 'fetch', remote],
+            [self.repository.executable(), 'fetch', remote, '--prune'],
             cwd=self.repository.root_path,
         ).returncode
 
@@ -270,7 +270,7 @@ class Checkout(object):
         elif not self.repository.prod_branches.match(branch):
             return False
         elif track and branch not in self.repository.branches_for(remote=remote):
-            run([self.repository.executable(), 'fetch'], cwd=self.repository.root_path)
+            run([self.repository.executable(), 'fetch', '--prune'], cwd=self.repository.root_path)
             run(
                 [self.repository.executable(), 'branch', '--track', branch, 'remotes/{}/{}'.format(remote, branch)],
                 cwd=self.repository.root_path,
@@ -303,10 +303,7 @@ class Checkout(object):
 
         print('Forwarding updates from {}'.format(remote))
 
-        run(
-            [self.repository.executable(), 'fetch', remote],
-            cwd=self.repository.root_path,
-        )
+        self.fetch(remote)
         self.repository.pull(remote=remote)
         self.repository.cache.populate(branch=self.repository.default_branch)
 

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.3',
+    version='0.7.4',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 78c97d5d2d89d46af00723dc1e9650a3d9eb346f
<pre>
[commits.webkit.org] prune when fetching
<a href="https://bugs.webkit.org/show_bug.cgi?id=242769">https://bugs.webkit.org/show_bug.cgi?id=242769</a>
&lt;rdar://problem/97036346&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/setup.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py:
(Checkout.fetch): Prune remote when fetching.
(Checkout.update_for): Ditto.
(Checkout.update_all): Invoke self.fetch.

Canonical link: <a href="https://commits.webkit.org/252512@main">https://commits.webkit.org/252512@main</a>
</pre>
