### PR TITLE
Web Inspector: harden `InspectorDebuggerAgent::didDispatchAsyncCall` to avoid problems if Web Inspector is opened after enqueuing before dispatch

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -129,7 +129,7 @@ public:
     void didScheduleAsyncCall(JSC::JSGlobalObject*, AsyncCallType, int callbackId, bool singleShot);
     void didCancelAsyncCall(AsyncCallType, int callbackId);
     void willDispatchAsyncCall(AsyncCallType, int callbackId);
-    void didDispatchAsyncCall();
+    void didDispatchAsyncCall(AsyncCallType, int callbackId);
     AsyncStackTrace* currentParentStackTrace() const;
 
     void schedulePauseAtNextOpportunity(DebuggerFrontendDispatcher::Reason, RefPtr<JSON::Object>&& data = nullptr);

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -858,6 +858,9 @@ public:
     void remove(size_t position, size_t length);
     template<typename U> bool removeFirst(const U&);
     template<typename MatchFunction> bool removeFirstMatching(const MatchFunction&, size_t startIndex = 0);
+    template<typename U> bool removeLast(const U&);
+    template<typename MatchFunction> bool removeLastMatching(const MatchFunction&);
+    template<typename MatchFunction> bool removeLastMatching(const MatchFunction&, size_t startIndex);
     template<typename U> unsigned removeAll(const U&);
     template<typename MatchFunction> unsigned removeAllMatching(const MatchFunction&, size_t startIndex = 0);
 
@@ -1593,6 +1596,35 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
     for (size_t i = startIndex; i < size(); ++i) {
         if (matches(at(i))) {
             remove(i);
+            return true;
+        }
+    }
+    return false;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<typename U>
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLast(const U& value)
+{
+    return removeLastMatching([&value] (const T& current) {
+        return current == value;
+    });
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<typename MatchFunction>
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const MatchFunction& matches)
+{
+    return removeLastMatching(matches, size());
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<typename MatchFunction>
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const MatchFunction& matches, size_t startIndex)
+{
+    for (size_t i = std::min(startIndex + 1, size()); i > 0; --i) {
+        if (matches(at(i - 1))) {
+            remove(i - 1);
             return true;
         }
     }

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -169,9 +169,10 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
             userGestureTokenToForward = nullptr;
         UserGestureIndicator gestureIndicator(userGestureTokenToForward);
 
-        InspectorInstrumentation::willFireAnimationFrame(protectedDocument, callback->m_id);
+        auto identifier = callback->m_id;
+        InspectorInstrumentation::willFireAnimationFrame(protectedDocument, identifier);
         callback->handleEvent(highResNowMs);
-        InspectorInstrumentation::didFireAnimationFrame(protectedDocument);
+        InspectorInstrumentation::didFireAnimationFrame(protectedDocument, identifier);
     }
 
     // Remove any callbacks we fired from the list of pending callbacks.

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -431,7 +431,7 @@ void InspectorInstrumentation::willHandleEventImpl(InstrumentingAgents& instrume
 void InspectorInstrumentation::didHandleEventImpl(InstrumentingAgents& instrumentingAgents, ScriptExecutionContext& context, Event& event, const RegisteredEventListener& listener)
 {
     if (auto* webDebuggerAgent = instrumentingAgents.enabledWebDebuggerAgent())
-        webDebuggerAgent->didDispatchAsyncCall();
+        webDebuggerAgent->didHandleEvent(listener);
 
     if (auto* domDebuggerAgent = instrumentingAgents.enabledDOMDebuggerAgent())
         domDebuggerAgent->didHandleEvent(context, event, listener);
@@ -483,10 +483,10 @@ void InspectorInstrumentation::willFireTimerImpl(InstrumentingAgents& instrument
         timelineAgent->willFireTimer(timerId, frameForScriptExecutionContext(context));
 }
 
-void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumentingAgents, int /* timerId */, bool oneShot)
+void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId, bool oneShot)
 {
     if (auto* webDebuggerAgent = instrumentingAgents.enabledWebDebuggerAgent())
-        webDebuggerAgent->didDispatchAsyncCall();
+        webDebuggerAgent->didDispatchAsyncCall(InspectorDebuggerAgent::AsyncCallType::DOMTimer, timerId);
     if (auto* domDebuggerAgent = instrumentingAgents.enabledDOMDebuggerAgent())
         domDebuggerAgent->didFireTimer(oneShot);
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
@@ -1242,10 +1242,10 @@ void InspectorInstrumentation::willFireAnimationFrameImpl(InstrumentingAgents& i
         timelineAgent->willFireAnimationFrame(callbackId, document.frame());
 }
 
-void InspectorInstrumentation::didFireAnimationFrameImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::didFireAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId)
 {
-    if (auto* webDebuggerAgent = instrumentingAgents.enabledWebDebuggerAgent())
-        webDebuggerAgent->didDispatchAsyncCall();
+    if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
+        pageDebuggerAgent->didFireAnimationFrame(callbackId);
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())
         pageDOMDebuggerAgent->didFireAnimationFrame();
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -267,7 +267,7 @@ public:
     static void didRequestAnimationFrame(Document&, int callbackId);
     static void didCancelAnimationFrame(Document&, int callbackId);
     static void willFireAnimationFrame(Document&, int callbackId);
