### PR TITLE
REGRESSION(252551@main) ASSERTION FAILED: isEventDispatchAllowedInSubtree(*this) in BaseDateAndTimeInputType::createShadowSubtree

### DIFF
--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -322,8 +322,8 @@ void BaseDateAndTimeInputType::createShadowSubtree()
         element.userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, *m_dateTimeEditElement);
     } else {
         auto valueContainer = HTMLDivElement::create(document);
-        valueContainer->setPseudo(ShadowPseudoIds::webkitDateAndTimeValue());
         element.userAgentShadowRoot()->appendChild(ContainerNode::ChildChange::Source::Parser, valueContainer);
+        valueContainer->setPseudo(ShadowPseudoIds::webkitDateAndTimeValue());
     }
     updateInnerTextValue();
 }


### PR DESCRIPTION
#### d992e35e2e9d3d866966d1d1ad410596267c8dc5
<pre>
REGRESSION(252551@main) ASSERTION FAILED: isEventDispatchAllowedInSubtree(*this) in BaseDateAndTimeInputType::createShadowSubtree
<a href="https://bugs.webkit.org/show_bug.cgi?id=242866">https://bugs.webkit.org/show_bug.cgi?id=242866</a>

Reviewed by Alan Bujtas and Wenson Hsieh.

The assertion failure was caused by setPseudo call in BaseDateAndTimeInputType::createShadowSubtree()
on a newly created div element. Append the div to the container element with EventAllowedScope first
before setting an attribute to allow this mutation without an assertion failure.

* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::createShadowSubtree):

Canonical link: <a href="https://commits.webkit.org/252576@main">https://commits.webkit.org/252576@main</a>
</pre>
