### PR TITLE
Remove syscall telemetry

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2122,9 +2122,6 @@
         (apply-message-filter
             (deny mach-message-send (with telemetry))
             (allow mach-message-send
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
-                (with telemetry-backtrace)
-#endif
                 (kernel-mig-routine
                     _mach_make_memory_entry
                     clock_get_time


### PR DESCRIPTION
#### 798e7a8e8216e5f886bfcf9820346b5bff31f837
<pre>
Remove syscall telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=243096">https://bugs.webkit.org/show_bug.cgi?id=243096</a>
&lt;rdar://problem/97436960&gt;

Reviewed by Sihui Liu.

Remove syscall telemetry in the WebContent process on macOS, since the amount of data collected is sufficient.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252733@main">https://commits.webkit.org/252733@main</a>
</pre>
