### PR TITLE
[git-webkit] Use graphQL API to search for pull requests

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.2',
+    version='5.3.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 2)
+version = Version(5, 3, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))


### PR DESCRIPTION
#### 500b3dbc7c61814787e117e9e724f990f9fa2ec2
<pre>
[git-webkit] Use graphQL API to search for pull requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=242927">https://bugs.webkit.org/show_bug.cgi?id=242927</a>
&lt;rdar://problem/97290312&gt;

Reviewed by Aakash Jain and Ryan Haddad.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.graphql): Added.
(GitHub.request): Add graphql endpoint.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.PRGenerator.find): Use GraphQL API instead of REST API. The GraphQL API is faster and
allows for more flexible queries.
(GitHub.graphql): Added.

Canonical link: <a href="https://commits.webkit.org/252661@main">https://commits.webkit.org/252661@main</a>
</pre>
