### PR TITLE
xhr/send-authentication-competing-names-passwords.htm WPT test is failing in WebKit

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -910,7 +910,6 @@ http/tests/cache-storage/page-cache-domcache-pending-promise.html [ DumpJSConsol
 
 imported/w3c/web-platform-tests/xhr/event-timeout-order.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session.htm [ Failure ]
-imported/w3c/web-platform-tests/xhr/send-authentication-competing-names-passwords.htm [ Failure ]
 imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm [ Failure ]
 
 # textarea.animate is not supported

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-competing-names-passwords-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-competing-names-passwords-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL XMLHttpRequest user/pass options: user in open() assert_equals: responseText should contain the right user and password expected "739ef6f9-aa09-412d-bc54-f5c57fe710c8\n" but got "FAIL (did not authorize)"
+PASS XMLHttpRequest user/pass options: user in open()
 PASS XMLHttpRequest user/pass options: user/pass in open()
 PASS XMLHttpRequest user/pass options: another user/pass in open(); must override cached credentials from previous test
 PASS XMLHttpRequest user/pass options: pass in URL, user in open()

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -524,7 +524,7 @@ bool ResourceHandle::tryHandlePasswordBasedAuthentication(const AuthenticationCh
     if (!challenge.protectionSpace().isPasswordBased())
         return false;
 
-    if (!d->m_user.isNull() && !d->m_password.isNull()) {
+    if (!d->m_user.isEmpty() || !d->m_password.isEmpty()) {
         auto credential = adoptNS([[NSURLCredential alloc] initWithUser:d->m_user
             password:d->m_password persistence:NSURLCredentialPersistenceForSession]);
         d->m_currentMacChallenge = challenge.nsURLAuthenticationChallenge();

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -611,7 +611,7 @@ bool NetworkDataTaskCocoa::tryPasswordBasedAuthentication(const WebCore::Authent
     if (!challenge.protectionSpace().isPasswordBased())
         return false;
     
-    if (!m_user.isNull() && !m_password.isNull()) {
+    if (!m_user.isEmpty() || !m_password.isEmpty()) {
         auto persistence = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use ? WebCore::CredentialPersistenceForSession : WebCore::CredentialPersistenceNone;
         completionHandler(AuthenticationChallengeDisposition::UseCredential, WebCore::Credential(m_user, m_password, persistence));
         m_user = String();


### PR DESCRIPTION
#### 318531a136d138050fa165cd2cdd3229d53bbf5d
<pre>
xhr/send-authentication-competing-names-passwords.htm WPT test is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=242968">https://bugs.webkit.org/show_bug.cgi?id=242968</a>

Reviewed by Alex Christensen and Geoffrey Garen.

The subtest is a user but not password was failing to authenticate.
The reason was that NetworkDataTaskCocoa::tryPasswordBasedAuthentication()
would fail to use its m_user for authentication when m_password was null.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-competing-names-passwords-expected.txt:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::tryPasswordBasedAuthentication):

Canonical link: <a href="https://commits.webkit.org/252696@main">https://commits.webkit.org/252696@main</a>
</pre>
