### PR TITLE
Crash at HTMLMediaElement::mediaPlayerGetRawCookies()

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7448,8 +7448,10 @@ String HTMLMediaElement::mediaPlayerNetworkInterfaceName() const
 void HTMLMediaElement::mediaPlayerGetRawCookies(const URL& url, MediaPlayerClient::GetRawCookiesCallback&& completionHandler) const
 {
     auto* page = document().page();
-    if (!page)
+    if (!page) {
         completionHandler({ });
+        return;
+    }
 
     Vector<Cookie> cookies;
     page->cookieJar().getRawCookies(document(), url, cookies);


### PR DESCRIPTION
#### 9f7d2c570a4c8b8841a0b2573fa024303f5182bc
<pre>
Crash at HTMLMediaElement::mediaPlayerGetRawCookies()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242870">https://bugs.webkit.org/show_bug.cgi?id=242870</a>
&lt;rdar://80778666&gt;

Reviewed by Chris Dumez.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerGetRawCookies const):

Bail out early if the document() does not have a current page().

Canonical link: <a href="https://commits.webkit.org/252607@main">https://commits.webkit.org/252607@main</a>
</pre>
