### PR TITLE
[GTK][WPE] Revamp focus rings

### DIFF
--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -35,10 +35,11 @@ class Path;
 
 class ThemeAdwaita : public Theme {
 public:
-    static Color focusColor(bool focusColor);
-    static void paintFocus(GraphicsContext&, const FloatRect&, int offset, bool useDarkAppearance);
+    enum class PaintRounded : bool { No, Yes };
+
+    static void paintFocus(GraphicsContext&, const FloatRect&, int offset, const Color&, PaintRounded = PaintRounded::No);
     static void paintFocus(GraphicsContext&, const Path&, const Color&);
-    static void paintFocus(GraphicsContext&, const Vector<FloatRect>&, const Color&);
+    static void paintFocus(GraphicsContext&, const Vector<FloatRect>&, const Color&, PaintRounded = PaintRounded::No);
     enum class ArrowDirection { Up, Down };
     static void paintArrow(GraphicsContext&, ArrowDirection, bool);
 
@@ -56,6 +57,8 @@ private:
     void paintRadio(ControlStates&, GraphicsContext&, const FloatRect&, bool, const Color&);
     void paintButton(ControlStates&, GraphicsContext&, const FloatRect&, bool);
     void paintSpinButton(ControlStates&, GraphicsContext&, const FloatRect&, bool);
+
+    static Color focusColor(const Color&);
 
     Color m_accentColor;
 };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1965,7 +1965,7 @@ void RenderElement::drawLineForBoxSide(GraphicsContext& graphicsContext, const F
 
 static bool usePlatformFocusRingColorForOutlineStyleAuto()
 {
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     return true;
 #else
     return false;
@@ -1974,7 +1974,7 @@ static bool usePlatformFocusRingColorForOutlineStyleAuto()
 
 static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 {
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     return true;
 #else
     return false;


### PR DESCRIPTION
#### c63818df574ba14a0947d15860522e21cd3ffe31
<pre>
[GTK][WPE] Revamp focus rings
<a href="https://bugs.webkit.org/show_bug.cgi?id=241228">https://bugs.webkit.org/show_bug.cgi?id=241228</a>

Reviewed by Carlos Garcia Campos.

Use semi-transparent accent-colored focus rings, like macOS or GTK4.
Round them for radios and scales. Make sure to support CSS accent-color
for checks, radios and scales.

Use the same opacity as the libadwaita high contrast style and not the
regular one - the regular one doesn&apos;t work well on colorful backgrounds
like most webpages. This is also closer to the macOS style.

Make ThemeAdwaita::focusColor() private as it&apos;s both unused and doesn&apos;t
make much sense to be called from outside anymore.

This should fix the issue with modern media controls turning black
when focused.

* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::focusColor):
(WebCore::getRectRadius):
(WebCore::ThemeAdwaita::paintFocus):
(WebCore::ThemeAdwaita::paintCheckbox):
(WebCore::ThemeAdwaita::paintRadio):
(WebCore::ThemeAdwaita::paintButton):
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::usePlatformFocusRingColorForOutlineStyleAuto):
(WebCore::useShrinkWrappedFocusRingForOutlineStyleAuto):
* Source/WebCore/rendering/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::platformFocusRingColor const):
(WebCore::RenderThemeAdwaita::systemColor const):
(WebCore::RenderThemeAdwaita::paintTextField):
(WebCore::RenderThemeAdwaita::paintMenuList):
(WebCore::RenderThemeAdwaita::paintSliderTrack):

Canonical link: <a href="https://commits.webkit.org/252596@main">https://commits.webkit.org/252596@main</a>
</pre>
