### PR TITLE
rename @globalPrivate to @linkTimeConstant for more accuracy

### DIFF
--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py
@@ -169,8 +169,8 @@ extern const JSC::ImplementationVisibility s_%(codeName)sImplementationVisibilit
         }
 
         lines = []
-        lines.append("#define %(macroPrefix)s_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(macro) \\" % args)
-        functions = [function for function in self.model().all_functions() if function.is_global_private]
+        lines.append("#define %(macroPrefix)s_FOREACH_BUILTIN_LINK_TIME_CONSTANT(macro) \\" % args)
+        functions = [function for function in self.model().all_functions() if function.is_link_time_constant]
         functions.sort(key=lambda x: x.function_name)
         for function in functions:
             function_args = {

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -134,7 +134,7 @@ class BuiltinsGenerator:
             constructorKind = "Naked"
 
         visibility = "Public"
-        if function.is_global_private:
+        if function.is_link_time_constant:
             visibility = "Private"
 
         return {

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
@@ -43,7 +43,7 @@ _FRAMEWORK_CONFIG_MAP = {
 }
 
 functionHeadRegExp = re.compile(r"(?:@[\w|=\[\] \"\.]+\s*\n)*(?:async\s+)?function\s+\w+\s*\(.*?\)", re.MULTILINE | re.DOTALL)
-functionGlobalPrivateRegExp = re.compile(r".*^@globalPrivate", re.MULTILINE | re.DOTALL)
+functionLinkTimeConstantRegExp = re.compile(r".*^@linkTimeConstant", re.MULTILINE | re.DOTALL)
 functionNakedConstructorRegExp = re.compile(r".*^@nakedConstructor", re.MULTILINE | re.DOTALL)
 functionIntrinsicRegExp = re.compile(r".*^@intrinsic=(\w+)", re.MULTILINE | re.DOTALL)
 functionIsConstructorRegExp = re.compile(r".*^@constructor", re.MULTILINE | re.DOTALL)
@@ -103,14 +103,14 @@ class BuiltinObject:
 
 
 class BuiltinFunction:
-    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_global_private, is_naked_constructor, intrinsic, overridden_name):
+    def __init__(self, function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, intrinsic, overridden_name):
         self.function_name = function_name
         self.function_source = function_source
         self.parameters = parameters
         self.is_async = is_async
         self.is_constructor = is_constructor
         self.is_naked_constructor = is_naked_constructor
-        self.is_global_private = is_global_private
+        self.is_link_time_constant = is_link_time_constant
         self.intrinsic = intrinsic
         self.overridden_name = overridden_name
         self.object = None  # Set by the owning BuiltinObject
@@ -142,7 +142,7 @@ class BuiltinFunction:
         is_async = async_match != None and async_match.group(1) == "async"
         is_constructor = functionIsConstructorRegExp.match(function_source) != None
         is_getter = functionIsGetterRegExp.match(function_source) != None
-        is_global_private = functionGlobalPrivateRegExp.match(function_source) != None
+        is_link_time_constant = functionLinkTimeConstantRegExp.match(function_source) != None
         is_naked_constructor = functionNakedConstructorRegExp.match(function_source) != None
         if is_naked_constructor:
             is_constructor = True
@@ -159,7 +159,7 @@ class BuiltinFunction:
         if overridden_name[-1] == "\"":
             overridden_name += "_s"
 
-        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_global_private, is_naked_constructor, intrinsic, overridden_name)
+        return BuiltinFunction(function_name, function_source, parameters, is_async, is_constructor, is_link_time_constant, is_naked_constructor, intrinsic, overridden_name)
 
     def __str__(self):
         interface = "%s(%s)" % (self.function_name, ', '.join(self.parameters))

--- a/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
@@ -41,7 +41,7 @@ function next()
 
 // FIXME: We have to have this because we can't implement this all as one function and meet our inlining heuristics.
 // Collectively, next and this have ~130 bytes of bytecodes but our limit is 120.
