### PR TITLE
Web Inspector: should not include implementation details of the injected script in stack traces

### DIFF
--- a/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
+++ b/LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt
@@ -14,8 +14,6 @@ PASS: Animation created 'web-animation-test'.
   1: createAnimation - inspector/animation/resources/lifecycle-utilities.js:3:15
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 PASS: Animation type should be Web Animation.
 startDelay: 100
 endDelay: 200

--- a/LayoutTests/inspector/canvas/create-context-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-2d-expected.txt
@@ -11,8 +11,6 @@ PASS: Canvas context should be 2D.
   1: createAttachedCanvas - inspector/canvas/resources/create-context-utilities.js:4:36
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -22,8 +20,6 @@ PASS: Canvas context should be 2D.
   1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -34,8 +30,6 @@ PASS: Canvas context should be 2D.
   1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.
 

--- a/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
@@ -11,8 +11,6 @@ PASS: Canvas context should be Bitmap Renderer.
   1: createAttachedCanvas - inspector/canvas/resources/create-context-utilities.js:4:36
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -22,8 +20,6 @@ PASS: Canvas context should be Bitmap Renderer.
   1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 

--- a/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
@@ -11,8 +11,6 @@ PASS: Canvas context should be WebGL.
   1: createAttachedCanvas - inspector/canvas/resources/create-context-utilities.js:4:36
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -22,8 +20,6 @@ PASS: Canvas context should be WebGL.
   1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -34,8 +30,6 @@ PASS: Canvas context should be WebGL.
   1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.
 

--- a/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
@@ -11,8 +11,6 @@ PASS: Canvas context should be WebGL2.
   1: createAttachedCanvas - inspector/canvas/resources/create-context-utilities.js:4:36
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -22,8 +20,6 @@ PASS: Canvas context should be WebGL2.
   1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Removed canvas has expected ID.
 
@@ -34,8 +30,6 @@ PASS: Canvas context should be WebGL2.
   1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
   2: Global Code - [program code]
   3: evaluateWithScopeExtension - [native code]
-  4: (anonymous function) - [native code]
-  5: _wrapCall - [native code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.
 

--- a/LayoutTests/inspector/canvas/recording-2d-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-2d-frameCount-expected.txt
@@ -46,8 +46,6 @@ frames:
         5: performActions
         6: Global Code
         7: evaluateWithScopeExtension
-        8: (anonymous function)
-        9: _wrapCall
     1: arc(6, 7, 8, 9, 10, true)
       swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
       trace:
@@ -59,6 +57,4 @@ frames:
         5: performActions
         6: Global Code
         7: evaluateWithScopeExtension
-        8: (anonymous function)
-        9: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-2d-full-expected.txt
@@ -46,8 +46,6 @@ frames:
         5: performActions
         6: Global Code
         7: evaluateWithScopeExtension
-        8: (anonymous function)
-        9: _wrapCall
     1: arc(6, 7, 8, 9, 10, true)
       swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
       trace:
@@ -59,8 +57,6 @@ frames:
         5: performActions
         6: Global Code
         7: evaluateWithScopeExtension
-        8: (anonymous function)
-        9: _wrapCall
   1: (duration)
     0: arcTo(1, 2, 3, 4, 5)
       swizzleTypes: [Number, Number, Number, Number, Number]

--- a/LayoutTests/inspector/canvas/recording-2d-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-2d-memoryLimit-expected.txt
@@ -46,6 +46,4 @@ frames:
         5: performActions
         6: Global Code
         7: evaluateWithScopeExtension
-        8: (anonymous function)
-        9: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-webgl-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-frameCount-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-full-expected.txt
@@ -21,8 +21,6 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
   1: (duration)
     0: attachShader(0, 0)
       swizzleTypes: [WebGLProgram, WebGLShader]

--- a/LayoutTests/inspector/canvas/recording-webgl-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-memoryLimit-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-webgl-snapshots-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl-snapshots-expected.txt
@@ -19,8 +19,6 @@ frames:
         1: performActions
         2: Global Code
         3: evaluateWithScopeExtension
-        4: (anonymous function)
-        5: _wrapCall
     1: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -29,8 +27,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     2: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -39,8 +35,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     3: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -50,8 +44,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     4: drawArrays(4, 0, 3)
       swizzleTypes: [Number, Number, Number]
       trace:
@@ -60,8 +52,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     5: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -71,8 +61,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     6: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -81,8 +69,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     7: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -92,8 +78,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     8: bufferData(34963, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
       trace:
@@ -102,8 +86,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     9: drawElements(4, 3, 5123, 0)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -112,8 +94,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     10: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -123,8 +103,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     11: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -133,7 +111,5 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
 

--- a/LayoutTests/inspector/canvas/recording-webgl2-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl2-frameCount-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-webgl2-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl2-full-expected.txt
@@ -21,8 +21,6 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
   1: (duration)
     0: attachShader(0, 0)
       swizzleTypes: [WebGLProgram, WebGLShader]

--- a/LayoutTests/inspector/canvas/recording-webgl2-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl2-memoryLimit-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/inspector/canvas/recording-webgl2-snapshots-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-webgl2-snapshots-expected.txt
@@ -19,8 +19,6 @@ frames:
         1: performActions
         2: Global Code
         3: evaluateWithScopeExtension
-        4: (anonymous function)
-        5: _wrapCall
     1: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -29,8 +27,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     2: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -39,8 +35,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     3: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -50,8 +44,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     4: drawArrays(4, 0, 3)
       swizzleTypes: [Number, Number, Number]
       trace:
@@ -60,8 +52,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     5: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -71,8 +61,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     6: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -81,8 +69,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     7: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -92,8 +78,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     8: bufferData(34963, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
       trace:
@@ -102,8 +86,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     9: drawElements(4, 3, 5123, 0)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -112,8 +94,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     10: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -123,8 +103,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     11: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -133,7 +111,5 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
 

--- a/LayoutTests/inspector/model/remote-object/error-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/error-expected.txt
@@ -31,7 +31,7 @@ EXPRESSION: error = null; try { [].x.x; } catch (e) { error = e; }; error
       {
         "_name": "stack",
         "_type": "string",
-        "_value": "global code@\nevaluateWithScopeExtension@[native code]\n@[native code]\n_wrapCall@[native code]"
+        "_value": "global code@\nevaluateWithScopeExtension@[native code]"
       }
     ],
     "_entries": null
@@ -70,7 +70,7 @@ EXPRESSION: error = null; try { eval("if()"); } catch (e) { error = e; }; error
       {
         "_name": "stack",
         "_type": "string",
-        "_value": "eval@[native code]\nglobal code@\nevaluateWithScopeE…tive code]\n@[native code]\n_wrapCall@[native code]"
+        "_value": "eval@[native code]\nglobal code@\nevaluateWithScopeExtension@[native code]"
       }
     ],
     "_entries": null
@@ -104,7 +104,7 @@ EXPRESSION: error = null; try { document.createTextNode("").splitText(100); } ca
       {
         "_name": "stack",
         "_type": "string",
-        "_value": "splitText@[native code]\nglobal code@\nevaluateWithS…tive code]\n@[native code]\n_wrapCall@[native code]"
+        "_value": "splitText@[native code]\nglobal code@\nevaluateWithScopeExtension@[native code]"
       },
       {
         "_name": "code",

--- a/LayoutTests/inspector/model/stack-trace-expected.txt
+++ b/LayoutTests/inspector/model/stack-trace-expected.txt
@@ -8,7 +8,7 @@ PASS: ConsoleMessage should have StackTrace.
 PASS: CallFrame in StackTrace has no identifier.
 PASS: CallFrame in StackTrace has no thisObject.
 PASS: CallFrame in StackTrace has no scopeChain.
-StackTrace: 10
+StackTrace: 8
   1: foo (Anonymous Script 1 (line 1)) - nativeCode (false) programCode (false)
   2: Eval Code (Anonymous Script 1 (line 1)) - nativeCode (false) programCode (true)
   3: eval - nativeCode (true) programCode (false)
@@ -17,8 +17,6 @@ StackTrace: 10
   6: triggerConsoleMessage (stack-trace.html:9) - nativeCode (false) programCode (false)
   7: Global Code (Anonymous Script 2 (line 1)) - nativeCode (false) programCode (true)
   8: evaluateWithScopeExtension - nativeCode (true) programCode (false)
-  9:  - nativeCode (true) programCode (false)
-  10: _wrapCall - nativeCode (true) programCode (false)
 
 -- Running test case: WI.StackTrace.FirstNonNativeNonAnonymousNotBlackboxedCallFrame.Normal
 PASS: Should be able to get the first non-native non-anonymous unblackboxed call frame.

--- a/LayoutTests/inspector/timeline/line-column-expected.txt
+++ b/LayoutTests/inspector/timeline/line-column-expected.txt
@@ -60,16 +60,8 @@ PASS: Capturing started.
                 "scriptId": "<filtered>",
                 "lineNumber": 0,
                 "columnNumber": 0
-              },
-              {
-                "functionName": "",
-                "url": "",
-                "scriptId": "<filtered>",
-                "lineNumber": "<filtered>",
-                "columnNumber": "<filtered>"
               }
-            ],
-            "truncated": true
+            ]
           },
           "frameId": "<filtered>",
           "data": {
@@ -116,16 +108,8 @@ PASS: Capturing started.
             "scriptId": "<filtered>",
             "lineNumber": 0,
             "columnNumber": 0
-          },
-          {
-            "functionName": "",
-            "url": "",
-            "scriptId": "<filtered>",
-            "lineNumber": "<filtered>",
-            "columnNumber": "<filtered>"
           }
