### PR TITLE
Enable the Permissions::query function to get the permission state of the Notifications API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Query "geolocation" permission
-FAIL Query "notifications" permission promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Query "notifications" permission
 FAIL Query "persistent-storage" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL Query "push" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL Query "accelerometer" permission promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2223,3 +2223,6 @@ webkit.org/b/242812 [ Release arm64 ] js/dom/Promise-reject-large-string.html [ 
 webkit.org/b/241205 [ Release arm64 ] fast/forms/textfield-outline.html [ Pass Failure ]
 
 webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]
+
+# The Notifications API is not supported on iOS
+imported/w3c/web-platform-tests/permissions/all-permissions.html [ Failure ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8853,6 +8853,12 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
 #if ENABLE(GEOLOCATION)
         name = "geolocation"_s;
 #endif
+    } else if (descriptor.name == PermissionName::Notifications) {
+#if ENABLE(NOTIFICATIONS)
+        name = "notifications"_s;
+        // Ensure that the true permission state of the Notifications API is returned.
+        shouldChangeDeniedToPrompt = false;
+#endif
     }
 
     if (name.isNull()) {


### PR DESCRIPTION
#### 0e4995e19c781db613b6c88ec19dcdc118f8267f
<pre>
Enable the Permissions::query function to get the permission state of the Notifications API
<a href="https://bugs.webkit.org/show_bug.cgi?id=242818">https://bugs.webkit.org/show_bug.cgi?id=242818</a>

Reviewed by Sihui Liu and Chris Dumez.

Previously, Permissions::query would recieve a &quot;NotSupportedError&quot; when trying to query the
permission state of the Notifications API. Now the operation is supported and
Permissions::query will be able to call the necessary functions to obtain the permission
state of the Notifications API.

* LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::queryPermission):

Canonical link: <a href="https://commits.webkit.org/252706@main">https://commits.webkit.org/252706@main</a>
</pre>
