### PR TITLE
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -72,9 +72,9 @@ accessibility
 perf/accessibility-title-ui-element.html
 
 # webkit.org/b/240843
-fast/images/heic-as-background-image.html [ Skip ]
-fast/images/animated-heics-verify.html [ Skip ]
-fast/images/animated-heics-draw.html [ Skip ]
+fast/images/heic-as-background-image.html [ Pass ]
+fast/images/animated-heics-verify.html [ Pass ]
+fast/images/animated-heics-draw.html [ Pass ]
 
 # No fullscreen API on iOS
 fullscreen

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -90,9 +90,9 @@ imported/w3c/web-platform-tests/speech-api [ Pass ]
 #//////////////////////////////////////////////////////////////////////////////////////////
 
 # webkit.org/b/240843
-fast/images/animated-heics-draw.html [ Skip ]
-fast/images/animated-heics-verify.html [ Skip ]
-fast/images/heic-as-background-image.html [ Skip ]
+fast/images/animated-heics-draw.html [ Pass ]
+fast/images/animated-heics-verify.html [ Pass ]
+fast/images/heic-as-background-image.html [ Pass ]
 
 # <rdar://problem/5647952> fast/events/mouseout-on-window.html needs mac DRT to issue mouse out events
 fast/events/mouseout-on-window.html [ Failure ]


### PR DESCRIPTION
#### 20d56bbc5cbb0f999aed1203bbb625569174f458
<pre>
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=240987">https://bugs.webkit.org/show_bug.cgi?id=240987</a>
&lt;rdar://94002031&gt;

Unreviewed test expectation change.

Reenable these tests to gather data from the bots, as we cannot reproduce the crashes locally.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252517@main">https://commits.webkit.org/252517@main</a>
</pre>
