### PR TITLE
Enable CSSColorMixEnabled and CSSGradientInterpolationColorSpacesEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -230,11 +230,11 @@ CSSColorMixEnabled:
   humanReadableDescription: "Enable support for CSS color-mix() defined in CSS Color 5"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSContainIntrinsicSizeEnabled:
   type: bool
@@ -314,11 +314,11 @@ CSSGradientInterpolationColorSpacesEnabled:
   humanReadableDescription: "Enable custom interpolation in CSS gradients"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSGradientPremultipliedAlphaInterpolationEnabled:
   type: bool


### PR DESCRIPTION
#### c905475c417ae647e71bfcc24010a621565fbb5c
<pre>
Enable CSSColorMixEnabled and CSSGradientInterpolationColorSpacesEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=242917">https://bugs.webkit.org/show_bug.cgi?id=242917</a>
&lt;rdar://97278994&gt;

Reviewed by Myles C. Maxfield.

CSSWG thinks these features are ready to ship: <a href="https://github.com/w3c/csswg-drafts/issues/7310#issuecomment-1156717607">https://github.com/w3c/csswg-drafts/issues/7310#issuecomment-1156717607</a>

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:

Canonical link: <a href="https://commits.webkit.org/252716@main">https://commits.webkit.org/252716@main</a>
</pre>
