### PR TITLE
SVGStyleElement.sheet is undefined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
@@ -431,7 +431,7 @@ PASS CSS namespace: has no name property
 PASS CSS namespace: operation escape(CSSOMString)
 PASS SVGElement interface: attribute style
 PASS SVGElement interface: svg_element must inherit property "style" with the proper type
-FAIL SVGStyleElement interface: attribute sheet assert_true: The prototype object must have a property "sheet" expected true got false
+PASS SVGStyleElement interface: attribute sheet
 PASS HTMLElement interface: attribute style
 PASS HTMLElement interface: style_element must inherit property "style" with the proper type
 PASS HTMLElement interface: document.createElement("unknownelement") must inherit property "style" with the proper type

--- a/LayoutTests/svg/dom/svg-style-element-sheet-expected.txt
+++ b/LayoutTests/svg/dom/svg-style-element-sheet-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVGStyleElement interface should include LinkStyle
+

--- a/LayoutTests/svg/dom/svg-style-element-sheet.html
+++ b/LayoutTests/svg/dom/svg-style-element-sheet.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://svgwg.org/svg2-draft/styling.html#InterfaceSVGStyleElement">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+        g { color: green; }
+    </style>
+</svg>
+<script>
+
+test(() => {
+    const style = document.querySelector('svg style');
+    assert_not_equals(style.sheet, undefined);
+    assert_true(style.sheet instanceof StyleSheet);
+}, "SVGStyleElement interface should include LinkStyle");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -816,6 +816,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/FontFace.idl
     css/FontFaceSet.idl
     css/FontFaceSource.idl
+    css/LinkStyle.idl
     css/MediaList.idl
     css/MediaQueryList.idl
     css/MediaQueryListEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -944,6 +944,7 @@ $(PROJECT_DIR)/css/ElementCSSInlineStyle.idl
 $(PROJECT_DIR)/css/FontFace.idl
 $(PROJECT_DIR)/css/FontFaceSet.idl
 $(PROJECT_DIR)/css/FontFaceSource.idl
+$(PROJECT_DIR)/css/LinkStyle.idl
 $(PROJECT_DIR)/css/MediaList.idl
 $(PROJECT_DIR)/css/MediaQueryList.idl
 $(PROJECT_DIR)/css/MediaQueryListEvent.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -823,6 +823,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/FontFace.idl \
     $(WebCore)/css/FontFaceSet.idl \
     $(WebCore)/css/FontFaceSource.idl \
+    $(WebCore)/css/LinkStyle.idl \
     $(WebCore)/css/MediaList.idl \
     $(WebCore)/css/MediaQueryList.idl \
     $(WebCore)/css/MediaQueryListEvent.idl \

--- a/Source/WebCore/css/LinkStyle.idl
+++ b/Source/WebCore/css/LinkStyle.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+interface mixin LinkStyle {
+  readonly attribute CSSStyleSheet? sheet;
+};
+

--- a/Source/WebCore/html/HTMLStyleElement.idl
+++ b/Source/WebCore/html/HTMLStyleElement.idl
@@ -25,9 +25,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString media;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
 
-    // DOM Level 2 Style
-    readonly attribute StyleSheet sheet;
-
     [Reflect] attribute DOMString nonce;
 };
 
+HTMLStyleElement includes LinkStyle;

--- a/Source/WebCore/svg/SVGStyleElement.idl
+++ b/Source/WebCore/svg/SVGStyleElement.idl
@@ -32,3 +32,6 @@
      attribute [AtomString] DOMString media;
      [Reflect] attribute DOMString title;
 };
+
+SVGStyleElement includes LinkStyle;
+


### PR DESCRIPTION
#### 737ccae0f4676feb85291509f4691a2235658104
<pre>
SVGStyleElement.sheet is undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=163324">https://bugs.webkit.org/show_bug.cgi?id=163324</a>

Reviewed by Chris Dumez.

Expose sheet property on SVGStyleElement. The new behavior matches the spec, Gecko, &amp; Blink:
<a href="https://svgwg.org/svg2-draft/styling.html#InterfaceSVGStyleElement">https://svgwg.org/svg2-draft/styling.html#InterfaceSVGStyleElement</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt:
* LayoutTests/svg/dom/svg-style-element-sheet-expected.txt: Added.
* LayoutTests/svg/dom/svg-style-element-sheet.html: Added.
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/LinkStyle.idl: Added.
* Source/WebCore/html/HTMLStyleElement.idl:
* Source/WebCore/svg/SVGStyleElement.idl:

Canonical link: <a href="https://commits.webkit.org/252491@main">https://commits.webkit.org/252491@main</a>
</pre>
