### PR TITLE
Web Inspector: should not include `@globalPrivate` functions in stack traces

### DIFF
--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt
@@ -19,9 +19,6 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: asyncFunctionResume
-        5: (anonymous function)
-        6: promiseReactionJobWithoutPromise
-        7: promiseReactionJob
+        4: (anonymous function)
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt
@@ -19,10 +19,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: asyncFunctionResume
-        5: (anonymous function)
-        6: promiseReactionJobWithoutPromise
-        7: promiseReactionJob
+        4: (anonymous function)
       snapshot: <filtered>
   1: (duration)
     0: width

--- a/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt
@@ -19,9 +19,6 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
         3: (anonymous function)
-        4: asyncFunctionResume
-        5: (anonymous function)
-        6: promiseReactionJobWithoutPromise
-        7: promiseReactionJob
+        4: (anonymous function)
       snapshot: <filtered>
 

--- a/LayoutTests/inspector/console/message-stack-trace-expected.txt
+++ b/LayoutTests/inspector/console/message-stack-trace-expected.txt
@@ -26,17 +26,15 @@ CALL STACK:
 -- Running test case: Console.StackTrace.UnhandledPromiseRejection.PromiseReject
 CALL STACK:
 0: [N] (anonymous function)
-1: [N] rejectPromise
-2: [N] reject
-3: [F] triggerUnhandledRejectionPromiseReject
+1: [N] reject
+2: [F] triggerUnhandledRejectionPromiseReject
 
 -- Running test case: Console.StackTrace.UnhandledPromiseRejection.ExplicitReject
 CALL STACK:
 0: [N] (anonymous function)
-1: [N] rejectPromise
-2: [F] (anonymous function)
-3: [N] Promise
-4: [F] triggerUnhandledRejectionExplicit
+1: [F] (anonymous function)
+2: [N] Promise
+3: [F] triggerUnhandledRejectionExplicit
 
 -- Running test case: Console.StackTrace.UnhandledPromiseRejection.ImplicitReject
 CALL STACK:

--- a/LayoutTests/inspector/debugger/js-stacktrace-expected.txt
+++ b/LayoutTests/inspector/debugger/js-stacktrace-expected.txt
@@ -150,24 +150,10 @@ console.trace():
         "programCode": false
     },
     {
-        "lineNumber": null,
-        "columnNumber": null,
-        "functionName": "generatorResume",
-        "nativeCode": true,
-        "programCode": false
-    },
-    {
         "lineNumber": 39,
         "columnNumber": 12,
         "functionName": "generator1",
         "nativeCode": false,
-        "programCode": false
-    },
-    {
-        "lineNumber": null,
-        "columnNumber": null,
-        "functionName": "generatorResume",
-        "nativeCode": true,
         "programCode": false
     },
     {

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1022,6 +1022,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/HashMapImplInlines.h
     runtime/Identifier.h
     runtime/IdentifierInlines.h
+    runtime/ImplementationVisibility.h
     runtime/IndexingHeader.h
     runtime/IndexingHeaderInlines.h
     runtime/IndexingType.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1349,6 +1349,7 @@
 		932F5BDD0822A1C700736975 /* jsc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45E12D8806A49B0F00E9DF84 /* jsc.cpp */; };
 		932F5BEA0822A1C700736975 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		933040040E6A749400786E6A /* SmallStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 93303FEA0E6A72C000786E6A /* SmallStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		95CA6AD328809E010062D5EC /* ImplementationVisibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CA6AD228809E010062D5EC /* ImplementationVisibility.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		960097A60EBABB58007A7297 /* LabelScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 960097A50EBABB58007A7297 /* LabelScope.h */; };
 		9688CB150ED12B4E001D649F /* AssemblerBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9688CB130ED12B4E001D649F /* AssemblerBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9688CB160ED12B4E001D6491 /* X86Registers.h in Headers */ = {isa = PBXBuildFile; fileRef = 9688CB140ED12B4E001D6491 /* X86Registers.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4555,6 +4556,7 @@
 		93F0B3AA09BB4DC00068FCE3 /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Parser.h; sourceTree = "<group>"; };
 		93F1981A08245AAE001E9ABC /* Keywords.table */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = text; path = Keywords.table; sourceTree = "<group>"; tabWidth = 8; };
 		95C18D3E0C90E7EF00E72F73 /* JSRetainPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSRetainPtr.h; sourceTree = "<group>"; };
+		95CA6AD228809E010062D5EC /* ImplementationVisibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImplementationVisibility.h; sourceTree = "<group>"; };
 		960097A50EBABB58007A7297 /* LabelScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LabelScope.h; sourceTree = "<group>"; };
 		9688CB130ED12B4E001D649F /* AssemblerBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AssemblerBuffer.h; sourceTree = "<group>"; };
 		9688CB140ED12B4E001D6491 /* X86Registers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = X86Registers.h; sourceTree = "<group>"; };
@@ -7789,6 +7791,7 @@
 				933A349D038AE80F008635CE /* Identifier.cpp */,
 				933A349A038AE7C6008635CE /* Identifier.h */,
 				8606DDE918DA44AB00A383D0 /* IdentifierInlines.h */,
