### PR TITLE
[JSC] Add VectorTraits for WriteBarrier

### DIFF
--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -352,3 +352,21 @@ private:
 };
 
 } // namespace JSC
+
+namespace WTF {
+
+template<typename T> struct VectorTraits<JSC::WriteBarrier<T>> : public SimpleClassVectorTraits {
+    static_assert(std::is_trivially_destructible<JSC::WriteBarrier<T>>::value);
+    static constexpr bool canCopyWithMemcpy = true;
+};
+
+template<> struct VectorTraits<JSC::WriteBarrier<JSC::Unknown>> : public SimpleClassVectorTraits {
+    static_assert(std::is_trivially_destructible<JSC::WriteBarrier<JSC::Unknown>>::value);
+#if USE(JSVALUE32_64)
+    // We can memset only in JSVALUE64 since empty value is zero. On the other hand, JSVALUE32_64's empty value is not zero.
+    static constexpr bool canInitializeWithMemset = false;
+#endif
+    static constexpr bool canCopyWithMemcpy = true;
+};
+
+} // namespace WTF


### PR DESCRIPTION
#### 1eb3c9f9ce70458c2df143468ece882e041cdd6f
<pre>
[JSC] Add VectorTraits for WriteBarrier
<a href="https://bugs.webkit.org/show_bug.cgi?id=196242">https://bugs.webkit.org/show_bug.cgi?id=196242</a>

Reviewed by Darin Adler.

WriteBarrier&lt;&gt; is one of the most frequently used class for Vector etc. in JSC.
Let&apos;s add VectorTraits for that.

* Source/JavaScriptCore/runtime/WriteBarrier.h:

Canonical link: <a href="https://commits.webkit.org/252556@main">https://commits.webkit.org/252556@main</a>
</pre>
