### PR TITLE
Web Inspector: <select> should be visually centered in WI.ScopeBar

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -91,7 +91,7 @@
 
 .scope-bar > li.multiple > select {
     position: absolute;
-    top: 1px;
+    top: -1px;
     inset-inline-start: calc(var(--scope-bar-padding) - var(--scope-bar-padding-default) - 2px);
     width: 0;
     height: 0;


### PR DESCRIPTION
#### 8b7cfc696c7dcd9e3d637fcb9b3a6fe8e875573a
<pre>
Web Inspector: &lt;select&gt; should be visually centered in WI.ScopeBar
<a href="https://bugs.webkit.org/show_bug.cgi?id=242906">https://bugs.webkit.org/show_bug.cgi?id=242906</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar &gt; li.multiple &gt; select):

Canonical link: <a href="https://commits.webkit.org/252609@main">https://commits.webkit.org/252609@main</a>
</pre>
