### PR TITLE
Fix event overlay regions for some websites

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -178,10 +178,6 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;
 #endif
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-- (NSArray<NSData *> *)_overlayRegions;
-#endif
-
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -47,6 +47,10 @@
 - (void)_setContentInsetAdjustmentBehaviorInternal:(UIScrollViewContentInsetAdjustmentBehavior)insetAdjustmentBehavior;
 #endif
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+- (bool)_updateOverlayRegions:(const Vector<CGRect> &)overlayRegions;
+#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### ccc3cf9168e4dfe44b314caeaa38867c3dde0eb7
<pre>
Fix event overlay regions for some websites
<a href="https://bugs.webkit.org/show_bug.cgi?id=242830">https://bugs.webkit.org/show_bug.cgi?id=242830</a>

Reviewed by Tim Horton.

Rectangle being passed was not in the web view&apos;s coordinate space.

Transform the rectangle into the correct coordinate space.

Also fix KVO notification where navigating between web pages would
not send a notification for overlayRegions. This requires storing
a copy of the rectangles in the scroll view representing the current
state to observe changes.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
Correctly map the rectangle into the web view&apos;s coordinate space.

(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
Pass the web view to the recursive function.

We could use iterators instead of creating a temporary vector of
CGRect instances but this vector is generally very small, 5-8 objects
in the worser cases, so it probably is not necessary.

(-[WKWebView _overlayRegions]): Deleted.
Done by WKScrollView now.

* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _updateOverlayRegions:]):
Post KVO notification if the data changes.

(-[WKScrollView overlayRegions]):
Getter returning an array of NSData instances.

Canonical link: <a href="https://commits.webkit.org/252680@main">https://commits.webkit.org/252680@main</a>
</pre>
