### PR TITLE
[css-break-3] widows: initial is not supported in multi-column container

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1562,7 +1562,7 @@ static inline LayoutUnit calculateMinimumPageHeight(const RenderStyle& renderSty
 {
     // We may require a certain minimum number of lines per page in order to satisfy
     // orphans and widows, and that may affect the minimum page height.
-    unsigned lineCount = std::max<unsigned>(renderStyle.hasAutoOrphans() ? 1 : renderStyle.orphans(), renderStyle.hasAutoWidows() ? 1 : renderStyle.widows());
+    unsigned lineCount = std::max<unsigned>(renderStyle.hasAutoOrphans() ? renderStyle.initialOrphans() : renderStyle.orphans(), renderStyle.hasAutoWidows() ? renderStyle.initialWidows() : renderStyle.widows());
     if (lineCount > 1) {
         LegacyRootInlineBox* line = &lastLine;
         for (unsigned i = 1; i < lineCount && line->prevRootBox(); i++)


### PR DESCRIPTION
#### 3a783f1a175739c9baebf80570f99330086a032f
<pre>
[css-break-3] widows: initial is not supported in multi-column container
<a href="https://bugs.webkit.org/show_bug.cgi?id=219882">https://bugs.webkit.org/show_bug.cgi?id=219882</a>
&lt;rdar://72366616&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::calculateMinimumPageHeight):

hasAutoOrphans and hasAutoWidows sets a default of lineCount to 1,
while the specification says that the initial value is 2.
</pre>