### PR TITLE
[check-webkit-style] Support branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.1',
+    version='5.3.2',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 1)
+version = Version(5, 3, 2)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -33,6 +33,7 @@ import re
 
 from webkitcorepy import string_utils
 from webkitscmpy import local
+from webkitscmpy.program import branch
 
 from webkitpy.common.memoized import memoized
 from webkitpy.common.system.executive import Executive, ScriptError
@@ -199,7 +200,7 @@ class Git(SCM, SVNRepository):
         current_branch = self._current_branch()
         return self._branch_from_ref(self.read_git_config('branch.%s.merge' % current_branch, cwd=self.checkout_root, executive=self._executive).strip())
 
-    def merge_base(self, git_commit):
+    def merge_base(self, git_commit, find_branch=False):
         if git_commit:
             # Rewrite UPSTREAM to the upstream branch
             if 'UPSTREAM' in git_commit:
@@ -216,7 +217,7 @@ class Git(SCM, SVNRepository):
                 git_commit = git_commit + "^.." + git_commit
             return git_commit
 
-        return self.remote_merge_base()
+        return self.remote_merge_base(find_branch=find_branch)
 
     def modifications_staged_for_commit(self):
         # This will only return non-deleted files with the "updated in index" status
@@ -234,9 +235,9 @@ class Git(SCM, SVNRepository):
         extractor = "^[?!][?!] (?P<filename>.+)$"
         return [value if not value.endswith('/') else value[:-1] for value in self.run_status_and_extract_filenames(status_command, extractor)]
 
-    def changed_files(self, git_commit=None):
+    def changed_files(self, git_commit=None, find_branch=False):
         # FIXME: --diff-filter could be used to avoid the "extract_filenames" step.
-        status_command = [self.executable_name, 'diff', '-r', '--name-status', "--no-renames", "--no-ext-diff", "--full-index", self.merge_base(git_commit), '--']
+        status_command = [self.executable_name, 'diff', '-r', '--name-status', "--no-renames", "--no-ext-diff", "--full-index", self.merge_base(git_commit, find_branch=find_branch), '--']
         status_command.extend(self._patch_directories)
         # FIXME: I'm not sure we're returning the same set of files that SVN.changed_files is.
         # Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R)
@@ -351,14 +352,14 @@ class Git(SCM, SVNRepository):
 
         return string_utils.encode("Subversion Revision: ") + string_utils.encode(revision) + string_utils.encode('\n') + string_utils.encode(diff)
 
-    def create_patch(self, git_commit=None, changed_files=None, git_index=False, commit_message=True):
+    def create_patch(self, git_commit=None, changed_files=None, git_index=False, commit_message=True, find_branch=False):
         """Returns a byte array (str()) representing the patch file.
         Patch files are effectively binary since they may contain files of multiple different encodings.
         If git_index is True, git_commit is ignored because only indexed files are handled.
         """
 
         head = self.rev_parse('HEAD')
-        merge_base = self.merge_base(git_commit)
+        merge_base = self.merge_base(git_commit, find_branch=find_branch)
         if not commit_message or merge_base == head:
             command = [self.executable_name, 'diff', '--binary', '--no-color', '--no-ext-diff', '--full-index', '--no-renames']
         else:
@@ -548,22 +549,22 @@ class Git(SCM, SVNRepository):
         if self.branch_ref_exists('refs/heads/' + branch_name):
             self._run_git(['branch', '-D', branch_name])
 
-    def remote_merge_base(self):
-        return self._run_git(['merge-base', self.remote_branch_ref(), 'HEAD']).strip()
+    def remote_merge_base(self, find_branch=False):
+        return self._run_git(['merge-base', self.remote_branch_ref(find_branch), 'HEAD']).strip()
 
