### PR TITLE
[JSC] Generic iterator protocol function should be invisible to Function's caller getter

### DIFF
--- a/JSTests/stress/for-each-null.js
+++ b/JSTests/stress/for-each-null.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var caller = null;
+
+function test()
+{
+    caller = test.caller;
+}
+
+function topLevel() {
+    [0].forEach(test);
+}
+topLevel();
+shouldBe(caller, null);

--- a/JSTests/stress/iteration-helper-hidden.js
+++ b/JSTests/stress/iteration-helper-hidden.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function foo(arr) {
+    return [...arr];
+}
+
+let obj = {};
+obj[Symbol.iterator] = function bar() {
+    shouldBe(arguments.callee.caller, foo);
+    return {
+        next() { return { done: true }; }
+    };
+};
+foo(obj);

--- a/Source/JavaScriptCore/builtins/IteratorHelpers.js
+++ b/Source/JavaScriptCore/builtins/IteratorHelpers.js
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@globalPrivate
 function performIteration(iterable)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -813,11 +813,6 @@ void JSGlobalObject::init(VM& vm)
             init.set(JSFunction::create(init.vm, init.owner, 0, init.vm.propertyNames->builtinNames().valuesPublicName().string(), arrayProtoFuncValues, ArrayValuesIntrinsic));
         });
 
-    m_iteratorProtocolFunction.initLater(
-        [] (const Initializer<JSFunction>& init) {
-            init.set(JSFunction::create(init.vm, iteratorHelpersPerformIterationCodeGenerator(init.vm), init.owner));
-        });
-
     m_promiseResolveFunction.initLater(
         [] (const Initializer<JSFunction>& init) {
             init.set(JSFunction::create(init.vm, promiseConstructorResolveCodeGenerator(init.vm), init.owner));
@@ -2287,7 +2282,6 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_arrayProtoToStringFunction.visit(visitor);
     thisObject->m_arrayProtoValuesFunction.visit(visitor);
     thisObject->m_evalFunction.visit(visitor);
-    thisObject->m_iteratorProtocolFunction.visit(visitor);
     thisObject->m_promiseResolveFunction.visit(visitor);
     visitor.append(thisObject->m_objectProtoValueOfFunction);
     thisObject->m_numberProtoToStringFunction.visit(visitor);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -354,7 +354,6 @@ public:
     LazyProperty<JSGlobalObject, JSFunction> m_arrayProtoToStringFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_arrayProtoValuesFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_evalFunction;
-    LazyProperty<JSGlobalObject, JSFunction> m_iteratorProtocolFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_promiseResolveFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_numberProtoToStringFunction;
     LazyProperty<JSGlobalObject, JSFunction> m_typedArrayProtoSort;
@@ -719,7 +718,7 @@ public:
     JSFunction* arrayProtoToStringFunction() const { return m_arrayProtoToStringFunction.get(this); }
     JSFunction* arrayProtoValuesFunction() const { return m_arrayProtoValuesFunction.get(this); }
     JSFunction* arrayProtoValuesFunctionConcurrently() const { return m_arrayProtoValuesFunction.getConcurrently(); }
-    JSFunction* iteratorProtocolFunction() const { return m_iteratorProtocolFunction.get(this); }
+    JSFunction* iteratorProtocolFunction() const;
     JSFunction* newPromiseCapabilityFunction() const;
     JSFunction* promiseResolveFunction() const { return m_promiseResolveFunction.get(this); }
     JSFunction* resolvePromiseFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -133,6 +133,7 @@ ALWAYS_INLINE Structure* JSGlobalObject::arrayStructureForIndexingTypeDuringAllo
 }
 
 inline JSFunction* JSGlobalObject::throwTypeErrorFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::throwTypeErrorFunction)); }
+inline JSFunction* JSGlobalObject::iteratorProtocolFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performIteration)); }
 inline JSFunction* JSGlobalObject::newPromiseCapabilityFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::newPromiseCapability)); }
 inline JSFunction* JSGlobalObject::resolvePromiseFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::resolvePromise)); }
 inline JSFunction* JSGlobalObject::rejectPromiseFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::rejectPromise)); }


### PR DESCRIPTION
#### 1a1af3bd846d98207ea02c8aa079351347a55205
<pre>
[JSC] Generic iterator protocol function should be invisible to Function&apos;s caller getter
<a href="https://bugs.webkit.org/show_bug.cgi?id=241953">https://bugs.webkit.org/show_bug.cgi?id=241953</a>

Reviewed by Alexey Shvayka.

When we use iterator protocol helper function, `caller` getter inside it can encounter this
function, and returning null because it is builtin function. Now, we leverage ImplementationVisibility
to skip iteration protocol helper function from `caller` getter&apos;s stack walk so that we can make it
invisible from user&apos;s code.

* JSTests/stress/iteration-helper-hidden.js: Added.
(shouldBe):
(foo):
(obj.Symbol.iterator):
* Source/JavaScriptCore/builtins/IteratorHelpers.js:
(performIteration): Deleted.
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::isAllowedReceiverFunctionForCallerAndArguments):
(JSC::RetrieveCallerFunctionFunctor::operator() const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::iteratorProtocolFunction const): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::iteratorProtocolFunction const):

Canonical link: <a href="https://commits.webkit.org/252578@main">https://commits.webkit.org/252578@main</a>
</pre>
