### PR TITLE
[CMake] Wrong message about dependency between introspection and gi-docgen

### DIFF
--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -329,7 +329,7 @@ endif ()
 
 find_package(GIDocgen)
 if (ENABLE_DOCUMENTATION AND NOT GIDocgen_FOUND)
-    message(FATAL_ERROR "gi-docgen is needed for ENABLE_INTROSPECTION.")
+    message(FATAL_ERROR "ENABLE_INTROSPECTION is needed for gi-docgen.")
 endif ()
 
 if (ENABLE_WEB_CRYPTO)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -143,7 +143,7 @@ endif ()
 
 find_package(GIDocgen)
 if (ENABLE_DOCUMENTATION AND NOT GIDocgen_FOUND)
-    message(FATAL_ERROR "gi-docgen is needed for ENABLE_INTROSPECTION.")
+    message(FATAL_ERROR "ENABLE_INTROSPECTION is needed for gi-docgen.")
 endif ()
 
 if (USE_SOUP2)


### PR DESCRIPTION
#### 85864ba4b06927ed06f9aec10807f642510adde0
<pre>
[CMake] Wrong message about dependency between introspection and gi-docgen
<a href="https://bugs.webkit.org/show_bug.cgi?id=242710">https://bugs.webkit.org/show_bug.cgi?id=242710</a>

Reviewed by Adrian Perez de Castro.

* Source/cmake/OptionsGTK.cmake: Fix the error message where introspection is needed
for the gi-docgen documentation generator.
* Source/cmake/OptionsWPE.cmake: Same as above.

Canonical link: <a href="https://commits.webkit.org/252538@main">https://commits.webkit.org/252538@main</a>
</pre>
