### PR TITLE
Seeking in Netflix triggers unbounded growth in WebCore::Audio&VideoTrackPrivateMediaSourceAVFObjC objects

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -156,7 +156,7 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // SourceBufferPrivateClient
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void()>&&) final;
+    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
     void sourceBufferPrivateStreamEndedWithDecodeError() final;
     void sourceBufferPrivateAppendError(bool decodeError) final;
     void sourceBufferPrivateAppendComplete(AppendResult) final;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2117,6 +2117,7 @@ platform/graphics/RoundedRect.cpp
 platform/graphics/ShadowBlur.cpp
 platform/graphics/SourceBrush.cpp
 platform/graphics/SourceBufferPrivate.cpp
+platform/graphics/SourceBufferPrivateClient.cpp
 platform/graphics/SourceImage.cpp
 platform/graphics/StringTruncator.cpp
 platform/graphics/SystemFontDatabase.cpp

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -75,6 +75,13 @@ public:
         if (m_client)
             m_client->configurationChanged(m_configuration);
     }
+    
+    virtual bool operator==(const AudioTrackPrivate& track) const
+    {
+        return TrackPrivateBase::operator==(track)
+            && configuration() == track.configuration()
+            && kind() == track.kind();
+    }
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "AudioTrackPrivate"; }

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -76,6 +76,20 @@ public:
     virtual AtomString inBandMetadataTrackDispatchType() const { return emptyAtom(); }
 
     CueFormat cueFormat() const { return m_format; }
+    
+    virtual bool operator==(const InbandTextTrackPrivate& track) const
+    {
+        return TrackPrivateBase::operator==(track)
+            && cueFormat() == track.cueFormat()
+            && kind() == track.kind()
+            && isClosedCaptions() == track.isClosedCaptions()
+            && isSDH() == track.isSDH()
+            && containsOnlyForcedSubtitles() == track.containsOnlyForcedSubtitles()
+            && isMainProgramContent() == track.isMainProgramContent()
+            && isEasyToRead() == track.isEasyToRead()
+            && isDefault() == track.isDefault()
+            && inBandMetadataTrackDispatchType() == track.inBandMetadataTrackDispatchType();
+    }
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "InbandTextTrackPrivate"; }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -559,15 +559,16 @@ void SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess()
         trackBuffer.get().setNeedRandomAccessFlag(true);
 }
 
-void SourceBufferPrivate::didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&& segment, CompletionHandler<void()>&& completionHandler)
+void SourceBufferPrivate::didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&& segment, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&& completionHandler)
 {
     if (!m_client) {
-        completionHandler();
+        completionHandler(SourceBufferPrivateClient::ReceiveResult::ClientDisconnected);
         return;
     }
 
     if (m_receivedFirstInitializationSegment && !validateInitializationSegment(segment)) {
         m_client->sourceBufferPrivateAppendError(true);
+        completionHandler(SourceBufferPrivateClient::ReceiveResult::AppendError);
         return;
     }
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -148,7 +148,7 @@ protected:
 
     void appendCompleted(bool parsingSucceeded, bool isEnded);
     void reenqueSamples(const AtomString& trackID);
-    WEBCORE_EXPORT void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void()>&&);
+    WEBCORE_EXPORT void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&&);
     WEBCORE_EXPORT void didReceiveSample(Ref<MediaSample>&&);
     WEBCORE_EXPORT void setBufferedRanges(const PlatformTimeRanges&);
     void provideMediaData(const AtomString& trackID);

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SourceBufferPrivateClient.h"
+
+#if ENABLE(MEDIA_SOURCE)
+
+namespace WebCore {
+
+String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult enumerationValue)
+{
+    static const NeverDestroyed<String> values[] = {
+        MAKE_STATIC_STRING_IMPL("RecieveSucceeded"),
+        MAKE_STATIC_STRING_IMPL("AppendError"),
+        MAKE_STATIC_STRING_IMPL("ClientDisconnected"),
+        MAKE_STATIC_STRING_IMPL("BufferRemoved"),
+        MAKE_STATIC_STRING_IMPL("IPCError"),
+    };
+    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::RecieveSucceeded) == 0, "ReceiveResult::RecieveSucceeded is not 0 as expected");
+    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::AppendError) == 1, "ReceiveResult::AppendError is not 1 as expected");
+    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::ClientDisconnected) == 2, "ReceiveResult::ClientDisconnected is not 2 as expected");
+    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::BufferRemoved) == 3, "ReceiveResult::BufferRemoved is not 3 as expected");
+    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::IPCError) == 4, "ReceiveResult::IPCError is not 4 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < WTF_ARRAY_LENGTH(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -65,7 +65,15 @@ public:
         };
         Vector<TextTrackInformation> textTracks;
     };
