### PR TITLE
[GStreamer][MediaStream] Capture pipeline remains active after track was stopped

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -58,9 +58,12 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivat
         });
     }), this);
     g_signal_connect_swapped(m_stream, "notify::tags", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
-        track->m_taskQueue.enqueueTask([track]() {
+        if (isMainThread())
             track->updateConfigurationFromTags();
-        });
+        else
+            track->m_taskQueue.enqueueTask([track]() {
+                track->updateConfigurationFromTags();
+            });
     }), this);
 
     updateConfigurationFromCaps();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -222,6 +222,7 @@ void GStreamerVideoCaptureSource::stopProducingData()
 {
     GST_INFO("Reset height and width after stopping source");
     setSize({ 0, 0 });
+    m_capturer->stop();
 }
 
 const RealtimeMediaSourceCapabilities& GStreamerVideoCaptureSource::capabilities()


### PR DESCRIPTION
#### a4d18a005735d0ec45217d9b0ca006770393e7ae
<pre>
[GStreamer][MediaStream] Capture pipeline remains active after track was stopped
<a href="https://bugs.webkit.org/show_bug.cgi?id=241549">https://bugs.webkit.org/show_bug.cgi?id=241549</a>

Reviewed by Philippe Normand.

It appears we need to call m_capturer-&gt;stop() to shutdown the capture pipeline.

This is called in GStreamerAudioCaptureSource::stopProducingData already.

We also need to ensure that the tags callback in VideoTrackPrivateGStreamer
does not call enqueueTask on the main thread otherwise we will deadlock when
shutting down the capture pipeline.

* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::stopProducingData):

Canonical link: <a href="https://commits.webkit.org/253192@main">https://commits.webkit.org/253192@main</a>
</pre>
