### PR TITLE
Memset WebAudioBufferList allocated data to 0 at initialisation to prevent bad audio values

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -98,6 +98,7 @@ void WebAudioBufferList::setSampleCount(uint32_t sampleCount)
 
     m_flatBuffer.resize(bufferSizes->second);
     auto* data = m_flatBuffer.data();
+    memset(data, 0, bufferSizes->second);
 
     for (uint32_t buffer = 0; buffer < m_canonicalList->mNumberBuffers; ++buffer) {
         m_canonicalList->mBuffers[buffer].mData = data;


### PR DESCRIPTION
#### d825717573426f3136e2f9e2b1ae1a0eb54e3cc4
<pre>
Memset WebAudioBufferList allocated data to 0 at initialisation to prevent bad audio values
<a href="https://bugs.webkit.org/show_bug.cgi?id=243052">https://bugs.webkit.org/show_bug.cgi?id=243052</a>

Reviewed by Chris Dumez.

* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::setSampleCount):
RemoteAudioDestinationProxy::renderQuantum may in case of error store a WebAudioBufferList buffered data to its ring buffer.
In case AudioDestinationCocoa::render and no data was writting in WebAudioBufferList before, this data might be unintialized.
In case of data containing NaN, this might break the audio rendering.
To prevent this, we memset the buffered data to 0 at initialization time.

Canonical link: <a href="https://commits.webkit.org/252725@main">https://commits.webkit.org/252725@main</a>
</pre>
