### PR TITLE
Align XHR aborting with the specification and other browser engines

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5326,6 +5326,11 @@ fast/text/install-font-style-recalc.html [ Failure ]
 # These tests have been timing out since their import.
 imported/w3c/web-platform-tests/web-locks/bfcache
 
+# This test is timing out in WebKit as well as Blink/Gecko because it expects an XHR to fail
+# with a network error instead of a abort one when its iframe goes away. The test should be
+# fixed.
+imported/w3c/web-platform-tests/xhr/open-url-multi-window-4.htm [ Skip ]
+
 webkit.org/b/239533 [ Debug ] editing/inserting/insert-list-user-select-none-crash.html [ Skip ]
 
 # Mismatching line wrapping when -webkit-hyphen is auto.

--- a/LayoutTests/http/tests/navigation/page-cache-xhr-expected.txt
+++ b/LayoutTests/http/tests/navigation/page-cache-xhr-expected.txt
@@ -4,8 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 pageshow - not from cache
-PASS Executed the XHR error handler before entering PageCache
-PASS xhr.status is 0
+PASS Executed the XHR abort handler
 pagehide - entering cache
 pageshow - from cache
 PASS Page did enter and was restored from the page cache

--- a/LayoutTests/http/tests/navigation/page-cache-xhr.html
+++ b/LayoutTests/http/tests/navigation/page-cache-xhr.html
@@ -34,18 +34,11 @@ function xhrLoaded()
 }
 
 function xhrAbort() {
-    testFailed("Executed the XHR abort handler unexpectedly");
-    finishJSTest();
+    testPassed("Executed the XHR abort handler");
 }
 
 function xhrError() {
-    if (restoredFromPageCache) {
-        testFailed("Executed the XHR error handler after restoring from PageCache");
-        return;
-    }
-
-    testPassed("Executed the XHR error handler before entering PageCache");
-    shouldBe("xhr.status", "0");
+    testFailed("Executed the XHR error handler unexpectedly");
 }
 
 window.addEventListener('load', function() {

--- a/LayoutTests/http/tests/navigation/resources/page-cache-xhr-in-loading-iframe.html
+++ b/LayoutTests/http/tests/navigation/resources/page-cache-xhr-in-loading-iframe.html
@@ -17,6 +17,9 @@ function doXHR()
     xhr.addEventListener("error", () => {
         doXHR();
     });
+    xhr.addEventListener("abort", () => {
+        doXHR();
+    });
     xhr.addEventListener("progress", () => {
     });
 

--- a/LayoutTests/http/tests/xmlhttprequest/cross-origin-redirect-responseURL-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/cross-origin-redirect-responseURL-expected.txt
@@ -1,5 +1,7 @@
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://localhost:22/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:22/ due to access control checks.
 Test XMLHttpRequest responseURL.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/xmlhttprequest/frame-load-cancelled-abort-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/frame-load-cancelled-abort-expected.txt
@@ -9,7 +9,6 @@ That didFinishedLoading() call should immediately exit and not update the object
 Loading subframe to cancel
 Ready State: 1
 Body of subframe is loaded. XMLHttpRequest should be in progress. Nuking the iframe
-Ready State: 4
 Iframe unloaded
 Iframe removed
 

--- a/LayoutTests/http/tests/xmlhttprequest/frame-unload-abort-crash-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/frame-unload-abort-crash-expected.txt
@@ -4,5 +4,4 @@ Test for bug 25394: crash in DocumentLoader::addResponse due to bad |this| point
 You should see a few messages followed by PASSED once.
 
 Ready State: 1
-Ready State: 4
 PASSED

--- a/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: PASS: Expected 'error', got 'error'.
+CONSOLE MESSAGE: PASS: Expected 'abort', got 'abort'.
 If this text shows up, you've successfully navigated to 'navigation-target.html'.

--- a/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort.html
+++ b/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort.html
@@ -8,10 +8,10 @@
         var req = new XMLHttpRequest();
         req.open("GET", "resources/endlessxml.py");
         req.onerror = function () {
-            console.log("PASS: Expected 'error', got 'error'.");
+            console.log("FAIL: Expected 'abort', got 'error'.");
         };
         req.onabort = function () {
-            console.log("FAIL: Expected 'error', got 'abort'.");
+            console.log("PASS: Expected 'abort', got 'abort'.");
         };
         req.send(null);
 

--- a/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-2-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-2-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://localhost:22/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:22/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_origin
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_origin due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_wildcard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_wildcard-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_wildcard
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_wildcard due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_multi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_multi-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=multi
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=multi due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_null-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_null-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=null
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=null due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=origin
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=origin due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'entry.redirectStart')
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin_uppercase-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin_uppercase-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=uppercase
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=uppercase due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_space-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=space
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=space due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_wildcard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_wildcard-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=wildcard
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=wildcard due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_zero-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_zero-expected.txt
@@ -1,4 +1,6 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=zero
+CONSOLE MESSAGE: Not allowed to use restricted network port
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=zero due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'entry.redirectStart')
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL XMLHttpRequest: abort event should fire when stop() method is used assert_equals: expected true but got false
+PASS XMLHttpRequest: abort event should fire when stop() method is used
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL open() after window.stop() assert_unreached: loadend should not be fired after window.stop() and open() Reached unreachable code
+PASS open() after window.stop()
 

