### PR TITLE
glib-reviewers should not own LayoutTests/platform directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,3 +180,10 @@ unix/ @WebKit/glib-reviewers
 xdg/ @WebKit/glib-reviewers
 wpe/ @WebKit/glib-reviewers @zdobersek
 **/wpe/qt/ @philn
+
+/LayoutTests/platform/glib/
+/LayoutTests/platform/gtk/
+/LayoutTests/platform/gtk4/
+/LayoutTests/platform/gtk-wayland/
+/LayoutTests/platform/gtk-wk2/
+/LayoutTests/platform/wpe/


### PR DESCRIPTION
#### 24461023f90524517f7a2bbbe51fc084d0923925
<pre>
glib-reviewers should not own LayoutTests/platform directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=242895">https://bugs.webkit.org/show_bug.cgi?id=242895</a>

Reviewed by Carlos Garcia Campos.

* .github/CODEOWNERS:

Canonical link: <a href="https://commits.webkit.org/252600@main">https://commits.webkit.org/252600@main</a>
</pre>
