### PR TITLE
Update libwebrtc RestoreEncodingLayers

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc
@@ -84,6 +84,7 @@ RtpParameters RestoreEncodingLayers(
       result.encodings.push_back(encoding);
       continue;
     }
+    RTC_CHECK_LT(index, parameters.encodings.size());
     result.encodings.push_back(parameters.encodings[index++]);
   }
   return result;


### PR DESCRIPTION
#### 0006fa5e6a5b10678251c393335e1d5d1072a305
<pre>
Update libwebrtc RestoreEncodingLayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=242852">https://bugs.webkit.org/show_bug.cgi?id=242852</a>
rdar://97183357

Reviewed by Alex Christensen.

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/rtp_sender.cc:

Canonical link: <a href="https://commits.webkit.org/252592@main">https://commits.webkit.org/252592@main</a>
</pre>
