### PR TITLE
Split the implementation of RemoteImageBufferProxy and RemoteImageBuffer to source and header files

### DIFF
--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -534,9 +534,9 @@ void Chrome::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
     m_client.setCursorHiddenUntilMouseMoves(hiddenUntilMouseMoves);
 }
 
-RefPtr<ImageBuffer> Chrome::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess) const
+RefPtr<ImageBuffer> Chrome::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck) const
 {
-    return m_client.createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, avoidIOSurfaceSizeCheckInWebProcess);
+    return m_client.createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, avoidBackendSizeCheck);
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -89,7 +89,7 @@ public:
     void setCursor(const Cursor&) override;
     void setCursorHiddenUntilMouseMoves(bool) override;
 
-    RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess = false) const override;
+    RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const override;
 
 #if ENABLE(WEBGL)
     RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const override;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -363,7 +363,7 @@ public:
     
     virtual DisplayRefreshMonitorFactory* displayRefreshMonitorFactory() const { return nullptr; }
 
-    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float, const DestinationColorSpace&, PixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess = false) const { UNUSED_PARAM(avoidIOSurfaceSizeCheckInWebProcess); return nullptr; }
+    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const { UNUSED_PARAM(avoidBackendSizeCheck); return nullptr; }
 
 #if ENABLE(WEBGL)
     WEBCORE_EXPORT virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const;

--- a/Source/WebCore/platform/HostWindow.h
+++ b/Source/WebCore/platform/HostWindow.h
@@ -66,7 +66,7 @@ public:
     virtual IntPoint accessibilityScreenToRootView(const IntPoint&) const = 0;
     virtual IntRect rootViewToAccessibilityScreen(const IntRect&) const = 0;
 
-    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess = false) const = 0;
+    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const = 0;
 
 #if ENABLE(WEBGL)
     virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const = 0;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteImageBuffer.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "RemoteDisplayListRecorder.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+RemoteImageBuffer::RemoteImageBuffer(const ImageBufferBackend::Parameters& parameters, const ImageBufferBackend::Info& info, std::unique_ptr<ImageBufferBackend>&& backend, RemoteRenderingBackend& remoteRenderingBackend, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+    : ImageBuffer(parameters, info, WTFMove(backend), renderingResourceIdentifier.object())
