### PR TITLE
[ macOS iOS15 Debug ] fast/dom/lazy-image-loading-document-leak.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/dom/lazy-image-loading-document-leak-expected.txt
+++ b/LayoutTests/fast/dom/lazy-image-loading-document-leak-expected.txt
@@ -4,6 +4,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS internals.isDocumentAlive(frameDocumentID) is true
 PASS The popup document didn't leak.
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/dom/lazy-image-loading-document-leak.html
+++ b/LayoutTests/fast/dom/lazy-image-loading-document-leak.html
@@ -6,24 +6,29 @@
 description("Tests that lazy image loading doesn't cause Document leaks.");
 jsTestIsAsync = true;
 
-frameDocumentID = 0;
 checkCount = 0;
-popup = null;
+
+const popupCount = 10;
+popups = [];
+frameDocumentIDs = [];
 
 function runTest()
 {
-    popup.close();
-    popup = null;
+    for (let popup of popups)
+        popup.close();
+    popups = [];
 
     handle = setInterval(() => {
         gc();
-        if (!internals.isDocumentAlive(frameDocumentID)) {
-            clearInterval(handle);
-            testPassed("The popup document didn't leak.");
-            finishJSTest();
+        for (let frameDocumentID of frameDocumentIDs) {
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The popup document didn't leak.");
+                finishJSTest();
+            }
         }
         checkCount++;
-        if (checkCount > 500) {
+        if (checkCount > 1000) {
             clearInterval(handle);
             testFailed("The popup document leaked.");
             finishJSTest();
@@ -31,13 +36,21 @@ function runTest()
     }, 10);
 }
 
-onload = () => {
-    popup = window.open("resources/lazy-image-loading-document-leak-popup.html");
-    popup.onload = () => {
-        popup.onload = null;
-        frameDocumentID = internals.documentIdentifier(popup.document);
-        shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
+popupDidLoad = function(popup, event)
+{
+    popup.onload = null;
+    frameDocumentID = internals.documentIdentifier(popup.document);
+    shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
+    popups.push(popup);
+    frameDocumentIDs.push(frameDocumentID);
+    if (popups.length == popupCount)
         setTimeout(runTest, 0);
+}
+
+onload = () => {
+    for (let i = 0; i < popupCount; i++) {
+        let popup = window.open("resources/lazy-image-loading-document-leak-popup.html");
+        popup.onload = popupDidLoad.bind(event, popup);
     }
 };
 </script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2287,5 +2287,3 @@ webkit.org/b/242481 fast/css/direct-adjacent-style-sharing-3.html [ Pass ImageOn
 webkit.org/b/242484 fast/css/display-contents-all.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass Crash ]
-
-webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]


### PR DESCRIPTION
#### 25c0e5a1c8b7f28d343438d5b6f00db970ea26de
<pre>
[ macOS iOS15 Debug ] fast/dom/lazy-image-loading-document-leak.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242904">https://bugs.webkit.org/show_bug.cgi?id=242904</a>
&lt;rdar://97262222&gt;

Reviewed by Ryosuke Niwa.

Because our GC is conservative, allocate several documents and make sure at least
one goes away.

* LayoutTests/fast/dom/lazy-image-loading-document-leak.html:

Canonical link: <a href="https://commits.webkit.org/252719@main">https://commits.webkit.org/252719@main</a>
</pre>
