### PR TITLE
[JSC] Introduce Replacement ObjectPropertyCondition to optimize replace cases

### DIFF
--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp
@@ -165,5 +165,13 @@ ObjectPropertyCondition ObjectPropertyCondition::attemptToMakeEquivalenceWithout
     return ObjectPropertyCondition(object(), result);
 }
 
+ObjectPropertyCondition ObjectPropertyCondition::attemptToMakeReplacementWithoutBarrier() const
+{
+    PropertyCondition result = condition().attemptToMakeReplacementWithoutBarrier(object());
+    if (!result)
+        return ObjectPropertyCondition();
+    return ObjectPropertyCondition(object(), result);
+}
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -70,6 +70,22 @@ public:
         return presenceWithoutBarrier(object, uid, offset, attributes);
     }
 
+    static ObjectPropertyCondition replacementWithoutBarrier(JSObject* object, UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)
+    {
+        ObjectPropertyCondition result;
+        result.m_object = object;
+        result.m_condition = PropertyCondition::replacementWithoutBarrier(uid, offset, attributes);
+        return result;
+    }
+
+    static ObjectPropertyCondition replacement(VM& vm, JSCell* owner, JSObject* object, UniquedStringImpl* uid, PropertyOffset offset,
+        unsigned attributes)
+    {
+        if (owner)
+            vm.writeBarrier(owner);
+        return replacementWithoutBarrier(object, uid, offset, attributes);
+    }
+
     // NOTE: The prototype is the storedPrototype, not the prototypeForLookup.
     static ObjectPropertyCondition absenceWithoutBarrier(
         JSObject* object, UniquedStringImpl* uid, JSObject* prototype)
@@ -271,6 +287,7 @@ public:
     }
 
     ObjectPropertyCondition attemptToMakeEquivalenceWithoutBarrier() const;
