### PR TITLE
[ews-build.webkit.org] Support alternate remotes in checkout-source (Follow-up fix)

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -628,9 +628,9 @@ class CheckOutSource(git.Git):
             return {'step': 'Cleaned and updated working directory'}
 
     def run(self):
-        project = self.getProperty('project', GITHUB_PROJECTS[0])
+        project = self.getProperty('project', '') or GITHUB_PROJECTS[0]
         self.repourl = f'{GITHUB_URL}{project}.git'
-        self.branch = self.getProperty('github.base.ref', self.branch)
+        self.branch = self.getProperty('github.base.ref') or self.branch
 
         username, access_token = GitHub.credentials(user=GitHub.user_for_queue(self.getProperty('buildername', '')))
         self.env = dict(


### PR DESCRIPTION
#### 0c370877d3e50821c2267771acc9e9f38c87ef82
<pre>
[ews-build.webkit.org] Support alternate remotes in checkout-source (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242824">https://bugs.webkit.org/show_bug.cgi?id=242824</a>
&lt;rdar://problem/97098737&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(CheckOutSource.__init__): Set repourl based on variables.
(CheckOutSource.run): Set repourl based on properties, forward credentials to process.

Canonical link: <a href="https://commits.webkit.org/252570@main">https://commits.webkit.org/252570@main</a>
</pre>
