### PR TITLE
run-webkit-tests -p svg does not finish (Python assertion)

### DIFF
--- a/Tools/Scripts/webkitpy/port/image_diff.py
+++ b/Tools/Scripts/webkitpy/port/image_diff.py
@@ -90,7 +90,8 @@ class ImageDiffer(object):
             self._process.write(buffer.getvalue())
             return self._read()
         except IOError as exception:
-            return (None, 0, "Failed to compute an image diff: %s" % str(exception))
+            err_str = 'Failed to compute an image diff: %s' % str(exception)
+            return ImageDiffResult(passed=False, diff_image=None, difference=0, tolerance=self._tolerance, fuzzy_data=None, error_string=err_str)
 
     def _start(self, tolerance):
         command = [self._port._path_to_image_diff(), '--difference']


### PR DESCRIPTION
#### 538f5387b7f6cf892be3a3391706455b9d61da5b
<pre>
run-webkit-tests -p svg does not finish (Python assertion)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242763">https://bugs.webkit.org/show_bug.cgi?id=242763</a>

Reviewed by Philippe Normand.

Fix for the case when ImageDiff fails.
return an ImageDiffResult instead of a tuple. Otherwise we&apos;ll fail later on.

run-webkit-tests -p svg now works again.

* Tools/Scripts/webkitpy/port/image_diff.py:
(ImageDiffer.diff_image):

Canonical link: <a href="https://commits.webkit.org/252498@main">https://commits.webkit.org/252498@main</a>
</pre>
