### PR TITLE
[Gardening]: [ iOS15 wk2 Release arm64 ] js/dom/Promise-reject-large-string.html is a almost constant failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2218,3 +2218,5 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitm
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html [ ImageOnlyFailure ]
 
 webkit.org/b/242515 [ arm64 ] compositing/reflections/mask-and-reflection.html [ ImageOnlyFailure ]
+
+webkit.org/b/242812 [ Release arm64 ] js/dom/Promise-reject-large-string.html [ Pass Failure ]


### PR DESCRIPTION
#### 03f30bc8f87b276fdec54c496b80df18e72c0209
<pre>
[Gardening]: [ iOS15 wk2 Release arm64 ] js/dom/Promise-reject-large-string.html is a almost constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242812">https://bugs.webkit.org/show_bug.cgi?id=242812</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252519@main">https://commits.webkit.org/252519@main</a>
</pre>
