### PR TITLE
Web Inspector: Elements Tab: Computed: variables section looks broken when the selected element has no CSS variables

### DIFF
--- a/LayoutTests/inspector/css/variablesForType-expected.txt
+++ b/LayoutTests/inspector/css/variablesForType-expected.txt
@@ -1,24 +1,24 @@
-Test for DOMNodeStyles.variableStylesByType
+Test for CSSStyleDeclaration.variableStylesByType
 
 
-== Running test suite: DOMNodeStyles.variableStylesByType
--- Running test case: DOMNodeStyles.variableStylesByType.Colors
+== Running test suite: CSSStyleDeclaration.variableStylesByType
+-- Running test case: CSSStyleDeclaration.variableStylesByType.Colors
 PASS: Should have "colors" variables group.
 PASS: Group should include all expected variables.
 
--- Running test case: DOMNodeStyles.variableStylesByType.Dimensions
+-- Running test case: CSSStyleDeclaration.variableStylesByType.Dimensions
 PASS: Should have "dimensions" variables group.
 PASS: Group should include all expected variables.
 
--- Running test case: DOMNodeStyles.variableStylesByType.Numbers
+-- Running test case: CSSStyleDeclaration.variableStylesByType.Numbers
 PASS: Should have "numbers" variables group.
 PASS: Group should include all expected variables.
 
--- Running test case: DOMNodeStyles.variableStylesByType.Other
+-- Running test case: CSSStyleDeclaration.variableStylesByType.Other
 PASS: Should have "other" variables group.
 PASS: Group should include all expected variables.
 
--- Running test case: DOMNodeStyles.variableStylesByType.Mixed
+-- Running test case: CSSStyleDeclaration.variableStylesByType.Mixed
 PASS: Should have "colors" variables group.
 PASS: Group should include all expected variables.
 PASS: Should have "dimensions" variables group.

--- a/LayoutTests/inspector/css/variablesForType.html
+++ b/LayoutTests/inspector/css/variablesForType.html
@@ -6,7 +6,7 @@
 
 function test()
 {
-    let suite = InspectorTest.createAsyncSuite("DOMNodeStyles.variableStylesByType");
+    let suite = InspectorTest.createAsyncSuite("CSSStyleDeclaration.variableStylesByType");
 
     function addTestCase({name, description, selector, expected})
     {
@@ -19,13 +19,14 @@ function test()
                 let domNode = await WI.domManager.nodeForId(nodeId);
                 InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
 
-                let cssStyles = WI.cssManager.stylesForNode(domNode);
-                await cssStyles.refreshIfNeeded();
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                await domNodeStyles.refreshIfNeeded();
 
-                let styleGroups = cssStyles.variableStylesByType;
+                domNodeStyles.computedStyle.useVariablesGrouping = true;
+
                 for (let {groupType, variables} of expected) {
-                    let propertyNames = styleGroups.get(groupType).properties.map(property => property.name);
-                    InspectorTest.expectTrue(styleGroups.has(groupType), `Should have "${groupType}" variables group.`);
+                    let propertyNames = domNodeStyles.computedStyle.variablesForType(groupType).map(property => property.name);
+                    InspectorTest.expectTrue(!!propertyNames.length, `Should have "${groupType}" variables group.`);
                     InspectorTest.expectShallowEqual(propertyNames.sort(), variables.sort(), "Group should include all expected variables.");
                 }
             },
@@ -33,72 +34,72 @@ function test()
     }
 
     addTestCase({
-        name: "DOMNodeStyles.variableStylesByType.Colors",
+        name: "CSSStyleDeclaration.variableStylesByType.Colors",
         description: "Check that variables with color values are correctly identified.",
         selector: "#colors",
         expected: [
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Colors,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Colors,
                 variables: ["--colorName", "--colorHEX", "--colorRGB", "--colorRGBA", "--colorHSL", "--colorHSLA"],
             },
         ],
     });
 
     addTestCase({
-        name: "DOMNodeStyles.variableStylesByType.Dimensions",
+        name: "CSSStyleDeclaration.variableStylesByType.Dimensions",
         description: "Check that variables with dimension values are correctly identified.",
         selector: "#dimensions",
         expected: [
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Dimensions,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Dimensions,
                 variables: ["--dimensionPX", "--dimensionPercent", "--dimensionFloat", "--dimensionNegative", "--dimensionNegativeFloat"],
             },
         ],
     });
 
     addTestCase({
-        name: "DOMNodeStyles.variableStylesByType.Numbers",
+        name: "CSSStyleDeclaration.variableStylesByType.Numbers",
         description: "Check that variables with number values are correctly identified.",
         selector: "#numbers",
         expected: [
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Numbers,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Numbers,
                 variables: ["--number", "--numberFloat", "--numberNegative", "--numberNegativeFloat"],
             },
         ],
     });
 
     addTestCase({
-        name: "DOMNodeStyles.variableStylesByType.Other",
+        name: "CSSStyleDeclaration.variableStylesByType.Other",
         description: "Check that variables with values with unmatched types are placed in the fallback group.",
         selector: "#other",
         expected: [
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Other,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Other,
                 variables: ["--shadow", "--font-family", "--font-shorthand", "--keyword"],
             },
         ],
     });
 
     addTestCase({
-        name: "DOMNodeStyles.variableStylesByType.Mixed",
+        name: "CSSStyleDeclaration.variableStylesByType.Mixed",
         description: "Check that all type groups have variables allocated.",
         selector: "#mixed",
         expected: [
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Colors,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Colors,
                 variables: ["--color"],
             },
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Dimensions,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Dimensions,
                 variables: ["--dimension"],
             },
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Numbers,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Numbers,
                 variables: ["--number"],
             },
             {
-                groupType: WI.DOMNodeStyles.VariablesGroupType.Other,
+                groupType: WI.CSSStyleDeclaration.VariablesGroupType.Other,
                 variables: ["--font-family"],
             },
         ],