-    def remote_branch_ref(self):
-        # Use references so that we can avoid collisions, e.g. we don't want to operate on refs/heads/trunk if it exists.
-        remote_branch_refs = self.read_git_config('svn-remote.svn.fetch', cwd=self.checkout_root, executive=self._executive)
-        if not remote_branch_refs:
-            for ref in ['refs/remotes/origin/main', 'refs/remotes/origin/master']:
-                if self.branch_ref_exists(ref):
-                    return ref
-            raise ScriptError(message="Can't find a branch to diff against. svn-remote.svn.fetch is not in the git config and neither main nor master exist")
-
-        # FIXME: What's the right behavior when there are multiple svn-remotes listed?
-        # For now, just use the first one.
-        first_remote_branch_ref = remote_branch_refs.split('\n')[0]
-        return first_remote_branch_ref.split(':')[1]
+    @memoized
+    def remote_branch_ref(self, find_branch=False):
+        if find_branch:
+            repository = local.Git(self.checkout_root)
+            branch_point = branch.Branch.branch_point(repository, limit=10)
+            if branch_point:
+                for remote in repository.source_remotes():
+                    if branch_point.branch in repository.branches_for(remote=remote, cached=True):
+                        return 'refs/remotes/{}/{}'.format(remote, branch_point.branch)
+        for ref in ['refs/remotes/origin/main', 'refs/remotes/origin/master']:
+            if self.branch_ref_exists(ref):
+                return ref
+        raise ScriptError(message="Can't find a branch to diff against.")
 
     def cherrypick_merge(self, commit):
         git_args = ['cherry-pick', '-n', commit]

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm.py
@@ -139,7 +139,7 @@ class SCM:
     def exists(self, path):
         self._subclass_must_implement()
 
-    def changed_files(self, git_commit=None):
+    def changed_files(self, git_commit=None, find_branch=False):
         self._subclass_must_implement()
 
     def changed_files_for_revision(self, revision):
@@ -172,7 +172,7 @@ class SCM:
     def timestamp_of_native_revision(self, path, revision):
         self._subclass_must_implement()
 
-    def create_patch(self, git_commit=None, changed_files=None, commit_message=False):
+    def create_patch(self, git_commit=None, changed_files=None, commit_message=False, find_branch=False):
         self._subclass_must_implement()
 
     def committer_email_for_revision(self, revision):

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py
@@ -72,7 +72,7 @@ class MockSCM(object):
     def absolute_path(self, *comps):
         return self._filesystem.join(self.checkout_root, *comps)
 
-    def changed_files(self, git_commit=None):
+    def changed_files(self, git_commit=None, find_branch=False):
         return self._mockChangedFiles
 
     def changed_files_for_revision(self, revision):
@@ -96,7 +96,7 @@ class MockSCM(object):
     def timestamp_of_native_revision(self, path, revision):
         return '2013-02-01 08:48:05 +0000'
 
-    def create_patch(self, git_commit, changed_files=None, commit_message=False):
+    def create_patch(self, git_commit, changed_files=None, commit_message=False, find_branch=False):
         return b"Patch1"
 
     def commit_ids_from_commitish_arguments(self, args):

--- a/Tools/Scripts/webkitpy/common/checkout/scm/svn.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/svn.py
@@ -237,7 +237,7 @@ class SVN(SCM, SVNRepository):
     def exists(self, path):
         return not self._run_svn(["info", path], return_exit_code=True, decode_output=False)
 
-    def changed_files(self, git_commit=None):
+    def changed_files(self, git_commit=None, find_branch=False):
         status_command = [self.executable_name, "status"]
         status_command.extend(self._patch_directories)
         # ACDMR: Addded, Conflicted, Deleted, Modified or Replaced
@@ -308,7 +308,7 @@ class SVN(SCM, SVNRepository):
         return self.timestamp_of_revision(path, revision)
 
     # FIXME: This method should be on Checkout.
-    def create_patch(self, git_commit=None, changed_files=None, git_index=None, commit_message=False):
+    def create_patch(self, git_commit=None, changed_files=None, git_index=None, commit_message=False, find_branch=False):
         """Returns a byte array (str()) representing the patch file.
         Patch files are effectively binary since they may contain
         files of multiple different encodings."""

