### PR TITLE
Having many active media elements can spin the main thread during playback

### DIFF
--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1225,6 +1225,12 @@ void MediaElementSession::updateMediaUsageIfChanged()
     if (!page || page->sessionID().isEphemeral())
         return;
 
+    // Bail out early if the currentSrc() is empty, and so was the previous currentSrc(), to
+    // avoid doing a large amount of unnecessary work below.
+    auto currentSrc = m_element.currentSrc();
+    if (currentSrc.isEmpty() && (!m_mediaUsageInfo || m_mediaUsageInfo->mediaURL.isEmpty()))
+        return;
+
     bool isOutsideOfFullscreen = false;
 #if ENABLE(FULLSCREEN_API)
     if (auto* fullscreenElement = document.fullscreenManager().currentFullscreenElement())
@@ -1236,7 +1242,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     bool isPlaying = m_element.isPlaying();
 
     MediaUsageInfo usage =  {
-        m_element.currentSrc(),
+        WTFMove(currentSrc),
         state() == PlatformMediaSession::Playing,
         canShowControlsManager(PlaybackControlsPurpose::ControlsManager),
         !page->isVisibleAndActive(),


### PR DESCRIPTION
#### f94d8d61f57b6b5e7fb2be96eb34f3b1bc6c60a4
<pre>
Having many active media elements can spin the main thread during playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=243062">https://bugs.webkit.org/show_bug.cgi?id=243062</a>
&lt;rdar://97105384&gt;

Reviewed by Eric Carlson.

Creating a media element and calling `.load()` on it will &quot;activate&quot; the element itself and, if called during a user gesture, remove playback restrictions. Subsequently, when determining which media element should be considered the &quot;main&quot; element for the purposes of remote control commands, now playing, and touch bar, all of these elements are subjected to numerous queries about their state. Some of these queries log, and this logging during a tight loop can hang the main thread for multiple hundreds of ms.

However, sites can have valid reasons for creating hundreds of media elements and calling `.load()` on each; they may want a pool of unlocked media elements for doing dynamic ad insertion, for playback of multiple episodes of content back-to-back, etc.

From sample trace data, the primary culprit in these hangs is `MediaElementSession::updateMediaUsageIfChanged()`. It will loop over every existing media element and run extensive queries against each. The queries themselves are relatively cheap, but allocating logging strings and sending them to syslog can be expensive.

Reduce the cost of `updateMediaUsageIfChanged()` by bailing out early if the media element in question does currently have a valid `currentURL()`, and did not have a valid URL the last pass either.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::updateMediaUsageIfChanged):

Canonical link: <a href="https://commits.webkit.org/252734@main">https://commits.webkit.org/252734@main</a>
</pre>
