### PR TITLE
Add dark mode support for text files

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -149,6 +149,7 @@ fast/css/apple-system-control-colors.html [ Skip ]
 inspector/css/force-page-appearance.html [ Skip ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Skip ]
 fast/forms/number/number-dark-appearance.html [ Skip ]
+fast/loader/plain-text-document-dark-mode.html [ Skip ]
 
 # Only Mac supports force tests.
 fast/events/cancelled-force-click-link-navigation.html [ Skip ]

--- a/LayoutTests/fast/loader/plain-text-document-dark-mode-expected-mismatch.html
+++ b/LayoutTests/fast/loader/plain-text-document-dark-mode-expected-mismatch.html
@@ -1,0 +1,1 @@
+<iframe src="resources/plain-text-document.txt">

--- a/LayoutTests/fast/loader/plain-text-document-dark-mode.html
+++ b/LayoutTests/fast/loader/plain-text-document-dark-mode.html
@@ -1,0 +1,5 @@
+<script>
+    if (window.internals)
+        internals.settings.setUseDarkAppearance(true);
+</script>
+<iframe src="resources/plain-text-document.txt">

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -56,6 +56,7 @@ webkit.org/b/191506 fast/css-grid-layout/grid-item-scroll-position.html [ Pass ]
 
 css-dark-mode [ Pass ]
 css-dark-mode/older-systems [ Skip ]
+fast/loader/plain-text-document-dark-mode.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-multicol/multicol-width-ch-001.xht [ Pass ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2972,6 +2972,7 @@ editing/selection/ios/select-non-editable-text-using-keyboard.html [ Skip ]
 css-dark-mode [ Pass ]
 css-dark-mode/older-systems [ Skip ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Pass ]
+fast/loader/plain-text-document-dark-mode.html [ Pass ]
 
 fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html [ Pass ]
 fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1369,6 +1369,7 @@ css-dark-mode/older-systems [ Skip ]
 inspector/css/force-page-appearance.html [ Pass ]
 editing/pasteboard/paste-dark-mode-color-filtered.html [ Pass ]
 fast/forms/number/number-dark-appearance.html [ Pass ]
+fast/loader/plain-text-document-dark-mode.html [ Pass ]
 
 webkit.org/b/189686 webgl/2.0.0/conformance/textures/misc/tex-image-and-sub-image-2d-with-array-buffer-view.html [ Slow ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -380,6 +380,7 @@ fast/text/selection-is-prevent-defaulted.html [ Skip ]
 
 css-dark-mode [ Pass ]
 css-dark-mode/older-systems [ Skip ]
+fast/loader/plain-text-document-dark-mode.html [ Pass ]
 
 # Tests below are copied from wk2 expectations, because we've marked
 #  as passing the whole fast/events directory.

--- a/Source/WebCore/html/parser/TextDocumentParser.cpp
+++ b/Source/WebCore/html/parser/TextDocumentParser.cpp
@@ -39,18 +39,24 @@ TextDocumentParser::TextDocumentParser(HTMLDocument& document)
 
 void TextDocumentParser::append(RefPtr<StringImpl>&& text)
 {
-    if (!m_haveInsertedFakePreElement)
-        insertFakePreElement();
+    if (!m_hasInsertedFakeFormattingElements)
+        insertFakeFormattingElements();
     HTMLDocumentParser::append(WTFMove(text));
 }
 
-void TextDocumentParser::insertFakePreElement()
+void TextDocumentParser::insertFakeFormattingElements()
 {
     // In principle, we should create a specialized tree builder for
     // TextDocuments, but instead we re-use the existing HTMLTreeBuilder.
-    // We create a fake token and give it to the tree builder rather than
+    // We create fake tokens and give it to the tree builder rather than
     // sending fake bytes through the front-end of the parser to avoid
     // distrubing the line/column number calculations.
+
+    Attribute nameAttribute(nameAttr, "color-scheme"_s);
+    Attribute contentAttribute(contentAttr, "light dark"_s);
+    AtomHTMLToken fakeMeta(HTMLToken::Type::StartTag, metaTag->localName(), { WTFMove(nameAttribute), WTFMove(contentAttribute) });
+    treeBuilder().constructTree(WTFMove(fakeMeta));
+
     Attribute attribute(styleAttr, "word-wrap: break-word; white-space: pre-wrap;"_s);
     AtomHTMLToken fakePre(HTMLToken::Type::StartTag, preTag->localName(), { WTFMove(attribute) });
     treeBuilder().constructTree(WTFMove(fakePre));
@@ -63,7 +69,7 @@ void TextDocumentParser::insertFakePreElement()
     // act like a <plaintext> tag, so we have to force plaintext mode.
     tokenizer().setPLAINTEXTState();
 
-    m_haveInsertedFakePreElement = true;
+    m_hasInsertedFakeFormattingElements = true;
 }
 
 }

--- a/Source/WebCore/html/parser/TextDocumentParser.h
+++ b/Source/WebCore/html/parser/TextDocumentParser.h
@@ -40,9 +40,9 @@ private:
 
     void append(RefPtr<StringImpl>&&) override;
 
-    void insertFakePreElement();
+    void insertFakeFormattingElements();
 
-    bool m_haveInsertedFakePreElement { false };
+    bool m_hasInsertedFakeFormattingElements { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9dbf11ad895f9d2ca09ef3e8305715de7ed75c71
<pre>
Add dark mode support for text files
<a href="https://bugs.webkit.org/show_bug.cgi?id=242950">https://bugs.webkit.org/show_bug.cgi?id=242950</a>
rdar://95050203

Reviewed by Megan Gardner.

Insert a color-scheme &lt;meta&gt; tag when the document tree when parsing a text
document, to opt-in to system dark mode. This logic is similar to how WebKit
inserts a &lt;pre&gt; tag to format the contents of a text document.

* LayoutTests/TestExpectations:
* LayoutTests/fast/loader/plain-text-document-dark-mode-expected-mismatch.html: Added.
* LayoutTests/fast/loader/plain-text-document-dark-mode.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/html/parser/TextDocumentParser.cpp:
(WebCore::TextDocumentParser::append):
(WebCore::TextDocumentParser::insertFakeFormattingElements):
(WebCore::TextDocumentParser::insertFakePreElement): Deleted.
* Source/WebCore/html/parser/TextDocumentParser.h:

Canonical link: <a href="https://commits.webkit.org/252673@main">https://commits.webkit.org/252673@main</a>
</pre>
