### PR TITLE
Revert macOS part of https://commits.webkit.org/r295560

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -646,7 +646,7 @@
 (allow ipc-posix-shm-read* ipc-posix-shm-write-data
     (ipc-posix-name-prefix "AudioIO"))
 
-#if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS)
+#if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS) && ENABLE(AUDIO_COMPONENT_SERVER_REGISTRATIONS_IN_GPU_PROCESS)
 (deny mach-lookup (with no-log)
     (global-name "com.apple.audio.AudioComponentRegistrar"))
 #else

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -172,10 +172,10 @@ GPUProcessProxy::GPUProcessProxy()
     // Initialize the GPU process.
     send(Messages::GPUProcess::InitializeGPUProcess(parameters), 0);
 
-#if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS)
+#if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS) && ENABLE(AUDIO_COMPONENT_SERVER_REGISTRATIONS_IN_GPU_PROCESS)
     auto registrations = fetchAudioComponentServerRegistrations();
-    if (registrations)
-        send(Messages::GPUProcess::ConsumeAudioComponentRegistrations(IPC::SharedBufferReference(WTFMove(registrations))), 0);
+    RELEASE_ASSERT(registrations);
+    send(Messages::GPUProcess::ConsumeAudioComponentRegistrations(IPC::SharedBufferReference(WTFMove(registrations))), 0);
 #endif
 
     updateProcessAssertion();


### PR DESCRIPTION
#### f5569cbc8d7a9d7b9aa2c914e0d873418be95e9b
<pre>
Revert macOS part of <a href="https://commits.webkit.org/r295560">https://commits.webkit.org/r295560</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=242799">https://bugs.webkit.org/show_bug.cgi?id=242799</a>
&lt;rdar://96718797&gt;

Reviewed by Chris Dumez.

Revert macOS part of <a href="https://commits.webkit.org/r295560">https://commits.webkit.org/r295560</a> since that introduced crashes.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):

Canonical link: <a href="https://commits.webkit.org/252506@main">https://commits.webkit.org/252506@main</a>
</pre>
