### PR TITLE
[Cocoa] Hard code the IOSurface bytesPerRowAlignment to 64

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -58,8 +58,7 @@ IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const Parameters& 
 unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backendSize)
 {
     unsigned bytesPerRow = ImageBufferCGBackend::calculateBytesPerRow(backendSize);
-    size_t alignmentMask = IOSurface::bytesPerRowAlignment() - 1;
-    return (bytesPerRow + alignmentMask) & ~alignmentMask;
+    return IOSurface::alignedBytesPerRow(bytesPerRow);
 }
 
 size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -113,8 +113,7 @@ public:
     WEBCORE_EXPORT static IntSize maximumSize();
     WEBCORE_EXPORT static void setMaximumSize(IntSize);
 
-    WEBCORE_EXPORT static size_t bytesPerRowAlignment();
-    WEBCORE_EXPORT static void setBytesPerRowAlignment(size_t);
+    WEBCORE_EXPORT static size_t alignedBytesPerRow(size_t bytesPerRow);
 
     WEBCORE_EXPORT WTF::MachSendRight createSendRight() const;
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -196,7 +196,6 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
 
 #if HAVE(IOSURFACE)
     encoder << maximumIOSurfaceSize;
-    encoder << bytesPerRowIOSurfaceAlignment;
 #endif
 
     encoder << accessibilityPreferences;
@@ -535,8 +534,6 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
 
 #if HAVE(IOSURFACE)
     if (!decoder.decode(parameters.maximumIOSurfaceSize))
-        return false;
-    if (!decoder.decode(parameters.bytesPerRowIOSurfaceAlignment))
         return false;
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -237,7 +237,6 @@ struct WebProcessCreationParameters {
 
 #if HAVE(IOSURFACE)
     WebCore::IntSize maximumIOSurfaceSize;
-    size_t bytesPerRowIOSurfaceAlignment;
 #endif
     
     AccessibilityPreferences accessibilityPreferences;

--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
@@ -93,8 +93,7 @@ CheckedUint32 ShareableBitmap::calculateBytesPerRow(WebCore::IntSize size, const
 #if HAVE(IOSURFACE)
     if (bytesPerRow.hasOverflowed())
         return bytesPerRow;
-    size_t alignmentMask = WebCore::IOSurface::bytesPerRowAlignment() - 1;
-    return (bytesPerRow + alignmentMask) & ~alignmentMask;
+    return IOSurface::alignedBytesPerRow(bytesPerRow);
 #else
     return bytesPerRow;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -437,8 +437,6 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     if (m_defaultPageGroup->preferences().useGPUProcessForDOMRenderingEnabled())
         parameters.maximumIOSurfaceSize = WebCore::IOSurface::maximumSize();
 
-    parameters.bytesPerRowIOSurfaceAlignment = WebCore::IOSurface::bytesPerRowAlignment();
-
     parameters.accessibilityPreferences = accessibilityPreferences();
 }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -452,8 +452,6 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     if (!parameters.maximumIOSurfaceSize.isEmpty())
         WebCore::IOSurface::setMaximumSize(parameters.maximumIOSurfaceSize);
 
-    WebCore::IOSurface::setBytesPerRowAlignment(parameters.bytesPerRowIOSurfaceAlignment);
-
     accessibilityPreferencesDidChange(parameters.accessibilityPreferences);
 
     disableURLSchemeCheckInDataDetectors();


### PR DESCRIPTION
#### 09ba9d1fdc6d1658e487bb98da2f5b19aa9673fc
<pre>
[Cocoa] Hard code the IOSurface bytesPerRowAlignment to 64
<a href="https://bugs.webkit.org/show_bug.cgi?id=242811">https://bugs.webkit.org/show_bug.cgi?id=242811</a>
rdar://79626142

Reviewed by NOBODY (OOPS!).

In WebKit, we use IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, ...) to ask IOKit
to do the alignment for us. And we use IOSurfaceGetPropertyAlignment() when we do
the alignment manually.

It seems other Cocoa frameworks sometimes use different alignment values. If the
alignment values are different, these frameworks will fail to complete IOSurface
operations.

Alignment of 64 should be enough to cover all cases.

* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateBytesPerRow):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::optionsForBiplanarSurface):
(WebCore::optionsFor32BitSurface):
(WebCore::IOSurface::alignedBytesPerRow):
(WebCore::surfaceBytesPerRowAlignment): Deleted.
(WebCore::IOSurface::bytesPerRowAlignment): Deleted.
(WebCore::IOSurface::setBytesPerRowAlignment): Deleted.
* Source/WebKit/Shared/WebProcessCreationParameters.cpp:
(WebKit::WebProcessCreationParameters::encode const):
(WebKit::WebProcessCreationParameters::decode):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/cg/ShareableBitmapCG.cpp:
(WebKit::ShareableBitmap::calculateBytesPerRow):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
</pre>