### PR TITLE
remove unused forward declarations for `AVFunctionBar*`

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -285,9 +285,6 @@ NS_ASSUME_NONNULL_END
 
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER) && PLATFORM(MAC)
 
-OBJC_CLASS AVFunctionBarMediaSelectionOption;
-OBJC_CLASS AVFunctionBarPlaybackControlsProvider;
-OBJC_CLASS AVFunctionBarScrubber;
 OBJC_CLASS AVTouchBarMediaSelectionOption;
 OBJC_CLASS AVTouchBarPlaybackControlsProvider;
 OBJC_CLASS AVTouchBarScrubber;
@@ -298,26 +295,7 @@ OBJC_CLASS AVTouchBarScrubber;
 #else
 NS_ASSUME_NONNULL_BEGIN
 
-__attribute__((availability(macosx, obsoleted = 10.13))) @protocol AVFunctionBarPlaybackControlsControlling <NSObject>;
-@property (readonly) NSTimeInterval contentDuration;
-@property (readonly, nullable) AVValueTiming *timing;
-@property (readonly, getter=isSeeking) BOOL seeking;
-@property (readonly) NSTimeInterval seekToTime;
-- (void)seekToTime:(NSTimeInterval)time toleranceBefore:(NSTimeInterval)toleranceBefore toleranceAfter:(NSTimeInterval)toleranceAfter;
-@property (readonly) BOOL hasEnabledAudio;
-@property (readonly) BOOL hasEnabledVideo;
-@end
-
-__attribute__((availability(macosx, obsoleted = 10.13))) @interface AVFunctionBarPlaybackControlsProvider : NSResponder
-@property (strong, readonly, nullable) NSTouchBar *touchBar;
-@property (assign, nullable) id<AVFunctionBarPlaybackControlsControlling> playbackControlsController;
-@end
-
 @class AVThumbnail;
-
-__attribute__((availability(macosx, obsoleted = 10.13))) @interface AVFunctionBarScrubber : NSView
-@property (assign, nullable) id<AVFunctionBarPlaybackControlsControlling> playbackControlsController;
-@end
 
 @protocol AVTouchBarPlaybackControlsControlling <NSObject>
 @property (readonly) NSTimeInterval contentDuration;


### PR DESCRIPTION
#### a3953bc9a2b9a8b2eb61b3388beaa58b327ca5d4
<pre>
remove unused forward declarations for `AVFunctionBar*`
<a href="https://bugs.webkit.org/show_bug.cgi?id=242915">https://bugs.webkit.org/show_bug.cgi?id=242915</a>
&lt;rdar://problem/53510918&gt;

Reviewed by Aditya Keerthi.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/252624@main">https://commits.webkit.org/252624@main</a>
</pre>
