### PR TITLE
Add fallback impl for FileSystem createTemporaryDirectory

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -833,6 +833,26 @@ String pathByAppendingComponents(StringView path, const Vector<StringView>& comp
 
 #endif
 
+#if !OS(WINDOWS) && !PLATFORM(COCOA)
+
+String createTemporaryDirectory()
+{
+    std::error_code ec;
+    std::string tempDir = std::filesystem::temp_directory_path(ec);
+    if (ec)
+        return String();
+
+    std::string newTempDirTemplate = tempDir + "XXXXXXXX";
+
+    Vector<char> newTempDir(newTempDirTemplate.c_str(), newTempDirTemplate.size());
+    if (!mkdtemp(newTempDir.data()))
+        return String();
+
+    return stringFromFileSystemRepresentation(newTempDir.data());
+}
+
+#endif // !OS(WINDOWS) && !PLATFORM(COCOA)
+
 #endif // HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)
 
 } // namespace WTF::FileSystemImpl

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -212,6 +212,11 @@ WTF_EXPORT_PRIVATE bool setAllowsMaterializingDatalessFiles(bool, PolicyScope);
 WTF_EXPORT_PRIVATE std::optional<bool> allowsMaterializingDatalessFiles(PolicyScope);
 #endif
 
+// Impl for systems that do not already have createTemporaryDirectory
+#if !OS(WINDOWS) && !PLATFORM(COCOA)
+WTF_EXPORT_PRIVATE String createTemporaryDirectory();
+#endif
+
 WTF_EXPORT_PRIVATE bool deleteNonEmptyDirectory(const String&);
 
 WTF_EXPORT_PRIVATE String realPath(const String&);


### PR DESCRIPTION
#### 00e1e0d6e977c7cc204944834d6af3254a1d5e5b
<pre>
Add fallback impl for FileSystem createTemporaryDirectory
<a href="https://bugs.webkit.org/show_bug.cgi?id=232499">https://bugs.webkit.org/show_bug.cgi?id=232499</a>

Reviewed by Chris Dumez.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::createTemporaryDirectory):
* Source/WTF/wtf/FileSystem.h:

Canonical link: <a href="https://commits.webkit.org/252799@main">https://commits.webkit.org/252799@main</a>
</pre>
