### PR TITLE
REGRESSION(243836@main): [GStreamer] Broke videos in yelp

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1511,6 +1511,11 @@ void HTMLMediaElement::loadResource(const URL& initialURL, ContentType& contentT
         mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
         return;
     }
+#elif USE(GSTREAMER)
+    if (!url.isEmpty() && !frame->loader().willLoadMediaElementURL(url, *this)) {
+        mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
+        return;
+    }
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)


### PR DESCRIPTION
#### 6cbee1cfa19be6f4e6bcca15577452c7b062034b
<pre>
REGRESSION(243836@main): [GStreamer] Broke videos in yelp
<a href="https://bugs.webkit.org/show_bug.cgi?id=242156">https://bugs.webkit.org/show_bug.cgi?id=242156</a>

Reviewed by Jer Noble.

243836@main removed a call to frame-&gt;loader().willLoadMediaElementURL(),
which broke video playback in Yelp (the GNOME help viewer, not the
popular website). Put it back.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):

Canonical link: <a href="https://commits.webkit.org/252746@main">https://commits.webkit.org/252746@main</a>
</pre>