@@ -169,7 +170,7 @@ div#mixed {
 </style>
 </head>
 <body onload="runTest();">
-<p>Test for DOMNodeStyles.variableStylesByType</p>
+<p>Test for CSSStyleDeclaration.variableStylesByType</p>
 <div>
     <div id="colors"></div>
     <div id="dimensions"></div>

--- a/LayoutTests/inspector/view/asynchronous-layout-expected.txt
+++ b/LayoutTests/inspector/view/asynchronous-layout-expected.txt
@@ -31,6 +31,12 @@ PASS: Parent view should have 0 dirty descendants.
 PASS: Child view should have 0 dirty descendants.
 PASS: Parent view should have started a layout.
 PASS: Child view should have completed 1 layout.
+Parent view completed a layout.
+PASS: Root view should have 0 dirty descendants.
+PASS: Root view should have 0 dirty descendants.
+PASS: Root view should have 0 dirty descendants.
+PASS: Parent view should have completed 1 layout.
+PASS: Parent view should not have a pending layout.
 Child view completed a layout.
 PASS: Root view should have 0 dirty descendants.
 PASS: Parent view should have 0 dirty descendants.
@@ -49,4 +55,13 @@ Schedule parent view update.
 Layout complete.
 PASS: Chlid view should do an initial layout.
 PASS: Child view should update its layout.
+
+-- Running test case: View.didLayoutSubtree.parentView
+Flush pending layout on parent view.
+Schedule child view update.
+Layout complete.
+PASS: Child view should update its layout twice.
+PASS: Parent view should update its layout once.
+PASS: Child view should call didLayoutSubtree twice.
+PASS: Parent view should call didLayoutSubtree twice.
 

--- a/LayoutTests/inspector/view/asynchronous-layout.html
+++ b/LayoutTests/inspector/view/asynchronous-layout.html
@@ -115,7 +115,18 @@ function test()
                 InspectorTest.expectEqual(parentView.layoutCount, 1, "Parent view should have completed 1 layout.");
                 InspectorTest.expectFalse(parentView.layoutPending, "Parent view should not have a pending layout.");
 
