### PR TITLE
Add own Github username to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -5926,6 +5926,7 @@
       "emails" : [
          "repstein@apple.com"
       ],
+      "github" : "rjepstein",
       "name" : "Russell Epstein",
       "status" : "committer"
    },


### PR DESCRIPTION
#### 077b5c0278963974584b1e99936932cbd88a90e6
<pre>
Add own Github username to contributors.json

Reviewed by Alexey Proskuryakov.

* metadata/contributors.json: Add Github username.

Canonical link: <a href="https://commits.webkit.org/252612@main">https://commits.webkit.org/252612@main</a>
</pre>