+    ObjectPropertyCondition attemptToMakeReplacementWithoutBarrier() const;
 
 private:
     JSObject* m_object;

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -66,6 +66,7 @@ bool ObjectPropertyConditionSet::hasOneSlotBaseCondition() const
     for (const ObjectPropertyCondition& condition : *this) {
         switch (condition.kind()) {
         case PropertyCondition::Presence:
+        case PropertyCondition::Replacement:
         case PropertyCondition::Equivalence:
         case PropertyCondition::HasStaticProperty:
             if (sawBase)
@@ -86,6 +87,7 @@ ObjectPropertyCondition ObjectPropertyConditionSet::slotBaseCondition() const
     unsigned numFound = 0;
     for (const ObjectPropertyCondition& condition : *this) {
         if (condition.kind() == PropertyCondition::Presence
+            || condition.kind() == PropertyCondition::Replacement
             || condition.kind() == PropertyCondition::Equivalence
             || condition.kind() == PropertyCondition::HasStaticProperty) {
             result = condition;
@@ -193,6 +195,14 @@ ObjectPropertyCondition generateCondition(
         if (offset == invalidOffset)
             return ObjectPropertyCondition();
         result = ObjectPropertyCondition::presence(vm, owner, object, uid, offset, attributes);
+        break;
+    }
+    case PropertyCondition::Replacement: {
+        unsigned attributes;
+        PropertyOffset offset = structure->get(vm, concurrency, uid, attributes);
+        if (offset == invalidOffset || !!(attributes & PropertyAttribute::ReadOnly))
+            return ObjectPropertyCondition();
+        result = ObjectPropertyCondition::replacement(vm, owner, object, uid, offset, attributes);
         break;
     }
     case PropertyCondition::Absence: {

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.h
@@ -37,6 +37,7 @@ class PropertyCondition {
 public:
     enum Kind : uint8_t {
         Presence,
+        Replacement, // This implies the property is Present but cannot be watched for replacement.
         Absence,
         AbsenceOfSetEffect,
         Equivalence, // An adaptive watchpoint on this will be a pair of watchpoints, and when the structure transitions, we will set the replacement watchpoint on the new structure.
@@ -57,7 +58,7 @@ public:
     {
         memset(&u, 0, sizeof(u));
     }
-    
+
     static PropertyCondition presenceWithoutBarrier(UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)
     {
         PropertyCondition result;
@@ -71,6 +72,21 @@ public:
         VM&, JSCell*, UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)
     {
         return presenceWithoutBarrier(uid, offset, attributes);
+    }
+
+    static PropertyCondition replacementWithoutBarrier(UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)
+    {
+        ASSERT(!(attributes & PropertyAttribute::ReadOnly));
+        PropertyCondition result;
+        result.m_header = Header(uid, Replacement);
+        result.u.presence.offset = offset;
+        result.u.presence.attributes = attributes;
+        return result;
+    }
+
+    static PropertyCondition replacement(VM&, JSCell*, UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)
+    {
+        return replacementWithoutBarrier(uid, offset, attributes);
     }
 
     // NOTE: The prototype is the storedPrototype not the prototypeForLookup.
@@ -151,13 +167,13 @@ public:
     Kind kind() const { return m_header.type(); }
     UniquedStringImpl* uid() const { return m_header.pointer(); }
     
-    bool hasOffset() const { return !!*this && m_header.type() == Presence; };
+    bool hasOffset() const { return !!*this && (kind() == Presence || kind() == Replacement); };
     PropertyOffset offset() const
     {
         ASSERT(hasOffset());
         return u.presence.offset;
     }
-    bool hasAttributes() const { return !!*this && m_header.type() == Presence; };
+    bool hasAttributes() const { return !!*this && (kind() == Presence || kind() == Replacement); };
     unsigned attributes() const
     {
         ASSERT(hasAttributes());
@@ -190,6 +206,7 @@ public:
         unsigned result = WTF::PtrHash<UniquedStringImpl*>::hash(m_header.pointer()) + static_cast<unsigned>(m_header.type());
         switch (m_header.type()) {
         case Presence:
+        case Replacement:
             result ^= u.presence.offset;
             result ^= u.presence.attributes;
             break;
@@ -215,6 +232,7 @@ public:
             return false;
         switch (m_header.type()) {
         case Presence:
+        case Replacement:
             return u.presence.offset == other.u.presence.offset
                 && u.presence.attributes == other.u.presence.attributes;
         case Absence:
@@ -325,6 +343,7 @@ public:
     bool isValidValueForPresence(JSValue) const;
 
     PropertyCondition attemptToMakeEquivalenceWithoutBarrier(JSObject* base) const;
+    PropertyCondition attemptToMakeReplacementWithoutBarrier(JSObject* base) const;
 
 private:
     bool isWatchableWhenValid(Structure*, WatchabilityEffort) const;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -230,20 +230,18 @@ private:
 
     // Create a presence ObjectPropertyCondition based on some known offset and structure set. Does not
     // check the validity of the condition, but it may return a null one if it encounters a contradiction.
-    ObjectPropertyCondition presenceConditionIfConsistent(
-        JSObject* knownBase, UniquedStringImpl*, PropertyOffset, const StructureSet&);
+    ObjectPropertyCondition presenceConditionIfConsistent(JSObject* knownBase, UniquedStringImpl*, PropertyOffset, const StructureSet&);
     
-    // Attempt to watch the presence of a property. It will watch that the property is present in the same
-    // way as in all of the structures in the set. It may emit code instead of just setting a watchpoint.
-    // Returns true if this all works out.
-    bool checkPresence(JSObject* knownBase, UniquedStringImpl*, PropertyOffset, const StructureSet&);
-    void checkPresenceForReplace(Node* base, UniquedStringImpl*, PropertyOffset, const StructureSet&);
+    // Attempt to watch the presence/replacement of a property. It will watch that the property is present in the same
+    // way as in all of the structures in the set (or the base if it's a constant). It may emit code instead of just setting a watchpoint.
+    // Returns the condition if one is found/watched.
+    void checkReplacement(Node* base, UniquedStringImpl*, PropertyOffset, const StructureSet&);
     
     // Works with both GetByVariant and the setter form of PutByVariant.
     template<typename VariantType>
     Node* load(SpeculatedType, Node* base, unsigned identifierNumber, const VariantType&);
 
-    Node* store(Node* base, unsigned identifier, const PutByVariant&, Node* value);
+    Node* replace(Node* base, unsigned identifier, const PutByVariant&, Node* value);
 
     template<typename Op>
     void parseGetById(const JSInstruction*);
@@ -4486,8 +4484,7 @@ Node* ByteCodeParser::load(
         method, op);
 }
 
-ObjectPropertyCondition ByteCodeParser::presenceConditionIfConsistent(
-    JSObject* knownBase, UniquedStringImpl* uid, PropertyOffset offset, const StructureSet& set)
+ObjectPropertyCondition ByteCodeParser::presenceConditionIfConsistent(JSObject* knownBase, UniquedStringImpl* uid, PropertyOffset offset, const StructureSet& set)
 {
     if (set.isEmpty())
         return ObjectPropertyCondition();
@@ -4504,25 +4501,22 @@ ObjectPropertyCondition ByteCodeParser::presenceConditionIfConsistent(
     return ObjectPropertyCondition::presenceWithoutBarrier(knownBase, uid, offset, attributes);
 }
 
-bool ByteCodeParser::checkPresence(
-    JSObject* knownBase, UniquedStringImpl* uid, PropertyOffset offset, const StructureSet& set)
-{
-    return check(presenceConditionIfConsistent(knownBase, uid, offset, set));
-}
-
-void ByteCodeParser::checkPresenceForReplace(
+void ByteCodeParser::checkReplacement(
     Node* base, UniquedStringImpl* uid, PropertyOffset offset, const StructureSet& set)
 {
     if (JSObject* knownBase = base->dynamicCastConstant<JSObject*>()) {
         auto condition = presenceConditionIfConsistent(knownBase, uid, offset, set);
-        if (check(condition)) {
-            auto* watchpointSet = knownBase->structure()->propertyReplacementWatchpointSet(condition.offset());
-            // This means that we probably have a stale cache and we should gather more information.
-            if (!watchpointSet || watchpointSet->isStillValid())
-                addToGraph(ForceOSRExit);
-            return;
+        if (condition) {
+            auto replacementCondition = condition.attemptToMakeReplacementWithoutBarrier();
+            if (check(replacementCondition))
+                return;
         }
     }
+
+#if ASSERT_ENABLED
+    for (auto structure : set)
+        ASSERT(!structure->propertyReplacementWatchpointSet(offset)->isStillValid());
+#endif
 
     addToGraph(CheckStructure, OpInfo(m_graph.addStructureSet(set)), base);
 }
@@ -4627,11 +4621,11 @@ Node* ByteCodeParser::load(
     return loadedValue;
 }
 
-Node* ByteCodeParser::store(Node* base, unsigned identifier, const PutByVariant& variant, Node* value)
+Node* ByteCodeParser::replace(Node* base, unsigned identifier, const PutByVariant& variant, Node* value)
 {
     RELEASE_ASSERT(variant.kind() == PutByVariant::Replace);
 
-    checkPresenceForReplace(base, m_graph.identifiers()[identifier], variant.offset(), variant.structure());
+    checkReplacement(base, m_graph.identifiers()[identifier], variant.offset(), variant.structure());
     return handlePutByOffset(base, identifier, variant.offset(), value);
 }
 
@@ -5094,7 +5088,7 @@ void ByteCodeParser::handlePutById(
     case PutByVariant::Replace: {
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
 
-        store(base, identifierNumber, variant, value);
+        replace(base, identifierNumber, variant, value);
         if (UNLIKELY(m_graph.compilation()))
             m_graph.compilation()->noticeInlinedPutById();
         return;
@@ -5267,7 +5261,7 @@ void ByteCodeParser::handlePutPrivateNameById(
         ASSERT(privateFieldPutKind.isSet());
         addToGraph(FilterPutByStatus, OpInfo(m_graph.m_plan.recordedStatuses().addPutByStatus(currentCodeOrigin(), putByStatus)), base);
     
-        store(base, identifierNumber, variant, value);
+        replace(base, identifierNumber, variant, value);
         if (UNLIKELY(m_graph.compilation()))
             m_graph.compilation()->noticeInlinedPutById();
         return;
@@ -8051,7 +8045,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                     break;
                 }
                 Node* base = weakJSConstant(globalObject);
-                store(base, identifierNumber, status[0], get(bytecode.m_value));
+                replace(base, identifierNumber, status[0], get(bytecode.m_value));
                 // Keep scope alive until after put.
                 addToGraph(Phantom, get(bytecode.m_scope));
                 break;


### PR DESCRIPTION
#### d9bc763dc1a652600642a1d3874331da6012f56d
<pre>
[JSC] Introduce Replacement ObjectPropertyCondition to optimize replace cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=242924">https://bugs.webkit.org/show_bug.cgi?id=242924</a>
rdar://92504944

Reviewed by Saam Barati.

This patch adds Replacement ObjectPropertyCondition to optimize property
replacement case in DFG and FTL, which is decoupled from Presence case to
further narrow the code path.

* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.cpp:
(JSC::ObjectPropertyCondition::attemptToMakeReplacementWithoutBarrier const):
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
(JSC::ObjectPropertyCondition::replacementWithoutBarrier):
(JSC::ObjectPropertyCondition::replacement):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::ObjectPropertyConditionSet::hasOneSlotBaseCondition const):
(JSC::ObjectPropertyConditionSet::slotBaseCondition const):
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::dumpInContext const):
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):
(JSC::PropertyCondition::validityRequiresImpurePropertyWatchpoint const):
(JSC::PropertyCondition::isStillValid const):
(JSC::PropertyCondition::isWatchableWhenValid const):
(JSC::PropertyCondition::attemptToMakeReplacementWithoutBarrier const):
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/PropertyCondition.h:
(JSC::PropertyCondition::replacementWithoutBarrier):
(JSC::PropertyCondition::replacement):
(JSC::PropertyCondition::hasOffset const):
(JSC::PropertyCondition::hasAttributes const):
(JSC::PropertyCondition::hash const):
(JSC::PropertyCondition::operator== const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::presenceConditionIfConsistent):
(JSC::DFG::ByteCodeParser::checkReplacement):
(JSC::DFG::ByteCodeParser::replace):
(JSC::DFG::ByteCodeParser::handlePutById):
(JSC::DFG::ByteCodeParser::handlePutPrivateNameById):
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::checkPresence): Deleted.
(JSC::DFG::ByteCodeParser::checkPresenceForReplace): Deleted.
(JSC::DFG::ByteCodeParser::store): Deleted.
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::emitPutByOffset):
(JSC::DFG::ConstantFoldingPhase::tryFoldAsPutByOffset):

Canonical link: <a href="https://commits.webkit.org/252636@main">https://commits.webkit.org/252636@main</a>
</pre>
