### PR TITLE
Unreferenced DedicatedWorker may be garbage collected during importScripts()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -906,6 +906,9 @@ imported/w3c/web-platform-tests/workers/semantics/multiple-workers/003.html [ Sk
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-options-credentials.html [ Skip ]
 imported/w3c/web-platform-tests/workers/modules/shared-worker-import-csp.html [ Skip ]
 
+imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc.html [ Slow ]
+imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc.html [ Slow ]
+
 http/tests/cache-storage/page-cache-domcache-pending-promise.html [ DumpJSConsoleLogInStdErr ]
 
 imported/w3c/web-platform-tests/xhr/event-timeout-order.any.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Unreferenced shared worker that imports scripts doesn't get garbage collected.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Unreferenced shared worker that imports scripts doesn't get garbage collected.</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/garbage-collect.js"></script>
+<script>
+async_test(function(t) {
+  const workersCreated = 5;
+  let workersFinished = 0;
+
+  const messageHandler = t.step_func((e) => {
+    if (e.data === "worker_finished") workersFinished++;
+    if (workersFinished === workersCreated) t.done();
+  });
+
+  for (let i = 0; i < workersCreated; i++) {
+    new SharedWorker(`support/importScripts-delayed-shared-worker.js?id=${i}`).port.onmessage = messageHandler;
+  }
+
+  setInterval(garbageCollect, 300);
+}, "Unreferenced shared worker that imports scripts doesn't get garbage collected.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Unreferenced dedicated worker that imports scripts doesn't get garbage collected.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Unreferenced dedicated worker that imports scripts doesn't get garbage collected.</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/garbage-collect.js"></script>
+<script>
+async_test(function(t) {
+  const workersCreated = 5;
+  let workersFinished = 0;
+
+  const messageHandler = t.step_func((e) => {
+    if (e.data === "worker_finished") workersFinished++;
+    if (workersFinished === workersCreated) t.done();
+  });
+
+  for (let i = 0; i < workersCreated; i++) {
+    new Worker("support/importScripts-delayed.js").onmessage = messageHandler;
+  }
+
+  setInterval(garbageCollect, 300);
+}, "Unreferenced dedicated worker that imports scripts doesn't get garbage collected.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/support/garbage-collect.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/support/garbage-collect.js
@@ -1,0 +1,16 @@
+self.garbageCollect = () => {
+  if (self.gc) {
+    // Use --expose_gc for V8 (and Node.js)
+    // to pass this flag at chrome launch use: --js-flags="--expose-gc"
+    // Exposed in SpiderMonkey shell as well
+    self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    GCController.collect();
+  } else {
+    /* eslint-disable no-console */
+    console.warn('Tests are running without the ability to do manual garbage collection. They will still work, but ' +
+      'coverage will be suboptimal.');
+    /* eslint-enable no-console */
+  }
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-dedicated-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-dedicated-worker.js
@@ -1,0 +1,7 @@
+const importCount = Math.trunc(Math.random() * 5);
+
+for (let i = 0; i < importCount; i++) {
+  importScripts(`imported_script_delay.py?cache_bust=${i}`);
+}
+
+postMessage("worker_finished");

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-shared-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-shared-worker.js
@@ -1,0 +1,10 @@
+onconnect = (e) => {
+  const port = e.ports[0];
+  const importCount = Math.trunc(Math.random() * 5);
+
+  for (let i = 0; i < importCount; i++) {
+    importScripts(`imported_script_delay.py?cache_bust=${i}`);
+  }
+
+  port.postMessage("worker_finished");
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/support/imported_script_delay.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/support/imported_script_delay.py
@@ -1,0 +1,10 @@
+import random
+import time
+
+from wptserve.utils import isomorphic_encode
+
+
+def main(request, response):
+    time.sleep(random.uniform(0.2, 0.4))
+
+    return [(b"Content-Type", b"application/javascript")], u"// Do nothing."

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -97,6 +97,7 @@ ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& s
 
 ExceptionOr<void> DedicatedWorkerGlobalScope::importScripts(const FixedVector<String>& urls)
 {
+    thread().workerObjectProxy().reportPendingActivity(true);
     auto result = Base::importScripts(urls);
     thread().workerObjectProxy().reportPendingActivity(hasPendingActivity());
     return result;


### PR DESCRIPTION
#### 62f60bc87f22053f20ce018f5133dc95805061a9
<pre>
Unreferenced DedicatedWorker may be garbage collected during importScripts()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242874">https://bugs.webkit.org/show_bug.cgi?id=242874</a>
&lt;rdar://93085008&gt;

Reviewed by NOBODY (OOPS!).

This change reports a pending activity to a worker proxy before executing importScripts()
to ensure DedicatedWorker won&apos;t be garbage collected until all networking is finished.
SharedWorker doesn&apos;t require similar change as demonstrated by added test case.

* LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerGlobalScope_importScripts_prevents_gc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/WorkerGlobalScope_importScripts_prevents_gc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/support/garbage-collect.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-dedicated-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/support/importScripts-delayed-shared-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/workers/support/imported_script_delay.py: Added.
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::importScripts):
</pre>