### PR TITLE
[libpas] Make configuration parameter const

### DIFF
--- a/Source/bmalloc/libpas/Documentation.md
+++ b/Source/bmalloc/libpas/Documentation.md
@@ -194,7 +194,7 @@ Is an out-of-line direct function call to the specialization of
 `pas_local_allocator_try_allocate_small_segregated_slow`. And this would be a virtual call to the same
 function:
 
-    pas_heap_config* config = ...;
+    const pas_heap_config* config = ...;
     config->specialized_local_allocator_try_allocate_small_segregated_slow(...);
 
 Note that in many cases where you have a `pas_heap_config`, you are in specialized code and the heap config is
@@ -1181,7 +1181,7 @@ The header file usually looks like this:
         .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
         .pgm_enabled = false)
     
-    PAS_API extern pas_heap_config iso_heap_config;
+    PAS_API extern const pas_heap_config iso_heap_config;
     
     PAS_BASIC_HEAP_CONFIG_DECLARATIONS(iso, ISO);
 
@@ -1189,7 +1189,7 @@ Note the use of `PAS_BASIC_HEAP_CONFIG`, which creates a config literal that aut
 heap config, segregated page config, and bitfit page config fields based on the arguments you pass to
 `PAS_BASIC_HEAP_CONFIG`. The corresponding `.c` file looks like this:
 
-    pas_heap_config iso_heap_config = ISO_HEAP_CONFIG;
+    const pas_heap_config iso_heap_config = ISO_HEAP_CONFIG;
     
     PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
         iso, ISO,

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.c
@@ -38,7 +38,7 @@
 
 PAS_BEGIN_EXTERN_C;
 
-pas_heap_config bmalloc_heap_config = BMALLOC_HEAP_CONFIG;
+const pas_heap_config bmalloc_heap_config = BMALLOC_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     bmalloc, BMALLOC,

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h
@@ -77,7 +77,7 @@ PAS_API void bmalloc_heap_config_activate(void);
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config bmalloc_heap_config;
+PAS_API extern const pas_heap_config bmalloc_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(bmalloc, BMALLOC);
 

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.c
@@ -35,7 +35,7 @@
 #include "pas_designated_intrinsic_heap.h"
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config hotbit_heap_config = HOTBIT_HEAP_CONFIG;
+const pas_heap_config hotbit_heap_config = HOTBIT_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     hotbit, HOTBIT,

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h
@@ -78,7 +78,7 @@ PAS_API void hotbit_heap_config_activate(void);
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config hotbit_heap_config;
+PAS_API extern const pas_heap_config hotbit_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(hotbit, HOTBIT);
 

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_config.c
@@ -33,7 +33,7 @@
 
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config iso_heap_config = ISO_HEAP_CONFIG;
+const pas_heap_config iso_heap_config = ISO_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     iso, ISO,

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_config.h
@@ -76,7 +76,7 @@ PAS_BEGIN_EXTERN_C;
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config iso_heap_config;
+PAS_API extern const pas_heap_config iso_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(iso, ISO);
 

--- a/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.c
@@ -33,7 +33,7 @@
 
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config iso_test_heap_config = ISO_TEST_HEAP_CONFIG;
+const pas_heap_config iso_test_heap_config = ISO_TEST_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     iso_test, ISO_TEST,

--- a/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h
@@ -76,7 +76,7 @@ PAS_BEGIN_EXTERN_C;
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config iso_test_heap_config;
+PAS_API extern const pas_heap_config iso_test_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(iso_test, ISO_TEST);
 

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -52,7 +52,7 @@ void jit_type_dump(const pas_heap_type* type, pas_stream* stream)
     pas_stream_printf(stream, "JIT");
 }
 
-pas_heap_config jit_heap_config = JIT_HEAP_CONFIG;
+const pas_heap_config jit_heap_config = JIT_HEAP_CONFIG;
 
 pas_simple_large_free_heap jit_fresh_memory_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER;
 
