### PR TITLE
[Gardening]: [ BigSur wk2 ] imported/w3c/web-platform-tests/resource-timing/redirects.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-bigsur-wk2/TestExpectations
@@ -12,3 +12,5 @@ webkit.org/b/243069 http/tests/storageAccess/request-and-grant-access-cross-orig
 
 webkit.org/b/243074 imported/w3c/web-platform-tests/media-capabilities/decodingInfo.any.worker.html [ Pass Failure ]
 webkit.org/b/243074 imported/w3c/web-platform-tests/media-capabilities/encodingInfo.any.worker.html [ Pass Failure ]
+
+webkit.org/b/243076 imported/w3c/web-platform-tests/resource-timing/redirects.html [ Pass Failure ]


### PR DESCRIPTION
#### dde44c38f6d9e06a48a37a0ee41302c49fc7d4b8
<pre>
[Gardening]: [ BigSur wk2 ] imported/w3c/web-platform-tests/resource-timing/redirects.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243076">https://bugs.webkit.org/show_bug.cgi?id=243076</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-bigsur-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252708@main">https://commits.webkit.org/252708@main</a>
</pre>
