### PR TITLE
When a WebLock gets aborted via a Signal, we should reject its promise with the AbortSignal's reason

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any-expected.txt
@@ -8,6 +8,6 @@ PASS Synchronously signaled abort
 PASS Abort signaled after lock granted
 PASS Abort signaled after lock released
 PASS Abort should process the next pending lock request
-FAIL Aborted promise should reject with the custom abort reason promise_rejects_exactly: Rejection should give the abort reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw "My cat handled it"
-FAIL Aborted promise should reject with the default abort reason promise_rejects_exactly: Should be the same reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Aborted promise should reject with the custom abort reason
+PASS Aborted promise should reject with the default abort reason
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.serviceworker-expected.txt
@@ -8,6 +8,6 @@ PASS Synchronously signaled abort
 PASS Abort signaled after lock granted
 PASS Abort signaled after lock released
 PASS Abort should process the next pending lock request
-FAIL Aborted promise should reject with the custom abort reason promise_rejects_exactly: Rejection should give the abort reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw "My cat handled it"
-FAIL Aborted promise should reject with the default abort reason promise_rejects_exactly: Should be the same reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Aborted promise should reject with the custom abort reason
+PASS Aborted promise should reject with the default abort reason
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.sharedworker-expected.txt
@@ -8,6 +8,6 @@ PASS Synchronously signaled abort
 PASS Abort signaled after lock granted
 PASS Abort signaled after lock released
 PASS Abort should process the next pending lock request
-FAIL Aborted promise should reject with the custom abort reason promise_rejects_exactly: Rejection should give the abort reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw "My cat handled it"
-FAIL Aborted promise should reject with the default abort reason promise_rejects_exactly: Should be the same reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Aborted promise should reject with the custom abort reason
+PASS Aborted promise should reject with the default abort reason
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.worker-expected.txt
@@ -8,6 +8,6 @@ PASS Synchronously signaled abort
 PASS Abort signaled after lock granted
 PASS Abort signaled after lock released
 PASS Abort should process the next pending lock request
-FAIL Aborted promise should reject with the custom abort reason promise_rejects_exactly: Rejection should give the abort reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw "My cat handled it"
-FAIL Aborted promise should reject with the default abort reason promise_rejects_exactly: Should be the same reason function "function () { throw e }" threw object "AbortError: Lock request was aborted via AbortSignal" but we expected it to throw object "AbortError: The operation was aborted."
+PASS Aborted promise should reject with the custom abort reason
+PASS Aborted promise should reject with the default abort reason
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -205,7 +205,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone()
 void FetchResponse::addAbortSteps(Ref<AbortSignal>&& signal)
 {
     m_abortSignal = WTFMove(signal);
-    m_abortSignal->addAlgorithm([this, weakThis = WeakPtr { *this }] {
+    m_abortSignal->addAlgorithm([this, weakThis = WeakPtr { *this }](JSC::JSValue) {
         // FIXME: Cancel request body if it is a stream.
         if (!weakThis)
             return;

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -65,7 +65,7 @@ private:
 
     void didCompleteLockRequest(WebLockIdentifier, bool success);
     void settleReleasePromise(WebLockIdentifier, ExceptionOr<JSC::JSValue>&&);
-    void signalToAbortTheRequest(WebLockIdentifier);
+    void signalToAbortTheRequest(WebLockIdentifier, JSC::JSValue reason);
     void clientIsGoingAway();
 
     // ActiveDOMObject.

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -63,7 +63,7 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
-    using Algorithm = Function<void()>;
+    using Algorithm = Function<void(JSC::JSValue reason)>;
     void addAlgorithm(Algorithm&& algorithm) { m_algorithms.append(WTFMove(algorithm)); }
 
     bool isFollowingSignal() const { return !!m_followingSignal; }

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -96,7 +96,7 @@ bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListene
         return false;
 
     if (options.signal) {
-        options.signal->addAlgorithm([weakThis = WeakPtr { *this }, eventType, listener = WeakPtr { listener }, capture = options.capture] {
+        options.signal->addAlgorithm([weakThis = WeakPtr { *this }, eventType, listener = WeakPtr { listener }, capture = options.capture](JSC::JSValue) {
             if (weakThis && listener)
                 weakThis->removeEventListener(eventType, *listener, capture);
         });


### PR DESCRIPTION
#### e5684a5d823b0cb5012b9bbebddb94c3fd048101
<pre>
When a WebLock gets aborted via a Signal, we should reject its promise with the AbortSignal&apos;s reason
<a href="https://bugs.webkit.org/show_bug.cgi?id=242771">https://bugs.webkit.org/show_bug.cgi?id=242771</a>

Reviewed by Ryosuke Niwa.

When a WebLock gets aborted via a Signal, we should reject its promise with the AbortSignal&apos;s reason:
- <a href="https://w3c.github.io/web-locks/#signal-to-abort-the-request">https://w3c.github.io/web-locks/#signal-to-abort-the-request</a>

Previously, we were rejecting the promise with an AbortError.

* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-locks/signal.tentative.https.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::addAbortSteps):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):
(WebCore::WebLockManager::signalToAbortTheRequest):
* Source/WebCore/Modules/web-locks/WebLockManager.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::signalAbort):
(WebCore::AbortSignal::signalFollow):
(WebCore::AbortSignal::whenSignalAborted):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListener):

Canonical link: <a href="https://commits.webkit.org/252503@main">https://commits.webkit.org/252503@main</a>
</pre>
