### PR TITLE
Handle an empty array as the payload in CSP WPT framework

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/child-navigates-parent-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/child-navigates-parent-blocked.sub-expected.txt
@@ -1,5 +1,5 @@
 
 
 FAIL Test that the child can't navigate the parent because the relevant policy belongs to the navigation initiator (in this case the child which has the policy `navigate-to 'none'`) assert_equals: expected "fail" but got "success"
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/form-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/form-blocked.sub-expected.txt
@@ -1,5 +1,5 @@
 
 
 FAIL Test that the child iframe navigation is not allowed assert_equals: expected "fail" but got "success"
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/href-location-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/href-location-blocked.sub-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Test that the child iframe navigation is not allowed assert_equals: expected "fail" but got "success"
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/link-click-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/link-click-blocked.sub-expected.txt
@@ -1,5 +1,5 @@
 
 
 FAIL Test that the child iframe navigation is not allowed assert_equals: expected "fail" but got "success"
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/meta-refresh-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/meta-refresh-blocked.sub-expected.txt
@@ -1,5 +1,5 @@
 
 
 FAIL Test that the child iframe navigation is not allowed assert_equals: expected "fail" but got "success"
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/parent-navigates-child-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/parent-navigates-child-blocked-expected.txt
@@ -1,5 +1,5 @@
 
 
 FAIL Test that the parent can't navigate the child because the relevant policy belongs to the navigation initiator (in this case the parent, which has the policy `navigate-to support/wait_for_navigation.html;`) assert_unreached: Should not have received a message as the navigation should not have been successful Reached unreachable code
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub-expected.txt
@@ -2,5 +2,5 @@
 
 PASS Test that image does not load
 PASS Event is fired
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub-expected.txt
@@ -3,5 +3,5 @@
 PASS Test that image does not load
 PASS Event is fired
 FAIL Report is observable to ReportingObserver Can't find variable: ReportingObserver
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-ancestors.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-ancestors.https.sub-expected.txt
@@ -3,6 +3,6 @@ CONSOLE MESSAGE: Unrecognized Content-Security-Policy directive 'report-to'.
 CONSOLE MESSAGE: Refused to load https://127.0.0.1:9443/content-security-policy/reporting-api/support/non-embeddable-frame.html?id=c61bd952-3b19-4c26-90dc-da5b33f0603d because it does not appear in the frame-ancestors directive of the Content Security Policy.
 
 
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 PASS No report to parent.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-unsafe-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-unsafe-eval-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Eval is allowed because the CSP is report-only
 FAIL SPV event is still raised assert_unreached: SPV event has not been received Reached unreachable code
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Eval is allowed because the CSP is report-only
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+FAIL Violation report status OK. assert_true: No CSP report sent, but expecting one. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/checkReport.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/checkReport.sub.js
@@ -74,10 +74,11 @@
         } else {
           // With the 'report-uri' directive, the report is contained in
           // `data[0]["csp-report"]`. With the 'report-to' directive, the report
-          // is contained in `data[0]["body"]`.
-          const reportBody = data[0]["body"]
+          // is contained in `data[0]["body"]`. If the test times-out, then the
+          // payload is an empty array and data[0] is undefined.
+          const reportBody = data[0]?.["body"]
                 ? data[0]["body"]
-                : data[0]["csp-report"];
+                : data[0]?.["csp-report"];
 
           assert_true(reportBody !== undefined,
                       "No CSP report sent, but expecting one.");


### PR DESCRIPTION
#### 67f9cdd0e157abd12493f2e391d5c0e18302b194
<pre>
Handle an empty array as the payload in CSP WPT framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=243057">https://bugs.webkit.org/show_bug.cgi?id=243057</a>

Reviewed by NOBODY (OOPS!).

If a WPT CSP test times-out, then the framework (in report.py) uses an empty
array as the default &quot;report&quot;. This default value does not match the assumption
in checkReport.sub.js where data[0] must be defined. We resolve this issue by
ensuring data[0] is defined before accessing it.

We also update the test expectations for tests where the current expectation
includes the error result of the current behavior.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/child-navigates-parent-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/form-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/href-location-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/link-click-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/meta-refresh-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/navigate-to/parent-navigates-child-blocked-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-ancestors.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-only-unsafe-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/support/checkReport.sub.js:
(reportTest.step):
</pre>