### PR TITLE
Use RetainPtr in NetworkDataTask constructor

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -372,14 +372,14 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
         break;
     case WebCore::StoredCredentialsPolicy::DoNotUse:
 #if HAVE(NSURLSESSION_EFFECTIVE_CONFIGURATION_OBJECT)
-        NSURLSessionConfiguration *copiedConfiguration = m_sessionWrapper->session.get().configuration;
-        copiedConfiguration.URLCredentialStorage = nil;
-        auto effectiveConfiguration = adoptNS([[NSURLSessionEffectiveConfiguration alloc] _initWithConfiguration:copiedConfiguration]);
+        RetainPtr<NSURLSessionConfiguration> copiedConfiguration = m_sessionWrapper->session.get().configuration;
+        copiedConfiguration.get().URLCredentialStorage = nil;
+        auto effectiveConfiguration = adoptNS([[NSURLSessionEffectiveConfiguration alloc] _initWithConfiguration:copiedConfiguration.get()]);
         [m_task _adoptEffectiveConfiguration:effectiveConfiguration.get()];
 #else
-        NSURLSessionConfiguration *effectiveConfiguration = m_sessionWrapper->session.get().configuration;
-        effectiveConfiguration.URLCredentialStorage = nil;
-        [m_task _adoptEffectiveConfiguration:effectiveConfiguration];
+        RetainPtr<NSURLSessionConfiguration> effectiveConfiguration = m_sessionWrapper->session.get().configuration;
+        effectiveConfiguration.get().URLCredentialStorage = nil;
+        [m_task _adoptEffectiveConfiguration:effectiveConfiguration.get()];
 #endif
         break;
     };


### PR DESCRIPTION
#### 74625369100c3fdb04dc7c00395fa5d2c4684abc
<pre>
Use RetainPtr in NetworkDataTask constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=242821">https://bugs.webkit.org/show_bug.cgi?id=242821</a>
rdar://91340995

Reviewed by David Kilzer, Chris Dumez and Geoffrey Garen.

This shouldn&apos;t be necessary, but it certainly can&apos;t make things worse.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):

Canonical link: <a href="https://commits.webkit.org/252528@main">https://commits.webkit.org/252528@main</a>
</pre>
