### PR TITLE
builtins generator tests failing after 252554@main and 252613@main

### DIFF
--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result
@@ -37,6 +37,7 @@ class VM;
 
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
+enum class ImplementationVisibility : uint8_t;
 }
 
 namespace JSC {
@@ -50,10 +51,12 @@ extern const char* const s_builtinPromiseRejectPromiseCode;
 extern const int s_builtinPromiseRejectPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility;
 extern const char* const s_builtinPromiseFulfillPromiseCode;
 extern const int s_builtinPromiseFulfillPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTINPROMISE_BUILTIN_DATA(macro) \
     macro(rejectPromise, builtinPromiseRejectPromise, 2) \
@@ -67,7 +70,7 @@ extern const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorK
     macro(fulfillPromise) \
     macro(rejectPromise) \
 
-#define JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(macro) \
+#define JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(macro) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
@@ -128,6 +131,7 @@ const unsigned s_JSCCombinedCodeLength = 673;
 
 const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPromiseFulfillPromiseCodeLength = 336;
 static const JSC::Intrinsic s_builtinPromiseFulfillPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseFulfillPromiseCode =
@@ -136,6 +140,7 @@ s_JSCCombinedCode + 0
 
 const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPromiseRejectPromiseCodeLength = 337;
 static const JSC::Intrinsic s_builtinPromiseRejectPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseRejectPromiseCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result
@@ -44,10 +44,12 @@ extern const char* const s_builtinPromiseRejectPromiseCode;
 extern const int s_builtinPromiseRejectPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility;
 extern const char* const s_builtinPromiseFulfillPromiseCode;
 extern const int s_builtinPromiseFulfillPromiseCodeLength;
 extern const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTIN_PROMISE_BUILTIN_DATA(macro) \
     macro(rejectPromise, builtinPromiseRejectPromise, 2) \
@@ -118,6 +120,7 @@ namespace JSC {
 
 const JSC::ConstructAbility s_builtinPromiseRejectPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseRejectPromiseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPromiseRejectPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPromiseRejectPromiseCodeLength = 337;
 static const JSC::Intrinsic s_builtinPromiseRejectPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseRejectPromiseCode =
@@ -137,6 +140,7 @@ const char* const s_builtinPromiseRejectPromiseCode =
 
 const JSC::ConstructAbility s_builtinPromiseFulfillPromiseCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPromiseFulfillPromiseCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPromiseFulfillPromiseCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPromiseFulfillPromiseCodeLength = 336;
 static const JSC::Intrinsic s_builtinPromiseFulfillPromiseCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPromiseFulfillPromiseCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result
@@ -37,6 +37,7 @@ class VM;
 
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
+enum class ImplementationVisibility : uint8_t;
 }
 
 namespace JSC {
@@ -50,18 +51,22 @@ extern const char* const s_builtinPrototypeEveryCode;
 extern const int s_builtinPrototypeEveryCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeForEachCode;
 extern const int s_builtinPrototypeForEachCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeMatchCode;
 extern const int s_builtinPrototypeMatchCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeTestCode;
 extern const int s_builtinPrototypeTestCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTINPROTOTYPE_BUILTIN_DATA(macro) \
     macro(every, builtinPrototypeEvery, 1) \
@@ -81,7 +86,7 @@ extern const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind;
     macro(match) \
     macro(test) \
 
-#define JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(macro) \
+#define JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(macro) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
@@ -142,6 +147,7 @@ const unsigned s_JSCCombinedCodeLength = 3198;
 
 const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeEveryCodeLength = 762;
 static const JSC::Intrinsic s_builtinPrototypeEveryCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeEveryCode =
@@ -150,6 +156,7 @@ s_JSCCombinedCode + 0
 
 const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeForEachCodeLength = 694;
 static const JSC::Intrinsic s_builtinPrototypeForEachCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeForEachCode =
@@ -158,6 +165,7 @@ s_JSCCombinedCode + 762
 
 const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeMatchCodeLength = 1238;
 static const JSC::Intrinsic s_builtinPrototypeMatchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeMatchCode =
@@ -166,6 +174,7 @@ s_JSCCombinedCode + 1456
 
 const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeTestCodeLength = 504;
 static const JSC::Intrinsic s_builtinPrototypeTestCodeIntrinsic = JSC::RegExpTestIntrinsic;
 const char* const s_builtinPrototypeTestCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result
@@ -44,18 +44,22 @@ extern const char* const s_builtinPrototypeEveryCode;
 extern const int s_builtinPrototypeEveryCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeForEachCode;
 extern const int s_builtinPrototypeForEachCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeMatchCode;
 extern const int s_builtinPrototypeMatchCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility;
 extern const char* const s_builtinPrototypeTestCode;
 extern const int s_builtinPrototypeTestCodeLength;
 extern const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTIN_PROTOTYPE_BUILTIN_DATA(macro) \
     macro(every, builtinPrototypeEvery, 1) \
@@ -134,6 +138,7 @@ namespace JSC {
 
 const JSC::ConstructAbility s_builtinPrototypeEveryCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeEveryCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeEveryCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeEveryCodeLength = 762;
 static const JSC::Intrinsic s_builtinPrototypeEveryCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeEveryCode =
@@ -168,6 +173,7 @@ const char* const s_builtinPrototypeEveryCode =
 
 const JSC::ConstructAbility s_builtinPrototypeForEachCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeForEachCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeForEachCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeForEachCodeLength = 694;
 static const JSC::Intrinsic s_builtinPrototypeForEachCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeForEachCode =
@@ -198,6 +204,7 @@ const char* const s_builtinPrototypeForEachCode =
 
 const JSC::ConstructAbility s_builtinPrototypeMatchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeMatchCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeMatchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeMatchCodeLength = 1238;
 static const JSC::Intrinsic s_builtinPrototypeMatchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinPrototypeMatchCode =
@@ -255,6 +262,7 @@ const char* const s_builtinPrototypeMatchCode =
 
 const JSC::ConstructAbility s_builtinPrototypeTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinPrototypeTestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinPrototypeTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinPrototypeTestCodeLength = 504;
 static const JSC::Intrinsic s_builtinPrototypeTestCodeIntrinsic = JSC::RegExpTestIntrinsic;
 const char* const s_builtinPrototypeTestCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result
@@ -36,6 +36,7 @@ class VM;
 
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
+enum class ImplementationVisibility : uint8_t;
 }
 
 namespace JSC {
@@ -49,10 +50,12 @@ extern const char* const s_builtinConstructorOfCode;
 extern const int s_builtinConstructorOfCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility;
 extern const char* const s_builtinConstructorFromCode;
 extern const int s_builtinConstructorFromCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTINCONSTRUCTOR_BUILTIN_DATA(macro) \
     macro(of, builtinConstructorOf, 0) \
@@ -66,7 +69,7 @@ extern const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind;
     macro(from) \
     macro(of) \
 
-#define JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(macro) \
+#define JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(macro) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
@@ -126,6 +129,7 @@ const unsigned s_JSCCombinedCodeLength = 2340;
 
 const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinConstructorFromCodeLength = 2046;
 static const JSC::Intrinsic s_builtinConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorFromCode =
@@ -134,6 +138,7 @@ s_JSCCombinedCode + 0
 
 const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinConstructorOfCodeLength = 294;
 static const JSC::Intrinsic s_builtinConstructorOfCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorOfCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result
@@ -43,10 +43,12 @@ extern const char* const s_builtinConstructorOfCode;
 extern const int s_builtinConstructorOfCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility;
 extern const char* const s_builtinConstructorFromCode;
 extern const int s_builtinConstructorFromCodeLength;
 extern const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility;
 extern const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility;
 
 #define JSC_FOREACH_BUILTINCONSTRUCTOR_BUILTIN_DATA(macro) \
     macro(of, builtinConstructorOf, 0) \
@@ -116,6 +118,7 @@ namespace JSC {
 
 const JSC::ConstructAbility s_builtinConstructorOfCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorOfCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinConstructorOfCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinConstructorOfCodeLength = 294;
 static const JSC::Intrinsic s_builtinConstructorOfCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorOfCode =
@@ -135,6 +138,7 @@ const char* const s_builtinConstructorOfCode =
 
 const JSC::ConstructAbility s_builtinConstructorFromCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_builtinConstructorFromCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_builtinConstructorFromCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_builtinConstructorFromCodeLength = 2046;
 static const JSC::Intrinsic s_builtinConstructorFromCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_builtinConstructorFromCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result
@@ -37,6 +37,7 @@ class VM;
 
 enum class ConstructAbility : uint8_t;
 enum class ConstructorKind : uint8_t;
+enum class ImplementationVisibility : uint8_t;
 }
 
 namespace JSC {
@@ -50,10 +51,12 @@ extern const char* const s_internalClashingNamesIsReadableStreamLockedCode;
 extern const int s_internalClashingNamesIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility;
 extern const char* const s_internalClashingNamesIsReadableStreamLockedCode;
 extern const int s_internalClashingNamesIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility;
 
 #define JSC_FOREACH_INTERNALCLASHINGNAMES_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, internalClashingNamesIsReadableStreamLocked, 1) \
@@ -66,7 +69,7 @@ extern const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedC
 #define JSC_FOREACH_BUILTIN_FUNCTION_NAME(macro) \
     macro(isReadableStreamLocked) \
 
-#define JSC_FOREACH_BUILTIN_FUNCTION_PRIVATE_GLOBAL_NAME(macro) \
+#define JSC_FOREACH_BUILTIN_LINK_TIME_CONSTANT(macro) \
 
 #define DECLARE_BUILTIN_GENERATOR(codeName, functionName, overriddenName, argumentCount) \
     JSC::FunctionExecutable* codeName##Generator(JSC::VM&);
@@ -127,6 +130,7 @@ const unsigned s_JSCCombinedCodeLength = 142;
 
 const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_internalClashingNamesIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_internalClashingNamesIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_internalClashingNamesIsReadableStreamLockedCode =
@@ -135,6 +139,7 @@ s_JSCCombinedCode + 0
 
 const JSC::ConstructAbility s_internalClashingNamesIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_internalClashingNamesIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_internalClashingNamesIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_internalClashingNamesIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_internalClashingNamesIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_internalClashingNamesIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result
@@ -48,6 +48,7 @@ extern const char* const s_anotherGuardedInternalBuiltinLetsFetchCode;
 extern const int s_anotherGuardedInternalBuiltinLetsFetchCodeLength;
 extern const JSC::ConstructAbility s_anotherGuardedInternalBuiltinLetsFetchCodeConstructAbility;
 extern const JSC::ConstructorKind s_anotherGuardedInternalBuiltinLetsFetchCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_anotherGuardedInternalBuiltinLetsFetchCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_ANOTHERGUARDEDINTERNALBUILTIN_BUILTIN_DATA(macro) \
     macro(letsFetch, anotherGuardedInternalBuiltinLetsFetch, 0) \
@@ -107,7 +108,7 @@ inline JSC::UnlinkedFunctionExecutable* AnotherGuardedInternalBuiltinBuiltinsWra
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -211,6 +212,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_anotherGuardedInternalBuiltinLetsFetchCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_anotherGuardedInternalBuiltinLetsFetchCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_anotherGuardedInternalBuiltinLetsFetchCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_anotherGuardedInternalBuiltinLetsFetchCodeLength = 83;
 static const JSC::Intrinsic s_anotherGuardedInternalBuiltinLetsFetchCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_anotherGuardedInternalBuiltinLetsFetchCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result
@@ -49,6 +49,7 @@ extern const char* const s_arbitraryConditionalGuardIsReadableStreamLockedCode;
 extern const int s_arbitraryConditionalGuardIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_arbitraryConditionalGuardIsReadableStreamLockedCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_ARBITRARYCONDITIONALGUARD_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, arbitraryConditionalGuardIsReadableStreamLocked, 1) \
@@ -108,7 +109,7 @@ inline JSC::UnlinkedFunctionExecutable* ArbitraryConditionalGuardBuiltinsWrapper
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -176,6 +177,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_arbitraryConditionalGuardIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_arbitraryConditionalGuardIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_arbitraryConditionalGuardIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_arbitraryConditionalGuardIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_arbitraryConditionalGuardIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result
@@ -49,6 +49,7 @@ extern const char* const s_guardedBuiltinIsReadableStreamLockedCode;
 extern const int s_guardedBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_guardedBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_guardedBuiltinIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_guardedBuiltinIsReadableStreamLockedCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_GUARDEDBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, guardedBuiltinIsReadableStreamLocked, 1) \
@@ -108,7 +109,7 @@ inline JSC::UnlinkedFunctionExecutable* GuardedBuiltinBuiltinsWrapper::name##Exe
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -176,6 +177,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_guardedBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_guardedBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_guardedBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_guardedBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_guardedBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_guardedBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result
@@ -49,6 +49,7 @@ extern const char* const s_guardedInternalBuiltinIsReadableStreamLockedCode;
 extern const int s_guardedInternalBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_guardedInternalBuiltinIsReadableStreamLockedCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_GUARDEDINTERNALBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, guardedInternalBuiltinIsReadableStreamLocked, 1) \
@@ -108,7 +109,7 @@ inline JSC::UnlinkedFunctionExecutable* GuardedInternalBuiltinBuiltinsWrapper::n
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -213,6 +214,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_guardedInternalBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_guardedInternalBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_guardedInternalBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_guardedInternalBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_guardedInternalBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result
@@ -47,6 +47,7 @@ extern const char* const s_unguardedBuiltinIsReadableStreamLockedCode;
 extern const int s_unguardedBuiltinIsReadableStreamLockedCodeLength;
 extern const JSC::ConstructAbility s_unguardedBuiltinIsReadableStreamLockedCodeConstructAbility;
 extern const JSC::ConstructorKind s_unguardedBuiltinIsReadableStreamLockedCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_unguardedBuiltinIsReadableStreamLockedCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_UNGUARDEDBUILTIN_BUILTIN_DATA(macro) \
     macro(isReadableStreamLocked, unguardedBuiltinIsReadableStreamLocked, 1) \
@@ -106,7 +107,7 @@ inline JSC::UnlinkedFunctionExecutable* UnguardedBuiltinBuiltinsWrapper::name##E
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -170,6 +171,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_unguardedBuiltinIsReadableStreamLockedCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_unguardedBuiltinIsReadableStreamLockedCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_unguardedBuiltinIsReadableStreamLockedCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_unguardedBuiltinIsReadableStreamLockedCodeLength = 71;
 static const JSC::Intrinsic s_unguardedBuiltinIsReadableStreamLockedCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_unguardedBuiltinIsReadableStreamLockedCode =

--- a/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result
+++ b/Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result
@@ -49,14 +49,17 @@ extern const char* const s_xmlCasingTestXMLCasingTestCode;
 extern const int s_xmlCasingTestXMLCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestXMLCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestXMLCasingTestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_xmlCasingTestXMLCasingTestCodeImplementationVisibility;
 extern const char* const s_xmlCasingTestCssCasingTestCode;
 extern const int s_xmlCasingTestCssCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestCssCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestCssCasingTestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_xmlCasingTestCssCasingTestCodeImplementationVisibility;
 extern const char* const s_xmlCasingTestUrlCasingTestCode;
 extern const int s_xmlCasingTestUrlCasingTestCodeLength;
 extern const JSC::ConstructAbility s_xmlCasingTestUrlCasingTestCodeConstructAbility;
 extern const JSC::ConstructorKind s_xmlCasingTestUrlCasingTestCodeConstructorKind;
+extern const JSC::ImplementationVisibility s_xmlCasingTestUrlCasingTestCodeImplementationVisibility;
 
 #define WEBCORE_FOREACH_XMLCASINGTEST_BUILTIN_DATA(macro) \
     macro(xmlCasingTest, xmlCasingTestXMLCasingTest, 1) \
@@ -124,7 +127,7 @@ inline JSC::UnlinkedFunctionExecutable* xmlCasingTestBuiltinsWrapper::name##Exec
         JSC::Identifier executableName = functionName##PublicName();\
         if (overriddenName)\
             executableName = JSC::Identifier::fromString(m_vm, overriddenName);\
-        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
+        m_##name##Executable = JSC::Weak<JSC::UnlinkedFunctionExecutable>(JSC::createBuiltinExecutable(m_vm, m_##name##Source, executableName, s_##name##ImplementationVisibility, s_##name##ConstructorKind, s_##name##ConstructAbility), this, &m_##name##Executable);\
     }\
     return m_##name##Executable.get();\
 }
