### PR TITLE
Commit queue fails to land patch with changes to prepare-ChangeLog script (Follow-up)

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4883,7 +4883,7 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
         'Unreviewed',
         'Versioning.',
     )
-    RE_CHANGELOG = r'^(\+\+\+)\s+(.*/ChangeLog.*)'
+    RE_CHANGELOG = br'^(\+\+\+)\s+(.*/ChangeLog.*)'
     BY_RE = re.compile(r'.+\s+by\s+(.+)$')
     SPLIT_RE = re.compile(r'(,\s*)|( and )')
 


### PR DESCRIPTION
#### da71edd76bae70d09833647bff0fcc272c804545
<pre>
Commit queue fails to land patch with changes to prepare-ChangeLog script (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242735">https://bugs.webkit.org/show_bug.cgi?id=242735</a>
&lt;rdar://97106200&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ValidateCommitMessage): Make RE_CHANGELOG a bytes regex.

Canonical link: <a href="https://commits.webkit.org/252571@main">https://commits.webkit.org/252571@main</a>
</pre>
