### PR TITLE
Add myself to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -745,6 +745,16 @@
    },
    {
       "emails" : [
+         "aizquierdogarcia@apple.com"
+      ],
+      "github" : "angelaizg",
+      "name" : "Angela Izquierdo Garcia",
+      "nicks" : [
+         "angie"
+      ]
+   },
+   {
+      "emails" : [
          "angelos@igalia.com"
       ],
       "expertise" : "JavaScriptCore",


### PR DESCRIPTION
#### 0186b1d6fbeb062ba67fae6bc3a263bf93286978
<pre>
Add myself to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=243070">https://bugs.webkit.org/show_bug.cgi?id=243070</a>

Reviewed by Chris Dumez.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/252704@main">https://commits.webkit.org/252704@main</a>
</pre>
