### PR TITLE
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing

### DIFF
--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -870,3 +870,5 @@ imported/w3c/web-platform-tests/file-system-access/ [ Pass ]
 storage/filesystemaccess/ [ Pass ]
 
 fast/canvas/large-getImageData.html [ Pass ]
+
+webkit.org/b/240987 fast/images/heic-as-background-image.html [ Failure ]


### PR DESCRIPTION
#### 92b4f5717db9cd7a26c4e6647432552584ba40b7
<pre>
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=240987">https://bugs.webkit.org/show_bug.cgi?id=240987</a>

Unreviewed. Adding failure test expectation.

* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252559@main">https://commits.webkit.org/252559@main</a>
</pre>
