### PR TITLE
HTMLCanvasElement::setSurfaceSize() fails to remove document as observer after clearing the buffer

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -59,7 +59,7 @@ CanvasBase::CanvasBase(IntSize size)
 CanvasBase::~CanvasBase()
 {
     ASSERT(m_didNotifyObserversCanvasDestroyed);
-    ASSERT(m_observers.isEmpty());
+    ASSERT(m_observers.computesEmpty());
     ASSERT(!m_imageBuffer);
 }
 
@@ -123,7 +123,7 @@ size_t CanvasBase::externalMemoryCost() const
 
 void CanvasBase::addObserver(CanvasObserver& observer)
 {
-    m_observers.add(&observer);
+    m_observers.add(observer);
 
     if (is<CSSCanvasValue::CanvasObserverProxy>(observer))
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*this);
@@ -131,7 +131,7 @@ void CanvasBase::addObserver(CanvasObserver& observer)
 
 void CanvasBase::removeObserver(CanvasObserver& observer)
 {
-    m_observers.remove(&observer);
+    m_observers.remove(observer);
 
     if (is<CSSCanvasValue::CanvasObserverProxy>(observer))
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*this);
@@ -140,23 +140,21 @@ void CanvasBase::removeObserver(CanvasObserver& observer)
 void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& rect)
 {
     for (auto& observer : m_observers)
-        observer->canvasChanged(*this, rect);
+        observer.canvasChanged(*this, rect);
 }
 
 void CanvasBase::notifyObserversCanvasResized()
 {
     for (auto& observer : m_observers)
-        observer->canvasResized(*this);
+        observer.canvasResized(*this);
 }
 
 void CanvasBase::notifyObserversCanvasDestroyed()
 {
     ASSERT(!m_didNotifyObserversCanvasDestroyed);
 
-    for (auto& observer : copyToVector(m_observers))
-        observer->canvasDestroyed(*this);
-
-    m_observers.clear();
+    for (auto& observer : std::exchange(m_observers, WeakHashSet<CanvasObserver>()))
+        observer.canvasDestroyed(*this);
 
 #if ASSERT_ENABLED
     m_didNotifyObserversCanvasDestroyed = true;
@@ -186,7 +184,7 @@ HashSet<Element*> CanvasBase::cssCanvasClients() const
         if (!is<CSSCanvasValue::CanvasObserverProxy>(observer))
             continue;
 
-        auto clients = downcast<CSSCanvasValue::CanvasObserverProxy>(observer)->ownerValue().clients();
+        auto clients = downcast<CSSCanvasValue::CanvasObserverProxy>(observer).ownerValue().clients();
         for (auto& entry : clients) {
             if (RefPtr<Element> element = entry.key->element())
                 cssCanvasClients.add(element.get());

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -45,7 +45,7 @@ class ScriptExecutionContext;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
 
-class CanvasObserver {
+class CanvasObserver : public CanMakeWeakPtr<CanvasObserver> {
 public:
     virtual ~CanvasObserver() = default;
 
@@ -144,7 +144,7 @@ private:
 #if ASSERT_ENABLED
     bool m_didNotifyObserversCanvasDestroyed { false };
 #endif
-    HashSet<CanvasObserver*> m_observers;
+    WeakHashSet<CanvasObserver> m_observers;
     WeakHashSet<CanvasDisplayBufferObserver> m_displayBufferObservers;
 };
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -685,6 +685,11 @@ void HTMLCanvasElement::setSurfaceSize(const IntSize& size)
     m_hasCreatedImageBuffer = false;
     setImageBuffer(nullptr);
     clearCopiedImage();
+
+    if (!needsPreparationForDisplay()) {
+        document().clearCanvasPreparation(*this);
+        removeObserver(document());
+    }
 }
 
 static String toEncodingMimeType(const String& mimeType)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -54,7 +54,7 @@ class WebGLProgram;
 class WebGLRenderingContextBase;
 #endif // ENABLE(WEBGL)
 
-class InspectorCanvasAgent final : public InspectorAgentBase, public Inspector::CanvasBackendDispatcherHandler, public CanvasObserver, public CanMakeWeakPtr<InspectorCanvasAgent> {
+class InspectorCanvasAgent final : public InspectorAgentBase, public Inspector::CanvasBackendDispatcherHandler, public CanvasObserver {
     WTF_MAKE_NONCOPYABLE(InspectorCanvasAgent);
     WTF_MAKE_FAST_ALLOCATED;
 public:


### PR DESCRIPTION
#### 719da043b8d1d102fced507a23b8b80d137ab8ee
<pre>
HTMLCanvasElement::setSurfaceSize() fails to remove document as observer after clearing the buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=243080">https://bugs.webkit.org/show_bug.cgi?id=243080</a>
&lt;rdar://97057937&gt;

Reviewed by Geoffrey Garen.

Fix HTMLCanvasElement::setSurfaceSize() and also do some hardening by using
a WeakHashSet instead of a HashSet of raw pointers for the observers.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::~CanvasBase):
(WebCore::CanvasBase::addObserver):
(WebCore::CanvasBase::removeObserver):
(WebCore::CanvasBase::notifyObserversCanvasChanged):
(WebCore::CanvasBase::notifyObserversCanvasResized):
(WebCore::CanvasBase::notifyObserversCanvasDestroyed):
(WebCore:: const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::setSurfaceSize):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:

Canonical link: <a href="https://commits.webkit.org/252728@main">https://commits.webkit.org/252728@main</a>
</pre>
