### PR TITLE
[ews-build.webkit.org] Ignore PR updates by merge-queue (Follow-up)

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -376,7 +376,7 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
         action = payload.get('action')
         state = payload.get('pull_request', {}).get('state')
         labels = [label.get('name') for label in payload.get('pull_request', {}).get('labels', [])]
-        user = payload.get('pull_request', {}).get('user', {}).get('login', '')
+        sender = payload.get('sender', {}).get('login', '')
 
         if state not in self.OPEN_STATES:
             log.msg("PR #{} is '{}', which triggers nothing".format(pr_number, state))
@@ -395,8 +395,8 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             time.sleep(self.LABEL_PROCESS_DELAY)
             return super(GitHubEventHandlerNoEdits, self).handle_pull_request(payload, 'merge_queue')
 
-        if user in self.ACCOUNTS_TO_IGNORE:
-            log.msg(f"PR #{pr_number} was updated by '{user}', ignore it")
+        if sender in self.ACCOUNTS_TO_IGNORE:
+            log.msg(f"PR #{pr_number} was updated by '{sender}', ignore it")
             return ([], 'git')
 
         return super(GitHubEventHandlerNoEdits, self).handle_pull_request(payload, event)


### PR DESCRIPTION
#### d4fc32a2fd29dab4cb3ca71c416dc4720ab36a7e
<pre>
[ews-build.webkit.org] Ignore PR updates by merge-queue (Follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242897">https://bugs.webkit.org/show_bug.cgi?id=242897</a>
&lt;rdar://problem/97257669&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits.handle_pull_request): Ignore PRs based on sender not user.

Canonical link: <a href="https://commits.webkit.org/252605@main">https://commits.webkit.org/252605@main</a>
</pre>