-        ],
-        "truncated": true
+        ]
       },
       "frameId": "<filtered>",
       "data": {
@@ -179,16 +163,8 @@ PASS: Capturing started.
             "scriptId": "<filtered>",
             "lineNumber": 0,
             "columnNumber": 0
-          },
-          {
-            "functionName": "",
-            "url": "",
-            "scriptId": "<filtered>",
-            "lineNumber": "<filtered>",
-            "columnNumber": "<filtered>"
           }
-        ],
-        "truncated": true
+        ]
       },
       "frameId": "<filtered>",
       "data": {

--- a/LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt
@@ -56,16 +56,8 @@ PASS: Capturing started.
             "scriptId": "<filtered>",
             "lineNumber": 0,
             "columnNumber": 0
-          },
-          {
-            "functionName": "",
-            "url": "",
-            "scriptId": "<filtered>",
-            "lineNumber": "<filtered>",
-            "columnNumber": "<filtered>"
           }
-        ],
-        "truncated": true
+        ]
       },
       "frameId": "<filtered>",
       "data": {
@@ -112,16 +104,8 @@ PASS: Capturing started.
         "scriptId": "<filtered>",
         "lineNumber": 0,
         "columnNumber": 0
-      },
-      {
-        "functionName": "",
-        "url": "",
-        "scriptId": "<filtered>",
-        "lineNumber": "<filtered>",
-        "columnNumber": "<filtered>"
       }
-    ],
-    "truncated": true
+    ]
   },
   "frameId": "<filtered>",
   "data": {
@@ -167,16 +151,8 @@ PASS: Capturing started.
         "scriptId": "<filtered>",
         "lineNumber": 0,
         "columnNumber": 0
-      },
-      {
-        "functionName": "",
-        "url": "",
-        "scriptId": "<filtered>",
-        "lineNumber": "<filtered>",
-        "columnNumber": "<filtered>"
       }
