### PR TITLE
[Gardening]: [ iOS15 x86 ] editing/selection/ios/hide-selection-in-tiny-contenteditable.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3672,3 +3672,5 @@ webkit.org/b/242273 fast/events/ios/dragstart-on-image-by-long-pressing.html [ P
 
 # Requires platform support (see rdar://94324932).
 http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
+
+webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable.html [ Pass Failure ]


### PR DESCRIPTION
#### 1bee7f4f64a1b8ce8754a5687b9a8e05a119eeef
<pre>
[Gardening]: [ iOS15 x86 ] editing/selection/ios/hide-selection-in-tiny-contenteditable.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242825">https://bugs.webkit.org/show_bug.cgi?id=242825</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252527@main">https://commits.webkit.org/252527@main</a>
</pre>
