### PR TITLE
Fix typo in SVGAttributeAnimator

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h
@@ -75,7 +75,7 @@ public:
 
     void apply(SVGElement& targetElement) override
     {
-        if (isAnimatedStylePropertyAniamtor(targetElement))
+        if (isAnimatedStylePropertyAnimator(targetElement))
             applyAnimatedStylePropertyChange(targetElement, m_animated->animValAsString());
         applyAnimatedPropertyChange(targetElement);
     }
@@ -86,7 +86,7 @@ public:
             return;
 
         applyAnimatedPropertyChange(targetElement);
-        if (isAnimatedStylePropertyAniamtor(targetElement))
+        if (isAnimatedStylePropertyAnimator(targetElement))
             removeAnimatedStyleProperty(targetElement);
 
         m_animated->stopAnimation(*this);

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
@@ -302,7 +302,7 @@ public:
     }
 
 private:
-    bool isAnimatedStyleClassAniamtor() const
+    bool isAnimatedStyleClassAnimator() const
     {
         return m_attributeName.matches(HTMLNames::classAttr);
     }
@@ -316,7 +316,7 @@ private:
     void apply(SVGElement& targetElement) final
     {
         Base::apply(targetElement);
-        if (isAnimatedStyleClassAniamtor())
+        if (isAnimatedStyleClassAnimator())
             invalidateStyle(targetElement);
     }
     
@@ -326,7 +326,7 @@ private:
             return;
 
         Base::stop(targetElement);
-        if (isAnimatedStyleClassAniamtor())
+        if (isAnimatedStyleClassAnimator())
             invalidateStyle(targetElement);
     }
 };

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-bool SVGAttributeAnimator::isAnimatedStylePropertyAniamtor(const SVGElement& targetElement) const
+bool SVGAttributeAnimator::isAnimatedStylePropertyAnimator(const SVGElement& targetElement) const
 {
     return targetElement.isAnimatedStyleAttribute(m_attributeName);
 }

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.h
@@ -76,7 +76,7 @@ public:
     virtual std::optional<float> calculateDistance(SVGElement&, const String&, const String&) const { return { }; }
 
 protected:
-    bool isAnimatedStylePropertyAniamtor(const SVGElement&) const;
+    bool isAnimatedStylePropertyAnimator(const SVGElement&) const;
 
     static void invalidateStyle(SVGElement&);
     static void applyAnimatedStylePropertyChange(SVGElement&, CSSPropertyID, const String& value);


### PR DESCRIPTION
#### e87c1bd54692630839fc5618ffc72576d85e532d
<pre>
Fix typo in SVGAttributeAnimator
<a href="https://bugs.webkit.org/show_bug.cgi?id=240950">https://bugs.webkit.org/show_bug.cgi?id=240950</a>

Reviewed by Said Abou-Hallawa.

* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimator.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAttributeAnimator.cpp:
(WebCore::SVGAttributeAnimator::isAnimatedStylePropertyAnimator const):
(WebCore::SVGAttributeAnimator::isAnimatedStylePropertyAniamtor const): Deleted.
* Source/WebCore/svg/properties/SVGAttributeAnimator.h:

Canonical link: <a href="https://commits.webkit.org/252587@main">https://commits.webkit.org/252587@main</a>
</pre>
