### PR TITLE
[ews-build.webkit.org] Support alternate remotes when canonicalizing

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5110,10 +5110,11 @@ class Canonicalize(steps.ShellSequence, ShellMixin, AddToLogMixin):
 
         base_ref = self.getProperty('github.base.ref', DEFAULT_BRANCH)
         head_ref = self.getProperty('github.head.ref', None)
+        remote = self.getProperty('remote', 'origin')
 
         commands = [self.shell_command('rm .git/identifiers.json || {}'.format(self.shell_exit_0()))]
         if self.rebase_enabled:
-            commands += [['git', 'pull', 'origin', base_ref, '--rebase']]
+            commands += [['git', 'pull', remote, base_ref, '--rebase']]
             if head_ref:
                 commands += [['git', 'branch', '-f', base_ref, head_ref]]
             commands += [['git', 'checkout', base_ref]]


### PR DESCRIPTION
#### c6afdd3e8f9f5d5a2761fc8102154a2085e1dbee
<pre>
[ews-build.webkit.org] Support alternate remotes when canonicalizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=242923">https://bugs.webkit.org/show_bug.cgi?id=242923</a>
&lt;rdar://problem/97286956&gt;

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/steps.py:
(Canonicalize.run): Fetch branch from target remote.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/252621@main">https://commits.webkit.org/252621@main</a>
</pre>
