### PR TITLE
[Gardening]: [ iOS15 ] fast/css/counters/element-removal-crash.xhtml is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-simulator/TestExpectations
+++ b/LayoutTests/platform/ios-simulator/TestExpectations
@@ -133,3 +133,5 @@ model-element/model-element-ready.html [ Skip ]
 webkit.org/b/239990 css3/calc/transitions-dependent.html [ Pass Failure ]
 
 webkit.org/b/227369 [ Release ] http/tests/privateClickMeasurement/store-private-click-measurement-with-source-nonce.html [ Pass Failure ]
+
+webkit.org/b/242800 fast/css/counters/element-removal-crash.xhtml [ Pass Failure ]


### PR DESCRIPTION
#### 633d948347843d4b7e473a05c64a77b3c3af757b
<pre>
[Gardening]: [ iOS15 ] fast/css/counters/element-removal-crash.xhtml is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242800">https://bugs.webkit.org/show_bug.cgi?id=242800</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-simulator/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252507@main">https://commits.webkit.org/252507@main</a>
</pre>
