### PR TITLE
[iOS] REGRESSION(252407@main?): fast/text/international/system-language/han-text-style.html is failing on bots

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3673,4 +3673,4 @@ http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
 
 webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable.html [ Pass Failure ]
 
-webkit.org/b/242840 fast/text/international/system-language/han-text-style.html [ Failure ]
+webkit.org/b/242840 fast/text/international/system-language/han-text-style.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### bcec951918ca59f53cf554904b90b21449ae2657
<pre>
[iOS] REGRESSION(252407@main?): fast/text/international/system-language/han-text-style.html is failing on bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=242840">https://bugs.webkit.org/show_bug.cgi?id=242840</a>
&lt;rdar://97141625&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252615@main">https://commits.webkit.org/252615@main</a>
</pre>
