### PR TITLE
[macOS] Canvas.getContext('2d').drawImage on a camera video stream does not work when tab is backgrounded

### DIFF
--- a/LayoutTests/fast/mediastream/video-background-with-canvas-expected.txt
+++ b/LayoutTests/fast/mediastream/video-background-with-canvas-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Ensure that video elements that get drawn on canvas do not get paused due to being backgrounded
+PASS Ensure that video elements that get drawn on canvas get resumed even if backgrounded
+

--- a/LayoutTests/fast/mediastream/video-background-with-canvas.html
+++ b/LayoutTests/fast/mediastream/video-background-with-canvas.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video playsInline id=video1 width=300px></video>
+        <video playsInline id=video2 width=300px></video>
+        <canvas id=canvas width=300px height=200px></canvas>
+        <script>
+async function waitForPaused(video, expectedState, message, counter)
+{
+    if (video.paused === expectedState)
+        return;
+    if (!counter)
+        counter = 0;
+    else if (counter > 100)
+        return Promise.reject("waitForPaused timed out for: " + message);
+    await new Promise(resolve => setTimeout(resolve, 20));
+    return waitForPaused(video, expectedState, message, ++counter);
+}
+
+promise_test(async (test) => {
+    if (!window.internals)
+        return Promise.reject("Test requires internals API");
+
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    video1.srcObject = stream;
+    video2.srcObject = stream;
+    await video1.play();
+    await video2.play();
+
+    canvas.getContext('2d').drawImage(video1, 0, 0, 300, 200);
+
+    internals.setPageVisibility(false);
+
+    await waitForPaused(video2, true, "video2 should be paused");
+    assert_false(video1.paused, "video1 is paused");
+
+    internals.setPageVisibility(true);
+
+    await waitForPaused(video2, false, "video2 should be unpaused");
+    assert_false(video1.paused, "video1 is not paused");
+}, "Ensure that video elements that get drawn on canvas do not get paused due to being backgrounded");
+
+promise_test(async (test) => {
+    if (!window.internals)
+        return Promise.reject("Test requires internals API");
+
+    internals.setPageVisibility(true);
+
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    video1.srcObject = stream;
+    video2.srcObject = stream;
+    await video1.play();
+    await video2.play();
+
+    internals.setPageVisibility(false);
+
+    await waitForPaused(video1, true, "video1 should be paused");
+    await waitForPaused(video2, true, "video2 should be paused");
+
+    canvas.getContext('2d').drawImage(video1, 0, 0, 300, 200);
+
+    await waitForPaused(video1, false, "video1 should be unpaused");
+    assert_true(video2.paused, "video2 should still be paused");
+
+    internals.setPageVisibility(true);
+
+    await waitForPaused(video2, false, "video2 should be unpaused");
+    assert_false(video1.paused, "video1 should be unpaused");
+}, "Ensure that video elements that get drawn on canvas get resumed even if backgrounded");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6097,7 +6097,7 @@ bool HTMLMediaElement::elementIsHidden() const
     if (m_videoFullscreenMode != VideoFullscreenModeNone)
         return false;
 
-    return document().hidden();
+    return document().hidden() && (!m_player || !m_player->isVisibleForCanvas());
 }
 
 void HTMLMediaElement::visibilityStateChanged()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -650,6 +650,7 @@ protected:
     bool isChangingVideoFullscreenMode() const { return m_changingVideoFullscreenMode; }
 
     void mediaPlayerEngineUpdated() override;
+    void visibilityStateChanged() final;
 
 private:
     friend class Internals;
@@ -681,8 +682,6 @@ private:
     void stopWithoutDestroyingMediaPlayer();
     void contextDestroyed() override;
     
-    void visibilityStateChanged() final;
-
     void setReadyState(MediaPlayer::ReadyState);
     void setNetworkState(MediaPlayer::NetworkState);
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -306,8 +306,11 @@ void HTMLVideoElement::paintCurrentFrameInContext(GraphicsContext& context, cons
     RefPtr<MediaPlayer> player = HTMLMediaElement::player();
     if (!player)
         return;
-    
-    player->setVisibleForCanvas(true); // Make player visible or it won't draw.
+
+    if (!player->isVisibleForCanvas()) {
+        player->setVisibleForCanvas(true); // Make player visible or it won't draw.
+        visibilityStateChanged();
+    }
     context.paintFrameForMedia(*player, destRect);
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1071,6 +1071,10 @@ void MediaPlayer::setPageIsVisible(bool visible)
 
 void MediaPlayer::setVisibleForCanvas(bool visible)
 {
+    if (visible == m_visibleForCanvas)
+        return;
+
+    m_visibleForCanvas = visible;
     m_private->setVisibleForCanvas(visible);
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -367,6 +367,7 @@ public:
 
     void setPageIsVisible(bool);
     void setVisibleForCanvas(bool);
+    bool isVisibleForCanvas() const { return m_visibleForCanvas; }
 
     void setVisibleInViewport(bool);
     bool isVisibleInViewport() const { return m_visibleInViewport; }
@@ -734,6 +735,7 @@ private:
     Preload m_preload { Preload::Auto };
     double m_volume { 1 };
     bool m_pageIsVisible { false };
+    bool m_visibleForCanvas { false };
     bool m_visibleInViewport { false };
     bool m_muted { false };
     bool m_preservesPitch { true };


### PR DESCRIPTION
#### de9dae2e531980a6645db42ed91b2cfb8921653c
<pre>
[macOS] Canvas.getContext(&apos;2d&apos;).drawImage on a camera video stream does not work when tab is backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=242679">https://bugs.webkit.org/show_bug.cgi?id=242679</a>
rdar://problem/96937033

When page gets hidden, silent videos are paused.
This is fine, except if videos are drawn to canvas, since canvas might be updated, might be captured and sent to the network.
In fact, when videos are drawn to canvas, we can no longer consider that they are hidden.
For that reason, we update HTMLMediaElement::elementIsHidden to return false when a video is drawn to canvas.
This ensures that the video will not get paused in that case.

Covered by LayoutTests/fast/mediastream/video-background-with-canvas.html.

Reviewed by Eric Carlson.

* LayoutTests/fast/mediastream/video-background-with-canvas-expected.txt: Added.
* LayoutTests/fast/mediastream/video-background-with-canvas.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::elementIsHidden const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::paintCurrentFrameInContext):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::setVisibleForCanvas):
* Source/WebCore/platform/graphics/MediaPlayer.h:

Canonical link: <a href="https://commits.webkit.org/252738@main">https://commits.webkit.org/252738@main</a>
</pre>
