### PR TITLE
Support for the "scan" media feature.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -717,9 +717,9 @@ PASS subtest_709
 PASS subtest_710
 PASS subtest_711
 PASS subtest_712
-FAIL subtest_713 assert_true: expected true got false
-FAIL subtest_714 assert_true: expected true got false
-FAIL subtest_715 assert_true: expected true got false
+PASS subtest_713
+PASS subtest_714
+PASS subtest_715
 PASS subtest_716
 PASS subtest_717
 PASS subtest_718
@@ -727,9 +727,9 @@ PASS subtest_719
 PASS subtest_720
 PASS subtest_721
 PASS subtest_722
-FAIL subtest_723 assert_true: not all and (scan) should apply expected true got false
-FAIL subtest_724 assert_true: not all and (scan: progressive) should apply expected true got false
-FAIL subtest_725 assert_true: not all and (scan: interlace) should apply expected true got false
+PASS subtest_723
+PASS subtest_724
+PASS subtest_725
 PASS subtest_726
 PASS subtest_727
 PASS subtest_728

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -717,9 +717,9 @@ PASS subtest_709
 PASS subtest_710
 PASS subtest_711
 PASS subtest_712
-FAIL subtest_713 assert_true: expected true got false
-FAIL subtest_714 assert_true: expected true got false
-FAIL subtest_715 assert_true: expected true got false
+PASS subtest_713
+PASS subtest_714
+PASS subtest_715
 PASS subtest_716
 PASS subtest_717
 PASS subtest_718
@@ -727,9 +727,9 @@ PASS subtest_719
 PASS subtest_720
 PASS subtest_721
 PASS subtest_722
-FAIL subtest_723 assert_true: not all and (scan) should apply expected true got false
-FAIL subtest_724 assert_true: not all and (scan: progressive) should apply expected true got false
-FAIL subtest_725 assert_true: not all and (scan: interlace) should apply expected true got false
+PASS subtest_723
+PASS subtest_724
+PASS subtest_725
 PASS subtest_726
 PASS subtest_727
 PASS subtest_728

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -717,9 +717,9 @@ PASS subtest_709
 PASS subtest_710
 PASS subtest_711
 PASS subtest_712
-FAIL subtest_713 assert_true: expected true got false
-FAIL subtest_714 assert_true: expected true got false
-FAIL subtest_715 assert_true: expected true got false
+PASS subtest_713
+PASS subtest_714
+PASS subtest_715
 PASS subtest_716
 PASS subtest_717
 PASS subtest_718
@@ -727,9 +727,9 @@ PASS subtest_719
 PASS subtest_720
 PASS subtest_721
 PASS subtest_722
-FAIL subtest_723 assert_true: not all and (scan) should apply expected true got false
-FAIL subtest_724 assert_true: not all and (scan: progressive) should apply expected true got false
-FAIL subtest_725 assert_true: not all and (scan: interlace) should apply expected true got false
+PASS subtest_723
+PASS subtest_724
+PASS subtest_725
 PASS subtest_726
 PASS subtest_727
 PASS subtest_728

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1168,6 +1168,10 @@ fine
 // none
 hover
 
+// (scan:) media feature.
+progressive
+interlace
+
 // blend modes
 // normal
 multiply

--- a/Source/WebCore/css/MediaFeatureNames.h
+++ b/Source/WebCore/css/MediaFeatureNames.h
@@ -81,6 +81,7 @@
     macro(prefersDarkInterface, "prefers-dark-interface") \
     macro(prefersReducedMotion, "prefers-reduced-motion") \
     macro(resolution, "resolution") \
+    macro(scan, "scan") \
     macro(transform2d, "-webkit-transform-2d") \
     macro(transform3d, "-webkit-transform-3d") \
     macro(transition, "-webkit-transition") \

--- a/Source/WebCore/css/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -481,6 +481,28 @@ static bool dynamicRangeEvaluate(CSSValue* value, const CSSToLengthConversionDat
     }
 }
 
+static bool scanEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame& frame, MediaFeaturePrefix)
+{
+    RefPtr view = frame.view();
+    if (!view)
+        return false;
+
+    /* With Media Queries Level 4, the "tv" media type is deprecated
+     * and the "scan" feature applies to all media types.
+     * We are currently supporting Media Queries Level 3,
+     * thus the check against "tv".
+     */
+    if (!equalLettersIgnoringASCIICase(view->mediaType(), "tv"_s))
+        return false;
+
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
+        return false;
+
+    // All known implementations (Blink, Gecko) assume and match "progressive".
+    return primitiveValue->valueID() == CSSValueProgressive;
+}
+
 static bool gridEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame&, MediaFeaturePrefix op)
 {
     return zeroEvaluate(value, op);

--- a/Source/WebCore/css/MediaQueryExpression.cpp
+++ b/Source/WebCore/css/MediaQueryExpression.cpp
@@ -67,6 +67,8 @@ static inline bool isValidValueForIdentMediaFeature(const AtomString& feature, c
         return valueID == CSSValuePrefers || valueID == CSSValueNoPreference;
     if (feature == MediaFeatureNames::dynamicRange)
         return valueID == CSSValueHigh || valueID == CSSValueStandard;
+    if (feature == MediaFeatureNames::scan)
+        return valueID == CSSValueProgressive || valueID == CSSValueInterlace;
 
     return false;
 }
@@ -92,7 +94,8 @@ static inline bool featureWithValidIdent(const AtomString& mediaFeature, const C
         || mediaFeature == MediaFeatureNames::prefersContrast
         || mediaFeature == MediaFeatureNames::prefersReducedMotion
         || (mediaFeature == MediaFeatureNames::prefersDarkInterface && (context.useSystemAppearance || isUASheetBehavior(context.mode)))
-        || mediaFeature == MediaFeatureNames::dynamicRange;
+        || mediaFeature == MediaFeatureNames::dynamicRange
+        || mediaFeature == MediaFeatureNames::scan;
 }
 
 static inline bool featureWithValidDensity(const String& mediaFeature, const CSSPrimitiveValue& value)
@@ -210,6 +213,7 @@ static inline bool isFeatureValidWithoutValue(const AtomString& mediaFeature, co
 #if ENABLE(APPLICATION_MANIFEST)
         || mediaFeature == MediaFeatureNames::displayMode
 #endif
+        || mediaFeature == MediaFeatureNames::scan
         || mediaFeature == MediaFeatureNames::videoPlayableInline;
 }
 


### PR DESCRIPTION
#### a74d36b48f3e9b63b0f7384e616cfc97e0fc38d8
<pre>
Support for the &quot;scan&quot; media feature.
<a href="https://bugs.webkit.org/show_bug.cgi?id=114426">https://bugs.webkit.org/show_bug.cgi?id=114426</a>

Reviewed by Aditya Keerthi, Tim Nguyen and Chris Dumez.

Support parsing/matching for the &quot;scan&quot; media feature (Media Queries Level 3).
<a href="https://www.w3.org/TR/mediaqueries-3/#scan">https://www.w3.org/TR/mediaqueries-3/#scan</a>
Like the other implementations, it assumes a modern TV with progressive
display.

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/MediaFeatureNames.h:
* Source/WebCore/css/MediaQueryEvaluator.cpp:
(WebCore::scanEvaluate):
* Source/WebCore/css/MediaQueryExpression.cpp:
(WebCore::isValidValueForIdentMediaFeature):
(WebCore::featureWithValidIdent):
(WebCore::isFeatureValidWithoutValue):

Canonical link: <a href="https://commits.webkit.org/252717@main">https://commits.webkit.org/252717@main</a>
</pre>
