### PR TITLE
XHR error events should return 0 for loaded & total

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/onabort-progressevent-attributes.html
+++ b/LayoutTests/http/tests/xmlhttprequest/onabort-progressevent-attributes.html
@@ -18,9 +18,9 @@ var loaded = 0;
 
 function onProgressEvent(e)
 {
-    if (total != e.total || loaded != e.loaded)
+    if (e.total != 0 || e.loaded != 0)
         fail("Event " + e.type + "total/loaded values not matching: " 
-            + "(" + e.loaded + " / " + e.total + "), expected (" + loaded + " / " + total + ")");
+            + "(" + e.loaded + " / " + e.total + "), expected (0 / 0)");
 }
 
 function onUnexpectedProgressEvent(e)

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/event-error.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/event-error.sub.any-expected.txt
@@ -1,5 +1,5 @@
 Blocked access to external URL http://nonexistent.localhost:8800/
 
 PASS onerror should be called
-FAIL error while reading body should report zeros for loaded and total assert_equals: loaded expected 0 but got 50
+PASS error while reading body should report zeros for loaded and total
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/event-error.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/event-error.sub.any.worker-expected.txt
@@ -1,5 +1,5 @@
 Blocked access to external URL http://nonexistent.localhost:8800/
 
 PASS onerror should be called
-FAIL error while reading body should report zeros for loaded and total assert_equals: loaded expected 0 but got 50
+PASS error while reading body should report zeros for loaded and total
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1106,8 +1106,8 @@ void XMLHttpRequest::dispatchErrorEvents(const AtomString& type)
             m_upload->dispatchProgressEvent(eventNames().loadendEvent, 0, 0);
         }
     }
-    m_progressEventThrottle.dispatchProgressEvent(type);
-    m_progressEventThrottle.dispatchProgressEvent(eventNames().loadendEvent);
+    m_progressEventThrottle.dispatchErrorProgressEvent(type);
+    m_progressEventThrottle.dispatchErrorProgressEvent(eventNames().loadendEvent);
 }
 
 void XMLHttpRequest::timeoutTimerFired()

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -88,7 +88,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchEventWhenPossible(Event& event
 
 void XMLHttpRequestProgressEventThrottle::dispatchProgressEvent(const AtomString& type)
 {
-    ASSERT(type == eventNames().loadstartEvent || type == eventNames().progressEvent || type == eventNames().loadEvent || type == eventNames().loadendEvent || type == eventNames().abortEvent || type == eventNames().errorEvent || type == eventNames().timeoutEvent);
+    ASSERT(type == eventNames().loadstartEvent || type == eventNames().progressEvent || type == eventNames().loadEvent || type == eventNames().loadendEvent);
 
     if (type == eventNames().loadstartEvent) {
         m_lengthComputable = false;
@@ -98,6 +98,14 @@ void XMLHttpRequestProgressEventThrottle::dispatchProgressEvent(const AtomString
 
     if (m_target.hasEventListeners(type))
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, m_lengthComputable, m_loaded, m_total));
+}
+
+void XMLHttpRequestProgressEventThrottle::dispatchErrorProgressEvent(const AtomString& type)
+{
+    ASSERT(type == eventNames().loadendEvent || type == eventNames().abortEvent || type == eventNames().errorEvent || type == eventNames().timeoutEvent);
+
+    if (m_target.hasEventListeners(type))
+        dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(type, false, 0, 0));
 }
 
 void XMLHttpRequestProgressEventThrottle::flushProgressEvent()

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -50,6 +50,7 @@ public:
     void updateProgress(bool isAsync, bool lengthComputable, unsigned long long loaded, unsigned long long total);
     void dispatchReadyStateChangeEvent(Event&, ProgressEventAction = DoNotFlushProgressEvent);
     void dispatchProgressEvent(const AtomString&);
+    void dispatchErrorProgressEvent(const AtomString&);
 
     void suspend();
     void resume();


### PR DESCRIPTION
#### 2040449337eec2b7d422ecf01b6082b1a0aaf9ea
<pre>
XHR error events should return 0 for loaded &amp; total
<a href="https://bugs.webkit.org/show_bug.cgi?id=243085">https://bugs.webkit.org/show_bug.cgi?id=243085</a>

Reviewed by Darin Adler.

XHR error events should return 0 for loaded &amp; total:
- <a href="https://xhr.spec.whatwg.org/#handle-errors">https://xhr.spec.whatwg.org/#handle-errors</a> (steps 7 &amp; 8)

This behavior matches Blink &amp; Gecko.

* LayoutTests/imported/w3c/web-platform-tests/xhr/event-error.sub.any-expected.txt:
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::dispatchErrorEvents):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchProgressEvent):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:

Canonical link: <a href="https://commits.webkit.org/252743@main">https://commits.webkit.org/252743@main</a>
</pre>
