### PR TITLE
REGRESSION(252541@main): accessibility/mac/basic-embed-pdf-accessibility.html is timing out on bots

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5345,5 +5345,4 @@ imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqu
 streams/readable-byte-stream-controller.html [ Skip ]
 streams/readable-byte-stream-controller-worker.html [ Skip ]
 
-webkit.org/b/242848 accessibility/mac/basic-embed-pdf-accessibility.html [ Pass Timeout ]
 webkit.org/b/242849 [ Release ] editing/execCommand/outdent-paragraph-crash.html [ Pass Failure ]

--- a/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
+++ b/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
@@ -28,7 +28,9 @@
         window.jsTestIsAsync = true;
 
         var hitTestResult, pdfAxObject, pdfEmbedElement, pdfLayerController, searchResultElement;
-        setTimeout(async function() {
+        requestAnimationFrame(async function() {
+            await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for the embed plugin to load after style update.
+
             // First, ensure the <embed> and the PDF inside the <embed> are completely initialized.
             // It would be nice if we could listen for an <embed> load event to be fired, but WebKit erroneously
             // doesn't fire those for <embed>s: https://bugs.webkit.org/show_bug.cgi?id=230054
@@ -94,7 +96,7 @@
             shouldBe("searchResultElement.stringAttributeValue('AXSubrole')", "'AXPDFPluginSubrole'");
 
             finishJSTest();
-        }, 0)
+        });
     }
 </script>
 </body>


### PR DESCRIPTION
#### 97982e9e39614b53751b8358a1e3deca4fb2d209
<pre>
REGRESSION(252541@main): accessibility/mac/basic-embed-pdf-accessibility.html is timing out on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=242848">https://bugs.webkit.org/show_bug.cgi?id=242848</a>

Reviewed by Cameron McCormack.

Fixed the test to wait (rAF + 0s timer) for embed element&apos;s PDF viewer to become ready.

* LayoutTests/TestExpectations:
* LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html:

Canonical link: <a href="https://commits.webkit.org/252560@main">https://commits.webkit.org/252560@main</a>
</pre>