+    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+    , m_remoteDisplayList({ RemoteDisplayListRecorder::create(*this, renderingResourceIdentifier, renderingResourceIdentifier.processIdentifier(), remoteRenderingBackend) })
+    , m_renderingResourcesRequest(ScopedRenderingResourcesRequest::acquire())
+{
+}
+
+RemoteImageBuffer::~RemoteImageBuffer()
+{
+    // Volatile image buffers do not have contexts.
+    if (this->volatilityState() == VolatilityState::Volatile)
+        return;
+    // Unwind the context's state stack before destruction, since calls to restore may not have
+    // been flushed yet, or the web process may have terminated.
+    while (context().stackSize())
+        context().restore();
+}
+
+void RemoteImageBuffer::setOwnershipIdentity(const ProcessIdentity& resourceOwner)
+{
+    if (m_backend)
+        m_backend->setOwnershipIdentity(resourceOwner);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "PlatformImageBufferShareableBackend.h"
 #include "QualifiedRenderingResourceIdentifier.h"
+#include "RemoteDisplayListRecorder.h"
 #include "RemoteDisplayListRecorderMessages.h"
 #include "RemoteImageBuffer.h"
 #include "RemoteMediaPlayerManagerProxy.h"

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -32,6 +32,7 @@
 #include "RemoteLegacyCDMFactoryProxy.h"
 #include "RemoteLegacyCDMSessionMessages.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
+#include <JavaScriptCore/TypedArrayAdaptors.h>
 #include <WebCore/LegacyCDM.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/LoggerHelper.h>

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -28,6 +28,7 @@ GPUProcess/GPUProcessPreferences.cpp
 GPUProcess/graphics/ImageBufferShareableAllocator.cpp
 GPUProcess/graphics/RemoteDisplayListRecorder.cpp
 GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+GPUProcess/graphics/RemoteImageBuffer.cpp
 GPUProcess/graphics/RemoteRenderingBackend.cpp
 GPUProcess/graphics/RemoteResourceCache.cpp
 GPUProcess/graphics/ScopedRenderingResourcesRequest.cpp
@@ -721,6 +722,7 @@ WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
 WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
 WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
 WebProcess/GPU/graphics/ThreadSafeRemoteImageBufferFlusher.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5379,6 +5379,8 @@
 		7203449A26A6C44C000A5F54 /* MonotonicObjectIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MonotonicObjectIdentifier.h; sourceTree = "<group>"; };
 		7203449B26A6C476000A5F54 /* RenderingUpdateID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RenderingUpdateID.h; sourceTree = "<group>"; };
 		722E1CDB2840B7E7005828BD /* PixelBufferReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PixelBufferReference.h; sourceTree = "<group>"; };
+		72440D33287CCC0500FADBC4 /* RemoteImageBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageBuffer.cpp; sourceTree = "<group>"; };
+		72440D3A287CF58900FADBC4 /* RemoteImageBufferProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageBufferProxy.cpp; sourceTree = "<group>"; };
 		7246963A275B7E6700A9156A /* FilterReference.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterReference.h; sourceTree = "<group>"; };
 		724DCF21284862FC0026ACF4 /* ImageBufferShareableAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableAllocator.h; sourceTree = "<group>"; };
 		724DCF22284862FC0026ACF4 /* ImageBufferShareableAllocator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableAllocator.cpp; sourceTree = "<group>"; };
@@ -10433,6 +10435,7 @@
 				7B904166254AFDEB006EEB8C /* RemoteGraphicsContextGLProxy.h */,
 				7B904167254AFE17006EEB8C /* RemoteGraphicsContextGLProxy.messages.in */,
 				7BE726572574F67200E85D98 /* RemoteGraphicsContextGLProxyFunctionsGenerated.cpp */,
+				72440D3A287CF58900FADBC4 /* RemoteImageBufferProxy.cpp */,
 				727A7F492408AEE6004D2931 /* RemoteImageBufferProxy.h */,
 				5506409D2407160900AAE045 /* RemoteRenderingBackendProxy.cpp */,
 				5506409E2407160900AAE045 /* RemoteRenderingBackendProxy.h */,
@@ -10462,6 +10465,7 @@
 				7B904168254AFEA7006EEB8C /* RemoteGraphicsContextGL.messages.in */,
 				7BE72668257680EF00E85D98 /* RemoteGraphicsContextGLCocoa.cpp */,
 				7B90416D2550108C006EEB8C /* RemoteGraphicsContextGLFunctionsGenerated.h */,
+				72440D33287CCC0500FADBC4 /* RemoteImageBuffer.cpp */,
 				55AD09422408A02E00DE4D2F /* RemoteImageBuffer.h */,
 				72A87BBB287678A700289098 /* RemoteRenderingBackend.cpp */,
 				550640A324071A6100AAE045 /* RemoteRenderingBackend.h */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteImageBufferProxy.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "Logging.h"
+#include "RemoteRenderingBackendProxy.h"
+#include "ThreadSafeRemoteImageBufferFlusher.h"
+#include <wtf/SystemTracing.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+RemoteImageBufferProxy::RemoteImageBufferProxy(const ImageBufferBackend::Parameters& parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy)
+    : ImageBuffer(parameters, info)
+    , m_remoteRenderingBackendProxy(remoteRenderingBackendProxy)
+    , m_remoteDisplayList(*this, remoteRenderingBackendProxy, { { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform())
+{
+    ASSERT(m_remoteRenderingBackendProxy);
+    m_remoteRenderingBackendProxy->remoteResourceCacheProxy().cacheImageBuffer(*this);
+}
+
+RemoteImageBufferProxy::~RemoteImageBufferProxy()
+{
+    if (!m_remoteRenderingBackendProxy || m_remoteRenderingBackendProxy->isGPUProcessConnectionClosed()) {
+        m_needsFlush = false;
+        return;
+    }
+
+    flushDrawingContextAsync();
+    m_remoteRenderingBackendProxy->remoteResourceCacheProxy().releaseImageBuffer(m_renderingResourceIdentifier);
+}
+
+void RemoteImageBufferProxy::waitForDidFlushOnSecondaryThread(GraphicsContextFlushIdentifier targetFlushIdentifier)
+{
+    ASSERT(!isMainRunLoop());
+    Locker locker { m_receivedFlushIdentifierLock };
+    m_receivedFlushIdentifierChangedCondition.wait(m_receivedFlushIdentifierLock, [&] {
+        assertIsHeld(m_receivedFlushIdentifierLock);
+        return m_receivedFlushIdentifier == targetFlushIdentifier;
+    });
+
+    // Nothing should have sent more drawing commands to the GPU process
+    // while waiting for this ImageBuffer to be flushed.
+    ASSERT(m_sentFlushIdentifier == targetFlushIdentifier);
+}
+
+bool RemoteImageBufferProxy::hasPendingFlush() const
+{
+    // It is safe to access m_receivedFlushIdentifier from the main thread without locking since it
+    // only gets modified on the main thread.
+    ASSERT(isMainRunLoop());
+    return m_sentFlushIdentifier != m_receivedFlushIdentifier;
+}
+
+void RemoteImageBufferProxy::didFlush(GraphicsContextFlushIdentifier flushIdentifier)
+{
+    ASSERT(isMainRunLoop());
+    Locker locker { m_receivedFlushIdentifierLock };
+    m_receivedFlushIdentifier = flushIdentifier;
+    m_receivedFlushIdentifierChangedCondition.notifyAll();
+}
+
+void RemoteImageBufferProxy::backingStoreWillChange()
+{
+    if (m_needsFlush)
+        return;
+    m_needsFlush = true;
+
+    // Prepare for the backing store change the first time this notification comes after flush has
+    // completed.
+
+    // If we already need a flush, this cannot be the first notification for change,
+    // handled by the m_needsFlush case above.
+
+    // If we already have a pending flush, this cannot be the first notification for change.
+    if (hasPendingFlush())
+        return;
+
+    prepareForBackingStoreChange();
+}
+
+void RemoteImageBufferProxy::waitForDidFlushWithTimeout()
+{
+    if (!m_remoteRenderingBackendProxy)
+        return;
+
+    // Wait for our DisplayList to be flushed but do not hang.
+    static constexpr unsigned maximumNumberOfTimeouts = 3;
+    unsigned numberOfTimeouts = 0;
+#if !LOG_DISABLED
+    auto startTime = MonotonicTime::now();
+#endif
+    LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " waitForDidFlushWithTimeout: waiting for flush {" << m_sentFlushIdentifier);
+    while (numberOfTimeouts < maximumNumberOfTimeouts && hasPendingFlush()) {
+        if (!m_remoteRenderingBackendProxy->waitForDidFlush())
+            ++numberOfTimeouts;
+    }
+
+    LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " waitForDidFlushWithTimeout: done waiting " << (MonotonicTime::now() - startTime).milliseconds() << "ms; " << numberOfTimeouts << " timeout(s)");
+
+    if (UNLIKELY(numberOfTimeouts >= maximumNumberOfTimeouts))
+        RELEASE_LOG_FAULT(SharedDisplayLists, "Exceeded timeout while waiting for flush in remote rendering backend: %" PRIu64 ".", m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64());
+}
+
+ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const
+{
+    if (!m_remoteRenderingBackendProxy)
+        return m_backend.get();
+
+    static constexpr unsigned maximumTimeoutOrFailureCount = 3;
+    unsigned numberOfTimeoutsOrFailures = 0;
+    while (!m_backend && numberOfTimeoutsOrFailures < maximumTimeoutOrFailureCount) {
+        if (m_remoteRenderingBackendProxy->waitForDidCreateImageBufferBackend() == RemoteRenderingBackendProxy::DidReceiveBackendCreationResult::TimeoutOrIPCFailure)
+            ++numberOfTimeoutsOrFailures;
+    }
+    if (numberOfTimeoutsOrFailures == maximumTimeoutOrFailureCount) {
+        LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " ensureBackendCreated: exceeded max number of timeouts");
+        RELEASE_LOG_FAULT(SharedDisplayLists, "Exceeded max number of timeouts waiting for image buffer backend creation in remote rendering backend %" PRIu64 ".", m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64());
+    }
+    return m_backend.get();
+}
+
+RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage(BackingStoreCopy copyBehavior) const
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return { };
+
+    if (canMapBackingStore())
+        return ImageBuffer::copyNativeImage(copyBehavior);
+
+    const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
+    auto bitmap = m_remoteRenderingBackendProxy->getShareableBitmap(m_renderingResourceIdentifier, PreserveResolution::Yes);
+    if (!bitmap)
+        return { };
+    return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore));
+}
+
+void RemoteImageBufferProxy::drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& options)
+{
+    ASSERT(&destContext != &context());
+    destContext.drawImageBuffer(*this, destRect, srcRect, options);
+}
+
+RefPtr<NativeImage> RemoteImageBufferProxy::sinkIntoNativeImage()
+{
+    return copyNativeImage();
+}
+
+RefPtr<Image> RemoteImageBufferProxy::filteredImage(Filter& filter)
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return { };
+    flushDrawingContext();
+    return m_remoteRenderingBackendProxy->getFilteredImage(m_renderingResourceIdentifier, filter);
+}
+
+RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator) const
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return nullptr;
+    auto& mutableThis = const_cast<RemoteImageBufferProxy&>(*this);
+    mutableThis.flushDrawingContextAsync();
+    auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, srcRect.size());
+    if (!pixelBuffer)
+        return nullptr;
+    if (!m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, srcRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))
+        return nullptr;
+    return pixelBuffer;
+}
+
+void RemoteImageBufferProxy::clearBackend()
+{
+    m_needsFlush = false;
+    didFlush(m_sentFlushIdentifier);
+    prepareForBackingStoreChange();
+    ImageBuffer::clearBackend();
+}
+
+GraphicsContext& RemoteImageBufferProxy::context() const
+{
+    return const_cast<RemoteImageBufferProxy*>(this)->m_remoteDisplayList;
+}
+
+GraphicsContext* RemoteImageBufferProxy::drawingContext()
+{
+    return &m_remoteDisplayList;
+}
+
+void RemoteImageBufferProxy::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return;
+    // The math inside PixelBuffer::create() doesn't agree with the math inside ImageBufferBackend::putPixelBuffer() about how m_resolutionScale interacts with the data in the ImageBuffer.
+    // This means that putPixelBuffer() is only called when resolutionScale() == 1.
+    ASSERT(resolutionScale() == 1);
+    auto& mutableThis = const_cast<RemoteImageBufferProxy&>(*this);
+    mutableThis.flushDrawingContextAsync();
+    backingStoreWillChange();
+    m_remoteRenderingBackendProxy->putPixelBufferForImageBuffer(m_renderingResourceIdentifier, pixelBuffer, srcRect, destPoint, destFormat);
+}
+
+void RemoteImageBufferProxy::convertToLuminanceMask()
+{
+    m_remoteDisplayList.convertToLuminanceMask();
+}
+
+void RemoteImageBufferProxy::transformToColorSpace(const DestinationColorSpace& colorSpace)
+{
+    m_remoteDisplayList.transformToColorSpace(colorSpace);
+}
+
+void RemoteImageBufferProxy::flushContext()
+{
+    flushDrawingContext();
+    m_backend->flushContext();
+}
+
+void RemoteImageBufferProxy::flushDrawingContext()
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return;
+
+    TraceScope tracingScope(FlushRemoteImageBufferStart, FlushRemoteImageBufferEnd);
+
+    bool shouldWait = flushDrawingContextAsync();
+    LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContext: shouldWait " << shouldWait);
+    if (shouldWait)
+        waitForDidFlushWithTimeout();
+}
+
+bool RemoteImageBufferProxy::flushDrawingContextAsync()
+{
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return false;
+
+    if (!m_needsFlush)
+        return hasPendingFlush();
+
+    m_sentFlushIdentifier = GraphicsContextFlushIdentifier::generate();
+    LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContextAsync - flush " << m_sentFlushIdentifier);
+    m_remoteDisplayList.flushContext(m_sentFlushIdentifier);
+    m_needsFlush = false;
+    return true;
+}
+
+std::unique_ptr<ThreadSafeImageBufferFlusher> RemoteImageBufferProxy::createFlusher()
+{
+    return WTF::makeUnique<ThreadSafeRemoteImageBufferFlusher>(*this);
+}
+
+void RemoteImageBufferProxy::prepareForBackingStoreChange()
+{
+    ASSERT(!hasPendingFlush());
+    // If the backing store is mapped in the process and the changes happen in the other
+    // process, we need to prepare for the backing store change before we let the change happen.
+    if (!canMapBackingStore())
+        return;
+    if (auto* backend = ensureBackendCreated())
+        backend->ensureNativeImagesHaveCopiedBackingStore();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,303 +27,73 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "Logging.h"
 #include "RemoteDisplayListRecorderProxy.h"
-#include "RemoteRenderingBackendMessages.h"
-#include "RemoteRenderingBackendProxy.h"
-#include "ThreadSafeRemoteImageBufferFlusher.h"
 #include <WebCore/ImageBuffer.h>
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
-#include <wtf/SystemTracing.h>
 
 namespace WebKit {
 
-class RemoteRenderingBackend;
+class RemoteRenderingBackendProxy;
 
 class RemoteImageBufferProxy : public WebCore::ImageBuffer {
 public:
     template<typename BackendType>
-    static RefPtr<RemoteImageBufferProxy> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, bool avoidIOSurfaceSizeCheckInWebProcess = false)
+    static RefPtr<RemoteImageBufferProxy> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, bool avoidBackendSizeCheck = false)
     {
         auto parameters = WebCore::ImageBufferBackend::Parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
-        if (!avoidIOSurfaceSizeCheckInWebProcess && BackendType::calculateSafeBackendSize(parameters).isEmpty())
+        if (!avoidBackendSizeCheck && BackendType::calculateSafeBackendSize(parameters).isEmpty())
             return nullptr;
         auto info = populateBackendInfo<BackendType>(parameters);
         return adoptRef(new RemoteImageBufferProxy(parameters, info, remoteRenderingBackendProxy));
     }
 
-    ~RemoteImageBufferProxy()
-    {
-        if (!m_remoteRenderingBackendProxy || m_remoteRenderingBackendProxy->isGPUProcessConnectionClosed()) {
-            m_needsFlush = false;
-            return;
-        }
-
-        flushDrawingContextAsync();
-        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().releaseImageBuffer(m_renderingResourceIdentifier);
-    }
+    ~RemoteImageBufferProxy();
 
     WebCore::GraphicsContextFlushIdentifier lastSentFlushIdentifier() const { return m_sentFlushIdentifier; }
 
-    void waitForDidFlushOnSecondaryThread(WebCore::GraphicsContextFlushIdentifier targetFlushIdentifier)
-    {
-        ASSERT(!isMainRunLoop());
-        Locker locker { m_receivedFlushIdentifierLock };
-        m_receivedFlushIdentifierChangedCondition.wait(m_receivedFlushIdentifierLock, [&] {
-            assertIsHeld(m_receivedFlushIdentifierLock);
-            return m_receivedFlushIdentifier == targetFlushIdentifier;
-        });
+    void waitForDidFlushOnSecondaryThread(WebCore::GraphicsContextFlushIdentifier);
 
-        // Nothing should have sent more drawing commands to the GPU process
-        // while waiting for this ImageBuffer to be flushed.
-        ASSERT(m_sentFlushIdentifier == targetFlushIdentifier);
-    }
-
-protected:
-    RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy)
-        : ImageBuffer(parameters, info)
-        , m_remoteRenderingBackendProxy(remoteRenderingBackendProxy)
-        , m_remoteDisplayList(*this, remoteRenderingBackendProxy, { { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform())
-    {
-        ASSERT(m_remoteRenderingBackendProxy);
-        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().cacheImageBuffer(*this);
-    }
+private:
+    RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&);
 
     // It is safe to access m_receivedFlushIdentifier from the main thread without locking since it
     // only gets modified on the main thread.
-    bool hasPendingFlush() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
-    {
-        ASSERT(isMainRunLoop());
-        return m_sentFlushIdentifier != m_receivedFlushIdentifier;
-    }
+    bool hasPendingFlush() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
 
-    void didFlush(WebCore::GraphicsContextFlushIdentifier flushIdentifier) final
-    {
-        ASSERT(isMainRunLoop());
-        Locker locker { m_receivedFlushIdentifierLock };
-        m_receivedFlushIdentifier = flushIdentifier;
-        m_receivedFlushIdentifierChangedCondition.notifyAll();
-    }
+    void didFlush(WebCore::GraphicsContextFlushIdentifier) final;
 
-    void backingStoreWillChange() final
-    {
-        if (m_needsFlush)
-            return;
-        m_needsFlush = true;
+    void backingStoreWillChange() final;
 
-        // Prepare for the backing store change the first time this notification comes after flush has
-        // completed.
+    void waitForDidFlushWithTimeout();
 
-        // If we already need a flush, this cannot be the first notification for change,
-        // handled by the m_needsFlush case above.
+    WebCore::ImageBufferBackend* ensureBackendCreated() const final;
+    void clearBackend() final;
 
-        // If we already have a pending flush, this cannot be the first notification for change.
-        if (hasPendingFlush())
-            return;
+    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
+    RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
-        prepareForBackingStoreChange();
-    }
+    RefPtr<WebCore::Image> filteredImage(WebCore::Filter&) final;
 
-    void waitForDidFlushWithTimeout()
-    {
-        if (!m_remoteRenderingBackendProxy)
-            return;
+    void drawConsuming(WebCore::GraphicsContext& destContext, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&) final;
 
-        // Wait for our DisplayList to be flushed but do not hang.
-        static constexpr unsigned maximumNumberOfTimeouts = 3;
-        unsigned numberOfTimeouts = 0;
-#if !LOG_DISABLED
-        auto startTime = MonotonicTime::now();
-#endif
-        LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " waitForDidFlushWithTimeout: waiting for flush {" << m_sentFlushIdentifier);
-        while (numberOfTimeouts < maximumNumberOfTimeouts && hasPendingFlush()) {
-            if (!m_remoteRenderingBackendProxy->waitForDidFlush())
-                ++numberOfTimeouts;
-        }
+    WebCore::GraphicsContext& context() const final;
+    WebCore::GraphicsContext* drawingContext() final;
 
-        LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " waitForDidFlushWithTimeout: done waiting " << (MonotonicTime::now() - startTime).milliseconds() << "ms; " << numberOfTimeouts << " timeout(s)");
+    RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, const WebCore::ImageBufferAllocator&) const final;
+    void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint = { }, WebCore::AlphaPremultiplication = WebCore::AlphaPremultiplication::Premultiplied) final;
 
