### PR TITLE
Interaction region layers can sometimes accumulate

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -92,13 +92,18 @@ void updateLayersForInteractionRegions(CALayer *layer, const RemoteLayerTreeTran
         auto enclosingFrame = enclosingIntRect(sublayer.frame);
         if (enclosingFrame.isEmpty())
             continue;
-        interactionRegionLayers.set(enclosingFrame, sublayer);
+        auto result = interactionRegionLayers.add(enclosingFrame, sublayer);
+        ASSERT_UNUSED(result, result.isNewEntry);
     }
 
     bool applyBackgroundColorForDebugging = [[NSUserDefaults standardUserDefaults] boolForKey:@"WKInteractionRegionDebugFill"];
 
+    HashSet<IntRect> liveLayerBounds;
     for (const WebCore::InteractionRegion& region : properties.eventRegion.interactionRegions()) {
         for (IntRect rect : region.regionInLayerCoordinates.rects()) {
+            if (!liveLayerBounds.add(rect).isNewEntry)
+                continue;
+
             auto layerIterator = interactionRegionLayers.find(rect);
 
             RetainPtr<CALayer> interactionRegionLayer;


### PR DESCRIPTION
#### ee92a2b5fd269995df014fcde7f998f00e380ae6
<pre>
Interaction region layers can sometimes accumulate
<a href="https://bugs.webkit.org/show_bug.cgi?id=242773">https://bugs.webkit.org/show_bug.cgi?id=242773</a>
&lt;rdar://96468979&gt;

Reviewed by Dean Jackson.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
`updateLayersForInteractionRegions` makes a rect-&gt;layer map from the existing
region layers, then pulls layers out of it for any currently-live interaction regions.
The layers that remain in the map are then removed, since they were not in the
currently-live set.

This depends on every layer having a unique rectangle, though; in the case where
you add two layers with identical bounds, the next time we `updateLayersForInteractionRegions`,
we will end up with only one of them in the map, and thus will only end up removing
one (or zero, if it is re-used) of the layers. So, you end up slowly accumulating layers.

Since we don&apos;t have any need to indicate identical regions, fix this by avoiding
creating duplicates in the first place (and also assert that we didn&apos;t end up with duplicates).

Canonical link: <a href="https://commits.webkit.org/252494@main">https://commits.webkit.org/252494@main</a>
</pre>
