### PR TITLE
[Gardening]: [ macOS iOS15 Debug ] fast/dom/lazy-image-loading-document-leak.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2222,3 +2222,5 @@ webkit.org/b/242515 [ arm64 ] compositing/reflections/mask-and-reflection.html [
 webkit.org/b/242812 [ Release arm64 ] js/dom/Promise-reject-large-string.html [ Pass Failure ]
 
 webkit.org/b/241205 [ Release arm64 ] fast/forms/textfield-outline.html [ Pass Failure ]
+
+webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2294,3 +2294,5 @@ webkit.org/b/242481 fast/css/direct-adjacent-style-sharing-3.html [ Pass ImageOn
 webkit.org/b/242484 fast/css/display-contents-all.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass Crash ]
+
+webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]


### PR DESCRIPTION
#### 41c08a72b8beeaa27e549f6adf5dd74516a08666
<pre>
[Gardening]: [ macOS iOS15 Debug ] fast/dom/lazy-image-loading-document-leak.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242904">https://bugs.webkit.org/show_bug.cgi?id=242904</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252604@main">https://commits.webkit.org/252604@main</a>
</pre>
