### PR TITLE
CrashTracer: com.apple.WebKit.GPU at AVFCore: -[AVPlayerItem _seekToTime:toleranceBefore:toleranceAfter:seekID:completionHandler:]

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3228,7 +3228,10 @@ void HTMLMediaElement::seekTask()
     MediaTime positiveTolerance = m_pendingSeek->positiveTolerance;
     m_pendingSeek = nullptr;
 
+    ASSERT(negativeTolerance.isValid());
     ASSERT(negativeTolerance >= MediaTime::zeroTime());
+    ASSERT(positiveTolerance.isValid());
+    ASSERT(positiveTolerance >= MediaTime::zeroTime());
 
     // 6 - If the new playback position is later than the end of the media resource, then let it be the end
     // of the media resource instead.


### PR DESCRIPTION
#### cfafcbaf3fab37592eaa85b929b236d1ea670cd0
<pre>
CrashTracer: com.apple.WebKit.GPU at AVFCore: -[AVPlayerItem _seekToTime:toleranceBefore:toleranceAfter:seekID:completionHandler:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=243068">https://bugs.webkit.org/show_bug.cgi?id=243068</a>
&lt;rdar://95237949&gt;

Reviewed by Jer Noble.

AVPlayerItem throws an exception when an invalid or negative tolerance value
is passed to the -seekToTime: method. If we run into a bad tolerance value,
we can just ignore the tolerance by setting it to positive infinity.

From the AVF documentation: (<a href="https://developer.apple.com/documentation/avfoundation/avplayer/1388493-seektotime)">https://developer.apple.com/documentation/avfoundation/avplayer/1388493-seektotime)</a>
Invoking this method with toleranceBefore set to kCMTimePositiveInfinity
and toleranceAfter set to kCMTimePositiveInfinity is the same as invoking seekToTime:.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekTask):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::seekToTime):

Canonical link: <a href="https://commits.webkit.org/252714@main">https://commits.webkit.org/252714@main</a>
</pre>
