### PR TITLE
Move the SystemFallbackCache to FontCache

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1614,6 +1614,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/SourceBufferPrivateClient.h
     platform/graphics/SourceImage.h
     platform/graphics/StringTruncator.h
+    platform/graphics/SystemFallbackFontCache.h
     platform/graphics/SystemImage.h
     platform/graphics/TabSize.h
     platform/graphics/TextRun.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2122,6 +2122,7 @@ platform/graphics/SourceBufferPrivate.cpp
 platform/graphics/SourceImage.cpp
 platform/graphics/StringTruncator.cpp
 platform/graphics/SystemFontDatabase.cpp
+platform/graphics/SystemFallbackFontCache.cpp
 platform/graphics/TextRun.cpp
 platform/graphics/TextTrackRepresentation.cpp
 platform/graphics/TrackBuffer.cpp

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -211,6 +211,9 @@ public:
     static float ascentConsideringMacAscentHack(const WCHAR*, float ascent, float descent);
 #endif
 
+    void setIsUsedInSystemFallbackFontCache() { m_isUsedInSystemFallbackFontCache = true; }
+    bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
+
 private:
     WEBCORE_EXPORT Font(const FontPlatformData&, Origin, Interstitial, Visibility, OrientationFallback, std::optional<RenderingResourceIdentifier>);
 
@@ -225,8 +228,6 @@ private:
     RefPtr<Font> createScaledFont(const FontDescription&, float scaleFactor) const;
     RefPtr<Font> platformCreateScaledFont(const FontDescription&, float scaleFactor) const;
 
-    void removeFromSystemFallbackCache();
-    
     struct DerivedFonts;
     DerivedFonts& ensureDerivedFontData() const;
 
@@ -339,7 +340,7 @@ private:
     unsigned m_isBrokenIdeographFallback : 1;
     unsigned m_hasVerticalGlyphs : 1;
 
-    unsigned m_isUsedInSystemFallbackCache : 1;
+    unsigned m_isUsedInSystemFallbackFontCache : 1;
     
     unsigned m_allowsAntialiasing : 1;
 

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -35,6 +35,7 @@
 #include "FontPlatformData.h"
 #include "FontSelector.h"
 #include "FontTaggedSettings.h"
+#include "SystemFallbackFontCache.h"
 #include "Timer.h"
 #include <array>
 #include <limits.h>
@@ -375,6 +376,8 @@ public:
     void prewarm(PrewarmInformation&&);
     static void prewarmGlobally();
 
+    SystemFallbackFontCache& systemFallbackFontCache() { return m_systemFallbackFontCache; }
+
 private:
     void invalidate();
     void platformInvalidate();
@@ -402,6 +405,7 @@ private:
     struct FontDataCaches;
     UniqueRef<FontDataCaches> m_fontDataCaches;
     FontCascadeCache m_fontCascadeCache;
