### PR TITLE
[GTK][WPE] WebDriver: add support for pac proxy type

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -93,6 +93,7 @@ public:
             Vector<std::pair<String, String>> certificates;
             struct Proxy {
                 String type;
+                std::optional<String> autoconfigURL;
                 std::optional<String> ftpURL;
                 std::optional<String> httpURL;
                 std::optional<String> httpsURL;

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -67,6 +67,10 @@ static RemoteInspector::Client::SessionCapabilities processSessionCapabilities(G
         g_variant_lookup(proxy.get(), "type", "&s", &proxyType);
         capabilities.proxy->type = String::fromUTF8(proxyType);
 
+        const char* autoconfigURL;
+        if (g_variant_lookup(proxy.get(), "autoconfigURL", "&s", &autoconfigURL))
+            capabilities.proxy->autoconfigURL = String::fromUTF8(autoconfigURL);
+
         const char* ftpURL;
         if (g_variant_lookup(proxy.get(), "ftpURL", "&s", &ftpURL))
             capabilities.proxy->ftpURL = String::fromUTF8(ftpURL);

--- a/Source/WebCore/platform/SourcesSoup.txt
+++ b/Source/WebCore/platform/SourcesSoup.txt
@@ -36,5 +36,6 @@ platform/network/soup/SoupNetworkSession.cpp
 platform/network/soup/SynchronousLoaderClientSoup.cpp
 platform/network/soup/URLSoup.cpp
 platform/network/soup/WebKitFormDataInputStream.cpp @no-unify
+platform/network/soup/WebKitAutoconfigProxyResolver.cpp @no-unify
 
 platform/soup/PublicSuffixSoup.cpp

--- a/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 struct SoupNetworkProxySettings {
-    enum class Mode { Default, NoProxy, Custom };
+    enum class Mode { Default, NoProxy, Custom, Auto };
 
     SoupNetworkProxySettings() = default;
 
@@ -59,7 +59,19 @@ struct SoupNetworkProxySettings {
         return *this;
     }
 
-    bool isEmpty() const { return mode == Mode::Custom && defaultProxyURL.isNull() && !ignoreHosts && proxyMap.isEmpty(); }
+    bool isEmpty() const
+    {
+        switch (mode) {
+        case Mode::Default:
+        case Mode::NoProxy:
+            return false;
+        case Mode::Custom:
+            return defaultProxyURL.isNull() && !ignoreHosts && proxyMap.isEmpty();
+        case Mode::Auto:
+            return defaultProxyURL.isNull();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
 
     Mode mode { Mode::Default };
     CString defaultProxyURL;
@@ -76,7 +88,8 @@ template<> struct EnumTraits<WebCore::SoupNetworkProxySettings::Mode> {
         WebCore::SoupNetworkProxySettings::Mode,
         WebCore::SoupNetworkProxySettings::Mode::Default,
         WebCore::SoupNetworkProxySettings::Mode::NoProxy,
-        WebCore::SoupNetworkProxySettings::Mode::Custom
+        WebCore::SoupNetworkProxySettings::Mode::Custom,
+        WebCore::SoupNetworkProxySettings::Mode::Auto
     >;
 };
 

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -33,6 +33,7 @@
 #include "GUniquePtrSoup.h"
 #include "Logging.h"
 #include "SoupVersioning.h"
+#include "WebKitAutoconfigProxyResolver.h"
 #include <glib/gstdio.h>
 #include <libsoup/soup.h>
 #include <pal/crypto/CryptoDigest.h>
@@ -313,6 +314,9 @@ void SoupNetworkSession::setProxySettings(const SoupNetworkProxySettings& settin
             g_simple_proxy_resolver_set_ignore_hosts(G_SIMPLE_PROXY_RESOLVER(resolver.get()), m_proxySettings.ignoreHosts.get());
         for (const auto& iter : m_proxySettings.proxyMap)
             g_simple_proxy_resolver_set_uri_proxy(G_SIMPLE_PROXY_RESOLVER(resolver.get()), iter.key.data(), iter.value.data());
+        break;
+    case SoupNetworkProxySettings::Mode::Auto:
+        resolver = webkitAutoconfigProxyResolverNew(m_proxySettings.defaultProxyURL);
         break;
     }
 

--- a/Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.cpp
+++ b/Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebKitAutoconfigProxyResolver.h"
+
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WebKitAutoconfigProxyResolverPrivate {
+    GRefPtr<GDBusProxy> pacRunner;
+    CString autoconfigURL;
+};
+
+static void webkitAutoconfigProxyResolverInterfaceInit(GProxyResolverInterface*);
+
+WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitAutoconfigProxyResolver, webkit_autoconfig_proxy_resolver, G_TYPE_OBJECT,
+    G_IMPLEMENT_INTERFACE(G_TYPE_PROXY_RESOLVER, webkitAutoconfigProxyResolverInterfaceInit))
+
+static void webkit_autoconfig_proxy_resolver_class_init(WebKitAutoconfigProxyResolverClass*)
+{
+}
+
+GRefPtr<GProxyResolver> webkitAutoconfigProxyResolverNew(const CString& autoconfigURL)
+{
+    GUniqueOutPtr<GError> error;
+    GRefPtr<GDBusProxy> pacRunner = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+        static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS),
+        nullptr, "org.gtk.GLib.PACRunner", "/org/gtk/GLib/PACRunner", "org.gtk.GLib.PACRunner", nullptr, &error.outPtr()));
+    if (!pacRunner) {
+        g_warning("Could not start proxy autoconfiguration helper: %s\n", error->message);
+        return nullptr;
+    }
+
+    auto* proxyResolver = WEBKIT_AUTOCONFIG_PROXY_RESOLVER(g_object_new(WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER, nullptr));
+    proxyResolver->priv->pacRunner = WTFMove(pacRunner);
+    proxyResolver->priv->autoconfigURL = autoconfigURL;
+
+    return adoptGRef(G_PROXY_RESOLVER(proxyResolver));
+}
+
+static gchar** webkitAutoconfigProxyResolverLookup(GProxyResolver* proxyResolver, const char* uri, GCancellable* cancellable, GError** error)
+{
+    auto* priv = WEBKIT_AUTOCONFIG_PROXY_RESOLVER(proxyResolver)->priv;
+    GRefPtr<GVariant> variant = adoptGRef(g_dbus_proxy_call_sync(priv->pacRunner.get(), "Lookup", g_variant_new("(ss)", priv->autoconfigURL.data(), uri),
+        G_DBUS_CALL_FLAGS_NONE, -1, cancellable, error));
+    if (!variant)
+        return nullptr;
+
+    gchar** proxies;
+    g_variant_get(variant.get(), "(^as)", &proxies);
+    return proxies;
+}
+
+static void webkitAutoconfigProxyResolverLookupAsync(GProxyResolver* proxyResolver, const char* uri, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    GTask* task = g_task_new(proxyResolver, cancellable, callback, userData);
+    auto* priv = WEBKIT_AUTOCONFIG_PROXY_RESOLVER(proxyResolver)->priv;
+    g_dbus_proxy_call(priv->pacRunner.get(), "Lookup", g_variant_new("(ss)", priv->autoconfigURL.data(), uri), G_DBUS_CALL_FLAGS_NONE, -1, cancellable,
+        [](GObject* source, GAsyncResult* result, gpointer userData) {
+            GRefPtr<GTask> task = adoptGRef(G_TASK(userData));
+            GUniqueOutPtr<GError> error;
+            GRefPtr<GVariant> variant = adoptGRef(g_dbus_proxy_call_finish(G_DBUS_PROXY(source), result, &error.outPtr()));
+            if (variant) {
+                gchar** proxies;
+                g_variant_get(variant.get(), "(^as)", &proxies);
+                g_task_return_pointer(task.get(), proxies, reinterpret_cast<GDestroyNotify>(g_strfreev));
+            } else
+                g_task_return_error(task.get(), error.release());
+        }, task);
+}
+
+static gchar** webkitAutoconfigProxyResolverLookupFinish(GProxyResolver*, GAsyncResult* result, GError** error)
+{
+    return static_cast<char**>(g_task_propagate_pointer(G_TASK(result), error));
+}
+
+static void webkitAutoconfigProxyResolverInterfaceInit(GProxyResolverInterface* interface)
+{
+    interface->lookup = webkitAutoconfigProxyResolverLookup;
+    interface->lookup_async = webkitAutoconfigProxyResolverLookupAsync;
+    interface->lookup_finish = webkitAutoconfigProxyResolverLookupFinish;
+}

--- a/Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.h
+++ b/Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/text/CString.h>
+
+#define WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER            (webkit_autoconfig_proxy_resolver_get_type ())
+#define WEBKIT_AUTOCONFIG_PROXY_RESOLVER(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER, WebKitAutoconfigProxyResolver))
+#define WEBKIT_IS_AUTOCONFIG_PROXY_RESOLVER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER))
+#define WEBKIT_AUTOCONFIG_PROXY_RESOLVER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER, WebKitAutoconfigProxyResolverClass))
+#define WEBKIT_IS_AUTOCONFIG_PROXY_RESOLVER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((obj), WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER))
+#define WEBKIT_AUTOCONFIG_PROXY_RESOLVER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), WEBKIT_TYPE_AUTOCONFIG_PROXY_RESOLVER, WebKitAutoconfigProxyResolverClass))
+
+typedef struct _WebKitAutoconfigProxyResolver WebKitAutoconfigProxyResolver;
+typedef struct _WebKitAutoconfigProxyResolverClass WebKitAutoconfigProxyResolverClass;
+typedef struct _WebKitAutoconfigProxyResolverPrivate WebKitAutoconfigProxyResolverPrivate;
+
+struct _WebKitAutoconfigProxyResolver {
+    GObject parent;
+
+    WebKitAutoconfigProxyResolverPrivate* priv;
+};
+
+struct _WebKitAutoconfigProxyResolverClass {
+    GObjectClass parentClass;
+};
+
+GType webkit_autoconfig_proxy_resolver_get_type(void);
+
+GRefPtr<GProxyResolver> webkitAutoconfigProxyResolverNew(const CString&);

--- a/Source/WebDriver/Capabilities.h
+++ b/Source/WebDriver/Capabilities.h
@@ -55,7 +55,7 @@ enum class UnhandledPromptBehavior {
 
 struct Proxy {
     String type;
-    std::optional<String> autoconfigURL;
+    std::optional<URL> autoconfigURL;
     std::optional<URL> ftpURL;
     std::optional<URL> httpURL;
     std::optional<URL> httpsURL;

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -409,8 +409,12 @@ static std::optional<Proxy> deserializeProxy(JSON::Object& proxyObject)
         return proxy;
 
     if (proxy.type == "pac"_s) {
-        proxy.autoconfigURL = proxyObject.getString("proxyAutoconfigUrl"_s);
-        if (!proxy.autoconfigURL)
+        auto autoconfigURL = proxyObject.getString("proxyAutoconfigUrl"_s);
+        if (!autoconfigURL)
+            return std::nullopt;
+
+        proxy.autoconfigURL = URL({ }, autoconfigURL);
+        if (!proxy.autoconfigURL->isValid())
             return std::nullopt;
 
         return proxy;

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -264,6 +264,8 @@ bool SessionHost::buildSessionCapabilities(GVariantBuilder* builder) const
         GVariantBuilder dictBuilder;
         g_variant_builder_init(&dictBuilder, G_VARIANT_TYPE("a{sv}"));
         g_variant_builder_add(&dictBuilder, "{sv}", "type", g_variant_new_string(m_capabilities.proxy->type.utf8().data()));
+        if (m_capabilities.proxy->autoconfigURL)
+            g_variant_builder_add(&dictBuilder, "{sv}", "autoconfigURL", g_variant_new_string(m_capabilities.proxy->autoconfigURL->string().utf8().data()));
         if (m_capabilities.proxy->ftpURL)
             g_variant_builder_add(&dictBuilder, "{sv}", "ftpURL", g_variant_new_string(m_capabilities.proxy->ftpURL->string().utf8().data()));
         if (m_capabilities.proxy->httpURL)

--- a/Source/WebDriver/glib/WebDriverServiceGLib.cpp
+++ b/Source/WebDriver/glib/WebDriverServiceGLib.cpp
@@ -80,9 +80,9 @@ bool WebDriverService::platformCompareBrowserVersions(const String& requiredVers
         || (proposedMajor == requiredMajor && proposedMinor == requiredMinor && proposedMicro >= requiredMicro);
 }
 
-bool WebDriverService::platformSupportProxyType(const String& proxyType) const
+bool WebDriverService::platformSupportProxyType(const String&) const
 {
-    return proxyType != "pac"_s;
+    return true;
 }
 
 } // namespace WebDriver

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -135,10 +135,13 @@ void ArgumentCoder<SoupNetworkProxySettings>::encode(Encoder& encoder, const Sou
 {
     ASSERT(!settings.isEmpty());
     encoder << settings.mode;
-    if (settings.mode != SoupNetworkProxySettings::Mode::Custom)
+    if (settings.mode != SoupNetworkProxySettings::Mode::Custom && settings.mode != SoupNetworkProxySettings::Mode::Auto)
         return;
 
     encoder << settings.defaultProxyURL;
+    if (settings.mode == SoupNetworkProxySettings::Mode::Auto)
+        return;
+
     uint32_t ignoreHostsCount = settings.ignoreHosts ? g_strv_length(settings.ignoreHosts.get()) : 0;
     encoder << ignoreHostsCount;
     if (ignoreHostsCount) {
@@ -153,11 +156,14 @@ bool ArgumentCoder<SoupNetworkProxySettings>::decode(Decoder& decoder, SoupNetwo
     if (!decoder.decode(settings.mode))
         return false;
 
-    if (settings.mode != SoupNetworkProxySettings::Mode::Custom)
+    if (settings.mode != SoupNetworkProxySettings::Mode::Custom && settings.mode != SoupNetworkProxySettings::Mode::Auto)
         return true;
 
     if (!decoder.decode(settings.defaultProxyURL))
         return false;
+
+    if (settings.mode == SoupNetworkProxySettings::Mode::Auto)
+        return !settings.isEmpty();
 
     uint32_t ignoreHostsCount;
     if (!decoder.decode(ignoreHostsCount))

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -23,8 +23,10 @@
 #include "APIAutomationSessionClient.h"
 #include "WebKitApplicationInfo.h"
 #include "WebKitAutomationSessionPrivate.h"
+#include "WebKitNetworkProxySettingsPrivate.h"
 #include "WebKitWebContextPrivate.h"
 #include "WebKitWebViewPrivate.h"
+#include "WebKitWebsiteDataManagerPrivate.h"
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -318,7 +320,7 @@ static void webkit_automation_session_class_init(WebKitAutomationSessionClass* s
 #if ENABLE(REMOTE_INSPECTOR)
 static WebKitNetworkProxyMode parseProxyCapabilities(const Inspector::RemoteInspector::Client::SessionCapabilities::Proxy& proxy, WebKitNetworkProxySettings** settings)
 {
-    if (proxy.type == "system"_s)
+    if (proxy.type == "system"_s || proxy.type == "autodetect"_s)
         return WEBKIT_NETWORK_PROXY_MODE_DEFAULT;
 
     if (proxy.type == "direct"_s)
@@ -358,11 +360,22 @@ WebKitAutomationSession* webkitAutomationSessionCreate(WebKitWebContext* webCont
             webkit_web_context_allow_tls_certificate_for_host(webContext, tlsCertificate.get(), certificate.first.utf8().data());
     }
     if (capabilities.proxy) {
-        WebKitNetworkProxySettings* proxySettings = nullptr;
-        auto proxyMode = parseProxyCapabilities(*capabilities.proxy, &proxySettings);
-        webkit_website_data_manager_set_network_proxy_settings(webkit_web_context_get_website_data_manager(webContext), proxyMode, proxySettings);
-        if (proxySettings)
-            webkit_network_proxy_settings_free(proxySettings);
+        if (capabilities.proxy->type == "pac"_s) {
+            // FIXME: expose pac proxy in public API.
+            auto settings = WebCore::SoupNetworkProxySettings(WebCore::SoupNetworkProxySettings::Mode::Auto);
+            if (capabilities.proxy->autoconfigURL)
+                settings.defaultProxyURL = capabilities.proxy->autoconfigURL->utf8();
+            if (!settings.isEmpty()) {
+                auto& dataStore = webkitWebsiteDataManagerGetDataStore(webkit_web_context_get_website_data_manager(webContext));
+                dataStore.setNetworkProxySettings(WTFMove(settings));
+            }
+        } else {
+            WebKitNetworkProxySettings* proxySettings = nullptr;
+            auto proxyMode = parseProxyCapabilities(*capabilities.proxy, &proxySettings);
+            webkit_website_data_manager_set_network_proxy_settings(webkit_web_context_get_website_data_manager(webContext), proxyMode, proxySettings);
+            if (proxySettings)
+                webkit_network_proxy_settings_free(proxySettings);
+        }
     }
     return session;
 }

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -250,6 +250,8 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebCore', 'platform', 'mediastream', 'gstreamer', 'GStreamerVideoEncoder.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'ProxyResolverSoup.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'ProxyResolverSoup.h'),
+      os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitAutoconfigProxyResolver.cpp'),
+      os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitAutoconfigProxyResolver.h'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitFormDataInputStream.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'network', 'soup', 'WebKitFormDataInputStream.h'),
       os.path.join('Source', 'WebKit', 'NetworkProcess', 'soup', 'WebKitDirectoryInputStream.h')],


### PR DESCRIPTION
#### 3c23c02162ebcb06f89f51206b73bc5daf4b2ed7
<pre>
[GTK][WPE] WebDriver: add support for pac proxy type
<a href="https://bugs.webkit.org/show_bug.cgi?id=242792">https://bugs.webkit.org/show_bug.cgi?id=242792</a>

Reviewed by Adrian Perez de Castro and Carlos Alberto Lopez Perez.

Add WebKitAutoconfigProxyResolver to handle pac proxy type using
PACRunner DBus service.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h: Add autoconfigURL to capabilities
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
(Inspector::processSessionCapabilities): Handle autoconfigURL.
* Source/WebCore/platform/SourcesSoup.txt: Add WebKitAutoconfigProxyResolver.cpp
* Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h:
(WebCore::SoupNetworkProxySettings::isEmpty const): Handle Auto mode too.
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::SoupNetworkSession::setProxySettings): Handle Auto mode and
create a WebKitAutoconfigProxyResolver.
* Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.cpp: Added.
(webkit_autoconfig_proxy_resolver_class_init):
(webkitAutoconfigProxyResolverNew):
(webkitAutoconfigProxyResolverLookup):
(webkitAutoconfigProxyResolverLookupAsync):
(webkitAutoconfigProxyResolverLookupFinish):
(webkitAutoconfigProxyResolverInterfaceInit):
* Source/WebCore/platform/network/soup/WebKitAutoconfigProxyResolver.h: Added.
* Source/WebDriver/Capabilities.h: Make autoconfigURL a URL instead of a String.
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::deserializeProxy): Make sure autoconfigURL is a valid URL.
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::buildSessionCapabilities const): Add autoconfigURL.
* Source/WebDriver/glib/WebDriverServiceGLib.cpp:
(WebDriver::WebDriverService::platformSupportProxyType const): All proxy
types are now supported.
* Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp:
(IPC::ArgumentCoder&lt;SoupNetworkProxySettings&gt;::encode): Stop after
encoding defaultProxyURL if mode is Auto.
(IPC::ArgumentCoder&lt;SoupNetworkProxySettings&gt;::decode): Stop after
decoding defaultProxyURL if mode is Auto.
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
(parseProxyCapabilities): Return default mode for autodetect.
(webkitAutomationSessionCreate): Create a SoupNetworkProxySettings with
Auto mode if proxy type is pac.

Canonical link: <a href="https://commits.webkit.org/252501@main">https://commits.webkit.org/252501@main</a>
</pre>