-@globalPrivate
+@linkTimeConstant
 function arrayIteratorNextHelper(array, kind)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -395,7 +395,7 @@ function includes(searchElement /*, fromIndex*/)
     return false;
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortStringComparator(a, b)
 {
     "use strict";
@@ -409,7 +409,7 @@ function sortStringComparator(a, b)
     return aString > bString ? 1 : -1;
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortCompact(receiver, receiverLength, compacted, isStringSort)
 {
     "use strict";
@@ -433,7 +433,7 @@ function sortCompact(receiver, receiverLength, compacted, isStringSort)
     return undefinedCount;
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortCommit(receiver, receiverLength, sorted, undefinedCount)
 {
     "use strict";
@@ -460,7 +460,7 @@ function sortCommit(receiver, receiverLength, sorted, undefinedCount)
         delete receiver[i];
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortMerge(dst, src, srcIndex, srcEnd, width, comparator)
 {
     "use strict";
@@ -493,7 +493,7 @@ function sortMerge(dst, src, srcIndex, srcEnd, width, comparator)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortMergeSort(array, comparator)
 {
     "use strict";
@@ -515,7 +515,7 @@ function sortMergeSort(array, comparator)
     return src;
 }
 
-@globalPrivate
+@linkTimeConstant
 function sortBucketSort(array, dst, bucket, depth)
 {
     "use strict";
@@ -589,7 +589,7 @@ function sort(comparator)
     return receiver;
 }
 
-@globalPrivate
+@linkTimeConstant
 function concatSlowPath()
 {
     "use strict";
@@ -648,7 +648,7 @@ function concat(first)
     return @tailCallForwardArguments(@concatSlowPath, this);
 }
 
-@globalPrivate
+@linkTimeConstant
 function maxWithPositives(a, b)
 {
     "use strict";
@@ -656,7 +656,7 @@ function maxWithPositives(a, b)
     return (a < b) ? b : a;
 }
 
-@globalPrivate
+@linkTimeConstant
 function minWithMaybeNegativeZeroAndPositive(maybeNegativeZero, positive)
 {
     "use strict";
@@ -705,7 +705,7 @@ function copyWithin(target, start /*, end */)
     return array;
 }
 
-@globalPrivate
+@linkTimeConstant
 function flatIntoArray(target, source, sourceLength, targetIndex, depth)
 {
     "use strict";
@@ -744,7 +744,7 @@ function flat()
     return result;
 }
 
-@globalPrivate
+@linkTimeConstant
 function flatIntoArrayWithCallback(target, source, sourceLength, targetIndex, callback, thisArg)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
@@ -146,7 +146,7 @@ function throw(exception)
     return promise;
 }
 
-@globalPrivate
+@linkTimeConstant
 function createAsyncFromSyncIterator(syncIterator, nextMethod)
 {
     "use strict";
@@ -157,7 +157,7 @@ function createAsyncFromSyncIterator(syncIterator, nextMethod)
     return new @AsyncFromSyncIterator(syncIterator, nextMethod);
 }
 
-@globalPrivate
+@linkTimeConstant
 @constructor
 function AsyncFromSyncIterator(syncIterator, nextMethod)
 {

--- a/Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function asyncFunctionResume(generator, promise, sentValue, resumeMode)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorQueueIsEmpty(generator)
 {
     "use strict";
@@ -32,7 +32,7 @@ function asyncGeneratorQueueIsEmpty(generator)
     return @getAsyncGeneratorInternalField(generator, @asyncGeneratorFieldQueueFirst) === null;
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorQueueEnqueue(generator, item)
 {
     "use strict";
@@ -51,7 +51,7 @@ function asyncGeneratorQueueEnqueue(generator, item)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorQueueDequeue(generator)
 {
     "use strict";
@@ -69,7 +69,7 @@ function asyncGeneratorQueueDequeue(generator)
     return result;
 }
 
-@globalPrivate
+@linkTimeConstant
 function isExecutionState(generator)
 {
     "use strict";
@@ -81,7 +81,7 @@ function isExecutionState(generator)
         || reason === @AsyncGeneratorSuspendReasonAwait;
 }
 
-@globalPrivate
+@linkTimeConstant
 function isSuspendYieldState(generator)
 {
     "use strict";
@@ -91,7 +91,7 @@ function isSuspendYieldState(generator)
         || state === @AsyncGeneratorStateSuspendedYield;
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorReject(generator, exception)
 {
     "use strict";
@@ -105,7 +105,7 @@ function asyncGeneratorReject(generator, exception)
     return @asyncGeneratorResumeNext(generator);
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorResolve(generator, value, done)
 {
     "use strict";
@@ -119,7 +119,7 @@ function asyncGeneratorResolve(generator, value, done)
     return @asyncGeneratorResumeNext(generator);
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorYield(generator, value, resumeMode)
 {
     "use strict";
@@ -135,7 +135,7 @@ function asyncGeneratorYield(generator, value, resumeMode)
     @awaitValue(generator, value, asyncGeneratorYieldAwaited);
 }
 
-@globalPrivate
+@linkTimeConstant
 function awaitValue(generator, value, onFulfilled)
 {
     "use strict";
@@ -144,7 +144,7 @@ function awaitValue(generator, value, onFulfilled)
     @resolveWithoutPromiseForAsyncAwait(value, onFulfilled, onRejected);
 }
 
-@globalPrivate
+@linkTimeConstant
 function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
 {
     "use strict";
@@ -195,7 +195,7 @@ function doAsyncGeneratorBodyCall(generator, resumeValue, resumeMode)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorResumeNext(generator)
 {
     "use strict";
@@ -247,7 +247,7 @@ function asyncGeneratorResumeNext(generator)
     @doAsyncGeneratorBodyCall(generator, next.value, next.resumeMode);
 }
 
-@globalPrivate
+@linkTimeConstant
 function asyncGeneratorEnqueue(generator, value, resumeMode)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/DatePrototype.js
+++ b/Source/JavaScriptCore/builtins/DatePrototype.js
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function toDateTimeOptionsAnyAll(opts)
 {
     "use strict";
@@ -90,7 +90,7 @@ function toLocaleString(/* locales, options */)
     return @dateTimeFormat(locales, options, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function toDateTimeOptionsDateDate(opts)
 {
     "use strict";
@@ -150,7 +150,7 @@ function toLocaleDateString(/* locales, options */)
     return @dateTimeFormat(locales, options, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function toDateTimeOptionsTimeTime(opts)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/GeneratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/GeneratorPrototype.js
@@ -26,7 +26,7 @@
 
 // 25.3.3.3 GeneratorResume ( generator, value )
 // 25.3.3.4 GeneratorResumeAbrupt(generator, abruptCompletion)
-@globalPrivate
+@linkTimeConstant
 function generatorResume(generator, state, generatorThis, sentValue, value, resumeMode)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/GlobalObject.js
+++ b/Source/JavaScriptCore/builtins/GlobalObject.js
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function isFinite(value)
 {
     "use strict";
@@ -36,7 +36,7 @@ function isFinite(value)
     return numberValue !== @Infinity && numberValue !== -@Infinity;
 }
 
-@globalPrivate
+@linkTimeConstant
 function isNaN(value)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/GlobalOperations.js
+++ b/Source/JavaScriptCore/builtins/GlobalOperations.js
@@ -26,7 +26,7 @@
 
 // @internal
 
-@globalPrivate
+@linkTimeConstant
 function toIntegerOrInfinity(target)
 {
     "use strict";
@@ -39,7 +39,7 @@ function toIntegerOrInfinity(target)
     return @trunc(numberValue);
 }
 
-@globalPrivate
+@linkTimeConstant
 function toLength(target)
 {
     "use strict";
@@ -49,7 +49,7 @@ function toLength(target)
     return +(length > 0 ? (length < @MAX_SAFE_INTEGER ? length : @MAX_SAFE_INTEGER) : 0);
 }
 
-@globalPrivate
+@linkTimeConstant
 @getter
 @overriddenName="get [Symbol.species]"
 function speciesGetter()
@@ -58,7 +58,7 @@ function speciesGetter()
     return this;
 }
 
-@globalPrivate
+@linkTimeConstant
 function speciesConstructor(obj, defaultConstructor)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/IteratorHelpers.js
+++ b/Source/JavaScriptCore/builtins/IteratorHelpers.js
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function performIteration(iterable)
 {
     "use strict";
@@ -53,7 +53,7 @@ function performIteration(iterable)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function wrappedIterator(iterator)
 {
     let wrapper = @Object.@create(null);
@@ -61,7 +61,7 @@ function wrappedIterator(iterator)
     return wrapper;
 }
 
-@globalPrivate
+@linkTimeConstant
 function builtinSetIterable(set)
 {
     "use strict";
@@ -77,7 +77,7 @@ function builtinSetIterable(set)
     return @wrappedIterator(iteratorFunction.@call(set));
 }
 
-@globalPrivate
+@linkTimeConstant
 function builtinMapIterable(map)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/MapIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/MapIteratorPrototype.js
@@ -24,7 +24,7 @@
  */
 
 // We keep this function small very carefully to encourage inlining.
-@globalPrivate
+@linkTimeConstant
 function mapIteratorNext(bucket, kind)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -31,7 +31,7 @@
 //    1. Loader.resolve
 //    2. Loader.fetch
 
-@globalPrivate
+@linkTimeConstant
 function setStateToMax(entry, newState)
 {
     // https://whatwg.github.io/loader/#set-state-to-max
@@ -42,7 +42,7 @@ function setStateToMax(entry, newState)
         entry.state = newState;
 }
 
-@globalPrivate
+@linkTimeConstant
 function newRegistryEntry(key)
 {
     // https://whatwg.github.io/loader/#registry

--- a/Source/JavaScriptCore/builtins/PromiseOperations.js
+++ b/Source/JavaScriptCore/builtins/PromiseOperations.js
@@ -26,7 +26,7 @@
 
 // @internal
 
-@globalPrivate
+@linkTimeConstant
 function pushNewPromiseReaction(thenable, existingReactions, promiseOrCapability, onFulfilled, onRejected)
 {
     "use strict";
@@ -49,7 +49,7 @@ function pushNewPromiseReaction(thenable, existingReactions, promiseOrCapability
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function newPromiseCapabilitySlow(constructor)
 {
     "use strict";
@@ -81,7 +81,7 @@ function newPromiseCapabilitySlow(constructor)
     return promiseCapability;
 }
 
-@globalPrivate
+@linkTimeConstant
 function newPromiseCapability(constructor)
 {
     "use strict";
@@ -101,7 +101,7 @@ function newPromiseCapability(constructor)
     return @newPromiseCapabilitySlow(constructor);
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolve(constructor, value)
 {
     "use strict";
@@ -118,7 +118,7 @@ function promiseResolve(constructor, value)
     return @promiseResolveSlow(constructor, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolveSlow(constructor, value)
 {
     "use strict";
@@ -129,7 +129,7 @@ function promiseResolveSlow(constructor, value)
     return promiseCapability.@promise;
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseRejectSlow(constructor, reason)
 {
     "use strict";
@@ -140,7 +140,7 @@ function promiseRejectSlow(constructor, reason)
     return promiseCapability.@promise;
 }
 
-@globalPrivate
+@linkTimeConstant
 function newHandledRejectedPromise(error)
 {
     "use strict";
@@ -150,7 +150,7 @@ function newHandledRejectedPromise(error)
     return promise;
 }
 
-@globalPrivate
+@linkTimeConstant
 function triggerPromiseReactions(state, reactions, argument)
 {
     "use strict";
@@ -170,7 +170,7 @@ function triggerPromiseReactions(state, reactions, argument)
     @assert(i === count);
 }
 
-@globalPrivate
+@linkTimeConstant
 function resolvePromise(promise, resolution)
 {
     "use strict";
@@ -202,7 +202,7 @@ function resolvePromise(promise, resolution)
 }
 
 // Keep in sync with JSPromise::rejectedPromise.
-@globalPrivate
+@linkTimeConstant
 function rejectPromise(promise, reason)
 {
     "use strict";
@@ -221,7 +221,7 @@ function rejectPromise(promise, reason)
     @triggerPromiseReactions(@promiseStateRejected, reactions, reason);
 }
 
-@globalPrivate
+@linkTimeConstant
 function fulfillPromise(promise, value)
 {
     "use strict";
@@ -237,7 +237,7 @@ function fulfillPromise(promise, value)
     @triggerPromiseReactions(@promiseStateFulfilled, reactions, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function resolvePromiseWithFirstResolvingFunctionCallCheck(promise, value)
 {
     "use strict";
@@ -250,7 +250,7 @@ function resolvePromiseWithFirstResolvingFunctionCallCheck(promise, value)
     return @resolvePromise(promise, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function fulfillPromiseWithFirstResolvingFunctionCallCheck(promise, value)
 {
     "use strict";
@@ -263,7 +263,7 @@ function fulfillPromiseWithFirstResolvingFunctionCallCheck(promise, value)
     return @fulfillPromise(promise, value);
 }
 
-@globalPrivate
+@linkTimeConstant
 function rejectPromiseWithFirstResolvingFunctionCallCheck(promise, reason)
 {
     "use strict";
@@ -276,7 +276,7 @@ function rejectPromiseWithFirstResolvingFunctionCallCheck(promise, reason)
     return @rejectPromise(promise, reason);
 }
 
-@globalPrivate
+@linkTimeConstant
 function createResolvingFunctions(promise)
 {
     "use strict";
@@ -303,7 +303,7 @@ function createResolvingFunctions(promise)
     return { @resolve: resolve, @reject: reject };
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseReactionJobWithoutPromise(handler, argument)
 {
     "use strict";
@@ -316,7 +316,7 @@ function promiseReactionJobWithoutPromise(handler, argument)
 }
 
 // This function has strong guarantee that each handler function (onFulfilled and onRejected) will be called at most once.
-@globalPrivate
+@linkTimeConstant
 function resolveWithoutPromise(resolution, onFulfilled, onRejected)
 {
     "use strict";
@@ -349,7 +349,7 @@ function resolveWithoutPromise(resolution, onFulfilled, onRejected)
 }
 
 // This function has strong guarantee that each handler function (onFulfilled and onRejected) will be called at most once.
-@globalPrivate
+@linkTimeConstant
 function rejectWithoutPromise(reason, onFulfilled, onRejected)
 {
     "use strict";
@@ -358,7 +358,7 @@ function rejectWithoutPromise(reason, onFulfilled, onRejected)
 }
 
 // This function has strong guarantee that each handler function (onFulfilled and onRejected) will be called at most once.
-@globalPrivate
+@linkTimeConstant
 function fulfillWithoutPromise(value, onFulfilled, onRejected)
 {
     "use strict";
@@ -369,7 +369,7 @@ function fulfillWithoutPromise(value, onFulfilled, onRejected)
 // This function has strong guarantee that each handler function (onFulfilled and onRejected) will be called at most once.
 // This is special version of resolveWithoutPromise which skips resolution's then handling.
 // https://github.com/tc39/ecma262/pull/1250
-@globalPrivate
+@linkTimeConstant
 function resolveWithoutPromiseForAsyncAwait(resolution, onFulfilled, onRejected)
 {
     "use strict";
@@ -383,7 +383,7 @@ function resolveWithoutPromiseForAsyncAwait(resolution, onFulfilled, onRejected)
     return @resolveWithoutPromise(resolution, onFulfilled, onRejected);
 }
 
-@globalPrivate
+@linkTimeConstant
 function createResolvingFunctionsWithoutPromise(onFulfilled, onRejected)
 {
     "use strict";
@@ -409,7 +409,7 @@ function createResolvingFunctionsWithoutPromise(onFulfilled, onRejected)
     return { @resolve: resolve, @reject: reject };
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseReactionJob(state, promiseOrCapability, handler, argument)
 {
     // Promise Reaction has four types.
@@ -463,7 +463,7 @@ function promiseReactionJob(state, promiseOrCapability, handler, argument)
     promiseOrCapability.@resolve.@call(@undefined, result);
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolveThenableJobFast(thenable, promiseToResolve)
 {
     "use strict";
@@ -492,7 +492,7 @@ function promiseResolveThenableJobFast(thenable, promiseToResolve)
     @putPromiseInternalField(thenable, @promiseFieldFlags, @getPromiseInternalField(thenable, @promiseFieldFlags) | @promiseFlagsIsHandled);
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolveThenableJobWithoutPromiseFast(thenable, onFulfilled, onRejected)
 {
     "use strict";
@@ -523,7 +523,7 @@ function promiseResolveThenableJobWithoutPromiseFast(thenable, onFulfilled, onRe
     @putPromiseInternalField(thenable, @promiseFieldFlags, @getPromiseInternalField(thenable, @promiseFieldFlags) | @promiseFlagsIsHandled);
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolveThenableJob(thenable, then, resolvingFunctions)
 {
     "use strict";
@@ -535,7 +535,7 @@ function promiseResolveThenableJob(thenable, then, resolvingFunctions)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseResolveThenableJobWithDerivedPromise(thenable, constructor, resolvingFunctions)
 {
     "use strict";
@@ -549,7 +549,7 @@ function promiseResolveThenableJobWithDerivedPromise(thenable, constructor, reso
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseEmptyOnFulfilled(argument)
 {
     "use strict";
@@ -557,7 +557,7 @@ function promiseEmptyOnFulfilled(argument)
     return argument;
 }
 
-@globalPrivate
+@linkTimeConstant
 function promiseEmptyOnRejected(argument)
 {
     "use strict";
@@ -565,7 +565,7 @@ function promiseEmptyOnRejected(argument)
     throw argument;
 }
 
-@globalPrivate
+@linkTimeConstant
 function performPromiseThen(promise, onFulfilled, onRejected, promiseOrCapability)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-@globalPrivate
+@linkTimeConstant
 @constructor
 function RegExpStringIterator(regExp, string, global, fullUnicode)
 {
@@ -36,7 +36,7 @@ function RegExpStringIterator(regExp, string, global, fullUnicode)
     @putByIdDirectPrivate(this, "regExpStringIteratorDone", false);
 }
 
-@globalPrivate
+@linkTimeConstant
 function advanceStringIndex(string, index, unicode)
 {
     // This function implements AdvanceStringIndex described in ES6 21.2.5.2.3.
@@ -59,7 +59,7 @@ function advanceStringIndex(string, index, unicode)
     return index + 2;
 }
 
-@globalPrivate
+@linkTimeConstant
 function regExpExec(regexp, str)
 {
     "use strict";
@@ -75,7 +75,7 @@ function regExpExec(regexp, str)
     return builtinExec.@call(regexp, str);
 }
 
-@globalPrivate
+@linkTimeConstant
 function hasObservableSideEffectsForRegExpMatch(regexp)
 {
     "use strict";
@@ -98,7 +98,7 @@ function hasObservableSideEffectsForRegExpMatch(regexp)
     return typeof regexp.lastIndex !== "number";
 }
 
-@globalPrivate
+@linkTimeConstant
 function matchSlow(regexp, str)
 {
     "use strict";
@@ -174,7 +174,7 @@ function matchAll(strArg)
     return new @RegExpStringIterator(matcher, string, global, fullUnicode);
 }
 
-@globalPrivate
+@linkTimeConstant
 function getSubstitution(matched, str, position, captures, namedCaptures, replacement)
 {
     "use strict";
@@ -426,7 +426,7 @@ function search(strArg)
     return result.index;
 }
 
-@globalPrivate
+@linkTimeConstant
 function hasObservableSideEffectsForRegExpSplit(regexp)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/SetIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetIteratorPrototype.js
@@ -24,7 +24,7 @@
  */
 
 // We keep this function small very carefully to encourage inlining.
-@globalPrivate
+@linkTimeConstant
 function setIteratorNext(bucket, kind)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
+++ b/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
@@ -26,7 +26,7 @@
 // Wrap a value at the boundary between the incubating realm and `shadowRealm`:
 // if `fromShadowRealm` is false, we are wrapping an object from the incubating
 // realm; if true, we are wrapping an object from the shadow realm
-@globalPrivate
+@linkTimeConstant
 function wrap(fromShadowRealm, shadowRealm, target)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -64,7 +64,7 @@ function matchAll(arg)
     return regExp.@@matchAll(string);
 }
 
-@globalPrivate
+@linkTimeConstant
 function repeatSlowPath(string, count)
 {
     "use strict";
@@ -94,7 +94,7 @@ function repeatSlowPath(string, count)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function repeatCharactersSlowPath(string, count)
 {
     "use strict";
@@ -211,7 +211,7 @@ function padEnd(maxLength/*, fillString*/)
     return string + truncatedStringFiller;
 }
 
-@globalPrivate
+@linkTimeConstant
 function hasObservableSideEffectsForStringReplace(regexp, replacer)
 {
     "use strict";
@@ -317,7 +317,7 @@ function split(separator, limit)
     return @stringSplitFast.@call(this, separator, limit);
 }
 
-@globalPrivate
+@linkTimeConstant
 function stringConcatSlowPath()
 {
     "use strict";
@@ -359,7 +359,7 @@ function at(index)
     return (k >= 0 && k < length) ? string[k] : @undefined; 
 }
 
-@globalPrivate
+@linkTimeConstant
 function createHTML(func, string, tag, attribute, value)
 {
     "use strict";

--- a/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
@@ -31,7 +31,7 @@
 // to look up their default constructor, which is expensive. If we used the
 // normal speciesConstructor helper we would need to look up the default
 // constructor every time.
-@globalPrivate
+@linkTimeConstant
 function typedArraySpeciesConstructor(value)
 {
     "use strict";
@@ -166,7 +166,7 @@ function some(callback /* [, thisArg] */)
     return false;
 }
 
-@globalPrivate
+@linkTimeConstant
 function typedArrayMerge(array, dst, src, srcIndex, srcEnd, width, comparator)
 {
     "use strict";
@@ -188,7 +188,7 @@ function typedArrayMerge(array, dst, src, srcIndex, srcEnd, width, comparator)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function typedArrayMergeSort(array, valueCount, comparator)
 {
     "use strict";
@@ -213,7 +213,7 @@ function typedArrayMergeSort(array, valueCount, comparator)
     }
 }
 
-@globalPrivate
+@linkTimeConstant
 function sort(comparator)
 {
     "use strict";

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -33,7 +33,7 @@ class CodeBlock;
 class JSGlobalObject;
 
 #define JSC_FOREACH_LINK_TIME_CONSTANTS(v) \
-    JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(v) \
+    JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(v) \
     v(throwTypeErrorFunction, nullptr) \
     v(importModule, nullptr) \
     v(mapBucketHead, nullptr) \

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -27,7 +27,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@globalPrivate
+@linkTimeConstant
 function createObjectWithoutPrototype(/* key1, value1, key2, value2, ... */)
 {
     if (arguments.length % 2 !== 0)
@@ -40,7 +40,7 @@ function createObjectWithoutPrototype(/* key1, value1, key2, value2, ... */)
     return object;
 }
 
-@globalPrivate
+@linkTimeConstant
 function createArrayWithoutPrototype(/* value1, value2, ... */)
 {
     let array = new @Array(arguments.length);
@@ -52,7 +52,7 @@ function createArrayWithoutPrototype(/* value1, value2, ... */)
     return array;
 }
 
-@globalPrivate
+@linkTimeConstant
 function createInspectorInjectedScript(InjectedScriptHost, inspectedGlobalObject, injectedScriptId)
 {
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1377,7 +1377,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner); \
             init.set(JSFunction::create(init.vm, code ## CodeGenerator(init.vm), globalObject)); \
         });
-    JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(INIT_PRIVATE_GLOBAL)
+    JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(INIT_PRIVATE_GLOBAL)
 #undef INIT_PRIVATE_GLOBAL
 
     // FIXME: Initializing them lazily.


### PR DESCRIPTION
#### 4af19ec51c9701398197618fb2a384ac5cc37594
<pre>
rename @globalPrivate to @linkTimeConstant for more accuracy
<a href="https://bugs.webkit.org/show_bug.cgi?id=242907">https://bugs.webkit.org/show_bug.cgi?id=242907</a>

Reviewed by Yusuke Suzuki.

The naming `@globalPrivate` is really more of a holdover when functions annotated as such were
actually privately attached to the global object.

Nowadays they are actually link time constants, so we should name them as such.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.__init__):
(BuiltinFunction.fromString):
* Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js:
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
* Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js:
* Source/JavaScriptCore/builtins/AsyncFunctionPrototype.js:
* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
* Source/JavaScriptCore/builtins/DatePrototype.js:
* Source/JavaScriptCore/builtins/GeneratorPrototype.js:
* Source/JavaScriptCore/builtins/GlobalObject.js:
* Source/JavaScriptCore/builtins/GlobalOperations.js:
* Source/JavaScriptCore/builtins/IteratorHelpers.js:
* Source/JavaScriptCore/builtins/MapIteratorPrototype.js:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
* Source/JavaScriptCore/builtins/PromiseOperations.js:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
* Source/JavaScriptCore/builtins/SetIteratorPrototype.js:
* Source/JavaScriptCore/builtins/ShadowRealmPrototype.js:
* Source/JavaScriptCore/builtins/StringPrototype.js:
* Source/JavaScriptCore/builtins/TypedArrayPrototype.js:
* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
Replace `@globalPrivate` with `@linkTimeConstant`.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_combined_header.py:
(BuiltinsCombinedHeaderGenerator.generate_section_for_global_private_code_name_macro):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
Also rename `JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME` to `JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT`.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
Still treat `@linkTimeConstant` as having `ImplementationVisibility::Private`.

Canonical link: <a href="https://commits.webkit.org/252613@main">https://commits.webkit.org/252613@main</a>
</pre>
