### PR TITLE
Align StorageEvent.initStorageEvent() with the HTML specification

### DIFF
--- a/LayoutTests/fast/events/init-events-expected.txt
+++ b/LayoutTests/fast/events/init-events-expected.txt
@@ -116,7 +116,7 @@ PASS testInitEvent('Storage', '"a", true, false, "b", "c", "d", "e"').bubbles is
 PASS testInitEvent('Storage', '"a", false, false, "b", "c", "d", "e"').cancelable is false
 PASS testInitEvent('Storage', '"a", false, true, "b", "c", "d", "e"').cancelable is true
 PASS testInitEvent('Storage', '"a", false, false, "b", "c", "d", "e"').key is 'b'
-PASS testInitEvent('Storage', '"a", false, false, null, "c", "d", "e"').key is 'null'
+PASS testInitEvent('Storage', '"a", false, false, null, "c", "d", "e"').key is null
 PASS testInitEvent('Storage', '"a", false, false, "b", "c", "d", "e"').oldValue is 'c'
 PASS testInitEvent('Storage', '"a", false, false, "b", null, "d", "e"').oldValue is null
 PASS testInitEvent('Storage', '"a", false, false, "b", "c", "d", "e"').newValue is 'd'

--- a/LayoutTests/fast/events/init-events.html
+++ b/LayoutTests/fast/events/init-events.html
@@ -145,7 +145,7 @@ shouldBe("testInitEvent('Storage', '\"a\", true, false, \"b\", \"c\", \"d\", \"e
 shouldBe("testInitEvent('Storage', '\"a\", false, false, \"b\", \"c\", \"d\", \"e\"').cancelable", "false");
 shouldBe("testInitEvent('Storage', '\"a\", false, true, \"b\", \"c\", \"d\", \"e\"').cancelable", "true");
 shouldBe("testInitEvent('Storage', '\"a\", false, false, \"b\", \"c\", \"d\", \"e\"').key", "'b'");
-shouldBe("testInitEvent('Storage', '\"a\", false, false, null, \"c\", \"d\", \"e\"').key", "'null'");
+shouldBe("testInitEvent('Storage', '\"a\", false, false, null, \"c\", \"d\", \"e\"').key", "null");
 shouldBe("testInitEvent('Storage', '\"a\", false, false, \"b\", \"c\", \"d\", \"e\"').oldValue", "'c'");
 shouldBe("testInitEvent('Storage', '\"a\", false, false, \"b\", null, \"d\", \"e\"').oldValue", "null");
 shouldBe("testInitEvent('Storage', '\"a\", false, false, \"b\", \"c\", \"d\", \"e\"').newValue", "'d'");

--- a/LayoutTests/imported/w3c/web-platform-tests/webstorage/event_initstorageevent.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webstorage/event_initstorageevent.window-expected.txt
@@ -1,7 +1,7 @@
 
 PASS initStorageEvent with 0 arguments
-FAIL initStorageEvent with 1 argument assert_equals: event.key expected (object) null but got (string) "undefined"
+PASS initStorageEvent with 1 argument
 PASS initStorageEvent with 8 sensible arguments
-FAIL initStorageEvent with 8 null arguments assert_equals: event.key expected (object) null but got (string) "null"
-FAIL initStorageEvent with 8 undefined arguments assert_equals: event.key expected (object) null but got (string) "undefined"
+PASS initStorageEvent with 8 null arguments
+PASS initStorageEvent with 8 undefined arguments
 

--- a/Source/WebCore/storage/StorageEvent.idl
+++ b/Source/WebCore/storage/StorageEvent.idl
@@ -34,14 +34,14 @@
     readonly attribute USVString url;
     readonly attribute Storage? storageArea;
 
-    undefined initStorageEvent([AtomString] DOMString typeArg,
-                          optional boolean canBubbleArg = false,
-                          optional boolean cancelableArg = false,
-                          optional DOMString keyArg = "undefined",
-                          optional DOMString? oldValueArg = null,
-                          optional DOMString? newValueArg = null,
-                          optional USVString urlArg = "undefined",
-                          optional Storage? storageAreaArg = null);
+    undefined initStorageEvent([AtomString] DOMString type,
+                               optional boolean bubbles = false,
+                               optional boolean cancelable = false,
+                               optional DOMString? key = null,
+                               optional DOMString? oldValue = null,
+                               optional DOMString? newValue = null,
+                               optional USVString url = "",
+                               optional Storage? storageArea = null);
 
     // Needed once we support init<blank>EventNS
     // undefined initStorageEventNS(DOMString namespaceURI, DOMString typeArg, boolean canBubbleArg, boolean cancelableArg, DOMString keyArg, DOMString oldValueArg, DOMString newValueArg, USVString urlArg, Storage? storageAreaArg);


### PR DESCRIPTION
#### 72a64cdb3901b1b260f71c09ae944c34e494c802
<pre>
Align StorageEvent.initStorageEvent() with the HTML specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=242809">https://bugs.webkit.org/show_bug.cgi?id=242809</a>

Reviewed by Geoffrey Garen.

Align StorageEvent.initStorageEvent() with the HTML specification and Blink:
- <a href="https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface">https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/webstorage/event_initstorageevent.window-expected.txt:
* Source/WebCore/storage/StorageEvent.idl:

Canonical link: <a href="https://commits.webkit.org/252521@main">https://commits.webkit.org/252521@main</a>
</pre>
