### PR TITLE
Rename RealtimeMediaSource::m_VideoFrameObservers to m_videoFrameObservers

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -78,15 +78,15 @@ void RealtimeMediaSource::removeAudioSampleObserver(AudioSampleObserver& observe
 void RealtimeMediaSource::addVideoFrameObserver(VideoFrameObserver& observer)
 {
     ASSERT(isMainThread());
-    Locker locker { m_VideoFrameObserversLock };
-    m_VideoFrameObservers.add(&observer);
+    Locker locker { m_videoFrameObserversLock };
+    m_videoFrameObservers.add(&observer);
 }
 
 void RealtimeMediaSource::removeVideoFrameObserver(VideoFrameObserver& observer)
 {
     ASSERT(isMainThread());
-    Locker locker { m_VideoFrameObserversLock };
-    m_VideoFrameObservers.remove(&observer);
+    Locker locker { m_videoFrameObserversLock };
+    m_videoFrameObservers.remove(&observer);
 }
 
 void RealtimeMediaSource::addObserver(Observer& observer)
@@ -210,8 +210,8 @@ void RealtimeMediaSource::videoFrameAvailable(VideoFrame& videoFrame, VideoFrame
 
     updateHasStartedProducingData();
 
-    Locker locker { m_VideoFrameObserversLock };
-    for (auto* observer : m_VideoFrameObservers)
+    Locker locker { m_videoFrameObserversLock };
+    for (auto* observer : m_videoFrameObservers)
         observer->videoFrameAvailable(videoFrame, metadata);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -289,8 +289,8 @@ private:
     mutable Lock m_audioSampleObserversLock;
     HashSet<AudioSampleObserver*> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
 
-    mutable Lock m_VideoFrameObserversLock;
-    HashSet<VideoFrameObserver*> m_VideoFrameObservers WTF_GUARDED_BY_LOCK(m_VideoFrameObserversLock);
+    mutable Lock m_videoFrameObserversLock;
+    HashSet<VideoFrameObserver*> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
 
     // Set on the main thread from constraints.
     IntSize m_size;


### PR DESCRIPTION
#### d4a82d81f59c6aaf6740e47d79e6424fd03bd428
<pre>
Rename RealtimeMediaSource::m_VideoFrameObservers to m_videoFrameObservers
<a href="https://bugs.webkit.org/show_bug.cgi?id=243094">https://bugs.webkit.org/show_bug.cgi?id=243094</a>

Reviewed by Eric Carlson.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::addVideoFrameObserver):
(WebCore::RealtimeMediaSource::removeVideoFrameObserver):
(WebCore::RealtimeMediaSource::videoFrameAvailable):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:

Canonical link: <a href="https://commits.webkit.org/252730@main">https://commits.webkit.org/252730@main</a>
</pre>
