### PR TITLE
hide private builtins from exception stack traces

### DIFF
--- a/LayoutTests/inspector/console/message-stack-trace-expected.txt
+++ b/LayoutTests/inspector/console/message-stack-trace-expected.txt
@@ -54,7 +54,6 @@ ASYNC CALL STACK:
 -- Running test case: Console.StackTrace.UnhandledPromiseRejection.ImplicitReject
 CALL STACK:
 0: [F] (anonymous function)
-1: [N] promiseReactionJob
 ASYNC CALL STACK:
 0: --- enqueueJob ---
 1: [N] then

--- a/LayoutTests/inspector/debugger/js-stacktrace-expected.txt
+++ b/LayoutTests/inspector/debugger/js-stacktrace-expected.txt
@@ -187,22 +187,10 @@ Error object:
         "columnNumber": 20
     },
     {
-        "functionName": "generatorResume",
-        "url": "[native code]",
-        "lineNumber": 0,
-        "columnNumber": 0
-    },
-    {
         "functionName": "generator1",
         "url": "/inspector/debugger/js-stacktrace.html",
         "lineNumber": 40,
         "columnNumber": 12
-    },
-    {
-        "functionName": "generatorResume",
-        "url": "[native code]",
-        "lineNumber": 0,
-        "columnNumber": 0
     },
     {
         "functionName": "triggerGeneratorError",

--- a/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp
@@ -59,14 +59,14 @@ public:
 
     IterationStatus operator()(StackVisitor& visitor) const
     {
-        if (auto* codeBlock = visitor->codeBlock()) {
-            if (codeBlock->ownerExecutable()->implementationVisibility() == ImplementationVisibility::Private)
-                return IterationStatus::Continue;
-        }
-
         if (m_needToSkipAFrame) {
             m_needToSkipAFrame = false;
             return IterationStatus::Continue;
+        }
+
+        if (auto* codeBlock = visitor->codeBlock()) {
+            if (codeBlock->ownerExecutable()->implementationVisibility() != ImplementationVisibility::Public)
+                return IterationStatus::Continue;
         }
 
         if (m_remainingCapacityForFrameCapture) {

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -397,6 +397,11 @@ public:
             return IterationStatus::Continue;
         }
 
+        if (auto* codeBlock = visitor->codeBlock()) {
+            if (codeBlock->ownerExecutable()->implementationVisibility() != ImplementationVisibility::Public)
+                return IterationStatus::Continue;
+        }
+
         if (m_remainingCapacityForFrameCapture) {
             if (visitor->isWasmFrame()) {
                 m_results.append(StackFrame(visitor->wasmFunctionIndexOrName()));


### PR DESCRIPTION
#### 8d17ce89dc8babf5bf8383ed3f6402a693c21871
<pre>
hide private builtins from exception stack traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=242980">https://bugs.webkit.org/show_bug.cgi?id=242980</a>

Reviewed by Yusuke Suzuki.

Private builtins are really just an implementation detail, and as such should not be exposed to developers.

* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::GetStackTraceFunctor::operator() const):

* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::CreateScriptCallStackFunctor::operator() const):
Drive-by: Move the `ImplementationVisibility` check after the `needToSkipAFrame` check to make it
          easier for callers to reason about the value to provide.

* LayoutTests/inspector/console/message-stack-trace-expected.txt:
* LayoutTests/inspector/debugger/js-stacktrace-expected.txt:
* LayoutTests/inspector/model/remote-object/error-expected.txt:

Canonical link: <a href="https://commits.webkit.org/252693@main">https://commits.webkit.org/252693@main</a>
</pre>
