### PR TITLE
exceptions thrown in `WKNavigationDelegate` methods should not affect WebKit

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -268,6 +268,7 @@ Tests/WebKitCocoa/WKInspectorExtensionDelegate.mm
 Tests/WebKitCocoa/WKInspectorExtensionHost.mm
 Tests/WebKitCocoa/WKNSDictionaryEmptyDictionaryCrash.mm
 Tests/WebKitCocoa/WKNSNumber.mm
+Tests/WebKitCocoa/WKNavigationDelegate.mm
 Tests/WebKitCocoa/WKNavigationResponse.mm
 Tests/WebKitCocoa/WKObject.mm
 Tests/WebKitCocoa/WKPDFView.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2650,6 +2650,7 @@
 		952F7166270BD99700D00DCD /* CSSViewportUnits.svg */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = CSSViewportUnits.svg; sourceTree = "<group>"; };
 		953ABB3425C0D681004C8B73 /* WKWebViewUnderPageBackgroundColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewUnderPageBackgroundColor.mm; sourceTree = "<group>"; };
 		953DF77B27C6DE5D00FDF3A5 /* WKWebViewResize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewResize.mm; sourceTree = "<group>"; };
+		956E6BE528861A0B00D9C63F /* WKNavigationDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKNavigationDelegate.mm; sourceTree = "<group>"; };
 		958B70E026C46EDC00B2022B /* NSAttributedStringWebKitAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSAttributedStringWebKitAdditions.mm; sourceTree = "<group>"; };
 		95A524942581A10D00461FE9 /* WKWebViewThemeColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewThemeColor.mm; sourceTree = "<group>"; };
 		95B6B3B6251EBF2F00FC4382 /* MediaDocument.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaDocument.mm; sourceTree = "<group>"; };
@@ -3787,6 +3788,7 @@
 				99C607EC26FB90AC00A0953F /* WKInspectorExtension.mm */,
 				99E2846326F91F7F0003F1FA /* WKInspectorExtensionDelegate.mm */,
 				999B7EE22551C63B00F450A4 /* WKInspectorExtensionHost.mm */,
+				956E6BE528861A0B00D9C63F /* WKNavigationDelegate.mm */,
 				A5A729F01F622A9A00DE5A28 /* WKNavigationResponse.mm */,
 				DF4B273821A47727009BD1CA /* WKNSDictionaryEmptyDictionaryCrash.mm */,
 				375E0E151D66674400EFEC2C /* WKNSNumber.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationDelegate.mm
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+TEST(WKNavigationDelegate, NoCrashIfExceptionInDecidePolicyForNavigationAction)
+{
+    __block bool didCallDelegate = false;
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDecidePolicyForNavigationAction:^(WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        didCallDelegate = true;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            decisionHandler(WKNavigationActionPolicyAllow);
+        });
+
+        @throw [NSException exceptionWithName:@"test" reason:@"should not crash" userInfo:nil];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadTestPageNamed:@"simple"];
+    TestWebKitAPI::Util::run(&didCallDelegate);
+}
+
+TEST(WKNavigationDelegate, NoCrashIfExceptionInDecidePolicyForNavigationActionWithPreferences)
+{
+    __block bool didCallDelegate = false;
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDecidePolicyForNavigationActionWithPreferences:^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        didCallDelegate = true;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            decisionHandler(WKNavigationActionPolicyAllow, preferences);
+        });
+
+        @throw [NSException exceptionWithName:@"test" reason:@"should not crash" userInfo:nil];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadTestPageNamed:@"simple"];
+    TestWebKitAPI::Util::run(&didCallDelegate);
+}
+
+TEST(WKNavigationDelegate, NoCrashIfExceptionInDecidePolicyForNavigationResponse)
+{
+    __block bool didCallDelegate = false;
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDecidePolicyForNavigationResponse:^(WKNavigationResponse *, void (^decisionHandler)(WKNavigationResponsePolicy)) {
+        didCallDelegate = true;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            decisionHandler(WKNavigationResponsePolicyAllow);
+        });
+
+        @throw [NSException exceptionWithName:@"test" reason:@"should not crash" userInfo:nil];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadTestPageNamed:@"simple"];
+    TestWebKitAPI::Util::run(&didCallDelegate);
+}
+
+TEST(WKNavigationDelegate, NoCrashIfExceptionInDidCommitNavigation)
+{
+    __block bool didCallDelegate = false;
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDidCommitNavigation:^(WKWebView *, WKNavigation *) {
+        didCallDelegate = true;
+
+        @throw [NSException exceptionWithName:@"test" reason:@"should not crash" userInfo:nil];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadTestPageNamed:@"simple"];
+    TestWebKitAPI::Util::run(&didCallDelegate);
+}
+
+TEST(WKNavigationDelegate, NoCrashIfExceptionInDidFinishNavigation)
+{
+    __block bool didCallDelegate = false;
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        didCallDelegate = true;
+
+        @throw [NSException exceptionWithName:@"test" reason:@"should not crash" userInfo:nil];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadTestPageNamed:@"simple"];
+    TestWebKitAPI::Util::run(&didCallDelegate);
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm
@@ -25,6 +25,12 @@
 
 #import "config.h"
 
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKFrameHandle.h>
+
 typedef void (^CallCompletionBlock)();
 
 @interface PrintUIDelegate : NSObject <WKUIDelegate>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -29,6 +29,7 @@
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
 #import "TestProtocol.h"
+#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import <WebKit/WKUserContentControllerPrivate.h>
 #import <WebKit/WKUserScriptPrivate.h>


### PR DESCRIPTION
#### f8589ec57e638daae20a968fb9bd37c893e704ca
<pre>
exceptions thrown in `WKNavigationDelegate` methods should not affect WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=242875">https://bugs.webkit.org/show_bug.cgi?id=242875</a>
&lt;rdar://problem/94757789&gt;

Reviewed by NOBODY (OOPS!).

Wrap each call inside `BEGIN_BLOCK_OBJC_EXCEPTIONS` and `END_BLOCK_OBJC_EXCEPTIONS`.

Note that we don&apos;t try to be smart by also invoking any completions, as it&apos;s possible for the app to
have already saved a reference to it before the exception was thrown, meaning that it could still be
invoked at some later time. In other words, there&apos;s no way for WebKit to know for sure whether the
completion will be invoked, so we can&apos;t do it on behalf of the app just in case.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
(WebKit::NavigationState::NavigationClient::shouldAllowLegacyTLS):
(WebKit::NavigationState::NavigationClient::processDidTerminate):
(WebKit::NavigationState::NavigationClient::navigationActionDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::navigationResponseDidBecomeDownload):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationDelegate.mm: Added.
(TEST.WKNavigationDelegate.NoCrashIfExceptionInDecidePolicyForNavigationAction):
(TEST.WKNavigationDelegate.NoCrashIfExceptionInDecidePolicyForNavigationActionWithPreferences):
(TEST.WKNavigationDelegate.NoCrashIfExceptionInDecidePolicyForNavigationResponse):
(TEST.WKNavigationDelegate.NoCrashIfExceptionInDidCommitNavigation):
(TEST.WKNavigationDelegate.NoCrashIfExceptionInDidFinishNavigation):

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPrinting.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:
Drive-by: Add missing includes.
</pre>