### PR TITLE
REGRESSION (252335@main): overriding language per WKContext no longer works

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
@@ -28,6 +28,7 @@
 
 #include "APIArray.h"
 #include "APIProcessPoolConfiguration.h"
+#include "OverrideLanguages.h"
 #include "WKAPICast.h"
 
 using namespace WebKit;
@@ -151,10 +152,12 @@ WKArrayRef WKContextConfigurationCopyOverrideLanguages(WKContextConfigurationRef
     return toAPI(&API::Array::create().leakRef());
 }
 
-void WKContextConfigurationSetOverrideLanguages(WKContextConfigurationRef, WKArrayRef)
+void WKContextConfigurationSetOverrideLanguages(WKContextConfigurationRef, WKArrayRef overrideLanguages)
 {
-    // Use +[WKWebView _setOverrideLanguagesForTesting:] instead.
-    // FIXME: Delete this function.
+    // FIXME: This is an SPI function, and is only (supposed to be) used for testing.
+    // However, playwright automation tests rely on it.
+    // See https://bugs.webkit.org/show_bug.cgi?id=242827 for details.
+    WebKit::setOverrideLanguages(toImpl(overrideLanguages)->toStringVector());
 }
 
 bool WKContextConfigurationProcessSwapsOnNavigation(WKContextConfigurationRef configuration)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -123,8 +123,6 @@ struct WKAppPrivacyReportTestingData {
 
 - (void)_setConnectedToHardwareConsoleForTesting:(BOOL)connected;
 
-+ (void)_setOverrideLanguagesForTesting:(NSArray<NSString *> *)languages;
-
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -29,7 +29,6 @@
 #import "AudioSessionRoutingArbitratorProxy.h"
 #import "GPUProcessProxy.h"
 #import "MediaSessionCoordinatorProxyPrivate.h"
-#import "OverrideLanguages.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "PrintInfo.h"
 #import "UserMediaProcessManager.h"
@@ -465,15 +464,6 @@
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     WebKit::WindowServerConnection::singleton().hardwareConsoleStateChanged(connected ? WebKit::WindowServerConnection::HardwareConsoleState::Connected : WebKit::WindowServerConnection::HardwareConsoleState::Disconnected);
 #endif
-}
-
-+ (void)_setOverrideLanguagesForTesting:(NSArray<NSString *> *)languages
-{
-    Vector<String> internalLanguages;
-    internalLanguages.reserveInitialCapacity(languages.count);
-    for (NSString *language in languages)
-        internalLanguages.uncheckedAppend(language);
-    WebKit::setOverrideLanguages(WTFMove(internalLanguages));
 }
 
 - (void)_createMediaSessionCoordinatorForTesting:(id <_WKMediaSessionCoordinator>)privateCoordinator completionHandler:(void(^)(BOOL))completionHandler

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -596,6 +596,11 @@ WKRetainPtr<WKContextConfigurationRef> TestController::generateContextConfigurat
     WKContextConfigurationSetFullySynchronousModeIsAllowedForTesting(configuration.get(), true);
     WKContextConfigurationSetIgnoreSynchronousMessagingTimeoutsForTesting(configuration.get(), options.ignoreSynchronousMessagingTimeouts());
 
+    auto overrideLanguages = adoptWK(WKMutableArrayCreate());
+    for (auto& language : options.overrideLanguages())
+        WKArrayAppendItem(overrideLanguages.get(), toWK(language).get());
+    WKContextConfigurationSetOverrideLanguages(configuration.get(), overrideLanguages.get());
+
     if (options.shouldEnableProcessSwapOnNavigation()) {
         WKContextConfigurationSetProcessSwapsOnNavigation(configuration.get(), true);
         if (options.enableProcessSwapOnWindowOpen())

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -205,12 +205,6 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
         [copiedConfiguration _setApplicationManifest:[_WKApplicationManifest applicationManifestFromJSON:text manifestURL:nil documentURL:nil]];
     }
 
-    auto overrideLanguages = options.overrideLanguages();
-    NSMutableArray<NSString *> *overrideLanguagesForAPI = [NSMutableArray arrayWithCapacity:overrideLanguages.size()];
-    for (auto& language : overrideLanguages)
-        [overrideLanguagesForAPI addObject:[NSString stringWithUTF8String:language.c_str()]];
-    [TestRunnerWKWebView _setOverrideLanguagesForTesting:overrideLanguagesForAPI];
-
     m_mainWebView = makeUnique<PlatformWebView>(copiedConfiguration.get(), options);
     finishCreatingPlatformWebView(m_mainWebView.get(), options);
 


### PR DESCRIPTION
#### 7b1621ce397b1726fa1a582a0f633799ecd1c29d
<pre>
REGRESSION (252335@main): overriding language per WKContext no longer works
<a href="https://bugs.webkit.org/show_bug.cgi?id=242827">https://bugs.webkit.org/show_bug.cgi?id=242827</a>
&lt;rdar://97102623&gt;

Reviewed by Chris Dumez.

In 252335@main, I replaced WKContextConfigurationSetOverrideLanguages() with
+[WKWebView _setOverrideLanguagesForTesting:]. The old function is an SPI function, and is
only supposed to be use by tests. However, it seems like it&apos;s being used by playwright
automation tests are currently using it. This patch puts the new functionality in the old
function name, so the existing code will continue to work.

* Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp:
(WKContextConfigurationSetOverrideLanguages):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(+[WKWebView _setOverrideLanguagesForTesting:]): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generateContextConfiguration const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/252646@main">https://commits.webkit.org/252646@main</a>
</pre>
