### PR TITLE
Add Alexander Mikhaylenko's GitHub account to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -367,6 +367,7 @@
          "alexm@gnome.org"
       ],
       "expertise" : "WebkitGTK, Epiphany",
+      "github" : "Exalm",
       "name" : "Alexander Mikhaylenko",
       "nicks" : [
          "alexm"


### PR DESCRIPTION
#### fdcccbf90ee0dffa3d5b4a0698153f39608be84a
<pre>
Add Alexander Mikhaylenko&apos;s GitHub account to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=242896">https://bugs.webkit.org/show_bug.cgi?id=242896</a>

Reviewed by Adrian Perez de Castro.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252599@main">https://commits.webkit.org/252599@main</a>
</pre>