-    virtual void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void()>&&) = 0;
+    
+    enum class ReceiveResult : uint8_t {
+        RecieveSucceeded,
+        AppendError,
+        ClientDisconnected,
+        BufferRemoved,
+        IPCError,
+    };
+    virtual void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) = 0;
     virtual void sourceBufferPrivateStreamEndedWithDecodeError() = 0;
     virtual void sourceBufferPrivateAppendError(bool decodeError) = 0;
     enum class AppendResult : uint8_t {
@@ -83,9 +91,33 @@ public:
     virtual void sourceBufferPrivateReportExtraMemoryCost(uint64_t) = 0;
 };
 
+String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult);
+
 } // namespace WebCore
 
 namespace WTF {
+
+template<typename Type>
+struct LogArgument;
+
+template <>
+struct LogArgument<WebCore::SourceBufferPrivateClient::ReceiveResult> {
+    static String toString(const WebCore::SourceBufferPrivateClient::ReceiveResult result)
+    {
+        return convertEnumerationToString(result);
+    }
+};
+
+template<> struct EnumTraits<WebCore::SourceBufferPrivateClient::ReceiveResult> {
+    using values = EnumValues<
+        WebCore::SourceBufferPrivateClient::ReceiveResult,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::RecieveSucceeded,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::AppendError,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::ClientDisconnected,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::BufferRemoved,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::IPCError
+    >;
+};
 
 template<> struct EnumTraits<WebCore::SourceBufferPrivateClient::AppendResult> {
     using values = EnumValues<

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -42,6 +42,17 @@ std::optional<bool> TrackPrivateBase::defaultEnabled() const
     return std::nullopt;
 }
 
+bool TrackPrivateBase::operator==(const TrackPrivateBase& track) const
+{
+    return id() == track.id()
+        && label() == track.label()
+        && language() == track.language()
+        && trackIndex() == track.trackIndex()
+        && trackUID() == track.trackUID()
+        && defaultEnabled() == track.defaultEnabled()
+        && startTimeVariance() == track.startTimeVariance();
+}
+
 #if !RELEASE_LOG_DISABLED
 
 static uint64_t s_uniqueId = 0;

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -65,6 +65,8 @@ public:
         if (auto* client = this->client())
             client->willRemove();
     }
+    
+    virtual bool operator==(const TrackPrivateBase&) const;
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, const void*);

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -71,6 +71,13 @@ public:
         if (m_client)
             m_client->configurationChanged(m_configuration);
     }
+    
+    virtual bool operator==(const VideoTrackPrivate& track) const
+    {
+        return TrackPrivateBase::operator==(track)
+            && configuration() == track.configuration()
+            && kind() == track.kind();
+    }
 
 protected:
     VideoTrackPrivate() = default;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -49,11 +49,14 @@ typedef struct __CVBuffer *CVOpenGLTextureRef;
 
 namespace WebCore {
 
+class AudioTrackPrivate;
 class CDMSessionMediaSourceAVFObjC;
 class EffectiveRateChangedListener;
+class InbandTextTrackPrivate;
 class MediaSourcePrivateAVFObjC;
 class PixelBufferConformerCV;
 class VideoLayerManagerObjC;
+class VideoTrackPrivate;
 class WebCoreDecompressionSession;
 
 
@@ -77,6 +80,10 @@ public:
     void addAudioRenderer(AVSampleBufferAudioRenderer*);
     void removeAudioRenderer(AVSampleBufferAudioRenderer*);
     ALLOW_NEW_API_WITHOUT_GUARDS_END
+    
+    void removeAudioTrack(AudioTrackPrivate&);
+    void removeVideoTrack(VideoTrackPrivate&);
+    void removeTextTrack(InbandTextTrackPrivate&);
 
     MediaPlayer::NetworkState networkState() const override;
     MediaPlayer::ReadyState readyState() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1330,6 +1330,21 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     m_player->renderingModeChanged();
 }
 
