### PR TITLE
[ANGLE] Bounds check index buffer generation

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
@@ -146,6 +146,7 @@ struct IndexGenerationParams
     BufferRef dstBuffer;
     uint32_t dstOffset;
     bool primitiveRestartEnabled = false;
+    GLsizei maxIndexCount = std::numeric_limits<GLsizei>::max();
 };
 
 struct CopyPixelsCommonParams
@@ -388,6 +389,7 @@ class IndexGeneratorUtils final : angle::NonCopyable
         ContextMtl *contextMtl,
         gl::DrawElementsType srcType,
         uint32_t indexCount,
+        uint32_t maxIndexCount,
         const BufferRef &srcBuffer,
         uint32_t srcOffset,
         const BufferRef &dstBuffer,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -87,8 +87,9 @@ struct IndexConversionUniform
 {
     uint32_t srcOffset;
     uint32_t indexCount;
+    uint32_t maxIndex;
     uint8_t primitiveRestartEnabled;
-    uint8_t padding[7];
+    uint8_t padding[3];
 };
 
 // See libANGLE/renderer/metal/shaders/visibility.metal
@@ -223,8 +224,14 @@ void GetBlitTexCoords(const NormalizedCoords &normalizedCoords,
 }
 
 template <typename T>
+inline T accessBounded(const T * array, GLsizei idx, GLsizei maxIdx)
+{
+    return idx < maxIdx ? array[idx] : 0;
+}
+template <typename T>
 angle::Result GenTriFanFromClientElements(ContextMtl *contextMtl,
                                           GLsizei count,
+                                          GLsizei maxIndex,
                                           bool primitiveRestartEnabled,
                                           const T *indices,
                                           const BufferRef &dstBuffer,
@@ -236,23 +243,23 @@ angle::Result GenTriFanFromClientElements(ContextMtl *contextMtl,
     GLsizei dstTriangle                   = 0;
     uint32_t *dstPtr = reinterpret_cast<uint32_t *>(dstBuffer->map(contextMtl) + dstOffset);
     T triFirstIdx, srcPrevIdx;
-    memcpy(&triFirstIdx, indices, sizeof(triFirstIdx));
-    memcpy(&srcPrevIdx, indices + 1, sizeof(srcPrevIdx));
-
+    triFirstIdx = accessBounded(indices, 0, maxIndex);
+    srcPrevIdx =  accessBounded(indices, 1, maxIndex);
+    
     if (primitiveRestartEnabled)
     {
         GLsizei triFirstIdxLoc = 0;
         while (triFirstIdx == kSrcPrimitiveRestartIndex)
         {
             ++triFirstIdxLoc;
-            memcpy(&triFirstIdx, indices + triFirstIdxLoc, sizeof(triFirstIdx));
+            triFirstIdx = accessBounded(indices, triFirstIdxLoc, maxIndex);
         }
 
         for (GLsizei i = triFirstIdxLoc + 2; i < count; ++i)
         {
             uint32_t triIndices[3];
             T srcIdx;
-            memcpy(&srcIdx, indices + i, sizeof(srcIdx));
+            srcIdx = accessBounded(indices, i, maxIndex);
             bool completeTriangle = true;
             if (srcPrevIdx == kSrcPrimitiveRestartIndex || srcIdx == kSrcPrimitiveRestartIndex)
             {
@@ -285,8 +292,7 @@ angle::Result GenTriFanFromClientElements(ContextMtl *contextMtl,
         for (GLsizei i = 2; i < count; ++i)
         {
             T srcIdx;
-            memcpy(&srcIdx, indices + i, sizeof(srcIdx));
-
+            srcIdx = accessBounded(indices,i,maxIndex);
             uint32_t triIndices[3];
             triIndices[0] = triFirstIdx;
             triIndices[1] = srcPrevIdx;
@@ -2089,11 +2095,14 @@ angle::Result IndexGeneratorUtils::generateTriFanBufferFromElementsArray(
         size_t srcOffset            = reinterpret_cast<size_t>(params.indices);
         ANGLE_CHECK(contextMtl, srcOffset <= std::numeric_limits<uint32_t>::max(),
                     "Index offset is too large", GL_INVALID_VALUE);
+        IndexGenerationParams limitedParams = params;
+        limitedParams.maxIndexCount = std::min<GLsizei>(params.indexCount, (GLsizei)(elementBufferMtl->size() - srcOffset) / (GLsizei)GetDrawElementsTypeSize(params.srcType));
+                
         if (params.primitiveRestartEnabled ||
             (!contextMtl->getDisplay()->getFeatures().hasCheapRenderPass.enabled &&
              contextMtl->getRenderCommandEncoder()))
         {
-            IndexGenerationParams cpuPathParams = params;
+            IndexGenerationParams cpuPathParams = limitedParams;
             cpuPathParams.indices =
                 elementBufferMtl->getClientShadowCopyData(contextMtl) + srcOffset;
             return generateTriFanBufferFromElementsArrayCPU(contextMtl, cpuPathParams,
@@ -2102,7 +2111,7 @@ angle::Result IndexGeneratorUtils::generateTriFanBufferFromElementsArray(
         else
         {
             return generateTriFanBufferFromElementsArrayGPU(
-                contextMtl, params.srcType, params.indexCount, elementBufferMtl->getCurrentBuffer(),
+                contextMtl, params.srcType, params.indexCount, limitedParams.maxIndexCount, elementBufferMtl->getCurrentBuffer(),
                 static_cast<uint32_t>(srcOffset), params.dstBuffer, params.dstOffset);
         }
     }
@@ -2116,6 +2125,7 @@ angle::Result IndexGeneratorUtils::generateTriFanBufferFromElementsArrayGPU(
     ContextMtl *contextMtl,
     gl::DrawElementsType srcType,
     uint32_t indexCount,
+    uint32_t maxIndexCount,
     const BufferRef &srcBuffer,
     uint32_t srcOffset,
     const BufferRef &dstBuffer,
@@ -2140,7 +2150,7 @@ angle::Result IndexGeneratorUtils::generateTriFanBufferFromElementsArrayGPU(
     IndexConversionUniform uniform;
     uniform.srcOffset  = srcOffset;
     uniform.indexCount = indexCount - 2;  // Only start from the 3rd element.
-
+    uniform.maxIndex   = maxIndexCount;
     cmdEncoder->setData(uniform, 0);
     cmdEncoder->setBuffer(srcBuffer, 0, 1);
     cmdEncoder->setBufferForWrite(dstBuffer, dstOffset, 2);
@@ -2158,17 +2168,17 @@ angle::Result IndexGeneratorUtils::generateTriFanBufferFromElementsArrayCPU(
     switch (params.srcType)
     {
         case gl::DrawElementsType::UnsignedByte:
-            return GenTriFanFromClientElements(contextMtl, params.indexCount,
+            return GenTriFanFromClientElements(contextMtl, params.indexCount, params.maxIndexCount,
                                                params.primitiveRestartEnabled,
                                                static_cast<const uint8_t *>(params.indices),
                                                params.dstBuffer, params.dstOffset, genIndices);
         case gl::DrawElementsType::UnsignedShort:
-            return GenTriFanFromClientElements(contextMtl, params.indexCount,
+            return GenTriFanFromClientElements(contextMtl, params.indexCount, params.maxIndexCount,
                                                params.primitiveRestartEnabled,
                                                static_cast<const uint16_t *>(params.indices),
                                                params.dstBuffer, params.dstOffset, genIndices);
         case gl::DrawElementsType::UnsignedInt:
-            return GenTriFanFromClientElements(contextMtl, params.indexCount,
+            return GenTriFanFromClientElements(contextMtl, params.indexCount, params.maxIndexCount,
                                                params.primitiveRestartEnabled,
                                                static_cast<const uint32_t *>(params.indices),
                                                params.dstBuffer, params.dstOffset, genIndices);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/format_autogen.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/format_autogen.h
@@ -249,5 +249,5 @@ enum
 
 }
 
-}  // namespace mtl_shader
-}  // namespace rx
+}
+}

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/gen_indices.metal
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/gen_indices.metal
@@ -22,6 +22,7 @@ struct IndexConversionParams
 {
     uint32_t srcOffset;  // offset in bytes
     uint32_t indexCount;
+    uint32_t maxIndex;
     bool primitiveRestartEnabled;
 };
 
@@ -187,10 +188,10 @@ kernel void genTriFanIndicesFromElements(uint idx [[thread_position_in_grid]],
     ANGLE_IDX_CONVERSION_GUARD(idx, options);
 
     uint elemIdx = 2 + idx;
-
-    output[3 * idx]     = getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32);
-    output[3 * idx + 1] = getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32);
-    output[3 * idx + 2] = getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32);
+    
+    output[3 * idx]     = (options.maxIndex > 0)           ? getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 1] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 2] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32) : 0;
 }
 
 // Generate line loop indices for glDrawArray()

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.inc
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.inc
@@ -736,6 +736,7 @@ struct IndexConversionParams
 {
     uint32_t srcOffset;
     uint32_t indexCount;
+    uint32_t maxIndex;
     bool primitiveRestartEnabled;
 };
 
@@ -902,9 +903,9 @@ kernel void genTriFanIndicesFromElements(uint idx [[thread_position_in_grid]],
 
     uint elemIdx = 2 + idx;
 
-    output[3 * idx] = getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32);
-    output[3 * idx + 1] = getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32);
-    output[3 * idx + 2] = getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32);
+    output[3 * idx] = (options.maxIndex > 0) ? getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 1] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 2] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32) : 0;
 }
 
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.metal
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.metal
@@ -733,6 +733,7 @@ struct IndexConversionParams
 {
     uint32_t srcOffset;
     uint32_t indexCount;
+    uint32_t maxIndex;
     bool primitiveRestartEnabled;
 };
 
