### PR TITLE
Crash under WTF::charactersAreAllASCII<unsigned char>(unsigned char const*, unsigned long)

### DIFF
--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -91,6 +91,9 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
             writeData({ entry.segment->data(), entry.segment->size() });
     };
 
+    // Make sure we delete the file before writing as there may be code using a mmap'd version of this file.
+    FileSystem::deleteFile(scriptPath);
+
     if (!shouldUseFileMapping(script.buffer()->size())) {
         auto handle = FileSystem::openFile(scriptPath, FileSystem::FileOpenMode::Write);
         if (!FileSystem::isHandleValid(handle)) {
@@ -105,8 +108,6 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
         return script;
     }
 
-    // Make sure we delete the file before writing as there may be code using a mmap'd version of this file.
-    FileSystem::deleteFile(scriptPath);
     auto mappedFile = FileSystem::mapToFile(scriptPath, script.buffer()->size(), WTFMove(iterateOverBufferAndWriteData));
     if (!mappedFile) {
         RELEASE_LOG_ERROR(ServiceWorker, "SWScriptStorage::store: Failure to store %s, FileSystem::mapToFile() failed", scriptPath.utf8().data());


### PR DESCRIPTION
#### 147e4eda9ad90bbd17194b948d7b35c477ffddad
<pre>
Crash under WTF::charactersAreAllASCII&lt;unsigned char&gt;(unsigned char const*, unsigned long)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242899">https://bugs.webkit.org/show_bug.cgi?id=242899</a>
&lt;rdar://94931119&gt;

Reviewed by Cameron McCormack.

We&apos;re crashing when reading the memory of a service worker script. Such memory is often mmap&apos;d
from disk to reduce memory usage. Such crash could theoretically occur if the file gets modified
on disk so that its size becomes smaller, *after* it&apos;s been mmap&apos;d and *before* the mmap&apos;d memory
is read. Normally, we protect against this by deleting the existing script file on disk before
attempting to write it, as this keeps existing mmap&apos;d handles valid. However, there was one code
path inside SWScriptStorage::store() where we were failing to delete the file before attempting
to write it. Namely, in the case where the new size of the file is less than the page size, we
would use a different code path where we choose not to mmap(), and we would fail to delete the
existing file then. This file addresses this issue.

This is a speculative fix for the crash in the radar which I believe could happen if:
1. Write service worker script file with size &gt; pageSize to disk and mmap it
2. Rewrite service worker script file with size &lt; pageSize to disk
3. Attempt to read the mmap&apos;d memory from step 1

* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):

Canonical link: <a href="https://commits.webkit.org/252617@main">https://commits.webkit.org/252617@main</a>
</pre>
