### PR TITLE
In iOS 16 beta 20A5312j, Chrome 103 calls getUserMedia() will get black video

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -423,10 +423,7 @@ bool AVVideoCaptureSource::setupSession()
 
 #if ENABLE(APP_PRIVACY_REPORT)
     auto identity = RealtimeMediaSourceCenter::singleton().identity();
-    if (!identity) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "RealtimeMediaSourceCenter::identity() returned null!");
-        return false;
-    }
+    ERROR_LOG_IF(loggerPtr() && !identity, LOGIDENTIFIER, "RealtimeMediaSourceCenter::identity() returned null!");
 
     if (identity && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithAssumedIdentity:)])
         m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithAssumedIdentity:identity.get()]);
@@ -437,6 +434,7 @@ bool AVVideoCaptureSource::setupSession()
 
     if (!m_session) {
         ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "failed to allocate AVCaptureSession");
+        captureFailed();
         return false;
     }
 


### PR DESCRIPTION
#### 19a6a37532229477bbf1de8c6ae22d4916cab708
<pre>
In iOS 16 beta 20A5312j, Chrome 103 calls getUserMedia() will get black video
<a href="https://bugs.webkit.org/show_bug.cgi?id=242795">https://bugs.webkit.org/show_bug.cgi?id=242795</a>
rdar://problem/97102894

Reviewed by Jer Noble.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupSession):
WKWebView applications may not always have an identity due to a lower level bug.
In that case, we can capture using the previous API without identity.
Add logging to ensure we notice that we do not provide identity.

Canonical link: <a href="https://commits.webkit.org/252591@main">https://commits.webkit.org/252591@main</a>
</pre>
