### PR TITLE
[Gardening]: [ iOS wk2 arm64 ] fast/forms/textfield-outline.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2220,3 +2220,5 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitm
 webkit.org/b/242515 [ arm64 ] compositing/reflections/mask-and-reflection.html [ ImageOnlyFailure ]
 
 webkit.org/b/242812 [ Release arm64 ] js/dom/Promise-reject-large-string.html [ Pass Failure ]
+
+webkit.org/b/241205 [ Release arm64 ] fast/forms/textfield-outline.html [ Pass Failure ]


### PR DESCRIPTION
#### 945df646018d701789f2787bf0f07894221b7098
<pre>
[Gardening]: [ iOS wk2 arm64 ] fast/forms/textfield-outline.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241205">https://bugs.webkit.org/show_bug.cgi?id=241205</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252575@main">https://commits.webkit.org/252575@main</a>
</pre>
