### PR TITLE
[C++20] libwebrtc build fix. rdar://96912027

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h
@@ -158,7 +158,7 @@ class MasterParser : public ElementParser {
   struct IdHash : StdHashId {
     // Type aliases for conforming to the std::hash interface.
     using argument_type = Id;
-    using result_type = StdHashId::result_type;
+    using result_type = size_t;
 
     // Returns the hash of the given id.
     result_type operator()(argument_type id) const {


### PR DESCRIPTION
#### 0aa7ddec3edbd4021efa9f9e38dda007cf76e34f
<pre>
[C++20] libwebrtc build fix. rdar://96912027

Reviewed by Youenn Fablet.

 * Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h:

Canonical link: <a href="https://commits.webkit.org/252610@main">https://commits.webkit.org/252610@main</a>
</pre>
