### PR TITLE
WebPageProxy::isConnectedToHardwareConsoleDidChange can erroneously unmute capture for a page

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -808,7 +808,9 @@ public:
     void activateMediaStreamCaptureInPage();
     bool isMediaStreamCaptureMuted() const { return m_mutedState.containsAny(WebCore::MediaProducer::MediaStreamCaptureIsMuted); }
     void setMediaStreamCaptureMuted(bool);
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     void isConnectedToHardwareConsoleDidChange();
+#endif
     bool isAllowedToChangeMuteState() const;
 
     void requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&&);
@@ -3075,8 +3077,10 @@ private:
     bool m_mayStartMediaWhenInWindow { true };
     bool m_mediaPlaybackIsSuspended { false };
     bool m_mediaCaptureEnabled { true };
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     bool m_isProcessingIsConnectedToHardwareConsoleDidChangeNotification { false };
-    bool m_captureWasMutedWhenHardwareConsoleDisconnected { false };
+    bool m_captureWasMutedDueToDisconnectedHardwareConsole { false };
+#endif
 
     bool m_waitingForDidUpdateActivityState { false };
 


### PR DESCRIPTION
#### 6d08f816b25d9a3b4143cdd0227498b70f5ec279
<pre>
WebPageProxy::isConnectedToHardwareConsoleDidChange can erroneously unmute capture for a page
<a href="https://bugs.webkit.org/show_bug.cgi?id=242856">https://bugs.webkit.org/show_bug.cgi?id=242856</a>
rdar://96885262

Reviewed by Chris Dumez.

WebPageProxy::isConnectedToHardwareConsoleDidChange can be called in cases where all flags are set, for instance when triggering a thumbnail preview.
In that case, isConnectedToHardwareConsoleDidChange might unmute a page that was previously muted.
We update the code to prevent this by making sure that isConnectedToHardwareConsoleDidChange will not unmute unless it actually muted the page in the first place.
We also conditionally compile this code for Mac/Catalyst only.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::isConnectedToHardwareConsoleDidChange):
(WebKit::WebPageProxy::isAllowedToChangeMuteState const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:

Canonical link: <a href="https://commits.webkit.org/252593@main">https://commits.webkit.org/252593@main</a>
</pre>
