### PR TITLE
[GStreamer][VideoCapture] GStreamerCapturer: Disable last-sample in appsink

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -170,6 +170,7 @@ void GStreamerCapturer::setupPipeline()
     m_sink = makeElement("appsink");
 
     gst_app_sink_set_emit_signals(GST_APP_SINK(m_sink.get()), TRUE);
+    g_object_set(m_sink.get(), "enable-last-sample", FALSE, nullptr);
     g_object_set(m_capsfilter.get(), "caps", m_caps.get(), nullptr);
 
     gst_bin_add_many(GST_BIN(m_pipeline.get()), source.get(), converter.get(), m_capsfilter.get(), m_valve.get(), m_tee.get(), nullptr);


### PR DESCRIPTION
#### 66fe1fcd80981a73e08b73bf88c85714a82dda12
<pre>
[GStreamer][VideoCapture] GStreamerCapturer: Disable last-sample in appsink
<a href="https://bugs.webkit.org/show_bug.cgi?id=242961">https://bugs.webkit.org/show_bug.cgi?id=242961</a>

Reviewed by Xabier Rodriguez-Calvar.

We need to set the appsink enable-last-sample property to FALSE so that sample
buffers can be returned to their pools.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::setupPipeline):

Canonical link: <a href="https://commits.webkit.org/253033@main">https://commits.webkit.org/253033@main</a>
</pre>
