### PR TITLE
[GStreamer][VideoCapture] VideoTrackPrivateGStreamer: Assert that we are not on the main thread when we enqueueTask from a callback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -53,11 +53,17 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivat
     }
 
     g_signal_connect_swapped(m_stream, "notify::caps", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
+        if (isMainThread())
+            LOG_ERROR("Caps callback received on main thread.");
+        ASSERT(!isMainThread());
         track->m_taskQueue.enqueueTask([track]() {
             track->updateConfigurationFromCaps();
         });
     }), this);
     g_signal_connect_swapped(m_stream, "notify::tags", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
+        if (isMainThread())
+            LOG_ERROR("Tags callback received on main thread.");
+        ASSERT(!isMainThread());
         track->m_taskQueue.enqueueTask([track]() {
             track->updateConfigurationFromTags();
         });


### PR DESCRIPTION
#### 9c677e32a2de47db72e977c825e453770e5699fe
<pre>
[GStreamer][VideoCapture] VideoTrackPrivateGStreamer: Assert that we are not on the main thread when we enqueueTask from a callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=242794">https://bugs.webkit.org/show_bug.cgi?id=242794</a>

Reviewed by NOBODY (OOPS!).

This should make threading issues in the callbacks easier to identify.

Also log an error message to make this easier to identify on release builds.

* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/False/commit/9c677e32a2de47db72e977c825e453770e5699fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/83335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/27300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/14673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/91363 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/145246 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/87355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/25625 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/23106 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/75513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/87911 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/88930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/20845 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/70866 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/21119 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/76734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/64276 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/23794 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/10589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/23695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/11474 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3529 "Failed to checkout and rebase branch from PR 2447") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/25263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/34612 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/25199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/30851 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->