### PR TITLE
Fix webkitpy error: 'NoneType' object has no attribute 'handle_script_error'

### DIFF
--- a/Tools/Scripts/webkitpy/tool/commands/stepsequence.py
+++ b/Tools/Scripts/webkitpy/tool/commands/stepsequence.py
@@ -82,5 +82,6 @@ class StepSequence(object):
                 _log.error(e.message_with_output(output_limit=5000))
             if options.parent_command:
                 command = tool.command_by_name(options.parent_command)
-                command.handle_script_error(tool, state, e)
+                if command:
+                    command.handle_script_error(tool, state, e)
             QueueEngine.exit_after_handled_error(e)


### PR DESCRIPTION
#### 0eeb2156b9438da5deb70407085b3dbafd244359
<pre>
Fix webkitpy error: &apos;NoneType&apos; object has no attribute &apos;handle_script_error&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=242972">https://bugs.webkit.org/show_bug.cgi?id=242972</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/tool/commands/stepsequence.py:
(StepSequence.run_and_handle_errors):

Canonical link: <a href="https://commits.webkit.org/252690@main">https://commits.webkit.org/252690@main</a>
</pre>