--- a/Tools/Scripts/webkitpy/style/main.py
+++ b/Tools/Scripts/webkitpy/style/main.py
@@ -154,7 +154,7 @@ class CheckWebKitStyle(object):
             file_reader.do_association_check(host.scm().checkout_root)
         else:
             changed_files = paths if options.diff_files else None
-            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files, git_index=options.git_index)
+            patch = host.scm().create_patch(options.git_commit, changed_files=changed_files, git_index=options.git_index, find_branch=True)
             patch_checker = PatchReader(file_reader)
             patch_checker.check(patch)
 

--- a/Tools/Scripts/webkitpy/tool/steps/abstractstep.py
+++ b/Tools/Scripts/webkitpy/tool/steps/abstractstep.py
@@ -48,8 +48,8 @@ class AbstractStep(object):
         "bug": lambda self, state: self._tool.bugs.fetch_bug(state["bug_id"]),
         # bug_title can either be a new title given by the user, or one from an existing bug.
         "bug_title": lambda self, state: self.cached_lookup(state, 'bug').title(),
-        "changed_files": lambda self, state: self._tool.scm().changed_files(self._options.git_commit),
-        "diff": lambda self, state: self._tool.scm().create_patch(self._options.git_commit, changed_files=self._changed_files(state)),
+        "changed_files": lambda self, state: self._tool.scm().changed_files(self._options.git_commit, find_branch=True),
+        "diff": lambda self, state: self._tool.scm().create_patch(self._options.git_commit, changed_files=self._changed_files(state), find_branch=True),
         # Absolute path to ChangeLog files.
         "changelogs": lambda self, state: self._tool.checkout().modified_changelogs(self._options.git_commit, changed_files=self._changed_files(state)),
         "has_local_commit": lambda self, state: self._tool.scm().merge_base(None) != self._tool.scm().rev_parse('HEAD') if isinstance(self._tool.scm(), Git) else False

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -96,7 +96,7 @@ class TestExporterTest(unittest.TestCase):
         def branch_ref_exists(self, name):
             return False
 
-        def create_patch(self, commit, arguments, commit_message=False):
+        def create_patch(self, commit, arguments, commit_message=False, find_branch=False):
             self.calls.append('create_patch ' + commit + ' ' + str(arguments))
             return self.mock_format_patch_result
 


### PR DESCRIPTION
#### 64078f4d67054e7bdd5a617cc0bb596a3d327ac7
<pre>
[check-webkit-style] Support branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=242664">https://bugs.webkit.org/show_bug.cgi?id=242664</a>
&lt;rdar://96914421&gt;

Reviewed by Stephanie Lewis.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.editable): Check all source remotes, not just origin.
(Branch.branch_point): Provide a limit.
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.merge_base): Pass find_branch flag.
(Git.changed_files): Ditto.
(Git.create_patch): Ditto.
(Git.remote_merge_base): Ditto.
(Git.remote_branch_ref): If requested, attempt to find the branch point of the
current branch. This allows for development from branches other than main.
* Tools/Scripts/webkitpy/common/checkout/scm/scm.py:
(SCM.changed_files): Pass find_branch flag.
(SCM.create_patch): Ditto.
* Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py:
(MockSCM.changed_files): Pass find_branch flag.
(MockSCM.create_patch): Ditto.
* Tools/Scripts/webkitpy/common/checkout/scm/svn.py:
(SVN.changed_files): Pass find_branch flag.
(SVN.create_patch): Ditto.
* Tools/Scripts/webkitpy/style/main.py:
(CheckWebKitStyle.main): Check style from the branch point, not main.
* Tools/Scripts/webkitpy/tool/steps/abstractstep.py:
(AbstractStep): Create a patch from the branch point.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.MockGit.create_patch): Pass find_branch flag.

Canonical link: <a href="https://commits.webkit.org/252647@main">https://commits.webkit.org/252647@main</a>
</pre>