-                resolve();
+                parentView.evaluateAfterLayout(() => {
+                    InspectorTest.log("Parent view completed a layout.");
+
+                    InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+                    InspectorTest.expectEqual(parentView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+                    InspectorTest.expectEqual(childView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+
+                    InspectorTest.expectEqual(parentView.layoutCount, 1, "Parent view should have completed 1 layout.");
+                    InspectorTest.expectFalse(parentView.layoutPending, "Parent view should not have a pending layout.");
+
+                    resolve();
+                });
             });
         }
     });
@@ -134,6 +145,31 @@ function test()
                 InspectorTest.log("Layout complete.");
                 InspectorTest.expectEqual(child.initialLayoutCount, 1, "Chlid view should do an initial layout.");
                 InspectorTest.expectEqual(child.layoutCount, 1, "Child view should update its layout.");
+                resolve();
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "View.didLayoutSubtree.parentView",
+        test(resolve, reject) {
+            let parent = new WI.TestView;
+            let child = new WI.TestView;
+            WI.View.rootView().addSubview(parent);
+            parent.addSubview(child);
+
+            InspectorTest.log("Flush pending layout on parent view.");
+            parent.updateLayout();
+
+            InspectorTest.log("Schedule child view update.");
+            child.needsLayout();
+
+            parent.evaluateAfterLayout(() => {
+                InspectorTest.log("Layout complete.");
+                InspectorTest.expectEqual(child.layoutCount, 2, "Child view should update its layout twice.");
+                InspectorTest.expectEqual(parent.layoutCount, 1, "Parent view should update its layout once.");
+                InspectorTest.expectEqual(child.didLayoutSubtreeCount, 2, "Child view should call didLayoutSubtree twice.");
+                InspectorTest.expectEqual(parent.didLayoutSubtreeCount, 2, "Parent view should call didLayoutSubtree twice.");
                 resolve();
             });
         }

