### PR TITLE
[libpas] Fix pas_segregated_directory_get_use_epoch

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -326,13 +326,11 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_scan_bits_to_set_up_free_bits(
 
     switch (view_kind) {
     case pas_segregated_exclusive_view_kind:
-        page->num_non_empty_words =
-            pas_segregated_size_directory_data_ptr_load_non_null(
-                &directory->data)->full_num_non_empty_words;
+        page->emptiness.num_non_empty_words = pas_segregated_size_directory_data_ptr_load_non_null(&directory->data)->full_num_non_empty_words;
         break;
         
     case pas_segregated_partial_view_kind:
-        page->num_non_empty_words += num_denullified_words;
+        page->emptiness.num_non_empty_words += num_denullified_words;
         break;
         
     default:
@@ -440,7 +438,7 @@ pas_local_allocator_prepare_to_allocate(
 
     page_boundary = (uintptr_t)pas_segregated_page_boundary(page, page_config);
     
-    if (view_kind == pas_segregated_exclusive_view_kind && !page->num_non_empty_words) {
+    if (view_kind == pas_segregated_exclusive_view_kind && !page->emptiness.num_non_empty_words) {
         uintptr_t payload_begin;
         uintptr_t payload_end;
         pas_segregated_size_directory_data* data;
@@ -456,7 +454,7 @@ pas_local_allocator_prepare_to_allocate(
         payload_begin = page_boundary + data->offset_from_page_boundary_to_first_object;
         payload_end = page_boundary + data->offset_from_page_boundary_to_end_of_last_object;
         
-        page->num_non_empty_words = data->full_num_non_empty_words;
+        page->emptiness.num_non_empty_words = data->full_num_non_empty_words;
 
         pas_local_allocator_make_bump(
             allocator, page_boundary, payload_begin, payload_end, page_config);
@@ -571,7 +569,7 @@ pas_local_allocator_set_up_primordial_bump(
                     handle->partial_views + word_index, view);
             }
             
-            page->num_non_empty_words++;
+            page->emptiness.num_non_empty_words++;
         }
         if (page_config.sharing_shift != PAS_BITVECTOR_WORD_SHIFT) {
             pas_compact_atomic_segregated_partial_view_ptr* ptr;

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base.c
@@ -113,7 +113,7 @@ bool pas_page_base_is_empty(pas_page_base* page)
 {
     switch (pas_page_base_get_config_kind(page)) {
     case pas_page_config_kind_segregated:
-        return !pas_page_base_get_segregated(page)->num_non_empty_words;
+        return !pas_page_base_get_segregated(page)->emptiness.num_non_empty_words;
     case pas_page_config_kind_bitfit:
         return !pas_page_base_get_bitfit(page)->num_live_bits;
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
@@ -52,9 +52,12 @@ pas_page_base* pas_page_header_table_add(pas_page_header_table* table,
     /* This protects against leaks. */
     PAS_ASSERT(!pas_page_header_table_get_for_boundary(table, page_size, boundary));
 
+    /* We allocate two slots before the pas_page_base. The one is used for storing boundary.
+       Another is not used, just allocated to align the page with 16byte alignment, which is
+       required since it includes 16byte aligned data structures. */
     page_base = (pas_page_base*)(
-        (void**)pas_utility_heap_allocate(
-            sizeof(void*) + header_size, "pas_page_header_table/header") + 1);
+        (void**)pas_utility_heap_allocate_with_alignment(
+            sizeof(void*) * 2 + header_size, 16, "pas_page_header_table/header") + 2);
 
     if (verbose)
         pas_log("created page header at %p\n", page_base);

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
@@ -74,7 +74,7 @@ static PAS_ALWAYS_INLINE void** pas_page_header_table_get_boundary_ptr(pas_page_
 {
     PAS_TESTING_ASSERT(page_size == table->page_size);
 
-    return ((void**)page_base) - 1;
+    return ((void**)page_base) - 2;
 }
 
 static PAS_ALWAYS_INLINE void* pas_page_header_table_get_boundary(pas_page_header_table* table,

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -341,10 +341,10 @@ pas_segregated_page_deallocate_with_page(pas_segregated_page* page,
     PAS_ASSERT(page_config.base.is_enabled);
     
     if (verbose) {
-        pas_log("Freeing %p in %p(%s), num_non_empty_words = %u\n",
+        pas_log("Freeing %p in %p(%s), num_non_empty_words = %llu\n",
                 (void*)begin, page,
                 pas_segregated_page_config_kind_get_string(page_config.kind),
-                page->num_non_empty_words);
+                (uint64_t)page->emptiness.num_non_empty_words);
     }
 
     bit_index_unmasked = begin >> page_config.base.min_align_shift;
@@ -478,17 +478,19 @@ pas_segregated_page_deallocate_with_page(pas_segregated_page* page,
             pas_segregated_page_verify_granules(page);
 
         if (did_find_empty_granule)
-            pas_segregated_page_note_emptiness(page);
+            pas_segregated_page_note_emptiness(page, pas_note_emptiness_keep_num_non_empty_words);
     }
     
     if (!new_word) {
-        PAS_TESTING_ASSERT(page->num_non_empty_words);
-        if (!--page->num_non_empty_words) {
+        PAS_TESTING_ASSERT(page->emptiness.num_non_empty_words);
+        uintptr_t num_non_empty_words = page->emptiness.num_non_empty_words;
+        if (!--num_non_empty_words) {
             /* This has to happen last since it effectively unlocks the lock. That's due to
                the things that happen in switch_lock_and_try_to_take_bias. Specifically, its
                reliance on the fully_empty bit. */
-            pas_segregated_page_note_emptiness(page);
-        }
+            pas_segregated_page_note_emptiness(page, pas_note_emptiness_clear_num_non_empty_words);
+        } else
+            page->emptiness.num_non_empty_words = num_non_empty_words;
     }
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
@@ -162,7 +162,7 @@ bool pas_segregated_partial_view_should_table(
     shared_handle_or_page_boundary = shared_view->shared_handle_or_page_boundary;
     shared_handle = pas_unwrap_shared_handle(shared_handle_or_page_boundary, *page_config);
     page = pas_segregated_page_for_boundary(shared_handle->page_boundary, *page_config);
-    return !page->num_non_empty_words;
+    return !page->emptiness.num_non_empty_words;
 }
 
 static pas_heap_summary compute_summary(pas_segregated_partial_view* view)

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
@@ -433,7 +433,7 @@ take_last_empty_consider_view(
         goto return_taken_partial_views_after_decommit;
     }
     
-    if (page->num_non_empty_words) {
+    if (page->emptiness.num_non_empty_words) {
         size_t num_committed_granules;
 
         PAS_ASSERT(page_config.base.page_size > page_config.base.granule_size);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
@@ -754,7 +754,7 @@ take_last_empty_consider_view(pas_segregated_directory_iterate_config* config)
         return true;
     }
     
-    if (page->num_non_empty_words) {
+    if (page->emptiness.num_non_empty_words) {
         bool decommit_result;
         size_t num_committed_granules;
         

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -68,8 +68,10 @@ PAS_BEGIN_EXTERN_C;
 
 #if PAS_PLATFORM(PLAYSTATION) && !defined(alignof)
 #define PAS_ALIGNOF(type) _Alignof(type)
-#else
+#elif defined(__cplusplus)
 #define PAS_ALIGNOF(type) alignof(type)
+#else
+#define PAS_ALIGNOF(type) _Alignof(type)
 #endif
 
 #define PAS_FORMAT_PRINTF(fmt, args) __attribute__((format(__printf__, fmt, args)))
@@ -987,6 +989,16 @@ static inline void pas_atomic_store_pair(void* raw_ptr, pas_pair value)
     __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
 #else
     __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
+#endif
+}
+
+static inline void pas_atomic_store_pair_relaxed(void* raw_ptr, pas_pair value)
+{
+    /* Since it is __ATOMIC_RELAXED, we do not need to care about memory barrier even when the implementation uses LL/SC. */
+#if PAS_COMPILER(CLANG)
+    __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
+#else
+    __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
 #endif
 }
 


### PR DESCRIPTION
#### 4a099b3ac61b95b0e8304c6d6b6d1dea93827f7f
<pre>
[libpas] Fix pas_segregated_directory_get_use_epoch
<a href="https://bugs.webkit.org/show_bug.cgi?id=242911">https://bugs.webkit.org/show_bug.cgi?id=242911</a>
rdar://87308366

Reviewed by Mark Lam.

We observed some crashes in pas_segregated_directory_get_use_epoch assertion which is saying num_non_empty_words and use_epoch are both zero.
This can happen since pas_segregated_directory_get_use_epoch is not taking the page lock. We are taking the ownership lock, but this does not
guarantee that num_non_empty_words and use_epoch will not be modified. However, the problem is that (1) taking the ownership lock is required
to keep the page alive, and (2) taking both the page lock and the owership lock is not possible because of lack of locking ordering between them
throughout the code.

To fix this issue, we apply two changes.
Keep in mind that this pas_segregated_directory_get_use_epoch returns approximate value. If it is not precise in the face of race condition, it is OK.

1. Whenever changing num_non_empty_words to zero, we update use_epoch atomically. And in pas_segregated_directory_get_use_epoch, we load both
   atomically. This ensures that, whenever num_non_empty_words is zero, we do not get a stale value for use_epoch. This fixes one issue: we had
   small race window, after num_non_empty_words becomes zero and resetting use_epoch a new epoch, old use_epoch value can be read from the other
   thread while num_non_empty_words is zero. By doing this, we can ensure that old use_epoch value will not be visible to the other thread if
   num_non_empty_words is zero. This is one source of this crash because the newly created fresh page&apos;s use_epoch is zero. If the page is new and
   we encounter this race condition, we will get zero num_non_empty_words and use_epoch.
2. Still it is possible that we observe zero num_non_empty_words and use_epoch. This is because this function is not taking eligible bit at all.
   This means that, between checking empty bit and taking the onwership lock, the underlying page can be purged, reallocated, or whatever can happen.
   If the page is destroyed and reallocated, and just before actually starting use of this page, this page&apos;s num_non_empty_words and use_epoch are both
   zero. In this case, we can just ignore this page since it is already in use.

* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_scan_bits_to_set_up_free_bits):
(pas_local_allocator_prepare_to_allocate):
(pas_local_allocator_set_up_primordial_bump):
* Source/bmalloc/libpas/src/libpas/pas_page_base.c:
(pas_page_base_is_empty):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c:
(pas_segregated_directory_get_use_epoch):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.c:
(pas_segregated_page_construct):
(pas_segregated_page_note_emptiness):
(pas_segregated_page_take_physically):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.h:
(pas_segregated_page_qualifies_for_decommit):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
(pas_segregated_page_deallocate_with_page):
* Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c:
(pas_segregated_partial_view_should_table):
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c:
(take_last_empty_consider_view):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c:
(take_last_empty_consider_view):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:
(pas_atomic_store_pair_relaxed):

Canonical link: <a href="https://commits.webkit.org/252635@main">https://commits.webkit.org/252635@main</a>
</pre>
