### PR TITLE
Use 'CanvasText' instead of 'text' in the UA stylesheet

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -26,7 +26,7 @@
 html {
     display: block;
 #if defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT
-    color: text;
+    color: CanvasText;
 #endif
 }
 
@@ -410,8 +410,8 @@ textarea,
 input {
     appearance: auto;
 #if defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT
-    color: text;
-    background-color: -webkit-control-background;
+    color: CanvasText;
+    background-color: Canvas;
 #else
     background-color: white;
 #endif
@@ -732,8 +732,8 @@ textarea {
     appearance: auto;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
 #if defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT
-    color: text;
-    background-color: -webkit-control-background;
+    color: CanvasText;
+    background-color: Canvas;
 #else
     background-color: white;
 #endif
@@ -1058,8 +1058,8 @@ select {
 #else
     border: 1px solid;
 #if defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT
-    color: text;
-    background-color: -webkit-control-background;
+    color: CanvasText;
+    background-color: Canvas;
 #else
     color: black;
     background-color: white;


### PR DESCRIPTION
#### 58a8fc782a7d3dd00aedf6bd5054c51f1dd5d412
<pre>
Use &apos;CanvasText&apos; instead of &apos;text&apos; in the UA stylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=232954">https://bugs.webkit.org/show_bug.cgi?id=232954</a>
rdar://85510727

Reviewed by Wenson Hsieh.

&apos;CanvasText&apos; is a standard system color which should be used for &quot;text in
application content or documents&quot;.

Spec: <a href="https://www.w3.org/TR/css-color-4/#valdef-system-color-canvastext">https://www.w3.org/TR/css-color-4/#valdef-system-color-canvastext</a>

* Source/WebCore/css/html.css:

Use the matching &apos;Canvas&apos; value alongside &apos;CanvasText&apos;, rather than the
non-standard &apos;-webkit-control-background&apos;.

This is a slight behavior change on macOS, as &apos;CanvasText&apos; is implemented using
&apos;-[NSColor textBackgroundColor]&apos;, while &apos;-webkit-control-background&apos; is
implemented using &apos;-[NSColor controlBackgroundColor]&apos;. However, AppKit actually
uses &apos;-[NSColor textBackgroundColor]&apos; for text-based controls.
&apos;-[NSColor controlBackgroundColor]` is intended for &quot;content areas&quot;, such as
scroll views, table views, and collection views.

On other platforms, &apos;CanvasText&apos; and &apos;-webkit-control-background&apos; are equivalent.

Canonical link: <a href="https://commits.webkit.org/252845@main">https://commits.webkit.org/252845@main</a>
</pre>