@@ -899,9 +900,9 @@ kernel void genTriFanIndicesFromElements(uint idx [[thread_position_in_grid]],
 
     uint elemIdx = 2 + idx;
 
-    output[3 * idx] = getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32);
-    output[3 * idx + 1] = getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32);
-    output[3 * idx + 2] = getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32);
+    output[3 * idx] = (options.maxIndex > 0) ? getIndexU32(options.srcOffset, 0, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 1] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx - 1, inputU8, inputU16, inputU32) : 0;
+    output[3 * idx + 2] = (elemIdx - 1 < options.maxIndex) ? getIndexU32(options.srcOffset, elemIdx, inputU8, inputU16, inputU32) : 0;
 }
 
 


### PR DESCRIPTION
#### 7bf231b1fd3527ff9135e257bd192a004caa6548
<pre>
[ANGLE] Bounds check index buffer generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242762">https://bugs.webkit.org/show_bug.cgi?id=242762</a>

Bounds check element buffer access during triangle fan generation.
Out of bounds reads of the element buffer on both the CPU and GPU will result in getting back
index zero, rather than reading garbage memory

Reviewed by Dean Jackson.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::IndexGeneratorUtils::generateTriFanBufferFromElementsArray):
(rx::mtl::IndexGeneratorUtils::generateTriFanBufferFromElementsArrayGPU):
(rx::mtl::IndexGeneratorUtils::generateTriFanBufferFromElementsArrayCPU):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/format_autogen.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/gen_indices.metal:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.inc:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/shaders/mtl_default_shaders_src_autogen.metal:

Canonical link: <a href="https://commits.webkit.org/252526@main">https://commits.webkit.org/252526@main</a>
</pre>
