### PR TITLE
We should maintain the original Content-Type header on 303 HTTP redirect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-expected.txt
@@ -1,6 +1,6 @@
 
 PASS XMLHttpRequest: send() - Redirects (basics) (301)
 PASS XMLHttpRequest: send() - Redirects (basics) (302)
-FAIL XMLHttpRequest: send() - Redirects (basics) (303) assert_equals: expected "application/x-pony" but got "NO"
+PASS XMLHttpRequest: send() - Redirects (basics) (303)
 PASS XMLHttpRequest: send() - Redirects (basics) (307)
 

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -425,8 +425,14 @@ void ResourceHandle::willSendRequest(ResourceRequest&& request, ResourceResponse
             if (!originalContentType.isEmpty())
                 request.setHTTPHeaderField(HTTPHeaderName::ContentType, originalContentType);
         }
-    } else if (redirectResponse.httpStatusCode() == 303 && equalLettersIgnoringASCIICase(d->m_firstRequest.httpMethod(), "head"_s)) // FIXME: (rdar://problem/13706454).
-        request.setHTTPMethod("HEAD"_s);
+    } else if (redirectResponse.httpStatusCode() == 303) { // FIXME: (rdar://problem/13706454).
+        if (equalLettersIgnoringASCIICase(d->m_firstRequest.httpMethod(), "head"_s))
+            request.setHTTPMethod("HEAD"_s);
+
+        String originalContentType = d->m_firstRequest.httpContentType();
+        if (!originalContentType.isEmpty())
+            request.setHTTPHeaderField(HTTPHeaderName::ContentType, originalContentType);
+    }
 
     // Should not set Referer after a redirect from a secure resource to non-secure one.
     if (!request.url().protocolIs("https"_s) && protocolIs(request.httpReferrer(), "https"_s) && d->m_context->shouldClearReferrerOnHTTPSToHTTPRedirect())

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -510,8 +510,14 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
         String originalContentType = m_firstRequest.httpContentType();
         if (!originalContentType.isEmpty())
             request.setHTTPHeaderField(WebCore::HTTPHeaderName::ContentType, originalContentType);
-    } else if (redirectResponse.httpStatusCode() == 303 && equalLettersIgnoringASCIICase(m_firstRequest.httpMethod(), "head"_s)) // FIXME: (rdar://problem/13706454).
-        request.setHTTPMethod("HEAD"_s);
+    } else if (redirectResponse.httpStatusCode() == 303) { // FIXME: (rdar://problem/13706454).
+        if (equalLettersIgnoringASCIICase(m_firstRequest.httpMethod(), "head"_s))
+            request.setHTTPMethod("HEAD"_s);
+
+        String originalContentType = m_firstRequest.httpContentType();
+        if (!originalContentType.isEmpty())
+            request.setHTTPHeaderField(WebCore::HTTPHeaderName::ContentType, originalContentType);
+    }
     
     // Should not set Referer after a redirect from a secure resource to non-secure one.
     if (m_shouldClearReferrerOnHTTPSToHTTPRedirect && !request.url().protocolIs("https"_s) && WTF::protocolIs(request.httpReferrer(), "https"_s))


### PR DESCRIPTION
#### afacf71feeaa0d25da0098a38f039ff6cc5cbdb5
<pre>
We should maintain the original Content-Type header on 303 HTTP redirect
<a href="https://bugs.webkit.org/show_bug.cgi?id=242969">https://bugs.webkit.org/show_bug.cgi?id=242969</a>

Reviewed by Darin Adler and Alex Christensen.

Maintain the original Content-Type header on 303 HTTP redirect, like we do for
the 307 and 308 ones. This aligns our behavior with both Blink and Gecko.

* LayoutTests/imported/w3c/web-platform-tests/xhr/send-redirect-expected.txt:
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::willSendRequest):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):

Canonical link: <a href="https://commits.webkit.org/252713@main">https://commits.webkit.org/252713@main</a>
</pre>
