### PR TITLE
Fix formatting of event region dumping

### DIFF
--- a/LayoutTests/interaction-region/click-handler-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-expected.txt
@@ -9,14 +9,11 @@
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (0,0) width=100 height=100)
-)
-        (hasLightBackground 1)
-        (borderRadius 10.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (0,0) width=100 height=100))
+          (hasLightBackground 1)
+          (borderRadius 10.00)]))
     )
   )
 )

--- a/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
@@ -8,8 +8,7 @@
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=600)
-      )
+        (rect (0,0) width=800 height=600))
       (children 1
         (GraphicsLayer
           (offsetFromRenderer width=-28 height=-28)
@@ -18,14 +17,11 @@
           (drawsContent 1)
           (event region
             (rect (28,28) width=200 height=200)
-
-          (interaction regions [
-            (region
-                (rect (28,28) width=100 height=100)
-)
-            (hasLightBackground 1)
-            (borderRadius 10.00)])
-          )
+            (interaction regions [
+              (region
+                (rect (28,28) width=100 height=100))
+              (hasLightBackground 1)
+              (borderRadius 10.00)]))
         )
       )
     )

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -10,14 +10,11 @@ This is a link.
       (backgroundColor #000000)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (-3,-3) width=35 height=24)
-)
-        (hasLightBackground 0)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (-3,-3) width=35 height=24))
+          (hasLightBackground 0)
+          (borderRadius 0.00)]))
     )
   )
 )

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -10,14 +10,11 @@ This is a link.
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (-3,-3) width=35 height=24)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (-3,-3) width=35 height=24))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
     )
   )
 )

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -11,14 +11,11 @@ This is a link, outside the frame.
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (-3,-3) width=35 height=24)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (-3,-3) width=35 height=24))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
       (children 1
         (GraphicsLayer
           (position 0.00 18.00)
@@ -26,14 +23,11 @@ This is a link, outside the frame.
           (drawsContent 1)
           (event region
             (rect (2,2) width=200 height=200)
-
-          (interaction regions [
-            (region
-                (rect (7,7) width=35 height=24)
-)
-            (hasLightBackground 1)
-            (borderRadius 0.00)])
-          )
+            (interaction regions [
+              (region
+                (rect (7,7) width=35 height=24))
+              (hasLightBackground 1)
+              (borderRadius 0.00)]))
         )
       )
     )

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -11,14 +11,11 @@ This is a link, inside the layer.
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (-3,-3) width=35 height=24)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (-3,-3) width=35 height=24))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
       (children 1
         (GraphicsLayer
           (position 0.00 18.00)
@@ -26,14 +23,11 @@ This is a link, inside the layer.
           (drawsContent 1)
           (event region
             (rect (0,0) width=200 height=200)
-
-          (interaction regions [
-            (region
-                (rect (-3,-3) width=35 height=24)
-)
-            (hasLightBackground 1)
-            (borderRadius 0.00)])
-          )
+            (interaction regions [
+              (region
+                (rect (-3,-3) width=35 height=24))
+              (hasLightBackground 1)
+              (borderRadius 0.00)]))
         )
       )
     )

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -11,19 +11,15 @@ This is a link, outside the frame.
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (7,25) width=35 height=24)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00),
-        (region
-            (rect (-3,-3) width=35 height=24)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (7,25) width=35 height=24))
+          (hasLightBackground 1)
+          (borderRadius 0.00),
+          (region
+            (rect (-3,-3) width=35 height=24))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
     )
   )
 )

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -11,17 +11,14 @@ short second line.
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
+        (interaction regions [
+          (region
             (rect (197,-3) width=31 height=18)
             (rect (-3,15) width=115 height=6)
             (rect (197,15) width=31 height=6)
-            (rect (-3,21) width=115 height=18)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+            (rect (-3,21) width=115 height=18))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
     )
   )
 )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -13,14 +13,11 @@ Line
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
-
-      (interaction regions [
-        (region
-            (rect (-3,-3) width=36 height=78)
-)
-        (hasLightBackground 1)
-        (borderRadius 0.00)])
-      )
+        (interaction regions [
+          (region
+            (rect (-3,-3) width=36 height=78))
+          (hasLightBackground 1)
+          (borderRadius 0.00)]))
     )
   )
 )

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -905,8 +905,10 @@ void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOpti
     }
 
     if (options & LayerTreeAsTextOptions::IncludeEventRegion && !m_eventRegion.isEmpty()) {
-        ts << indent << "(event region" << m_eventRegion;
-        ts << indent << ")\n";
+        ts << indent << "(event region ";
+
+        TextStream::IndentScope indentScope(ts);
+        ts << m_eventRegion << ")\n";
     }
     
 #if ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -655,12 +655,8 @@ void Region::setShape(Shape&& shape)
 
 TextStream& operator<<(TextStream& ts, const Region& region)
 {
-    ts << "\n";
-    {
-        TextStream::IndentScope indentScope(ts);
-        for (auto& rect : region.rects())
-            ts << indent << "(rect " << rect << ")\n";
-    }
+    for (auto& rect : region.rects())
+        ts.dumpProperty("rect", rect);
 
     return ts;
 }

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -378,29 +378,20 @@ void EventRegion::dump(TextStream& ts) const
 #endif
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
-    if (!m_wheelEventListenerRegion.isEmpty()) {
-        ts << indent << "(wheel event listener region" << m_wheelEventListenerRegion;
-        if (!m_nonPassiveWheelEventListenerRegion.isEmpty()) {
-            TextStream::IndentScope indentScope(ts);
-            ts << indent << "(non-passive" << m_nonPassiveWheelEventListenerRegion;
-            ts << indent << ")\n";
-        }
-        ts << indent << ")\n";
-    }
+    if (!m_wheelEventListenerRegion.isEmpty())
+        ts.dumpProperty("wheel event listener region", m_wheelEventListenerRegion);
+    if (!m_nonPassiveWheelEventListenerRegion.isEmpty())
+        ts.dumpProperty("non-passive wheel event listener region", m_nonPassiveWheelEventListenerRegion);
 #endif
 
 #if ENABLE(EDITABLE_REGION)
