### PR TITLE
Regression(251783@main) Back navigation after browsing source tree on GitHub unexpectedly skips history items

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7262,6 +7262,14 @@ bool Document::processingUserGestureForMedia() const
     return false;
 }
 
+bool Document::hasRecentUserInteractionForNavigationFromJS() const
+{
+    if (UserGestureIndicator::processingUserGesture(this))
+        return true;
+
+    return (MonotonicTime::now() - lastHandledUserGestureTimestamp()) <= UserGestureToken::maximumIntervalForUserGestureForwarding;
+}
+
 void Document::startTrackingStyleRecalcs()
 {
     m_styleRecalcCount = 0;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1267,6 +1267,7 @@ public:
     bool hasHadUserInteraction() const { return static_cast<bool>(m_lastHandledUserGestureTimestamp); }
     void updateLastHandledUserGestureTimestamp(MonotonicTime);
     bool processingUserGestureForMedia() const;
+    bool hasRecentUserInteractionForNavigationFromJS() const;
     void userActivatedMediaFinishedPlaying() { m_userActivatedMediaFinishedPlayingTimestamp = MonotonicTime::now(); }
 
     void setUserDidInteractWithPage(bool userDidInteractWithPage) { ASSERT(isTopDocument()); m_userDidInteractWithPage = userDidInteractWithPage; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3243,7 +3243,8 @@ void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequ
         setProvisionalDocumentLoader(nullptr);
     }
 
-    if (!UserGestureIndicator::processingUserGesture(m_frame.document())) {
+    auto* document = m_frame.document();
+    if (document && !document->hasRecentUserInteractionForNavigationFromJS()) {
         if (auto* currentItem = history().currentItem())
             currentItem->setWasCreatedByJSWithoutUserInteraction(true);
     }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -860,9 +860,10 @@ void FrameLoader::HistoryController::pushState(RefPtr<SerializedScriptValue>&& s
 
     bool shouldRestoreScrollPosition = m_currentItem->shouldRestoreScrollPosition();
 
-    if (!UserGestureIndicator::processingUserGesture(m_frame.document()))
+    auto* document = m_frame.document();
+    if (document && !document->hasRecentUserInteractionForNavigationFromJS())
         m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
-    
+
     // Get a HistoryItem tree for the current frame tree.
     Ref<HistoryItem> topItem = m_frame.mainFrame().loader().history().createItemTree(m_frame, false);
     


### PR DESCRIPTION
#### 048c68aca363063546a4efb9e64f210ef706d8d5
<pre>
Regression(251783@main) Back navigation after browsing source tree on GitHub unexpectedly skips history items
<a href="https://bugs.webkit.org/show_bug.cgi?id=242947">https://bugs.webkit.org/show_bug.cgi?id=242947</a>
&lt;rdar://97031026&gt;

Reviewed by Geoffrey Garen.

Source tree navigations on github cause a history.pushState() to occur asynchronously,
causing us to lose track of the fact that the JS-triggered navigation was indeed the
result of user interaction. As a result, we would unexpectedly skip the created
HistoryItems on back navigation.

To address the issue, we relax our policy and mark HistoryItem as not having a user
gesture if there was no user gesture within the last second.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasRecentUserInteractionForNavigationFromJS const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::pushState):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardList.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/252649@main">https://commits.webkit.org/252649@main</a>
</pre>
