### PR TITLE
Store correct value of bytes per row alignment

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -278,8 +278,8 @@ size_t IOSurface::bytesPerRowAlignment()
 {
     auto alignment = surfaceBytesPerRowAlignment().load();
     if (!alignment) {
-        surfaceBytesPerRowAlignment().store(IOSurfaceGetPropertyAlignment(kIOSurfaceBytesPerRow));
-        alignment = surfaceBytesPerRowAlignment().load();
+        alignment = IOSurfaceGetPropertyAlignment(kIOSurfaceBytesPerRow);
+
         // A return value for IOSurfaceGetPropertyAlignment(kIOSurfaceBytesPerRow) of 1 is invalid.
         // See https://developer.apple.com/documentation/iosurface/1419453-iosurfacegetpropertyalignment?language=objc
         // This likely means that the sandbox is blocking access to the IOSurface IOKit class,
@@ -289,6 +289,8 @@ size_t IOSurface::bytesPerRowAlignment()
             // 64 bytes is currently the alignment on all platforms.
             alignment = 64;
         }
+
+        surfaceBytesPerRowAlignment().store(alignment);
     }
     return alignment;
 }


### PR DESCRIPTION
#### 56f4658b0a4be463aba0e0dabce8755338fe6aaa
<pre>
Store correct value of bytes per row alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=242815">https://bugs.webkit.org/show_bug.cgi?id=242815</a>
&lt;rdar://problem/97088844&gt;

Reviewed by Simon Fraser.

If the sandbox is blocking access, we end up storing an incorrect value for the alignment.

* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::bytesPerRowAlignment):

Canonical link: <a href="https://commits.webkit.org/252536@main">https://commits.webkit.org/252536@main</a>
</pre>
