### PR TITLE
REGRESSION(252541@main): accessibility/mac/basic-embed-pdf-accessibility.html is timing out on bots

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5344,3 +5344,5 @@ imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqu
 imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.worker.html [ Skip ]
 streams/readable-byte-stream-controller.html [ Skip ]
 streams/readable-byte-stream-controller-worker.html [ Skip ]
+
+webkit.org/b/242848 accessibility/mac/basic-embed-pdf-accessibility.html [ Pass Timeout ]


### PR DESCRIPTION
#### 5ac3eac3f8785c90c0c050cd9bef4d2ed3415dab
<pre>
REGRESSION(252541@main): accessibility/mac/basic-embed-pdf-accessibility.html is timing out on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=242848">https://bugs.webkit.org/show_bug.cgi?id=242848</a>

Unreviewed. Adding a flaky timeout expectation for now.

* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252557@main">https://commits.webkit.org/252557@main</a>
</pre>
