### PR TITLE
Crash under maskedURLForBindings

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -721,7 +721,7 @@ public:
 
     inline bool shouldMaskURLForBindings(const URL&) const;
     inline const URL& maskedURLForBindingsIfNeeded(const URL&) const;
-    static const AtomString& maskedURLStringForBindings();
+    static StaticStringImpl& maskedURLStringForBindings();
     static const URL& maskedURLForBindings();
 
     String userAgent(const URL&) const final;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4704,6 +4704,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
     if (resolveURLs == ResolveURLs::No)
         return urlString;
 
+    static MainThreadNeverDestroyed<const AtomString> maskedURLStringForBindings(document().maskedURLStringForBindings());
     URL completeURL = base.isNull() ? document().completeURL(urlString) : URL(base, urlString);
 
     switch (resolveURLs) {
@@ -4712,7 +4713,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
 
     case ResolveURLs::YesExcludingURLsForPrivacy: {
         if (document().shouldMaskURLForBindings(completeURL))
-            return document().maskedURLStringForBindings();
+            return maskedURLStringForBindings.get();
         if (!document().url().isLocalFile())
             return completeURL.string();
         break;
@@ -4720,7 +4721,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
 
     case ResolveURLs::NoExcludingURLsForPrivacy:
         if (document().shouldMaskURLForBindings(completeURL))
-            return document().maskedURLStringForBindings();
+            return maskedURLStringForBindings.get();
         break;
 
     case ResolveURLs::No:


### PR DESCRIPTION
#### 7626eadf0a70b425cf472ec22d17bcb66e16468a
<pre>
Crash under maskedURLForBindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=243086">https://bugs.webkit.org/show_bug.cgi?id=243086</a>
rdar://97409683

Reviewed by Mark Lam, Chris Dumez and Timothy Hatcher.

JSC has a feature materializing Error stack from GC heap thread because of massive memory saving: if we keep
call stack information via JSCell, it can keeps a lot of JSCells from that, and keeping massive amount of memory forever
until an error object is GC-ed.

However, 252418@main introduced a hook into this stack materialization, and this hook function is not designed to be called
from GC heap thread: it is assuming the main thread, and it is generating AtomString. This does not work since GC heap thread
is not a main thread. JSC is intentionally clears AtomStringTable in GC heap threads to catch these errors, and thus we crash now.

This patch fixes Document::maskedURLForBindings so that it creates a URL in a thread-safe way: creating it via LazyNeverDestroyed + std::call_once.
And it is intentionally using StaticStringImpl since which cannot be converted to AtomString and this string can be used from any threads
at the same time. On the other hand, Element::resolveURLStringIfNeeded is called only from the main thread. Thus we make the used string
AtomString in that function so that we can avoid atomizing the same string repeatedly.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::maskedURLStringForBindings):
(WebCore::Document::maskedURLForBindings):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveURLStringIfNeeded const):

Canonical link: <a href="https://commits.webkit.org/252724@main">https://commits.webkit.org/252724@main</a>
</pre>