-    ],
-    "truncated": true
+    ]
   },
   "frameId": "<filtered>",
   "data": {

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-frameCount-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-frameCount-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt
@@ -21,8 +21,6 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
   1: (duration)
     0: attachShader(0, 0)
       swizzleTypes: [WebGLProgram, WebGLShader]

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-memoryLimit-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-memoryLimit-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt
@@ -19,8 +19,6 @@ frames:
         1: performActions
         2: Global Code
         3: evaluateWithScopeExtension
-        4: (anonymous function)
-        5: _wrapCall
     1: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -29,8 +27,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     2: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -39,8 +35,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     3: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -50,8 +44,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     4: drawArrays(4, 0, 3)
       swizzleTypes: [Number, Number, Number]
       trace:
@@ -60,8 +52,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     5: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -71,8 +61,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     6: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -81,8 +69,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     7: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -92,8 +78,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     8: bufferData(34963, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
       trace:
@@ -102,8 +86,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     9: drawElements(4, 3, 5123, 0)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -112,8 +94,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     10: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -123,8 +103,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     11: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -133,7 +111,5 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
 

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-frameCount-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-frameCount-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt
@@ -21,8 +21,6 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
   1: (duration)
     0: attachShader(0, 0)
       swizzleTypes: [WebGLProgram, WebGLShader]

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-memoryLimit-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-memoryLimit-expected.txt
@@ -21,6 +21,4 @@ frames:
         3: performActions
         4: Global Code
         5: evaluateWithScopeExtension
-        6: (anonymous function)
-        7: _wrapCall
 

--- a/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt
+++ b/LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt
@@ -19,8 +19,6 @@ frames:
         1: performActions
         2: Global Code
         3: evaluateWithScopeExtension
-        4: (anonymous function)
-        5: _wrapCall
     1: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -29,8 +27,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     2: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -39,8 +35,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     3: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -50,8 +44,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     4: drawArrays(4, 0, 3)
       swizzleTypes: [Number, Number, Number]
       trace:
@@ -60,8 +52,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     5: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -71,8 +61,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     6: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -81,8 +69,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     7: bufferData(34962, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
@@ -92,8 +78,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     8: bufferData(34963, 0, 35044)
       swizzleTypes: [Number, TypedArray, Number]
       trace:
@@ -102,8 +86,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     9: drawElements(4, 3, 5123, 0)
       swizzleTypes: [Number, Number, Number, Number]
       trace:
@@ -112,8 +94,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
     10: clearColor(0, 0, 0, 1)
       swizzleTypes: [Number, Number, Number, Number]
@@ -123,8 +103,6 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
     11: clear(16384)
       swizzleTypes: [Number]
       trace:
@@ -133,7 +111,5 @@ frames:
         2: performActions
         3: Global Code
         4: evaluateWithScopeExtension
-        5: (anonymous function)
-        6: _wrapCall
       snapshot: <PASS: content changed>
 

--- a/Source/JavaScriptCore/API/JSScriptRef.cpp
+++ b/Source/JavaScriptCore/API/JSScriptRef.cpp
@@ -73,7 +73,7 @@ private:
 static bool parseScript(VM& vm, const SourceCode& source, ParserError& error)
 {
     return !!JSC::parse<JSC::ProgramNode>(
-        vm, source, Identifier(), JSParserBuiltinMode::NotBuiltin,
+        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, SuperBinding::NotNeeded,
         error);
 }

--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -979,11 +979,11 @@ JSCCheckSyntaxResult jsc_context_check_syntax(JSCContext* context, const char* c
     JSC::ParserError error;
     switch (mode) {
     case JSC_CHECK_SYNTAX_MODE_SCRIPT:
-        success = !!JSC::parse<JSC::ProgramNode>(vm, source, JSC::Identifier(), JSC::JSParserBuiltinMode::NotBuiltin,
+        success = !!JSC::parse<JSC::ProgramNode>(vm, source, JSC::Identifier(), JSC::ImplementationVisibility::Public, JSC::JSParserBuiltinMode::NotBuiltin,
             JSC::JSParserStrictMode::NotStrict, JSC::JSParserScriptMode::Classic, JSC::SourceParseMode::ProgramMode, JSC::SuperBinding::NotNeeded, error);
         break;
     case JSC_CHECK_SYNTAX_MODE_MODULE:
-        success = !!JSC::parse<JSC::ModuleProgramNode>(vm, source, JSC::Identifier(), JSC::JSParserBuiltinMode::NotBuiltin,
+        success = !!JSC::parse<JSC::ModuleProgramNode>(vm, source, JSC::Identifier(), JSC::ImplementationVisibility::Public, JSC::JSParserBuiltinMode::NotBuiltin,
             JSC::JSParserStrictMode::Strict, JSC::JSParserScriptMode::Module, JSC::SourceParseMode::ModuleAnalyzeMode, JSC::SuperBinding::NotNeeded, error);
         break;
     }

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py
@@ -133,10 +133,6 @@ class BuiltinsGenerator:
         if function.is_naked_constructor:
             constructorKind = "Naked"
 
-        visibility = "Public"
-        if function.is_link_time_constant:
-            visibility = "Private"
-
         return {
             'codeName': BuiltinsGenerator.mangledNameForFunction(function) + 'Code',
             'embeddedSource': embeddedSource,
@@ -144,7 +140,7 @@ class BuiltinsGenerator:
             'originalSource': text + "\n",
             'constructAbility': constructAbility,
             'constructorKind': constructorKind,
-            'visibility': visibility,
+            'visibility': function.visibility,
             'intrinsic': function.intrinsic
         }
 

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -204,7 +204,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     end.endOffset = std::numeric_limits<unsigned>::max();
 
     FunctionMetadataNode metadata(
-        start, end, startColumn, endColumn, source.startOffset() + functionKeywordStart, source.startOffset() + functionNameStart, source.startOffset() + parametersStart,
+        start, end, startColumn, endColumn, source.startOffset() + functionKeywordStart, source.startOffset() + functionNameStart, source.startOffset() + parametersStart, implementationVisibility,
         isInStrictContext ? StrictModeLexicalFeature : NoLexicalFeatures, constructorKind, constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded,
         parameterCount, parseMode, isArrowFunctionBodyExpression);
 
@@ -217,7 +217,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         ParserError error;
         JSParserBuiltinMode builtinMode = isBuiltinDefaultClassConstructor ? JSParserBuiltinMode::NotBuiltin : JSParserBuiltinMode::Builtin;
         std::unique_ptr<ProgramNode> program = parse<ProgramNode>(
-            vm, source, Identifier(), builtinMode,
+            vm, source, Identifier(), implementationVisibility, builtinMode,
             JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, SuperBinding::NotNeeded, error,
             &positionBeforeLastNewlineFromParser, constructorKind);
 
@@ -258,7 +258,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
         }
     }
 
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, implementationVisibility, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, &metadata, kind, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
     return functionExecutable;
 }
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -57,7 +57,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     ASSERT(isFunctionParseMode(executable->parseMode()));
     auto* classFieldLocations = executable->classFieldLocations();
     std::unique_ptr<FunctionNode> function = parse<FunctionNode>(
-        vm, source, executable->name(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->superBinding(), error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None, nullptr, nullptr, classFieldLocations);
+        vm, source, executable->name(), executable->implementationVisibility(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->superBinding(), error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None, nullptr, nullptr, classFieldLocations);
 
     if (!function) {
         ASSERT(error.isValid());
@@ -81,7 +81,7 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     return result;
 }
 
-UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ImplementationVisibility implementationVisibility, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
+UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* structure, const SourceCode& parentSource, FunctionMetadataNode* node, UnlinkedFunctionKind kind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor)
     : Base(vm, structure)
     , m_firstLineOffset(node->firstLine() - parentSource.firstLine().oneBasedInt())
     , m_isGeneratedFromCache(false)
@@ -107,7 +107,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_features(0)
     , m_constructorKind(static_cast<unsigned>(node->constructorKind()))
     , m_sourceParseMode(node->parseMode())
-    , m_implementationVisibility(static_cast<unsigned>(implementationVisibility))
+    , m_implementationVisibility(static_cast<unsigned>(node->implementationVisibility()))
     , m_lexicalScopeFeatures(node->lexicalScopeFeatures())
     , m_functionMode(static_cast<unsigned>(node->functionMode()))
     , m_derivedContextType(static_cast<unsigned>(derivedContextType))
@@ -117,7 +117,7 @@ UnlinkedFunctionExecutable::UnlinkedFunctionExecutable(VM& vm, Structure* struct
     , m_ecmaName(node->ecmaName())
 {
     // Make sure these bitfields are adequately wide.
-    ASSERT(m_implementationVisibility == static_cast<unsigned>(implementationVisibility));
+    ASSERT(m_implementationVisibility == static_cast<unsigned>(node->implementationVisibility()));
     ASSERT(m_constructAbility == static_cast<unsigned>(constructAbility));
     ASSERT(m_constructorKind == static_cast<unsigned>(node->constructorKind()));
     ASSERT(m_functionMode == static_cast<unsigned>(node->functionMode()));

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -72,10 +72,10 @@ public:
         return &vm.unlinkedFunctionExecutableSpace();
     }
 
-    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ImplementationVisibility implementationVisibility, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
+    static UnlinkedFunctionExecutable* create(VM& vm, const SourceCode& source, FunctionMetadataNode* node, UnlinkedFunctionKind unlinkedFunctionKind, ConstructAbility constructAbility, JSParserScriptMode scriptMode, RefPtr<TDZEnvironmentLink> parentScopeTDZVariables, std::optional<PrivateNameEnvironment> parentPrivateNameEnvironment, DerivedContextType derivedContextType, NeedsClassFieldInitializer needsClassFieldInitializer, PrivateBrandRequirement privateBrandRequirement, bool isBuiltinDefaultClassConstructor = false)
     {
         UnlinkedFunctionExecutable* instance = new (NotNull, allocateCell<UnlinkedFunctionExecutable>(vm))
-            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, implementationVisibility, constructAbility, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
+            UnlinkedFunctionExecutable(vm, vm.unlinkedFunctionExecutableStructure.get(), source, node, unlinkedFunctionKind, constructAbility, scriptMode, WTFMove(parentScopeTDZVariables), WTFMove(parentPrivateNameEnvironment), derivedContextType, needsClassFieldInitializer, privateBrandRequirement, isBuiltinDefaultClassConstructor);
         instance->finishCreation(vm);
         return instance;
     }
@@ -245,7 +245,7 @@ public:
     }
 
 private:
-    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ImplementationVisibility, ConstructAbility, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
+    UnlinkedFunctionExecutable(VM&, Structure*, const SourceCode&, FunctionMetadataNode*, UnlinkedFunctionKind, ConstructAbility, JSParserScriptMode, RefPtr<TDZEnvironmentLink>, std::optional<PrivateNameEnvironment>, JSC::DerivedContextType, JSC::NeedsClassFieldInitializer, PrivateBrandRequirement, bool isBuiltinDefaultClassConstructor);
     UnlinkedFunctionExecutable(Decoder&, const CachedFunctionExecutable&);
 
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3334,9 +3334,9 @@ RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* 
     SourceParseMode parseMode = SourceParseMode::ClassFieldInitializerMode;
     ConstructAbility constructAbility = ConstructAbility::CannotConstruct;
 
-    FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, StrictModeLexicalFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
+    FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, ImplementationVisibility::Private, StrictModeLexicalFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
     metadata.finishParsing(m_scopeNode->source(), Identifier(), FunctionMode::MethodDefinition);
-    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, ImplementationVisibility::Private, constructAbility, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(variablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
     initializer->setClassFieldLocations(WTFMove(classFieldLocations));
 
     unsigned index = m_codeBlock->addFunctionExpr(initializer);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1158,10 +1158,7 @@ namespace JSC {
             if (parseMode == SourceParseMode::MethodMode && metadata->constructorKind() != ConstructorKind::None)
                 constructAbility = ConstructAbility::CanConstruct;
 
-            // FIXME: <https://webkit.org/b/242808> add a way to mark sub-functions as `ImplementationVisibility::Private`
-            auto implementationVisibility = ImplementationVisibility::Public;
-
-            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, implementationVisibility, constructAbility, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
+            return UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, scriptMode(), WTFMove(optionalVariablesUnderTDZ), WTFMove(parentPrivateNameEnvironment), newDerivedContextType, needsClassFieldInitializer, privateBrandRequirement);
         }
 
         RefPtr<TDZEnvironmentLink> getVariablesUnderTDZ();

--- a/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
@@ -136,7 +136,7 @@ bool gatherDebuggerParseData(VM& vm, const SourceCode& source, DebuggerParseData
     JSParserScriptMode scriptMode = DebuggerParseInfo<T>::scriptMode;
 
     ParserError error;
-    std::unique_ptr<RootNode> rootNode = parse<RootNode>(vm, source, Identifier(),
+    std::unique_ptr<RootNode> rootNode = parse<RootNode>(vm, source, Identifier(), ImplementationVisibility::Public,
         JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, parseMode, SuperBinding::NotNeeded,
         error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None,
         &debuggerParseData);

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -53,6 +53,7 @@ function createArrayWithoutPrototype(/* value1, value2, ... */)
 }
 
 @linkTimeConstant
+@visibility=PrivateRecursive
 function createInspectorInjectedScript(InjectedScriptHost, inspectedGlobalObject, injectedScriptId)
 {
 

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -463,14 +463,14 @@ public:
     FunctionMetadataNode* createFunctionMetadata(
         const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, 
         unsigned startColumn, unsigned endColumn, int functionKeywordStart, 
-        int functionNameStart, int parametersStart, LexicalScopeFeatures lexicalScopeFeatures, 
+        int functionNameStart, int parametersStart, ImplementationVisibility implementationVisibility, LexicalScopeFeatures lexicalScopeFeatures,
         ConstructorKind constructorKind, SuperBinding superBinding,
         unsigned parameterCount,
         SourceParseMode mode, bool isArrowFunctionBodyExpression)
     {
         return new (m_parserArena) FunctionMetadataNode(
             m_parserArena, startLocation, endLocation, startColumn, endColumn, 
-            functionKeywordStart, functionNameStart, parametersStart, 
+            functionKeywordStart, functionNameStart, parametersStart, implementationVisibility,
             lexicalScopeFeatures, constructorKind, superBinding,
             parameterCount, mode, isArrowFunctionBodyExpression);
     }

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -197,9 +197,10 @@ EvalNode::EvalNode(ParserArena& parserArena, const JSTokenLocation& startLocatio
 FunctionMetadataNode::FunctionMetadataNode(
     ParserArena&, const JSTokenLocation& startLocation, 
     const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, 
-    int functionKeywordStart, int functionNameStart, int parametersStart, LexicalScopeFeatures lexicalScopeFeatures,
+    int functionKeywordStart, int functionNameStart, int parametersStart, ImplementationVisibility implementationVisibility, LexicalScopeFeatures lexicalScopeFeatures,
     ConstructorKind constructorKind, SuperBinding superBinding, unsigned parameterCount, SourceParseMode mode, bool isArrowFunctionBodyExpression)
         : Node(endLocation)
+        , m_implementationVisibility(static_cast<unsigned>(implementationVisibility))
         , m_lexicalScopeFeatures(lexicalScopeFeatures)
         , m_superBinding(static_cast<unsigned>(superBinding))
         , m_constructorKind(static_cast<unsigned>(constructorKind))
@@ -215,6 +216,7 @@ FunctionMetadataNode::FunctionMetadataNode(
         , m_startStartOffset(startLocation.startOffset)
         , m_parameterCount(parameterCount)
 {
+    ASSERT(m_implementationVisibility == static_cast<unsigned>(implementationVisibility));
     ASSERT(m_superBinding == static_cast<unsigned>(superBinding));
     ASSERT(m_constructorKind == static_cast<unsigned>(constructorKind));
 }
@@ -222,9 +224,10 @@ FunctionMetadataNode::FunctionMetadataNode(
 FunctionMetadataNode::FunctionMetadataNode(
     const JSTokenLocation& startLocation, 
     const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, 
-    int functionKeywordStart, int functionNameStart, int parametersStart, LexicalScopeFeatures lexicalScopeFeatures, 
+    int functionKeywordStart, int functionNameStart, int parametersStart, ImplementationVisibility implementationVisibility, LexicalScopeFeatures lexicalScopeFeatures,
     ConstructorKind constructorKind, SuperBinding superBinding, unsigned parameterCount, SourceParseMode mode, bool isArrowFunctionBodyExpression)
         : Node(endLocation)
+        , m_implementationVisibility(static_cast<unsigned>(implementationVisibility))
         , m_lexicalScopeFeatures(lexicalScopeFeatures)
         , m_superBinding(static_cast<unsigned>(superBinding))
         , m_constructorKind(static_cast<unsigned>(constructorKind))
@@ -240,6 +243,7 @@ FunctionMetadataNode::FunctionMetadataNode(
         , m_startStartOffset(startLocation.startOffset)
         , m_parameterCount(parameterCount)
 {
+    ASSERT(m_implementationVisibility == static_cast<unsigned>(implementationVisibility));
     ASSERT(m_superBinding == static_cast<unsigned>(superBinding));
     ASSERT(m_constructorKind == static_cast<unsigned>(constructorKind));
 }
@@ -260,6 +264,7 @@ void FunctionMetadataNode::setEndPosition(JSTextPosition position)
 bool FunctionMetadataNode::operator==(const FunctionMetadataNode& other) const
 {
     return m_parseMode == other.m_parseMode
+        && m_implementationVisibility == other.m_implementationVisibility
         && m_lexicalScopeFeatures == other.m_lexicalScopeFeatures
         && m_superBinding == other.m_superBinding
         && m_constructorKind == other.m_constructorKind
@@ -283,6 +288,7 @@ bool FunctionMetadataNode::operator==(const FunctionMetadataNode& other) const
 void FunctionMetadataNode::dump(PrintStream& stream) const
 {
     stream.println("m_parseMode ", static_cast<uint32_t>(m_parseMode));
+    stream.println("m_implementationVisibility ", m_implementationVisibility);
     stream.println("m_lexicalScopeFeatures ", m_lexicalScopeFeatures);
     stream.println("m_superBinding ", m_superBinding);
     stream.println("m_constructorKind ", m_constructorKind);

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "BytecodeIntrinsicRegistry.h"
+#include "ImplementationVisibility.h"
 #include "JITCode.h"
 #include "Label.h"
 #include "ParserArena.h"
@@ -2190,13 +2191,13 @@ namespace JSC {
         FunctionMetadataNode(
             ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, 
             unsigned startColumn, unsigned endColumn, int functionKeywordStart, 
-            int functionNameStart, int parametersStart, LexicalScopeFeatures, 
+            int functionNameStart, int parametersStart, ImplementationVisibility, LexicalScopeFeatures,
             ConstructorKind, SuperBinding, unsigned parameterCount,
             SourceParseMode, bool isArrowFunctionBodyExpression);
         FunctionMetadataNode(
             const JSTokenLocation& start, const JSTokenLocation& end, 
             unsigned startColumn, unsigned endColumn, int functionKeywordStart, 
-            int functionNameStart, int parametersStart, LexicalScopeFeatures, 
+            int functionNameStart, int parametersStart, ImplementationVisibility, LexicalScopeFeatures,
             ConstructorKind, SuperBinding, unsigned parameterCount,
             SourceParseMode, bool isArrowFunctionBodyExpression);
 
@@ -2229,6 +2230,7 @@ namespace JSC {
         void setClassSource(const SourceCode& source) { m_classSource = source; }
 
         int startStartOffset() const { return m_startStartOffset; }
+        ImplementationVisibility implementationVisibility() const { return static_cast<ImplementationVisibility>(m_implementationVisibility); }
         LexicalScopeFeatures lexicalScopeFeatures() const { return static_cast<LexicalScopeFeatures>(m_lexicalScopeFeatures); }
         SuperBinding superBinding() { return static_cast<SuperBinding>(m_superBinding); }
         ConstructorKind constructorKind() { return static_cast<ConstructorKind>(m_constructorKind); }
@@ -2255,6 +2257,7 @@ namespace JSC {
         }
 
     public:
+        unsigned m_implementationVisibility : bitWidthOfImplementationVisibility;
         unsigned m_lexicalScopeFeatures : bitWidthOfLexicalScopeFeatures;
         unsigned m_superBinding : 1;
         unsigned m_constructorKind : 2;

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -127,12 +127,13 @@ void Parser<LexerType>::logError(bool shouldPrintToken, Args&&... args)
 }
 
 template <typename LexerType>
-Parser<LexerType>::Parser(VM& vm, const SourceCode& source, JSParserBuiltinMode builtinMode, JSParserStrictMode strictMode, JSParserScriptMode scriptMode, SourceParseMode parseMode, SuperBinding superBinding, ConstructorKind defaultConstructorKindForTopLevelFunction, DerivedContextType derivedContextType, bool isEvalContext, EvalContextType evalContextType, DebuggerParseData* debuggerParseData, bool isInsideOrdinaryFunction)
+Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibility implementationVisibility, JSParserBuiltinMode builtinMode, JSParserStrictMode strictMode, JSParserScriptMode scriptMode, SourceParseMode parseMode, SuperBinding superBinding, ConstructorKind defaultConstructorKindForTopLevelFunction, DerivedContextType derivedContextType, bool isEvalContext, EvalContextType evalContextType, DebuggerParseData* debuggerParseData, bool isInsideOrdinaryFunction)
     : m_vm(vm)
     , m_source(&source)
     , m_hasStackOverflow(false)
     , m_allowsIn(true)
     , m_statementDepth(0)
+    , m_implementationVisibility(implementationVisibility)
     , m_parsingBuiltin(builtinMode == JSParserBuiltinMode::Builtin)
     , m_parseMode(parseMode)
     , m_scriptMode(scriptMode)
@@ -367,7 +368,9 @@ template <class TreeBuilder> bool Parser<LexerType>::isArrowFunctionParameters(T
             SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
             // We make fake scope, otherwise parseFormalParameters will add variable to current scope that lead to errors
             AutoPopScopeRef fakeScope(this, pushScope());
+
             fakeScope->setSourceParseMode(SourceParseMode::ArrowFunctionMode);
+            resetImplementationVisibilityIfNeeded();
 
             unsigned parametersCount = 0;
             bool isArrowFunctionParameterList = true;
@@ -542,7 +545,10 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
 
     {
         AutoPopScopeRef generatorBodyScope(this, pushScope());
+
         generatorBodyScope->setSourceParseMode(SourceParseMode::GeneratorBodyMode);
+        resetImplementationVisibilityIfNeeded();
+
         generatorBodyScope->setConstructorKind(ConstructorKind::None);
         generatorBodyScope->setExpectedSuperBinding(m_superBinding);
 
@@ -550,7 +556,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseGenerato
         failIfFalse(parseSourceElements(generatorFunctionContext, mode), "Cannot parse the body of a generator");
         popScope(generatorBodyScope, TreeBuilder::NeedsFreeVariableInfo);
     }
-    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, SourceParseMode::GeneratorBodyMode, false);
+    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, implementationVisibility(), lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, SourceParseMode::GeneratorBodyMode, false);
 
     info.endLine = tokenLine();
     info.endOffset = m_token.m_data.offset;
@@ -586,7 +592,10 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
     SetForScope innerParseMode(m_parseMode, parseMode);
     {
         AutoPopScopeRef asyncFunctionBodyScope(this, pushScope());
+
         asyncFunctionBodyScope->setSourceParseMode(sourceParseMode());
+        resetImplementationVisibilityIfNeeded();
+
         SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
         if (isArrowFunctionBodyExpression) {
             if (m_debuggerParseData)
@@ -601,7 +610,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncFun
         }
         popScope(asyncFunctionBodyScope, TreeBuilder::NeedsFreeVariableInfo);
     }
-    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
+    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, implementationVisibility(), lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
 
     info.endLine = tokenLine();
     info.endOffset = isArrowFunctionBodyExpression ? tokenLocation().endOffset : m_token.m_data.offset;
@@ -637,7 +646,10 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
     SetForScope innerParseMode(m_parseMode, parseMode);
     {
         AutoPopScopeRef asyncFunctionBodyScope(this, pushScope());
+
         asyncFunctionBodyScope->setSourceParseMode(sourceParseMode());
+        resetImplementationVisibilityIfNeeded();
+
         SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
         if (isArrowFunctionBodyExpression) {
             if (m_debuggerParseData)
@@ -652,7 +664,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseAsyncGen
         }
         popScope(asyncFunctionBodyScope, TreeBuilder::NeedsFreeVariableInfo);
     }
-    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, parseMode, isArrowFunctionBodyExpression);
+    info.body = context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, tokenColumn(), functionKeywordStart, functionNameStart, parametersStart, implementationVisibility(), lexicalScopeFeatures(), ConstructorKind::None, m_superBinding, info.parameterCount, parseMode, isArrowFunctionBodyExpression);
 
     info.endLine = tokenLine();
     info.endOffset = isArrowFunctionBodyExpression ? tokenLocation().endOffset : m_token.m_data.offset;
@@ -2162,7 +2174,7 @@ template <class TreeBuilder> TreeFunctionBody Parser<LexerType>::parseFunctionBo
         if (match(CLOSEBRACE)) {
             unsigned endColumn = tokenColumn();
             SuperBinding functionSuperBinding = adjustSuperBindingForBaseConstructor(constructorKind, superBinding, currentScope());
-            return context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, endColumn, functionKeywordStart, functionNameStart, parametersStart, lexicalScopeFeatures(), constructorKind, functionSuperBinding, parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
+            return context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, endColumn, functionKeywordStart, functionNameStart, parametersStart, implementationVisibility(), lexicalScopeFeatures(), constructorKind, functionSuperBinding, parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
         }
     }
 
@@ -2181,7 +2193,7 @@ template <class TreeBuilder> TreeFunctionBody Parser<LexerType>::parseFunctionBo
     }
     unsigned endColumn = tokenColumn();
     SuperBinding functionSuperBinding = adjustSuperBindingForBaseConstructor(constructorKind, superBinding, currentScope());
-    return context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, endColumn, functionKeywordStart, functionNameStart, parametersStart, lexicalScopeFeatures(), constructorKind, functionSuperBinding, parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
+    return context.createFunctionMetadata(startLocation, tokenLocation(), startColumn, endColumn, functionKeywordStart, functionNameStart, parametersStart, implementationVisibility(), lexicalScopeFeatures(), constructorKind, functionSuperBinding, parameterCount, sourceParseMode(), isArrowFunctionBodyExpression);
 }
 
 static const char* stringArticleForFunctionMode(SourceParseMode mode)
@@ -2372,9 +2384,13 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     const char* isDisallowedAwaitFunctionNameReason = functionNameIsAwait && !canUseIdentifierAwait() ? disallowedIdentifierAwaitReason() : nullptr;
 
     AutoPopScopeRef functionScope(this, pushScope());
+
     functionScope->setSourceParseMode(mode);
+    resetImplementationVisibilityIfNeeded();
+
     functionScope->setExpectedSuperBinding(expectedSuperBinding);
     functionScope->setConstructorKind(constructorKind);
+
     SetForScope functionParsePhasePoisoner(m_parserState.functionParsePhase, FunctionParsePhase::Body);
     int functionNameStart = m_token.m_location.startOffset;
     const Identifier* lastFunctionName = m_parserState.lastFunctionName;
@@ -2422,9 +2438,13 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
             SuperBinding functionSuperBinding = adjustSuperBindingForBaseConstructor(constructorKind, expectedSuperBinding, cachedInfo->needsSuperBinding, cachedInfo->usesEval, cachedInfo->innerArrowFunctionFeatures);
 
+            // Grab this from the current `Scope` instead of saving it to `SourceProviderCacheItem`
+            // since it's trivial to compute each time.
+            auto implementationVisibility = this->implementationVisibility();
+
             functionInfo.body = context.createFunctionMetadata(
                 startLocation, endLocation, startColumn, bodyEndColumn, 
-                functionKeywordStart, functionNameStart, parametersStart, 
+                functionKeywordStart, functionNameStart, parametersStart, implementationVisibility,
                 cachedInfo->lexicalScopeFeatures(), constructorKind, functionSuperBinding,
                 cachedInfo->parameterCount,
                 mode, functionBodyType == ArrowFunctionBodyExpression);
@@ -2614,6 +2634,8 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
             innerParseMode = getAsynFunctionBodyParseMode(mode);
 
         generatorBodyScope->setSourceParseMode(innerParseMode);
+        resetImplementationVisibilityIfNeeded();
+
         generatorBodyScope->setConstructorKind(ConstructorKind::None);
         generatorBodyScope->setExpectedSuperBinding(expectedSuperBinding);
 

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -312,8 +312,8 @@ const LexicalScopeFeatures NoLexicalFeatures                           = 0;
 const LexicalScopeFeatures StrictModeLexicalFeature               = 1 << 0;
 
 const LexicalScopeFeatures AllLexicalFeatures = NoLexicalFeatures | StrictModeLexicalFeature;
-static constexpr unsigned bitWidthOfLexicalScopeFeatures = 3;
-static_assert(AllLexicalFeatures <= (1 << bitWidthOfLexicalScopeFeatures) - 1, "LexicalScopeFeatures must be 3bits");
+static constexpr unsigned bitWidthOfLexicalScopeFeatures = 2;
+static_assert(AllLexicalFeatures <= (1 << bitWidthOfLexicalScopeFeatures) - 1, "LexicalScopeFeatures must be 2bits");
 
 typedef uint16_t CodeFeatures;
 

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ImplementationVisibility.h"
 #include "Lexer.h"
 #include "ParserFunctionInfo.h"
 #include "YarrSyntaxChecker.h"
@@ -197,7 +198,7 @@ public:
     ExpressionType createFunctionExpr(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
     ExpressionType createGeneratorFunctionBody(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&, const Identifier&) { return FunctionExpr; }
     ExpressionType createAsyncFunctionBody(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
-    int createFunctionMetadata(const JSTokenLocation&, const JSTokenLocation&, unsigned, unsigned, int, int, int, LexicalScopeFeatures, ConstructorKind, SuperBinding, unsigned, SourceParseMode, bool) { return FunctionBodyResult; }
+    int createFunctionMetadata(const JSTokenLocation&, const JSTokenLocation&, unsigned, unsigned, int, int, int, ImplementationVisibility, LexicalScopeFeatures, ConstructorKind, SuperBinding, unsigned, SourceParseMode, bool) { return FunctionBodyResult; }
     ExpressionType createArrowFunctionExpr(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
     ExpressionType createMethodDefinition(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return FunctionExpr; }
     void setFunctionNameStart(int, int) { }

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -77,7 +77,7 @@ UnlinkedCodeBlockType* generateUnlinkedCodeBlockImpl(VM& vm, const SourceCode& s
     bool isInsideOrdinaryFunction = executable && executable->isInsideOrdinaryFunction();
 
     std::unique_ptr<RootNode> rootNode = parse<RootNode>(
-        vm, source, Identifier(), JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, CacheTypes<UnlinkedCodeBlockType>::parseMode, SuperBinding::NotNeeded, error, nullptr, ConstructorKind::None, derivedContextType, evalContextType, nullptr, privateNameEnvironment, nullptr, isInsideOrdinaryFunction);
+        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin, strictMode, scriptMode, CacheTypes<UnlinkedCodeBlockType>::parseMode, SuperBinding::NotNeeded, error, nullptr, ConstructorKind::None, derivedContextType, evalContextType, nullptr, privateNameEnvironment, nullptr, isInsideOrdinaryFunction);
 
     if (!rootNode)
         return nullptr;
@@ -248,7 +248,7 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
     // The Function constructor only has access to global variables, so no variables will be under TDZ unless they're
     // in the global lexical environment, which we always TDZ check accesses from.
     ConstructAbility constructAbility = constructAbilityForParseMode(metadata->parseMode());
-    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, ImplementationVisibility::Public, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
+    UnlinkedFunctionExecutable* functionExecutable = UnlinkedFunctionExecutable::create(vm, source, metadata, UnlinkedNormalFunction, constructAbility, JSParserScriptMode::Classic, nullptr, std::nullopt, DerivedContextType::None, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
 
     if (!source.provider()->sourceURLDirective().isNull())
         functionExecutable->setSourceURLDirective(source.provider()->sourceURLDirective());

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -43,7 +43,7 @@ namespace JSC {
 static inline bool checkSyntaxInternal(VM& vm, const SourceCode& source, ParserError& error)
 {
     return !!parse<ProgramNode>(
-        vm, source, Identifier(), JSParserBuiltinMode::NotBuiltin,
+        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         JSParserStrictMode::NotStrict, JSParserScriptMode::Classic, SourceParseMode::ProgramMode, SuperBinding::NotNeeded, error);
 }
 
@@ -75,7 +75,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
     JSLockHolder lock(vm);
     RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
     std::unique_ptr<ModuleProgramNode> moduleProgramNode = parse<ModuleProgramNode>(
-        vm, source, Identifier(), JSParserBuiltinMode::NotBuiltin,
+        vm, source, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, SuperBinding::NotNeeded, error);
     if (!moduleProgramNode)
         return false;

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -109,7 +109,7 @@ static ALWAYS_INLINE bool isAllowedReceiverFunctionForCallerAndArguments(JSFunct
         return false;
 
     FunctionExecutable* executable = function->jsExecutable();
-    if (executable->implementationVisibility() == ImplementationVisibility::Private)
+    if (executable->implementationVisibility() != ImplementationVisibility::Public)
         return false;
     return !executable->isInStrictContext() && executable->parseMode() == SourceParseMode::NormalFunctionMode && !executable->isClassConstructorFunction();
 }
@@ -197,7 +197,7 @@ public:
             if (callee->inherits<JSBoundFunction>() || callee->inherits<JSRemoteFunction>() || callee->type() == ProxyObjectType)
                 return IterationStatus::Continue;
             if (callee->inherits<JSFunction>()) {
-                if (jsCast<JSFunction*>(callee)->executable()->implementationVisibility() == ImplementationVisibility::Private)
+                if (jsCast<JSFunction*>(callee)->executable()->implementationVisibility() != ImplementationVisibility::Public)
                     return IterationStatus::Continue;
             }
 

--- a/Source/JavaScriptCore/runtime/ImplementationVisibility.h
+++ b/Source/JavaScriptCore/runtime/ImplementationVisibility.h
@@ -30,8 +30,9 @@ namespace JSC {
 enum class ImplementationVisibility : uint8_t {
     Public,
     Private,
+    PrivateRecursive,
 };
 
-static constexpr unsigned bitWidthOfImplementationVisibility = 1;
+static constexpr unsigned bitWidthOfImplementationVisibility = 2;
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -372,7 +372,7 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
 
     ParserError error;
     std::unique_ptr<ModuleProgramNode> moduleProgramNode = parse<ModuleProgramNode>(
-        vm, sourceCode, Identifier(), JSParserBuiltinMode::NotBuiltin,
+        vm, sourceCode, Identifier(), ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         JSParserStrictMode::Strict, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, SuperBinding::NotNeeded, error);
     if (error.isValid())
         RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(error.toErrorObject(globalObject, sourceCode))));


### PR DESCRIPTION
#### 37f814d56d6446ea011af18ee65b6644c1127b4e
<pre>
Web Inspector: should not include implementation details of the injected script in stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=242954">https://bugs.webkit.org/show_bug.cgi?id=242954</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/runtime/ImplementationVisibility.h:
Add a new `PrivateRecursive` that tells JSC to also propagate it to any nested functions.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generator.py:
(BuiltinsGenerator.generate_embedded_code_data_for_function):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.__init__):
(BuiltinFunction.fromString):
Allow builtins to define a custom `@visibility=...`. If not defined, `@linkTimeConstant` is
`Private` and everything else is `Public`.

* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
Annotate `createInspectorInjectedScript` with `@visibility=PrivateRecursive`.

* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/Nodes.cpp:
(JSC::FunctionMetadataNode::FunctionMetadataNode):
(JSC::FunctionMetadataNode::operator== const):
(JSC::FunctionMetadataNode::dump const):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
(JSC::UnlinkedFunctionExecutable::create):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::generateUnlinkedFunctionCodeBlock):
(JSC::UnlinkedFunctionExecutable::UnlinkedFunctionExecutable):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::makeFunction):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitNewClassFieldInitializerFunction):
Have the `FunctionMetadataNode` hold the `ImplementationVisibility` instead of directly giving it to
the `UnlinkedFunctionExecutable`, as the `FunctionMetadataNode` has more widespread usage.

* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createFunctionMetadata):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::Scope):
(JSC::Scope::implementationVisibility const): Added.
(JSC::Parser::pushScope):
(JSC::Parser::resetImplementationVisibilityIfNeeded): Added.
(JSC::Parser::implementationVisibility): Added.
(JSC::parse):
(JSC::parseFunctionForFunctionConstructor):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::Parser):
(JSC::Parser&lt;LexerType&gt;::isArrowFunctionParameters):
(JSC::Parser&lt;LexerType&gt;::parseGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseFunctionBody):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::createFunctionMetadata):
Pass along the `ImplementationVisibility` to the creation of the `FunctionMetadataNode` when parsing.
Make sure the `ImplementationVisibility` is properly propagated when new `Scope` are created.

* Source/JavaScriptCore/debugger/DebuggerParseData.cpp:
(JSC::gatherDebuggerParseData):
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::generateUnlinkedCodeBlockImpl):
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkSyntaxInternal):
(JSC::checkModuleSyntax):
* Source/JavaScriptCore/API/JSScriptRef.cpp:
(parseScript):
* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jsc_context_check_syntax):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::moduleLoaderParseModule):
Non-builtins should be `ImplementationVisibility::Public`.

