### PR TITLE
Add myself (James Hilliard) to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -3248,6 +3248,13 @@
    },
    {
       "emails" : [
+         "james.hilliard1@gmail.com"
+      ],
+      "github" : "jameshilliard",
+      "name" : "James Hilliard"
+   },
+   {
+      "emails" : [
          "koz@chromium.org",
          "koz@google.com"
       ],


### PR DESCRIPTION
#### d35362ead2303dfd1198cbda45596264260ae944
<pre>
Add myself (James Hilliard) to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=242776">https://bugs.webkit.org/show_bug.cgi?id=242776</a>

Reviewed by Jonathan Bedard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252483@main">https://commits.webkit.org/252483@main</a>
</pre>
