### PR TITLE
xhr/send-authentication-basic-setrequestheader-existing-session.htm WPT test is failing in WebKit

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -908,7 +908,6 @@ imported/w3c/web-platform-tests/workers/modules/shared-worker-import-csp.html [ 
 http/tests/cache-storage/page-cache-domcache-pending-promise.html [ DumpJSConsoleLogInStdErr ]
 
 imported/w3c/web-platform-tests/xhr/event-timeout-order.any.html [ Pass Failure ]
-imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session.htm [ Failure ]
 imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm [ Failure ]
 
 # textarea.animate is not supported

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL XMLHttpRequest: send() - "Basic" authenticated request using setRequestHeader() when there is an existing session assert_equals: expected "5089bca3-d8d4-4c86-bb33-fc1427e3edc7\npass" but got "dcecdc89-20a0-49aa-b216-afb725b6534c\nopen-pass"
+PASS XMLHttpRequest: send() - "Basic" authenticated request using setRequestHeader() when there is an existing session
 Note: this test will only work as expected once per browsing session. Restart browser to re-test.

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1866,6 +1866,8 @@ imported/w3c/web-platform-tests/xhr/preserve-ua-header-on-redirect.htm [ Failure
 # Push subscription tests fail without platform-specific PushCrypto implementations.
 http/tests/push-api [ Skip ]
 
+imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session.htm [ Failure ]
+
 # Ftp code is disabled in gtk port
 http/tests/misc/ftp-eplf-directory.py [ Skip ]
 

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -162,7 +162,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
         }
     }
         
-    if (!d->m_initialCredential.isEmpty()) {
+    if (!d->m_initialCredential.isEmpty() && !firstRequest().hasHTTPHeaderField(HTTPHeaderName::Authorization)) {
         // FIXME: Support Digest authentication, and Proxy-Authorization.
         applyBasicAuthorizationHeader(firstRequest(), d->m_initialCredential);
     }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -321,7 +321,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     }
 
 #if USE(CREDENTIAL_STORAGE_WITH_NETWORK_SESSION)
-    if (!m_initialCredential.isEmpty()) {
+    if (!m_initialCredential.isEmpty() && !request.hasHTTPHeaderField(WebCore::HTTPHeaderName::Authorization)) {
         // FIXME: Support Digest authentication, and Proxy-Authorization.
         applyBasicAuthorizationHeader(request, m_initialCredential);
     }


### PR DESCRIPTION
#### 45bd6106c182cc1f3aa7c1331e0e5874f1624690
<pre>
xhr/send-authentication-basic-setrequestheader-existing-session.htm WPT test is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243081">https://bugs.webkit.org/show_bug.cgi?id=243081</a>

Reviewed by Darin Adler.

If we managed to find credentials in the credential storage, we would construct an Authorization
HTTP header from them and add it to the HTTP request. However, in the event where the HTTP
request already had an Authorization header, we would overwrite it, which didn&apos;t match the
behavior of Blink &amp; Gecko. This patch aligns us with other browsers.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-setrequestheader-existing-session-expected.txt:
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::createNSURLConnection):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):

Canonical link: <a href="https://commits.webkit.org/252784@main">https://commits.webkit.org/252784@main</a>
</pre>
