### PR TITLE
[Alternate WebM Player] Implement CORS checking

### DIFF
--- a/Source/WebCore/platform/graphics/WebMResourceClient.cpp
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.cpp
@@ -62,6 +62,15 @@ void WebMResourceClient::stop()
     resource->setClient(nullptr);
 }
 
+void WebMResourceClient::responseReceived(PlatformMediaResource& resource, const ResourceResponse& response, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
+{
+    if (!m_parent)
+        return;
+    
+    m_parent->responseReceived(resource, response);
+    completionHandler(ShouldContinuePolicyCheck::Yes);
+}
+
 void WebMResourceClient::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)
 {
     if (!m_parent)

--- a/Source/WebCore/platform/graphics/WebMResourceClient.h
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class WebMResourceClientParent : public CanMakeWeakPtr<WebMResourceClientParent> {
 public:
     virtual ~WebMResourceClientParent() = default;
-    
+    virtual void responseReceived(PlatformMediaResource&, const ResourceResponse&) = 0;
     virtual void dataReceived(const SharedBuffer&) = 0;
     virtual void loadFailed(const ResourceError&) = 0;
     virtual void loadFinished(const FragmentedSharedBuffer&) = 0;
@@ -54,6 +54,7 @@ public:
 private:
     WebMResourceClient(WebMResourceClientParent&, Ref<PlatformMediaResource>&&);
 
+    void responseReceived(PlatformMediaResource&, const ResourceResponse&, CompletionHandler<void(ShouldContinuePolicyCheck)>&&) final;
     void dataReceived(PlatformMediaResource&, const SharedBuffer&) final;
     void loadFailed(PlatformMediaResource&, const ResourceError&) final;
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -84,6 +84,7 @@ private:
     
     // WebMResourceClientParent
     friend class WebMResourceClient;
+    void responseReceived(PlatformMediaResource&, const ResourceResponse&) final;
     void dataReceived(const SharedBuffer&) final;
     void loadFailed(const ResourceError&) final;
     void loadFinished(const FragmentedSharedBuffer&) final;
@@ -170,6 +171,10 @@ private:
     bool requiresTextTrackRepresentation() const final;
     void setTextTrackRepresentation(TextTrackRepresentation*) final;
     void syncTextTrackBounds() final;
+        
+    bool hasSingleSecurityOrigin() const final;
+    bool didPassCORSAccessCheck() const final { return m_didPassCORSAccessCheck; }
+    std::optional<bool> wouldTaintOrigin(const SecurityOrigin&) const final;
         
     String engineDescription() const final;
     MediaPlayer::MovieLoadType movieLoadType() const final { return MediaPlayer::MovieLoadType::Download; }
@@ -264,6 +269,12 @@ private:
 
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
+        
+    RefPtr<SecurityOrigin> m_requestedOrigin;
+    RefPtr<SecurityOrigin> m_resolvedOrigin;
+    HashSet<RefPtr<WebCore::SecurityOrigin>> m_origins;
+    bool m_didPassCORSAccessCheck { false };
+        
 #if !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     bool m_hasBeenAskedToPaintGL { false };
 #endif


### PR DESCRIPTION
#### ca9b269100dc5ac60d7e1ab5ecefeb682d3b9fa2
<pre>
[Alternate WebM Player] Implement CORS checking
<a href="https://bugs.webkit.org/show_bug.cgi?id=242869">https://bugs.webkit.org/show_bug.cgi?id=242869</a>

Reviewed by NOBODY (OOPS!).

Currently the player does not know how to handle cross-origin media and
fails to load. This patch brings CORS support to the player and proper
handling for canvas origin tainting.

* Source/WebCore/platform/graphics/WebMResourceClient.cpp:
(WebCore::WebMResourceClient::responseReceived):
* Source/WebCore/platform/graphics/WebMResourceClient.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):
(WebCore::MediaPlayerPrivateWebM::responseReceived):
(WebCore::MediaPlayerPrivateWebM::hasSingleSecurityOrigin const):
(WebCore::MediaPlayerPrivateWebM::wouldTaintOrigin const):
</pre>