### PR TITLE
Make RenderSVGResourceMask lazily recompute mask images when referencing element is changed

### DIFF
--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -86,7 +86,7 @@ static bool hasPaintResourceRequiringRemovalOnClientLayoutChange(RenderSVGResour
 
 static bool hasResourcesRequiringRemovalOnClientLayoutChange(SVGResources& resources)
 {
-    return resources.masker() || resources.filter() || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.fill()) || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.stroke());
+    return resources.filter() || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.fill()) || hasPaintResourceRequiringRemovalOnClientLayoutChange(resources.stroke());
 }
 
 void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)


### PR DESCRIPTION
#### 0790c9ed12c6d4bd018cad0c770b146cc005448a
<pre>
Make RenderSVGResourceMask lazily recompute mask images when referencing element is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=242778">https://bugs.webkit.org/show_bug.cgi?id=242778</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::removeAllClientsFromCache):
(WebCore::RenderSVGResourceMasker::removeClientFromCache):
(WebCore::RenderSVGResourceMasker::computeInputs):
(WebCore::RenderSVGResourceMasker::applyResource):
(WebCore::RenderSVGResourceMasker::drawContentIntoMaskImage):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
(WebCore::MaskerData::Inputs::operator==):
(WebCore::MaskerData::invalidate):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::hasResourcesRequiringRemovalOnClientLayoutChange):
</pre>