--- a/LayoutTests/inspector/view/resources/test-view.js
+++ b/LayoutTests/inspector/view/resources/test-view.js
@@ -8,12 +8,14 @@ TestPage.registerInitializer(() => {
             this._layoutCallbacks = [];
             this._initialLayoutCount = 0;
             this._layoutCount = 0;
+            this._didLayoutSubtreeCount = 0;
         }
 
         // Public
 
         get initialLayoutCount() { return this._initialLayoutCount; }
         get layoutCount() { return this._layoutCount; }
+        get didLayoutSubtreeCount() { return this._didLayoutSubtreeCount; }
 
         evaluateAfterLayout(callback)
         {
@@ -34,6 +36,8 @@ TestPage.registerInitializer(() => {
 
         didLayoutSubtree()
         {
+            this._didLayoutSubtreeCount++;
+
             let callbacks = this._layoutCallbacks;
             this._layoutCallbacks = [];
             for (let callback of callbacks)

--- a/LayoutTests/inspector/view/synchronous-layout-expected.txt
+++ b/LayoutTests/inspector/view/synchronous-layout-expected.txt
@@ -22,3 +22,10 @@ PASS: View should update if an initial layout never happened.
 PASS: View should update if a layout is pending.
 PASS: View should not update if no layout is pending.
 
+-- Running test case: View.didLayoutSubtree.parentView
+Update child view layout.
+PASS: Child view should update its layout once.
+PASS: Parent view should not update its layout.
+PASS: Child view should call didLayoutSubtree once.
+PASS: Parent view should call didLayoutSubtree once.
+

--- a/LayoutTests/inspector/view/synchronous-layout.html
+++ b/LayoutTests/inspector/view/synchronous-layout.html
@@ -71,6 +71,25 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "View.didLayoutSubtree.parentView",
+        test() {
+            let parent = new WI.TestView;
+            let child = new WI.TestView;
+            parent.addSubview(child);
+
+            InspectorTest.log("Update child view layout.");
+            child.updateLayout();
+
+            InspectorTest.expectEqual(child.layoutCount, 1, "Child view should update its layout once.");
+            InspectorTest.expectEqual(parent.layoutCount, 0, "Parent view should not update its layout.");
+            InspectorTest.expectEqual(child.didLayoutSubtreeCount, 1, "Child view should call didLayoutSubtree once.");
+            InspectorTest.expectEqual(parent.didLayoutSubtreeCount, 1, "Parent view should call didLayoutSubtree once.");
+
+            return true;
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -48,7 +48,6 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         this._propertyNameToEffectivePropertyMap = {};
         this._usedCSSVariables = new Set;
         this._allCSSVariables = new Set;
-        this._variableStylesByType = null;
 
         this._pendingRefreshTask = null;
         this.refresh();
@@ -143,67 +142,6 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     get uniqueOrderedStyles()
     {
         return WI.DOMNodeStyles.uniqueOrderedStyles(this._orderedStyles);
-    }
-
-    get variableStylesByType()
-    {
-        if (this._variableStylesByType)
-            return this._variableStylesByType;
-
-        let properties = this._computedStyle?.properties;
-        if (!properties)
-            return new Map;
-
-        // Will iterate in order through type checkers for each CSS variable to identify its type.
-        // The catch-all "other" must always be last.
-        const typeCheckFunctions = [
-            {
-                type: WI.DOMNodeStyles.VariablesGroupType.Colors,
-                checker: (property) => WI.Color.fromString(property.value),
-            },
-            {
-                type: WI.DOMNodeStyles.VariablesGroupType.Dimensions,
-                // FIXME: <https://webkit.org/b/233576> build RegExp from `WI.CSSCompletions.lengthUnits`.
-                checker: (property) => /^-?\d+(\.\d+)?\D+$/.test(property.value),
-            },
-            {
-                type: WI.DOMNodeStyles.VariablesGroupType.Numbers,
-                checker: (property) => /^-?\d+(\.\d+)?$/.test(property.value),
-            },
-            {
-                type: WI.DOMNodeStyles.VariablesGroupType.Other,
-                checker: (property) => true,
-            },
-        ];
-
-        let variablesForType = {};
-        for (let property of properties) {
-            if (!property.isVariable)
-                continue;
-
-            for (let {type, checker} of typeCheckFunctions) {
-                if (checker(property)) {
-                    variablesForType[type] ||= [];
-                    variablesForType[type].push(property);
-                    break;
-                }
-            }
-        }
-
-        this._variableStylesByType = new Map;
-        for (let {type} of typeCheckFunctions) {
-            if (!variablesForType[type]?.length)
-                continue;
-
-            const ownerStyleSheet = null;
-            const id = null;
-            const inherited = false;
-            const text = null;
-            let style = new WI.CSSStyleDeclaration(this, ownerStyleSheet, id, WI.CSSStyleDeclaration.Type.Computed, this._node, inherited, text, variablesForType[type]);
-            this._variableStylesByType.set(type, style);
-        }
-
-        return this._variableStylesByType;
     }
 
     refreshIfNeeded()
@@ -376,9 +314,6 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
                     break;
                 }
             }
-
-            if (significantChange)
-                this._variableStylesByType = null;
 
             this._previousStylesMap = null;
             this._includeUserAgentRulesOnNextRefresh = false;
@@ -1056,12 +991,4 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 WI.DOMNodeStyles.Event = {
     NeedsRefresh: "dom-node-styles-needs-refresh",
     Refreshed: "dom-node-styles-refreshed"
-};
-
-WI.DOMNodeStyles.VariablesGroupType = {
-    Ungrouped: "ungrouped",
-    Colors: "colors",
-    Dimensions: "dimensions",
-    Numbers: "numbers",
-    Other: "other",
 };

--- a/Source/WebInspectorUI/UserInterface/Views/View.js
+++ b/Source/WebInspectorUI/UserInterface/Views/View.js
@@ -157,6 +157,7 @@ WI.View = class View extends WI.Object
     {
         this._setLayoutReason(layoutReason);
         this._layoutSubtree();
+        this._parentView?.didLayoutSubtree();
     }
 
     updateLayoutIfNeeded(layoutReason)
@@ -211,6 +212,7 @@ WI.View = class View extends WI.Object
         // Implemented by subclasses.
 
         // Called after the view and its entire subtree have finished layout.
+        // Also called on the immediate parent view that did not layout because it wasn't dirty.
     }
 
     sizeDidChange()
@@ -280,7 +282,6 @@ WI.View = class View extends WI.Object
     {
         this._setDirty(false);
         let isInitialLayout = !this._didInitialLayout;
-
         if (isInitialLayout) {
             console.assert(WI.setReentrantCheck(this, "initialLayout"), "ERROR: calling `initialLayout` while already in it", this);
             this.initialLayout();
@@ -367,12 +368,37 @@ WI.View = class View extends WI.Object
         WI.View._scheduledLayoutUpdateIdentifier = undefined;
 
         let views = [WI.View._rootView];
+        let cleanViews = new Set;
         for (let i = 0; i < views.length; ++i) {
             let view = views[i];
-            if (view.layoutPending)
+
+            if (cleanViews.has(view)) {
+                console.assert(WI.setReentrantCheck(view, "didLayoutSubtree"), "ERROR: calling `didLayoutSubtree` while already in it", view);
+                view.didLayoutSubtree();
+                console.assert(WI.clearReentrantCheck(view, "didLayoutSubtree"), "ERROR: missing return from `didLayoutSubtree`", view);
+                continue;
+            }
+
+            if (view.layoutPending) {
                 view._layoutSubtree();
-            else if (view._dirtyDescendantsCount)
-                views.pushAll(view.subviews);
+                continue;
+            }
+
+            if (view._dirtyDescendantsCount) {
+                cleanViews.add(view);
+
+                let hasDirtySubview = false;
+                for (let subview of view.subviews) {
+                    hasDirtySubview ||= subview.layoutPending;
+                    views.push(subview);
+                }
+
+                // Add again the parent view to the list we're iterating over, right after its subviews.
+                // By the time it is encountered again, all its subviews will have done _layoutSubtree() and then we can call didLayoutSubtree() on it.
+                if (hasDirtySubview)
+                    views.push(view);
+                continue;
+            }
         }
     }
 };


### PR DESCRIPTION
#### e069140a859cad8a65a868427fff4fdd6f1bf6aa
<pre>
Web Inspector: Elements Tab: Computed: variables section looks broken when the selected element has no CSS variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=242704">https://bugs.webkit.org/show_bug.cgi?id=242704</a>

Reviewed by Devin Rousso.

The original implementation made some wrong assumptions about the layout lifecycle
for CSS variable groups. This patch introduces a refactoring to correct that and
fix a bunch issues at once.

Context:

The properties section of the Computed panel is updated in response to the event
`WI.CSSStyleDeclaration.Event.PropertiesChanged` fired by
`WI.DOMNodeStyles.computedStyle` which is a `WI.CSSDeclaration` instance.
This allows it to dynamically reflect changes to any styles of the selected node.

There&apos;s an optimization in `WI.DOMNodeStyles.refresh() -&gt; fetchedComputedStyle()`
where a change to styles of existing CSS rules isn&apos;t considered a `significantChange`.
This prevents a lot of needless re-layout in components which observe style refreshes.

The Properties section of the Computed panel listens for the event on `WI.DOMNodeStyles.computedStyle`
to address this optimization.

When grouping CSS variables, the groups were distinct `WI.CSSDeclaration` instances for clarity.
But they were cached and never updated in response to style changes on a node.
Because of this, the sections for variable groups in the Computed panel did not reflect
any changes: adding/removing variables, changing their type, etc.

The changes:

1) The logic for grouping variables by type is moved from `WI.DOMNodeStyles` to
`WI.CSSDeclaration`. This way, all sections in the Computed panel rely on a single
data source: `WI.DOMNodeStyles.computedStyle`.
It&apos;s the view&apos;s job to pick the subset of properties to render.

2) A new getter is added, `WI.CSSDeclaration.variablesForType`, to do this extra work
for all variable groups when consumers ask for them.

There can be a growing number of groups, so having separate iterations on every style
change over a potentially long list of properties is wasteful.
Plus, anything that doesn&apos;t match a type checker needs to go in the &quot;Other&quot; group.

3) `WI.ComputedStyleSection` is modified to obtain a list of properties to render
depending on the variables group type set on `WI.ComputedStyleSection.variablesGroupType`.
This subset of properties is then used in `WI.ComputedStyleSection.layout()`.

