### PR TITLE
Remove newlines from FloatRoundedRect TextStream output

### DIFF
--- a/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
@@ -205,16 +205,12 @@ bool FloatRoundedRect::intersectionIsRectangular(const FloatRect& rect) const
 
 TextStream& operator<<(TextStream& ts, const FloatRoundedRect& roundedRect)
 {
-    ts << roundedRect.rect().x() << " " << roundedRect.rect().y() << " " << roundedRect.rect().width() << " " << roundedRect.rect().height() << "\n";
-
-    TextStream::IndentScope indentScope(ts);
-    ts << indent << "topLeft=" << roundedRect.topLeftCorner().width() << " " << roundedRect.topLeftCorner().height() << "\n";
-    ts << indent << "topRight=" << roundedRect.topRightCorner().width() << " " << roundedRect.topRightCorner().height() << "\n";
-    ts << indent << "bottomLeft=" << roundedRect.bottomLeftCorner().width() << " " << roundedRect.bottomLeftCorner().height() << "\n";
-    ts << indent << "bottomRight=" << roundedRect.bottomRightCorner().width() << " " << roundedRect.bottomRightCorner().height();
+    ts << roundedRect.rect();
+    ts.dumpProperty("top-left", roundedRect.radii().topLeft());
+    ts.dumpProperty("top-right", roundedRect.radii().topRight());
+    ts.dumpProperty("bottom-left", roundedRect.radii().bottomLeft());
+    ts.dumpProperty("bottom-right", roundedRect.radii().bottomRight());
     return ts;
 }
-
-
 
 } // namespace WebCore


### PR DESCRIPTION
#### cdb0c4a68794035df705609ca0ec8c7fb373091b
<pre>
Remove newlines from FloatRoundedRect TextStream output
<a href="https://bugs.webkit.org/show_bug.cgi?id=242791">https://bugs.webkit.org/show_bug.cgi?id=242791</a>

Reviewed by Simon Fraser.

It interferes with single line TextStream output.

* Source/WebCore/platform/graphics/FloatRoundedRect.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/252537@main">https://commits.webkit.org/252537@main</a>
</pre>
