### PR TITLE
[commits.webkit.org] Accept hooks from non-origin remotes

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 2)
+version = Version(0, 7, 3)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py
@@ -84,12 +84,12 @@ class HookProcessor(object):
             try:
                 if branch.startswith(self.BRANCH_PREFIX):
                     branch = branch[len(self.BRANCH_PREFIX):]
-                    self.checkout.update_for(branch, track=True)
+                    self.checkout.update_for(branch, track=True, remote=remote)
                     self.checkout.forward_update(branch=branch, remote=remote, track=True)
 
                 if branch.startswith(self.TAG_PREFIX):
                     tag = branch[len(self.TAG_PREFIX):]
-                    self.checkout.fetch()
+                    self.checkout.fetch(remote=remote)
                     self.checkout.forward_update(tag=tag, remote=remote)
 
             except BaseException as e:

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.2',
+    version='0.7.3',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### f94484033bebcda7cc4b3ea92ffba3a4b07c355f
<pre>
[commits.webkit.org] Accept hooks from non-origin remotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=242807">https://bugs.webkit.org/show_bug.cgi?id=242807</a>
&lt;rdar://problem/97080157&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/setup.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py:
(HookProcessor.process_worker_hook):

Canonical link: <a href="https://commits.webkit.org/252510@main">https://commits.webkit.org/252510@main</a>
</pre>
