### PR TITLE
Web Inspector: rename WI.CallFrameTreeController to WI.StackTraceTreeController since it now deals with WI.StackTrace

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/StackTraceTreeController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/StackTraceTreeController.js
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-WI.CallFrameTreeController = class CallFrameTreeController extends WI.Object
+WI.StackTraceTreeController = class StackTraceTreeController extends WI.Object
 {
     constructor(treeOutline)
     {
@@ -51,7 +51,7 @@ WI.CallFrameTreeController = class CallFrameTreeController extends WI.Object
 
         let CallFrameUIClass = parentIsNode ? WI.CallFrameView : WI.CallFrameTreeElement;
 
-        let activeCallFrameTreeElement = WI.CallFrameTreeController._groupBlackboxedCallFrames(parent, stackTrace.callFrames, {rememberBlackboxedCallFrameGroupToAutoExpand});
+        let activeCallFrameTreeElement = WI.StackTraceTreeController._groupBlackboxedCallFrames(parent, stackTrace.callFrames, {rememberBlackboxedCallFrameGroupToAutoExpand});
 
         let parentStackTrace = stackTrace.parentStackTrace;
         while (parentStackTrace) {
@@ -75,7 +75,7 @@ WI.CallFrameTreeController = class CallFrameTreeController extends WI.Object
 
             let startIndex = parentStackTrace.topCallFrameIsBoundary ? 1 : 0;
             let parentCallFrames = startIndex ? parentStackTrace.callFrames.slice(startIndex) : parentStackTrace.callFrames;
-            WI.CallFrameTreeController._groupBlackboxedCallFrames(parent, parentCallFrames, {rememberBlackboxedCallFrameGroupToAutoExpand});
+            WI.StackTraceTreeController._groupBlackboxedCallFrames(parent, parentCallFrames, {rememberBlackboxedCallFrameGroupToAutoExpand});
 
             if (parentStackTrace.truncated) {
                 let truncatedCallFrame = new WI.CallFrame(parentStackTrace.callFrames[0].target, {
@@ -178,7 +178,7 @@ WI.CallFrameTreeController = class CallFrameTreeController extends WI.Object
         this._treeOutline.removeChildren();
 
         if (this._stackTrace)
-            WI.CallFrameTreeController.groupBlackboxedStackTrace(this._treeOutline, this._stackTrace);
+            WI.StackTraceTreeController.groupBlackboxedStackTrace(this._treeOutline, this._stackTrace);
     }
 
     disconnect()

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -918,7 +918,6 @@
     <script src="Controllers/BreakpointLogMessageLexer.js"></script>
     <script src="Controllers/BrowserManager.js"></script>
     <script src="Controllers/CSSManager.js"></script>
-    <script src="Controllers/CallFrameTreeController.js"></script>
     <script src="Controllers/CanvasManager.js"></script>
     <script src="Controllers/CodeMirrorColorEditingController.js"></script>
     <script src="Controllers/CodeMirrorCompletionController.js"></script>
@@ -948,6 +947,7 @@
     <script src="Controllers/CSSQueryController.js"></script>
     <script src="Controllers/ResourceQueryController.js"></script>
     <script src="Controllers/RuntimeManager.js"></script>
+    <script src="Controllers/StackTraceTreeController.js"></script>
     <script src="Controllers/TargetManager.js"></script>
     <script src="Controllers/TimelineManager.js"></script>
     <script src="Controllers/TypeTokenAnnotator.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
@@ -116,7 +116,7 @@ WI.AnimationDetailsSidebarPanel = class AnimationDetailsSidebarPanel extends WI.
         const selectable = false;
         let backtraceTreeOutline = new WI.TreeOutline(selectable);
         backtraceTreeOutline.disclosureButtons = false;
-        this._backtraceTreeController = new WI.CallFrameTreeController(backtraceTreeOutline);
+        this._backtraceTreeController = new WI.StackTraceTreeController(backtraceTreeOutline);
 
         let backtraceRow = new WI.DetailsSectionRow;
         backtraceRow.element.appendChild(backtraceTreeOutline.element);

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js
@@ -138,7 +138,7 @@ WI.CanvasDetailsSidebarPanel = class CanvasDetailsSidebarPanel extends WI.Detail
         const selectable = false;
         let backtraceTreeOutline = new WI.TreeOutline(selectable);
         backtraceTreeOutline.disclosureButtons = false;
-        this._backtraceTreeController = new WI.CallFrameTreeController(backtraceTreeOutline);
+        this._backtraceTreeController = new WI.StackTraceTreeController(backtraceTreeOutline);
 
         let backtraceRow = new WI.DetailsSectionRow;
         backtraceRow.element.appendChild(backtraceTreeOutline.element);

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingTraceDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingTraceDetailsSidebarPanel.js
@@ -32,7 +32,7 @@ WI.RecordingTraceDetailsSidebarPanel = class RecordingTraceDetailsSidebarPanel e
         const selectable = false;
         this._backtraceTreeOutline = new WI.TreeOutline(selectable);
         this._backtraceTreeOutline.disclosureButtons = false;
-        this._backtraceTreeController = new WI.CallFrameTreeController(this._backtraceTreeOutline);
+        this._backtraceTreeController = new WI.StackTraceTreeController(this._backtraceTreeOutline);
 
         this._recording = null;
         this._action = null;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
@@ -293,7 +293,7 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
                     const selectable = false;
                     let callFramesTreeOutline = new WI.TreeOutline(selectable);
                     callFramesTreeOutline.disclosureButtons = false;
-                    let callFrameTreeController = new WI.CallFrameTreeController(callFramesTreeOutline);
+                    let callFrameTreeController = new WI.StackTraceTreeController(callFramesTreeOutline);
                     callFrameTreeController.stackTrace = this._resource.initiatorStackTrace;
 
                     let popoverContent = document.createElement("div");

--- a/Source/WebInspectorUI/UserInterface/Views/StackTraceView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StackTraceView.js
@@ -32,7 +32,7 @@ WI.StackTraceView = class StackTraceView
         var element = this._element = document.createElement("div");
         element.classList.add("stack-trace");
 
-        WI.CallFrameTreeController.groupBlackboxedStackTrace(element, stackTrace);
+        WI.StackTraceTreeController.groupBlackboxedStackTrace(element, stackTrace);
 
         return element;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js
@@ -52,7 +52,7 @@ WI.ThreadTreeElement = class ThreadTreeElement extends WI.GeneralTreeElement
             return;
         }
 
-        let activeCallFrameTreeElement = WI.CallFrameTreeController.groupBlackboxedStackTrace(this, targetData.stackTrace, {rememberBlackboxedCallFrameGroupToAutoExpand: true});
+        let activeCallFrameTreeElement = WI.StackTraceTreeController.groupBlackboxedStackTrace(this, targetData.stackTrace, {rememberBlackboxedCallFrameGroupToAutoExpand: true});
         if (activeCallFrameTreeElement) {
             activeCallFrameTreeElement.select(true, true);
             activeCallFrameTreeElement.isActiveCallFrame = true;

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.js
@@ -400,7 +400,7 @@ WI.TimelineDataGrid = class TimelineDataGrid extends WI.DataGrid
             this._popoverCallStackTreeOutline.removeChildren();
 
         if (this.selectedNode.record.stackTrace)
-            WI.CallFrameTreeController.groupBlackboxedStackTrace(this._popoverCallStackTreeOutline, this.selectedNode.record.stackTrace);
+            WI.StackTraceTreeController.groupBlackboxedStackTrace(this._popoverCallStackTreeOutline, this.selectedNode.record.stackTrace);
 
         let content = document.createElement("div");
         content.appendChild(this._popoverCallStackTreeOutline.element);


### PR DESCRIPTION
#### 3e899a15fd4251dc28730e7b098e83f7cf9a202e
<pre>
Web Inspector: rename WI.CallFrameTreeController to WI.StackTraceTreeController since it now deals with WI.StackTrace
<a href="https://bugs.webkit.org/show_bug.cgi?id=242934">https://bugs.webkit.org/show_bug.cgi?id=242934</a>

Reviewed by Patrick Angle.

After 252630@main, `WI.CallFrameTreeController` now only deals with a `WI.StackTrace` instead of an
array of `WI.CallFrame`. As such, it should be (re)named `WI.StackTraceTreeController`.

* Source/WebInspectorUI/UserInterface/Controllers/StackTraceTreeController.js: Renamed from Source/WebInspectorUI/UserInterface/Controllers/CallFrameTreeController.js.
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js:
(WI.AnimationDetailsSidebarPanel.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/CanvasDetailsSidebarPanel.js:
(WI.CanvasDetailsSidebarPanel.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/RecordingTraceDetailsSidebarPanel.js:
(WI.RecordingTraceDetailsSidebarPanel):
* Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js:
(WI.ResourceHeadersContentView.prototype._refreshSummarySection):
* Source/WebInspectorUI/UserInterface/Views/StackTraceView.js:
(WI.StackTraceView):
* Source/WebInspectorUI/UserInterface/Views/ThreadTreeElement.js:
(WI.ThreadTreeElement.prototype.refresh):
* Source/WebInspectorUI/UserInterface/Views/TimelineDataGrid.js:
(WI.TimelineDataGrid.prototype._createPopoverContent):

Canonical link: <a href="https://commits.webkit.org/252639@main">https://commits.webkit.org/252639@main</a>
</pre>
