### PR TITLE
Crash under WTF::Detail::CallableWrapper<IPC::Connection::connectionDidClose()::$_10, void>::call()

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -56,6 +56,8 @@ AuxiliaryProcess::AuxiliaryProcess()
 
 AuxiliaryProcess::~AuxiliaryProcess()
 {
+    if (m_connection)
+        m_connection->invalidate();
 }
 
 void AuxiliaryProcess::didClose(IPC::Connection&)


### PR DESCRIPTION
#### 4e5551a51e2428a61718798aff001d6bfc2d3af2
<pre>
Crash under WTF::Detail::CallableWrapper&lt;IPC::Connection::connectionDidClose()::$_10, void&gt;::call()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242805">https://bugs.webkit.org/show_bug.cgi?id=242805</a>
&lt;rdar://97002281&gt;

Reviewed by Geoffrey Garen.

It seems we are crashing inside the lambda in Connection::connectionDidClose() when
dereferencing m_client, indicating that m_client has likely become invalid.
The way we normally avoid this is that the client is supposed to call
Connection::invalidate() before getting destroyed. The lambda inside
Connection::connectionDidClose() would then return early before trying to use m_client,
because Connection::isValid() returns false.

I noticed that the AuxiliaryProcess destructor was failing to call invalidate() so
it was possible indeed for this situation to happen.

* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::~AuxiliaryProcess):

Canonical link: <a href="https://commits.webkit.org/252518@main">https://commits.webkit.org/252518@main</a>
</pre>
