### PR TITLE
Fix build after [252515@main](https://commits.webkit.org/252515@main)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
@@ -30,6 +30,7 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKFindConfiguration.h>
 #import <WebKit/WKFindResult.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <wtf/RetainPtr.h>
 


### PR DESCRIPTION
#### 7c9eacf8ae34b243f5e09a8d97696faf3ef368b5
<pre>
Fix build after [252515@main](<a href="https://commits.webkit.org/252515@main)">https://commits.webkit.org/252515@main)</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=242823">https://bugs.webkit.org/show_bug.cgi?id=242823</a>
rdar://97098003

Reviewed by Nikolas Zimmermann.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
Imported &lt;WebKit/WKPreferencesPrivate.h&gt;

Canonical link: <a href="https://commits.webkit.org/252525@main">https://commits.webkit.org/252525@main</a>
</pre>
