### PR TITLE
Add mdubet to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -4842,6 +4842,13 @@
    },
    {
       "emails" : [
+         "m_dubet@apple.com"
+      ],
+      "github" : "mdubet",
+      "name" : "Matthieu Dubet"
+   },
+   {
+      "emails" : [
          "mvujovic@adobe.com",
          "maxvujovic@gmail.com"
       ],


### PR DESCRIPTION
#### 99dc8abc7bd342806f12f5b6059bbee6bec0499a
<pre>
Add mdubet to contributors.json

Reviewed by Jonathan Bedard.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252603@main">https://commits.webkit.org/252603@main</a>
</pre>
