### PR TITLE
`WebPageProxy::requestDOMPasteAccess` should validate the incoming pasteboard origin identifier

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6948,6 +6948,8 @@ void WebPageProxy::setIsNeverRichlyEditableForTouchBar(bool isNeverRichlyEditabl
 
 void WebPageProxy::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, const WebCore::IntRect& elementRect, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION(m_process, !originIdentifier.isEmpty(), completionHandler(DOMPasteAccessResponse::DeniedForGesture));
+
     m_pageClient->requestDOMPasteAccess(pasteAccessCategory, elementRect, originIdentifier, WTFMove(completionHandler));
 }
 


### PR DESCRIPTION
#### d388faa7b580445fa560f5c4b313dd672a0709e3
<pre>
`WebPageProxy::requestDOMPasteAccess` should validate the incoming pasteboard origin identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=242942">https://bugs.webkit.org/show_bug.cgi?id=242942</a>
rdar://97197233

Reviewed by Aditya Keerthi and Chris Dumez.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestDOMPasteAccess):

Canonical link: <a href="https://commits.webkit.org/252648@main">https://commits.webkit.org/252648@main</a>
</pre>