+void MediaPlayerPrivateMediaSourceAVFObjC::removeAudioTrack(AudioTrackPrivate& track)
+{
+    m_player->removeAudioTrack(track);
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::removeVideoTrack(VideoTrackPrivate& track)
+{
+    m_player->removeVideoTrack(track);
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::removeTextTrack(InbandTextTrackPrivate& track)
+{
+    m_player->removeTextTrack(track);
+}
+
 void MediaPlayerPrivateMediaSourceAVFObjC::characteristicsChanged()
 {
     updateAllRenderersHaveAvailableSamples();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -198,8 +198,8 @@ private:
     void keyStatusesChanged();
 #endif
 
-    Vector<RefPtr<VideoTrackPrivate>> m_videoTracks;
-    Vector<RefPtr<AudioTrackPrivate>> m_audioTracks;
+    HashMap<AtomString, RefPtr<VideoTrackPrivate>> m_videoTracks;
+    HashMap<AtomString, RefPtr<AudioTrackPrivate>> m_audioTracks;
     Vector<SourceBufferPrivateAVFObjCErrorClient*> m_errorClients;
 
     WeakPtrFactory<SourceBufferPrivateAVFObjC> m_appendWeakFactory;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1377,12 +1377,16 @@ void MediaPlayerPrivateWebM::destroyAudioRenderers()
 
 void MediaPlayerPrivateWebM::clearTracks()
 {
-    for (auto& track : m_videoTracks)
+    for (auto& track : m_videoTracks) {
         track->setSelectedChangedCallback(nullptr);
+        m_player->removeVideoTrack(*track);
+    }
     m_videoTracks.clear();
 
-    for (auto& track : m_audioTracks)
+    for (auto& track : m_audioTracks) {
         track->setEnabledChangedCallback(nullptr);
+        m_player->removeAudioTrack(*track);
+    }
     m_audioTracks.clear();
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -554,7 +554,7 @@ void AppendPipeline::didReceiveInitializationSegment()
     m_hasReceivedFirstInitializationSegment = true;
     GST_DEBUG("Notifying SourceBuffer of initialization segment.");
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "append-pipeline-received-init-segment");
-    m_sourceBufferPrivate.didReceiveInitializationSegment(WTFMove(initializationSegment), []() { });
+    m_sourceBufferPrivate.didReceiveInitializationSegment(WTFMove(initializationSegment), [](SourceBufferPrivateClient::ReceiveResult) { });
 }
 
 void AppendPipeline::consumeAppsinksAvailableSamples()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -209,7 +209,7 @@ bool SourceBufferPrivateGStreamer::isActive() const
     return m_isActive;
 }
 
-void SourceBufferPrivateGStreamer::didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&& initializationSegment, CompletionHandler<void()>&& completionHandler)
+void SourceBufferPrivateGStreamer::didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&& initializationSegment, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&& completionHandler)
 {
     m_hasReceivedInitializationSegment = true;
     for (auto& trackInfo : initializationSegment.videoTracks) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -71,7 +71,7 @@ public:
     void setActive(bool) final;
     bool isActive() const final;
 
-    void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void()>&&);
+    void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&&);
     void didReceiveSample(Ref<MediaSample>&&);
     void didReceiveAllPendingSamples();
     void appendParsingFailed();

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -193,7 +193,7 @@ void MockSourceBufferPrivate::didReceiveInitializationSegment(const MockInitiali
         }
     }
 
