### PR TITLE
Do not interrupt due to invisible autoplay if the HMLMediaElement is paused

### DIFF
--- a/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay-expected.txt
+++ b/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay-expected.txt
@@ -1,0 +1,13 @@
+
+Test that "invisible autoplay not allowed restriction" pauses realtime media when scrolled out of view and restarts as expected.
+
+** setting video.srcObject
+** waiting to play
+
+** element played, going to pause it
+** Setting style display none
+** playing video
+** removing style display none
+** element played
+** test finished
+

--- a/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html
+++ b/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html
@@ -1,0 +1,72 @@
+<html>
+    <head>
+    </head>
+        <script>
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                testRunner.waitUntilDone();
+            }
+            if (window.internals)
+                internals.settings.setInvisibleAutoplayNotPermitted(true);
+        </script>
+    <body>
+        <video autoplay width=320px height=240px id=myVideo controls playsInline></video>
+        <p>Test that "invisible autoplay not allowed restriction" pauses realtime media when scrolled out of view and restarts as expected.</p>
+        <div id="log"></div>
+        <script>
+            function doLog(msg)
+            {
+                log.innerHTML += msg + "<br>";
+            }
+
+            async function start()
+            {
+                doLog('** setting video.srcObject');
+                myVideo.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });
+                doLog('** waiting to play');
+                myVideo.onplay = play1;
+                doLog('');
+            }
+
+            async function play1()
+            {
+                myVideo.onplay = undefined;
+
+                doLog('** element played, going to pause it');
+                myVideo.pause();
+                myVideo.onpause = pause1;
+            }
+
+            async function pause1()
+            {
+                myVideo.onpause = undefined;
+                doLog('** Setting style display none');
+                myVideo.style.display = "none";
+                await new Promise(resolve => setTimeout(resolve, 500));
+
+                doLog('** playing video');
+                myVideo.play();
+                await new Promise(resolve => setTimeout(resolve, 500));
+
+                doLog('** removing style display none');
+                myVideo.style.removeProperty("display");
+                await new Promise(resolve => setTimeout(resolve, 500));
+                if (!myVideo.paused) {
+                    finish();
+                    return;
+                }
+                myVideo.onplay = finish;
+            }
+
+            function finish()
+            {
+                myVideo.onplay = undefined;
+                doLog('** element played');
+                doLog('** test finished');
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }
+            start();
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -244,6 +244,7 @@ bool PlatformMediaSession::clientWillBeginPlayback()
         return false;
     }
 
+    m_stateToRestore = Playing;
     setState(Playing);
     return true;
 }


### PR DESCRIPTION
#### 0c9362e7e0a5a97f98964de63426bbd05ac54656
<pre>
Do not interrupt due to invisible autoplay if the HMLMediaElement is paused
<a href="https://bugs.webkit.org/show_bug.cgi?id=243051">https://bugs.webkit.org/show_bug.cgi?id=243051</a>
rdar://96710633

Reviewed by Jer Noble.

Some websites do the following:
- pause the media element and set display style to none
Then later on:
- play the media element and set display style to display

The first step triggers pausing the media element and an invisible autoplay interruption.
The interruption will remember that it was paused and the state to restore will be paused.

Later on the media element is played and the state will be playing but the state to restore it is still Paused.
At the time the display style is none, so it will not be allowed to play.
In the current implementation, when we know we interrupted due to invisible autoplay but we are not interrupted, we end interruption and begin interruption right after.
This ensures the number of endInterruption/beginInterruption matches.
But the issue is that the first endInterruption, will change the state from Playing to Paused since the state to restore was Paused.
We fix this by setting the state to restore to Playing when the state moves to Playing as well.

Covered by existing tests and newly added test.

* LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay-expected.txt: Added.
* LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html: Added.
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::clientWillBeginPlayback):

Canonical link: <a href="https://commits.webkit.org/252735@main">https://commits.webkit.org/252735@main</a>
</pre>