--- a/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/platform/win/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/win/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/platform/wincairo-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/wincairo-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
+CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3631,7 +3631,7 @@ void FrameLoader::requestFromDelegate(ResourceRequest& request, ResourceLoaderId
     notifier().dispatchWillSendRequest(m_documentLoader.get(), identifier, newRequest, ResourceResponse(), nullptr);
 
     if (newRequest.isNull())
-        error = cancelledError(request);
+        error = blockedError(request);
     else
         error = ResourceError();
 
@@ -3962,7 +3962,7 @@ ResourceError FrameLoader::blockedByContentBlockerError(const ResourceRequest& r
 ResourceError FrameLoader::blockedError(const ResourceRequest& request) const
 {
     ResourceError error = m_client->blockedError(request);
-    error.setType(ResourceError::Type::Cancellation);
+    error.setType(ResourceError::Type::AccessControl);
     return error;
 }
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -113,7 +113,6 @@ XMLHttpRequest::XMLHttpRequest(ScriptExecutionContext& context)
     , m_error(false)
     , m_uploadListenerFlag(false)
     , m_uploadComplete(false)
-    , m_wasAbortedByClient(false)
     , m_responseCacheIsValid(false)
     , m_readyState(static_cast<unsigned>(UNSENT))
     , m_responseType(static_cast<unsigned>(ResponseType::EmptyString))
@@ -376,7 +375,6 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
     m_method = normalizeHTTPMethod(method);
     m_error = false;
     m_uploadComplete = false;
-    m_wasAbortedByClient = false;
 
     // clear stuff from possible previous load
     clearResponse();
@@ -683,7 +681,6 @@ void XMLHttpRequest::abort()
 {
     Ref<XMLHttpRequest> protectedThis(*this);
 
-    m_wasAbortedByClient = true;
     if (!internalAbort())
         return;
 
@@ -702,6 +699,7 @@ void XMLHttpRequest::abort()
 
 bool XMLHttpRequest::internalAbort()
 {
+    m_pendingAbortEvent.cancel();
     m_error = true;
 
     // FIXME: when we add the support for multi-part XHR, we will have to think be careful with this initialization.
@@ -772,7 +770,6 @@ void XMLHttpRequest::networkError()
     
 void XMLHttpRequest::abortError()
 {
-    ASSERT(m_wasAbortedByClient);
     genericError();
     dispatchErrorEvents(eventNames().abortEvent);
 }
@@ -900,10 +897,12 @@ void XMLHttpRequest::didFail(const ResourceError& error)
     if (m_error)
         return;
 
-    // The XHR specification says we should only fire an abort event if the cancelation was requested by the client.
-    if (m_wasAbortedByClient && error.isCancellation()) {
-        m_exceptionCode = AbortError;
-        abortError();
+    if (error.isCancellation()) {
+        internalAbort();
+        queueCancellableTaskKeepingObjectAlive(*this, TaskSource::Networking, m_pendingAbortEvent, [this] {
+            m_exceptionCode = AbortError;
+            abortError();
+        });
         return;
     }
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -207,7 +207,6 @@ private:
     unsigned m_error : 1;
     unsigned m_uploadListenerFlag : 1;
     unsigned m_uploadComplete : 1;
-    unsigned m_wasAbortedByClient : 1;
     unsigned m_responseCacheIsValid : 1;
     unsigned m_readyState : 3; // State
     unsigned m_responseType : 3; // ResponseType
@@ -254,6 +253,7 @@ private:
 
     std::optional<ExceptionCode> m_exceptionCode;
     RefPtr<UserGestureToken> m_userGestureToken;
+    TaskCancellationGroup m_pendingAbortEvent;
     std::atomic<bool> m_hasRelevantEventListener;
 };
 


### PR DESCRIPTION
#### 74337e4bd0b1caa8f9edd9e6cbc6bbcc6135449f
<pre>
Align XHR aborting with the specification and other browser engines
<a href="https://bugs.webkit.org/show_bug.cgi?id=242817">https://bugs.webkit.org/show_bug.cgi?id=242817</a>

Reviewed by Geoffrey Garen.

Align XHR aborting with the specification and other browser engines:
- window.stop() should cause an abort event to get fired
- The abort event should get fired asynchronously

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::requestFromDelegate):
(WebCore::FrameLoader::blockedError const):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::XMLHttpRequest):
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::abort):
(WebCore::XMLHttpRequest::internalAbort):
(WebCore::XMLHttpRequest::abortError):
(WebCore::XMLHttpRequest::didFail):
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/252611@main">https://commits.webkit.org/252611@main</a>
</pre>
