### PR TITLE
Do not create and resolve directories for resolved directories in WebsiteDataStore

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -726,14 +726,14 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
-    if (auto directory = websiteDataStore.cookieStorageDirectory(); !directory.isEmpty())
-        cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
+    if (auto directory = websiteDataStore.resolvedCookieStorageDirectory(); !directory.isEmpty())
+        cookieStorageDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
-    if (auto directory = websiteDataStore.containerCachesDirectory(); !directory.isEmpty())
-        containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
+    if (auto directory = websiteDataStore.resolvedContainerCachesWebContentDirectory(); !directory.isEmpty())
+        containerCachesDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
     std::optional<SandboxExtension::Handle> containerTemporaryDirectoryExtensionHandle;
-    if (auto directory = websiteDataStore.containerTemporaryDirectory(); !directory.isEmpty())
-        containerTemporaryDirectoryExtensionHandle = SandboxExtension::createHandleForReadWriteDirectory(directory);
+    if (auto directory = websiteDataStore.resolvedContainerTemporaryDirectory(); !directory.isEmpty())
+        containerTemporaryDirectoryExtensionHandle = SandboxExtension::createHandleWithoutResolvingPath(directory, SandboxExtension::Type::ReadWrite);
 #endif
 
     return WebProcessDataStoreParameters {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -156,12 +156,11 @@ public:
 
     uint64_t perOriginStorageQuota() const { return m_resolvedConfiguration->perOriginStorageQuota(); }
     uint64_t perThirdPartyOriginStorageQuota() const;
-    const String& cacheStorageDirectory() const { return m_resolvedConfiguration->cacheStorageDirectory(); }
 
 #if PLATFORM(IOS_FAMILY)
-    String cookieStorageDirectory() const;
-    String containerCachesDirectory() const;
-    String containerTemporaryDirectory() const;
+    String resolvedCookieStorageDirectory();
+    String resolvedContainerCachesWebContentDirectory();
+    String resolvedContainerTemporaryDirectory();
     static String defaultContainerTemporaryDirectory();
     static String cacheDirectoryInContainerOrHomeDirectory(const String& subpath);
 #endif
@@ -250,6 +249,7 @@ public:
     void resetCacheMaxAgeCapForPrevalentResources(CompletionHandler<void()>&&);
     void resolveDirectoriesIfNecessary();
     const String& applicationCacheFlatFileSubdirectoryName() const { return m_configuration->applicationCacheFlatFileSubdirectoryName(); }
+    const String& resolvedCacheStorageDirectory() const { return m_resolvedConfiguration->cacheStorageDirectory(); }
     const String& resolvedApplicationCacheDirectory() const { return m_resolvedConfiguration->applicationCacheDirectory(); }
     const String& resolvedLocalStorageDirectory() const { return m_resolvedConfiguration->localStorageDirectory(); }
     const String& resolvedNetworkCacheDirectory() const { return m_resolvedConfiguration->networkCacheDirectory(); }
@@ -261,6 +261,7 @@ public:
     const String& resolvedIndexedDBDatabaseDirectory() const { return m_resolvedConfiguration->indexedDBDatabaseDirectory(); }
     const String& resolvedServiceWorkerRegistrationDirectory() const { return m_resolvedConfiguration->serviceWorkerRegistrationDirectory(); }
     const String& resolvedResourceLoadStatisticsDirectory() const { return m_resolvedConfiguration->resourceLoadStatisticsDirectory(); }
+    const String& resolvedPrivateClickMeasurementStorageDirectory() const { return m_resolvedConfiguration->privateClickMeasurementStorageDirectory(); }
     const String& resolvedHSTSStorageDirectory() const { return m_resolvedConfiguration->hstsStorageDirectory(); }
     const String& resolvedGeneralStorageDirectory() const { return m_resolvedConfiguration->generalStorageDirectory(); }
 #if ENABLE(ARKIT_INLINE_PREVIEW)
@@ -430,7 +431,7 @@ private:
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    String networkingCachesDirectory() const;
+    String resolvedContainerCachesNetworkingDirectory();
     String parentBundleDirectory() const;
 #endif
 
@@ -440,6 +441,12 @@ private:
     Ref<const WebsiteDataStoreConfiguration> m_configuration;
     bool m_hasResolvedDirectories { false };
     const Ref<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
+#if PLATFORM(IOS_FAMILY)
+    String m_resolvedContainerCachesWebContentDirectory;
+    String m_resolvedContainerCachesNetworkingDirectory;
+    String m_resolvedContainerTemporaryDirectory;
+    String m_resolvedCookieStorageDirectory;
+#endif
 
 #if ENABLE(INTELLIGENT_TRACKING_PREVENTION)
     bool m_resourceLoadStatisticsDebugMode { false };


### PR DESCRIPTION
#### dc2259320c914a459734ec48128cdd4a1ed6a43e
<pre>
Do not create and resolve directories for resolved directories in WebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=242803">https://bugs.webkit.org/show_bug.cgi?id=242803</a>
rdar://96917273

Reviewed by Geoffrey Garen.

We cache resolved directories in WebsiteDataStore, so we can use them to create sandbox extension handle without
resolving them again. This should help reduce some syscalls.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::cacheDirectoryInContainerOrHomeDirectory):
(WebKit::WebsiteDataStore::parentBundleDirectory const):
(WebKit::WebsiteDataStore::resolvedCookieStorageDirectory):
(WebKit::WebsiteDataStore::resolvedContainerCachesNetworkingDirectory):
(WebKit::WebsiteDataStore::resolvedContainerCachesWebContentDirectory):
(WebKit::WebsiteDataStore::resolvedContainerTemporaryDirectory):
(WebKit::WebsiteDataStore::defaultContainerTemporaryDirectory):
(WebKit::WebsiteDataStore::cookieStorageDirectory const): Deleted.
(WebKit::WebsiteDataStore::containerCachesDirectory const): Deleted.
(WebKit::WebsiteDataStore::networkingCachesDirectory const): Deleted.
(WebKit::WebsiteDataStore::containerTemporaryDirectory const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):
(WebKit::createHandleFromResolvedPathIfPossible):
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::resolvedCacheStorageDirectory const):
(WebKit::WebsiteDataStore::resolvedPrivateClickMeasurementStorageDirectory const):
(WebKit::WebsiteDataStore::cacheStorageDirectory const): Deleted.

Canonical link: <a href="https://commits.webkit.org/252534@main">https://commits.webkit.org/252534@main</a>
</pre>
