### PR TITLE
Convert the arguments to ClipRectsContext() into an OptionSet<>

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2116,7 +2116,7 @@ void RenderLayerCompositor::addToOverlapMap(LayerOverlapMap& overlapMap, const R
         // Compute a clip up to the composited scrolling ancestor, then convert it to absolute coordinates.
         auto& scrollingScope = clippingScopes.last();
         auto& scopeLayer = scrollingScope.layer;
-        clipRect = layer.backgroundClipRect(RenderLayer::ClipRectsContext(&scopeLayer, TemporaryClipRects, IgnoreOverlayScrollbarSize, IgnoreOverflowClip)).rect();
+        clipRect = layer.backgroundClipRect(RenderLayer::ClipRectsContext(&scopeLayer, TemporaryClipRects, { })).rect();
         if (!clipRect.isInfinite())
             clipRect.setLocation(scopeLayer.convertToLayerCoords(&rootRenderLayer(), clipRect.location()));
     } else
@@ -2938,8 +2938,11 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
     const RenderLayer* currentClippedLayer = &layer;
     
     auto pushNonScrollableClip = [&](const RenderLayer& clippedLayer, const RenderLayer& clippingRoot, ShouldRespectOverflowClip respectClip = IgnoreOverflowClip) {
-        // Pass IgnoreOverflowClip to ignore overflow contributed by clippingRoot (which may be a scroller).
-        auto clipRect = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, IgnoreOverlayScrollbarSize, respectClip)).rect();
+        // Use IgnoreOverflowClip to ignore overflow contributed by clippingRoot (which may be a scroller).
+        OptionSet<RenderLayer::ClipRectsOption> options;
+        if (respectClip == RespectOverflowClip)
+            options.add(RenderLayer::ClipRectsOption::RespectOverflowClip);
+        auto clipRect = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, options)).rect();
         auto offset = layer.convertToLayerCoords(&clippingRoot, { }, RenderLayer::AdjustForColumns);
         clipRect.moveBy(-offset);
 

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -800,7 +800,7 @@ static void writeLayers(TextStream& ts, const RenderLayer& rootLayer, RenderLaye
         
         if (behavior.contains(RenderAsTextFlag::ShowLayerFragments)) {
             LayerFragments layerFragments;
-            layer.collectFragments(layerFragments, &rootLayer, paintDirtyRect, RenderLayer::PaginationInclusionMode::ExcludeCompositedPaginatedLayers, TemporaryClipRects, IgnoreOverlayScrollbarSize, RespectOverflowClip, offsetFromRoot);
+            layer.collectFragments(layerFragments, &rootLayer, paintDirtyRect, RenderLayer::PaginationInclusionMode::ExcludeCompositedPaginatedLayers, TemporaryClipRects, { RenderLayer::ClipRectsOption::RespectOverflowClip }, offsetFromRoot);
             
             if (layerFragments.size() > 1) {
                 TextStream::IndentScope indentScope(ts, 2);


### PR DESCRIPTION
#### b7e27bd9c7864d4e2968d7c54b2f613568f77a49
<pre>
Convert the arguments to ClipRectsContext() into an OptionSet&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243089">https://bugs.webkit.org/show_bug.cgi?id=243089</a>

Reviewed by Alan Bujtas.

Replace the &quot;OverlayScrollbarSizeRelevancy, ShouldRespectOverflowClip&quot; arguments to ClipRectsContext and collectFragments
with OptionSet&lt;ClipRectsOption&gt;.

Add getters on ClipRectsContext for the individual behaviors, using a bool for `respectOverflowClip()` because
it results in better readability at the call sites.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::ClipRectsCache::getClipRects const):
(WebCore::ClipRectsCache::setClipRects):
(WebCore::ClipRectsCache::getIndex const):
(WebCore::RenderLayer::paintLayerWithEffects):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::collectFragments):
(WebCore::RenderLayer::paintTransformedLayerIntoFragments):
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::hitTestTransformedLayerInFragments):
(WebCore::RenderLayer::updateClipRects):
(WebCore::RenderLayer::clipRects const):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::ClipRectsContext::ClipRectsContext):
(WebCore::RenderLayer::ClipRectsContext::respectOverflowClip const):
(WebCore::RenderLayer::ClipRectsContext::overlayScrollbarSizeRelevancy const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::addToOverlapMap const):
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::writeLayers):

Canonical link: <a href="https://commits.webkit.org/252758@main">https://commits.webkit.org/252758@main</a>
</pre>
