### PR TITLE
REGRESSION(252485@main): Restore previous usage of pthred_main_np()

### DIFF
--- a/Source/WTF/wtf/generic/MainThreadGeneric.cpp
+++ b/Source/WTF/wtf/generic/MainThreadGeneric.cpp
@@ -61,9 +61,7 @@ void initializeMainThreadPlatform()
 bool isMainThread()
 {
 #if HAVE(PTHREAD_MAIN_NP)
-    int mainThreadNp = pthread_main_np();
-    ASSERT(mainThreadNp != -1);
-    return mainThreadNp == 1;
+    return pthread_main_np();
 #elif OS(LINUX)
     return getpid() == static_cast<pid_t>(syscall(SYS_gettid));
 #else


### PR DESCRIPTION
#### 0307ab9b687a20115e7c2200f58ecaca0d268afd
<pre>
REGRESSION(252485@main): Restore previous usage of pthred_main_np()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242690">https://bugs.webkit.org/show_bug.cgi?id=242690</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/generic/MainThreadGeneric.cpp:
(WTF::isMainThread): Partially revert 252485@main to restore the
previous usage of pthread_main_np(), which should have not been
changed.

Canonical link: <a href="https://commits.webkit.org/252601@main">https://commits.webkit.org/252601@main</a>
</pre>
