### PR TITLE
Fix miscellaneous compiler warnings, July 2022 edition

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -385,7 +385,9 @@ static unsigned atspiRole(AccessibilityRole role)
     case AccessibilityRole::SystemWide:
     case AccessibilityRole::TableHeaderContainer:
     case AccessibilityRole::ValueIndicator:
+    case AccessibilityRole::Suggestion:
         return Atspi::Role::Unknown;
+    // Add most new roles above. The release assert is for roles that are handled specially.
     case AccessibilityRole::ListMarker:
     case AccessibilityRole::MathElement:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -730,10 +730,10 @@ AtomString Element::getAttributeForBindings(const QualifiedName& name, ResolveUR
         return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
 
     case ResolveURLs::No:
-        return attribute->value();
+        break;
     }
 
-    ASSERT_NOT_REACHED();
+    return attribute->value();
 }
 
 Vector<String> Element::getAttributeNames() const
@@ -1828,10 +1828,10 @@ AtomString Element::getAttributeForBindings(const AtomString& qualifiedName, Res
         return AtomString(completeURLsInAttributeValue(URL(), *attribute, resolveURLs));
 
     case ResolveURLs::No:
-        return attribute->value();
+        break;
     }
 
-    ASSERT_NOT_REACHED();
+    return attribute->value();
 }
 
 const AtomString& Element::getAttributeNS(const AtomString& namespaceURI, const AtomString& localName) const


### PR DESCRIPTION
#### aff87f6cbcf56b5fe448770a00f51814fa626b7c
<pre>
Fix miscellaneous compiler warnings, July 2022 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=243065">https://bugs.webkit.org/show_bug.cgi?id=243065</a>

Reviewed by Chris Dumez.

* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::atspiRole):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getAttributeForBindings const):

Canonical link: <a href="https://commits.webkit.org/252745@main">https://commits.webkit.org/252745@main</a>
</pre>