* Source/JavaScriptCore/parser/ParserModes.h:
Decrease the width of `LexicalScopeFeatures` to make room for the wider `ImplementationVisibility`.

* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::isAllowedReceiverFunctionForCallerAndArguments):
(JSC::RetrieveCallerFunctionFunctor::operator() const):
Ignore anything that isn&apos;t `ImplementationVisibility::Public`.

* LayoutTests/inspector/animation/lifecycle-web-animation-expected.txt:
* LayoutTests/inspector/canvas/create-context-2d-expected.txt:
* LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt:
* LayoutTests/inspector/canvas/create-context-webgl-expected.txt:
* LayoutTests/inspector/canvas/create-context-webgl2-expected.txt:
* LayoutTests/inspector/canvas/recording-2d-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-2d-full-expected.txt:
* LayoutTests/inspector/canvas/recording-2d-memoryLimit-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl-full-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl-memoryLimit-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl-snapshots-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl2-frameCount-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl2-full-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl2-memoryLimit-expected.txt:
* LayoutTests/inspector/canvas/recording-webgl2-snapshots-expected.txt:
* LayoutTests/inspector/model/remote-object/error-expected.txt:
* LayoutTests/inspector/model/stack-trace-expected.txt:
* LayoutTests/inspector/timeline/line-column-expected.txt:
* LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-frameCount-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-full-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-memoryLimit-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl-snapshots-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-frameCount-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-full-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-memoryLimit-expected.txt:
* LayoutTests/platform/mac-wk1/inspector/canvas/recording-webgl2-snapshots-expected.txt:

Canonical link: <a href="https://commits.webkit.org/252914@main">https://commits.webkit.org/252914@main</a>
</pre>