Introduced debouncing for layout in respose to `WI.DOMNodeStyles.Events.PropertiesChanged`
because it is expensive; throwing away all elements for properties and rebuilding from scratch.

4) Filtering is implemented. Sections that have no matches are hidden.

5) The test that checks CSS variables grouping is renamed and updated.

6) Modify `WI.View` to call `WI.View.didSubtreeLayout()` on the immediate parent
of the first dirty view that did layout on itself and all of its descendant views.
This allows a parent view to react in response to layout under its subtree.

This behavior is used to call `WI.ComputedStyleDetailsPanel.didSubtreeLayout()` where we can
toggle the visibility of the &quot;Variables&quot; section when the nested sections for variable groups are empty.

* LayoutTests/inspector/css/variablesForType-expected.txt: Renamed from LayoutTests/inspector/css/variableStylesByType-expected.txt.
* LayoutTests/inspector/css/variablesForType.html: Renamed from LayoutTests/inspector/css/variableStylesByType.html.
* LayoutTests/inspector/view/asynchronous-layout-expected.txt:
* LayoutTests/inspector/view/asynchronous-layout.html:
* LayoutTests/inspector/view/resources/test-view.js:
(TestPage.registerInitializer.WI.TestView):
(TestPage.registerInitializer.WI.TestView.prototype.get didLayoutSubtreeCount):
(TestPage.registerInitializer.WI.TestView.prototype.didLayoutSubtree):
(TestPage.registerInitializer):
* LayoutTests/inspector/view/synchronous-layout-expected.txt:
* LayoutTests/inspector/view/synchronous-layout.html:
* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:
(WI.CSSStyleDeclaration):
(WI.CSSStyleDeclaration.prototype.variablesForType):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles):
(WI.DOMNodeStyles.prototype.refresh.fetchedComputedStyle):
(WI.DOMNodeStyles.prototype.get variableStylesByType): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ComputedStyleDetailsPanel.js:
(WI.ComputedStyleDetailsPanel.displayNameForVariablesGroupType):
(WI.ComputedStyleDetailsPanel.prototype.refresh):
(WI.ComputedStyleDetailsPanel.prototype.layout):
(WI.ComputedStyleDetailsPanel.prototype.didLayoutSubtree):
(WI.ComputedStyleDetailsPanel.prototype._createVariablesStyleSection):
(WI.ComputedStyleDetailsPanel.prototype._removeVariablesStyleSection):
(WI.ComputedStyleDetailsPanel.prototype._renderVariablesStyleSectionGroup): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.js:
(WI.ComputedStyleSection.prototype.get variablesGroupType):
(WI.ComputedStyleSection.prototype.get isEmpty):
(WI.ComputedStyleSection.prototype.get properties):
(WI.ComputedStyleSection.prototype.layout):
(WI.ComputedStyleSection.prototype.detached):
(WI.ComputedStyleSection.prototype.applyFilter):
(WI.ComputedStyleSection.prototype._handlePropertiesChanged):
(WI.ComputedStyleSection):
* Source/WebInspectorUI/UserInterface/Views/View.js:
(WI.View.prototype.updateLayout):
(WI.View.prototype._layoutSubtree):
(WI.View._visitViewTreeForLayout):
(WI.View):

Canonical link: <a href="https://commits.webkit.org/253562@main">https://commits.webkit.org/253562@main</a>
</pre>















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff86a6dc24a74b69f5a519222e8b8c994307d32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95249 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148957 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28686 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90493 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92002 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23358 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/66364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26636 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2535 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28227 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32847 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->