### PR TITLE
[JSC] BakcwardPropagationPhase should carry NaN / Infinity handling

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -81,7 +81,9 @@ private:
         if (optimizeForX86() || optimizeForARM64() || optimizeForARMv7IDIVSupported()) {
             fixIntOrBooleanEdge(leftChild);
             fixIntOrBooleanEdge(rightChild);
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
+            // We need to be careful about skipping overflow check because div / mod can generate non integer values
+            // from (Int32, Int32) inputs. For now, we always check non-zero divisor.
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) && bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::Unchecked);
             else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::CheckOverflow);
@@ -122,7 +124,7 @@ private:
 
     void fixupArithDiv(Node* node, Edge& leftChild, Edge& rightChild)
     {
-        if (m_graph.binaryArithShouldSpeculateInt32(node, FixupPass)) {
+        if (m_graph.divShouldSpeculateInt32(node, FixupPass)) {
             fixupArithDivInt32(node, leftChild, rightChild);
             return;
         }

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -373,6 +373,17 @@ public:
 
         return shouldSpeculateInt52ForAdd(left) && shouldSpeculateInt52ForAdd(right);
     }
+
+    bool divShouldSpeculateInt32(Node* node, PredictionPass pass)
+    {
+        // Even if inputs are Int32, div can generate NaN or Infinity.
+        // Thus, Overflow in div can be caused by these non integer values as well as actual Int32 overflow.
+        Node* left = node->child1().node();
+        Node* right = node->child2().node();
+
+        return Node::shouldSpeculateInt32OrBooleanForArithmetic(left, right)
+            && nodeCanSpeculateInt32ForDiv(node->arithNodeFlags(), node->sourceFor(pass));
+    }
     
     bool binaryArithShouldSpeculateInt32(Node* node, PredictionPass pass)
     {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3308,21 +3308,25 @@ public:
         out.printf(", @%u", child3()->index());
     }
 
-    NodeOrigin origin;
+    NO_UNIQUE_ADDRESS NodeOrigin origin;
 
+private:
+    NO_UNIQUE_ADDRESS NodeType m_op;
+
+    NO_UNIQUE_ADDRESS unsigned m_index { std::numeric_limits<unsigned>::max() };
+
+public:
     // References to up to 3 children, or links to a variable length set of children.
     AdjacencyList children;
 
 private:
     friend class B3::SparseCollection<Node>;
 
-    unsigned m_index { std::numeric_limits<unsigned>::max() };
-    unsigned m_op : 10; // real type is NodeType
-    unsigned m_flags : 21;
     // The virtual register number (spill location) associated with this .
     VirtualRegister m_virtualRegister;
     // The number of uses of the result of this operation (+1 for 'must generate' nodes, which have side-effects).
     unsigned m_refCount;
+    NodeFlags m_flags;
     // The prediction ascribed to this node after propagation.
     SpeculatedType m_prediction { SpecNone };
     // Immediate values, accesses type-checked via accessors above.

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
@@ -74,12 +74,14 @@ void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
         out.print(comma, "VarArgs");
     
     if (flags & NodeResultMask) {
-        if (!(flags & NodeBytecodeUsesAsNumber) && !(flags & NodeBytecodeNeedsNegZero))
+        if (!(flags & NodeBytecodeUsesAsNumber))
             out.print(comma, "PureInt");
-        else if (!(flags & NodeBytecodeUsesAsNumber))
-            out.print(comma, "PureInt(w/ neg zero)");
-        else if (!(flags & NodeBytecodeNeedsNegZero))
+        else
             out.print(comma, "PureNum");
+        if (flags & NodeBytecodeNeedsNegZero)
+            out.print(comma, "NeedsNegZero");
+        if (flags & NodeBytecodeNeedsNaNOrInfinity)
+            out.print(comma, "NeedsNaNOrInfinity");
         if (flags & NodeBytecodeUsesAsOther)
             out.print(comma, "UseAsOther");
     }

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.h
@@ -61,18 +61,19 @@ namespace JSC { namespace DFG {
 #define NodeBytecodeUseBottom            0x00000
 #define NodeBytecodeUsesAsNumber         0x04000 // The result of this computation may be used in a context that observes fractional, or bigger-than-int32, results.
 #define NodeBytecodeNeedsNegZero         0x08000 // The result of this computation may be used in a context that observes -0.
-#define NodeBytecodeUsesAsOther          0x10000 // The result of this computation may be used in a context that distinguishes between NaN and other things (like undefined).
-#define NodeBytecodeUsesAsInt            0x20000 // The result of this computation is known to be used in a context that prefers, but does not require, integer values.
-#define NodeBytecodeUsesAsArrayIndex     0x40000 // The result of this computation is known to be used in a context that strongly prefers integer values, to the point that we should avoid using doubles if at all possible.
-#define NodeBytecodeUsesAsValue          (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeUsesAsOther)
-#define NodeBytecodeBackPropMask         (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodeUsesAsArrayIndex)
+#define NodeBytecodeNeedsNaNOrInfinity   0x10000 // The result of this computation may be used in a context that observes NaN or Infinity.
+#define NodeBytecodeUsesAsOther          0x20000 // The result of this computation may be used in a context that distinguishes between NaN and other things (like undefined).
+#define NodeBytecodeUsesAsInt            0x40000 // The result of this computation is known to be used in a context that prefers, but does not require, integer values.
+#define NodeBytecodeUsesAsArrayIndex     0x80000 // The result of this computation is known to be used in a context that strongly prefers integer values, to the point that we should avoid using doubles if at all possible.
+#define NodeBytecodeUsesAsValue          (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther)
+#define NodeBytecodeBackPropMask         (NodeBytecodeUsesAsNumber | NodeBytecodeNeedsNegZero | NodeBytecodeNeedsNaNOrInfinity | NodeBytecodeUsesAsOther | NodeBytecodeUsesAsInt | NodeBytecodeUsesAsArrayIndex)
 
 #define NodeArithFlagsMask               (NodeBehaviorMask | NodeBytecodeBackPropMask)
 
-#define NodeIsFlushed                    0x80000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
+#define NodeIsFlushed                   0x100000 // Computed by CPSRethreadingPhase, will tell you which local nodes are backwards-reachable from a Flush.
 
-#define NodeMiscFlag1                   0x100000
-#define NodeMiscFlag2                   0x200000
+#define NodeMiscFlag1                   0x200000
+#define NodeMiscFlag2                   0x400000
 
 typedef uint32_t NodeFlags;
 
@@ -89,6 +90,11 @@ static inline bool bytecodeCanTruncateInteger(NodeFlags flags)
 static inline bool bytecodeCanIgnoreNegativeZero(NodeFlags flags)
 {
     return !(flags & NodeBytecodeNeedsNegZero);
+}
+
+static inline bool bytecodeCanIgnoreNaNAndInfinity(NodeFlags flags)
+{
+    return !(flags & NodeBytecodeNeedsNaNOrInfinity);
 }
 
 enum RareCaseProfilingSource {
@@ -144,6 +150,21 @@ static inline bool nodeCanSpeculateInt32(NodeFlags flags, RareCaseProfilingSourc
     if (nodeMayNegZero(flags, source))
         return bytecodeCanIgnoreNegativeZero(flags);
     
+    return true;
+}
+
+static inline bool nodeCanSpeculateInt32ForDiv(NodeFlags flags, RareCaseProfilingSource source)
+{
+    if (nodeMayOverflowInt32(flags, source)) {
+        if (bytecodeUsesAsNumber(flags))
+            return false;
+        if (!bytecodeCanIgnoreNaNAndInfinity(flags))
+            return false;
+    }
+
+    if (nodeMayNegZero(flags, source))
+        return bytecodeCanIgnoreNegativeZero(flags);
+
     return true;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -567,7 +567,7 @@ namespace JSC { namespace DFG {
 
 // This enum generates a monotonically increasing id for all Node types,
 // and is used by the subsequent enum to fill out the id (as accessed via the NodeIdMask).
-enum NodeType {
+enum NodeType : uint16_t {
 #define DFG_OP_ENUM(opcode, flags) opcode,
     FOR_EACH_DFG_OP(DFG_OP_ENUM)
 #undef DFG_OP_ENUM
@@ -577,6 +577,7 @@ enum NodeType {
 #define DFG_OP_COUNT(opcode, flags) + 1
 constexpr unsigned numberOfNodeTypes = FOR_EACH_DFG_OP(DFG_OP_COUNT);
 #undef DFG_OP_COUNT
+static_assert(numberOfNodeTypes <= UINT16_MAX);
 
 // Specifies the default flags for each node.
 inline NodeFlags defaultFlags(NodeType op)


### PR DESCRIPTION
#### ef76e31a2a066c3d65a9c94a9e2cd88133260c1f
<pre>
[JSC] BakcwardPropagationPhase should carry NaN / Infinity handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=242964">https://bugs.webkit.org/show_bug.cgi?id=242964</a>
rdar://96791603

Reviewed by Mark Lam.

For correctness, we should carry NaN / Infinity handling to make it more clear in the code generation site.

* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDivInt32):
(JSC::DFG::FixupPhase::fixupArithDiv):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGNodeFlags.cpp:
(JSC::DFG::dumpNodeFlags):
* Source/JavaScriptCore/dfg/DFGNodeFlags.h:
(JSC::DFG::bytecodeCanIgnoreNaNAndInfinity):
(JSC::DFG::nodeCanSpeculateInt32ForDiv):
* Source/JavaScriptCore/dfg/DFGNodeType.h:

Canonical link: <a href="https://commits.webkit.org/252675@main">https://commits.webkit.org/252675@main</a>
</pre>
