### PR TITLE
Make  --lint-test-files work with variant tests

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -582,7 +582,18 @@ class Port(object):
         """Return True if the test name refers to an existing test or baseline."""
         # Used by test_expectations.py to determine if an entry refers to a
         # valid test and by printing.py to determine if baselines exist.
-        return self.test_isfile(test_name) or self.test_isdir(test_name)
+        if self.test_isfile(test_name) or self.test_isdir(test_name):
+            return True
+        if '?' in test_name or '#' in test_name:
+            fs = self._filesystem
+            ext_parts = fs.splitext(test_name)
+            test_name = ext_parts[0]
+            if len(ext_parts) > 1 and '?' in ext_parts[1]:
+                test_name += ext_parts[1].split('?')[0]
+            if len(ext_parts) > 1 and '#' in ext_parts[1]:
+                test_name += ext_parts[1].split('#')[0]
+            return self.test_isfile(test_name)
+        return False
 
     def split_test(self, test_name):
         """Splits a test name into the 'directory' part and the 'basename' part."""

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -269,6 +269,7 @@ class PortTest(unittest.TestCase):
         self.assertTrue(port.test_exists('passes'))
         self.assertTrue(port.test_exists('passes/text.html'))
         self.assertFalse(port.test_exists('passes/does_not_exist.html'))
+        self.assertTrue(port.test_exists('variant/variant.any.html?1-100'))
 
     def test_test_isfile(self):
         port = self.make_port(with_tests=True)

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -107,7 +107,7 @@ class TestList(object):
 #
 # These numbers may need to be updated whenever we add or delete tests.
 #
-TOTAL_TESTS = 83
+TOTAL_TESTS = 84
 TOTAL_SKIPS = 11
 TOTAL_RETRIES = 13
 
@@ -283,6 +283,8 @@ layer at (0,0) size 800x34
         expected_text=None, actual_text=None, actual_image=None, actual_checksum=None, crash=True, is_wpt_crash_test=True)
     tests.add('imported/w3c/web-platform-tests/crashtests/dir/test.html',
         expected_text=None, actual_text='ok', actual_image=None, actual_checksum=None, is_wpt_crash_test=True)
+
+    tests.add('variant/variant.any.html')
 
     return tests
 


### PR DESCRIPTION
#### 3b8f761bb15022bf27394546bc0e49183104d0b1
<pre>
Make  --lint-test-files work with variant tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=242967">https://bugs.webkit.org/show_bug.cgi?id=242967</a>
&lt;rdar://97346770&gt;

Reviewed by Jonathan Bedard.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=231544">https://bugs.webkit.org/show_bug.cgi?id=231544</a>, support for WPT&apos;s templated tests
was added. However, the TestExpectation linter doesn&apos;t know how to handle tests
that are variants. This patch mitigates that by checking if the file without the
variant part of the test name exists.

We could also open the test file and confirm it contains the proper &lt;!-- META: variant=...
line, but this was not done in this iteration of the patch in interest of keeping IO minimal.

* Tools/Scripts/webkitpy/port/base.py:
(Port.test_exists):
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test_test_exists):
* Tools/Scripts/webkitpy/port/test.py:

Canonical link: <a href="https://commits.webkit.org/252732@main">https://commits.webkit.org/252732@main</a>
</pre>