-    static void didFireAnimationFrame(Document&);
+    static void didFireAnimationFrame(Document&, int callbackId);
 
     static void willFireObserverCallback(ScriptExecutionContext&, const String& callbackType);
     static void didFireObserverCallback(ScriptExecutionContext&);
@@ -470,7 +470,7 @@ private:
     static void didRequestAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
     static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
     static void willFireAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
-    static void didFireAnimationFrameImpl(InstrumentingAgents&);
+    static void didFireAnimationFrameImpl(InstrumentingAgents&, int callbackId);
 
     static void willFireObserverCallbackImpl(InstrumentingAgents&, const String&, ScriptExecutionContext&);
     static void didFireObserverCallbackImpl(InstrumentingAgents&);
@@ -1661,11 +1661,11 @@ inline void InspectorInstrumentation::willFireAnimationFrame(Document& document,
         willFireAnimationFrameImpl(*agents, callbackId, document);
 }
 
-inline void InspectorInstrumentation::didFireAnimationFrame(Document& document)
+inline void InspectorInstrumentation::didFireAnimationFrame(Document& document, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(document))
-        didFireAnimationFrameImpl(*agents);
+        didFireAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::willFireObserverCallback(ScriptExecutionContext& context, const String& callbackType)

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -47,6 +47,7 @@ public:
     void didAddEventListener(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     void willRemoveEventListener(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     void willHandleEvent(const RegisteredEventListener&);
+    void didHandleEvent(const RegisteredEventListener&);
     int willPostMessage();
     void didPostMessage(int postMessageIdentifier, JSC::JSGlobalObject&);
     void didFailPostMessage(int postMessageIdentifier);
@@ -64,6 +65,7 @@ protected:
 
 private:
     HashMap<const RegisteredEventListener*, int> m_registeredEventListeners;
+    HashMap<const RegisteredEventListener*, int> m_dispatchedEventListeners;
     HashSet<int> m_postMessageTasks;
     int m_nextEventListenerIdentifier { 1 };
     int m_nextPostMessageIdentifier { 1 };

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -199,4 +199,9 @@ void PageDebuggerAgent::didCancelAnimationFrame(int callbackId)
     didCancelAsyncCall(InspectorDebuggerAgent::AsyncCallType::RequestAnimationFrame, callbackId);
 }
 
+void PageDebuggerAgent::didFireAnimationFrame(int callbackId)
+{
+    didDispatchAsyncCall(InspectorDebuggerAgent::AsyncCallType::RequestAnimationFrame, callbackId);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.h
@@ -67,6 +67,7 @@ public:
     void didRequestAnimationFrame(int callbackId, Document&);
     void willFireAnimationFrame(int callbackId);
     void didCancelAnimationFrame(int callbackId);
+    void didFireAnimationFrame(int callbackId);
 
 private:
     void internalEnable();

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -583,6 +583,42 @@ TEST(WTF_Vector, RemoveFirst)
     EXPECT_TRUE(v.isEmpty());
 }
 
+TEST(WTF_Vector, RemoveLast)
+{
+    Vector<int> v;
+    EXPECT_TRUE(v.isEmpty());
+    EXPECT_FALSE(v.removeLast(1));
+    EXPECT_FALSE(v.removeLast(-1));
+    EXPECT_TRUE(v.isEmpty());
+
+    v.fill(2, 10);
+    EXPECT_EQ(10U, v.size());
+    EXPECT_FALSE(v.removeLast(1));
+    EXPECT_EQ(10U, v.size());
+    v.clear();
+
+    v.fill(1, 10);
+    EXPECT_EQ(10U, v.size());
+    EXPECT_TRUE(v.removeLast(1));
+    EXPECT_TRUE(v == Vector<int>({1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    EXPECT_EQ(9U, v.size());
+    EXPECT_FALSE(v.removeLast(2));
+    EXPECT_EQ(9U, v.size());
+    EXPECT_TRUE(v == Vector<int>({1, 1, 1, 1, 1, 1, 1, 1, 1}));
+
+    unsigned removed = 0;
+    while (v.removeLast(1))
+        ++removed;
+    EXPECT_EQ(9U, removed);
+    EXPECT_TRUE(v.isEmpty());
+
+    v.resize(1);
+    EXPECT_EQ(1U, v.size());
+    EXPECT_TRUE(v.removeLast(1));
+    EXPECT_EQ(0U, v.size());
+    EXPECT_TRUE(v.isEmpty());
+}
+
 TEST(WTF_Vector, RemoveAll)
 {
     // Using a memcpy-able type.
@@ -773,6 +809,39 @@ TEST(WTF_Vector, RemoveFirstMatching)
     EXPECT_FALSE(v.removeFirstMatching([] (int value) { return value == 1; }, 7));
     EXPECT_EQ(7U, v.size());
     EXPECT_FALSE(v.removeFirstMatching([] (int value) { return value == 1; }, 10));
+    EXPECT_EQ(7U, v.size());
+}
+
+TEST(WTF_Vector, RemoveLastMatching)
+{
+    Vector<int> v;
+    EXPECT_TRUE(v.isEmpty());
+    EXPECT_FALSE(v.removeLastMatching([] (int value) { return value > 0; }));
+    EXPECT_FALSE(v.removeLastMatching([] (int) { return true; }));
+    EXPECT_FALSE(v.removeLastMatching([] (int) { return false; }));
+
+    v = {3, 1, 1, 1, 2, 2, 1, 2, 1, 2, 1, 3};
+    EXPECT_EQ(12U, v.size());
+    EXPECT_FALSE(v.removeLastMatching([] (int) { return false; }));
+    EXPECT_EQ(12U, v.size());
+    EXPECT_FALSE(v.removeLastMatching([] (int value) { return value < 0; }));
+    EXPECT_EQ(12U, v.size());
+    EXPECT_TRUE(v.removeLastMatching([] (int value) { return value < 3; }));
+    EXPECT_EQ(11U, v.size());
+    EXPECT_TRUE(v == Vector<int>({3, 1, 1, 1, 2, 2, 1, 2, 1, 2, 3}));
+    EXPECT_TRUE(v.removeLastMatching([] (int value) { return value > 2; }));
+    EXPECT_EQ(10U, v.size());
+    EXPECT_TRUE(v == Vector<int>({3, 1, 1, 1, 2, 2, 1, 2, 1, 2}));
+    EXPECT_TRUE(v.removeLastMatching([] (int value) { return value > 2; }, 10));
+    EXPECT_EQ(9U, v.size());
+    EXPECT_TRUE(v == Vector<int>({1, 1, 1, 2, 2, 1, 2, 1, 2}));
+    EXPECT_TRUE(v.removeLastMatching([] (int value) { return value == 1; }, 7));
+    EXPECT_EQ(8U, v.size());
+    EXPECT_TRUE(v == Vector<int>({1, 1, 1, 2, 2, 1, 2, 2}));
+    EXPECT_TRUE(v.removeLastMatching([] (int value) { return value == 1; }, 4));
+    EXPECT_EQ(7U, v.size());
+    EXPECT_TRUE(v == Vector<int>({1, 1, 2, 2, 1, 2, 2}));
+    EXPECT_FALSE(v.removeLastMatching([] (int value) { return value == 2; }, 1));
     EXPECT_EQ(7U, v.size());
 }
 


### PR DESCRIPTION
#### f407fbb287465a0ff68442eb7297862518e211cc
<pre>
Web Inspector: harden `InspectorDebuggerAgent::didDispatchAsyncCall` to avoid problems if Web Inspector is opened after enqueuing before dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=242865">https://bugs.webkit.org/show_bug.cgi?id=242865</a>

Reviewed by Patrick Angle.

Imagine a series of events like this:

1. page calls `queueMicrotask`
2. developer opens Web Inspector
3. page calls `setTimeout`
4. microtask from (1) fires

Step (4) will cause the `AsyncStackTrace` created by step (3) to be immediately &quot;resolved&quot; since
`didDispatchAsyncCall` doesn&apos;t do any checking to validate that the async call matches the `AsyncCallType`
and identifier of the current `AsyncStackTrace`.

We should be providing the `AsyncCallType` and identifier at every step of the process so that we&apos;re
always &quot;resolving&quot; the right `AsyncStackTrace` for the given async call.

This will also give us some defense if in the future async calls somehow can become interleaved.

* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::willDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didDispatchAsyncCall):
(Inspector::InspectorDebuggerAgent::didQueueMicrotask):
(Inspector::InspectorDebuggerAgent::willRunMicrotask):
(Inspector::InspectorDebuggerAgent::didRunMicrotask):
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::serviceRequestAnimationFrameCallbacks):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didFireAnimationFrame):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didHandleEventImpl):
(WebCore::InspectorInstrumentation::didFireTimerImpl):
(WebCore::InspectorInstrumentation::didFireAnimationFrameImpl):
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::willHandleEvent):
(WebCore::WebDebuggerAgent::didHandleEvent): Added.
(WebCore::WebDebuggerAgent::didDispatchPostMessage):
(WebCore::WebDebuggerAgent::didClearAsyncStackTraceData):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.h:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::didFireAnimationFrame): Added.

* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::removeLast): Added.
(WTF::Malloc&gt;::removeLastMatching): Added.
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST.WTF_Vector.RemoveLast): Added.
(TestWebKitAPI::TEST.WTF_Vector.RemoveLastMatching): Added.
New utility functions similar to `WTF::Vector::removeFirst` and `WTF::Vector::removeFirstMatching`
to make it easier to use a `WTF::Vector` like a LIFO structure (with a bit more flexibility).

Canonical link: <a href="https://commits.webkit.org/252869@main">https://commits.webkit.org/252869@main</a>
</pre>
