### PR TITLE
Prompt download for models in captive portal mode

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5948,7 +5948,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
         ), webPageID);
         });
 #if USE(QUICK_LOOK)
-        if (process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Enabled && (MIMETypeRegistry::isPDFOrPostScriptMIMEType(navigationResponse->response().mimeType()) || PreviewConverter::supportsMIMEType(navigationResponse->response().mimeType())))
+        if (policyAction == PolicyAction::Use && process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Enabled && (MIMETypeRegistry::isPDFOrPostScriptMIMEType(navigationResponse->response().mimeType()) || MIMETypeRegistry::isSupportedModelMIMEType(navigationResponse->response().mimeType()) || PreviewConverter::supportsMIMEType(navigationResponse->response().mimeType())))
             policyAction = PolicyAction::Download;
 #endif
         receivedPolicyDecision(policyAction, navigation.get(), nullptr, WTFMove(navigationResponse), WTFMove(sender));


### PR DESCRIPTION
#### a34fa2d34bd998ddd6fe2f24d1260632abea3340
<pre>
Prompt download for models in captive portal mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=243061">https://bugs.webkit.org/show_bug.cgi?id=243061</a>
rdar://97381599

Reviewed by Dean Jackson.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForResponseShared):
We should prompt for download when viewing model files instead of showing them.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(tempUSDZThatDoesNotExist):
Add test for download prompt.

Canonical link: <a href="https://commits.webkit.org/252798@main">https://commits.webkit.org/252798@main</a>
</pre>
