### PR TITLE
REGRESSION(r294536): Drawing the ImageBuffer should not invalidate its cached copied images

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -222,6 +222,15 @@ RefPtr<NativeImage> ImageBuffer::copyNativeImage(BackingStoreCopy copyBehavior) 
     return nullptr;
 }
 
+RefPtr<NativeImage> ImageBuffer::copyNativeImageForDrawing(BackingStoreCopy copyBehavior) const
+{
+    if (auto* backend = ensureBackendCreated()) {
+        const_cast<ImageBuffer&>(*this).flushDrawingContext();
+        return backend->copyNativeImageForDrawing(copyBehavior);
+    }
+    return nullptr;
+}
+
 RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage()
 {
     if (auto* backend = ensureBackendCreated()) {
@@ -311,7 +320,7 @@ void ImageBuffer::draw(GraphicsContext& destContext, const FloatRect& destRect, 
     srcRectScaled.scale(resolutionScale());
 
     if (auto* backend = ensureBackendCreated()) {
-        if (auto image = copyNativeImage(&destContext == &context() ? CopyBackingStore : DontCopyBackingStore))
+        if (auto image = copyNativeImageForDrawing(&destContext == &context() ? CopyBackingStore : DontCopyBackingStore))
             destContext.drawNativeImage(*image, backendSize(), destRect, srcRectScaled, options);
         backend->finalizeDrawIntoContext(destContext);
     }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -163,6 +163,7 @@ public:
     void setBackendInfo(ImageBufferBackend::Info&& parameters) { m_backendInfo = WTFMove(parameters); }
 
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) const;
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy = CopyBackingStore) const;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     WEBCORE_EXPORT virtual RefPtr<Image> filteredImage(Filter&);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -55,6 +55,11 @@ ImageBufferBackend::ImageBufferBackend(const Parameters& parameters)
 
 ImageBufferBackend::~ImageBufferBackend() = default;
 
+RefPtr<NativeImage> ImageBufferBackend::copyNativeImageForDrawing(BackingStoreCopy copyBehavior) const
+{
+    return copyNativeImage(copyBehavior);
+}
+
 RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
 {
     return copyNativeImage(DontCopyBackingStore);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -121,6 +121,7 @@ public:
     virtual void finalizeDrawIntoContext(GraphicsContext&) { }
     virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy) const = 0;
 
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy copyBehavior) const;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
 
     virtual void clipToMask(GraphicsContext&, const FloatRect&) { }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -61,6 +61,7 @@ protected:
     IntSize backendSize() const override;
     
     RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) const override;
+    RefPtr<NativeImage> copyNativeImageForDrawing(BackingStoreCopy = CopyBackingStore) const override;
     RefPtr<NativeImage> sinkIntoNativeImage() override;
 
     RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect&, const ImageBufferAllocator&) const override;
@@ -81,6 +82,7 @@ protected:
 
     void finalizeDrawIntoContext(GraphicsContext& destinationContext) override;
     void invalidateCachedNativeImage() const;
+    void invalidateCachedNativeImageIfNeeded() const;
 
     std::unique_ptr<IOSurface> m_surface;
     mutable bool m_mayHaveOutstandingBackingStoreReferences { false };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -148,17 +148,24 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const
 
 RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage(BackingStoreCopy copyBehavior) const
 {
-    if (UNLIKELY(!m_remoteRenderingBackendProxy))
-        return { };
-
     if (canMapBackingStore())
         return ImageBuffer::copyNativeImage(copyBehavior);
+
+    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+        return { };
 
     const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
     auto bitmap = m_remoteRenderingBackendProxy->getShareableBitmap(m_renderingResourceIdentifier, PreserveResolution::Yes);
     if (!bitmap)
         return { };
     return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore));
+}
+
+RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImageForDrawing(BackingStoreCopy copyBehavior) const
+{
+    if (canMapBackingStore())
+        return ImageBuffer::copyNativeImageForDrawing(copyBehavior);
+    return copyNativeImage(copyBehavior);
 }
 
 void RemoteImageBufferProxy::drawConsuming(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& options)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -71,6 +71,7 @@ private:
     void clearBackend() final;
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
+    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
     RefPtr<WebCore::Image> filteredImage(WebCore::Filter&) final;


### PR DESCRIPTION
#### c7880bea0dcacd97dba2d8a7265f70509dd87d04
<pre>
REGRESSION(r294536): Drawing the ImageBuffer should not invalidate its cached copied images
<a href="https://bugs.webkit.org/show_bug.cgi?id=242879">https://bugs.webkit.org/show_bug.cgi?id=242879</a>
rdar://93775177

Reviewed by Simon Fraser.

IOSurface caches the CGImage which CGIOSurfaceContextCreateImage() returns. The
same cached CGImage can be returned if the backing store did not change. The
memory of the cached CGImage is mapped to the IOSurface backing store as copy-on-
write. Accessing the pixels of the IOSurface directly does not dirty the cached
CGImage. So these ImageBuffer scenarios need special handling:

Before we putPixelBuffer() to the IOSurface, we need to detach the IOSurface
cached CGImage such that its memory is copied before the pixels of the IOSurface
get changed. So we need to call invalidateCachedNativeImage() which makes CG
draws an empty rectangle. This will kick off the copy-on-write operation.

When drawing the ImageBuffer to a destination GraphicContext, a new CGImage is
created from the IOSurface or the cached CGImage is used. It does not really matter
what the state of this CGImage. CG will behave correctly as long as the CGImage
is used in its drawing pipeline. So we do not need to invoke the empty rectangle
draw hack in subsequent calls if ImageBuffer::draw() is called.

The fix is to introduce copyNativeImageForDrawing() which copy the IOSurface to
a CGImage but will not require the empty rectangle draw hack in subsequent calls.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::copyNativeImageForDrawing const):
(WebCore::ImageBuffer::draw):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::copyNativeImageForDrawing const):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage const):
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImageIfNeeded const):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing const):
(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::copyNativeImageForDrawing const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/252813@main">https://commits.webkit.org/252813@main</a>
</pre>
