### PR TITLE
[Gardening]: [ macOS wk2 ] media/track/track-forced-subtitles-in-band.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1720,3 +1720,5 @@ webkit.org/b/242212 [ Monterey+ ] media/media-source/media-webm-vorbis-partial.h
 webkit.org/b/227555 http/tests/privateClickMeasurement/attribution-conversion-through-fetch-keepalive.html [ Pass Failure ]
 
 webkit.org/b/242462 [ Monterey Release ] imported/w3c/web-platform-tests/IndexedDB/string-list-ordering.htm [ Pass Crash ]
+
+webkit.org/b/242804 media/track/track-forced-subtitles-in-band.html [ Pass Failure ]


### PR DESCRIPTION
#### acf9538fef4b992164b4fc64cab6149d81cc548b
<pre>
[Gardening]: [ macOS wk2 ] media/track/track-forced-subtitles-in-band.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242804">https://bugs.webkit.org/show_bug.cgi?id=242804</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252511@main">https://commits.webkit.org/252511@main</a>
</pre>
