### PR TITLE
Rewrite Display P3 canvas video tests to run sequentially

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html
@@ -11,47 +11,40 @@ for (let [filenameBase, expectedPixels] of Object.entries(videoTests)) {
     for (let contextColorSpace of ["srgb", "display-p3"]) {
         for (let imageDataColorSpace of ["srgb", "display-p3"]) {
             for (let cropSource of [false, true]) {
-                async_test(function(t) {
+                promise_test(async function(t) {
+
                     let video = document.createElement("video");
-                    let testVideo = t.step_func(function() {
-
-                        let canvas = document.createElement("canvas");
-                        canvas.width = 2;
-                        canvas.height = 2;
-
-                        let ctx = canvas.getContext("2d", { colorSpace: contextColorSpace });
-
-                        let imageBitmapPromise;
-                        if (cropSource)
-                            imageBitmapPromise = createImageBitmap(video, 1, 1, 1, 1);
-                        else
-                            imageBitmapPromise = createImageBitmap(video);
-
-                        imageBitmapPromise.then(t.step_func_done(function(imageBitmap) {
-                            video.remove();
-                            ctx.drawImage(imageBitmap, 0, 0);
-
-                            let imageData = ctx.getImageData(0, 0, 1, 1, { colorSpace: imageDataColorSpace });
-
-                            let expected = expectedPixels[`${contextColorSpace} ${imageDataColorSpace}`];
-                            assert_true(pixelsApproximatelyEqual(imageData.data, expected), `Actual pixel value ${[...imageData.data]} is approximately equal to ${expected}.`);
-                        }), t.step_func(function(error) {
-                            video.remove();
-                            throw error;
-                        }));
-                    });
-                    if (video.requestVideoFrameCallback)
-                        video.requestVideoFrameCallback(testVideo)
-                    else
-                        video.onloadeddata = testVideo;
                     for (let format of ["mp4", "webm"]) {
                         let source = document.createElement("source");
                         source.src = `resources/${filenameBase}.${format}`;
                         source.type = `video/${format}`;
                         video.append(source);
                     }
+
                     document.body.append(video);
-                    video.play();
+                    await video.play();
+
+                    let imageBitmap;
+                    if (cropSource)
+                        imageBitmap = await createImageBitmap(video, 1, 1, 1, 1);
+                    else
+                        imageBitmap = await createImageBitmap(video);
+
+                    video.remove();
+
+                    let canvas = document.createElement("canvas");
+                    canvas.width = 2;
+                    canvas.height = 2;
+
+                    let ctx = canvas.getContext("2d", { colorSpace: contextColorSpace });
+
+                    ctx.drawImage(imageBitmap, 0, 0);
+
+                    let imageData = ctx.getImageData(0, 0, 1, 1, { colorSpace: imageDataColorSpace });
+
+                    let expected = expectedPixels[`${contextColorSpace} ${imageDataColorSpace}`];
+                    assert_true(pixelsApproximatelyEqual(imageData.data, expected), `Actual pixel value ${[...imageData.data]} is approximately equal to ${expected}.`);
+
                 }, `${filenameBase}, Context ${contextColorSpace}, ImageData ${imageDataColorSpace}, cropSource=${cropSource}`);
             }
         }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html
@@ -11,38 +11,35 @@ for (let [filenameBase, expectedPixels] of Object.entries(videoTests)) {
     for (let contextColorSpace of ["srgb", "display-p3"]) {
         for (let imageDataColorSpace of ["srgb", "display-p3"]) {
             for (let scaleImage of [false, true]) {
-                async_test(function(t) {
+                promise_test(async function(t) {
+
                     let video = document.createElement("video");
-                    let testVideo = t.step_func_done(function() {
-
-                        let canvas = document.createElement("canvas");
-                        canvas.width = 2;
-                        canvas.height = 2;
-
-                        let ctx = canvas.getContext("2d", { colorSpace: contextColorSpace });
-                        if (scaleImage)
-                            ctx.drawImage(video, 0, 0, 10, 10);
-                        else
-                            ctx.drawImage(video, 0, 0);
-                        video.remove();
-
-                        let imageData = ctx.getImageData(0, 0, 1, 1, { colorSpace: imageDataColorSpace });
-
-                        let expected = expectedPixels[`${contextColorSpace} ${imageDataColorSpace}`];
-                        assert_true(pixelsApproximatelyEqual(imageData.data, expected), `Actual pixel value ${[...imageData.data]} is approximately equal to ${expected}.`);
-                    });
-                    if (video.requestVideoFrameCallback)
-                        video.requestVideoFrameCallback(testVideo)
-                    else
-                        video.onloadeddata = testVideo;
                     for (let format of ["mp4", "webm"]) {
                         let source = document.createElement("source");
                         source.src = `resources/${filenameBase}.${format}`;
                         source.type = `video/${format}`;
                         video.append(source);
                     }
+
                     document.body.append(video);
-                    video.play();
+                    await video.play();
+
+                    let canvas = document.createElement("canvas");
+                    canvas.width = 2;
+                    canvas.height = 2;
+
+                    let ctx = canvas.getContext("2d", { colorSpace: contextColorSpace });
+                    if (scaleImage)
+                        ctx.drawImage(video, 0, 0, 10, 10);
+                    else
+                        ctx.drawImage(video, 0, 0);
+                    video.remove();
+
+                    let imageData = ctx.getImageData(0, 0, 1, 1, { colorSpace: imageDataColorSpace });
+
+                    let expected = expectedPixels[`${contextColorSpace} ${imageDataColorSpace}`];
+                    assert_true(pixelsApproximatelyEqual(imageData.data, expected), `Actual pixel value ${[...imageData.data]} is approximately equal to ${expected}.`);
+
                 }, `${filenameBase}, Context ${contextColorSpace}, ImageData ${imageDataColorSpace}, scaleImage=${scaleImage}`);
             }
         }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3641,9 +3641,6 @@ webkit.org/b/240927 [ Debug ]  storage/indexeddb/request-with-null-open-db-reque
 
 webkit.org/b/240929 [ Debug ]  resize-observer/resize-observer-with-zoom.html [ Pass Timeout ]
 
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Failure ] 
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Failure ] 
-
 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
 # Accessibility bold only exists on iOS.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1853,9 +1853,6 @@ webkit.org/b/232630 fast/forms/autofocus-opera-003.html [ Failure ]
 
 webkit.org/b/240841 fast/forms/scroll-into-view-and-show-validation-message.html [ Pass Failure ]
 
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Failure Timeout ]
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Failure Timeout ]
-
 webkit.org/b/241266 compositing/video/video-border-radius.html [ Pass Timeout ]
 
 webkit.org/b/241376 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1694,9 +1694,6 @@ webkit.org/b/240830 [ Monterey ] webgl/2.0.0/conformance/attribs/gl-vertexattrib
 
 webkit.org/b/240927 [ BigSur Debug ] storage/indexeddb/request-with-null-open-db-request.html [ Pass Crash ]
 
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Pass Failure ]
-webkit.org/b/241048 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Pass Failure ]
-
 webkit.org/b/241265 [ Debug ] imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html [ Pass Crash ]
 
 webkit.org/b/241283 fast/animation/request-animation-frame-throttling-detached-iframe.html [ Pass Failure ]


### PR DESCRIPTION
#### 6f74311b11e53e8c1f2d1ba090cb421ac847bb74
<pre>
Rewrite Display P3 canvas video tests to run sequentially
<a href="https://bugs.webkit.org/show_bug.cgi?id=241048">https://bugs.webkit.org/show_bug.cgi?id=241048</a>
rdar://94056966

Reviewed by Jean-Yves Avenard.

The tests currently use async_test, which results in all 30 or so videos
being present in the document at once, which is triggering some
non-determinism in CoreMedia. Changing to promise_test makes them run
sequentially and less flakily.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html:

Canonical link: <a href="https://commits.webkit.org/252686@main">https://commits.webkit.org/252686@main</a>
</pre>