-    if (m_editableRegion && !m_editableRegion->isEmpty()) {
-        ts << indent << "(editable region" << *m_editableRegion;
-        ts << indent << ")\n";
-    }
+    if (m_editableRegion && !m_editableRegion->isEmpty()) 
+        ts.dumpProperty("editable region", *m_editableRegion);
 #endif
     
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (!m_interactionRegions.isEmpty()) {
+    if (!m_interactionRegions.isEmpty())
         ts.dumpProperty("interaction regions", m_interactionRegions);
-        ts << "\n";
-    }
 #endif
 }
 


### PR DESCRIPTION
#### 63d0a7970b89bc257fac00fbcb85eac2d4ae1978
<pre>
Fix formatting of event region dumping
<a href="https://bugs.webkit.org/show_bug.cgi?id=242891">https://bugs.webkit.org/show_bug.cgi?id=242891</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::dump const):
Adjust indentation of event region dumping to look a little neater.

* LayoutTests/fast/scrolling/mac/border-radius-event-region-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-is-leaking-out-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-scrolled-contents-layer-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-subframe-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-subscroller-frame-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-subscroller-overflow-expected.txt:
* LayoutTests/fast/scrolling/mac/event-region-visibility-hidden-expected.txt:
* LayoutTests/fast/scrolling/mac/negative-z-index-overflow-scroll-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-basic-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-document-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-element-invalidation-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-inside-overflow-scroll-clipped-out-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-inside-overflow-scroll-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-layer-offset-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-root-invalidation-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-siblings-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-expected.txt:
* LayoutTests/fast/scrolling/mac/wheel-event-listener-region-window-scrollable-expected.txt:
* LayoutTests/interaction-region/click-handler-expected.txt:
* LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/handlers-in-iframes-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-fixed-child-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-in-columns-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-in-overflow-scroll-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-inside-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-document-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-on-fixed-expected.txt:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/wheel-handler-region-basic-expected.txt:
Rebaseline some tests.
</pre>