### PR TITLE
Make getPath() virtual for PathOperation

### DIFF
--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -28,6 +28,8 @@
 
 #include "GeometryUtilities.h"
 #include "SVGElement.h"
+#include "SVGPathData.h"
+#include "SVGPathElement.h"
 
 namespace WebCore {
 
@@ -48,6 +50,13 @@ ReferencePathOperation::ReferencePathOperation(const String& url, const AtomStri
 const SVGElement* ReferencePathOperation::element() const
 {
     return m_element.get();
+}
+
+const std::optional<Path> ReferencePathOperation::getPath(const FloatRect&, FloatPoint, OffsetRotation) const
+{
+    if (!is<SVGPathElement>(m_element.get()) && !is<SVGGeometryElement>(m_element.get()))
+        return std::nullopt;
+    return pathFromGraphicsElement(m_element.get());
 }
 
 double RayPathOperation::lengthForPath() const
@@ -118,14 +127,14 @@ double RayPathOperation::lengthForContainPath(const FloatRect& elementRect, doub
     return computedPathLength;
 }
 
-const Path RayPathOperation::pathForReferenceRect(const FloatRect& elementRect, const FloatPoint& anchor, const OffsetRotation rotation) const
+const std::optional<Path> RayPathOperation::getPath(const FloatRect& referenceRect, FloatPoint anchor, OffsetRotation rotation) const
 {
     Path path;
     if (m_containingBlockBoundingRect.isZero())
-        return path;
+        return std::nullopt;
     double length = lengthForPath();
     if (m_isContaining)
-        length = lengthForContainPath(elementRect, length, anchor, rotation);
+        length = lengthForContainPath(referenceRect, length, anchor, rotation);
     auto radians = deg2rad(toPositiveAngle(m_angle) - 90.0);
     auto point = FloatPoint(std::cos(radians) * length, std::sin(radians) * length);
     path.addLineTo(point);

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -57,13 +57,12 @@ public:
 
     OperationType type() const { return m_type; }
     bool isSameType(const PathOperation& o) const { return o.type() == m_type; }
-
+    virtual const std::optional<Path> getPath(const FloatRect& reference = { }, FloatPoint anchor = { }, OffsetRotation rotation = { }) const = 0;
 protected:
     explicit PathOperation(OperationType type)
         : m_type(type)
     {
     }
-
     OperationType m_type;
 };
 
@@ -73,7 +72,7 @@ public:
     const String& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
     const SVGElement* element() const;
-
+    const std::optional<Path> getPath(const FloatRect&, FloatPoint, OffsetRotation) const final;
 private:
     bool operator==(const PathOperation& other) const override
     {
@@ -103,6 +102,7 @@ public:
 
     void setReferenceBox(CSSBoxType referenceBox) { m_referenceBox = referenceBox; }
     CSSBoxType referenceBox() const { return m_referenceBox; }
+    const std::optional<Path> getPath(const FloatRect& reference, FloatPoint, OffsetRotation) const final { return pathForReferenceRect(reference); }
 
 private:
     bool operator==(const PathOperation& other) const override
@@ -145,7 +145,7 @@ public:
         m_path.addRoundedRect(boundingRect);
     }
     
-    const Path getPath() const { return m_path; }
+    const std::optional<Path> getPath(const FloatRect&, FloatPoint, OffsetRotation) const final { return m_path; }
     CSSBoxType referenceBox() const { return m_referenceBox; }
 
 private:
@@ -197,7 +197,6 @@ public:
         return RayPathOperation::create(WebCore::blend(m_angle, to.m_angle, context), m_size, m_isContaining);
     }
 
-    const Path pathForReferenceRect(const FloatRect& elementRect, const FloatPoint& anchor, const OffsetRotation rotation) const;
     double lengthForPath() const;
     double lengthForContainPath(const FloatRect& elementRect, double computedPathLength, const FloatPoint& anchor, const OffsetRotation rotation) const;
     
@@ -209,6 +208,7 @@ public:
     {
         m_position = position;
     }
+    const std::optional<Path> getPath(const FloatRect& referenceRect = { }, FloatPoint anchor = { }, OffsetRotation rotation = { }) const final;
 private:
     bool operator==(const PathOperation& other) const override
     {

--- a/Source/WebCore/rendering/style/OffsetRotation.h
+++ b/Source/WebCore/rendering/style/OffsetRotation.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class OffsetRotation {
 public:
-    OffsetRotation(bool hasAuto, float angle);
+    OffsetRotation(bool hasAuto = false, float angle = 0);
 
     bool hasAuto() const { return m_hasAuto; }
     float angle() const { return m_angle; }


### PR DESCRIPTION
#### 493e2312e591137af161682ddbfab705c8132f7b
<pre>
Make getPath() virtual for PathOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=242882">https://bugs.webkit.org/show_bug.cgi?id=242882</a>

Reviewed by Simon Fraser.

Make getPath() virtual to get rid of need for getPathFromPathOperation.

* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::getPath const):
(WebCore::RayPathOperation::getPath const):
(WebCore::RayPathOperation::pathForReferenceRect const): Deleted.
* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::setTransformInfo):
(WebCore::PathOperation::PathOperation):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::applyMotionPathTransform const):
(WebCore::getPathFromPathOperation): Deleted.

Canonical link: <a href="https://commits.webkit.org/252623@main">https://commits.webkit.org/252623@main</a>
</pre>