@@ -244,7 +244,7 @@ void jit_medium_destroy_page_header(
 }
 
 pas_aligned_allocation_result jit_aligned_allocator(
-    size_t size, pas_alignment alignment, pas_large_heap* large_heap, pas_heap_config* config)
+    size_t size, pas_alignment alignment, pas_large_heap* large_heap, const pas_heap_config* config)
 {
     pas_aligned_allocation_result result;
     size_t aligned_size;
@@ -276,18 +276,18 @@ pas_aligned_allocation_result jit_aligned_allocator(
 void* jit_prepare_to_enumerate(pas_enumerator* enumerator)
 {
     pas_basic_heap_config_enumerator_data* result;
-    pas_heap_config** configs;
-    pas_heap_config* config;
+    const pas_heap_config** configs;
+    const pas_heap_config* config;
     jit_heap_config_root_data* root_data;
 
-    configs = (pas_heap_config**)pas_enumerator_read(
+    configs = (const pas_heap_config**)pas_enumerator_read(
         enumerator, enumerator->root->heap_configs,
-        sizeof(pas_heap_config*) * pas_heap_config_kind_num_kinds);
+        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds);
     if (!configs)
         return NULL;
     
-    config = (pas_heap_config*)pas_enumerator_read(
-        enumerator, configs[pas_heap_config_kind_jit], sizeof(pas_heap_config));
+    config = (const pas_heap_config*)pas_enumerator_read(
+        enumerator, (void*)(uintptr_t)configs[pas_heap_config_kind_jit], sizeof(pas_heap_config));
     if (!config)
         return NULL;
 

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
@@ -108,7 +108,7 @@ jit_heap_config_fast_megapage_kind(uintptr_t begin)
 
 static PAS_ALWAYS_INLINE pas_page_base* jit_heap_config_page_header(uintptr_t begin);
 PAS_API pas_aligned_allocation_result jit_aligned_allocator(
-    size_t size, pas_alignment alignment, pas_large_heap* large_heap, pas_heap_config* config);
+    size_t size, pas_alignment alignment, pas_large_heap* large_heap, const pas_heap_config* config);
 PAS_API void* jit_prepare_to_enumerate(pas_enumerator* enumerator);
 PAS_API bool jit_heap_config_for_each_shared_page_directory(
     pas_segregated_heap* heap,
@@ -227,7 +227,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
         PAS_HEAP_CONFIG_SPECIALIZATIONS(jit_heap_config) \
     })
 
-PAS_API extern pas_heap_config jit_heap_config;
+PAS_API extern const pas_heap_config jit_heap_config;
 
 /* The JIT heap manages memory that is given to it by clients. Clients add memory to the JIT heap
    by freeing it into the fresh memory heap. The JIT heap never allocates pages from the OS by

--- a/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.c
@@ -35,7 +35,7 @@
 #include "pas_designated_intrinsic_heap.h"
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config minalign32_heap_config = MINALIGN32_HEAP_CONFIG;
+const pas_heap_config minalign32_heap_config = MINALIGN32_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     minalign32, MINALIGN32,

--- a/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h
@@ -80,7 +80,7 @@ PAS_API void minalign32_heap_config_activate(void);
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config minalign32_heap_config;
+PAS_API extern const pas_heap_config minalign32_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(minalign32, MINALIGN32);
 

--- a/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.c
@@ -35,7 +35,7 @@
 #include "pas_designated_intrinsic_heap.h"
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config pagesize64k_heap_config = PAGESIZE64K_HEAP_CONFIG;
+const pas_heap_config pagesize64k_heap_config = PAGESIZE64K_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     pagesize64k, PAGESIZE64K,

--- a/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h
@@ -79,7 +79,7 @@ PAS_API void pagesize64k_heap_config_activate(void);
     .use_marge_bitfit = false, \
     .pgm_enabled = false)
 
-PAS_API extern pas_heap_config pagesize64k_heap_config;
+PAS_API extern const pas_heap_config pagesize64k_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(pagesize64k, PAGESIZE64K);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_all_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_all_heaps.c
@@ -254,7 +254,7 @@ static bool for_each_segregated_directory_shared_page_directory_callback(
 }
 
 static bool for_each_segregated_directory_segregated_heap_callback(
-    pas_segregated_heap* heap, pas_heap_config* config, void* arg)
+    pas_segregated_heap* heap, const pas_heap_config* config, void* arg)
 {
     for_each_segregated_directory_data* data;
 
@@ -321,7 +321,7 @@ static bool verify_in_steady_state_segregated_directory_callback(
     pas_segregated_directory* directory, void* arg)
 {
     size_t index;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     
     PAS_UNUSED_PARAM(arg);
 
@@ -410,7 +410,7 @@ static bool compute_total_non_utility_segregated_summary_directory_callback(
 {
     pas_heap_summary* result;
     size_t index;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
 
     if (!pas_segregated_page_config_kind_is_utility(directory->page_config_kind))
         return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_all_heaps.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_all_heaps.h
@@ -66,7 +66,7 @@ PAS_API bool pas_all_heaps_for_each_heap(pas_all_heaps_for_each_heap_callback ca
                                          void* arg);
 
 typedef bool (*pas_all_heaps_for_each_segregated_heap_callback)(
-    pas_segregated_heap* heap, pas_heap_config* heap_config, void* arg);
+    pas_segregated_heap* heap, const pas_heap_config* heap_config, void* arg);
 
 PAS_API bool pas_all_heaps_for_each_static_segregated_heap_not_part_of_a_heap(
     pas_all_heaps_for_each_segregated_heap_callback callback,

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c
@@ -49,7 +49,7 @@ void pas_bitfit_allocator_stop(pas_bitfit_allocator* allocator)
 }
 
 bool pas_bitfit_allocator_commit_view(pas_bitfit_view* view,
-                                      pas_bitfit_page_config* config,
+                                      const pas_bitfit_page_config* config,
                                       pas_lock_hold_mode commit_lock_hold_mode)
 {
     static const bool verbose = false;
@@ -222,7 +222,7 @@ pas_bitfit_view* pas_bitfit_allocator_finish_failing(pas_bitfit_allocator* alloc
                                                      size_t size,
                                                      size_t alignment,
                                                      size_t largest_available,
-                                                     pas_bitfit_page_config* config)
+                                                     const pas_bitfit_page_config* config)
 {
     static const bool verbose = false;
     

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h
@@ -40,7 +40,7 @@
 PAS_BEGIN_EXTERN_C;
 
 PAS_API bool pas_bitfit_allocator_commit_view(pas_bitfit_view* view,
-                                              pas_bitfit_page_config* config,
+                                              const pas_bitfit_page_config* config,
                                               pas_lock_hold_mode commit_lock_hold_mode);
 
 PAS_API pas_bitfit_view*
@@ -49,7 +49,7 @@ pas_bitfit_allocator_finish_failing(pas_bitfit_allocator* allocator,
                                     size_t size,
                                     size_t alignment,
                                     size_t largest_available,
-                                    pas_bitfit_page_config* config);
+                                    const pas_bitfit_page_config* config);
 
 static PAS_ALWAYS_INLINE pas_fast_path_allocation_result
 pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
@@ -94,7 +94,7 @@ pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
             PAS_TESTING_ASSERT(!allocator->view);
             
             view = pas_bitfit_size_class_get_first_free_view(
-                allocator->size_class, (pas_bitfit_page_config*)config.base.page_config_ptr);
+                allocator->size_class, (const pas_bitfit_page_config*)config.base.page_config_ptr);
             if (!view)
                 return pas_fast_path_allocation_result_create_out_of_memory();
             allocator->view = view;
@@ -129,7 +129,7 @@ pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
             if (PAS_UNLIKELY(!view->is_owned)) {
                 /* Note that this would have flashed the ownership lock possibly. */
                 if (!pas_bitfit_allocator_commit_view(
-                        view, (pas_bitfit_page_config*)config.base.page_config_ptr,
+                        view, (const pas_bitfit_page_config*)config.base.page_config_ptr,
                         commit_lock_hold_mode)) {
                     if (verbose)
                         pas_log("bitfit is out of memory\n");
@@ -172,7 +172,7 @@ pas_bitfit_allocator_try_allocate(pas_bitfit_allocator* allocator,
             
             view = pas_bitfit_allocator_finish_failing(
                 allocator, view, size, alignment, bitfit_result.u.largest_available,
-                (pas_bitfit_page_config*)config.base.page_config_ptr);
+                (const pas_bitfit_page_config*)config.base.page_config_ptr);
             
             if (view)
                 PAS_TESTING_ASSERT(alignment > pas_page_base_config_min_align(config.base));

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
@@ -41,7 +41,7 @@
 #include "pas_stream.h"
 
 void pas_bitfit_directory_construct(pas_bitfit_directory* directory,
-                                    pas_bitfit_page_config* config,
+                                    const pas_bitfit_page_config* config,
                                     pas_segregated_heap* heap)
 {
     static const bool verbose = false;
@@ -103,7 +103,7 @@ pas_bitfit_view_and_index
 pas_bitfit_directory_get_first_free_view(pas_bitfit_directory* directory,
                                          unsigned start_index,
                                          unsigned size,
-                                         pas_bitfit_page_config* page_config)
+                                         const pas_bitfit_page_config* page_config)
 {
     static const bool verbose = false;
 
@@ -380,7 +380,7 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
     
     pas_versioned_field last_empty_plus_one_value;
     size_t index;
-    pas_bitfit_page_config* page_config;
+    const pas_bitfit_page_config* page_config;
     size_t num_granules;
 
     last_empty_plus_one_value = pas_versioned_field_read(&directory->last_empty_plus_one);

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.h
@@ -88,7 +88,7 @@ struct PAS_ALIGNED(sizeof(pas_versioned_field)) pas_bitfit_directory {
 };
 
 PAS_API void pas_bitfit_directory_construct(pas_bitfit_directory* directory,
-                                            pas_bitfit_page_config* config,
+                                            const pas_bitfit_page_config* config,
                                             pas_segregated_heap* heap);
 
 static inline unsigned pas_bitfit_directory_size(pas_bitfit_directory* directory)
@@ -217,7 +217,7 @@ PAS_API pas_bitfit_view_and_index
 pas_bitfit_directory_get_first_free_view(pas_bitfit_directory* directory,
                                          unsigned start_index,
                                          unsigned size,
-                                         pas_bitfit_page_config* page_config);
+                                         const pas_bitfit_page_config* page_config);
 
 PAS_API pas_heap_summary pas_bitfit_directory_compute_summary(pas_bitfit_directory* directory);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
@@ -38,7 +38,7 @@
 #include "pas_segregated_size_directory.h"
 
 pas_bitfit_heap* pas_bitfit_heap_create(pas_segregated_heap* segregated_heap,
-                                        pas_heap_config* heap_config)
+                                        const pas_heap_config* heap_config)
 {
     pas_bitfit_heap* result;
     pas_bitfit_page_config_variant variant;
@@ -60,7 +60,7 @@ pas_bitfit_heap* pas_bitfit_heap_create(pas_segregated_heap* segregated_heap,
 }
 
 pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_object_size,
-                                                            pas_heap_config* config,
+                                                            const pas_heap_config* config,
                                                             pas_heap_runtime_config* runtime_config)
 {
     static const bool verbose = false;
@@ -126,7 +126,7 @@ pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_obj
 void pas_bitfit_heap_construct_and_insert_size_class(pas_bitfit_heap* heap,
                                                      pas_bitfit_size_class* size_class,
                                                      unsigned object_size,
-                                                     pas_heap_config* config,
+                                                     const pas_heap_config* config,
                                                      pas_heap_runtime_config* runtime_config)
 {
     static const bool verbose = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.h
@@ -47,7 +47,7 @@ struct PAS_ALIGNED(sizeof(pas_versioned_field)) pas_bitfit_heap {
 };
 
 PAS_API pas_bitfit_heap* pas_bitfit_heap_create(pas_segregated_heap* heap,
-                                                pas_heap_config* heap_config);
+                                                const pas_heap_config* heap_config);
 
 static inline pas_bitfit_directory* pas_bitfit_heap_get_directory(
     pas_bitfit_heap* heap,
@@ -64,13 +64,13 @@ typedef struct {
 
 PAS_API pas_bitfit_variant_selection
 pas_bitfit_heap_select_variant(size_t object_size,
-                               pas_heap_config* config,
+                               const pas_heap_config* config,
                                pas_heap_runtime_config* runtime_config);
 
 PAS_API void pas_bitfit_heap_construct_and_insert_size_class(pas_bitfit_heap* heap,
                                                              pas_bitfit_size_class* size_class,
                                                              unsigned object_size,
-                                                             pas_heap_config* config,
+                                                             const pas_heap_config* config,
                                                              pas_heap_runtime_config* runtime_config);
 
 PAS_API pas_heap_summary pas_bitfit_heap_compute_summary(pas_bitfit_heap* heap);

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
@@ -36,7 +36,7 @@
 
 void pas_bitfit_page_construct(pas_bitfit_page* page,
                                pas_bitfit_view* view,
-                               pas_bitfit_page_config* config_ptr)
+                               const pas_bitfit_page_config* config_ptr)
 {
     static const bool verbose = false;
     
@@ -120,7 +120,7 @@ void pas_bitfit_page_construct(pas_bitfit_page* page,
     }
 }
 
-pas_bitfit_page_config* pas_bitfit_page_get_config(pas_bitfit_page* page)
+const pas_bitfit_page_config* pas_bitfit_page_get_config(pas_bitfit_page* page)
 {
     return pas_bitfit_page_config_kind_get_config(
         pas_compact_bitfit_directory_ptr_load_non_null(
@@ -189,7 +189,7 @@ bool pas_bitfit_page_for_each_live_object(
     pas_bitfit_page_for_each_live_object_callback callback,
     void* arg)
 {
-    pas_bitfit_page_config* config_ptr;
+    const pas_bitfit_page_config* config_ptr;
     pas_bitfit_page_config config;
     void* boundary;
     pas_bitfit_view* view;
@@ -235,7 +235,7 @@ bool pas_bitfit_page_for_each_live_object(
 }
 
 typedef struct {
-    pas_bitfit_page_config* config;
+    const pas_bitfit_page_config* config;
     uintptr_t boundary;
     pas_page_granule_use_count my_use_counts[PAS_MAX_GRANULES];
 } verify_for_each_object_data;
@@ -263,7 +263,7 @@ void pas_bitfit_page_verify(pas_bitfit_page* page)
     size_t begin;
     size_t end;
     size_t offset;
-    pas_bitfit_page_config* config_ptr;
+    const pas_bitfit_page_config* config_ptr;
     pas_bitfit_page_config config;
     size_t num_live_bits;
     verify_for_each_object_data data;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.h
@@ -94,7 +94,7 @@ pas_bitfit_page_get_granule_use_counts(pas_bitfit_page* page,
 
 PAS_API void pas_bitfit_page_construct(pas_bitfit_page* page,
                                        pas_bitfit_view* view,
-                                       pas_bitfit_page_config* config);
+                                       const pas_bitfit_page_config* config);
 
 static PAS_ALWAYS_INLINE uintptr_t
 pas_bitfit_page_offset_to_first_object(pas_bitfit_page_config page_config)
@@ -166,7 +166,7 @@ pas_bitfit_page_for_address_and_page_config(uintptr_t begin,
         pas_page_base_for_address_and_page_config(begin, page_config.base));
 }
 
-PAS_API pas_bitfit_page_config* pas_bitfit_page_get_config(pas_bitfit_page* page);
+PAS_API const pas_bitfit_page_config* pas_bitfit_page_get_config(pas_bitfit_page* page);
 
 PAS_API void pas_bitfit_page_log_bits(
     pas_bitfit_page* page, uintptr_t mark_begin_offset, uintptr_t mark_end_offset);

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c
@@ -64,14 +64,14 @@ bool pas_bitfit_page_config_kind_for_each(
     return true;    
 }
 
-pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[
+const pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[
     0
 #define PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND(name, value) + 1
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
     ] = {
 #define PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND(name, value) \
-    (pas_bitfit_page_config*)(value).base.page_config_ptr,
+    (const pas_bitfit_page_config*)(value).base.page_config_ptr,
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
 };

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h
@@ -45,16 +45,16 @@ typedef enum pas_bitfit_page_config_kind pas_bitfit_page_config_kind;
 PAS_API const char* pas_bitfit_page_config_kind_get_string(pas_bitfit_page_config_kind kind);
 
 typedef bool (*pas_bitfit_page_config_kind_callback)(pas_bitfit_page_config_kind kind,
-                                                         pas_bitfit_page_config* config,
+                                                         const pas_bitfit_page_config* config,
                                                          void* arg);
 
 PAS_API bool pas_bitfit_page_config_kind_for_each(
     pas_bitfit_page_config_kind_callback callback,
     void *arg);
 
-PAS_API extern pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[];
+PAS_API extern const pas_bitfit_page_config* pas_bitfit_page_config_kind_for_config_table[];
 
-static inline pas_bitfit_page_config* pas_bitfit_page_config_kind_get_config(
+static inline const pas_bitfit_page_config* pas_bitfit_page_config_kind_get_config(
     pas_bitfit_page_config_kind kind)
 {
     return pas_bitfit_page_config_kind_for_config_table[kind];

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.c
@@ -77,7 +77,7 @@ void pas_bitfit_size_class_construct(pas_bitfit_size_class* size_class,
 
 pas_bitfit_view*
 pas_bitfit_size_class_get_first_free_view(pas_bitfit_size_class* size_class,
-                                          pas_bitfit_page_config* page_config)
+                                          const pas_bitfit_page_config* page_config)
 {
     pas_bitfit_directory* directory;
     pas_versioned_field first_free_for_size;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.h
@@ -61,7 +61,7 @@ PAS_API void pas_bitfit_size_class_construct(
 
 PAS_API pas_bitfit_view*
 pas_bitfit_size_class_get_first_free_view(pas_bitfit_size_class* size_class,
-                                          pas_bitfit_page_config* page_config);
+                                          const pas_bitfit_page_config* page_config);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c
@@ -105,7 +105,7 @@ static pas_heap_summary compute_summary(pas_bitfit_view* view)
 {
     static const bool verbose = false;
     
-    pas_bitfit_page_config* config_ptr;
+    const pas_bitfit_page_config* config_ptr;
     pas_bitfit_page_config config;
     void* boundary;
     pas_bitfit_page* page;
@@ -197,7 +197,7 @@ static bool for_each_live_object(
     pas_bitfit_view_for_each_live_object_callback callback,
     void* arg)
 {
-    pas_bitfit_page_config* config_ptr;
+    const pas_bitfit_page_config* config_ptr;
     pas_bitfit_page_config config;
     void* boundary;
     pas_bitfit_page* page;

--- a/Source/bmalloc/libpas/src/libpas/pas_commit_span.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_commit_span.c
@@ -57,7 +57,7 @@ void pas_commit_span_add_to_change(pas_commit_span* span, uintptr_t granule_inde
 void pas_commit_span_add_unchanged(pas_commit_span* span,
                                    pas_page_base* page,
                                    uintptr_t granule_index,
-                                   pas_page_base_config* config,
+                                   const pas_page_base_config* config,
                                    void (*commit_or_decommit)(void* base, size_t size, void* arg),
                                    void* arg)
 {
@@ -95,7 +95,7 @@ static void commit(void* base, size_t size, void* arg)
 void pas_commit_span_add_unchanged_and_commit(pas_commit_span* span,
                                               pas_page_base* page,
                                               uintptr_t granule_index,
-                                              pas_page_base_config* config)
+                                              const pas_page_base_config* config)
 {
     pas_commit_span_add_unchanged(span, page, granule_index, config, commit, span);
 }
@@ -131,7 +131,7 @@ void pas_commit_span_add_unchanged_and_decommit(pas_commit_span* span,
                                                 uintptr_t granule_index,
                                                 pas_deferred_decommit_log* log,
                                                 pas_lock* commit_lock,
-                                                pas_page_base_config* config,
+                                                const pas_page_base_config* config,
                                                 pas_lock_hold_mode heap_lock_hold_mode)
 {
     decommit_data data;

--- a/Source/bmalloc/libpas/src/libpas/pas_commit_span.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_commit_span.h
@@ -52,20 +52,20 @@ PAS_API void pas_commit_span_add_to_change(pas_commit_span* span, uintptr_t gran
 PAS_API void pas_commit_span_add_unchanged(pas_commit_span* span,
                                            pas_page_base* page,
                                            uintptr_t granule_index,
-                                           pas_page_base_config* config,
+                                           const pas_page_base_config* config,
                                            void (*commit_or_decommit)(
                                                void* base, size_t size, void* arg),
                                            void* arg);
 PAS_API void pas_commit_span_add_unchanged_and_commit(pas_commit_span* span,
                                                       pas_page_base* page,
                                                       uintptr_t granule_index,
-                                                      pas_page_base_config* config);
+                                                      const pas_page_base_config* config);
 PAS_API void pas_commit_span_add_unchanged_and_decommit(pas_commit_span* span,
                                                         pas_page_base* page,
                                                         uintptr_t granule_index,
                                                         pas_deferred_decommit_log* log,
                                                         pas_lock* commit_lock,
-                                                        pas_page_base_config* config,
+                                                        const pas_page_base_config* config,
                                                         pas_lock_hold_mode heap_lock_hold_mode);
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.c
@@ -76,7 +76,7 @@ bool pas_compute_summary_live_object_callback_without_physical_sharing(uintptr_t
     return true;
 }
 
-bool (*pas_compute_summary_live_object_callback_for_config(pas_heap_config* config))(
+bool (*pas_compute_summary_live_object_callback_for_config(const pas_heap_config* config))(
     uintptr_t begin,
     uintptr_t end,
     void* arg)
@@ -128,7 +128,7 @@ bool pas_compute_summary_dead_object_callback_without_physical_sharing(pas_large
     return true;
 }
 
-bool (*pas_compute_summary_dead_object_callback_for_config(pas_heap_config* config))(
+bool (*pas_compute_summary_dead_object_callback_for_config(const pas_heap_config* config))(
     pas_large_free free,
     void* arg)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.h
@@ -42,7 +42,7 @@ PAS_API bool pas_compute_summary_live_object_callback_without_physical_sharing(
     uintptr_t end,
     void* arg);
 
-PAS_API bool (*pas_compute_summary_live_object_callback_for_config(pas_heap_config* config))(
+PAS_API bool (*pas_compute_summary_live_object_callback_for_config(const pas_heap_config* config))(
     uintptr_t begin,
     uintptr_t end,
     void* arg);
@@ -55,7 +55,7 @@ PAS_API bool pas_compute_summary_dead_object_callback_without_physical_sharing(
     pas_large_free free,
     void* arg);
 
-PAS_API bool (*pas_compute_summary_dead_object_callback_for_config(pas_heap_config* config))(
+PAS_API bool (*pas_compute_summary_dead_object_callback_for_config(const pas_heap_config* config))(
     pas_large_free free,
     void* arg);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -34,7 +34,7 @@
 #include "pas_segregated_page_inlines.h"
 
 bool pas_try_deallocate_known_large(void* ptr,
-                                    pas_heap_config* config,
+                                    const pas_heap_config* config,
                                     pas_deallocation_mode deallocation_mode)
 {
     uintptr_t begin;
@@ -63,13 +63,13 @@ bool pas_try_deallocate_known_large(void* ptr,
 }
 
 void pas_deallocate_known_large(void* ptr,
-                                pas_heap_config* config)
+                                const pas_heap_config* config)
 {
     pas_try_deallocate_known_large(ptr, config, pas_deallocate_mode);
 }
 
 bool pas_try_deallocate_slow(uintptr_t begin,
-                             pas_heap_config* config,
+                             const pas_heap_config* config,
                              pas_deallocation_mode deallocation_mode)
 {
     if (!begin)
@@ -79,7 +79,7 @@ bool pas_try_deallocate_slow(uintptr_t begin,
 }
 
 static void deallocate_segregated(uintptr_t begin,
-                                  pas_segregated_page_config* page_config,
+                                  const pas_segregated_page_config* page_config,
                                   pas_segregated_page_role role)
 {
     pas_lock* held_lock;
@@ -90,7 +90,7 @@ static void deallocate_segregated(uintptr_t begin,
 }
 
 bool pas_try_deallocate_slow_no_cache(void* ptr,
-                                      pas_heap_config* config_ptr,
+                                      const pas_heap_config* config_ptr,
                                       pas_deallocation_mode deallocation_mode)
 {
     static const bool verbose = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -41,11 +41,11 @@
 PAS_BEGIN_EXTERN_C;
 
 PAS_API bool pas_try_deallocate_slow(uintptr_t begin,
-                                     pas_heap_config* config,
+                                     const pas_heap_config* config,
                                      pas_deallocation_mode deallocation_mode);
 
 PAS_API bool pas_try_deallocate_slow_no_cache(void* ptr,
-                                              pas_heap_config* config_ptr,
+                                              const pas_heap_config* config_ptr,
                                               pas_deallocation_mode deallocation_mode);
 
 static PAS_ALWAYS_INLINE void
@@ -65,11 +65,11 @@ pas_deallocate_known_segregated(void* ptr,
 }
 
 PAS_API bool pas_try_deallocate_known_large(void* ptr,
-                                            pas_heap_config* config,
+                                            const pas_heap_config* config,
                                             pas_deallocation_mode deallocation_mode);
 
 PAS_API void pas_deallocate_known_large(void* ptr,
-                                        pas_heap_config* config);
+                                        const pas_heap_config* config);
 
 static PAS_ALWAYS_INLINE bool pas_try_deallocate_not_small_exclusive_segregated(
     pas_thread_local_cache* thread_local_cache,

--- a/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.c
@@ -37,7 +37,7 @@
 
 typedef struct {
     pas_segregated_heap* heap;
-    pas_heap_config* config_ptr;
+    const pas_heap_config* config_ptr;
     pas_allocator_index num_allocator_indices;
     pas_allocator_index next_index_to_set;
 } initialize_data;
@@ -129,7 +129,7 @@ static void set_up_range(initialize_data* data,
 }
 
 void pas_designated_intrinsic_heap_initialize(pas_segregated_heap* heap,
-                                              pas_heap_config* config_ptr)
+                                              const pas_heap_config* config_ptr)
 {
     pas_heap_config config;
     initialize_data data;

--- a/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.h
@@ -44,7 +44,7 @@ typedef enum pas_intrinsic_heap_designation_mode pas_intrinsic_heap_designation_
 /* This can only be done once ever. Once you do it for an intrinsic heap you cannot do it for
    any other intrinsic heaps. It sets up the ability to use the fast size class lookup function. */
 PAS_API void pas_designated_intrinsic_heap_initialize(pas_segregated_heap* heap,
-                                                      pas_heap_config* config);
+                                                      const pas_heap_config* config);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.c
@@ -36,7 +36,7 @@
 pas_heap* pas_ensure_heap_forced_into_reserved_memory(
     pas_heap_ref* heap_ref,
     pas_heap_ref_kind heap_ref_kind,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_heap_runtime_config* template_runtime_config,
     uintptr_t begin,
     uintptr_t end)

--- a/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.h
@@ -40,7 +40,7 @@ PAS_BEGIN_EXTERN_C;
 PAS_API pas_heap* pas_ensure_heap_forced_into_reserved_memory(
     pas_heap_ref* heap_ref,
     pas_heap_ref_kind heap_ref_kind,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_heap_runtime_config* template_runtime_config,
     uintptr_t begin,
     uintptr_t end);

--- a/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.c
@@ -36,7 +36,7 @@
 pas_heap* pas_ensure_heap_with_page_caches(
     pas_heap_ref* heap_ref,
     pas_heap_ref_kind heap_ref_kind,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_heap_runtime_config* template_runtime_config,
     pas_basic_heap_page_caches* page_caches)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.h
@@ -41,7 +41,7 @@ typedef struct pas_basic_heap_page_caches pas_basic_heap_page_caches;
 PAS_API pas_heap* pas_ensure_heap_with_page_caches(
     pas_heap_ref* heap_ref,
     pas_heap_ref_kind heap_ref_kind,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_heap_runtime_config* template_runtime_config,
     pas_basic_heap_page_caches* page_caches);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
@@ -44,7 +44,7 @@ static bool view_callback(pas_enumerator* enumerator,
     
     pas_bitfit_view* view;
     pas_bitfit_directory* directory;
-    pas_bitfit_page_config* page_config;
+    const pas_bitfit_page_config* page_config;
     uintptr_t page_boundary;
     pas_bitfit_page* page;
     pas_page_granule_use_count* use_counts;

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
@@ -192,7 +192,7 @@ static bool collect_shared_page_directories_heap_callback(
     void* arg)
 {
     enumeration_context* context;
-    pas_heap_config* config;
+    const pas_heap_config* config;
 
     context = arg;
 
@@ -205,7 +205,7 @@ static bool collect_shared_page_directories_heap_callback(
 }
 
 static void record_page_payload_and_meta(pas_enumerator* enumerator,
-                                         pas_segregated_page_config* page_config,
+                                         const pas_segregated_page_config* page_config,
                                          uintptr_t page_boundary,
                                          pas_segregated_page* page,
                                          uintptr_t payload_begin,
@@ -230,7 +230,7 @@ static void record_page_payload_and_meta(pas_enumerator* enumerator,
 static void record_page_objects(pas_enumerator* enumerator,
                                 enumeration_context* context,
                                 pas_segregated_size_directory* directory,
-                                pas_segregated_page_config* page_config,
+                                const pas_segregated_page_config* page_config,
                                 uintptr_t page_boundary,
                                 pas_segregated_page* page,
                                 pas_local_allocator* allocator,
@@ -316,7 +316,7 @@ static bool enumerate_exclusive_view(pas_enumerator* enumerator,
                                      enumeration_context* context)
 {
     pas_segregated_size_directory* directory;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     pas_segregated_size_directory_data* data;
     uintptr_t page_boundary;
     pas_segregated_page* page;
@@ -384,7 +384,7 @@ static bool enumerate_shared_view(pas_enumerator* enumerator,
                                   pas_segregated_shared_page_directory* directory,
                                   enumeration_context* context)
 {
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     pas_shared_handle_or_page_boundary shared_handle_or_page_boundary;
     pas_segregated_shared_handle* shared_handle;
     uintptr_t page_boundary;
@@ -454,7 +454,7 @@ static bool enumerate_partial_view(pas_enumerator* enumerator,
                                    enumeration_context* context)
 {
     pas_segregated_size_directory* directory;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     pas_segregated_shared_view* shared_view;
     pas_shared_handle_or_page_boundary shared_handle_or_page_boundary;
     pas_segregated_shared_handle* shared_handle;
@@ -593,7 +593,7 @@ static bool enumerate_segregated_heap_callback(pas_enumerator* enumerator,
 static PAS_NEVER_INLINE void consider_allocator(pas_enumerator* enumerator, enumeration_context* context, pas_local_allocator* allocator)
 {
     local_allocator_map_add_result add_result;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     uintptr_t page_boundary;
     local_allocator_node* allocator_node;
     

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
@@ -76,7 +76,7 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
     size_t* compact_heap_size;
     size_t* compact_heap_guard_size;
     pas_enumerator_region* region;
-    pas_heap_config** configs;
+    const pas_heap_config** configs;
     pas_heap_config_kind config_kind;
 
     region = NULL;
@@ -143,14 +143,14 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
     configs = reader(
         result,
         result->root->heap_configs,
-        sizeof(pas_heap_config*) * pas_heap_config_kind_num_kinds,
+        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds,
         reader_arg);
     if (!configs)
         goto fail;
     
     for (PAS_EACH_HEAP_CONFIG_KIND(config_kind)) {
-        pas_heap_config* config;
-        pas_heap_config* remote_config;
+        const pas_heap_config* config;
+        const pas_heap_config* remote_config;
 
         if (config_kind == pas_heap_config_kind_null)
             continue;
@@ -159,7 +159,7 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
 
         PAS_ASSERT_WITH_DETAIL(config);
 
-        remote_config = reader(result, configs[config->kind], sizeof(pas_heap_config), reader_arg);
+        remote_config = reader(result, (void*)(uintptr_t)configs[config->kind], sizeof(pas_heap_config), reader_arg);
         if (!remote_config)
             goto fail;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c
@@ -61,7 +61,7 @@ static void table_set_by_index(size_t index, void* arg)
 void* pas_fast_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
     pas_fast_megapage_table* table,
-    pas_page_base_config* config,
+    const pas_page_base_config* config,
     pas_fast_megapage_kind kind,
     bool should_zero,
     pas_heap* heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h
@@ -48,7 +48,7 @@ typedef struct pas_physical_memory_transaction pas_physical_memory_transaction;
 PAS_API void* pas_fast_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
     pas_fast_megapage_table* table,
-    pas_page_base_config* config,
+    const pas_page_base_config* config,
     pas_fast_megapage_kind kind,
     bool should_zero,
     pas_heap* heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
@@ -94,7 +94,7 @@ void pas_free_granules_decommit_after_locking_range(pas_free_granules* free_gran
                                                     pas_page_base* page,
                                                     pas_deferred_decommit_log* log,
                                                     pas_lock* commit_lock,
-                                                    pas_page_base_config* page_config,
+                                                    const pas_page_base_config* page_config,
                                                     pas_lock_hold_mode heap_lock_hold_mode)
 {
     size_t granule_index;

--- a/Source/bmalloc/libpas/src/libpas/pas_free_granules.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_free_granules.h
@@ -70,7 +70,7 @@ PAS_API void pas_free_granules_decommit_after_locking_range(pas_free_granules* f
                                                             pas_page_base* page,
                                                             pas_deferred_decommit_log* log,
                                                             pas_lock* commit_lock,
-                                                            pas_page_base_config* page_config,
+                                                            const pas_page_base_config* page_config,
                                                             pas_lock_hold_mode heap_lock_hold_mode);
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -42,7 +42,7 @@
 
 pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
                           pas_heap_ref_kind heap_ref_kind,
-                          pas_heap_config* config,
+                          const pas_heap_config* config,
                           pas_heap_runtime_config* runtime_config)
 {
     static const bool verbose = false;
@@ -77,7 +77,7 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
 size_t pas_heap_get_type_size(pas_heap* heap)
 {
     pas_heap_config_kind kind;
-    pas_heap_config* config;
+    const pas_heap_config* config;
     if (!heap)
         return 1;
     kind = heap->config_kind;
@@ -201,7 +201,7 @@ pas_heap_ensure_size_directory_for_size_slow(
     size_t size,
     size_t alignment,
     pas_size_lookup_mode force_size_lookup,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index)
 {
     pas_segregated_size_directory* result;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.h
@@ -54,7 +54,7 @@ struct pas_heap {
 
 PAS_API pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
                                   pas_heap_ref_kind heap_ref_kind,
-                                  pas_heap_config* config,
+                                  const pas_heap_config* config,
                                   pas_heap_runtime_config* runtime_config);
 
 /* Returns 1 for NULL heap. */

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config.c
@@ -29,7 +29,7 @@
 
 #include "pas_heap_config.h"
 
-bool pas_heap_config_activate(pas_heap_config* config)
+bool pas_heap_config_activate(const pas_heap_config* config)
 {
     pas_heap_lock_assert_held();
     

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config.h
@@ -72,7 +72,7 @@ typedef pas_aligned_allocation_result (*pas_heap_config_aligned_allocator)(
     size_t size,
     pas_alignment alignment,
     pas_large_heap* large_heap,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 typedef void* (*pas_heap_config_prepare_to_enumerate)(pas_enumerator* enumerator);
 typedef bool (*pas_heap_config_for_each_shared_page_directory)(
     pas_segregated_heap* heap,
@@ -120,7 +120,7 @@ typedef bool (*pas_heap_config_specialized_try_deallocate_not_small_exclusive_se
 
 struct pas_heap_config {
     /* This always self-points. It's useful for going from a config to a config_ptr. */
-    pas_heap_config* config_ptr;
+    const pas_heap_config* config_ptr;
 
     pas_heap_config_kind kind;
 
@@ -247,9 +247,9 @@ struct pas_heap_config {
         pas_deallocation_mode deallocation_mode, \
         pas_fast_megapage_kind megapage_kind)
 
-static PAS_ALWAYS_INLINE pas_segregated_page_config*
+static PAS_ALWAYS_INLINE const pas_segregated_page_config*
 pas_heap_config_segregated_page_config_ptr_for_variant(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_segregated_page_config_variant variant)
 {
     switch (variant) {
@@ -262,9 +262,9 @@ pas_heap_config_segregated_page_config_ptr_for_variant(
     return NULL;
 }
 
-static PAS_ALWAYS_INLINE pas_bitfit_page_config*
+static PAS_ALWAYS_INLINE const pas_bitfit_page_config*
 pas_heap_config_bitfit_page_config_ptr_for_variant(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     pas_bitfit_page_config_variant variant)
 {
     switch (variant) {
@@ -331,7 +331,7 @@ static PAS_ALWAYS_INLINE size_t pas_heap_config_segregated_heap_min_align(pas_he
 /* Returns true if we were the first to active it. Must hold the heap lock to call this. This is
    permissive of recursive initialization: in that case, it will just pretend that the config is
    already initialized. */
-bool pas_heap_config_activate(pas_heap_config* config);
+bool pas_heap_config_activate(const pas_heap_config* config);
 
 /* NOTE: always pass pas_heap_config by value to inline functions, using constants if possible.
    Pass pas_heap_config by pointer to out-of-line functions, using the provided globals if

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.c
@@ -61,7 +61,7 @@ bool pas_heap_config_kind_for_each(
     return true;    
 }
 
-pas_heap_config* pas_heap_config_kind_for_config_table[pas_heap_config_kind_num_kinds] = {
+const pas_heap_config* pas_heap_config_kind_for_config_table[pas_heap_config_kind_num_kinds] = {
 #define PAS_DEFINE_HEAP_CONFIG_KIND(name, value) \
     (value).config_ptr,
 #include "pas_heap_config_kind.def"

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.h
@@ -53,7 +53,7 @@ enum { pas_heap_config_kind_num_kinds =
 PAS_API const char* pas_heap_config_kind_get_string(pas_heap_config_kind kind);
 
 typedef bool (*pas_heap_config_kind_callback)(pas_heap_config_kind kind,
-                                              pas_heap_config* config,
+                                              const pas_heap_config* config,
                                               void* arg);
 
 PAS_API bool pas_heap_config_kind_for_each(
@@ -65,9 +65,9 @@ PAS_API bool pas_heap_config_kind_for_each(
     (unsigned)kind < (unsigned)pas_heap_config_kind_num_kinds; \
     kind = (pas_heap_config_kind)((unsigned)kind + 1)
 
-PAS_API extern pas_heap_config* pas_heap_config_kind_for_config_table[];
+PAS_API extern const pas_heap_config* pas_heap_config_kind_for_config_table[];
 
-static inline pas_heap_config* pas_heap_config_kind_get_config(pas_heap_config_kind kind)
+static inline const pas_heap_config* pas_heap_config_kind_get_config(pas_heap_config_kind kind)
 {
     PAS_TESTING_ASSERT((unsigned)kind < (unsigned)pas_heap_config_kind_num_kinds);
     return pas_heap_config_kind_for_config_table[kind];

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
@@ -99,7 +99,7 @@ pas_heap_config_utils_allocate_aligned(
     size_t size,
     pas_alignment alignment,
     pas_large_heap* large_heap,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     bool should_zero)
 {
     static const bool verbose = false;
@@ -150,20 +150,20 @@ pas_heap_config_utils_allocate_aligned(
 }
 
 void* pas_heap_config_utils_prepare_to_enumerate(pas_enumerator* enumerator,
-                                                 pas_heap_config* my_config)
+                                                 const pas_heap_config* my_config)
 {
     pas_basic_heap_config_enumerator_data* result;
-    pas_heap_config** configs;
-    pas_heap_config* config;
+    const pas_heap_config** configs;
+    const pas_heap_config* config;
     pas_basic_heap_config_root_data* root_data;
 
     configs = pas_enumerator_read(
         enumerator, enumerator->root->heap_configs,
-        sizeof(pas_heap_config*) * pas_heap_config_kind_num_kinds);
+        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds);
     if (!configs)
         return NULL;
     
-    config = pas_enumerator_read(enumerator, configs[my_config->kind], sizeof(pas_heap_config));
+    config = pas_enumerator_read(enumerator, (void*)(uintptr_t)configs[my_config->kind], sizeof(pas_heap_config));
     if (!config)
         return NULL;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -448,7 +448,7 @@ typedef struct {
         size_t size, \
         pas_alignment alignment, \
         pas_large_heap* large_heap, \
-        pas_heap_config* config); \
+        const pas_heap_config* config); \
     PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(name ## _heap_config); \
     PAS_BASIC_HEAP_CONFIG_SEGREGATED_HEAP_DECLARATIONS(name, upcase_name)
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
@@ -40,11 +40,11 @@ pas_heap_config_utils_allocate_aligned(
     size_t size,
     pas_alignment alignment,
     pas_large_heap* large_heap,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     bool should_zero);
 
 PAS_API void* pas_heap_config_utils_prepare_to_enumerate(pas_enumerator* enumerator,
-                                                         pas_heap_config* config);
+                                                         const pas_heap_config* config);
 
 typedef struct {
     bool allocate_page_should_zero;
@@ -291,7 +291,7 @@ typedef struct {
         size_t size, \
         pas_alignment alignment, \
         pas_large_heap* large_heap, \
-        pas_heap_config* config) \
+        const pas_heap_config* config) \
     { \
         return pas_heap_config_utils_allocate_aligned( \
             size, alignment, large_heap, config, \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_for_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_for_config.c
@@ -36,7 +36,7 @@
 bool pas_heap_for_config_force_bootstrap = false;
 
 void* pas_heap_for_config_allocate(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     const char* name)
 {
@@ -63,7 +63,7 @@ void* pas_heap_for_page_config_kind_allocate(
 }
 
 void* pas_heap_for_page_config_allocate(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     const char* name)
 {
@@ -72,7 +72,7 @@ void* pas_heap_for_page_config_allocate(
 }
 
 void* pas_heap_for_config_allocate_with_alignment(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     size_t alignment,
     const char* name)
@@ -86,7 +86,7 @@ void* pas_heap_for_config_allocate_with_alignment(
 }
 
 void* pas_heap_for_page_config_allocate_with_alignment(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     size_t alignment,
     const char* name)
@@ -101,7 +101,7 @@ void* pas_heap_for_page_config_allocate_with_alignment(
 }
 
 void* pas_heap_for_config_allocate_with_manual_alignment(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     size_t alignment,
     const char* name)
@@ -131,7 +131,7 @@ void* pas_heap_for_page_config_kind_allocate_with_manual_alignment(
 }
 
 void* pas_heap_for_page_config_allocate_with_manual_alignment(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     size_t alignment,
     const char* name)
@@ -141,7 +141,7 @@ void* pas_heap_for_page_config_allocate_with_manual_alignment(
 }
 
 void pas_heap_for_config_deallocate(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     void* ptr,
     size_t size)
 {
@@ -169,7 +169,7 @@ void pas_heap_for_page_config_kind_deallocate(
 }
 
 void pas_heap_for_page_config_deallocate(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     void* ptr,
     size_t size)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_for_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_for_config.h
@@ -37,7 +37,7 @@ typedef struct pas_allocation_config pas_allocation_config;
 PAS_API extern bool pas_heap_for_config_force_bootstrap;
 
 PAS_API void* pas_heap_for_config_allocate(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     const char* name);
 
@@ -47,24 +47,24 @@ PAS_API void* pas_heap_for_page_config_kind_allocate(
     const char* name);
 
 PAS_API void* pas_heap_for_page_config_allocate(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     const char* name);
 
 PAS_API void* pas_heap_for_config_allocate_with_alignment(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     size_t alignment,
     const char* name);
 
 PAS_API void* pas_heap_for_page_config_allocate_with_alignment(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     size_t alignment,
     const char* name);
 
 PAS_API void* pas_heap_for_config_allocate_with_manual_alignment(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     size_t size,
     size_t alignment,
     const char* name);
@@ -76,13 +76,13 @@ PAS_API void* pas_heap_for_page_config_kind_allocate_with_manual_alignment(
     const char* name);
 
 PAS_API void* pas_heap_for_page_config_allocate_with_manual_alignment(
-    pas_segregated_page_config* page_config,
+    const pas_segregated_page_config* page_config,
     size_t size,
     size_t alignment,
     const char* name);
 
 PAS_API void pas_heap_for_config_deallocate(
-    pas_heap_config* config,
+    const pas_heap_config* config,
     void* ptr,
     size_t size);
 
@@ -92,7 +92,7 @@ PAS_API void pas_heap_for_page_config_kind_deallocate(
     size_t size);
 
 PAS_API void pas_heap_for_page_config_deallocate(
-    pas_segregated_page_config* config,
+    const pas_segregated_page_config* config,
     void* ptr,
     size_t size);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h
@@ -40,7 +40,7 @@ pas_heap_ensure_size_directory_for_size_slow(
     size_t size,
     size_t alignment,
     pas_size_lookup_mode force_size_lookup,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index);
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_ref.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_ref.c
@@ -36,7 +36,7 @@
 
 pas_heap* pas_ensure_heap_slow(pas_heap_ref* heap_ref,
                                pas_heap_ref_kind heap_ref_kind,
-                               pas_heap_config* config,
+                               const pas_heap_config* config,
                                pas_heap_runtime_config* runtime_config)
 {
     pas_heap* heap;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_ref.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_ref.h
@@ -51,12 +51,12 @@ typedef struct pas_heap_runtime_config pas_heap_runtime_config;
 
 PAS_API pas_heap* pas_ensure_heap_slow(pas_heap_ref* heap_ref,
                                        pas_heap_ref_kind heap_ref_kind,
-                                       pas_heap_config* config,
+                                       const pas_heap_config* config,
                                        pas_heap_runtime_config* runtime_config);
 
 static inline pas_heap* pas_ensure_heap(pas_heap_ref* heap_ref,
                                         pas_heap_ref_kind heap_ref_kind,
-                                        pas_heap_config* config,
+                                        const pas_heap_config* config,
                                         pas_heap_runtime_config* runtime_config)
 {
     pas_heap* heap = heap_ref->heap;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.c
@@ -34,7 +34,7 @@
 uint8_t pas_heap_runtime_config_view_cache_capacity_for_object_size(
     pas_heap_runtime_config* config,
     size_t object_size,
-    pas_segregated_page_config* page_config)
+    const pas_segregated_page_config* page_config)
 {
     size_t result;
 
@@ -45,7 +45,7 @@ uint8_t pas_heap_runtime_config_view_cache_capacity_for_object_size(
 }
 
 size_t pas_heap_runtime_config_zero_view_cache_capacity(
-    size_t object_size, pas_segregated_page_config* page_config)
+    size_t object_size, const pas_segregated_page_config* page_config)
 {
     PAS_UNUSED_PARAM(object_size);
     PAS_UNUSED_PARAM(page_config);
@@ -53,7 +53,7 @@ size_t pas_heap_runtime_config_zero_view_cache_capacity(
 }
 
 size_t pas_heap_runtime_config_aggressive_view_cache_capacity(
-    size_t object_size, pas_segregated_page_config* page_config)
+    size_t object_size, const pas_segregated_page_config* page_config)
 {
     static const size_t cache_size = 1638400;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.h
@@ -39,7 +39,7 @@ typedef struct pas_heap_runtime_config pas_heap_runtime_config;
 typedef struct pas_segregated_page_config pas_segregated_page_config;
 
 typedef size_t (*pas_heap_runtime_config_view_cache_capacity_for_object_size_callback)(
-    size_t object_size, pas_segregated_page_config* page_config);
+    size_t object_size, const pas_segregated_page_config* page_config);
 
 struct pas_heap_runtime_config {
     pas_segregated_heap_lookup_kind lookup_kind : 8;
@@ -62,15 +62,15 @@ struct pas_heap_runtime_config {
 PAS_API uint8_t pas_heap_runtime_config_view_cache_capacity_for_object_size(
     pas_heap_runtime_config* config,
     size_t object_size,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_API size_t pas_heap_runtime_config_zero_view_cache_capacity(
     size_t object_size,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_API size_t pas_heap_runtime_config_aggressive_view_cache_capacity(
     size_t object_size,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -54,7 +54,7 @@ void pas_large_heap_construct(pas_large_heap* heap)
 typedef struct {
     pas_heap_config_aligned_allocator aligned_allocator;
     pas_large_heap* heap;
-    pas_heap_config* config;
+    const pas_heap_config* config;
 } aligned_allocator_data;
 
 static pas_aligned_allocation_result aligned_allocator(size_t size,
@@ -73,7 +73,7 @@ static pas_aligned_allocation_result aligned_allocator(size_t size,
 static void initialize_config(pas_large_free_heap_config* config,
                               aligned_allocator_data* data,
                               pas_large_heap* heap,
-                              pas_heap_config* heap_config)
+                              const pas_heap_config* heap_config)
 {
     if (data) {
         data->aligned_allocator = heap_config->aligned_allocator;
@@ -92,7 +92,7 @@ static void initialize_config(pas_large_free_heap_config* config,
 static pas_allocation_result allocate_impl(pas_large_heap* heap,
                                            size_t* size,
                                            size_t* alignment,
-                                           pas_heap_config* heap_config,
+                                           const pas_heap_config* heap_config,
                                            pas_physical_memory_transaction* transaction)
 {
     static const bool verbose = false;
@@ -156,7 +156,7 @@ pas_allocation_result
 pas_large_heap_try_allocate_and_forget(pas_large_heap* heap,
                                        size_t size,
                                        size_t alignment,
-                                       pas_heap_config* heap_config,
+                                       const pas_heap_config* heap_config,
                                        pas_physical_memory_transaction* transaction)
 {
     return allocate_impl(heap, &size, &alignment, heap_config, transaction);
@@ -166,7 +166,7 @@ pas_allocation_result
 pas_large_heap_try_allocate(pas_large_heap* heap,
                             size_t size,
                             size_t alignment,
-                            pas_heap_config* heap_config,
+                            const pas_heap_config* heap_config,
                             pas_physical_memory_transaction* transaction)
 {
     pas_allocation_result result;
@@ -189,7 +189,7 @@ pas_allocation_result
 pas_large_heap_try_allocate_pgm(pas_large_heap* heap,
                             size_t size,
                             size_t alignment,
-                            pas_heap_config* heap_config,
+                            const pas_heap_config* heap_config,
                             pas_physical_memory_transaction* transaction)
 {
     pas_allocation_result result;
@@ -204,7 +204,7 @@ pas_large_heap_try_allocate_pgm(pas_large_heap* heap,
 }
 
 bool pas_large_heap_try_deallocate(uintptr_t begin,
-                                   pas_heap_config* heap_config)
+                                   const pas_heap_config* heap_config)
 {
     pas_large_map_entry map_entry;
     pas_large_free_heap_config config;
@@ -239,7 +239,7 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
 
 bool pas_large_heap_try_shrink(uintptr_t begin,
                                size_t new_size,
-                               pas_heap_config* heap_config)
+                               const pas_heap_config* heap_config)
 {
     /* FIXME: This doesn't play nice with enumeration. I think that's fine for now because shrink()
        isn't a real malloc API. But it would be possible to make this work well with enumeration if
@@ -297,7 +297,7 @@ void pas_large_heap_shove_into_free(pas_large_heap* heap,
                                     uintptr_t begin,
                                     uintptr_t end,
                                     pas_zero_mode zero_mode,
-                                    pas_heap_config* heap_config)
+                                    const pas_heap_config* heap_config)
 {
     pas_large_free_heap_config config;
     initialize_config(&config, NULL, heap, heap_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
@@ -53,36 +53,36 @@ PAS_API void pas_large_heap_construct(pas_large_heap* heap);
 PAS_API pas_allocation_result
 pas_large_heap_try_allocate_and_forget(pas_large_heap* heap,
                                        size_t size, size_t alignment,
-                                       pas_heap_config* config,
+                                       const pas_heap_config* config,
                                        pas_physical_memory_transaction* transaction);
 
 PAS_API pas_allocation_result
 pas_large_heap_try_allocate(pas_large_heap* heap,
                             size_t size, size_t alignment,
-                            pas_heap_config* config,
+                            const pas_heap_config* config,
                             pas_physical_memory_transaction* transaction);
 
 PAS_API pas_allocation_result
 pas_large_heap_try_allocate_pgm(pas_large_heap* heap,
                             size_t size, size_t alignment,
-                            pas_heap_config* config,
+                            const pas_heap_config* config,
                             pas_physical_memory_transaction* transaction);
 
 /* Returns true if an object was found and deallocated. */
 PAS_API bool pas_large_heap_try_deallocate(uintptr_t base,
-                                           pas_heap_config* config);
+                                           const pas_heap_config* config);
 
 /* Returns true if an object was found and shrunk. */
 PAS_API bool pas_large_heap_try_shrink(uintptr_t base,
                                        size_t new_size,
-                                       pas_heap_config* config);
+                                       const pas_heap_config* config);
 
 /* This is a super crazy function that lets you shove memory into the allocator. There is
    one user (the large region) and it only does it to one heap (the primitive heap). It's
    not something you probably ever want to do. */
 PAS_API void pas_large_heap_shove_into_free(pas_large_heap* heap, uintptr_t begin, uintptr_t end,
                                             pas_zero_mode zero_mode,
-                                            pas_heap_config* config);
+                                            const pas_heap_config* config);
 
 typedef bool (*pas_large_heap_for_each_live_object_callback)(pas_large_heap* heap,
                                                              uintptr_t begin,

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
@@ -41,7 +41,7 @@ pas_enumerable_range_list pas_large_heap_physical_page_sharing_cache_page_list;
 
 typedef struct {
     pas_large_heap_physical_page_sharing_cache* cache;
-    pas_heap_config* config;
+    const pas_heap_config* config;
     bool should_zero;
 } aligned_allocator_data;
 
@@ -161,7 +161,7 @@ pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
     pas_large_heap_physical_page_sharing_cache* cache,
     size_t size,
     pas_alignment alignment,
-    pas_heap_config* heap_config,
+    const pas_heap_config* heap_config,
     bool should_zero)
 {
     static const bool verbose = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
@@ -66,7 +66,7 @@ pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment(
     pas_large_heap_physical_page_sharing_cache* cache,
     size_t size,
     pas_alignment alignment,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     bool should_zero);
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1685,7 +1685,7 @@ pas_local_allocator_try_allocate_slow_impl(pas_local_allocator* allocator,
     for (;;) {
         pas_fast_path_allocation_result fast_result;
         pas_allocation_result result;
-        pas_segregated_page_config* page_config;
+        const pas_segregated_page_config* page_config;
 
         fast_result = pas_local_allocator_try_allocate_out_of_line_cases(
             allocator, size, alignment, config);

--- a/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c
@@ -36,7 +36,7 @@
 
 void* pas_medium_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
-    pas_page_base_config* config,
+    const pas_page_base_config* config,
     bool should_zero,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction)

--- a/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h
@@ -42,7 +42,7 @@ typedef struct pas_physical_memory_transaction pas_physical_memory_transaction;
    base on the allocation. This is guaranteed to returned zeroed memory. */
 PAS_API void* pas_medium_megapage_cache_try_allocate(
     pas_megapage_cache* cache,
-    pas_page_base_config* config,
+    const pas_page_base_config* config,
     bool should_zero,
     pas_heap* heap,
     pas_physical_memory_transaction* transaction);

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base.c
@@ -32,7 +32,7 @@
 #include "pas_bitfit_page.h"
 #include "pas_segregated_page.h"
 
-size_t pas_page_base_header_size(pas_page_base_config* config,
+size_t pas_page_base_header_size(const pas_page_base_config* config,
                                  pas_page_kind page_kind)
 {
     switch (config->page_config_kind) {
@@ -49,7 +49,7 @@ size_t pas_page_base_header_size(pas_page_base_config* config,
     return 0;
 }
 
-pas_page_base_config* pas_page_base_get_config(pas_page_base* page)
+const pas_page_base_config* pas_page_base_get_config(pas_page_base* page)
 {
     switch (pas_page_base_get_config_kind(page)) {
     case pas_page_config_kind_segregated:
@@ -87,7 +87,7 @@ void pas_page_base_compute_committed_when_owned(pas_page_base* page,
     pas_page_granule_use_count* use_counts;
     uintptr_t num_granules;
     uintptr_t granule_index;
-    pas_page_base_config* config_ptr;
+    const pas_page_base_config* config_ptr;
     pas_page_base_config config;
 
     config_ptr = pas_page_base_get_config(page);
@@ -126,7 +126,7 @@ void pas_page_base_add_free_range(pas_page_base* page,
                                   pas_range range,
                                   pas_free_range_kind kind)
 {
-    pas_page_base_config* page_config_ptr;
+    const pas_page_base_config* page_config_ptr;
     pas_page_base_config page_config;
     size_t* ineligible_for_decommit;
     size_t* eligible_for_decommit;

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base.h
@@ -60,7 +60,7 @@ struct pas_page_base {
                           basically any reason. */
 };
 
-PAS_API size_t pas_page_base_header_size(pas_page_base_config* config,
+PAS_API size_t pas_page_base_header_size(const pas_page_base_config* config,
                                          pas_page_kind page_kind);
 
 static inline void pas_page_base_construct(pas_page_base* page_base,
@@ -167,7 +167,7 @@ pas_page_base_for_address_and_page_config(uintptr_t begin,
         page_config);
 }
 
-PAS_API pas_page_base_config* pas_page_base_get_config(pas_page_base* page);
+PAS_API const pas_page_base_config* pas_page_base_get_config(pas_page_base* page);
 
 PAS_API pas_page_granule_use_count*
 pas_page_base_get_granule_use_counts(pas_page_base* page);

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config.c
@@ -34,7 +34,7 @@
 
 PAS_BEGIN_EXTERN_C;
 
-const char* pas_page_base_config_get_kind_string(pas_page_base_config* config)
+const char* pas_page_base_config_get_kind_string(const pas_page_base_config* config)
 {
     switch (config->page_config_kind) {
     case pas_page_config_kind_segregated:

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
@@ -65,10 +65,10 @@ struct pas_page_base_config {
     bool is_enabled;
 
     /* This points to the owning heap config. Currently there is always an owning heap config. */
-    pas_heap_config* heap_config_ptr;
+    const pas_heap_config* heap_config_ptr;
     
     /* This always self-points. It's useful for going from a page_config to a page_config_ptr. */
-    pas_page_base_config* page_config_ptr;
+    const pas_page_base_config* page_config_ptr;
 
     /* What page_kind to put in pages allocated by this config. This happens to tell if the config
        is a segregated or a bitfit config. */
@@ -126,21 +126,21 @@ static PAS_ALWAYS_INLINE bool pas_page_base_config_is_bitfit(pas_page_base_confi
     return config.page_config_kind == pas_page_config_kind_bitfit;
 }
 
-static inline pas_segregated_page_config*
-pas_page_base_config_get_segregated(pas_page_base_config* config)
+static inline const pas_segregated_page_config*
+pas_page_base_config_get_segregated(const pas_page_base_config* config)
 {
     PAS_ASSERT(pas_page_base_config_is_segregated(*config));
-    return (pas_segregated_page_config*)config;
+    return (const pas_segregated_page_config*)config;
 }
 
-static inline pas_bitfit_page_config*
-pas_page_base_config_get_bitfit(pas_page_base_config* config)
+static inline const pas_bitfit_page_config*
+pas_page_base_config_get_bitfit(const pas_page_base_config* config)
 {
     PAS_ASSERT(pas_page_base_config_is_bitfit(*config));
-    return (pas_bitfit_page_config*)config;
+    return (const pas_bitfit_page_config*)config;
 }
 
-PAS_API const char* pas_page_base_config_get_kind_string(pas_page_base_config* config);
+PAS_API const char* pas_page_base_config_get_kind_string(const pas_page_base_config* config);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_inlines.h
@@ -30,7 +30,7 @@
 
 PAS_BEGIN_EXTERN_C;
 
-static inline bool pas_page_base_config_is_utility(pas_page_base_config* config)
+static inline bool pas_page_base_config_is_utility(const pas_page_base_config* config)
 {
     return pas_page_base_config_is_segregated(*config)
         && pas_segregated_page_config_is_utility(*pas_page_base_config_get_segregated(config));

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c
@@ -839,7 +839,7 @@ void pas_physical_page_sharing_pool_give_back(size_t bytes)
 
 void pas_physical_page_sharing_pool_take_for_page_config(
     size_t bytes,
-    pas_page_base_config* page_config,
+    const pas_page_base_config* page_config,
     pas_lock_hold_mode heap_lock_hold_mode,
     pas_lock** locks_already_held,
     size_t num_locks_already_held)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
@@ -159,7 +159,7 @@ PAS_API void pas_physical_page_sharing_pool_give_back(size_t bytes);
 
 PAS_API void pas_physical_page_sharing_pool_take_for_page_config(
     size_t bytes,
-    pas_page_base_config* page_config,
+    const pas_page_base_config* page_config,
     pas_lock_hold_mode heap_lock_hold_mode,
     pas_lock** locks_already_held,
     size_t num_locks_already_held);

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -58,7 +58,7 @@ static void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas
 #pragma mark ALLOC/DEALLOC
 #endif
 
-pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, pas_heap_config* heap_config,
+pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, const pas_heap_config* heap_config,
                                                               pas_physical_memory_transaction* transaction)
 {
     pas_heap_lock_assert_held();

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -61,7 +61,7 @@ struct pas_pgm_storage {
  * so just update this variable each time we allocate or deallocate. */
 extern PAS_API bool pas_pgm_can_use;
 
-pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
+pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
 void pas_probabilistic_guard_malloc_deallocate(void* memory);
 
 size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void);

--- a/Source/bmalloc/libpas/src/libpas/pas_promote_intrinsic_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_promote_intrinsic_heap.h
@@ -36,7 +36,7 @@ typedef struct pas_heap_config pas_heap_config;
 typedef struct pas_segregated_heap pas_segregated_heap;
 
 PAS_API void pas_promote_intrinsic_heap(pas_segregated_heap* heap,
-                                        pas_heap_config* config);
+                                        const pas_heap_config* config);
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -126,7 +126,7 @@ void pas_root_construct(pas_root* root)
         &pas_tiny_large_map_second_level_hashtable_in_flux_stash_instance;
 
     root->heap_configs = pas_immortal_heap_allocate(
-        sizeof(pas_heap_config*) * pas_heap_config_kind_num_kinds,
+        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds,
         "pas_root/heap_configs",
         pas_object_allocation);
     for (PAS_EACH_HEAP_CONFIG_KIND(config_kind))

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -88,7 +88,7 @@ struct pas_root {
     pas_tiny_large_map_hashtable* tiny_large_map_hashtable_instance;
     pas_tiny_large_map_hashtable_in_flux_stash* tiny_large_map_hashtable_instance_in_flux_stash;
     pas_tiny_large_map_second_level_hashtable_in_flux_stash* tiny_large_map_second_level_hashtable_in_flux_stash_instance;
-    pas_heap_config** heap_configs;
+    const pas_heap_config** heap_configs;
     unsigned num_heap_configs;
     pas_red_black_tree* large_sharing_tree;
     pas_red_black_tree_jettisoned_nodes* large_sharing_tree_jettisoned_nodes;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
@@ -429,7 +429,7 @@ void pas_segregated_directory_append(
 pas_heap_summary pas_segregated_directory_compute_summary(pas_segregated_directory* directory)
 {
     pas_heap_summary result;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     size_t index;
 
     page_config_ptr = pas_segregated_page_config_kind_get_config(directory->page_config_kind);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c
@@ -93,7 +93,7 @@ static pas_heap_summary compute_summary_impl(pas_segregated_exclusive_view* view
 {
     pas_segregated_size_directory* size_directory;
     pas_segregated_directory* directory;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_heap_summary result;
     void* boundary;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -48,17 +48,17 @@
 unsigned pas_segregated_heap_num_size_lookup_rematerializations;
 
 static void check_size_lookup_recomputation_if_appropriate(pas_segregated_heap* heap,
-                                                           pas_heap_config* config,
+                                                           const pas_heap_config* config,
                                                            unsigned *cached_index,
                                                            const char* where);
 
 static size_t min_align_for_heap(pas_segregated_heap* heap,
-                                 pas_heap_config* config)
+                                 const pas_heap_config* config)
 {
     pas_segregated_page_config_variant segregated_variant;
     pas_bitfit_page_config_variant bitfit_variant;
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_ASCENDING(segregated_variant)) {
-        pas_segregated_page_config* page_config;
+        const pas_segregated_page_config* page_config;
         page_config =
             pas_heap_config_segregated_page_config_ptr_for_variant(config, segregated_variant);
         if (!pas_segregated_page_config_is_enabled(*page_config, heap->runtime_config))
@@ -68,7 +68,7 @@ static size_t min_align_for_heap(pas_segregated_heap* heap,
     /* If segregated page configs are totally disabled then we want to give the minimum size according
        to bitfit. */
     for (PAS_EACH_BITFIT_PAGE_CONFIG_VARIANT_ASCENDING(bitfit_variant)) {
-        pas_bitfit_page_config* page_config;
+        const pas_bitfit_page_config* page_config;
         page_config =
             pas_heap_config_bitfit_page_config_ptr_for_variant(config, bitfit_variant);
         if (!pas_bitfit_page_config_is_enabled(*page_config, heap->runtime_config))
@@ -81,13 +81,13 @@ static size_t min_align_for_heap(pas_segregated_heap* heap,
 }
 
 static size_t min_object_size_for_heap(pas_segregated_heap* heap,
-                                       pas_heap_config* config)
+                                       const pas_heap_config* config)
 {
     return min_align_for_heap(heap, config);
 }
 
 static size_t max_object_size_for_page_config(pas_heap* parent_heap,
-                                              pas_page_base_config* page_config)
+                                              const pas_page_base_config* page_config)
 {
     static const bool verbose = false;
     
@@ -107,13 +107,13 @@ static size_t max_object_size_for_page_config(pas_heap* parent_heap,
 
 static size_t max_segregated_object_size_for_heap(pas_heap* parent_heap,
                                                   pas_segregated_heap* heap,
-                                                  pas_heap_config* config)
+                                                  const pas_heap_config* config)
 {
     static const bool verbose = false;
     
     pas_segregated_page_config_variant variant;
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_DESCENDING(variant)) {
-        pas_segregated_page_config* page_config;
+        const pas_segregated_page_config* page_config;
         size_t max_size_per_config;
         size_t result;
         
@@ -134,14 +134,14 @@ static size_t max_segregated_object_size_for_heap(pas_heap* parent_heap,
 
 static size_t max_bitfit_object_size_for_heap(pas_heap* parent_heap,
                                               pas_segregated_heap* heap,
-                                              pas_heap_config* config)
+                                              const pas_heap_config* config)
 {
     static const bool verbose = false;
     
     pas_bitfit_page_config_variant variant;
     
     for (PAS_EACH_BITFIT_PAGE_CONFIG_VARIANT_DESCENDING(variant)) {
-        pas_bitfit_page_config* page_config;
+        const pas_bitfit_page_config* page_config;
         size_t max_size_per_config;
         size_t result;
         
@@ -191,7 +191,7 @@ static size_t max_bitfit_object_size_for_heap(pas_heap* parent_heap,
 
 static size_t max_object_size_for_heap(pas_heap* parent_heap,
                                        pas_segregated_heap* heap,
-                                       pas_heap_config* config)
+                                       const pas_heap_config* config)
 {
     return PAS_MAX(max_segregated_object_size_for_heap(parent_heap, heap, config),
                    max_bitfit_object_size_for_heap(parent_heap, heap, config));
@@ -199,7 +199,7 @@ static size_t max_object_size_for_heap(pas_heap* parent_heap,
 
 void pas_segregated_heap_construct(pas_segregated_heap* segregated_heap,
                                    pas_heap* parent_heap,
-                                   pas_heap_config* config,
+                                   const pas_heap_config* config,
                                    pas_heap_runtime_config* runtime_config)
 {
     /* NOTE: the various primitive and utility heaps are constructed
@@ -229,7 +229,7 @@ void pas_segregated_heap_construct(pas_segregated_heap* segregated_heap,
 }
 
 pas_bitfit_heap* pas_segregated_heap_get_bitfit(pas_segregated_heap* heap,
-                                                pas_heap_config* heap_config,
+                                                const pas_heap_config* heap_config,
                                                 pas_lock_hold_mode heap_lock_hold_mode)
 {
     /* NOTE: This will never get called for utility heaps and we have no good way to assert this:
@@ -253,7 +253,7 @@ pas_bitfit_heap* pas_segregated_heap_get_bitfit(pas_segregated_heap* heap,
 }
 
 size_t pas_segregated_heap_get_cached_index_for_heap_type(pas_segregated_heap* heap,
-                                                          pas_heap_config* config)
+                                                          const pas_heap_config* config)
 {
     return pas_segregated_heap_index_for_size(
         pas_heap_get_type_size(pas_heap_for_segregated_heap(heap)), *config);
@@ -268,7 +268,7 @@ bool pas_segregated_heap_cached_index_is_set(unsigned* cached_index)
 
 size_t pas_segregated_heap_get_cached_index(pas_segregated_heap* heap,
                                             unsigned* cached_index,
-                                            pas_heap_config* config)
+                                            const pas_heap_config* config)
 {
     if (cached_index)
         return *cached_index;
@@ -278,7 +278,7 @@ size_t pas_segregated_heap_get_cached_index(pas_segregated_heap* heap,
 bool pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                        unsigned* cached_index,
                                                                        size_t index,
-                                                                       pas_heap_config* config)
+                                                                       const pas_heap_config* config)
 {
     return pas_segregated_heap_cached_index_is_set(cached_index)
         && index == pas_segregated_heap_get_cached_index(heap, cached_index, config);
@@ -287,7 +287,7 @@ bool pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(pas_segre
 bool pas_segregated_heap_index_is_cached_index_or_cached_index_is_unset(pas_segregated_heap* heap,
                                                                         unsigned* cached_index,
                                                                         size_t index,
-                                                                        pas_heap_config* config)
+                                                                        const pas_heap_config* config)
 {
     return !pas_segregated_heap_cached_index_is_set(cached_index)
         || index == pas_segregated_heap_get_cached_index(heap, cached_index, config);
@@ -296,7 +296,7 @@ bool pas_segregated_heap_index_is_cached_index_or_cached_index_is_unset(pas_segr
 bool pas_segregated_heap_index_is_not_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                            unsigned* cached_index,
                                                                            size_t index,
-                                                                           pas_heap_config* config)
+                                                                           const pas_heap_config* config)
 {
     return pas_segregated_heap_cached_index_is_set(cached_index)
         && index != pas_segregated_heap_get_cached_index(heap, cached_index, config);
@@ -305,7 +305,7 @@ bool pas_segregated_heap_index_is_not_cached_index_and_cached_index_is_set(pas_s
 bool pas_segregated_heap_index_is_greater_than_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                                     unsigned* cached_index,
                                                                                     size_t index,
-                                                                                    pas_heap_config* config)
+                                                                                    const pas_heap_config* config)
 {
     return pas_segregated_heap_cached_index_is_set(cached_index)
         && index > pas_segregated_heap_get_cached_index(heap, cached_index, config);
@@ -314,7 +314,7 @@ bool pas_segregated_heap_index_is_greater_than_cached_index_and_cached_index_is_
 bool pas_segregated_heap_index_is_greater_equal_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                                      unsigned* cached_index,
                                                                                      size_t index,
-                                                                                     pas_heap_config* config)
+                                                                                     const pas_heap_config* config)
 {
     return pas_segregated_heap_cached_index_is_set(cached_index)
         && index >= pas_segregated_heap_get_cached_index(heap, cached_index, config);
@@ -324,7 +324,7 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    pas_heap_config* config)
+    const pas_heap_config* config)
 {
     if (pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(heap, cached_index, index, config)) {
         pas_segregated_size_directory* result;
@@ -553,7 +553,7 @@ pas_segregated_size_directory* pas_segregated_heap_medium_size_directory_for_ind
 }
 
 static size_t compute_small_index_upper_bound(pas_segregated_heap* heap,
-                                              pas_heap_config* config)
+                                              const pas_heap_config* config)
 {
     if (heap->small_index_upper_bound) {
         /* This is important: some clients, like the intrinsic_heap, will initialize
@@ -565,7 +565,7 @@ static size_t compute_small_index_upper_bound(pas_segregated_heap* heap,
 }
 
 static void ensure_size_lookup(pas_segregated_heap* heap,
-                               pas_heap_config* config)
+                               const pas_heap_config* config)
 {
     static const bool verbose = false;
     
@@ -646,7 +646,7 @@ PAS_CREATE_MIN_HEAP(size_directory_min_heap, pas_segregated_size_directory*, 200
 /* NOTE: It's possible for this to call set_index_to_small_allocator_index for values of index that previously
    didn't have an allocator_index set. */
 static void recompute_size_lookup(pas_segregated_heap* heap,
-                                  pas_heap_config* config,
+                                  const pas_heap_config* config,
                                   unsigned* cached_index,
                                   void (*set_index_to_small_allocator_index)(
                                       size_t index, pas_allocator_index value, void* arg),
@@ -798,7 +798,7 @@ static void rematerialize_size_lookup_set_medium_directory_tuple(
 }
 
 static void rematerialize_size_lookup_if_necessary(pas_segregated_heap* heap,
-                                                   pas_heap_config* config,
+                                                   const pas_heap_config* config,
                                                    unsigned* cached_index)
 {
     pas_segregated_heap_rare_data* data;
@@ -832,7 +832,7 @@ pas_segregated_heap_ensure_allocator_index(
     pas_segregated_size_directory* directory,
     size_t size,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index)
 {
     static const bool verbose = false;
@@ -923,7 +923,7 @@ pas_segregated_heap_ensure_allocator_index(
 static size_t compute_ideal_object_size(pas_segregated_heap* heap,
                                         size_t object_size,
                                         size_t alignment,
-                                        pas_segregated_page_config* page_config_ptr)
+                                        const pas_segregated_page_config* page_config_ptr)
 {
     static const bool verbose = false;
     
@@ -1026,7 +1026,7 @@ static bool check_part_of_all_heaps_callback(pas_heap* heap, void* arg)
 }
 
 static bool check_part_of_all_segregated_heaps_callback(
-    pas_segregated_heap* heap, pas_heap_config* config, void* arg)
+    pas_segregated_heap* heap, const pas_heap_config* config, void* arg)
 {
     check_part_of_all_heaps_data* data;
 
@@ -1045,7 +1045,7 @@ static bool check_part_of_all_segregated_heaps_callback(
 static void
 ensure_size_lookup_if_necessary(pas_segregated_heap* heap,
                                 pas_size_lookup_mode size_lookup_mode,
-                                pas_heap_config* config,
+                                const pas_heap_config* config,
                                 unsigned* cached_index,
                                 size_t index)
 {
@@ -1208,7 +1208,7 @@ static bool check_size_lookup_recomputation_dump_directory(pas_segregated_heap* 
 }
 
 static void check_size_lookup_recomputation(pas_segregated_heap* heap,
-                                            pas_heap_config* config,
+                                            const pas_heap_config* config,
                                             unsigned *cached_index,
                                             const char* where)
 {
@@ -1295,7 +1295,7 @@ static void check_size_lookup_recomputation(pas_segregated_heap* heap,
 }
 
 static void check_size_lookup_recomputation_if_appropriate(pas_segregated_heap* heap,
-                                                           pas_heap_config* config,
+                                                           const pas_heap_config* config,
                                                            unsigned *cached_index,
                                                            const char* where)
 {
@@ -1312,7 +1312,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
     size_t size,
     size_t alignment,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index,
     pas_segregated_size_directory_creation_mode creation_mode)
 {
@@ -1655,7 +1655,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
         size_t medium_install_index;
         size_t medium_install_size;
         double best_bytes_dirtied_per_object;
-        pas_segregated_page_config* best_page_config;
+        const pas_segregated_page_config* best_page_config;
         pas_segregated_page_config_variant variant;
         pas_compact_atomic_segregated_size_directory_ptr* index_to_small_size_directory;
         pas_segregated_size_directory* basic_size_directory_and_head;
@@ -1710,7 +1710,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
         best_page_config = NULL;
         if (object_size <= heap->runtime_config->max_segregated_object_size) {
             for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_DESCENDING(variant)) {
-                pas_segregated_page_config* page_config_ptr;
+                const pas_segregated_page_config* page_config_ptr;
                 pas_segregated_page_config page_config;
                 double bytes_dirtied_per_object;
                 unsigned object_size_for_config;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h
@@ -145,11 +145,11 @@ PAS_API extern unsigned pas_segregated_heap_num_size_lookup_rematerializations;
    segregated_heap will assume type_size == 1. */
 PAS_API void pas_segregated_heap_construct(pas_segregated_heap* segregated_heap,
                                            pas_heap* parent_heap,
-                                           pas_heap_config* config,
+                                           const pas_heap_config* config,
                                            pas_heap_runtime_config* runtime_config);
 
 PAS_API pas_bitfit_heap* pas_segregated_heap_get_bitfit(pas_segregated_heap* heap,
-                                                        pas_heap_config* heap_config,
+                                                        const pas_heap_config* heap_config,
                                                         pas_lock_hold_mode heap_lock_hold_mode);
 
 static PAS_ALWAYS_INLINE size_t
@@ -176,33 +176,33 @@ pas_segregated_heap_size_for_index(size_t index, pas_heap_config config)
    2) cached_index is set and matches the index.
    3) cached_index is set and does not match the index. */
 PAS_API size_t pas_segregated_heap_get_cached_index_for_heap_type(pas_segregated_heap* heap,
-                                                                  pas_heap_config* config);
+                                                                  const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_cached_index_is_set(unsigned* cached_index);
 PAS_API size_t pas_segregated_heap_get_cached_index(pas_segregated_heap* heap,
                                                     unsigned* cached_index,
-                                                    pas_heap_config* config);
+                                                    const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                                unsigned* cached_index,
                                                                                size_t index,
-                                                                               pas_heap_config* config);
+                                                                               const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_index_is_cached_index_or_cached_index_is_unset(pas_segregated_heap* heap,
                                                                                 unsigned* cached_index,
                                                                                 size_t index,
-                                                                                pas_heap_config* config);
+                                                                                const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_index_is_not_cached_index_and_cached_index_is_set(pas_segregated_heap* heap,
                                                                                    unsigned* cached_index,
                                                                                    size_t index,
-                                                                                   pas_heap_config* config);
+                                                                                   const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_index_is_greater_than_cached_index_and_cached_index_is_set(
     pas_segregated_heap* heap,
     unsigned* cached_index,
     size_t index,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 PAS_API bool pas_segregated_heap_index_is_greater_equal_cached_index_and_cached_index_is_set(
     pas_segregated_heap* heap,
     unsigned* cached_index,
     size_t index,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 
 PAS_API pas_segregated_heap_medium_directory_tuple*
 pas_segregated_heap_medium_directory_tuple_for_index(
@@ -291,7 +291,7 @@ pas_segregated_heap_ensure_allocator_index(
     pas_segregated_size_directory* directory,
     size_t size,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index);
 
 /* This may return UINT_MAX if it determines that the wasteage from allocating this size with
@@ -319,7 +319,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
     pas_segregated_heap* heap,
     size_t size, size_t alignment,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index,
     pas_segregated_size_directory_creation_mode creation_mode);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
@@ -37,14 +37,14 @@ PAS_API pas_segregated_size_directory* pas_segregated_heap_size_directory_for_in
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*
 pas_segregated_heap_size_directory_for_index(
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    pas_heap_config* config)
+    const pas_heap_config* config)
 {
     pas_compact_atomic_segregated_size_directory_ptr* index_to_size_directory;
     pas_segregated_size_directory* result;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
@@ -191,7 +191,7 @@ void pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl(
 void pas_segregated_page_construct(pas_segregated_page* page,
                                    pas_segregated_view owner,
                                    bool was_stolen,
-                                   pas_segregated_page_config* page_config_ptr)
+                                   const pas_segregated_page_config* page_config_ptr)
 {
     static const bool verbose = false;
     
@@ -325,7 +325,7 @@ bool pas_segregated_page_take_empty_granules(
     
     pas_page_granule_use_count* use_counts;
     pas_segregated_view owner;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     uintptr_t num_granules;
     char* boundary;
@@ -422,7 +422,7 @@ void pas_segregated_page_commit_fully(
 {
     static const bool verbose = false;
     
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_page_granule_use_count* use_counts;
     uintptr_t num_granules;
@@ -649,7 +649,7 @@ void pas_segregated_page_deallocation_did_fail(uintptr_t begin)
 
 size_t pas_segregated_page_get_num_empty_granules(pas_segregated_page* page)
 {
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     size_t result;
     
@@ -677,7 +677,7 @@ size_t pas_segregated_page_get_num_empty_granules(pas_segregated_page* page)
 
 size_t pas_segregated_page_get_num_committed_granules(pas_segregated_page* page)
 {
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     size_t result;
     pas_page_granule_use_count* use_counts;
@@ -702,7 +702,7 @@ size_t pas_segregated_page_get_num_committed_granules(pas_segregated_page* page)
     return result;
 }
 
-pas_segregated_page_config* pas_segregated_page_get_config(pas_segregated_page* page)
+const pas_segregated_page_config* pas_segregated_page_get_config(pas_segregated_page* page)
 {
     return pas_segregated_view_get_page_config(page->owner);
 }
@@ -711,7 +711,7 @@ void pas_segregated_page_add_commit_range(pas_segregated_page* page,
                                           pas_heap_summary* result,
                                           pas_range range)
 {
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_page_granule_use_count* use_counts;
     uintptr_t first_granule_index;
@@ -762,7 +762,7 @@ void pas_segregated_page_add_commit_range(pas_segregated_page* page,
 
 pas_segregated_page_and_config
 pas_segregated_page_and_config_for_address_and_heap_config(uintptr_t begin,
-                                                           pas_heap_config* config)
+                                                           const pas_heap_config* config)
 {
     switch (config->fast_megapage_kind_func(begin)) {
     case pas_small_exclusive_segregated_fast_megapage_kind:

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.h
@@ -296,7 +296,7 @@ pas_segregated_page_bytes_dirtied_per_object(unsigned object_size,
 PAS_API void pas_segregated_page_construct(pas_segregated_page* page,
                                            pas_segregated_view owner,
                                            bool was_stolen,
-                                           pas_segregated_page_config* page_config);
+                                           const pas_segregated_page_config* page_config);
 
 static PAS_ALWAYS_INLINE pas_page_granule_use_count*
 pas_segregated_page_get_granule_use_counts(pas_segregated_page* page,
@@ -443,7 +443,7 @@ PAS_API bool pas_segregated_page_take_physically(
 PAS_API size_t pas_segregated_page_get_num_empty_granules(pas_segregated_page* page);
 PAS_API size_t pas_segregated_page_get_num_committed_granules(pas_segregated_page* page);
 
-PAS_API pas_segregated_page_config* pas_segregated_page_get_config(pas_segregated_page* page);
+PAS_API const pas_segregated_page_config* pas_segregated_page_get_config(pas_segregated_page* page);
 
 PAS_API void pas_segregated_page_add_commit_range(pas_segregated_page* page,
                                                   pas_heap_summary* result,
@@ -451,10 +451,10 @@ PAS_API void pas_segregated_page_add_commit_range(pas_segregated_page* page,
 
 PAS_API pas_segregated_page_and_config
 pas_segregated_page_and_config_for_address_and_heap_config(uintptr_t begin,
-                                                           pas_heap_config* config);
+                                                           const pas_heap_config* config);
 
 static inline pas_segregated_page*
-pas_segregated_page_for_address_and_heap_config(uintptr_t begin, pas_heap_config* config)
+pas_segregated_page_for_address_and_heap_config(uintptr_t begin, const pas_heap_config* config)
 {
     return pas_segregated_page_and_config_for_address_and_heap_config(begin, config).page;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_and_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_and_config.h
@@ -39,12 +39,12 @@ typedef struct pas_segregated_page_config pas_segregated_page_config;
 
 struct pas_segregated_page_and_config {
     pas_segregated_page* page;
-    pas_segregated_page_config* config;
+    const pas_segregated_page_config* config;
 };
 
 static inline pas_segregated_page_and_config
 pas_segregated_page_and_config_create(pas_segregated_page* page,
-                                      pas_segregated_page_config* config)
+                                      const pas_segregated_page_config* config)
 {
     pas_segregated_page_and_config result;
     PAS_ASSERT(!!page == !!config);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.c
@@ -40,7 +40,7 @@ bool pas_small_segregated_page_config_variant_is_enabled_override =
 bool pas_medium_segregated_page_config_variant_is_enabled_override =
     PAS_USE_MEDIUM_SEGREGATED_OVERRIDE;
 
-void pas_segregated_page_config_validate(pas_segregated_page_config* config)
+void pas_segregated_page_config_validate(const pas_segregated_page_config* config)
 {
     if (!pas_segregated_page_config_do_validate)
         return;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
@@ -333,10 +333,10 @@ pas_segregated_page_config_logging_mode_for_role(pas_segregated_page_config conf
     return pas_segregated_deallocation_no_logging_mode;
 }
 
-PAS_API void pas_segregated_page_config_validate(pas_segregated_page_config*);
+PAS_API void pas_segregated_page_config_validate(const pas_segregated_page_config*);
 
 static inline pas_segregated_page_config_kind pas_segregated_page_config_get_kind(
-    pas_segregated_page_config* page_config)
+    const pas_segregated_page_config* page_config)
 {
     return page_config ? page_config->kind : pas_segregated_page_config_kind_null;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c
@@ -60,14 +60,14 @@ bool pas_segregated_page_config_kind_for_each(
     return true;    
 }
 
-pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[
+const pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[
     0
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) + 1
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     ] = {
 #define PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND(name, value) \
-    (pas_segregated_page_config*)(value).base.page_config_ptr,
+    (const pas_segregated_page_config*)(value).base.page_config_ptr,
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
 };

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h
@@ -45,16 +45,16 @@ typedef enum pas_segregated_page_config_kind pas_segregated_page_config_kind;
 PAS_API const char* pas_segregated_page_config_kind_get_string(pas_segregated_page_config_kind kind);
 
 typedef bool (*pas_segregated_page_config_kind_callback)(pas_segregated_page_config_kind kind,
-                                                         pas_segregated_page_config* config,
+                                                         const pas_segregated_page_config* config,
                                                          void* arg);
 
 PAS_API bool pas_segregated_page_config_kind_for_each(
     pas_segregated_page_config_kind_callback callback,
     void *arg);
 
-PAS_API extern pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[];
+PAS_API extern const pas_segregated_page_config* pas_segregated_page_config_kind_for_config_table[];
 
-static inline pas_segregated_page_config* pas_segregated_page_config_kind_get_config(
+static inline const pas_segregated_page_config* pas_segregated_page_config_kind_get_config(
     pas_segregated_page_config_kind kind)
 {
     return pas_segregated_page_config_kind_for_config_table[kind];

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils_inlines.h
@@ -70,7 +70,7 @@ typedef struct {
         \
         directory = pas_shared_page_directory_by_size_get( \
             directory_by_size, size_directory->object_size, \
-            (pas_segregated_page_config*)arguments.page_config.base.page_config_ptr); \
+            (const pas_segregated_page_config*)arguments.page_config.base.page_config_ptr); \
         \
         return directory; \
     } \

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
@@ -141,7 +141,7 @@ void pas_segregated_partial_view_set_is_in_use_for_allocation(
 
 bool pas_segregated_partial_view_should_table(
     pas_segregated_partial_view* view,
-    pas_segregated_page_config* page_config)
+    const pas_segregated_page_config* page_config)
 {
     pas_segregated_shared_view* shared_view;
     pas_shared_handle_or_page_boundary shared_handle_or_page_boundary;
@@ -170,7 +170,7 @@ static pas_heap_summary compute_summary(pas_segregated_partial_view* view)
     pas_segregated_size_directory* size_directory;
     pas_segregated_directory* directory;
     pas_segregated_shared_view* shared_view;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_segregated_page* page;
     unsigned* full_alloc_bits;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.h
@@ -112,7 +112,7 @@ PAS_API void pas_segregated_partial_view_set_is_in_use_for_allocation(
 
 PAS_API bool pas_segregated_partial_view_should_table(
     pas_segregated_partial_view* view,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_API bool pas_segregated_partial_view_for_each_live_object(
     pas_segregated_partial_view* view,

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c
@@ -37,7 +37,7 @@
 pas_segregated_shared_handle* pas_segregated_shared_handle_create(
     pas_segregated_shared_view* view,
     pas_segregated_shared_page_directory* shared_page_directory,
-    pas_segregated_page_config* page_config_ptr)
+    const pas_segregated_page_config* page_config_ptr)
 {
     pas_segregated_page_config page_config;
     pas_segregated_shared_handle* result;
@@ -66,7 +66,7 @@ void pas_segregated_shared_handle_destroy(pas_segregated_shared_handle* handle)
 {
     pas_segregated_shared_page_directory* shared_page_directory;
     pas_segregated_directory* directory;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_segregated_shared_view* shared_view;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.h
@@ -125,7 +125,7 @@ pas_segregated_shared_handle_as_view_non_null(pas_segregated_shared_handle* hand
 PAS_API pas_segregated_shared_handle* pas_segregated_shared_handle_create(
     pas_segregated_shared_view* view,
     pas_segregated_shared_page_directory* directory,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 /* This uninstalls the handle from the shared_view. */
 PAS_API void pas_segregated_shared_handle_destroy(pas_segregated_shared_handle* handle);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
@@ -117,7 +117,7 @@ pas_segregated_shared_view* pas_segregated_shared_page_directory_find_first_elig
     static const bool verbose = false;
     
     pas_segregated_directory* directory;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_segregated_directory_iterate_config config;
     bool did_find_something;
@@ -188,7 +188,7 @@ pas_segregated_shared_view* pas_segregated_shared_page_directory_find_first_elig
 typedef struct {
     pas_deferred_decommit_log* decommit_log;
     pas_lock_hold_mode heap_lock_hold_mode;
-    pas_segregated_page_config* page_config; /* Needs to be a pointer since this activation is
+    const pas_segregated_page_config* page_config; /* Needs to be a pointer since this activation is
                                                 passed to out-of-line code. */
     pas_page_sharing_pool_take_result result;
 } take_last_empty_data;
@@ -565,7 +565,7 @@ pas_segregated_shared_page_directory_take_last_empty(
        including ones that hold the heap lock while doing business. */
 
     pas_segregated_directory* directory;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     bool did_find_something;
     pas_segregated_directory_iterate_config config;
     take_last_empty_data data;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c
@@ -81,7 +81,7 @@ pas_segregated_shared_handle* pas_segregated_shared_view_commit_page(
     pas_segregated_heap* heap,
     pas_segregated_shared_page_directory* shared_page_directory,
     pas_segregated_partial_view* partial_view,
-    pas_segregated_page_config* page_config_ptr)
+    const pas_segregated_page_config* page_config_ptr)
 {
     pas_segregated_directory* directory;
     pas_segregated_shared_handle* handle;
@@ -254,7 +254,7 @@ static bool compute_summary_for_each_live_object_callback(
 }
 
 static pas_heap_summary compute_summary(pas_segregated_shared_view* view,
-                                        pas_segregated_page_config* page_config_ptr)
+                                        const pas_segregated_page_config* page_config_ptr)
 {
     static const bool verbose = false;
     
@@ -359,7 +359,7 @@ static pas_heap_summary compute_summary(pas_segregated_shared_view* view,
 
 pas_heap_summary
 pas_segregated_shared_view_compute_summary(pas_segregated_shared_view* view,
-                                           pas_segregated_page_config* page_config)
+                                           const pas_segregated_page_config* page_config)
 {
     pas_heap_summary result;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
@@ -181,7 +181,7 @@ pas_segregated_shared_view_bump(
 
 PAS_API pas_heap_summary
 pas_segregated_shared_view_compute_summary(pas_segregated_shared_view* view,
-                                           pas_segregated_page_config* page_config);
+                                           const pas_segregated_page_config* page_config);
 
 PAS_API bool pas_segregated_shared_view_is_empty(pas_segregated_shared_view* view);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view_inlines.h
@@ -39,7 +39,7 @@ PAS_API pas_segregated_shared_handle* pas_segregated_shared_view_commit_page(
     pas_segregated_heap* heap,
     pas_segregated_shared_page_directory* directory,
     pas_segregated_partial_view* partial_view,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 /* Must be called holding the commit lock. */
 static PAS_ALWAYS_INLINE pas_segregated_shared_handle*
@@ -61,7 +61,7 @@ pas_segregated_shared_view_commit_page_if_necessary(
     else {
         result = pas_segregated_shared_view_commit_page(
             view, heap, directory, partial_view,
-            (pas_segregated_page_config*)page_config.base.page_config_ptr);
+            (const pas_segregated_page_config*)page_config.base.page_config_ptr);
     }
 
     PAS_TESTING_ASSERT(result->directory == directory);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
@@ -48,8 +48,8 @@ pas_segregated_size_directory* pas_segregated_size_directory_create(
     pas_segregated_heap* heap,
     unsigned object_size,
     unsigned alignment,
-    pas_heap_config* heap_config,
-    pas_segregated_page_config* page_config,
+    const pas_heap_config* heap_config,
+    const pas_segregated_page_config* page_config,
     pas_segregated_size_directory_creation_mode creation_mode)
 {
     static const bool verbose = false;
@@ -169,7 +169,7 @@ pas_segregated_size_directory_data* pas_segregated_size_directory_ensure_data(
     pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_segregated_size_directory_data* data;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
 
     data = pas_segregated_size_directory_data_ptr_load(&directory->data);
 
@@ -219,7 +219,7 @@ pas_extended_segregated_size_directory_data*
 pas_segregated_size_directory_get_extended_data(
     pas_segregated_size_directory* directory)
 {
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
 
     page_config = pas_segregated_page_config_kind_get_config(directory->base.page_config_kind);
     PAS_ASSERT(page_config);
@@ -296,7 +296,7 @@ void pas_segregated_size_directory_enable_exclusive_views(
     pas_segregated_size_directory_data* data;
     pas_segregated_size_directory* template_directory;
     pas_segregated_page_config_kind page_config_kind;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     unsigned object_size;
     size_t alloc_bits_bytes;
@@ -601,7 +601,7 @@ pas_segregated_view pas_segregated_size_directory_take_first_eligible(
 typedef struct {
     pas_deferred_decommit_log* decommit_log;
     pas_lock_hold_mode heap_lock_hold_mode;
-    pas_segregated_page_config* my_page_config_ptr;
+    const pas_segregated_page_config* my_page_config_ptr;
     pas_page_sharing_pool_take_result result;
 } take_last_empty_data;
 
@@ -631,7 +631,7 @@ take_last_empty_consider_view(pas_segregated_directory_iterate_config* config)
     pas_segregated_directory* directory;
     pas_deferred_decommit_log* decommit_log;
     pas_lock_hold_mode heap_lock_hold_mode;
-    pas_segregated_page_config* my_page_config_ptr;
+    const pas_segregated_page_config* my_page_config_ptr;
     pas_segregated_page_config my_page_config;
     size_t index;
     pas_segregated_view generic_view;
@@ -886,7 +886,7 @@ pas_segregated_size_directory_take_last_empty(
 
 pas_segregated_size_directory* pas_segregated_size_directory_for_object(
     uintptr_t begin,
-    pas_heap_config* config)
+    const pas_heap_config* config)
 {
     pas_segregated_view view;
     view = pas_segregated_view_for_object(begin, config);
@@ -900,7 +900,7 @@ pas_segregated_size_directory_get_allocator_from_tlc(
     pas_segregated_size_directory* directory,
     size_t size,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index)
 {
     pas_local_allocator_result tlc_result;
@@ -1027,7 +1027,7 @@ bool pas_segregated_size_directory_for_each_live_object(
 uint8_t pas_segregated_size_directory_view_cache_capacity(pas_segregated_size_directory* directory)
 {
     pas_segregated_page_config_kind kind;
-    pas_segregated_page_config* config;
+    const pas_segregated_page_config* config;
 
     kind = directory->base.page_config_kind;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
@@ -172,8 +172,8 @@ PAS_API pas_segregated_size_directory* pas_segregated_size_directory_create(
     pas_segregated_heap* heap,
     unsigned object_size,
     unsigned alignment,
-    pas_heap_config* heap_config,
-    pas_segregated_page_config* page_config, /* Pass NULL to create a bitfit size directory. */
+    const pas_heap_config* heap_config,
+    const pas_segregated_page_config* page_config, /* Pass NULL to create a bitfit size directory. */
     pas_segregated_size_directory_creation_mode creation_mode);
 
 PAS_API void pas_segregated_size_directory_finish_creation(pas_segregated_size_directory* directory);
@@ -336,7 +336,7 @@ pas_segregated_size_directory_take_last_empty(
 
 PAS_API pas_segregated_size_directory* pas_segregated_size_directory_for_object(
     uintptr_t begin,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 
 /* This assumes that we already have a data. That's a valid assumption if we have exclusives. */
 PAS_API pas_heap_summary pas_segregated_size_directory_compute_summary_for_unowned_exclusive(

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h
@@ -42,7 +42,7 @@ pas_segregated_size_directory_get_allocator_from_tlc(
     pas_segregated_size_directory* directory,
     size_t size,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index);
 
 PAS_API pas_baseline_allocator*
@@ -54,7 +54,7 @@ pas_segregated_size_directory_select_allocator(
     pas_segregated_size_directory* directory,
     size_t size,
     pas_size_lookup_mode size_lookup_mode,
-    pas_heap_config* config,
+    const pas_heap_config* config,
     unsigned* cached_index)
 {
     if (pas_segregated_size_directory_has_tlc_allocator(directory)
@@ -154,7 +154,7 @@ pas_segregated_size_directory_take_first_eligible_impl(
     static const bool verbose = false;
     
     bool did_find_something;
-    pas_segregated_page_config* page_config_ptr;
+    const pas_segregated_page_config* page_config_ptr;
     pas_segregated_page_config page_config;
     pas_segregated_view view;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
@@ -82,7 +82,7 @@ pas_segregated_page_config_kind pas_segregated_view_get_page_config_kind(pas_seg
     }
 }
 
-pas_segregated_page_config* pas_segregated_view_get_page_config(pas_segregated_view view)
+const pas_segregated_page_config* pas_segregated_view_get_page_config(pas_segregated_view view)
 {
     return pas_segregated_page_config_kind_get_config(
         pas_segregated_view_get_page_config_kind(view));
@@ -431,7 +431,7 @@ bool pas_segregated_view_for_each_live_object(
 }
 
 static pas_tri_state should_be_eligible(pas_segregated_view view,
-                                        pas_segregated_page_config* page_config)
+                                        const pas_segregated_page_config* page_config)
 {
     static const bool verbose = false;
     
@@ -526,7 +526,7 @@ static pas_tri_state should_be_eligible(pas_segregated_view view,
 }
 
 pas_tri_state pas_segregated_view_should_be_eligible(pas_segregated_view view,
-                                                     pas_segregated_page_config* page_config)
+                                                     const pas_segregated_page_config* page_config)
 {
     static const bool verbose = false;
     
@@ -546,11 +546,11 @@ pas_tri_state pas_segregated_view_should_be_eligible(pas_segregated_view view,
 
 pas_segregated_view pas_segregated_view_for_object(
     uintptr_t begin,
-    pas_heap_config* config)
+    const pas_heap_config* config)
 {
     pas_segregated_page* page;
     pas_segregated_view owning_view;
-    pas_segregated_page_config* page_config;
+    const pas_segregated_page_config* page_config;
     pas_segregated_page_and_config page_and_config;
 
     page_and_config = pas_segregated_page_and_config_for_address_and_heap_config(begin, config);
@@ -581,7 +581,7 @@ pas_segregated_view pas_segregated_view_for_object(
 }
 
 pas_heap_summary pas_segregated_view_compute_summary(pas_segregated_view view,
-                                                     pas_segregated_page_config* page_config)
+                                                     const pas_segregated_page_config* page_config)
 {
     switch (pas_segregated_view_get_kind(view)) {
     case pas_segregated_exclusive_view_kind:

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view.h
@@ -196,7 +196,7 @@ pas_segregated_view_get_size_directory(pas_segregated_view view)
 
 PAS_API pas_segregated_page_config_kind
 pas_segregated_view_get_page_config_kind(pas_segregated_view view);
-PAS_API pas_segregated_page_config* pas_segregated_view_get_page_config(pas_segregated_view view);
+PAS_API const pas_segregated_page_config* pas_segregated_view_get_page_config(pas_segregated_view view);
 
 static inline pas_segregated_page_role pas_segregated_view_get_page_role_for_owner(pas_segregated_view view)
 {
@@ -264,15 +264,15 @@ PAS_API bool pas_segregated_view_for_each_live_object(
    "maybe", since those are never in a state where they *cannot* be eligible. This can only be called
    during steady-state (no concurrent allocations or deallocations). */
 PAS_API pas_tri_state pas_segregated_view_should_be_eligible(pas_segregated_view view,
-                                                             pas_segregated_page_config* page_config);
+                                                             const pas_segregated_page_config* page_config);
 
 PAS_API pas_segregated_view pas_segregated_view_for_object(
     uintptr_t begin,
-    pas_heap_config* config);
+    const pas_heap_config* config);
 
 PAS_API pas_heap_summary pas_segregated_view_compute_summary(
     pas_segregated_view view,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_API bool pas_segregated_view_is_eligible(pas_segregated_view view);
 PAS_API bool pas_segregated_view_is_payload_empty(pas_segregated_view view);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
@@ -211,7 +211,7 @@ pas_segregated_view_will_start_allocating(pas_segregated_view view,
                 pas_segregated_page_for_boundary_unchecked(exclusive->page_boundary, page_config),
                 ineligible_owning_view,
                 was_stolen,
-                (pas_segregated_page_config*)page_config.base.page_config_ptr);
+                (const pas_segregated_page_config*)page_config.base.page_config_ptr);
 
             pas_lock_lock_conditionally(&exclusive->ownership_lock, heap_lock_hold_mode);
             exclusive->is_owned = true;

--- a/Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.c
@@ -38,7 +38,7 @@
 pas_segregated_shared_page_directory* pas_shared_page_directory_by_size_get(
     pas_shared_page_directory_by_size* by_size,
     unsigned size,
-    pas_segregated_page_config* page_config)
+    const pas_segregated_page_config* page_config)
 {
     pas_shared_page_directory_by_size_data* data;
     unsigned index;

--- a/Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.h
@@ -65,7 +65,7 @@ struct pas_shared_page_directory_by_size_data {
 PAS_API pas_segregated_shared_page_directory* pas_shared_page_directory_by_size_get(
     pas_shared_page_directory_by_size* by_size,
     unsigned size,
-    pas_segregated_page_config* page_config);
+    const pas_segregated_page_config* page_config);
 
 PAS_API bool pas_shared_page_directory_by_size_for_each(
     pas_shared_page_directory_by_size* by_size,

--- a/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
@@ -250,7 +250,7 @@ static void report_segregated_directory_contents(
     pas_stream_printf(stream, "\n");
 
     if (directory->directory_kind == pas_segregated_shared_page_directory_kind) {
-        pas_segregated_page_config* page_config;
+        const pas_segregated_page_config* page_config;
         uintptr_t payload_begin;
         uintptr_t payload_end;
 
@@ -567,7 +567,7 @@ void pas_status_reporter_dump_segregated_heap(pas_stream* stream, pas_segregated
 
 void pas_status_reporter_dump_heap(pas_stream* stream, pas_heap* heap)
 {
-    pas_heap_config* config;
+    const pas_heap_config* config;
     pas_heap_summary summary;
 
     config = pas_heap_config_kind_get_config(heap->config_kind);

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -272,7 +272,7 @@ void pas_thread_local_cache_destroy(pas_lock_hold_mode heap_lock_hold_mode)
     destroy(thread_local_cache, heap_lock_hold_mode);
 }
 
-pas_thread_local_cache* pas_thread_local_cache_get_slow(pas_heap_config* config,
+pas_thread_local_cache* pas_thread_local_cache_get_slow(const pas_heap_config* config,
                                                         pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_thread_local_cache* thread_local_cache;
@@ -486,7 +486,7 @@ void pas_thread_local_cache_ensure_committed(pas_thread_local_cache* thread_loca
 pas_local_allocator_result
 pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uninitialized_index_slow(
     unsigned allocator_index,
-    pas_heap_config* heap_config)
+    const pas_heap_config* heap_config)
 {
     if (!pas_thread_local_cache_can_set() || pas_debug_heap_is_enabled(heap_config->kind))
         return pas_local_allocator_result_create_failure();

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -141,7 +141,7 @@ PAS_API pas_thread_local_cache* pas_thread_local_cache_create(void);
 PAS_API void pas_thread_local_cache_destroy(pas_lock_hold_mode heap_lock_hold_mode);
 
 PAS_API pas_thread_local_cache* pas_thread_local_cache_get_slow(
-    pas_heap_config* config, pas_lock_hold_mode heap_lock_hold_mode);
+    const pas_heap_config* config, pas_lock_hold_mode heap_lock_hold_mode);
 
 static inline pas_thread_local_cache* pas_thread_local_cache_get_already_initialized(void)
 {
@@ -155,7 +155,7 @@ static inline pas_thread_local_cache* pas_thread_local_cache_get_already_initial
 }
 
 static inline pas_thread_local_cache*
-pas_thread_local_cache_get_with_heap_lock_hold_mode(pas_heap_config* config,
+pas_thread_local_cache_get_with_heap_lock_hold_mode(const pas_heap_config* config,
                                                     pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_thread_local_cache* result;
@@ -168,13 +168,13 @@ pas_thread_local_cache_get_with_heap_lock_hold_mode(pas_heap_config* config,
     return pas_thread_local_cache_get_slow(config, heap_lock_hold_mode);
 }
 
-static inline pas_thread_local_cache* pas_thread_local_cache_get(pas_heap_config* config)
+static inline pas_thread_local_cache* pas_thread_local_cache_get(const pas_heap_config* config)
 {
     return pas_thread_local_cache_get_with_heap_lock_hold_mode(config, pas_lock_is_not_held);
 }
 
 static inline pas_thread_local_cache* pas_thread_local_cache_get_holding_heap_lock(
-    pas_heap_config* config)
+    const pas_heap_config* config)
 {
     return pas_thread_local_cache_get_with_heap_lock_hold_mode(config, pas_lock_is_held);
 }
@@ -330,12 +330,12 @@ pas_thread_local_cache_try_get_local_allocator_for_possibly_uninitialized_but_no
 PAS_API pas_local_allocator_result
 pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uninitialized_index_slow(
     unsigned allocator_index,
-    pas_heap_config* heap_config);
+    const pas_heap_config* heap_config);
 
 static PAS_ALWAYS_INLINE pas_local_allocator_result
 pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uninitialized_index(
     unsigned allocator_index,
-    pas_heap_config* heap_config)
+    const pas_heap_config* heap_config)
 {
     pas_thread_local_cache* cache;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
@@ -36,7 +36,7 @@
 
 PAS_BEGIN_EXTERN_C;
 
-pas_heap_config pas_utility_heap_config = PAS_UTILITY_HEAP_CONFIG;
+const pas_heap_config pas_utility_heap_config = PAS_UTILITY_HEAP_CONFIG;
 
 PAS_SEGREGATED_PAGE_CONFIG_SPECIALIZATION_DEFINITIONS(
     pas_utility_heap_page_config, PAS_UTILITY_HEAP_CONFIG.small_segregated_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
@@ -164,17 +164,17 @@ PAS_API void pas_utility_heap_config_dump_shared_page_directory_arg(
         PAS_HEAP_CONFIG_SPECIALIZATIONS(pas_utility_heap_config) \
     })
 
-PAS_API extern pas_heap_config pas_utility_heap_config;
+PAS_API extern const pas_heap_config pas_utility_heap_config;
 
 PAS_SEGREGATED_PAGE_CONFIG_SPECIALIZATION_DECLARATIONS(pas_utility_heap_page_config);
 PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(pas_utility_heap_config);
 
-static PAS_ALWAYS_INLINE bool pas_heap_config_is_utility(pas_heap_config* config)
+static PAS_ALWAYS_INLINE bool pas_heap_config_is_utility(const pas_heap_config* config)
 {
     return config == &pas_utility_heap_config;
 }
 
-static PAS_ALWAYS_INLINE pas_lock_hold_mode pas_heap_config_heap_lock_hold_mode(pas_heap_config* config)
+static PAS_ALWAYS_INLINE pas_lock_hold_mode pas_heap_config_heap_lock_hold_mode(const pas_heap_config* config)
 {
     return pas_heap_config_is_utility(config)
         ? pas_lock_is_held

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap_config.c
@@ -33,7 +33,7 @@
 
 #include "pas_heap_config_utils_inlines.h"
 
-pas_heap_config thingy_heap_config = THINGY_HEAP_CONFIG;
+const pas_heap_config thingy_heap_config = THINGY_HEAP_CONFIG;
 
 PAS_BASIC_HEAP_CONFIG_DEFINITIONS(
     thingy, THINGY,

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap_config.h
@@ -78,7 +78,7 @@ PAS_BEGIN_EXTERN_C;
     .marge_bitfit_page_size = PAS_MARGE_PAGE_DEFAULT_SIZE, \
     .pgm_enabled = false)
 
-extern PAS_API pas_heap_config thingy_heap_config;
+PAS_API extern const pas_heap_config thingy_heap_config;
 
 PAS_BASIC_HEAP_CONFIG_DECLARATIONS(thingy, THINGY);
 

--- a/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
@@ -73,7 +73,7 @@ namespace {
 
 constexpr bool verbose = false;
 
-pas_heap_config* selectedHeapConfig;
+const pas_heap_config* selectedHeapConfig;
 void* (*selectedAllocateCommonPrimitive)(size_t size);
 void* (*selectedAllocate)(pas_heap_ref* heapRef);
 void* (*selectedAllocateArray)(pas_heap_ref* heapRef, size_t count, size_t alignment);


### PR DESCRIPTION
#### e1a91728aa9546490b69cc41f68aef017b49d760
<pre>
[libpas] Make configuration parameter const
<a href="https://bugs.webkit.org/show_bug.cgi?id=235505">https://bugs.webkit.org/show_bug.cgi?id=235505</a>
&lt;rdar://88258861&gt;

Reviewed by Darin Adler.

Let&apos;s define pas_heap_config as const since it is constant definition.

* Source/bmalloc/libpas/Documentation.md:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.c:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_config.h:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_config.c:
* Source/bmalloc/libpas/src/libpas/hotbit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_heap_config.c:
* Source/bmalloc/libpas/src/libpas/iso_heap_config.h:
* Source/bmalloc/libpas/src/libpas/iso_test_heap_config.c:
* Source/bmalloc/libpas/src/libpas/iso_test_heap_config.h:
* Source/bmalloc/libpas/src/libpas/jit_heap_config.c:
(jit_aligned_allocator):
(jit_prepare_to_enumerate):
* Source/bmalloc/libpas/src/libpas/jit_heap_config.h:
* Source/bmalloc/libpas/src/libpas/minalign32_heap_config.c:
* Source/bmalloc/libpas/src/libpas/minalign32_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.c:
* Source/bmalloc/libpas/src/libpas/pagesize64k_heap_config.h:
* Source/bmalloc/libpas/src/libpas/pas_all_heaps.c:
(for_each_segregated_directory_segregated_heap_callback):
(verify_in_steady_state_segregated_directory_callback):
(compute_total_non_utility_segregated_summary_directory_callback):
* Source/bmalloc/libpas/src/libpas/pas_all_heaps.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator.c:
(pas_bitfit_allocator_commit_view):
(pas_bitfit_allocator_finish_failing):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_allocator_inlines.h:
(pas_bitfit_allocator_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c:
(pas_bitfit_directory_construct):
(pas_bitfit_directory_get_first_free_view):
(pas_bitfit_directory_take_last_empty):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c:
(pas_bitfit_heap_create):
(pas_bitfit_heap_select_variant):
(pas_bitfit_heap_construct_and_insert_size_class):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c:
(pas_bitfit_page_construct):
(pas_bitfit_page_get_config):
(pas_bitfit_page_for_each_live_object):
(pas_bitfit_page_verify):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.c:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_kind.h:
(pas_bitfit_page_config_kind_get_config):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.c:
(pas_bitfit_size_class_get_first_free_view):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_size_class.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_view.c:
(compute_summary):
(for_each_live_object):
* Source/bmalloc/libpas/src/libpas/pas_commit_span.c:
(pas_commit_span_add_unchanged):
(pas_commit_span_add_unchanged_and_commit):
(pas_commit_span_add_unchanged_and_decommit):
* Source/bmalloc/libpas/src/libpas/pas_commit_span.h:
* Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.c:
(config):
* Source/bmalloc/libpas/src/libpas/pas_compute_summary_object_callbacks.h:
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_known_large):
(pas_deallocate_known_large):
(pas_try_deallocate_slow):
(deallocate_segregated):
(pas_try_deallocate_slow_no_cache):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
* Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.c:
(pas_designated_intrinsic_heap_initialize):
* Source/bmalloc/libpas/src/libpas/pas_designated_intrinsic_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.c:
(pas_ensure_heap_forced_into_reserved_memory):
* Source/bmalloc/libpas/src/libpas/pas_ensure_heap_forced_into_reserved_memory.h:
* Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.c:
(pas_ensure_heap_with_page_caches):
* Source/bmalloc/libpas/src/libpas/pas_ensure_heap_with_page_caches.h:
* Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c:
(view_callback):
* Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c:
(collect_shared_page_directories_heap_callback):
(record_page_payload_and_meta):
(record_page_objects):
(enumerate_exclusive_view):
(enumerate_shared_view):
(enumerate_partial_view):
(consider_allocator):
* Source/bmalloc/libpas/src/libpas/pas_enumerator.c:
(pas_enumerator_create):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.c:
(pas_fast_megapage_cache_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_free_granules.c:
(pas_free_granules_decommit_after_locking_range):
* Source/bmalloc/libpas/src/libpas/pas_free_granules.h:
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
(pas_heap_get_type_size):
(pas_heap_ensure_size_directory_for_size_slow):
* Source/bmalloc/libpas/src/libpas/pas_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config.c:
(pas_heap_config_activate):
* Source/bmalloc/libpas/src/libpas/pas_heap_config.h:
(pas_heap_config_segregated_page_config_ptr_for_variant):
(pas_heap_config_bitfit_page_config_ptr_for_variant):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.c:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_kind.h:
(pas_heap_config_kind_get_config):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c:
(pas_heap_config_utils_allocate_aligned):
(pas_heap_config_utils_prepare_to_enumerate):
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_for_config.c:
(pas_heap_for_config_allocate):
(pas_heap_for_page_config_allocate):
(pas_heap_for_config_allocate_with_alignment):
(pas_heap_for_page_config_allocate_with_alignment):
(pas_heap_for_config_allocate_with_manual_alignment):
(pas_heap_for_page_config_allocate_with_manual_alignment):
(pas_heap_for_config_deallocate):
(pas_heap_for_page_config_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_heap_for_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_ref.c:
(pas_ensure_heap_slow):
* Source/bmalloc/libpas/src/libpas/pas_heap_ref.h:
(pas_ensure_heap):
* Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.c:
(pas_heap_runtime_config_view_cache_capacity_for_object_size):
(pas_heap_runtime_config_zero_view_cache_capacity):
(pas_heap_runtime_config_aggressive_view_cache_capacity):
* Source/bmalloc/libpas/src/libpas/pas_heap_runtime_config.h:
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(initialize_config):
(allocate_impl):
(pas_large_heap_try_allocate_and_forget):
(pas_large_heap_try_allocate):
(pas_large_heap_try_allocate_pgm):
(pas_large_heap_try_deallocate):
(pas_large_heap_try_shrink):
(pas_large_heap_shove_into_free):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c:
(pas_large_heap_physical_page_sharing_cache_try_allocate_with_alignment):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate_slow_impl):
* Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.c:
(pas_medium_megapage_cache_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_medium_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base.c:
(pas_page_base_header_size):
(pas_page_base_get_config):
(pas_page_base_compute_committed_when_owned):
(pas_page_base_add_free_range):
* Source/bmalloc/libpas/src/libpas/pas_page_base.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config.c:
(pas_page_base_config_get_kind_string):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config.h:
(pas_page_base_config_get_segregated):
(pas_page_base_config_get_bitfit):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_inlines.h:
(pas_page_base_config_is_utility):
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.c:
(pas_physical_page_sharing_pool_take_for_page_config):
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h:
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_promote_intrinsic_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:
(pas_root_construct):
* Source/bmalloc/libpas/src/libpas/pas_root.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c:
(pas_segregated_directory_compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_exclusive_view.c:
(compute_summary_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(min_align_for_heap):
(min_object_size_for_heap):
(max_object_size_for_page_config):
(max_segregated_object_size_for_heap):
(max_bitfit_object_size_for_heap):
(max_object_size_for_heap):
(pas_segregated_heap_construct):
(pas_segregated_heap_get_bitfit):
(pas_segregated_heap_get_cached_index_for_heap_type):
(pas_segregated_heap_get_cached_index):
(pas_segregated_heap_index_is_cached_index_and_cached_index_is_set):
(pas_segregated_heap_index_is_cached_index_or_cached_index_is_unset):
(pas_segregated_heap_index_is_not_cached_index_and_cached_index_is_set):
(pas_segregated_heap_index_is_greater_than_cached_index_and_cached_index_is_set):
(pas_segregated_heap_index_is_greater_equal_cached_index_and_cached_index_is_set):
(pas_segregated_heap_size_directory_for_index_slow):
(compute_small_index_upper_bound):
(ensure_size_lookup):
(recompute_size_lookup):
(rematerialize_size_lookup_if_necessary):
(pas_segregated_heap_ensure_allocator_index):
(compute_ideal_object_size):
(check_part_of_all_segregated_heaps_callback):
(ensure_size_lookup_if_necessary):
(check_size_lookup_recomputation):
(check_size_lookup_recomputation_if_appropriate):
(pas_segregated_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h:
(pas_segregated_heap_size_directory_for_index):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.c:
(pas_segregated_page_construct):
(pas_segregated_page_take_empty_granules):
(pas_segregated_page_commit_fully):
(pas_segregated_page_get_num_empty_granules):
(pas_segregated_page_get_num_committed_granules):
(pas_segregated_page_get_config):
(pas_segregated_page_add_commit_range):
(pas_segregated_page_and_config_for_address_and_heap_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.h:
(pas_segregated_page_for_address_and_heap_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_and_config.h:
(pas_segregated_page_and_config_create):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.c:
(pas_segregated_page_config_validate):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h:
(pas_segregated_page_config_get_kind):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.c:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind.h:
(pas_segregated_page_config_kind_get_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c:
(pas_segregated_partial_view_should_table):
(compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.c:
(pas_segregated_shared_handle_create):
(pas_segregated_shared_handle_destroy):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_handle.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c:
(pas_segregated_shared_page_directory_find_first_eligible):
(pas_segregated_shared_page_directory_take_last_empty):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.c:
(pas_segregated_shared_view_commit_page):
(compute_summary):
(pas_segregated_shared_view_compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view_inlines.h:
(pas_segregated_shared_view_commit_page_if_necessary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c:
(pas_segregated_size_directory_create):
(pas_segregated_size_directory_ensure_data):
(pas_segregated_size_directory_get_extended_data):
(pas_segregated_size_directory_enable_exclusive_views):
(take_last_empty_consider_view):
(pas_segregated_size_directory_for_object):
(pas_segregated_size_directory_get_allocator_from_tlc):
(pas_segregated_size_directory_view_cache_capacity):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_inlines.h:
(pas_segregated_size_directory_select_allocator):
(pas_segregated_size_directory_take_first_eligible_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view.c:
(pas_segregated_view_get_page_config):
(should_be_eligible):
(pas_segregated_view_should_be_eligible):
(pas_segregated_view_for_object):
(pas_segregated_view_compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h:
(pas_segregated_view_will_start_allocating):
* Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.c:
(pas_shared_page_directory_by_size_get):
* Source/bmalloc/libpas/src/libpas/pas_shared_page_directory_by_size.h:
* Source/bmalloc/libpas/src/libpas/pas_status_reporter.c:
(report_segregated_directory_contents):
(pas_status_reporter_dump_heap):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(pas_thread_local_cache_get_slow):
(pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uninitialized_index_slow):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:
(pas_thread_local_cache_get_with_heap_lock_hold_mode):
(pas_thread_local_cache_get):
(pas_thread_local_cache_get_holding_heap_lock):
(pas_thread_local_cache_get_local_allocator_if_can_set_cache_for_possibly_uninitialized_index):
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c:
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h:
(pas_heap_config_is_utility):
(pas_heap_config_heap_lock_hold_mode):
* Source/bmalloc/libpas/src/libpas/thingy_heap_config.c:
* Source/bmalloc/libpas/src/libpas/thingy_heap_config.h:
* Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp:

Canonical link: <a href="https://commits.webkit.org/252545@main">https://commits.webkit.org/252545@main</a>
</pre>
