### PR TITLE
221486: Enable LayoutTests/imported/w3c/web-platform-tests/shadow-dom/nested-slot-remove-crash.html for ios

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3309,8 +3309,6 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode
 
 webkit.org/b/225607 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-system-colors.html [ Failure ]
 
-webkit.org/b/221486 imported/w3c/web-platform-tests/shadow-dom/nested-slot-remove-crash.html [ Skip ]
-
 webkit.org/b/221466 imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys.html [ Skip ]
 webkit.org/b/221465 imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-combinations.html [ Skip ]
 


### PR DESCRIPTION
#### a890d1b9830c628cc063b6fa172ddc389fb06632
<pre>
221486: Enable LayoutTests/imported/w3c/web-platform-tests/shadow-dom/nested-slot-remove-crash.html for ios
<a href="https://bugs.webkit.org/show_bug.cgi?id=221486">https://bugs.webkit.org/show_bug.cgi?id=221486</a>

Unreviewed. Unskipping this test.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252579@main">https://commits.webkit.org/252579@main</a>
</pre>
