### PR TITLE
REGRESSION(252534@main): [ macOS ] TestWebKitAPI.ServiceWorkers.ServiceWorkerAndCacheStorageSpecificDirectories is constantly timing out

### DIFF
--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1423,10 +1423,11 @@ void NetworkProcessProxy::retrieveCacheStorageParameters(PAL::SessionID sessionI
         return;
     }
 
-    auto& cacheStorageDirectory = store->configuration().cacheStorageDirectory();
+    store->resolveDirectoriesIfNecessary();
+    auto& cacheStorageDirectory = store->resolvedCacheStorageDirectory();
     SandboxExtension::Handle cacheStorageDirectoryExtensionHandle;
     if (!cacheStorageDirectory.isEmpty()) {
-        if (auto handle = SandboxExtension::createHandleForReadWriteDirectory(cacheStorageDirectory))
+        if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(cacheStorageDirectory, SandboxExtension::Type::ReadWrite))
             cacheStorageDirectoryExtensionHandle = WTFMove(*handle);
     }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -300,13 +300,13 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
         m_resolvedConfiguration->setResourceLoadStatisticsDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->resourceLoadStatisticsDirectory()));
     if (!m_configuration->privateClickMeasurementStorageDirectory().isEmpty())
         m_resolvedConfiguration->setPrivateClickMeasurementStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->privateClickMeasurementStorageDirectory()));
-    if (!m_configuration->serviceWorkerRegistrationDirectory().isEmpty() && m_resolvedConfiguration->serviceWorkerRegistrationDirectory().isEmpty())
+    if (!m_configuration->serviceWorkerRegistrationDirectory().isEmpty())
         m_resolvedConfiguration->setServiceWorkerRegistrationDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->serviceWorkerRegistrationDirectory()));
     if (!m_configuration->javaScriptConfigurationDirectory().isEmpty())
         m_resolvedConfiguration->setJavaScriptConfigurationDirectory(resolvePathForSandboxExtension(m_configuration->javaScriptConfigurationDirectory()));
-    if (!m_configuration->cacheStorageDirectory().isEmpty() && m_resolvedConfiguration->cacheStorageDirectory().isEmpty())
+    if (!m_configuration->cacheStorageDirectory().isEmpty())
         m_resolvedConfiguration->setCacheStorageDirectory(resolvePathForSandboxExtension(m_configuration->cacheStorageDirectory()));
-    if (!m_configuration->hstsStorageDirectory().isEmpty() && m_resolvedConfiguration->hstsStorageDirectory().isEmpty())
+    if (!m_configuration->hstsStorageDirectory().isEmpty())
         m_resolvedConfiguration->setHSTSStorageDirectory(resolvePathForSandboxExtension(m_configuration->hstsStorageDirectory()));
     if (!m_configuration->generalStorageDirectory().isEmpty())
         m_resolvedConfiguration->setGeneralStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->generalStorageDirectory()));


### PR DESCRIPTION
#### 0915e758ce09519ffc471d32a1504e23e75e7084
<pre>
REGRESSION(252534@main): [ macOS ] TestWebKitAPI.ServiceWorkers.ServiceWorkerAndCacheStorageSpecificDirectories is constantly timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=242864">https://bugs.webkit.org/show_bug.cgi?id=242864</a>
rdar://problem/97205394

Reviewed by Chris Dumez.

We didn&apos;t set resolved configuration correctly in WebsiteDataStore::resolveDirectoriesIfNecessary, and the directories
were not resolved.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::retrieveCacheStorageParameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):

Canonical link: <a href="https://commits.webkit.org/252625@main">https://commits.webkit.org/252625@main</a>
</pre>
