### PR TITLE
Make plugin load async instead of upon style resolution

### DIFF
--- a/LayoutTests/editing/editability/ignored-content.html
+++ b/LayoutTests/editing/editability/ignored-content.html
@@ -16,26 +16,33 @@ var test = document.getElementById('test');
 test.focus();
 
 Markup.description('This test ensures WebKit does not ignore the content of hr, datagrid, and object with child nodes.')
+Markup.noAutoDump();
+Markup.waitUntilDone();
 
-var text = 'hello world WebKit';
+(async () => {
+    var text = 'hello world WebKit';
 
-for (var i = 0; i < test.childNodes.length; i++) {
-    var textNode = document.createTextNode(text);
-    test.childNodes[i].appendChild(textNode);
-    window.getSelection().setBaseAndExtent(textNode, 6, textNode, 11);
-    document.execCommand('bold', false, null);
-}
+    for (var i = 0; i < test.childNodes.length; i++) {
+        var textNode = document.createTextNode(text);
+        test.childNodes[i].appendChild(textNode);
+        await new Promise((resolve) => { requestAnimationFrame(() => setTimeout(resolve, 0)); });
+        window.getSelection().setBaseAndExtent(textNode, 6, textNode, 11);
+        document.execCommand('bold', false, null);
+    }
 
-Markup.dump(test, '"world" and only "world" should be bolded in each element below');
+    Markup.dump(test, '"world" and only "world" should be bolded in each element below');
 
-window.getSelection().setPosition(test, 0);
+    window.getSelection().setPosition(test, 0);
 
-for (var i = 0; i < (text.length + 1) * test.childNodes.length - 1; i++)
-    window.getSelection().modify('extend', 'forward', 'character');
+    for (var i = 0; i < (text.length + 1) * test.childNodes.length - 1; i++)
+        window.getSelection().modify('extend', 'forward', 'character');
 
-var range = window.getSelection().getRangeAt(0).cloneContents();
+    var range = window.getSelection().getRangeAt(0).cloneContents();
 
-Markup.dump(range, 'The result below should be identical to the result above');
+    Markup.dump(range, 'The result below should be identical to the result above');
+
+    Markup.notifyDone();
+})();
 
 </script>
 </body>

--- a/LayoutTests/editing/execCommand/outdent-paragraph-crash.html
+++ b/LayoutTests/editing/execCommand/outdent-paragraph-crash.html
@@ -14,7 +14,7 @@
     onload = async () => {
       visualViewport.onresize = () => {
         document.execCommand('Outdent');
-        setTimeout(function() { document.write("Test passes if it does not crash."); testRunner.notifyDone(); });
+        setTimeout(function() { document.documentElement.innerHTML = "<body>Test passes if it does not crash.</body>"; testRunner.notifyDone(); });
       };
       let blockquote = document.createElement('blockquote');
       document.body.append(blockquote);

--- a/LayoutTests/fast/frames/sandboxed-iframe-plugins.html
+++ b/LayoutTests/fast/frames/sandboxed-iframe-plugins.html
@@ -2,9 +2,11 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script> 
-if (window.testRunner) 
+if (window.testRunner)  {
     testRunner.dumpAsText(); 
- 
+    testRunner.waitUntilDone();
+}
+
 window.onload = function() { 
     shouldBeTrue("(self.embedFrame1.document.getElementById('plugin').destroyStream) == undefined");
     shouldBeTrue("(self.embedFrame2.document.getElementById('plugin').destroyStream) == undefined");
@@ -13,6 +15,9 @@ window.onload = function() {
     shouldBeTrue("(self.objectFrame2.document.getElementById('plugin').destroyStream) == undefined");
 
     isSuccessfullyParsed();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
 } 
 </script> 
 </head> 

--- a/LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html
+++ b/LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html
@@ -43,6 +43,8 @@ function removeTheDiv() {
 	setTimeout("forceGC();", 0);
 }
 
-setTimeout("removeTheDiv();", 0);
+requestAnimationFrame(() => {
+    setTimeout("removeTheDiv();", 0);
+});
 
 </script>

--- a/LayoutTests/webarchive/loading/object-expected.txt
+++ b/LayoutTests/webarchive/loading/object-expected.txt
@@ -6,8 +6,8 @@ main frame - didFinishLoadForFrame
 main frame - didStartProvisionalLoadForFrame
 main frame - didCancelClientRedirectForFrame
 main frame - didCommitLoadForFrame
-frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 main frame - didFinishDocumentLoadForFrame
+frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -27,9 +27,11 @@
 #include "ContentSecurityPolicy.h"
 #include "DocumentLoader.h"
 #include "ElementInlines.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "Frame.h"
 #include "FrameLoaderClient.h"
+#include "GCReachableRef.h"
 #include "HTMLImageLoader.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertInterface.h"
@@ -195,8 +197,8 @@ void HTMLPlugInImageElement::scheduleUpdateForAfterStyleResolution()
 
     m_hasUpdateScheduledForAfterStyleResolution = true;
 
-    Style::deprecatedQueuePostResolutionCallback([protectedThis = Ref { *this }] {
-        protectedThis->updateAfterStyleResolution();
+    document().eventLoop().queueTask(TaskSource::DOMManipulation, [element = GCReachableRef { *this }] {
+        element->updateAfterStyleResolution();
     });
 }
 


### PR DESCRIPTION
#### f4b10fa093ec5898db23e16ab60ee81791098b4a
<pre>
Make plugin load async instead of upon style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=242789">https://bugs.webkit.org/show_bug.cgi?id=242789</a>

Reviewed by Geoffrey Garen.

This patch makes plugin load fully asynchronous instead of loading at the end of style resolution.

Some tests which load HTML content in object / embed contents are updated to wait for rAF then 0s timer.
This is needed to accommodate this new behavior in these tests.

* LayoutTests/editing/editability/ignored-content.html:
* LayoutTests/editing/execCommand/outdent-paragraph-crash.html: Made this test more robust.
* LayoutTests/fast/frames/sandboxed-iframe-plugins.html:
* LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html:
* LayoutTests/webarchive/loading/object-expected.txt:

* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::scheduleUpdateForAfterStyleResolution):

Canonical link: <a href="https://commits.webkit.org/252541@main">https://commits.webkit.org/252541@main</a>
</pre>
