### PR TITLE
SourceBufferPrivate::bufferedSamplesForTrackId should return early if invalid trackbuffer is found

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -195,8 +195,10 @@ void SourceBufferPrivate::clearTrackBuffers()
 void SourceBufferPrivate::bufferedSamplesForTrackId(const AtomString& trackId, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     auto* trackBuffer = m_trackBufferMap.get(trackId);
-    if (!trackBuffer)
+    if (!trackBuffer) {
         completionHandler({ });
+        return;
+    }
 
     auto sampleDescriptions = WTF::map(trackBuffer->samples().decodeOrder(), [](auto& entry) {
         return toString(*entry.second);


### PR DESCRIPTION
#### e4087cfce4e232cf9f956b721d43872d29959768
<pre>
SourceBufferPrivate::bufferedSamplesForTrackId should return early if invalid trackbuffer is found
<a href="https://bugs.webkit.org/show_bug.cgi?id=242872">https://bugs.webkit.org/show_bug.cgi?id=242872</a>

Reviewed by Jer Noble and Eric Carlson.

We forget to return early once an invalid track buffer is found in our map
within SourceBufferPrivate::bufferedSamplesForTrackId, this can lead to a
null pointer dereference.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::bufferedSamplesForTrackId):

Canonical link: <a href="https://commits.webkit.org/252582@main">https://commits.webkit.org/252582@main</a>
</pre>
