### PR TITLE
REGRESSION(iOS 15.2) [iOS] "Cross-Origin-Opener-Policy: same-origin" breaks forms after back action

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1514,6 +1514,7 @@ void DocumentLoader::detachFromFrame()
 void DocumentLoader::clearMainResourceLoader()
 {
     m_loadingMainResource = false;
+    m_isContinuingLoadAfterProvisionalLoadStarted = false;
 
     auto* frameLoader = this->frameLoader();
 


### PR DESCRIPTION
#### 2e2b021f6768ec3d23f20feeb311704cd90aa2bf
<pre>
REGRESSION(iOS 15.2) [iOS] &quot;Cross-Origin-Opener-Policy: same-origin&quot; breaks forms after back action
<a href="https://bugs.webkit.org/show_bug.cgi?id=242894">https://bugs.webkit.org/show_bug.cgi?id=242894</a>
&lt;rdar://97258473&gt;

Reviewed by Darin Adler.

The issue was that WKWebView._committedURL was returning null after navigating back
to the COOP page. This was confusing Safari and causing it to respond to
decidePolicyForFocusedElement with _WKFocusStartsInputSessionPolicyDisallow.

The reason WKWebView._committedURL was returning null is that didStartProvisionalLoad
was never called for the back navigation. As a result, the provisional URL stays null
and we end up committing this null URL. The UIProcess never received the
DidStartProvisionalLoad IPC because WebFrameLoaderClient::dispatchDidStartProvisionalLoad()
would return early due to the isContinuingLoadAfterProvisionalLoadStarted flag being
set.

The isContinuingLoadAfterProvisionalLoadStarted flag gets set on COOP process swap to
prevent the new WebProcess from sending the DidStartProvisionalLoad IPC, since the
pre-swap WebProcess has already sent it. The issue was that the
isContinuingLoadAfterProvisionalLoadStarted flag would not get cleared after finishing
the navigation. As a result, when navigating back to the COOP page later on, the flag
would remain set and we would fail the send the DidStartProvisionalLoad IPC, even though
there was no process swap.

To address the issue, we now clear the isContinuingLoadAfterProvisionalLoadStarted flag
once the main resource load is complete.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::clearMainResourceLoader):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/252651@main">https://commits.webkit.org/252651@main</a>
</pre>
