### PR TITLE
[iOS] REGRESSION(252407@main?): fast/text/international/system-language/han-text-style.html is failing on bots

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3674,3 +3674,5 @@ webkit.org/b/242273 fast/events/ios/dragstart-on-image-by-long-pressing.html [ P
 http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
 
 webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable.html [ Pass Failure ]
+
+webkit.org/b/242840 fast/text/international/system-language/han-text-style.html [ Failure ]


### PR DESCRIPTION
#### f76c9aa3f2faf6e97c2cbb4a649551a1b040204d
<pre>
[iOS] REGRESSION(252407@main?): fast/text/international/system-language/han-text-style.html is failing on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=242840">https://bugs.webkit.org/show_bug.cgi?id=242840</a>

Unreviewed. Adding a failing test expectation while the failure is investigated.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252546@main">https://commits.webkit.org/252546@main</a>
</pre>