-        if (UNLIKELY(numberOfTimeouts >= maximumNumberOfTimeouts))
-            RELEASE_LOG_FAULT(SharedDisplayLists, "Exceeded timeout while waiting for flush in remote rendering backend: %" PRIu64 ".", m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64());
-    }
-
-    WebCore::ImageBufferBackend* ensureBackendCreated() const final
-    {
-        if (!m_remoteRenderingBackendProxy)
-            return m_backend.get();
-
-        static constexpr unsigned maximumTimeoutOrFailureCount = 3;
-        unsigned numberOfTimeoutsOrFailures = 0;
-        while (!m_backend && numberOfTimeoutsOrFailures < maximumTimeoutOrFailureCount) {
-            if (m_remoteRenderingBackendProxy->waitForDidCreateImageBufferBackend() == RemoteRenderingBackendProxy::DidReceiveBackendCreationResult::TimeoutOrIPCFailure)
-                ++numberOfTimeoutsOrFailures;
-        }
-        if (numberOfTimeoutsOrFailures == maximumTimeoutOrFailureCount) {
-            LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " ensureBackendCreated: exceeded max number of timeouts");
-            RELEASE_LOG_FAULT(SharedDisplayLists, "Exceeded max number of timeouts waiting for image buffer backend creation in remote rendering backend %" PRIu64 ".", m_remoteRenderingBackendProxy->renderingBackendIdentifier().toUInt64());
-        }
-        return m_backend.get();
-    }
-
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy copyBehavior = WebCore::CopyBackingStore) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-
-        if (canMapBackingStore())
-            return ImageBuffer::copyNativeImage(copyBehavior);
-
-        const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        auto bitmap = m_remoteRenderingBackendProxy->getShareableBitmap(m_renderingResourceIdentifier, WebCore::PreserveResolution::Yes);
-        if (!bitmap)
-            return { };
-        return WebCore::NativeImage::create(bitmap->createPlatformImage(WebCore::DontCopyBackingStore));
-    }
-
-    void drawConsuming(WebCore::GraphicsContext& destContext, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions& options) final
-    {
-        ASSERT(&destContext != &context());
-        destContext.drawImageBuffer(*this, destRect, srcRect, options);
-    }
-
-    RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final
-    {
-        return copyNativeImage();
-    }
-
-    RefPtr<WebCore::Image> filteredImage(WebCore::Filter& filter) final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return { };
-        flushDrawingContext();
-        return m_remoteRenderingBackendProxy->getFilteredImage(m_renderingResourceIdentifier, filter);
-    }
-
-    RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, const WebCore::ImageBufferAllocator& allocator) const final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return nullptr;
-        auto& mutableThis = const_cast<RemoteImageBufferProxy&>(*this);
-        mutableThis.flushDrawingContextAsync();
-        auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, srcRect.size());
-        if (!pixelBuffer)
-            return nullptr;
-        if (!m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, srcRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))
-            return nullptr;
-        return pixelBuffer;
-    }
-
-    void clearBackend() final
-    {
-        m_needsFlush = false;
-        didFlush(m_sentFlushIdentifier);
-        prepareForBackingStoreChange();
-        ImageBuffer::clearBackend();
-    }
-
-    WebCore::GraphicsContext& context() const final
-    {
-        return const_cast<RemoteImageBufferProxy*>(this)->m_remoteDisplayList;
-    }
-
-    WebCore::GraphicsContext* drawingContext() final
-    {
-        return &m_remoteDisplayList;
-    }
-
-    void putPixelBuffer(const WebCore::PixelBuffer& pixelBuffer, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint = { }, WebCore::AlphaPremultiplication destFormat = WebCore::AlphaPremultiplication::Premultiplied) final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return;
-        // The math inside PixelBuffer::create() doesn't agree with the math inside ImageBufferBackend::putPixelBuffer() about how m_resolutionScale interacts with the data in the ImageBuffer.
-        // This means that putPixelBuffer() is only called when resolutionScale() == 1.
-        ASSERT(resolutionScale() == 1);
-        auto& mutableThis = const_cast<RemoteImageBufferProxy&>(*this);
-        mutableThis.flushDrawingContextAsync();
-        backingStoreWillChange();
-        m_remoteRenderingBackendProxy->putPixelBufferForImageBuffer(m_renderingResourceIdentifier, pixelBuffer, srcRect, destPoint, destFormat);
-    }
-
-    void convertToLuminanceMask() final
-    {
-        m_remoteDisplayList.convertToLuminanceMask();
-    }
-
-    void transformToColorSpace(const WebCore::DestinationColorSpace& colorSpace) final
-    {
-        m_remoteDisplayList.transformToColorSpace(colorSpace);
-    }
-
+    void convertToLuminanceMask() final;
+    void transformToColorSpace(const WebCore::DestinationColorSpace&) final;
+    
     bool prefersPreparationForDisplay() final { return true; }
