### PR TITLE
[GPUP] http/tests/media/hls/hls-hdr-switch.html always timeout with Media in GPUP enabled

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1885,9 +1885,8 @@ webkit.org/b/186045 imported/w3c/web-platform-tests/html/rendering/replaced-elem
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/extend-20.html [ Slow ]
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/extend-00.html [ Slow ]
 
-[ BigSur ] http/tests/media/hls/hls-hdr-switch.html [ Pass ]
-# rdar://96780622
-[ Monterey+ ] http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
+# This test is skipped in generic TestExpectations.
+http/tests/media/hls/hls-hdr-switch.html [ Pass ]
 
 # rdar://69347249
 [ arm64 ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/realtime-conv.html [ Failure ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -209,8 +209,6 @@ http/tests/download/inherited-encoding.html
 http/tests/images/loading-image-border.html
 http/tests/images/loading-image-no-border.html
 
-webkit.org/b/223280 http/tests/media/hls/hls-hdr-switch.html [ Timeout ]
-
 http/tests/media/hls/hls-progress.html [ Pass Crash Failure ]
 
 # webkit.org/b/221685


### PR DESCRIPTION
#### 3ffacc6bd6ddd3d88fbe903459bddedb83ad1521
<pre>
[GPUP] http/tests/media/hls/hls-hdr-switch.html always timeout with Media in GPUP enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=223280">https://bugs.webkit.org/show_bug.cgi?id=223280</a>
&lt;rdar://75494288&gt;

Unreviewed test gardening.

This test is passing on all webkit.org bots after increasing tolerance for red/green colors,
so removing test expectations.

Colors being off is tracked as <a href="https://webkit.org/b/242698.">https://webkit.org/b/242698.</a>

I&apos;m also seeing this test sometimes time out with (0, 0, 0, 0) colors on macOS Ventura beta.
Will be looking for more info on this failure mode, especially whether it ever happens on
shipping OS versions.

* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252523@main">https://commits.webkit.org/252523@main</a>
</pre>
