### PR TITLE
[DMABuf] More thoroughly check for DMABuf capabilities

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -280,6 +280,8 @@ void PlatformDisplay::initializeEGLDisplay()
                     });
             };
 
+        m_eglExtensions.KHR_image_base = findExtension("EGL_KHR_image_base"_s);
+        m_eglExtensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
         m_eglExtensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
     }
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -88,6 +88,8 @@ public:
     bool eglCheckVersion(int major, int minor) const;
 
     struct EGLExtensions {
+        bool KHR_image_base { false };
+        bool EXT_image_dma_buf_import { false };
         bool EXT_image_dma_buf_import_modifiers { false };
     };
     const EGLExtensions& eglExtensions() const { return m_eglExtensions; }

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -86,7 +86,11 @@ public:
     Swapchain& swapchain() { return m_swapchain; }
 
     struct EGLExtensions {
+        bool KHR_image_base { false };
+        bool KHR_surfaceless_context { false };
+        bool EXT_image_dma_buf_import { false };
         bool EXT_image_dma_buf_import_modifiers { false };
+        bool ANGLE_power_preference { false };
     };
     const EGLExtensions& eglExtensions() { return m_eglExtensions; }
 
@@ -94,8 +98,6 @@ protected:
     GraphicsContextGLGBM(WebCore::GraphicsContextGLAttributes&&);
 
 private:
-    bool isDMABufSupportedInPlatform(const char* displayExtensions);
-
     void allocateDrawBufferObject();
 
     EGLExtensions m_eglExtensions;


### PR DESCRIPTION
#### f9aca7f2ebe6a966458084282cb662f10c09b8aa
<pre>
[DMABuf] More thoroughly check for DMABuf capabilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=242938">https://bugs.webkit.org/show_bug.cgi?id=242938</a>

Reviewed by Adrian Perez de Castro.

Both ANGLE and native EGL platform must signal the necessary EGL extension
support for the DMABuf-based ANGLE execution to be used. If one or the other
fail, the fallback implementation should be used.

In createWebProcessGraphicsContextGL(), native EGL platform is queried for the
necessary extensions, and a GraphicsContextGLGBMTextureMapper instance is
spawned if the extensions are present.

GraphicsContextGLGBM extension handling is cleaned up and the query function
simplified.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::initializeEGLDisplay):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp:
(WebCore::isDMABufSupportedByNativePlatform):
(WebCore::createWebProcessGraphicsContextGL):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::isDMABufSupportedByANGLEPlatform):
(WebCore::GraphicsContextGLGBM::platformInitializeContext):
(WebCore::GraphicsContextGLGBM::isDMABufSupportedInPlatform): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:

Canonical link: <a href="https://commits.webkit.org/252644@main">https://commits.webkit.org/252644@main</a>
</pre>
