### PR TITLE
Unblock dyld related syscall in WebKit sandboxes

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1066,6 +1066,9 @@
         SYS_setsockopt
         SYS_sigaltstack
         SYS_sigprocmask
+#if !PLATFORM(MAC)
+        SYS_shared_region_map_and_slide_2_np
+#endif
         SYS_socket
         SYS_stat
         SYS_stat64

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -604,6 +604,9 @@
         SYS_setrlimit
         SYS_setsockopt
         SYS_shutdown
+#if !PLATFORM(MAC)
+        SYS_shared_region_map_and_slide_2_np
+#endif
         SYS_sigaction
         SYS_sigaltstack
         SYS_sigprocmask

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -812,6 +812,7 @@
         SYS_sem_open
         SYS_sendto
         SYS_shared_region_check_np
+        SYS_shared_region_map_and_slide_2_np
         SYS_shm_open
         SYS_sigaction
         SYS_sigprocmask

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -742,6 +742,7 @@
         SYS_setsockopt
         SYS_setxattr
         SYS_shared_region_check_np
+        SYS_shared_region_map_and_slide_2_np
         SYS_shm_open
         SYS_shutdown
         SYS_sigaction

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2014,6 +2014,7 @@
         SYS_mkdirat
         SYS_open_dprotected_np
         SYS_setrlimit
+        SYS_shared_region_map_and_slide_2_np
         SYS_ulock_wait2
 #endif
 ))


### PR DESCRIPTION
#### f90126638a875f1edaef2fe09afca5e0dfe79bb4
<pre>
Unblock dyld related syscall in WebKit sandboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243054">https://bugs.webkit.org/show_bug.cgi?id=243054</a>
&lt;rdar://95010198&gt;

Reviewed by Chris Dumez.

Unblock dyld related syscall in WebKit sandboxes on iOS and Catalyst.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252692@main">https://commits.webkit.org/252692@main</a>
</pre>
