### PR TITLE
fast/events/ios/blur-and-prompt-after-focus.html consistently hangs with a 1-second IPC deadlock

### DIFF
--- a/LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html
+++ b/LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ignoreSynchronousMessagingTimeouts=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>


### PR DESCRIPTION
#### 64a9834a301ffc84812b2efc7b20306752b75238
<pre>
fast/events/ios/blur-and-prompt-after-focus.html consistently hangs with a 1-second IPC deadlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=242774">https://bugs.webkit.org/show_bug.cgi?id=242774</a>

Reviewed by Ryosuke Niwa.

While investigating webkit.org/b/242753, I noticed that the titular layout test (which was
originally created to exercise a crash) triggers a consistent autocorrection context request
deadlock, before passing; this happens because the page triggers a modal alert at the same time as
the UI process requests an autocorrection context from the web page.

The change in `237399@main` was intended to mitigate this kind of scenario; however, it falls just
short of avoiding a deadlock on this particular test case, because we don&apos;t preemptively send an
autocorrection context before running the modal prompt. This is because the web page
programmatically blurs the focused element before prompting, so `m_focusedElement` is null).

To extend the mitigation in `237399@main` to address this scenario as well, we simply remove the
checks against a null `m_focusedElement` that prevent us from trying to send autocorrection context
before running the modal prompt. Instead, make `autocorrectionContext()` check for a null
`m_focusedElement` or non-editable selection, and bail early with an empty autocorrection context in
those cases. Doing so allows us to preemptively send a blank autocorrection context to the UI
process, which (1) correctly reflects the state of the web process, and (2) is sufficient to avoid
deadlocking.

* LayoutTests/fast/events/ios/blur-and-prompt-after-focus.html:

Adjust the test case to fail without this fix, by supplying the `ignoreSynchronousMessagingTimeouts`
test option.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::autocorrectionContext):
(WebKit::WebPage::prepareToRunModalJavaScriptDialog):

Canonical link: <a href="https://commits.webkit.org/252502@main">https://commits.webkit.org/252502@main</a>
</pre>
