### PR TITLE
LocalSampleBufferDisplayLayer::didFail should take into account LocalSampleBufferDisplayLayer::m_didFail

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -239,7 +239,7 @@ PlatformLayer* LocalSampleBufferDisplayLayer::rootLayer()
 
 bool LocalSampleBufferDisplayLayer::didFail() const
 {
-    return [m_sampleBufferDisplayLayer status] == AVQueuedSampleBufferRenderingStatusFailed;
+    return m_didFail || [m_sampleBufferDisplayLayer status] == AVQueuedSampleBufferRenderingStatusFailed;
 }
 
 void LocalSampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)


### PR DESCRIPTION
#### 2ba7200fe1f82fc979c95aa773396bdbb4acef5a
<pre>
LocalSampleBufferDisplayLayer::didFail should take into account LocalSampleBufferDisplayLayer::m_didFail
<a href="https://bugs.webkit.org/show_bug.cgi?id=242901">https://bugs.webkit.org/show_bug.cgi?id=242901</a>
rdar://problem/97261086

Reviewed by Eric Carlson.

* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::didFail const):

After some testing, we can see that LocalSampleBufferDisplayLayer::layerErrorDidChange is sometimes called while status is not AVQueuedSampleBufferRenderingStatusFailed.
This means LocalSampleBufferDisplayLayer::layerErrorDidChange is called but LocalSampleBufferDisplayLayer::didFail returns false.
This might be due to some callOnMainThread that we are doing.
This might prevent recreating the LocalSampleBufferDisplayLayer and break the video rendering, for instance in case of Siri interruptions (this reproes sometimes not always as per testing).
To fix this, LocalSampleBufferDisplayLayer::didFail will always return true if LocalSampleBufferDisplayLayer::m_didFail is set to true as well.

Canonical link: <a href="https://commits.webkit.org/252641@main">https://commits.webkit.org/252641@main</a>
</pre>
