### PR TITLE
Improve RTCRtpSender::setParameters spec compliance

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-codecs-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-codecs-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL setParameters() with codec.payloadType modified should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL setParameters() with codec.mimeType modified should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL setParameters() with codec.clockRate modified should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL setParameters() with codec.channels modified should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL setParameters() with codec.sdpFmtpLine modified should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL setParameters() with new codecs inserted should reject with InvalidModificationError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS setParameters() with codec.payloadType modified should reject with InvalidModificationError
+PASS setParameters() with codec.mimeType modified should reject with InvalidModificationError
+PASS setParameters() with codec.clockRate modified should reject with InvalidModificationError
+PASS setParameters() with codec.channels modified should reject with InvalidModificationError
+PASS setParameters() with codec.sdpFmtpLine modified should reject with InvalidModificationError
+PASS setParameters() with new codecs inserted should reject with InvalidModificationError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-degradationPreference-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-degradationPreference-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL setParameters with degradationPreference set should succeed assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
-FAIL setParameters with degradationPreference unset should succeed assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
+FAIL setParameters with degradationPreference set should succeed pc.setParameters is not a function. (In 'pc.setParameters(param)', 'pc.setParameters' is undefined)
+FAIL setParameters with degradationPreference unset should succeed pc.setParameters is not a function. (In 'pc.setParameters(param)', 'pc.setParameters' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings-expected.txt
@@ -4,7 +4,7 @@ PASS addTransceiver() with empty list sendEncodings should have default encoding
 FAIL sender.getParameters() should return sendEncodings set by addTransceiver() assert_not_own_property: rid should be removed with a single encoding unexpected property "rid" is found on object
 PASS sender.setParameters() with mismatch number of encodings should reject with InvalidModificationError
 PASS sender.setParameters() with encodings unset should reject with TypeError
-FAIL setParameters() with modified encoding.rid field should reject with InvalidModificationError assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
+PASS setParameters() with modified encoding.rid field should reject with InvalidModificationError
 PASS setParameters() with encoding.scaleResolutionDownBy field set to less than 1.0 should reject with RangeError
 PASS setParameters() with encoding.scaleResolutionDownBy field set to greater than 1.0 should succeed
 PASS setParameters() with modified encoding.active should succeed with RTCRtpTransceiverInit

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-headerExtensions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-headerExtensions-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL setParameters() with modified headerExtensions should reject with InvalidModificationError assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
+PASS setParameters() with modified headerExtensions should reject with InvalidModificationError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-rtcp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-rtcp-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL setParameters() with modified rtcp.cname should reject with InvalidModificationError assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
-FAIL setParameters() with modified rtcp.reducedSize should reject with InvalidModificationError assert_not_equals: Expect sender param.rtcp.cname to be set got disallowed value undefined
+PASS setParameters() with modified rtcp.cname should reject with InvalidModificationError
+PASS setParameters() with modified rtcp.reducedSize should reject with InvalidModificationError
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -207,8 +207,6 @@ RTCRtpParameters toRTCRtpParameters(const webrtc::RtpParameters& rtcParameters)
         parameters.codecs.append(toRTCCodecParameters(codec));
 
     parameters.rtcp.reducedSize = rtcParameters.rtcp.reduced_size;
-    if (rtcParameters.rtcp.cname.length())
-        parameters.rtcp.cname = fromStdString(rtcParameters.rtcp.cname);
 
     return parameters;
 }
@@ -216,6 +214,7 @@ RTCRtpParameters toRTCRtpParameters(const webrtc::RtpParameters& rtcParameters)
 RTCRtpSendParameters toRTCRtpSendParameters(const webrtc::RtpParameters& rtcParameters)
 {
     RTCRtpSendParameters parameters { toRTCRtpParameters(rtcParameters) };
+    parameters.rtcp.cname = fromStdString(rtcParameters.rtcp.cname);
 
     parameters.transactionId = fromStdString(rtcParameters.transaction_id);
     for (auto& rtcEncoding : rtcParameters.encodings)


### PR DESCRIPTION
#### b6965cf9b33991b4d175e1f2ed2389641014dfe4
<pre>
Improve RTCRtpSender::setParameters spec compliance
<a href="https://bugs.webkit.org/show_bug.cgi?id=242853">https://bugs.webkit.org/show_bug.cgi?id=242853</a>
rdar://problem/97183896

Reviewed by Alex Christensen.

Add parameter checks as per spec.
In particular, we only fill cname for sender and not receiver.
We also validate the parameters provided to setParameters.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-codecs-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-degradationPreference-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-headerExtensions-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-rtcp-expected.txt:
* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp:
(WebCore::RTCRtpSender::getParameters):
(WebCore::validateModifiedParameters):
(WebCore::RTCRtpSender::setParameters):
* Source/WebCore/Modules/mediastream/RTCRtpSender.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.cpp:
(WebCore::validateModifiedParameters):
(WebCore::LibWebRTCRtpSenderBackend::setParameters):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::toRTCRtpParameters):
(WebCore::toRTCRtpSendParameters):

Canonical link: <a href="https://commits.webkit.org/252787@main">https://commits.webkit.org/252787@main</a>
</pre>
