### PR TITLE
Sandbox extension to container temporary directory is not created for non persistent Website data stores

### DIFF
--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -148,7 +148,7 @@ GPUProcessProxy::GPUProcessProxy()
 
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
     auto containerCachesDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(gpuProcessCachesDirectory());
-    auto containerTemporaryDirectory = resolveAndCreateReadWriteDirectoryForSandboxExtension(WebsiteDataStore::defaultContainerTemporaryDirectory());
+    auto containerTemporaryDirectory = WebsiteDataStore::defaultResolvedContainerTemporaryDirectory();
 
     if (!containerCachesDirectory.isEmpty()) {
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(containerCachesDirectory, SandboxExtension::Type::ReadWrite))

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -684,19 +684,20 @@ String WebsiteDataStore::resolvedContainerCachesWebContentDirectory()
 
 String WebsiteDataStore::resolvedContainerTemporaryDirectory()
 {
-    if (m_resolvedContainerTemporaryDirectory.isNull()) {
-        if (!isPersistent())
-            m_resolvedContainerTemporaryDirectory = emptyString();
-        else
-            m_resolvedContainerTemporaryDirectory = defaultContainerTemporaryDirectory();
-    }
+    if (m_resolvedContainerTemporaryDirectory.isNull())
+        m_resolvedContainerTemporaryDirectory = defaultResolvedContainerTemporaryDirectory();
 
     return m_resolvedContainerTemporaryDirectory;
 }
 
-String WebsiteDataStore::defaultContainerTemporaryDirectory()
+String WebsiteDataStore::defaultResolvedContainerTemporaryDirectory()
 {
-    return NSTemporaryDirectory();
+    static NeverDestroyed<String> resolvedTemporaryDirectory;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        resolvedTemporaryDirectory.get() = resolveAndCreateReadWriteDirectoryForSandboxExtension(String(NSTemporaryDirectory()));
+    });
+    return resolvedTemporaryDirectory;
 }
 
 void WebsiteDataStore::setBackupExclusionPeriodForTesting(Seconds period, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -161,7 +161,7 @@ public:
     String resolvedCookieStorageDirectory();
     String resolvedContainerCachesWebContentDirectory();
     String resolvedContainerTemporaryDirectory();
-    static String defaultContainerTemporaryDirectory();
+    static String defaultResolvedContainerTemporaryDirectory();
     static String cacheDirectoryInContainerOrHomeDirectory(const String& subpath);
 #endif
 


### PR DESCRIPTION
#### ada763c496ca7c696e88ea4fa756db416d7e07ce
<pre>
Sandbox extension to container temporary directory is not created for non persistent Website data stores
<a href="https://bugs.webkit.org/show_bug.cgi?id=242946">https://bugs.webkit.org/show_bug.cgi?id=242946</a>
&lt;rdar://95817773&gt;

Reviewed by Chris Dumez.

For persistent Website data stores we create a sandbox extension to the container temporary directory for the WebContent process.
This is also needed for non persistent Website data stores, since other frameworks may depend on access to this directory. For
example, image decoding depends on having write access to this location. This patch removes the check for persistent data store
in WebsiteDataStore::resolvedContainerTemporaryDirectory. This method is only used when creating the sandbox extension, so the
only behavior change is that we will now get a sandbox extension also for non persistent data stores.

* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::resolvedContainerTemporaryDirectory):
(WebKit::WebsiteDataStore::defaultResolvedContainerTemporaryDirectory):
(WebKit::WebsiteDataStore::defaultContainerTemporaryDirectory): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/252676@main">https://commits.webkit.org/252676@main</a>
</pre>
