### PR TITLE
[Lockdown Mode] Per app mechanism to opt out of first-time-use prompt

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -503,6 +503,11 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
 + (void)_setCaptivePortalModeEnabledGloballyForTesting:(BOOL)isEnabled
 {
     WebKit::setCaptivePortalModeEnabledGloballyForTesting(!!isEnabled);
+}
+
++ (BOOL)_lockdownModeEnabledGloballyForTesting
+{
+    return WebKit::captivePortalModeEnabledBySystem();
 }
 
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -129,6 +129,7 @@
 + (void)_setLinkedOnOrBeforeEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_setCaptivePortalModeEnabledGloballyForTesting:(BOOL)isEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
++ (BOOL)_lockdownModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_preconnectToServer:(NSURL *)serverURL WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebView._preconnectToServer", macos(10.13.4, 10.15.4), ios(11.3, 13.4));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,18 @@ typedef NS_ENUM(NSInteger, WKMediaCaptureType) {
     WKMediaCaptureTypeMicrophone,
     WKMediaCaptureTypeCameraAndMicrophone,
 } WK_API_AVAILABLE(macos(12.0), ios(15.0));
+
+/*! @enum WKDialogResult
+@abstract Constants returned by showLockdownModeFirstUseMessage to indicate how WebKit should treat first use.
+@constant WKDialogResultShowDefault Indicates that the client did not display a first use message. WebKit should show the default.
+@constant WKDialogResultAskAgain Indicates the client handled the message, but wants to be checked if other WKWebViews are used.
+@constant WKDialogResultHandled Indicates the client handled the message and no further checks are needed.
+*/
+typedef NS_ENUM(NSInteger, WKDialogResult) {
+    WKDialogResultShowDefault = 1,
+    WKDialogResultAskAgain,
+    WKDialogResultHandled
+} WK_API_AVAILABLE(ios(16.0));
 
 /*! A class conforming to the WKUIDelegate protocol provides methods for
  presenting native UI on behalf of a webpage.
@@ -231,6 +243,16 @@ typedef NS_ENUM(NSInteger, WKMediaCaptureType) {
  */
 
 - (void)webView:(WKWebView *)webView contextMenuDidEndForElement:(WKContextMenuElementInfo *)elementInfo WK_API_AVAILABLE(ios(13.0));
+
+/*! @abstract Displays a Lockdown Mode warning panel.
+ @param webView The web view invoking the delegate method.
+ @param message The message WebKit would display if this delegate were not invoked.
+ @param completionHandler The completion handler you must invoke to resume after the first use message is displayed.
+ @discussion The panel should have a single OK button.
+
+ If you do not implement this method, the web view will display the default Lockdown Mode message.
+ */
+- (void)webView:(WKWebView *)webView showLockdownModeFirstUseMessage:(NSString *)message completionHandler:(void (^)(WKDialogResult))completionHandler WK_API_AVAILABLE(ios(13.0));
 
 #endif // TARGET_OS_IOS
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -369,6 +369,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     _allowsViewportShrinkToFit = defaultAllowsViewportShrinkToFit;
     _allowsLinkPreview = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LinkPreviewEnabledByDefault);
     _findInteractionEnabled = NO;
+    _needsToPresentLockdownModeMessage = YES;
 
     _pendingFindLayerID = 0;
     _committedFindLayerID = 0;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,6 +193,7 @@ class ViewGestureController;
     UIEdgeInsets _unobscuredSafeAreaInsets;
     BOOL _haveSetUnobscuredSafeAreaInsets;
     BOOL _avoidsUnsafeArea;
+    BOOL _needsToPresentLockdownModeMessage;
     UIRectEdge _obscuredInsetEdgesAffectedBySafeArea;
 
     UIInterfaceOrientation _interfaceOrientationOverride;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,6 +155,10 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_beginLiveResize;
 - (void)_endLiveResize;
+
+#if ENABLE(LOCKDOWN_MODE_API)
++ (void)_clearLockdownModeWarningNeeded;
+#endif
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 - (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -93,6 +93,8 @@
 - (BOOL)_hasResizeAssertion;
 - (void)_simulateSelectionStart;
 
++ (void)_resetPresentLockdownModeMessage;
+
 @end
 
 #endif // TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -495,6 +495,13 @@ static void dumpUIView(TextStream& ts, UIView *view)
     [_contentView _simulateSelectionStart];
 }
 
++ (void)_resetPresentLockdownModeMessage
+{
+#if ENABLE(LOCKDOWN_MODE_API)
+    [self _clearLockdownModeWarningNeeded];
+#endif
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -7910,7 +7910,7 @@ static void checkSettingsControlledByCaptivePortalMode(WKWebView *webView, Shoul
 
 @end
 
-void configureCaptivePortalWKWebViewConfiguration(WKWebViewConfiguration *config)
+static void configureCaptivePortalWKWebViewConfiguration(WKWebViewConfiguration *config)
 {
     [config.preferences _setMediaDevicesEnabled:YES];
     config.preferences._mediaCaptureRequiresSecureConnection = NO;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -32,6 +32,7 @@
 #import "Utilities.h"
 
 #import <WebKit/WKContentWorld.h>
+#import <WebKit/WKUIDelegate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WebKitPrivate.h>
@@ -526,6 +527,11 @@ static UICalloutBar *suppressUICalloutBar()
 
 - (void)addToTestWindow
 {
+    if (!_hostWindow) {
+        [self _setUpTestWindow:self.frame];
+        return;
+    }
+
 #if PLATFORM(MAC)
     [[_hostWindow contentView] addSubview:self];
 #else


### PR DESCRIPTION
#### ec6bbaa54fd8c0b5c94e26fa650c68ac93db8a8c
<pre>
[Lockdown Mode] Per app mechanism to opt out of first-time-use prompt
rdar://92423822

Reviewed by Chris Dumez.

Create a mechanism for apps to control the first-time-use behavior in Lockdown Mode.

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _captivePortalModeEnabledGloballyForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(isLockdownModeWarningNeeded):
(-[WKWebView _presentCaptivePortalMode]):
(-[WKWebView _presentCaptivePortalModeAlertIfNeeded]):
(+[WKWebView _resetPresentLockdownModeMessage]):
(-[WKWebView _presentCaptivePortalModeAlertOnce]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[NoLockdownFirstUseMessage webView:showLockdownModeFirstUseMessage:completionHandler:]):
(-[AskAgainFirstUseMessage webView:showLockdownModeFirstUseMessage:completionHandler:]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView setUpAndAddToTestWindow]):

Canonical link: <a href="https://commits.webkit.org/252700@main">https://commits.webkit.org/252700@main</a>
</pre>