@@ -229,6 +232,7 @@ namespace WebCore {
 
 const JSC::ConstructAbility s_xmlCasingTestXMLCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestXMLCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_xmlCasingTestXMLCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_xmlCasingTestXMLCasingTestCodeLength = 71;
 static const JSC::Intrinsic s_xmlCasingTestXMLCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestXMLCasingTestCode =
@@ -242,6 +246,7 @@ const char* const s_xmlCasingTestXMLCasingTestCode =
 
 const JSC::ConstructAbility s_xmlCasingTestCssCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestCssCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_xmlCasingTestCssCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_xmlCasingTestCssCasingTestCodeLength = 402;
 static const JSC::Intrinsic s_xmlCasingTestCssCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestCssCasingTestCode =
@@ -261,6 +266,7 @@ const char* const s_xmlCasingTestCssCasingTestCode =
 
 const JSC::ConstructAbility s_xmlCasingTestUrlCasingTestCodeConstructAbility = JSC::ConstructAbility::CannotConstruct;
 const JSC::ConstructorKind s_xmlCasingTestUrlCasingTestCodeConstructorKind = JSC::ConstructorKind::None;
+const JSC::ImplementationVisibility s_xmlCasingTestUrlCasingTestCodeImplementationVisibility = JSC::ImplementationVisibility::Public;
 const int s_xmlCasingTestUrlCasingTestCodeLength = 338;
 static const JSC::Intrinsic s_xmlCasingTestUrlCasingTestCodeIntrinsic = JSC::NoIntrinsic;
 const char* const s_xmlCasingTestUrlCasingTestCode =


### PR DESCRIPTION
#### bfdbc24636c7e2547c9ae519ba377d9d11f7eeaf
<pre>
builtins generator tests failing after 252554@main and 252613@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=242916">https://bugs.webkit.org/show_bug.cgi?id=242916</a>
&lt;rdar://97277965&gt;

Reviewed by Devin Rousso.

Rebaseline test results.

* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.Promise-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-Builtin.prototype-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-BuiltinConstructor-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/JavaScriptCore-InternalClashingNames-Combined.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-AnotherGuardedInternalBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-ArbitraryConditionalGuard-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-GuardedInternalBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-UnguardedBuiltin-Separate.js-result:
* Source/JavaScriptCore/Scripts/tests/builtins/expected/WebCore-xmlCasingTest-Separate.js-result:

Canonical link: <a href="https://commits.webkit.org/252622@main">https://commits.webkit.org/252622@main</a>
</pre>