+				95CA6AD228809E010062D5EC /* ImplementationVisibility.h */,
 				0FB7F38D15ED8E3800F167B2 /* IndexingHeader.h */,
 				0FB7F38E15ED8E3800F167B2 /* IndexingHeaderInlines.h */,
 				0F13E04C16164A1B00DC8DE7 /* IndexingType.cpp */,
@@ -10435,6 +10438,7 @@
 				BC18C40F0E16F5CD00B34460 /* Identifier.h in Headers */,
 				8606DDEA18DA44AB00A383D0 /* IdentifierInlines.h in Headers */,
 				A5FD0076189B038C00633231 /* IdentifiersFactory.h in Headers */,
+				95CA6AD328809E010062D5EC /* ImplementationVisibility.h in Headers */,
 				A38D5BFC2666D3DA00A109A6 /* InByStatus.h in Headers */,
 				A382C5312667111D0042CD99 /* InByVariant.h in Headers */,
 				C25F8BCE157544A900245B71 /* IncrementalSweeper.h in Headers */,

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
@@ -80,6 +80,7 @@ class VM;
 
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
+enum class ImplementationVisibility : uint8_t;
 }"""
 
     def generate_section_for_object(self, object):
@@ -101,7 +102,8 @@ enum class ConstructorKind : uint8_t;
             lines.append("""extern const char* const s_%(codeName)s;
 extern const int s_%(codeName)sLength;
 extern const JSC::ConstructAbility s_%(codeName)sConstructAbility;
-extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;""" % function_args)
+extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;
+extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;""" % function_args)
 
         return lines
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
@@ -128,7 +128,8 @@ class FunctionExecutable;
             lines.append("""extern const char* const s_%(codeName)s;
 extern const int s_%(codeName)sLength;
 extern const JSC::ConstructAbility s_%(codeName)sConstructAbility;
-extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;""" % function_args)
+extern const JSC::ConstructorKind s_%(codeName)sConstructorKind;
+extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility;""" % function_args)
 
         return lines
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -133,6 +133,10 @@ class BuiltinsGenerator:
         if function.is_naked_constructor:
             constructorKind = "Naked"
 
+        visibility = "Public"
+        if function.is_global_private:
+            visibility = "Private"
+
         return {
             'codeName': BuiltinsGenerator.mangledNameForFunction(function) + 'Code',
             'embeddedSource': embeddedSource,
@@ -140,6 +144,7 @@ class BuiltinsGenerator:
             'originalSource': text + "\n",
             'constructAbility': constructAbility,
             'constructorKind': constructorKind,
+            'visibility': visibility,
             'intrinsic': function.intrinsic
         }
 
@@ -147,6 +152,7 @@ class BuiltinsGenerator:
         lines = []
         lines.append("const JSC::ConstructAbility s_%(codeName)sConstructAbility = JSC::ConstructAbility::%(constructAbility)s;" % data);
         lines.append("const JSC::ConstructorKind s_%(codeName)sConstructorKind = JSC::ConstructorKind::%(constructorKind)s;" % data);
+        lines.append("const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibility = JSC::ImplementationVisibility::%(visibility)s;" % data);
         lines.append("const int s_%(codeName)sLength = %(embeddedSourceLength)d;" % data);
         lines.append("static const JSC::Intrinsic s_%(codeName)sIntrinsic = JSC::%(intrinsic)s;" % data);
         lines.append("const char* const s_%(codeName)s =\n%(embeddedSource)s\n;" % data);

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
@@ -168,7 +168,7 @@ inline JSC::UnlinkedFunctionExecutable* ${objectName}BuiltinsWrapper::name##Exec
         JSC::Identifier executableName = functionName##PublicName();\\
         if (overriddenName)\\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\\
     }\\
     return m_##name##Executable.get();\\
 }

--- a/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp
@@ -30,9 +30,9 @@
 
 namespace JSC {
 
-UnlinkedFunctionExecutable* createBuiltinExecutable(VM& vm, const SourceCode& source, const Identifier& ident, ConstructorKind kind, ConstructAbility ability)
+UnlinkedFunctionExecutable* createBuiltinExecutable(VM& vm, const SourceCode& source, const Identifier& ident, ImplementationVisibility implementationVisibility, ConstructorKind kind, ConstructAbility ability)
 {
-    return BuiltinExecutables::createExecutable(vm, source, ident, kind, ability, NeedsClassFieldInitializer::No);
+    return BuiltinExecutables::createExecutable(vm, source, ident, implementationVisibility, kind, ability, NeedsClassFieldInitializer::No);
 }
     
 } // namespace JSC

--- a/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h
@@ -27,11 +27,12 @@
 
 #include "ConstructAbility.h"
 #include "ConstructorKind.h"
+#include "ImplementationVisibility.h"
 #include "ParserModes.h"
 #include "SourceCode.h"
 
 namespace JSC {
 
-JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ConstructorKind, ConstructAbility);
+JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -67,18 +67,18 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createDefaultConstructor(Constru
         break;
     case ConstructorKind::Base:
     case ConstructorKind::Extends:
-        return createExecutable(m_vm, defaultConstructorSourceCode(constructorKind), name, constructorKind, ConstructAbility::CanConstruct, needsClassFieldInitializer, privateBrandRequirement);
+        return createExecutable(m_vm, defaultConstructorSourceCode(constructorKind), name, ImplementationVisibility::Public, constructorKind, ConstructAbility::CanConstruct, needsClassFieldInitializer, privateBrandRequirement);
     }
     ASSERT_NOT_REACHED();
     return nullptr;
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const Identifier& name, ConstructorKind constructorKind, ConstructAbility constructAbility)
+UnlinkedFunctionExecutable* BuiltinExecutables::createBuiltinExecutable(const SourceCode& code, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility)
 {
-    return createExecutable(m_vm, code, name, constructorKind, constructAbility, NeedsClassFieldInitializer::No);
+    return createExecutable(m_vm, code, name, implementationVisibility, constructorKind, constructAbility, NeedsClassFieldInitializer::No);
 }
 
-UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ConstructorKind constructorKind, ConstructAbility constructAbility, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
+UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const SourceCode& source, const Identifier& name, ImplementationVisibility implementationVisibility, ConstructorKind constructorKind, ConstructAbility constructAbility, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement)
 {
     // FIXME: Can we just make MetaData computation be constexpr and have the compiler do this for us?
     // https://bugs.webkit.org/show_bug.cgi?id=193272
@@ -258,7 +258,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         }
     }
 
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, implementationVisibility, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
     return functionExecutable;
 }
 
@@ -283,7 +283,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::name##Executable() \
         Identifier executableName = m_vm.propertyNames->builtinNames().functionName##PublicName();\
         if (overrideName)\
             executableName = Identifier::fromString(m_vm, overrideName);\
-        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), executableName, s_##name##ConstructorKind, s_##name##ConstructAbility);\
+        m_unlinkedExecutables[index] = createBuiltinExecutable(name##Source(), executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility);\
     }\
     return m_unlinkedExecutables[index];\
 }

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -60,14 +60,14 @@ SourceCode name##Source();
     static SourceCode defaultConstructorSourceCode(ConstructorKind);
     UnlinkedFunctionExecutable* createDefaultConstructor(ConstructorKind, const Identifier& name, NeedsClassFieldInitializer, PrivateBrandRequirement);
 
-    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
+    static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
 
     void finalizeUnconditionally();
 
 private:
     VM& m_vm;
 
-    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const Identifier&, ConstructorKind, ConstructAbility);
+    UnlinkedFunctionExecutable* createBuiltinExecutable(const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
 
     Ref<StringSourceProvider> m_combinedSourceProvider;
     UnlinkedFunctionExecutable* m_unlinkedExecutables[static_cast<unsigned>(BuiltinCodeIndex::NumberOfBuiltinCodes)] { };

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -421,7 +421,7 @@ private:
     unsigned m_age : 3;
     static_assert(((1U << 3) - 1) >= maxAge);
     bool m_hasCheckpoints : 1;
-    unsigned m_lexicalScopeFeatures : 4;
+    unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
 public:
     ConcurrentJSLock m_lock;
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -81,7 +81,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     return result;
 }
 
-UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
+UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ImplementationVisibility implementationVisibility, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
     : Base(vm, structure)
     , m_firstLineOffset(node->firstLine() - parentSource.firstLine().oneBasedInt())
     , m_isGeneratedFromCache(false)
@@ -107,6 +107,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_features(0)
     , m_constructorKind(static_cast<unsigned>(node->constructorKind()))
     , m_sourceParseMode(node->parseMode())
+    , m_implementationVisibility(static_cast<unsigned>(implementationVisibility))
     , m_lexicalScopeFeatures(node->lexicalScopeFeatures())
     , m_functionMode(static_cast<unsigned>(node->functionMode()))
     , m_derivedContextType(static_cast<unsigned>(derivedContextType))
@@ -116,6 +117,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_ecmaName(node->ecmaName())
 {
     // Make sure these bitfields are adequately wide.
+    ASSERT(m_implementationVisibility == static_cast<unsigned>(implementationVisibility));
     ASSERT(m_constructAbility == static_cast<unsigned>(constructAbility));
     ASSERT(m_constructorKind == static_cast<unsigned>(node->constructorKind()));
     ASSERT(m_functionMode == static_cast<unsigned>(node->functionMode()));

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -31,6 +31,7 @@
 #include "ExecutableInfo.h"
 #include "ExpressionRangeInfo.h"
 #include "Identifier.h"
+#include "ImplementationVisibility.h"
 #include "Intrinsic.h"
 #include "JSCast.h"
 #include "ParserModes.h"
@@ -71,10 +72,10 @@ public:
         return &vm.unlinkedFunctionExecutableSpace();
     }
 
-    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
+    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ImplementationVisibility implementationVisibility, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
     {
         UnlinkedFunctionExecutable* instance = new (NotNull, allocateCell<UnlinkedFunctionExecutable>(vm))
-            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, constructAbility, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, implementationVisibility, constructAbility, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
         instance->finishCreation(vm);
         return instance;
     }
@@ -152,6 +153,7 @@ public:
     static constexpr bool needsDestruction = true;
     static void destroy(JSCell*);
 
+    ImplementationVisibility implementationVisibility() const { return static_cast<ImplementationVisibility>(m_implementationVisibility); }
     bool isBuiltinFunction() const { return m_isBuiltinFunction; }
     ConstructAbility constructAbility() const { return static_cast<ConstructAbility>(m_constructAbility); }
     JSParserScriptMode scriptMode() const { return static_cast<JSParserScriptMode>(m_scriptMode); }
@@ -243,7 +245,7 @@ public:
     }
 
 private:
-    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ConstructAbility, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ImplementationVisibility, ConstructAbility, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
     UnlinkedFunctionExecutable(Decoder&, const CachedFunctionExecutable&);
 
     DECLARE_VISIT_CHILDREN;
@@ -281,7 +283,8 @@ private:
     unsigned m_features : 14;
     unsigned m_constructorKind : 2;
     SourceParseMode m_sourceParseMode;
-    unsigned m_lexicalScopeFeatures : 4;
+    unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;
+    unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
     unsigned m_functionMode : 2; // FunctionMode
     unsigned m_derivedContextType: 2;
 
@@ -319,5 +322,9 @@ public:
 
     DECLARE_EXPORT_INFO;
 };
+
+#if COMPILER(CLANG) && !ASSERT_ENABLED
+static_assert(sizeof(UnlinkedFunctionExecutable) <= 96, "UnlinkedFunctionExecutable needs to be small");
+#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3336,7 +3336,7 @@ RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* 
 
     FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, StrictModeLexicalFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
     metadata.finishParsing(m_scopeNode->source(), Identifier(), FunctionMode::MethodDefinition);
-    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, ImplementationVisibility::Private, constructAbility, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
     initializer->setClassFieldLocations(WTFMove(classFieldLocations));
 
     unsigned index = m_codeBlock->addFunctionExpr(initializer);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1158,7 +1158,10 @@ namespace JSC {
             if (parseMode == SourceParseMode::MethodMode && metadata->constructorKind() != ConstructorKind::None)
                 constructAbility = ConstructAbility::CanConstruct;
 
-            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
+            // FIXME: <https://webkit.org/b/242808> add a way to mark sub-functions as `ImplementationVisibility::Private`
+            auto implementationVisibility = ImplementationVisibility::Public;
+
+            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, implementationVisibility, constructAbility, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
         }
 
         RefPtr<TDZEnvironmentLink> getVariablesUnderTDZ();

--- a/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
@@ -33,9 +33,13 @@
 #include "config.h"
 #include "ScriptCallStackFactory.h"
 
+#include "CodeBlock.h"
+#include "ExecutableBaseInlines.h"
+#include "ImplementationVisibility.h"
 #include "JSCInlines.h"
 #include "ScriptArguments.h"
 #include "ScriptCallFrame.h"
+#include "ScriptExecutable.h"
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -53,6 +57,11 @@ public:
 
     IterationStatus operator()(StackVisitor& visitor) const
     {
+        if (auto* codeBlock = visitor->codeBlock()) {
+            if (codeBlock->ownerExecutable()->implementationVisibility() == ImplementationVisibility::Private)
+                return IterationStatus::Continue;
+        }
+
         if (m_needToSkipAFrame) {
             m_needToSkipAFrame = false;
             return IterationStatus::Continue;

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -2255,7 +2255,7 @@ namespace JSC {
         }
 
     public:
-        unsigned m_lexicalScopeFeatures : 4;
+        unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
         unsigned m_superBinding : 1;
         unsigned m_constructorKind : 2;
         unsigned m_needsClassFieldInitializer : 1;

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -312,7 +312,8 @@ const LexicalScopeFeatures NoLexicalFeatures                           = 0;
 const LexicalScopeFeatures StrictModeLexicalFeature               = 1 << 0;
 
 const LexicalScopeFeatures AllLexicalFeatures = NoLexicalFeatures | StrictModeLexicalFeature;
-static_assert(AllLexicalFeatures <= 0b1111, "LexicalScopeFeatures must be 4bits");
+static constexpr unsigned bitWidthOfLexicalScopeFeatures = 3;
+static_assert(AllLexicalFeatures <= (1 << bitWidthOfLexicalScopeFeatures) - 1, "LexicalScopeFeatures must be 3bits");
 
 typedef uint16_t CodeFeatures;
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1939,7 +1939,7 @@ private:
     unsigned m_hasTailCalls : 1;
     unsigned m_codeType : 2;
     unsigned m_hasCheckpoints : 1;
-    unsigned m_lexicalScopeFeatures : 4;
+    unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
 
     CodeFeatures m_features;
     SourceParseMode m_parseMode;

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -248,7 +248,7 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
     // The Function constructor only has access to global variables, so no variables will be under TDZ unless they're
     // in the global lexical environment, which we always TDZ check accesses from.
     ConstructAbility constructAbility = constructAbilityForParseMode(metadata->parseMode());
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, ImplementationVisibility::Public, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
 
     if (!source.provider()->sourceURLDirective().isNull())
         functionExecutable->setSourceURLDirective(source.provider()->sourceURLDirective());

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -195,6 +195,8 @@ public:
             return intrinsic();
         return NoIntrinsic;
     }
+
+    ImplementationVisibility implementationVisibility() const;
     
     void dump(PrintStream&) const;
         

--- a/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBaseInlines.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "ExecutableBase.h"
+#include "FunctionExecutable.h"
+#include "ImplementationVisibility.h"
 #include "NativeExecutable.h"
 #include "ScriptExecutable.h"
 
@@ -36,6 +38,13 @@ inline Intrinsic ExecutableBase::intrinsic() const
     if (isHostFunction())
         return jsCast<const NativeExecutable*>(this)->intrinsic();
     return jsCast<const ScriptExecutable*>(this)->intrinsic();
+}
+
+inline ImplementationVisibility ExecutableBase::implementationVisibility() const
+{
+    if (isFunctionExecutable())
+        return jsCast<const FunctionExecutable*>(this)->implementationVisibility();
+    return ImplementationVisibility::Public;
 }
 
 inline bool ExecutableBase::hasJITCodeForCall() const

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -129,6 +129,7 @@ public:
     }
         
     FunctionMode functionMode() { return m_unlinkedExecutable->functionMode(); }
+    ImplementationVisibility implementationVisibility() const { return m_unlinkedExecutable->implementationVisibility(); }
     bool isBuiltinFunction() const { return m_unlinkedExecutable->isBuiltinFunction(); }
     ConstructAbility constructAbility() const { return m_unlinkedExecutable->constructAbility(); }
     bool isClass() const { return m_unlinkedExecutable->isClass(); }

--- a/Source/JavaScriptCore/runtime/ImplementationVisibility.h
+++ b/Source/JavaScriptCore/runtime/ImplementationVisibility.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Canon Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,23 +25,13 @@
 
 #pragma once
 
-#include "ConstructAbility.h"
-#include "ConstructorKind.h"
-#include "ImplementationVisibility.h"
-
 namespace JSC {
 
-#define INITIALIZE_BUILTIN_NAMES(name) , m_##name(JSC::Identifier::fromString(vm, #name ""_s)), m_##name##PrivateName(JSC::Identifier::fromUid(JSC::PrivateName(JSC::PrivateName::PrivateSymbol, #name ""_s)))
-#define DECLARE_BUILTIN_NAMES(name) const JSC::Identifier m_##name; const JSC::Identifier m_##name##PrivateName;
-#define DECLARE_BUILTIN_IDENTIFIER_ACCESSOR(name) \
-    const JSC::Identifier& name##PublicName() const { return m_##name; } \
-    const JSC::Identifier& name##PrivateName() const { return m_##name##PrivateName; }
+enum class ImplementationVisibility : uint8_t {
+    Public,
+    Private,
+};
 
-class Identifier;
-class SourceCode;
-class UnlinkedFunctionExecutable;
-class VM;
+static constexpr unsigned bitWidthOfImplementationVisibility = 1;
 
-JS_EXPORT_PRIVATE UnlinkedFunctionExecutable* createBuiltinExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility);
-    
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ExecutableBase.h"
+#include "ParserModes.h"
 
 namespace JSC {
 
@@ -149,7 +150,7 @@ protected:
     Intrinsic m_intrinsic { NoIntrinsic };
     bool m_didTryToEnterInLoop { false };
     CodeFeatures m_features;
-    unsigned m_lexicalScopeFeatures : 4;
+    unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
     OptionSet<CodeGenerationMode> m_codeGenerationModeForGeneratorBody;
     bool m_hasCapturedVariables : 1;
     bool m_neverInline : 1;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3223,7 +3223,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateBuiltin, (JSGlobalObject* globalObject, C
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     SourceCode source = makeSource(WTFMove(functionText), { });
-    JSFunction* func = JSFunction::create(vm, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), ConstructorKind::None, ConstructAbility::CannotConstruct)->link(vm, nullptr, source), globalObject);
+    JSFunction* func = JSFunction::create(vm, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), ImplementationVisibility::Public, ConstructorKind::None, ConstructAbility::CannotConstruct)->link(vm, nullptr, source), globalObject);
 
     return JSValue::encode(func);
 }


### PR DESCRIPTION
#### ebb980b89e945e8c3997ecb3c760a1d66c0a901b
<pre>
Web Inspector: should not include `@globalPrivate` functions in stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=242806">https://bugs.webkit.org/show_bug.cgi?id=242806</a>

Reviewed by Yusuke Suzuki.

`@globalPrivate` are just internal implementation details, and therefore are likely to change (at
least more often than standardized functions) and be unknown to a developer.

* Source/JavaScriptCore/runtime/ImplementationVisibility.h: Added.
Create a new enum that (currently) allows indicating `Public` or `Private`.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
(BuiltinsGenerator.generate_embedded_code_string_section_for_data):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py:
(BuiltinsCombinedHeaderGenerator.generate_forward_declarations):
(BuiltinsCombinedHeaderGenerator.generate_externs_for_object):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py:
(BuiltinsSeparateHeaderGenerator.generate_externs_for_object):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py:
Mark functions annotated with `@globalPrivate` as being `ImplementationVisibility::Private`.

* Source/JavaScriptCore/builtins/BuiltinUtils.h:
* Source/JavaScriptCore/builtins/BuiltinExecutableCreator.h:
* Source/JavaScriptCore/builtins/BuiltinExecutableCreator.cpp:
(JSC::createBuiltinExecutable):
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createDefaultConstructor):
(JSC::BuiltinExecutables::createBuiltinExecutable):
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
Pass along the `ImplementationVisibility`.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::makeFunction):
Assume `ImplementationVisibility::Public` for now.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitNewClassFieldInitializerFunction):
Mark as `ImplementationVisibility::Private` as this is not supposed to be visible to developers.

* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(functionCreateBuiltin):
Mark as `ImplementationVisibility::Public`.

* Source/JavaScriptCore/runtime/ExecutableBase.h:
* Source/JavaScriptCore/runtime/ExecutableBaseInlines.h:
(JSC::ExecutableBase::implementationVisibility const): Added.
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
(JSC::FunctionExecutable::implementationVisibility const): Added.
Add a way to access the `ImplementationVisibility`.

* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::CreateScriptCallStackFunctor::operator() const):
Ignore anything marked as `ImplementationVisibility::Private`.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
* Source/JavaScriptCore/runtime/ScriptExecutable.h:
Drive-by: Decrease the bit width of `LexicalScopeFeatures` to make room for `ImplementationVisibility`.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:

* LayoutTests/inspector/canvas/recording-bitmaprenderer-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-full-expected.txt:
* LayoutTests/inspector/canvas/recording-bitmaprenderer-memoryLimit-expected.txt:
* LayoutTests/inspector/console/message-stack-trace-expected.txt:
* LayoutTests/inspector/debugger/js-stacktrace-expected.txt:

Canonical link: <a href="https://commits.webkit.org/252554@main">https://commits.webkit.org/252554@main</a>
</pre>
