### PR TITLE
REGRESSION (252033@main): Auto-PiP for YouTube no longer works on iPad

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -258,7 +258,7 @@ bool VideoFullscreenManager::supportsVideoFullscreen(WebCore::HTMLMediaElementEn
 
 bool VideoFullscreenManager::supportsVideoFullscreenStandby() const
 {
-#if HAVE(UIKIT_WEBKIT_INTERNALS)
+#if PLATFORM(IOS_FAMILY)
     return true;
 #else
     return false;


### PR DESCRIPTION
#### 3f0f00cc79a99b51af46fa40c31069622d04cae4
<pre>
REGRESSION (252033@main): Auto-PiP for YouTube no longer works on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=242953">https://bugs.webkit.org/show_bug.cgi?id=242953</a>
&lt;rdar://97138349&gt;

Reviewed by Jean-Yves Avenard and Chris Dumez.

Before 252033@main, auto-PiP was only enabled on IOS_FAMILY builds that
did not have UIKIT_INTERNALS. 252033@main attempted to enable auto-PiP for
UIKIT_INTERNALS enabled builds but also ended up disabling it on IOS_FAMILY
builds and enabling it on MacOS devices. The intended configuration is for
auto-PiP to work on IOS_FAMILY and UIKIT_INTERNALS enabled builds but not MacOS.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::supportsVideoFullscreenStandby const):

Canonical link: <a href="https://commits.webkit.org/252665@main">https://commits.webkit.org/252665@main</a>
</pre>
