### PR TITLE
Fix build after r95726585

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -370,6 +370,18 @@ IPCTestingAPIEnabled:
     WebKit:
       default: false
 
+ImageAnalysisDuringFindInPageEnabled:
+  type: bool
+  humanReadableName: "Image Analysis for Find-in-Page"
+  humanReadableDescription: "Trigger image analysis when performing Find-in-Page"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 InlineFormattingContextIntegrationEnabled:
   type: bool
   humanReadableName: "Next-generation inline layout integration (IFC)"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -808,6 +808,16 @@ bool Page::findString(const String& target, FindOptions options, DidWrap* didWra
     return false;
 }
 
+#if ENABLE(IMAGE_ANALYSIS)
+void Page::analyzeImagesForFindInPage()
+{
+    if (settings().imageAnalysisDuringFindInPageEnabled()) {
+        if (RefPtr mainDocument = m_mainFrame->document(); mainDocument && !m_imageAnalysisQueue)
+            imageAnalysisQueue().enqueueAllImages(*mainDocument, { }, { });
+    }
+}
+#endif
+
 auto Page::findTextMatches(const String& target, FindOptions options, unsigned limit, bool markMatches) -> MatchingRanges
 {
     MatchingRanges result;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -973,6 +973,9 @@ public:
 
     WEBCORE_EXPORT void forceRepaintAllFrames();
 
+#if ENABLE(IMAGE_ANALYSIS)
+    WEBCORE_EXPORT void analyzeImagesForFindInPage();
+#endif
 private:
     struct Navigation {
         RegistrableDomain domain;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/FrameView.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageAnalysisQueue.h>
 #include <WebCore/ImageOverlay.h>
 #include <WebCore/Page.h>
 #include <WebCore/PageOverlayController.h>
@@ -236,6 +237,10 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 {
 #if ENABLE(PDFKIT_PLUGIN)
     auto* pluginView = mainFramePlugIn();
+#endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+    m_webPage->corePage()->analyzeImagesForFindInPage();
 #endif
 
     WebCore::FindOptions coreOptions = core(options);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
@@ -30,6 +30,7 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKFindConfiguration.h>
 #import <WebKit/WKFindResult.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <wtf/RetainPtr.h>
 


### PR DESCRIPTION
#### a9e91b419b312a8bf4379b7141e53bea9072e3fc
<pre>
Fix build after r95726585
<a href="https://bugs.webkit.org/show_bug.cgi?id=242823">https://bugs.webkit.org/show_bug.cgi?id=242823</a>

Reviewed by NOBODY (OOPS!).

Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
Imported &lt;WebKit/WKPreferencesPrivate.h&gt;
</pre>
----------------------------------------------------------------------
#### 0064ed8f1edf3438550926d637d147f5668cbbd4
<pre>
Start Live Text image analysis when Find-in-Page is performed on MacOS Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=241877">https://bugs.webkit.org/show_bug.cgi?id=241877</a>
rdar://95726585

Reviewed by NOBODY (OOPS!).

Test:
FindInPAgeAPI.FindAPITextInImage

This patch makes it so that when Find-in-Page is performed, text within images
On the page is included in the results. This feature is placed behind a WebKit
internal feature flag.

Added a test that checks that an image analysis request is made after doing
Find-in-page.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:

Added internal feature flag &quot;ImageAnalysisDuringFindInPageEnabled&quot;.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::analyzeImagesForFindInPage):

Helper function that is called from FindController::FindString. If flag is
turned on, images are analyzed.

* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):

Now starts image analysis before beginning find-in-page.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
(FindInPageAPI::createWebViewWithImageAnalysisDuringFindInPageEnabled):
(FindInPageAPI::makeImageAnalysisRequestSwizzler):
(FindInPageAPI:makeFakeRequest):
(FindInPageAPI:processRequestWithResults):
</pre>