### PR TITLE
Remove twitter Quirks related to web-share

### DIFF
--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -129,7 +129,7 @@ static std::optional<URL> shareableURLForShareData(ScriptExecutionContext& conte
 
 static bool validateWebSharePolicy(Document& document)
 {
-    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::WebShare, document, LogFeaturePolicyFailure::Yes) || document.quirks().shouldDisableWebSharePolicy();
+    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::WebShare, document, LogFeaturePolicyFailure::Yes);
 }
 
 bool Navigator::canShare(Document& document, const ShareData& data)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -84,16 +84,6 @@ static inline bool isYahooMail(Document& document)
 }
 #endif
 
-static bool isTwitterDocument(Document& document)
-{
-    return RegistrableDomain(document.url()).string() == "twitter.com"_s;
-}
-
-static bool isYouTubeDocument(Document& document)
-{
-    return RegistrableDomain(document.url()).string() == "youtube.com"_s;
-}
-
 Quirks::Quirks(Document& document)
     : m_document(document)
 {
@@ -1390,8 +1380,10 @@ bool Quirks::requiresUserGestureToLoadInPictureInPicture() const
     if (!needsQuirks())
         return false;
 
-    if (!m_requiresUserGestureToLoadInPictureInPicture)
-        m_requiresUserGestureToLoadInPictureInPicture = isTwitterDocument(m_document->topDocument());
+    if (!m_requiresUserGestureToLoadInPictureInPicture) {
+        auto domain = RegistrableDomain(m_document->topDocument().url());
+        m_requiresUserGestureToLoadInPictureInPicture = domain.string() == "twitter.com"_s;
+    }
 
     return *m_requiresUserGestureToLoadInPictureInPicture;
 #else
@@ -1466,17 +1458,6 @@ bool Quirks::needsToForceUserSelectAndUserDragWhenInstallingImageOverlay() const
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
-
-bool Quirks::shouldDisableWebSharePolicy() const
-{
-    if (!needsQuirks())
-        return false;
-
-    if (!m_shouldDisableWebSharePolicy)
-        m_shouldDisableWebSharePolicy = isTwitterDocument(*m_document) || isYouTubeDocument(*m_document);
-
-    return *m_shouldDisableWebSharePolicy;
-}
 
 #if PLATFORM(IOS)
 bool Quirks::allowLayeredFullscreenVideos() const

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -156,8 +156,6 @@ public:
 #if ENABLE(IMAGE_ANALYSIS)
     bool needsToForceUserSelectAndUserDragWhenInstallingImageOverlay() const;
 #endif
-
-    bool shouldDisableWebSharePolicy() const;
     
 #if PLATFORM(IOS)
     WEBCORE_EXPORT bool allowLayeredFullscreenVideos() const;
@@ -209,7 +207,6 @@ private:
 #endif
     mutable std::optional<bool> m_blocksReturnToFullscreenFromPictureInPictureQuirk;
     mutable std::optional<bool> m_shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
-    mutable std::optional<bool> m_shouldDisableWebSharePolicy;
 #if PLATFORM(IOS)
     mutable std::optional<bool> m_allowLayeredFullscreenVideos;
 #endif


### PR DESCRIPTION
#### 29b13de20953a2bdfdb1f5dfa7bf3c856d120009
<pre>
Remove twitter Quirks related to web-share
<a href="https://bugs.webkit.org/show_bug.cgi?id=243088">https://bugs.webkit.org/show_bug.cgi?id=243088</a>

Reviewed by Youenn Fablet.

WebKit is now using the &quot;*&quot; permissions policy
for &quot;web-share&quot; and we are coordinating with
Twitter to add &quot;web-share&quot; to their
video-embedding iframes.

YouTube is also being contacted to add &quot;web-share&quot;.

We can remove the Quirks and related functions.

Manually tested.

* Source/WebCore/page/Navigator.cpp:
(WebCore::validateWebSharePolicy):
* Source/WebCore/page/Quirks.cpp:
(WebCore::isTwitterDocument): Deleted.
(WebCore::isYouTubeDocument): Deleted.
(WebCore::Quirks::requiresUserGestureToLoadInPictureInPicture const):
(WebCore::Quirks::shouldDisableWebSharePolicy const): Deleted.
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/252866@main">https://commits.webkit.org/252866@main</a>
</pre>
