### PR TITLE
Add StrokeLineWithColorAndThickness message to RemoteDisplayListRecorder

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -122,6 +122,7 @@ protected:
     virtual void recordStrokeRect(const FloatRect&, float) = 0;
 #if ENABLE(INLINE_PATH_DATA)
     virtual void recordStrokeLine(const LineData&) = 0;
+    virtual void recordStrokeLineWithColorAndThickness(SRGBA<uint8_t>, float, const LineData&) = 0;
     virtual void recordStrokeArc(const ArcData&) = 0;
     virtual void recordStrokeQuadCurve(const QuadCurveData&) = 0;
     virtual void recordStrokeBezierCurve(const BezierCurveData&) = 0;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -330,6 +330,13 @@ void RecorderImpl::recordStrokeLine(const LineData& line)
     append<StrokeLine>(line);
 }
 
+void RecorderImpl::recordStrokeLineWithColorAndThickness(SRGBA<uint8_t> color, float thickness, const LineData& line)
+{
+    append<SetInlineStrokeColor>(color);
+    append<SetStrokeThickness>(thickness);
+    append<StrokeLine>(line);
+}
+
 void RecorderImpl::recordStrokeArc(const ArcData& arc)
 {
     append<StrokeArc>(arc);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -102,6 +102,7 @@ private:
     void recordStrokeRect(const FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const LineData&) final;
+    void recordStrokeLineWithColorAndThickness(SRGBA<uint8_t>, float, const LineData&) final;
     void recordStrokeArc(const ArcData&) final;
     void recordStrokeQuadCurve(const QuadCurveData&) final;
     void recordStrokeBezierCurve(const BezierCurveData&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -495,6 +495,13 @@ void RemoteDisplayListRecorder::strokeLine(const LineData& data)
     handleItem(DisplayList::StrokeLine(data));
 }
 
+void RemoteDisplayListRecorder::strokeLineWithColorAndThickness(WebCore::DisplayList::SetInlineStrokeColor&& item, float thickness, const WebCore::LineData& data)
+{
+    handleItem(WTFMove(item));
+    handleItem(DisplayList::SetStrokeThickness(thickness));
+    handleItem(DisplayList::StrokeLine(data));
+}
+
 void RemoteDisplayListRecorder::strokeArc(const ArcData& data)
 {
     handleItem(DisplayList::StrokeArc(data));

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -116,6 +116,7 @@ public:
     void strokeRect(const WebCore::FloatRect&, float lineWidth);
 #if ENABLE(INLINE_PATH_DATA)
     void strokeLine(const WebCore::LineData&);
+    void strokeLineWithColorAndThickness(WebCore::DisplayList::SetInlineStrokeColor&&, float, const WebCore::LineData&);
     void strokeArc(const WebCore::ArcData&);
     void strokeQuadCurve(const WebCore::QuadCurveData&);
     void strokeBezierCurve(const WebCore::BezierCurveData&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -81,6 +81,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     StrokeRect(WebCore::FloatRect rect, float lineWidth)
 #if ENABLE(INLINE_PATH_DATA)
     StrokeLine(struct WebCore::LineData data) StreamBatched
+    StrokeLineWithColorAndThickness(WebCore::DisplayList::SetInlineStrokeColor color, float thickness, struct WebCore::LineData data) StreamBatched
     StrokeArc(struct WebCore::ArcData data) StreamBatched
     StrokeQuadCurve(struct WebCore::QuadCurveData data) StreamBatched
     StrokeBezierCurve(struct WebCore::BezierCurveData data) StreamBatched

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -157,7 +157,7 @@ private:
         Semaphore clientWait;
     };
     std::optional<Semaphores> m_semaphores;
-    unsigned m_maxBatchSize { 40 }; // Number of messages marked as StreamBatched to accumulate before notifying the server.
+    unsigned m_maxBatchSize { 20 }; // Number of messages marked as StreamBatched to accumulate before notifying the server.
     unsigned m_batchSize { 0 };
 
     friend class WebKit::IPCTestingAPI::JSIPCStreamClientConnection;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -341,6 +341,11 @@ void RemoteDisplayListRecorderProxy::recordStrokeLine(const LineData& data)
     send(Messages::RemoteDisplayListRecorder::StrokeLine(data));
 }
 
+void RemoteDisplayListRecorderProxy::recordStrokeLineWithColorAndThickness(SRGBA<uint8_t> color, float thickness, const LineData& data)
+{
+    send(Messages::RemoteDisplayListRecorder::StrokeLineWithColorAndThickness(color, thickness, data));
+}
+
 void RemoteDisplayListRecorderProxy::recordStrokeArc(const ArcData& data)
 {
     send(Messages::RemoteDisplayListRecorder::StrokeArc(data));

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -117,6 +117,7 @@ private:
     void recordStrokeRect(const WebCore::FloatRect&, float) final;
 #if ENABLE(INLINE_PATH_DATA)
     void recordStrokeLine(const WebCore::LineData&) final;
+    void recordStrokeLineWithColorAndThickness(WebCore::SRGBA<uint8_t>, float, const WebCore::LineData&) final;
     void recordStrokeArc(const WebCore::ArcData&) final;
     void recordStrokeQuadCurve(const WebCore::QuadCurveData&) final;
     void recordStrokeBezierCurve(const WebCore::BezierCurveData&) final;


### PR DESCRIPTION
#### 0eab85d1cfbec52489bb70f7bf2ad507c27d0fd1
<pre>
Add StrokeLineWithColorAndThickness message to RemoteDisplayListRecorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=242772">https://bugs.webkit.org/show_bug.cgi?id=242772</a>

Reviewed by Simon Fraser.

There&apos;s some overhead per-message sent, and stroking lines is frequently combined with
updating the current stroke color and line thickness. Adding a special combination message
for this common case helps improve performance.

This also reduces the batch size, since we&apos;re now sending fewer (but larger) messages, and
having the batch size be too large results in unnecessary idle time on the receiving end.

This solution won&apos;t scale well, but hopefully is sufficient to handle the most common cases
in the short term.

I think an ideal solution would be to dynamically include state changes as part of the message
payload for all draw calls, rather than defining a specific new message for every possible
combination.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::strokePath):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordStrokeLineWithColorAndThickness):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::strokeLineWithColorAndThickness):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordStrokeLineWithColorAndThickness):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/252522@main">https://commits.webkit.org/252522@main</a>
</pre>