+    
+    void flushContext() final;
+    void flushDrawingContext() final;
+    bool flushDrawingContextAsync() final;
 
-    void flushContext() final
-    {
-        flushDrawingContext();
-        m_backend->flushContext();
-    }
-
-    void flushDrawingContext() final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return;
-
-        TraceScope tracingScope(FlushRemoteImageBufferStart, FlushRemoteImageBufferEnd);
-
-        bool shouldWait = flushDrawingContextAsync();
-        LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContext: shouldWait " << shouldWait);
-        if (shouldWait)
-            waitForDidFlushWithTimeout();
-    }
-
-    bool flushDrawingContextAsync() final
-    {
-        if (UNLIKELY(!m_remoteRenderingBackendProxy))
-            return false;
-
-        if (!m_needsFlush)
-            return hasPendingFlush();
-
-        m_sentFlushIdentifier = WebCore::GraphicsContextFlushIdentifier::generate();
-        LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContextAsync - flush " << m_sentFlushIdentifier);
-        m_remoteDisplayList.flushContext(m_sentFlushIdentifier);
-        m_needsFlush = false;
-        return true;
-    }
-
-    void recordNativeImageUse(WebCore::NativeImage& image)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordNativeImageUse(image);
-    }
-
-    void recordFontUse(WebCore::Font& font)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordFontUse(font);
-    }
-
-    void recordImageBufferUse(WebCore::ImageBuffer& imageBuffer)
-    {
-        if (m_remoteRenderingBackendProxy)
-            m_remoteRenderingBackendProxy->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
-    }
-
-    std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> createFlusher() final
-    {
-        return WTF::makeUnique<ThreadSafeRemoteImageBufferFlusher>(*this);
-    }
-
-    void prepareForBackingStoreChange()
-    {
-        ASSERT(!hasPendingFlush());
-        // If the backing store is mapped in the process and the changes happen in the other
-        // process, we need to prepare for the backing store change before we let the change happen.
-        if (!canMapBackingStore())
-            return;
-        if (auto* backend = ensureBackendCreated())
-            backend->ensureNativeImagesHaveCopiedBackingStore();
-    }
+    std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> createFlusher() final;
+    void prepareForBackingStoreChange();
 
     WebCore::GraphicsContextFlushIdentifier m_sentFlushIdentifier;
     Lock m_receivedFlushIdentifierLock;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -128,7 +128,7 @@ void RemoteRenderingBackendProxy::createRemoteImageBuffer(ImageBuffer& imageBuff
     sendToStream(Messages::RemoteRenderingBackend::CreateImageBuffer(logicalSize, imageBuffer.renderingMode(), imageBuffer.renderingPurpose(), imageBuffer.resolutionScale(), imageBuffer.colorSpace(), imageBuffer.pixelFormat(), imageBuffer.renderingResourceIdentifier()));
 }
 
-RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess)
+RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck)
 {
     RefPtr<ImageBuffer> imageBuffer;
 
@@ -137,13 +137,13 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
         // we need to create ImageBuffers for e.g. Canvas that are actually mapped into the
         // Web Content process, so they can be painted into the tiles.
         if (!WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM))
-            imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferShareableMappedBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidIOSurfaceSizeCheckInWebProcess);
+            imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferShareableMappedBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
         else
-            imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferRemoteBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidIOSurfaceSizeCheckInWebProcess);
+            imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferRemoteBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
     }
 
     if (!imageBuffer)
-        imageBuffer = RemoteImageBufferProxy::create<UnacceleratedImageBufferShareableBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidIOSurfaceSizeCheckInWebProcess);
+        imageBuffer = RemoteImageBufferProxy::create<UnacceleratedImageBufferShareableBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
 
     if (imageBuffer) {
         createRemoteImageBuffer(*imageBuffer);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -84,7 +84,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Messages to be sent.
-    RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess = false);
+    RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidBackendSizeCheck = false);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, Span<uint8_t> result);
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat);
     RefPtr<ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -913,7 +913,7 @@ WebCore::DisplayRefreshMonitorFactory* WebChromeClient::displayRefreshMonitorFac
 }
 
 #if ENABLE(GPU_PROCESS)
-RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess) const
+RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, bool avoidBackendSizeCheck) const
 {
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(purpose)) {
         if (purpose != RenderingPurpose::ShareableSnapshot)
@@ -922,7 +922,7 @@ RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, Re
         return ImageBuffer::create<ImageBufferShareableBitmapBackend>(size, resolutionScale, colorSpace, PixelFormat::BGRA8, RenderingPurpose::ShareableSnapshot, { });
     }
 
-    return m_page.ensureRemoteRenderingBackendProxy().createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, avoidIOSurfaceSizeCheckInWebProcess);
+    return m_page.ensureRemoteRenderingBackendProxy().createImageBuffer(size, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, avoidBackendSizeCheck);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -249,7 +249,7 @@ private:
     WebCore::DisplayRefreshMonitorFactory* displayRefreshMonitorFactory() const final;
 
 #if ENABLE(GPU_PROCESS)
-    RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidIOSurfaceSizeCheckInWebProcess = false) const final;
+    RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidBackendSizeCheck = false) const final;
 #endif
 #if ENABLE(WEBGL)
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;


### PR DESCRIPTION
#### c1e23ae901d15bb71f24a013402214942b677cac
<pre>
Split the implementation of RemoteImageBufferProxy and RemoteImageBuffer to source and header files
<a href="https://bugs.webkit.org/show_bug.cgi?id=242835">https://bugs.webkit.org/show_bug.cgi?id=242835</a>

