### PR TITLE
Extend macOS and iOS sandboxes to enable CoreAudio logging in GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -841,7 +841,17 @@
 
 ;; Media capture, microphone access
 (with-filter (extension "com.apple.webkit.microphone")
-    (allow device-microphone))
+    (allow device-microphone)
+
+    (with-filter (system-attribute apple-internal)
+        (allow user-preference-read (preference-domain "com.apple.coreaudio"))
+        (allow file-read* file-write*
+            (subpath "/private/tmp/AudioCapture")
+            (subpath "/tmp/AudioCapture"))
+        (allow file-read* (subpath "/usr/local/lib"))
+        (allow file-read-data (path "/AppleInternal/Library/Audio/CASuperBowl"))
+    )
+)
 
 ;; Media capture, camera access
 (with-filter (extension "com.apple.webkit.camera")

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -156,7 +156,16 @@
 (define-once (media-capture-support)
     ;; Media capture, microphone access
     (with-filter (extension "com.apple.webkit.microphone")
-        (allow device-microphone))
+        (allow device-microphone)
+
+        (with-filter (system-attribute apple-internal)
+            (allow user-preference-read (preference-domain "com.apple.coreaudio"))
+            (allow file-read* file-write*
+                (subpath "/private/tmp/AudioCapture")
+                (subpath "/tmp/AudioCapture")
+            )
+        )
+    )
 
     ;; Media capture, camera access
     (with-filter (extension "com.apple.webkit.camera")


### PR DESCRIPTION
#### 73b9c9c738c159611f3dde1c9fe26f282e0fff40
<pre>
Extend macOS and iOS sandboxes to enable CoreAudio logging in GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=242937">https://bugs.webkit.org/show_bug.cgi?id=242937</a>
rdar://76778043

Reviewed by Per Arne Vollan.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/iOS/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/252785@main">https://commits.webkit.org/252785@main</a>
</pre>
