### PR TITLE
REGRESSION(252640@main): [ macOS iOS15 ] TestWebKitAPI.WebKit.AlternativeServicesDefaultDirectoryCreation is a constant failure

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -290,7 +290,7 @@ void WebsiteDataStore::resolveDirectoriesIfNecessary()
         m_resolvedConfiguration->setMediaKeysStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->mediaKeysStorageDirectory()));
     if (!m_configuration->indexedDBDatabaseDirectory().isEmpty())
         m_resolvedConfiguration->setIndexedDBDatabaseDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->indexedDBDatabaseDirectory()));
-    if (!m_configuration->alternativeServicesDirectory().isEmpty() && WebsiteDataStore::http3Enabled())
+    if (!m_configuration->alternativeServicesDirectory().isEmpty())
         m_resolvedConfiguration->setAlternativeServicesDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->alternativeServicesDirectory()));
     if (!m_configuration->deviceIdHashSaltsStorageDirectory().isEmpty())
         m_resolvedConfiguration->setDeviceIdHashSaltsStorageDirectory(resolveAndCreateReadWriteDirectoryForSandboxExtension(m_configuration->deviceIdHashSaltsStorageDirectory()));


### PR DESCRIPTION
#### 13e4866116a1babe39ba73ee61b6e033c95f65b8
<pre>
REGRESSION(252640@main): [ macOS iOS15 ] TestWebKitAPI.WebKit.AlternativeServicesDefaultDirectoryCreation is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242951">https://bugs.webkit.org/show_bug.cgi?id=242951</a>

Reviewed by Chris Dumez.

237210@main said we should create and resolve the directory no matter HTTP3 is enabled or not, so removing the condition
to match that.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):

Canonical link: <a href="https://commits.webkit.org/252699@main">https://commits.webkit.org/252699@main</a>
</pre>
