### PR TITLE
Overflow assertion under `interactionRegionForRenderedRegion` on yahoo.com

### DIFF
--- a/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
+++ b/LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt
@@ -1,0 +1,16 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 135800.00 35017.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 135800.00 35017.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=135800 height=35017)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/region-area-overflow-does-not-crash.html
+++ b/LayoutTests/interaction-region/region-area-overflow-does-not-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    #button {
+        display: inline-block;
+        width: 135800px;
+        height: 35000px;
+        background-color: green;
+        cursor: pointer;
+        border-radius: 10px;
+    }
+</style>
+<body>
+<div id="button" onclick="click()"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -72,7 +72,11 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     auto& mainFrameView = *regionRenderer.document().frame()->mainFrame().view();
     auto layoutArea = mainFrameView.layoutSize().area();
 
-    if (bounds.area() > layoutArea / 2)
+    auto checkedRegionArea = bounds.area<RecordOverflow>();
+    if (checkedRegionArea.hasOverflowed())
+        return std::nullopt;
+
+    if (checkedRegionArea.value() > layoutArea / 2)
         return std::nullopt;
 
     auto element = dynamicDowncast<Element>(regionRenderer.node());


### PR DESCRIPTION
#### c3670558b88295ac35a29099d23d912b8d30f748
<pre>
Overflow assertion under `interactionRegionForRenderedRegion` on yahoo.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=242877">https://bugs.webkit.org/show_bug.cgi?id=242877</a>
rdar://97219389

Reviewed by Wenson Hsieh and Devin Rousso.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Somehow, Yahoo&apos;s banner ad is getting an interaction region of 135800x35000,
which overflows when area() is called. Record the overflow and bail instead of
crashing.

* LayoutTests/interaction-region/region-area-overflow-does-not-crash-expected.txt: Added.
* LayoutTests/interaction-region/region-area-overflow-does-not-crash.html: Added.
Add a test: the event region exists, the interaction region does not, because we bailed out.

Canonical link: <a href="https://commits.webkit.org/252588@main">https://commits.webkit.org/252588@main</a>
</pre>
