### PR TITLE
[git-webkit] Support alternate remotes when pulling

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.4',
+    version='5.3.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 4)
+version = Version(5, 3, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
@@ -43,5 +43,11 @@ class Pull(Command):
 
         if isinstance(repository, local.Git):
             branch_point = Branch.branch_point(repository)
-            return repository.pull(rebase=True, branch=branch_point.branch)
+            bp_remotes = set(repository.branches_for(hash=branch_point.hash, remote=None).keys())
+            remote = None
+            for rmt in repository.source_remotes():
+                if rmt in bp_remotes:
+                    remote = rmt
+                    break
+            return repository.pull(rebase=True, branch=branch_point.branch, remote=remote)
         return repository.pull()


### PR DESCRIPTION
#### 3fc8ca1081825e7d2c22b2fcc3a5b9efc28c8e21
<pre>
[git-webkit] Support alternate remotes when pulling
<a href="https://bugs.webkit.org/show_bug.cgi?id=242966">https://bugs.webkit.org/show_bug.cgi?id=242966</a>
&lt;rdar://problem/97346019&gt;

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py:
(Pull.main): Determine remote based on branch_point.

Canonical link: <a href="https://commits.webkit.org/252679@main">https://commits.webkit.org/252679@main</a>
</pre>
