### PR TITLE
[ews-build.webkit.org] Always prune when fetching

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -705,7 +705,7 @@ class FetchBranches(steps.ShellSequence, ShellMixin):
         super(FetchBranches, self).__init__(timeout=5 * 60, logEnviron=False, **kwargs)
 
     def run(self):
-        self.commands = [util.ShellArg(command=['git', 'fetch', 'origin'], logname='stdio')]
+        self.commands = [util.ShellArg(command=['git', 'fetch', 'origin', '--prune'], logname='stdio')]
 
         project = self.getProperty('project', GITHUB_PROJECTS[0])
         remote = self.getProperty('remote', 'origin')
@@ -714,7 +714,7 @@ class FetchBranches(steps.ShellSequence, ShellMixin):
                 ['git', 'config', 'credential.helper', '!echo_credentials() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; echo_credentials'],
                 self.shell_command('git remote add {} {}{}.git || {}'.format(remote, GITHUB_URL, project, self.shell_exit_0())),
                 ['git', 'remote', 'set-url', remote, '{}{}.git'.format(GITHUB_URL, project)],
-                ['git', 'fetch', remote],
+                ['git', 'fetch', remote, '--prune'],
             ]:
                 self.commands.append(util.ShellArg(command=command, logname='stdio', haltOnFailure=True))
 
@@ -998,7 +998,7 @@ class CheckOutPullRequest(steps.ShellSequence, ShellMixin):
             ['git', 'config', 'credential.helper', '!echo_credentials() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; echo_credentials'],
             self.shell_command('git remote add {} {}{}.git || {}'.format(remote, GITHUB_URL, project, self.shell_exit_0())),
             ['git', 'remote', 'set-url', remote, '{}{}.git'.format(GITHUB_URL, project)],
-            ['git', 'fetch', remote],
+            ['git', 'fetch', remote, '--prune'],
             ['git', 'branch', '-f', pr_branch, 'remotes/{}/{}'.format(remote, pr_branch)],
             ['git', 'checkout', pr_branch],
         ]

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3292,7 +3292,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 logEnviron=False,
                 env=self.ENV,
-                command=['git', 'fetch', 'Contributor'],
+                command=['git', 'fetch', 'Contributor', '--prune'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=600,
@@ -3356,7 +3356,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 logEnviron=False,
                 env=self.ENV,
-                command=['git', 'fetch', 'Contributor'],
+                command=['git', 'fetch', 'Contributor', '--prune'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=600,
@@ -3419,7 +3419,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 logEnviron=False,
                 env=self.ENV,
-                command=['git', 'fetch', 'Contributor'],
+                command=['git', 'fetch', 'Contributor', '--prune'],
             ) + 1,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to checkout and rebase branch from PR 1234')
@@ -5639,7 +5639,7 @@ class TestFetchBranches(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'fetch', 'origin']) +
+                        command=['git', 'fetch', 'origin', '--prune']) +
             ExpectShell.log('stdio', stdout='   fb192c1de607..afb17ed1708b  main       -> origin/main\n') +
             0,
         )
@@ -5659,7 +5659,7 @@ class TestFetchBranches(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 logEnviron=False,
                 env=env,
-                command=['git', 'fetch', 'origin'],
+                command=['git', 'fetch', 'origin', '--prune'],
             ) + 0, ExpectShell(
                 workdir='wkdir',
                 timeout=300,
@@ -5683,7 +5683,7 @@ class TestFetchBranches(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=300,
                 logEnviron=False,
                 env=env,
-                command=['git', 'fetch', 'security'],
+                command=['git', 'fetch', 'security', '--prune'],
             ) + 0,
         )
         self.expectOutcome(result=SUCCESS)
@@ -5695,7 +5695,7 @@ class TestFetchBranches(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(workdir='wkdir',
                         timeout=300,
                         logEnviron=False,
-                        command=['git', 'fetch',  'origin']) +
+                        command=['git', 'fetch',  'origin', '--prune']) +
             ExpectShell.log('stdio', stdout="fatal: unable to access 'https://github.com/WebKit/WebKit/': Could not resolve host: github.com\n") +
             2,
         )


### PR DESCRIPTION
#### a95ba0d815a7f884d89110ecb95c9e9168a2584f
<pre>
[ews-build.webkit.org] Always prune when fetching
<a href="https://bugs.webkit.org/show_bug.cgi?id=243097">https://bugs.webkit.org/show_bug.cgi?id=243097</a>
&lt;rdar://problem/97437434&gt;

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(FetchBranches.run): Always prune when fetching.
(CheckOutPullRequest.run): Ditto.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/252729@main">https://commits.webkit.org/252729@main</a>
</pre>
