### PR TITLE
Interaction region for <video> play button is not round

### DIFF
--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -1,0 +1,79 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+      (children 1
+        (GraphicsLayer
+          (bounds 352.00 288.00)
+          (event region
+            (rect (0,0) width=352 height=288)
+          )
+          (children 1
+            (GraphicsLayer
+              (bounds 352.00 288.00)
+              (event region
+                (rect (0,0) width=352 height=288)
+              )
+              (children 1
+                (GraphicsLayer
+                  (position 176.00 144.00)
+                  (bounds 60.00 60.00)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-30.00 -30.00 0.00 1.00])
+                  (event region
+                    (rect (15,0) width=30 height=5)
+                    (rect (5,5) width=50 height=10)
+                    (rect (5,15) width=55 height=1)
+                    (rect (0,16) width=60 height=28)
+                    (rect (0,44) width=55 height=1)
+                    (rect (5,45) width=50 height=10)
+                    (rect (16,55) width=29 height=5)
+
+                  (interaction regions [
+                    (region
+                        (rect (0,0) width=60 height=60)
+)
+                    (hasLightBackground 1)
+                    (borderRadius 30.00)])
+                  )
+                  (children 3
+                    (GraphicsLayer
+                      (bounds 60.00 60.00)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (bounds 60.00 60.00)
+                      (blendMode lighten)
+                      (drawsContent 1)
+                    )
+                    (GraphicsLayer
+                      (position 3.00 0.00)
+                      (bounds 60.00 60.00)
+                      (blendMode plus-lighter)
+                      (transform [0.40 0.00 0.00 0.00] [0.00 0.40 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                      (mask layer)
+                        (GraphicsLayer
+                          (bounds 60.00 60.00)
+                          (drawsContent 1)
+                        )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+EVENT(canplaythrough)
+

--- a/LayoutTests/interaction-region/paused-video-regions.html
+++ b/LayoutTests/interaction-region/paused-video-regions.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+</style>
+<video src="../media/content/counting.mp4" controls></video>
+<pre id="results"></pre>
+<script src="../media/media-file.js"></script>
+<script src="../media/video-test.js"></script>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    waitForEvent('canplaythrough', function () {
+        if (window.internals)
+            results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+        
+        if (window.testRunner)
+            testRunner.notifyDone();
+    } );
+</script>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/button.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.css
@@ -106,10 +106,9 @@ button.small-center {
     height: 31px !important;
 }
 
-button.center > .background-tint,
-button.small-center > .background-tint,
-button.center > .background-tint > div,
-button.small-center > .background-tint > div {
+button:is(.center, .small-center),
+button:is(.center, .small-center) > .background-tint,
+button:is(.center, .small-center) > .background-tint > div {
     border-radius: 50%;
 }
 


### PR DESCRIPTION
#### fc190ad09c4664375ffba90c722a6049969b60c0
<pre>
Interaction region for &lt;video&gt; play button is not round
<a href="https://bugs.webkit.org/show_bug.cgi?id=242831">https://bugs.webkit.org/show_bug.cgi?id=242831</a>

Reviewed by Dean Jackson and Devin Rousso.

* LayoutTests/interaction-region/paused-video-regions-expected.txt: Added.
* LayoutTests/interaction-region/paused-video-regions.html: Added.
Add a test that dumps the interaction region for the play button.
Previously, it would not have had a non-zero radius.

* Source/WebCore/Modules/modern-media-controls/controls/button.css:
(button.center,):
(button.center &gt; .background-tint,): Deleted.
Apply the circular border radius to the &lt;button&gt; as well as its children,
in order to make its interaction region correct.

This has no impact on actual functionality, since the video itself and the button
can both be clicked to start playback.

Canonical link: <a href="https://commits.webkit.org/252594@main">https://commits.webkit.org/252594@main</a>
</pre>
