### PR TITLE
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1722,3 +1722,5 @@ webkit.org/b/227555 http/tests/privateClickMeasurement/attribution-conversion-th
 webkit.org/b/242462 [ Monterey Release ] imported/w3c/web-platform-tests/IndexedDB/string-list-ordering.htm [ Pass Crash ]
 
 webkit.org/b/242804 media/track/track-forced-subtitles-in-band.html [ Pass Failure ]
+
+webkit.org/b/240987 fast/images/heic-as-background-image.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -870,5 +870,3 @@ imported/w3c/web-platform-tests/file-system-access/ [ Pass ]
 storage/filesystemaccess/ [ Pass ]
 
 fast/canvas/large-getImageData.html [ Pass ]
-
-webkit.org/b/240987 fast/images/heic-as-background-image.html [ Failure ]


### PR DESCRIPTION
#### 668b1631918d7cdf19d3d259c626d0a84605b83a
<pre>
New test: [macOS WK2] fast/images/heic-as-background-image.html is consistently failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=240987">https://bugs.webkit.org/show_bug.cgi?id=240987</a>

Unreviewed. Corrected the test expectation to be ImageOnlyFailure on macOS WK2.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252562@main">https://commits.webkit.org/252562@main</a>
</pre>
