### PR TITLE
REGRESSION (r238524): SVG textPath cannot be rendered when <text> element is referred by <use> element

### DIFF
--- a/LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree-expected.html
+++ b/LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree-expected.html
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 500" >
+<path id="MyPath" d="M 100 100 C 100 100 400 100 400 100" fill="none" stroke="green"/>
+<text id="MyText" font-size="20" fill="green">
+    <textPath xlink:href="#MyPath">
+        PASS
+    </textPath>
+</text>
+</svg>

--- a/LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree.html
+++ b/LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree.html
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 500" >
+<defs>
+    <g id="g">
+        <defs>
+            <path id="path" d="M 100 100 C 100 100 400 100 400 100" />
+        </defs>
+        <text id="text" font-size="20" fill="green" >
+            <textPath xlink:href="#path">
+                PASS
+            </textPath>
+        </text>
+    </g>
+</defs>
+<use xlink:href="#path" fill="none" stroke="green"/>
+<use xlink:href="#g"/>
+</svg>

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -25,8 +25,9 @@
 #include "Document.h"
 #include "Element.h"
 #include "SVGElement.h"
-#include <wtf/URL.h>
+#include "SVGUseElement.h"
 #include "XLinkNames.h"
+#include <wtf/URL.h>
 
 namespace WebCore {
 
@@ -100,6 +101,10 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
     // Exit early if the referenced url is external, and we have no externalDocument given.
     if (isExternalURIReference(iri, document))
         return { nullptr, WTFMove(id) };
+
+    RefPtr shadowHost = treeScope.rootNode().shadowHost();
+    if (is<SVGUseElement>(shadowHost))
+        return { shadowHost->treeScope().getElementById(id), WTFMove(id) };
 
     return { treeScope.getElementById(id), WTFMove(id) };
 }


### PR DESCRIPTION
#### 72c9014cf9262c2994b15118e00cdd75561e5da2
<pre>
REGRESSION (r238524): SVG textPath cannot be rendered when &lt;text&gt; element is referred by &lt;use&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=198280">https://bugs.webkit.org/show_bug.cgi?id=198280</a>

Reviewed by Myles C. Maxfield.

The bug was caused by targetElementFromIRIString looking for a matching element in the use element&apos;s
UA shadow tree instead of the outer tree which defined the content of use element&apos;s shadow tree.

Fixed the bug by looking for the matching element in the tree that contains the use element instead.

* LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree-expected.html: Added.
* LayoutTests/svg/dom/use-element-reference-within-use-shadow-tree.html: Added.
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::targetElementFromIRIString): Fixed the bug.

Canonical link: <a href="https://commits.webkit.org/252547@main">https://commits.webkit.org/252547@main</a>
</pre>
