### PR TITLE
[ews-build.webkit.org] Check ownership of target branch (Follow-up fix)

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -562,6 +562,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
     def add_patch_id_url(self):
         patch_id = self.getProperty('patch_id', '')
         if patch_id:
+            self.setProperty('remote', 'origin')
             self.setProperty('change_id', patch_id, 'ConfigureBuild')
             self.addURL('Patch {}'.format(patch_id), Bugzilla.patch_url(patch_id))
 


### PR DESCRIPTION
#### 59ee02e5c6f437ee81f370e500c1924cc24e67ec
<pre>
[ews-build.webkit.org] Check ownership of target branch (Follow-up fix)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242873">https://bugs.webkit.org/show_bug.cgi?id=242873</a>
&lt;rdar://problem/97225367&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(ConfigureBuild.add_patch_id_url): Set default remote.

Canonical link: <a href="https://commits.webkit.org/252614@main">https://commits.webkit.org/252614@main</a>
</pre>
