### PR TITLE
[Gardening]: [ BigSur wk2] 2X imported/w3c/web-platform-tests/media-capabilities (Layout tests) are flaky failures

### DIFF
--- a/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
@@ -9,3 +9,6 @@ webkit.org/b/243067 http/tests/storageAccess/request-and-grant-access-cross-orig
 webkit.org/b/243069 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe.html [ Pass Failure ]
 webkit.org/b/243069 http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.html [ Pass Failure ]
 webkit.org/b/243069 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction.html [ Pass Failure ]
+
+webkit.org/b/243074 imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker.html [ Pass Failure ]
+webkit.org/b/243074 imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any.worker.html [ Pass Failure ]


### PR DESCRIPTION
#### d377d5f2a1e521c1e2d43fa003355fe404bb836a
<pre>
[Gardening]: [ BigSur wk2] 2X imported/w3c/web-platform-tests/media-capabilities (Layout tests) are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=243074">https://bugs.webkit.org/show_bug.cgi?id=243074</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-bigsur-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252705@main">https://commits.webkit.org/252705@main</a>
</pre>
