### PR TITLE
[LBSE] Enable compositing support for SVG elements

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1349,6 +1349,10 @@ webkit.org/b/240934 imported/w3c/web-platform-tests/css/filter-effects/root-elem
 
 imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html [ ImageOnlyFailure ]
 
+# Compositing/z-index needs LBSE enabled builds, which is off by default for this port.
+svg/compositing [ Skip ]
+svg/z-index [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of SVG-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
@@ -1,13 +1,14 @@
 # This TestExpectations file reflects the current status of the 'Layer-based SVG engine' (LBSE) in WebKit
 #
 # 1. Run tests against legacy SVG engine
-#    $ run-webkit-tests --additional-platform-directory=$PWD/LayoutTests/platform/mac-monterey-wk2-pixel --pixel-tests --tolerance=0 svg/W3C-SVG-1.1
+#    $ run-webkit-tests --additional-platform-directory=$PWD/LayoutTests/platform/mac-monterey-wk2-pixel --pixel-tests --tolerance=0 svg/W3C-SVG-1.1 svg/compositing svg/z-index
 #
 # 2. Run tests against LBSE
 #    $ run-webkit-tests --additional-platform-directory=$PWD/LayoutTests/platform/mac-monterey-wk2-pixel \
 #                       --additional-platform-directory=$PWD/LayoutTests/platform/mac-monterey-wk2-lbse-text \
 #                       --additional-expectations=$PWD/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations \
-#                       --pixel-tests --tolerance=0 --internal-feature=LayerBasedSVGEngineEnabled=true svg/W3C-SVG-1.1
+#                       --pixel-tests --tolerance=0 --internal-feature=LayerBasedSVGEngineEnabled=true svg/W3C-SVG-1.1 svg/compositing svg/z-index
+
 svg/W3C-SVG-1.1/animate-elem-02-t.svg       [ ImageOnlyFailure ]
 svg/W3C-SVG-1.1/animate-elem-03-t.svg       [ Pass ]
 svg/W3C-SVG-1.1/animate-elem-04-t.svg       [ ImageOnlyFailure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -2183,6 +2183,10 @@ svg/filters/feImage-self-and-other-referencing.html
 # GCController.collect() issues.
 svg/animations/svglength-element-removed-crash.svg [ Failure ]
 
+# Compositing/z-index needs LBSE enabled builds, which is off by default for this port.
+svg/compositing [ Skip ]
+svg/z-index [ Skip ]
+
 ################################################################################
 ###################          End SVG Issues              #######################
 ################################################################################

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    div {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    div.container {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+        background-color: lightgray;
+    }
+
+    div.content {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <div class="container">
+        <div class="content"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: Small AA differences, probably due to off-device-pixel-alignment issues -->
+<meta name="fuzzy" content="maxDifference=47; totalPixels=262" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    svg {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+        background-color: lightgray;
+        overflow: hidden;
+    }
+    g {
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <svg>
+        <g>
+            <rect x="100" y="50" width="100" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=0-102; totalPixels=709" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    svg {
+        width: 400px;
+        height: 400px;
+    }
+    g {
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <svg>
+        <g>
+            <rect x="100" y="50" width="100" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    div {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=0-102; totalPixels=709" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    svg {
+        width: 400px;
+        height: 400px;
+    }
+    rect {
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <svg>
+        <rect x="100" y="50" width="100" height="100" fill="green"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    div {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+        transform: scale(2) perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=0-102; totalPixels=2371-2372" />
+
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    svg {
+        width: 550px;
+        height: 550px;
+    }
+    g {
+        transform: scale(2);
+   }
+    rect {
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <svg>
+        <g>
+            <rect x="100" y="50" width="100" height="100" fill="green"/>
+	</g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-expected.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-hidden { overflow: hidden; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    div.container {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+    }
+
+    div.content {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 150px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+    }
+</style>
+</head>
+<body>
+    <div class="container first-row first-column">
+        <div class="content affine-transform"></div>
+    </div>
+    <div class="container first-row second-column overflow-hidden">
+        <div class="content affine-transform"></div>
+    </div>
+
+    <div class="container second-row first-column">
+        <div class="content perspective-transform"></div>
+    </div>
+    <div class="container second-row second-column overflow-hidden">
+        <div class="content perspective-transform "></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    div.container {
+        position: absolute;
+        top: 100px;
+        left: 100px;
+        width: 200px;
+        height: 200px;
+        overflow: visible;
+        background-color: lightgray;
+        border: 10px solid black;
+    }
+
+    div.content {
+        position: absolute;
+        left: 100px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <div class="container">
+        <div class="content"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=58; totalPixels=709" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+    svg {
+        position: absolute;
+        top: 100px;
+        left: 100px;
+        width: 200px;
+        height: 200px;
+        overflow: visible;
+        background-color: lightgray;
+        border: 10px solid black;
+    }
+    g {
+        transform: perspective(200px) rotateX(15deg) rotateZ(15deg);
+    }
+</style>
+</head>
+<body>
+    <svg>
+        <g>
+            <rect x="100" y="50" width="100" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding-expected.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-hidden { overflow: hidden; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    div.container {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+        padding: 15px;
+    }
+
+    /* Injected inbetween 'container' / 'content' layers to clip the content
+       layer as the SVG root clips the children: clip to content, not padding box.
+       (The overflow: hidden handling differs where SVG, clip to exact size of SVG
+        viewport is demanded, whereas CSS requires to clip to the padding-box.) */
+    div.clip {
+        position: absolute;
+        left: 0px;
+        top: 0px;
+        width: 100%;
+        height: 100%;
+        clip-path: inset(0px 15px 15px 0px); /* Inset by 'container' padding. */
+    }
+
+    div.content {
+        position: absolute;
+        left: 115px;
+        top: 65px;
+        width: 150px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+    }
+</style>
+</head>
+<body>
+    <div class="container first-row first-column">
+        <div class="content affine-transform"></div>
+    </div>
+    <div class="container first-row second-column overflow-hidden">
+        <div class="clip">
+            <div class="content affine-transform"></div>
+        </div>
+    </div>
+
+    <div class="container second-row first-column">
+        <div class="content perspective-transform"></div>
+    </div>
+    <div class="container second-row second-column overflow-hidden">
+        <div class="clip">
+            <div class="content perspective-transform "></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin-expected.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin-expected.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-hidden { overflow: hidden; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    div.container {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+        padding: 15px;
+        margin: 20px;
+    }
+
+    /* Injected inbetween 'container' / 'content' layers to clip the content
+       layer as the SVG root clips the children: clip to content, not padding box.
+       (The overflow: hidden handling differs where SVG, clip to exact size of SVG
+        viewport is demanded, whereas CSS requires to clip to the padding-box.) */
+    div.clip {
+        position: absolute;
+        left: 0px;
+        top: 0px;
+        width: 100%;
+        height: 100%;
+        clip-path: inset(0px 15px 15px 0px); /* Inset by 'container' padding. */
+    }
+
+    div.content {
+        position: absolute;
+        left: 115px;
+        top: 65px;
+        width: 150px;
+        height: 100px;
+        background-color: green;
+        transform-origin: -100px -50px;
+    }
+</style>
+</head>
+<body>
+    <div class="container first-row first-column">
+        <div class="content affine-transform"></div>
+    </div>
+    <div class="container first-row second-column overflow-hidden">
+        <div class="clip">
+            <div class="content affine-transform"></div>
+        </div>
+    </div>
+
+    <div class="container second-row first-column">
+        <div class="content perspective-transform"></div>
+    </div>
+    <div class="container second-row second-column overflow-hidden">
+        <div class="clip">
+            <div class="content perspective-transform "></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=111; totalPixels=847-857" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-visible { overflow: visible; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    svg {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+        padding: 15px;
+        margin: 20px;
+    }
+</style>
+</head>
+<body>
+    <svg class="first-row first-column overflow-visible">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="first-row second-column">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+
+    <svg class="second-row first-column overflow-visible">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="second-row second-column">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=111; totalPixels=848-852" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-visible { overflow: visible; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    svg {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+        padding: 15px;
+    }
+</style>
+</head>
+<body>
+    <svg class="first-row first-column overflow-visible">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="first-row second-column">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+
+    <svg class="second-row first-column overflow-visible">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="second-row second-column">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+<meta name="fuzzy" content="maxDifference=111; totalPixels=818" />
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .overflow-visible { overflow: visible; }
+    .first-row { top: 25px; }
+    .second-row { top: 300px; }
+    .first-column { left: 50px; }
+    .second-column { left: 350px; }
+    .affine-transform { transform: rotateZ(25deg); }
+    .perspective-transform { transform: perspective(300px) rotateX(15deg) rotateZ(15deg); }
+
+    svg {
+        position: absolute;
+        width: 150px;
+        height: 150px;
+        background-color: lightgray;
+        border: 10px solid black;
+    }
+</style>
+</head>
+<body>
+    <svg class="first-row first-column overflow-visible">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="first-row second-column">
+        <g class="affine-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+
+    <svg class="second-row first-column overflow-visible">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+    <svg class="second-row second-column">
+        <g class="perspective-transform">
+            <rect x="100" y="50" width="150" height="100" fill="green"/>
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/svg-poster-circle-expected.html
+++ b/LayoutTests/svg/compositing/svg-poster-circle-expected.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #stage {
+        background-color: lightgray;
+        margin: 150px auto;
+        width: 600px;
+        height: 400px;
+        perspective: 800px;
+      }
+
+      #rotate {
+        width: 600px;
+        height: 400px;
+        transform-style: preserve-3d;
+	transform: rotateX(30deg) rotateY(30deg) rotateZ(30deg) translateZ(25px);
+      }
+
+      .ring {
+        height: 110px;
+        width: 600px;
+        transform-style: preserve-3d;
+      }
+
+      .ring > :nth-child(odd) {
+        background-color: #995C7F;
+      }
+
+      .ring > :nth-child(even) {
+        background-color: #835A99;
+      }
+
+      .poster {
+        position: absolute;
+        left: 250px;
+        width: 100px;
+        height: 100px;
+        opacity: 0.5;
+        border-radius: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage">
+      <div id="rotate">
+        <div class="ring">
+	  <div class="poster" style="transform: rotateY(0deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(30deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(60deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(90deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(120deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(150deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(180deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(210deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(240deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(270deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(300deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(330deg) translateZ(200px);"></div>
+	</div>
+	<div class="ring">
+	  <div class="poster" style="transform: rotateY(0deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(30deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(60deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(90deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(120deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(150deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(180deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(210deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(240deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(270deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(300deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(330deg) translateZ(200px);"></div>
+	</div>
+	<div class="ring">
+	  <div class="poster" style="transform: rotateY(0deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(30deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(60deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(90deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(120deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(150deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(180deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(210deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(240deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(270deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(300deg) translateZ(200px);"></div>
+	  <div class="poster" style="transform: rotateY(330deg) translateZ(200px);"></div>
+	</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/svg/compositing/svg-poster-circle.html
+++ b/LayoutTests/svg/compositing/svg-poster-circle.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+  <head>
+    <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
+    <meta name="fuzzy" content="maxDifference=38; totalPixels=8904-8973" />
+
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+      }
+
+      svg {
+        display: block;
+        margin: 150px auto;
+        width: 600px;
+        height: 400px;
+        perspective: 800px;
+        background-color: lightgray;
+        overflow: visible;
+      }
+
+      #rotate {
+        transform: rotateX(30deg) rotateY(30deg) rotateZ(30deg) translateZ(25px);
+        transform-origin: 50% 50%;
+        transform-style: preserve-3d;
+      }
+
+      g.ring {
+        transform-style: preserve-3d;
+      }
+
+      g.ring > :nth-child(odd) {
+        fill: #995C7F;
+      }
+
+      g.ring > :nth-child(even) {
+        fill: #835A99;
+      }
+
+      rect.poster {
+        opacity: 0.5;
+        transform-origin: 50% 50%;
+      }
+    </style>
+  </head>
+  <body>
+    <svg>
+      <g id="rotate">
+        <g class="ring">
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(0deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(30deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(60deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(90deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(120deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(150deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(180deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(210deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(240deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(270deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(300deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(330deg) translateZ(200px);"/>
+        </g>
+        <g class="ring" transform="translate(0,110)">
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(0deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(30deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(60deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(90deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(120deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(150deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(180deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(210deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(240deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(270deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(300deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(330deg) translateZ(200px);"/>
+        </g>
+        <g class="ring" transform="translate(0,220)">
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(0deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(30deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(60deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(90deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(120deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(150deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(180deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(210deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(240deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(270deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(300deg) translateZ(200px);"/>
+          <rect x="250" y="0" width="100" height="100" rx="10" ry="10" class="poster" style="transform: rotateY(330deg) translateZ(200px);"/>
+        </g>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/LayoutTests/svg/z-index/group-with-zindex-expected.svg
+++ b/LayoutTests/svg/z-index/group-with-zindex-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" width="100" height="100" fill="red"/>
+  <rect x="20" width="100" height="100" fill="yellow"/>
+  <rect x="40" width="100" height="100" fill="lime"/>
+  <rect x="60" width="100" height="100" fill="aqua"/>
+</svg>

--- a/LayoutTests/svg/z-index/group-with-zindex.svg
+++ b/LayoutTests/svg/z-index/group-with-zindex.svg
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g style="z-index: 0;">
+    <!-- this is a self contained graphic -->
+    <rect x="40" width="100" height="100" fill="lime" style="z-index: 1;"/>
+    <rect x="20" width="100" height="100" fill="yellow"/>
+  </g>
+  <rect x="60" width="100" height="100" fill="aqua"/>
+  <rect x="0" width="100" height="100" fill="red" style="z-index: -1;"/>
+</svg>

--- a/LayoutTests/svg/z-index/shapes-with-zindex-expected.svg
+++ b/LayoutTests/svg/z-index/shapes-with-zindex-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0"  width="100" height="100" style="fill: red;"/>
+  <rect x="20" width="100" height="100" style="fill: yellow;"/>
+  <rect x="40" width="100" height="100" style="fill: lime;"/>
+  <rect x="60" width="100" height="100" style="fill: aqua;"/>
+  <rect x="80" width="100" height="100" style="fill: blue;"/>
+</svg>

--- a/LayoutTests/svg/z-index/shapes-with-zindex.svg
+++ b/LayoutTests/svg/z-index/shapes-with-zindex.svg
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0"  width="100" height="100" style="fill: red;    z-index: -1;"/>
+  <rect x="40" width="100" height="100" style="fill: lime;"/>
+  <rect x="80" width="100" height="100" style="fill: blue;   z-index: 1;"/>
+  <rect x="60" width="100" height="100" style="fill: aqua;"/>
+  <rect x="20" width="100" height="100" style="fill: yellow; z-index: -1;"/>
+</svg>

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -591,6 +591,8 @@ public:
     virtual bool allowsTiling() const { return m_allowsTiling; }
 
     virtual void deviceOrPageScaleFactorChanged() { }
+    virtual void setShouldUpdateRootRelativeScaleFactor(bool) { }
+
     WEBCORE_EXPORT void noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 
     void setIsInWindow(bool);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -170,6 +170,7 @@ public:
     WEBCORE_EXPORT void setCustomAppearance(CustomAppearance) override;
 
     WEBCORE_EXPORT void deviceOrPageScaleFactorChanged() override;
+    void setShouldUpdateRootRelativeScaleFactor(bool value) override { m_shouldUpdateRootRelativeScaleFactor = value; }
 
     FloatSize pixelAlignmentOffset() const override { return m_pixelAlignmentOffset; }
 
@@ -448,6 +449,7 @@ private:
     void updateSupportsSubpixelAntialiasedText();
     void updateDebugIndicators();
     void updateTiles();
+    void updateRootRelativeScale();
     void updateContentsScale(float pageScaleFactor);
     void updateCustomAppearance();
 
@@ -659,10 +661,11 @@ private:
     std::unique_ptr<DisplayList::InMemoryDisplayList> m_displayList;
 
     float m_contentsScaleLimitingFactor { 1 };
+    float m_rootRelativeScaleFactor { 1.0f };
 
     ContentsLayerPurpose m_contentsLayerPurpose { ContentsLayerPurpose::None };
     bool m_isCommittingChanges { false };
-
+    bool m_shouldUpdateRootRelativeScaleFactor : 1 { false };
     bool m_needsFullRepaint : 1;
     bool m_allowsBackingStoreDetaching : 1;
     bool m_intersectsCoverageRect : 1;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -358,6 +358,11 @@ Ref<GraphicsLayer> RenderLayerBacking::createGraphicsLayer(const String& name, G
     graphicsLayer->setAcceleratesDrawing(compositor().acceleratedDrawingEnabled());
     graphicsLayer->setUsesDisplayListDrawing(compositor().displayListDrawingEnabled());
 #endif
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (renderer().isSVGLayerAwareRenderer() && renderer().document().settings().layerBasedSVGEngineEnabled())
+        graphicsLayer->setShouldUpdateRootRelativeScaleFactor(true);
+#endif
     
     return graphicsLayer;
 }
@@ -2687,6 +2692,17 @@ bool RenderLayerBacking::paintsContent(RenderLayer::PaintedContentRequest& reque
 
     if (request.isSatisfied())
         return paintsContent;
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // FIXME: [LBSE] Eventually refine the logic to end up with a narrower set of conditions (webkit.org/b/243417).
+    if (is<RenderSVGModelObject>(m_owningLayer.renderer())) {
+        paintsContent = true;
+        request.setHasPaintedContent();
+    }
+
+    if (request.isSatisfied())
+        return paintsContent;
+#endif
 
     if (request.hasPaintedContent == RequestState::Unknown)
         request.hasPaintedContent = RequestState::False;


### PR DESCRIPTION
#### 5c46074bb656ecdbbc05d4d465e78416fad1ffe8
<pre>
[LBSE] Enable compositing support for SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=242833">https://bugs.webkit.org/show_bug.cgi?id=242833</a>

Reviewed by Simon Fraser.

Enable compositing / 3D-transforms / z-index for SVG.

To make compositing useful in the context of SVG, a long standing bug needs to be fixed:
webkit.org/b/27684 (&quot;Composited elements appear pixelated when scaled up using transform&quot;).
The idea is to include the maximum scale factor a CSS transform can induce into the &quot;content
scale factor&quot; belonging to the backing of the layer. Otherwise CSS transforms have no impact
on the internal GraphicsLayer size --&gt; we&apos;ll render at scale=1 and upscale according to the
CSS transform. This results in blurry rendering. This has been attempted by quit a few people
over the years, however there were reservations:
- JS driven, e.g. rAF() animations, that modify scale e.g. from 1 -&gt; 2 in 0.001 steps. Previously
  we never re-renderered, now we&apos;d to it on every scale change. Needs some heuristics, a treshold,
  (|old-new|/old&gt;x?) to enable this or stay with upscaling behavior.

- For WebAnimations/CSS animations/transitions we&apos;d need to figure out the max scale for the whole
  animation timeline, so that we can figure it out once, and can avoid re-rendering during the animation.
  (This is not implemented in this patch yet, but my colleague Miguel has a patch for that...)

The question is: do we want a setting to toggle this at runtime? Or a CSS prop so that authors can
express their intent? (Please never render blurry, or I don&apos;t care, but want max. performance...).
SVG definately needs sharp graphics without upscaling artifacts: there are documents defined in a
10px x 10px space that are upscaling to window size (e.g. 800px / 600px) that would look completly
blurry with the current upscaling strategy.
Therefore I decided to introduce a setShouldUpdateRootRelativeScaleFactor() setter for GraphicsLayer,
that&apos;s only used by LBSE for now to activate the new strategy, so that I can move on with LBSE
upstreaming. However it would be the right time now to generalize this for all ports and settle
on a future-proof strategy how to deal with this issue. Web Authors already waited way too long
for a solution :-)

3D transformations work out of the box now for every SVG element, tested under various conditions
&lt;svg&gt; embedded in HTML, with CSS box model properties applied, such as border/padding/margin
with/without overflow clipping, with/without non-default transform-origin etc.

To make z-index work, we only have to switch to a new logic to respect z-index for non-positioned
elements (position: static, is the default for SVG elements) in StyleAdjuster, not more.

The bulk of the prepartions were already upstreamed, this smallish patch finally enables the
new fance SVG2+ features.

Add new reftests that cover SVG compositing with 2D/3D transforms (LayoutTests/svg/compositing)
and new z-index reftests (LayoutTests/svg/z-index). These news tests enable LBSE at runtime
such that these features are tested by default on macOS/iOS platforms on EWS. To switch on LBSE
at runtime these tests utilize following marker: &lt;!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] --&gt;

Covered by new and existing tests.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-padding-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin-expected.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border-padding.html: Added.
* LayoutTests/svg/compositing/outermost-svg-with-border.html: Added.
* LayoutTests/svg/compositing/svg-poster-circle-expected.html: Added.
* LayoutTests/svg/compositing/svg-poster-circle.html: Added.
* LayoutTests/svg/z-index/group-with-zindex-expected.svg: Added.
* LayoutTests/svg/z-index/group-with-zindex.svg: Added.
* LayoutTests/svg/z-index/shapes-with-zindex-expected.svg: Added.
* LayoutTests/svg/z-index/shapes-with-zindex.svg: Added.
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setShouldUpdateRootRelativeScaleFactor):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateRootRelativeScale):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createGraphicsLayer):
(WebCore::RenderLayerBacking::paintsContent const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustSVGElementStyle):

Canonical link: <a href="https://commits.webkit.org/253054@main">https://commits.webkit.org/253054@main</a>
</pre>
