### PR TITLE
[VP8/VP9] Add support for alternate codec name

### DIFF
--- a/LayoutTests/media/vp-codec-parameters-expected.txt
+++ b/LayoutTests/media/vp-codec-parameters-expected.txt
@@ -18,6 +18,12 @@ EXPECTED (internals.parseVPCodecParameters("vp09.02.10.10.01.09.16.09.01.00") ==
 Test valid required and optional parameters:
 EXPECTED (internals.parseVPCodecParameters("vp09.02.10.10.01.09.16.09.01") === '{ vp09, 2, 10, 10, 1, 9, 16, 9, 1}') OK
 
+Test valid legacy parameterless codec types:
+EXPECTED (internals.parseVPCodecParameters("vp9") === '{ vp09, 0, 10, 8, 1, 1, 1, 1, 0}') OK
+EXPECTED (internals.parseVPCodecParameters("vp8") === '{ vp08, 0, 10, 8, 1, 1, 1, 1, 0}') OK
+EXPECTED (internals.parseVPCodecParameters("vp9.0") === '{ vp09, 0, 10, 8, 1, 1, 1, 1, 0}') OK
+EXPECTED (internals.parseVPCodecParameters("vp8.0") === '{ vp08, 0, 10, 8, 1, 1, 1, 1, 0}') OK
+
 Test invalid codec type
 EXPECTED (internals.parseVPCodecParameters("vp10.00.41.08") == 'null') OK
 

--- a/LayoutTests/media/vp-codec-parameters.html
+++ b/LayoutTests/media/vp-codec-parameters.html
@@ -65,6 +65,12 @@
         consoleWrite('Test valid required and optional parameters:')
         testExpectedVPCodecConfigurationRecord('internals.parseVPCodecParameters("vp09.02.10.10.01.09.16.09.01")', makeVPCodecConfigurationRecord('vp09', 2, 10, 10, 1, 9, 16, 9, 1));
         consoleWrite('');
+        consoleWrite('Test valid legacy parameterless codec types:')
+        testExpectedVPCodecConfigurationRecord('internals.parseVPCodecParameters("vp9")', makeVPCodecConfigurationRecord('vp09', 0, 10, 8, 1, 1, 1, 1, 0));
+        testExpectedVPCodecConfigurationRecord('internals.parseVPCodecParameters("vp8")', makeVPCodecConfigurationRecord('vp08', 0, 10, 8, 1, 1, 1, 1, 0));
+        testExpectedVPCodecConfigurationRecord('internals.parseVPCodecParameters("vp9.0")', makeVPCodecConfigurationRecord('vp09', 0, 10, 8, 1, 1, 1, 1, 0));
+        testExpectedVPCodecConfigurationRecord('internals.parseVPCodecParameters("vp8.0")', makeVPCodecConfigurationRecord('vp08', 0, 10, 8, 1, 1, 1, 1, 0));
+        consoleWrite('');
         consoleWrite('Test invalid codec type');
         testExpected('internals.parseVPCodecParameters("vp10.00.41.08")', null);
         consoleWrite('');

--- a/Source/WebCore/platform/graphics/VP9Utilities.cpp
+++ b/Source/WebCore/platform/graphics/VP9Utilities.cpp
@@ -135,8 +135,14 @@ std::optional<VPCodecConfigurationRecord> parseVPCodecParameters(StringView code
     ++nextElement;
 
     // Support the legacy identifiers (with no parameters) for VP8 and VP9.
-    if ((configuration.codecName == "vp8"_s || configuration.codecName == "vp9"_s) && nextElement == codecSplit.end())
-        return configuration;
+    if (configuration.codecName == "vp8"_s || configuration.codecName == "vp9"_s) {
+        if (nextElement == codecSplit.end())
+            return configuration;
+        
+        auto codecString = codecView.toStringWithoutCopying();
+        if (codecString == "vp8.0"_s || codecString == "vp9.0"_s)
+            return configuration;
+    }
 
     // The format of the 'vp09' codec string is specified in the webm GitHub repo:
     // <https://github.com/webmproject/vp9-dash/blob/master/VPCodecISOMediaFileFormatBinding.md#codecs-parameter-string>

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1321,7 +1321,12 @@ MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(co
 
     for (auto& codec : codecs) {
 #if ENABLE(VP9)
-        if (codec.startsWith("vp09"_s) || codec.startsWith("vp08"_s) || equal(codec, "vp8"_s) || equal(codec, "vp9"_s)) {
+        if (codec.startsWith("vp09"_s)
+            || codec.startsWith("vp08"_s)
+            || equal(codec, "vp8"_s)
+            || equal(codec, "vp9"_s)
+            || equal(codec, "vp8.0"_s)
+            || equal(codec, "vp9.0"_s)) {
 
             if (!isVP9DecoderAvailable())
                 return MediaPlayerEnums::SupportsType::IsNotSupported;


### PR DESCRIPTION
#### eccf68f1d1e90ed5e3ed8d2d04176f54b11f3015
<pre>
[VP8/VP9] Add support for alternate codec name
<a href="https://bugs.webkit.org/show_bug.cgi?id=242790">https://bugs.webkit.org/show_bug.cgi?id=242790</a>

Reviewed by Jean-Yves Avenard.

Currently the VPx codec parser in both VP9Utilities and SourceBufferParserWebM
do not recognize the alternate form of no parameter codec names (vp9.0 and vp8.0).

From the spec: `Note that, currently, the attribute string value &quot;vp8&quot; may
also be expressed as &quot;vp8.0&quot;, and &quot;vp9&quot; may be expressed as &quot;vp9.0&quot;.`

* Source/WebCore/platform/graphics/VP9Utilities.cpp:
(WebCore::parseVPCodecParameters):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::SourceBufferParserWebM::isContentTypeSupported):

* LayoutTests/media/vp-codec-parameters-expected.txt:
* LayoutTests/media/vp-codec-parameters.html:

Canonical link: <a href="https://commits.webkit.org/252535@main">https://commits.webkit.org/252535@main</a>
</pre>
