### PR TITLE
rdar://94005794 (Fix errors seen when linting TestExpectations files in LayoutTestsResultsForUnreleasedSoftware).

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -799,7 +799,6 @@ imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-
 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/worklet-audio.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/name/name.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/prefix/__secure.header.https.html [ Failure Pass ]
-imported/w3c/web-platform-tests/cookies/samesite-none-secure/cookies-without-samesite-must-be-secure.https.tentative.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/about-blank-subresource.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/about-blank-toplevel.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/cookies/samesite/iframe.document.https.html [ Failure Pass ]

--- a/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
@@ -1,2 +1,3 @@
 http/tests/paymentrequest/ApplePayModifier-paymentMethodType.https.html [ Skip ]
 webkit.org/b/229837 [ Release ] webgl/2.0.0/conformance2/textures/video/tex-2d-r8ui-red_integer-unsigned_byte.html [ Pass Timeout ]
+webkit.org/b/229502 [ Debug ] http/tests/inspector/paymentrequest/payment-request-internal-properties.https.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1525,8 +1525,6 @@ webkit.org/b/229472 [ BigSur Debug ] webgl/1.0.3/conformance/glsl/constructors/g
 [ BigSur+ ] media/modern-media-controls/tracks-support/hidden-tracks.html [ Pass Timeout ]
 [ BigSur+ ] media/modern-media-controls/tracks-support/off-text-track.html [ Pass Failure Timeout ]
 
-webkit.org/b/229502 [ BigSur Debug ] http/tests/inspector/paymentrequest/payment-request-internal-properties.https.html [ Pass Failure ]
-
 webkit.org/b/229523 [ Debug ] fast/canvas/webgl/lose-context-on-timeout.html [ Pass Timeout ]
 
 webkit.org/b/229561 http/tests/navigation/page-cache-video.html [ Pass Failure ]


### PR DESCRIPTION
#### 937faa22bf2253091bfad028060632968f3d4e0e
<pre>
rdar://94005794 (Fix errors seen when linting TestExpectations files in LayoutTestsResultsForUnreleasedSoftware).

Unreviewed test gardening/linting.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-bigsur-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252667@main">https://commits.webkit.org/252667@main</a>
</pre>