+    SystemFallbackFontCache m_systemFallbackFontCache;
 
     unsigned short m_generation { 0 };
 

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2005-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Alexey Proskuryakov
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SystemFallbackFontCache.h"
+
+#include "FontCache.h"
+#include "FontCascade.h"
+
+namespace WebCore {
+
+SystemFallbackFontCache& SystemFallbackFontCache::forCurrentThread()
+{
+    return FontCache::forCurrentThread().systemFallbackFontCache();
+}
+
+RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacter(const Font* font, UChar32 character, const FontDescription& description, IsForPlatformFont isForPlatformFont)
+{
+    auto fontAddResult = m_characterFallbackMaps.add(font, CharacterFallbackMap());
+
+    if (!character) {
+        UChar codeUnit = 0;
+        return FontCache::forCurrentThread().systemFallbackForCharacters(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, &codeUnit, 1);
+    }
+
+    auto key = CharacterFallbackMapKey { description.computedLocale(), character, isForPlatformFont != IsForPlatformFont::No };
+    return fontAddResult.iterator->value.ensure(WTFMove(key), [&] {
+        UChar codeUnits[2];
+        unsigned codeUnitsLength;
+        if (U_IS_BMP(character)) {
+            codeUnits[0] = FontCascade::normalizeSpaces(character);
+            codeUnitsLength = 1;
+        } else {
+            codeUnits[0] = U16_LEAD(character);
+            codeUnits[1] = U16_TRAIL(character);
+            codeUnitsLength = 2;
+        }
+        auto fallbackFont = FontCache::forCurrentThread().systemFallbackForCharacters(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, codeUnits, codeUnitsLength).get();
+        if (fallbackFont)
+            fallbackFont->setIsUsedInSystemFallbackFontCache();
+        return fallbackFont;
+    }).iterator->value;
+}
+
+void SystemFallbackFontCache::remove(Font* font)
+{
+    m_characterFallbackMaps.remove(font);
+
+    if (!font->isUsedInSystemFallbackFontCache())
+        return;
+
+    for (auto& characterMap : m_characterFallbackMaps.values()) {
+        Vector<CharacterFallbackMapKey, 512> toRemove;
+        for (auto& entry : characterMap) {
+            if (entry.value == font)
+                toRemove.append(entry.key);
+        }
+        for (auto& key : toRemove)
+            characterMap.remove(key);
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2005-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Alexey Proskuryakov
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer. 
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution. 
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/Hasher.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class Font;
+class FontDescription;
+enum class IsForPlatformFont : bool;
+    
+struct CharacterFallbackMapKey {
+    AtomString locale;
+    UChar32 character { 0 };
+    bool isForPlatformFont { false };
+
+    bool operator==(const CharacterFallbackMapKey& other) const
+    {
+        return locale == other.locale && character == other.character && isForPlatformFont == other.isForPlatformFont;
+    }
+};
+
+inline void add(Hasher& hasher, const CharacterFallbackMapKey& key)
+{
+    add(hasher, key.locale, key.character, key.isForPlatformFont);
+}
+
+struct CharacterFallbackMapKeyHash {
+    static unsigned hash(const CharacterFallbackMapKey& key) { return computeHash(key); }
+    static bool equal(const CharacterFallbackMapKey& a, const CharacterFallbackMapKey& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+
+class SystemFallbackFontCache {
+    WTF_MAKE_NONCOPYABLE(SystemFallbackFontCache);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static SystemFallbackFontCache& forCurrentThread();
+
+    SystemFallbackFontCache() = default;
+
+    RefPtr<Font> systemFallbackFontForCharacter(const Font*, UChar32 character, const FontDescription&, IsForPlatformFont);
+    void remove(Font*);
+
+private:
+    struct CharacterFallbackMapKeyHashTraits : SimpleClassHashTraits<CharacterFallbackMapKey> {
+        static void constructDeletedValue(CharacterFallbackMapKey& slot) { new (NotNull, &slot) CharacterFallbackMapKey { { }, U_SENTINEL, { } }; }
+        static bool isDeletedValue(const CharacterFallbackMapKey& key) { return key.character == U_SENTINEL; }
+    };
+
+    // Fonts are not ref'd to avoid cycles.
+    // FIXME: Consider changing these maps to use WeakPtr instead of raw pointers.
+    using CharacterFallbackMap = HashMap<CharacterFallbackMapKey, Font*, CharacterFallbackMapKeyHash, CharacterFallbackMapKeyHashTraits>;
+
+    HashMap<const Font*, CharacterFallbackMap> m_characterFallbackMaps;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 38edf7c001ddfea00c90e7db40ca57b0a02c2ebd
<pre>
Move the SystemFallbackCache to FontCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=233972">https://bugs.webkit.org/show_bug.cgi?id=233972</a>

Reviewed by Myles C. Maxfield.

With OffscreenCanvas, the SystemFallbackCache can be touched from
worker threads. This cache contains AtomStrings, which are thread
specific.

Move the SystemFallbackCache code from inside FontCache.cpp to separate
files (and rename it to SystemFallbackFontCache), to avoid FontCache.h
from getting too noisy. Also take the opportunity to wrap it in a class
to give it meaningful methods.

* platform/graphics/FontCache.h:
(WebCore::FontCache::systemFontFallbackCache):
* platform/graphics/Font.cpp:
* platform/graphics/FontCache.h:
(WebCore::FontCache::systemFontFallbackCache):
* platform/graphics/Font.cpp:
(WebCore::systemFallbackCache):
* platform/graphics/SystemFallbackFontCache.cpp:
(WebCore::SystemFallbackFontCache::forCurrentThread):
Move SystemFallbackCache from a singleton to FontCache.

* platform/graphics/Font.h:
(WebCore::Font::setIsUsedInSystemFallbackFontCache):
(WebCore::Font::isUsedInSystemFallbackFontCache const):
New functions to note a Font is in a SystemFallbackFontCache, since the
method that adds it to and checks its presence in the cache is no longer
in Font.

* platform/graphics/Font.cpp:
(WebCore::Font::~Font):
Call a new SystemFallbackFontCache::forCurrentThread function.

* platform/graphics/Font.cpp:
(WebCore::Font::systemFallbackFontForCharacter const):
(WebCore::Font::removeFromSystemFallbackCache):
* platform/graphics/SystemFallbackFontCache.cpp: Added.
(WebCore::SystemFallbackFontCache::systemFallbackFontForCharacter):
(WebCore::SystemFallbackFontCache::remove):
Move lookup and removal methods from Font to SystemFallbackFontCache.

* Headers.cmake:
* Sources.txt:
* WebCore.xcodeproj/project.pbxproj:
* platform/graphics/Font.cpp:
(): Deleted.
(WebCore::operator==): Deleted.
(WebCore::CharacterFallbackMapKeyHash::hash): Deleted.
(WebCore::CharacterFallbackMapKeyHash::equal): Deleted.
(WebCore::CharacterFallbackMapKeyHashTraits::constructDeletedValue): Deleted.
(WebCore::CharacterFallbackMapKeyHashTraits::isDeletedValue): Deleted.
* platform/graphics/SystemFallbackFontCache.h: Added.
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKey::operator== const):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHash::hash):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHash::equal):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHashTraits::constructDeletedValue):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHashTraits::isDeletedValue):
Move existing SystemFallbackFontCache code from Font.cpp to a new file and
wrap it in a class.

* platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::systemFallbackFontSetCache):
(WebCore::FontCache::systemFallbackForCharacters):
(WebCore::FontCache::platformPurgeInactiveFontData):
(WebCore::systemFallbackCache):
Rename the SystemFallbackCache in FontCacheFreeType.cpp, which is used
for a different purpose from the one that lived in Font.cpp.

Canonical link: <a href="https://commits.webkit.org/252618@main">https://commits.webkit.org/252618@main</a>
</pre>
