### PR TITLE
Service workers in browser extensions are not able to load resources over a custom protocol

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3864,6 +3864,12 @@ ImageOverlayController& Page::imageOverlayController()
     return *m_imageOverlayController;
 }
 
+Page* Page::serviceWorkerPage(ScriptExecutionContextIdentifier serviceWorkerPageIdentifier)
+{
+    auto* serviceWorkerPageDocument = Document::allDocumentsMap().get(serviceWorkerPageIdentifier);
+    return serviceWorkerPageDocument ? serviceWorkerPageDocument->page() : nullptr;
+}
+
 #if ENABLE(IMAGE_ANALYSIS)
 
 ImageAnalysisQueue& Page::imageAnalysisQueue()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -596,6 +596,8 @@ public:
     bool isServiceWorkerPage() const { return m_isServiceWorkerPage; }
     void markAsServiceWorkerPage() { m_isServiceWorkerPage = true; }
 
+    WEBCORE_EXPORT static Page* serviceWorkerPage(ScriptExecutionContextIdentifier);
+
 #if ENABLE(SERVICE_WORKER)
     // Service worker pages have an associated ServiceWorkerGlobalScope on the main thread.
     void setServiceWorkerGlobalScope(ServiceWorkerGlobalScope&);

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -108,8 +108,7 @@ Page* ServiceWorkerGlobalScope::serviceWorkerPage()
         return nullptr;
 
     RELEASE_ASSERT(isMainThread());
-    auto* serviceWorkerPageDocument = Document::allDocumentsMap().get(*m_contextData.serviceWorkerPageIdentifier);
-    return serviceWorkerPageDocument ? serviceWorkerPageDocument->page() : nullptr;
+    return Page::serviceWorkerPage(*m_contextData.serviceWorkerPageIdentifier);
 }
 
 void ServiceWorkerGlobalScope::skipWaiting(Ref<DeferredPromise>&& promise)

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
@@ -27,6 +27,7 @@
 
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/EmptyFrameLoaderClient.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 
 namespace WebKit {
 
@@ -37,6 +38,9 @@ public:
     WebPageProxyIdentifier webPageProxyID() const { return m_webPageProxyID; }
 
     void setUserAgent(String&& userAgent) { m_userAgent = WTFMove(userAgent); }
+
+    void setServiceWorkerPageIdentifier(WebCore::ScriptExecutionContextIdentifier serviceWorkerPageIdentifier) { m_serviceWorkerPageIdentifier = serviceWorkerPageIdentifier; }
+    std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const { return m_serviceWorkerPageIdentifier; }
 
 private:
     Ref<WebCore::DocumentLoader> createDocumentLoader(const WebCore::ResourceRequest&, const WebCore::SubstituteData&) final;
@@ -53,6 +57,7 @@ private:
     WebCore::PageIdentifier m_pageID;
     WebCore::FrameIdentifier m_frameID;
     String m_userAgent;
+    std::optional<WebCore::ScriptExecutionContextIdentifier> m_serviceWorkerPageIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -160,7 +160,10 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         if (effectiveUserAgent.isNull())
             effectiveUserAgent = m_userAgent;
 
-        pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, FrameIdentifier::generate(), effectiveUserAgent);
+        auto loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, FrameIdentifier::generate(), effectiveUserAgent);
+        if (contextData.serviceWorkerPageIdentifier)
+            loaderClientForMainFrame->setServiceWorkerPageIdentifier(*contextData.serviceWorkerPageIdentifier);
+        pageConfiguration.loaderClientForMainFrame = WTFMove(loaderClientForMainFrame);
 
 #if !RELEASE_LOG_DISABLED
         auto serviceWorkerIdentifier = contextData.serviceWorkerIdentifier;


### PR DESCRIPTION
#### fcb40ae5073a12b5493d32c839eb99ca83138fa7
<pre>
Service workers in browser extensions are not able to load resources over a custom protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=242871">https://bugs.webkit.org/show_bug.cgi?id=242871</a>
&lt;rdar://96973622&gt;

Reviewed by Geoffrey Garen and Timothy Hatcher.

Loads from service workers could not get serviced by a custom scheme handler. Part of the
issue is that the custom scheme handlers as per WKWebView but service workers can be shared
by many web views. However, the service workers from browser extensions are special in that
they run on the main thread and they have a tight coupling with a WKWevView (and its
internal service worker page). In WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(), we
now add support for service workers from browser extensions by using the URL scheme handlers
from their associated service worker page.

Regular / traditional service workers still have no support for custom scheme handlers and
this is something we should consider fixing in the future. However, this patch takes care
of extension service workers, which is what the radar is about since they rely on custom
scheme handlers to do loads from the extension bundle. This is an important use case we
need to support ASAP.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::serviceWorkerPage):
* Source/WebCore/page/Page.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::serviceWorkerPage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::tryLoadingUsingURLSchemeHandler):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerSchemeHandler webView:startURLSchemeTask:]):

Canonical link: <a href="https://commits.webkit.org/252585@main">https://commits.webkit.org/252585@main</a>
</pre>