-    SourceBufferPrivate::didReceiveInitializationSegment(WTFMove(segment), []() { });
+    SourceBufferPrivate::didReceiveInitializationSegment(WTFMove(segment), [](SourceBufferPrivateClient::ReceiveResult) { });
 }
 
 void MockSourceBufferPrivate::didReceiveSample(const MockSampleBox& sampleBox)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -557,9 +557,17 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteAudioTrackProxy(We
     ASSERT(m_manager && m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
+    
+    for (auto& [localTrack, remoteTrack] : m_audioTracks) {
+        if (localTrack == track) {
+            auto identifier = remoteTrack->identifier();
+            m_audioTracks.set(track, *m_audioTracks.take(localTrack));
+            return identifier;
+        }
+    }
 
     auto identifier = TrackPrivateRemoteIdentifier::generate();
-    m_audioTracks.set(&track, RemoteAudioTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
+    m_audioTracks.set(track, RemoteAudioTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
     return identifier;
 }
 
@@ -583,9 +591,17 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteVideoTrackProxy(We
     ASSERT(m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
+    
+    for (auto& [localTrack, remoteTrack] : m_videoTracks) {
+        if (localTrack == track) {
+            auto identifier = remoteTrack->identifier();
+            m_videoTracks.set(track, *m_videoTracks.take(localTrack));
+            return identifier;
+        }
+    }
 
     auto identifier = TrackPrivateRemoteIdentifier::generate();
-    m_videoTracks.set(&track, RemoteVideoTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
+    m_videoTracks.set(track, RemoteVideoTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
     return identifier;
 }
 
@@ -608,9 +624,17 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteTextTrackProxy(Web
     ASSERT(m_manager && m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
+    
+    for (auto& [localTrack, remoteTrack] : m_textTracks) {
+        if (localTrack == track) {
+            auto identifier = remoteTrack->identifier();
+            m_textTracks.set(track, *m_textTracks.take(localTrack));
+            return identifier;
+        }
+    }
 
     auto identifier = TrackPrivateRemoteIdentifier::generate();
-    m_textTracks.set(&track, RemoteTextTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
+    m_textTracks.set(track, RemoteTextTrackProxy::create(*m_manager->gpuConnectionToWebProcess(), identifier, track, m_id));
     return identifier;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -356,9 +356,9 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    HashMap<WebCore::AudioTrackPrivate*, Ref<RemoteAudioTrackProxy>> m_audioTracks;
-    HashMap<WebCore::VideoTrackPrivate*, Ref<RemoteVideoTrackProxy>> m_videoTracks;
-    HashMap<WebCore::InbandTextTrackPrivate*, Ref<RemoteTextTrackProxy>> m_textTracks;
+    HashMap<Ref<WebCore::AudioTrackPrivate>, Ref<RemoteAudioTrackProxy>> m_audioTracks;
+    HashMap<Ref<WebCore::VideoTrackPrivate>, Ref<RemoteVideoTrackProxy>> m_videoTracks;
+    HashMap<Ref<WebCore::InbandTextTrackPrivate>, Ref<RemoteTextTrackProxy>> m_textTracks;
 
     WebCore::MediaPlayerIdentifier m_id;
     RefPtr<SandboxExtension> m_sandboxExtension;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -70,7 +70,7 @@ private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 
     // SourceBufferPrivateClient
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void()>&&) final;
+    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
     void sourceBufferPrivateStreamEndedWithDecodeError() final;
     void sourceBufferPrivateAppendError(bool decodeError) final;
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult) final;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -365,10 +365,10 @@ void SourceBufferPrivateRemote::enqueuedSamplesForTrackID(const AtomString& trac
     }, m_remoteSourceBufferIdentifier);
 }
 
-void SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&& segmentInfo, CompletionHandler<void()>&& completionHandler)
+void SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&& segmentInfo, CompletionHandler<void(WebCore::SourceBufferPrivateClient::ReceiveResult)>&& completionHandler)
 {
     if (!m_client || !m_mediaPlayerPrivate) {
-        completionHandler();
+        completionHandler(WebCore::SourceBufferPrivateClient::ReceiveResult::ClientDisconnected);
         return;
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -108,7 +108,7 @@ private:
     void enqueuedSamplesForTrackID(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void()>&&);
+    void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::SourceBufferPrivateClient::ReceiveResult)>&&);
     void sourceBufferPrivateStreamEndedWithDecodeError();
     void sourceBufferPrivateAppendError(bool decodeError);
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult, const WebCore::PlatformTimeRanges& buffered, uint64_t totalTrackBufferSizeInBytes, const MediaTime& timestampOffset);

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 messages -> SourceBufferPrivateRemote NotRefCounted {
-    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> ()
+    SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::SourceBufferPrivateClient::ReceiveResult result)
     SourceBufferPrivateStreamEndedWithDecodeError()
     SourceBufferPrivateAppendError(bool decodeError)
     SourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult appendResult, WebCore::PlatformTimeRanges buffered, uint64_t totalTrackBufferSizeInBytes, MediaTime timeStampOffset)


### PR DESCRIPTION
#### ce149547adc310ce20758ebfd0c37440746c232e
<pre>
Seeking in Netflix triggers unbounded growth in WebCore::Audio&amp;VideoTrackPrivateMediaSourceAVFObjC objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=242925">https://bugs.webkit.org/show_bug.cgi?id=242925</a>
&lt;rdar://96300539&gt;

Reviewed by Eric Carlson.

Video/AudioTrackPrivate objects are created and stored in both the SourceBufferPrivateAVFObjC
layer and the RemoteMediaPlayerProxy layer, however, once we clear the tracks
from the SourceBufferPrivateAVFObjC layer, we fail to also delete them in
the RemoteMediaPlayerProxy layer. This causes unbounded memory growth especially
as new intialization segments + tracks keep getting added.

Instead of deleting the tracks in the HTMLMediaElement layer and send incorrect
events, we can override the &quot;old&quot; tracks in both the SourceBufferPrivateAVFObjC
and RemoteMediaPlayerProxy layers in the GPUP and still hold onto the existing
WebProcess tracks.

This patch also includes better error handling with the sourceBufferPrivateDidReceiveInitializationSegment
completion handler when a failure happens along the way.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::operator== const):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
(WebCore::InbandTextTrackPrivate::operator== const):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WTF::LogArgument&lt;WebCore::SourceBufferPrivateClient::ReceiveResult&gt;::toString):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp: Added.
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::operator== const):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(WebCore::VideoTrackPrivate::operator== const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeAudioTrack):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeVideoTrack):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeTextTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didParseInitializationData):
(WebCore::SourceBufferPrivateAVFObjC::clearTracks):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::clearTracks):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::addRemoteAudioTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteVideoTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteTextTrackProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in:

Canonical link: <a href="https://commits.webkit.org/252887@main">https://commits.webkit.org/252887@main</a>
</pre>
