### PR TITLE
Assertion failure (!m_invoking) in web-platform-tests/web-animations/interfaces/Animation/commitStyles-crash.html

### DIFF
--- a/LayoutTests/fast/custom-elements/reactions-for-element-animate-expected.txt
+++ b/LayoutTests/fast/custom-elements/reactions-for-element-animate-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Animation.animate must enqueue an attributeChanged reaction when it adds the observed style attribute
+PASS Animation.animate must enqueue an attributeChanged reaction when it mutates the observed style attribute
+PASS Animation.animate must not enqueue an attributeChanged reaction when it mutates the style attribute but the style attribute is not observed
+

--- a/LayoutTests/fast/custom-elements/reactions-for-element-animate.html
+++ b/LayoutTests/fast/custom-elements/reactions-for-element-animate.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on Element interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="commitStyles of Animation interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#element">
+<meta name="help" content="https://w3c.github.io/DOM-Parsing/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/custom-elements/resources/custom-elements-helpers.js"></script>
+<script src="../../imported/w3c/web-platform-tests/custom-elements/reactions/resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function () {
+    const element = define_new_custom_element(['style']);
+    const instance = document.createElement(element.name);
+    document.body.appendChild(instance);
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    const animation = instance.animate([{'borderColor': 'rgb(0, 0, 255)'}]);
+    animation.commitStyles();
+
+    const logEntries = element.takeLog();
+    assert_array_equals(logEntries.types(), ['attributeChanged']);
+    assert_equals(logEntries.last().name, 'style');
+    assert_equals(logEntries.last().namespace, null);
+}, 'Animation.animate must enqueue an attributeChanged reaction when it adds the observed style attribute');
+
+test(function () {
+    const element = define_new_custom_element(['style']);
+    const instance = document.createElement(element.name);
+    document.body.appendChild(instance);
+
+    let animation = instance.animate([{'borderColor': 'rgb(0, 0, 255)'}]);
+    animation.commitStyles();
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected', 'attributeChanged']);
+
+    animation = instance.animate([{'borderColor': 'rgb(0, 255, 0)'}]);
+    animation.commitStyles();
+
+    const logEntries = element.takeLog();
+    assert_array_equals(logEntries.types(), ['attributeChanged']);
+    assert_equals(logEntries.last().name, 'style');
+    assert_equals(logEntries.last().namespace, null);
+}, 'Animation.animate must enqueue an attributeChanged reaction when it mutates the observed style attribute');
+
+test(function () {
+    var element = define_new_custom_element([]);
+    const instance = document.createElement(element.name);
+    document.body.appendChild(instance);
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    const animation = instance.animate([{'borderColor': 'rgb(0, 0, 255)'}]);
+    animation.commitStyles();
+
+    assert_array_equals(element.takeLog().types(), []);
+}, 'Animation.animate must not enqueue an attributeChanged reaction when it mutates the style attribute but the style attribute is not observed');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -69,5 +69,5 @@ typedef unsigned long FramesPerSecond;
     undefined updatePlaybackRate(double playbackRate);
     [ImplementedAs=bindingsReverse] undefined reverse();
     undefined persist();
-    undefined commitStyles();
+    [CEReactions] undefined commitStyles();
 };


### PR DESCRIPTION
#### 5b863a0f92619931a5610dedb99595ea35cc932b
<pre>
Assertion failure (!m_invoking) in web-platform-tests/web-animations/interfaces/Animation/commitStyles-crash.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=242786">https://bugs.webkit.org/show_bug.cgi?id=242786</a>

Reviewed by Wenson Hsieh.

The assertion was failing because WebAnimation.prototype.commitStyles didn&apos;t have CEReactions
despite of the fact it mutates style content attribute.

The issue is tracked for the specification as <a href="https://github.com/w3c/csswg-drafts/issues/7507">https://github.com/w3c/csswg-drafts/issues/7507</a>

* LayoutTests/fast/custom-elements/reactions-for-element-animate-expected.txt: Added.
* LayoutTests/fast/custom-elements/reactions-for-element-animate.html: Added.
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/252553@main">https://commits.webkit.org/252553@main</a>
</pre>