Reviewed by Simon Fraser.

After 252266@main, it is now possible to split the implementation of RemoteImageBuffer
and RemoteImageBufferProxy to source and header files since they are not templates
anymore.

* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createImageBuffer const):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::createImageBuffer const):
* Source/WebCore/platform/HostWindow.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp: Added.
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::m_renderingResourcesRequest):
(WebKit::RemoteImageBuffer::~RemoteImageBuffer):
(WebKit::RemoteImageBuffer::setOwnershipIdentity):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
(WebKit::RemoteImageBuffer::RemoteImageBuffer): Deleted.
(WebKit::RemoteImageBuffer::m_renderingResourcesRequest): Deleted.
(WebKit::RemoteImageBuffer::~RemoteImageBuffer): Deleted.
(WebKit::RemoteImageBuffer::setOwnershipIdentity): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp: Added.
(WebKit::RemoteImageBufferProxy::RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::~RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::waitForDidFlushOnSecondaryThread):
(WebKit::RemoteImageBufferProxy::didFlush):
(WebKit::RemoteImageBufferProxy::backingStoreWillChange):
(WebKit::RemoteImageBufferProxy::waitForDidFlushWithTimeout):
(WebKit::RemoteImageBufferProxy::ensureBackendCreated const):
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::drawConsuming):
(WebKit::RemoteImageBufferProxy::sinkIntoNativeImage):
(WebKit::RemoteImageBufferProxy::filteredImage):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::clearBackend):
(WebKit::RemoteImageBufferProxy::context const):
(WebKit::RemoteImageBufferProxy::drawingContext):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::convertToLuminanceMask):
(WebKit::RemoteImageBufferProxy::transformToColorSpace):
(WebKit::RemoteImageBufferProxy::flushContext):
(WebKit::RemoteImageBufferProxy::flushDrawingContext):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
(WebKit::RemoteImageBufferProxy::createFlusher):
(WebKit::RemoteImageBufferProxy::prepareForBackingStoreChange):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteImageBufferProxy::create):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::~RemoteImageBufferProxy): Deleted.
(WebKit::RemoteImageBufferProxy::waitForDidFlushOnSecondaryThread): Deleted.
(WebKit::RemoteImageBufferProxy::RemoteImageBufferProxy): Deleted.
(WebKit::RemoteImageBufferProxy::waitForDidFlushWithTimeout): Deleted.
(WebKit::RemoteImageBufferProxy::recordNativeImageUse): Deleted.
(WebKit::RemoteImageBufferProxy::recordFontUse): Deleted.
(WebKit::RemoteImageBufferProxy::recordImageBufferUse): Deleted.
(WebKit::RemoteImageBufferProxy::prepareForBackingStoreChange): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createImageBuffer const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/252577@main">https://commits.webkit.org/252577@main</a>
</pre>
