### PR TITLE
Make PDF annotation creation more robust

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1773,8 +1773,9 @@ void PDFPlugin::createPasswordEntryForm()
     if (!supportsForms())
         return;
 
-    m_passwordField = PDFPluginPasswordField::create(m_pdfLayerController.get(), this);
-    m_passwordField->attach(m_annotationContainer.get());
+    auto passwordField = PDFPluginPasswordField::create(m_pdfLayerController.get(), this);
+    m_passwordField = passwordField.ptr();
+    passwordField->attach(m_annotationContainer.get());
 }
 
 void PDFPlugin::attemptToUnlockPDF(const String& password)
@@ -2439,8 +2440,9 @@ void PDFPlugin::setActiveAnnotation(PDFAnnotation *annotation)
         }
         ALLOW_DEPRECATED_DECLARATIONS_END
 
-        m_activeAnnotation = PDFPluginAnnotation::create(annotation, m_pdfLayerController.get(), this);
-        m_activeAnnotation->attach(m_annotationContainer.get());
+        auto activeAnnotation = PDFPluginAnnotation::create(annotation, m_pdfLayerController.get(), this);
+        m_activeAnnotation = activeAnnotation.get();
+        activeAnnotation->attach(m_annotationContainer.get());
     } else
         m_activeAnnotation = nullptr;
 }


### PR DESCRIPTION
#### 02857c1a71feeccf08af9c8b19415230437a1181
<pre>
Make PDF annotation creation more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=242781">https://bugs.webkit.org/show_bug.cgi?id=242781</a>
rdar://96688395

Reviewed by Aditya Keerthi.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::createPasswordEntryForm):
(WebKit::PDFPlugin::setActiveAnnotation):

Canonical link: <a href="https://commits.webkit.org/252513@main">https://commits.webkit.org/252513@main</a>
</pre>
