### PR TITLE
Stop exposing showModalDialog(), behind a linked-on-after check

### DIFF
--- a/LayoutTests/editing/execCommand/show-modal-dialog-during-execCommand.html
+++ b/LayoutTests/editing/execCommand/show-modal-dialog-during-execCommand.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/fast/animation/request-animation-frame-during-modal.html
+++ b/LayoutTests/fast/animation/request-animation-frame-during-modal.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/dom/Window/delete-operations.html
+++ b/LayoutTests/fast/dom/Window/delete-operations.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <body>
 <script src="../../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/dom/Window/forbid-showModalDialog.html
+++ b/LayoutTests/fast/dom/Window/forbid-showModalDialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/fast/dom/Window/open-window-min-size.html
+++ b/LayoutTests/fast/dom/Window/open-window-min-size.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/dom/Window/showModalDialog-mandatory-parameter.html
+++ b/LayoutTests/fast/dom/Window/showModalDialog-mandatory-parameter.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <script src="../../../resources/js-test-pre.js"></script>
 <script>

--- a/LayoutTests/fast/dom/Window/window-function-frame-getter-precedence.html
+++ b/LayoutTests/fast/dom/Window/window-function-frame-getter-precedence.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/dom/Window/window-function-name-getter-precedence.html
+++ b/LayoutTests/fast/dom/Window/window-function-name-getter-precedence.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/dom/Window/window-lookup-precedence.html
+++ b/LayoutTests/fast/dom/Window/window-lookup-precedence.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/dom/Window/window-property-shadowing.html
+++ b/LayoutTests/fast/dom/Window/window-property-shadowing.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/dom/null-page-show-modal-dialog-crash.html
+++ b/LayoutTests/fast/dom/null-page-show-modal-dialog-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 This is a test for <a href="https://bugs.webkit.org/show_bug.cgi?id=19541">https://bugs.webkit.org/show_bug.cgi?id=19541</a> 
 RBug 19541: Null pointer in showModalDialog()
 

--- a/LayoutTests/fast/dom/wrapper-identity.html
+++ b/LayoutTests/fast/dom/wrapper-identity.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/events/beforeunload-showModalDialog.html
+++ b/LayoutTests/fast/events/beforeunload-showModalDialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();

--- a/LayoutTests/fast/events/pagehide-showModalDialog.html
+++ b/LayoutTests/fast/events/pagehide-showModalDialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();

--- a/LayoutTests/fast/events/scroll-event-during-modal-dialog.html
+++ b/LayoutTests/fast/events/scroll-event-during-modal-dialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <script src="../../resources/js-test-pre.js"></script>
 <body style="min-height: 2000px"> 

--- a/LayoutTests/fast/events/show-modal-dialog-onblur-onfocus.html
+++ b/LayoutTests/fast/events/show-modal-dialog-onblur-onfocus.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/events/unload-showModalDialog.html
+++ b/LayoutTests/fast/events/unload-showModalDialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();

--- a/LayoutTests/fast/harness/show-modal-dialog.html
+++ b/LayoutTests/fast/harness/show-modal-dialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/http/tests/cookies/document-cookie-after-showModalDialog.html
+++ b/LayoutTests/http/tests/cookies/document-cookie-after-showModalDialog.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/tests/security/cross-frame-access-call.html
+++ b/LayoutTests/http/tests/security/cross-frame-access-call.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
     <script src="/js-test-resources/js-test-pre.js"></script>

--- a/LayoutTests/http/tests/security/cross-frame-access-get.html
+++ b/LayoutTests/http/tests/security/cross-frame-access-get.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
     <script src="resources/cross-frame-access.js"></script>

--- a/LayoutTests/http/tests/security/cross-frame-access-getOwnPropertyDescriptor.html
+++ b/LayoutTests/http/tests/security/cross-frame-access-getOwnPropertyDescriptor.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <html>
 <head>
     <script src="resources/cross-frame-access.js"></script>

--- a/LayoutTests/http/tests/security/cross-frame-access-put.html
+++ b/LayoutTests/http/tests/security/cross-frame-access-put.html
@@ -1,4 +1,4 @@
-
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <p>This test checks cross-frame access security of window attribute setters (rdar://problem/5326791).</p>
 <iframe src="http://localhost:8000/security/resources/cross-frame-iframe-for-put-test.html" style=""></iframe>
 <pre id="console"></pre>

--- a/LayoutTests/http/tests/security/cross-origin-modal-dialog-base.html
+++ b/LayoutTests/http/tests/security/cross-origin-modal-dialog-base.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html lang="en">
 <script src="../../../resources/js-test-pre.js"></script>

--- a/LayoutTests/http/tests/security/navigate-when-restoring-cached-page.html
+++ b/LayoutTests/http/tests/security/navigate-when-restoring-cached-page.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=true ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load.html
+++ b/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load2.html
+++ b/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load2.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/historical.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/historical.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL showModalDialog() has been removed from the platform assert_false: expected false got true
+PASS showModalDialog() has been removed from the platform
 

--- a/LayoutTests/js/dom/function-length.html
+++ b/LayoutTests/js/dom/function-length.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/js/dom/global-function-resolve.html
+++ b/LayoutTests/js/dom/global-function-resolve.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -618,6 +618,17 @@ webkit.org/b/151506 fast/events/beforeunload-showModalDialog.html [ Skip ]
 webkit.org/b/151506 fast/events/pagehide-showModalDialog.html [ Skip ]
 webkit.org/b/151506 fast/events/unload-showModalDialog.html [ Skip ]
 
+# ShowModalDialog preference currently cannot be enabled on Windows.
+fast/dom/Window/delete-operations.html [ Skip ]
+fast/dom/Window/forbid-showModalDialog.html [ Skip ]
+fast/dom/Window/showModalDialog-mandatory-parameter.html [ Skip ]
+fast/dom/Window/window-function-frame-getter-precedence.html [ Skip ]
+fast/dom/Window/window-function-name-getter-precedence.html [ Skip ]
+fast/events/show-modal-dialog-onblur-onfocus.html [ Skip ]
+http/tests/cookies/document-cookie-after-showModalDialog.html [ Skip ]
+js/dom/function-length.html [ Skip ]
+js/dom/global-function-resolve.html [ Skip ]
+
 # TODO Color input is not yet enabled.
 fast/forms/color/ [ Skip ]
 

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -853,6 +853,19 @@ ServiceWorkersUserGestureEnabled:
     WebCore:
       default: true
 
+ShowModalDialogEnabled:
+  type: bool
+  humanReadableName: "Legacy showModalDialog() API"
+  humanReadableDescription: "Legacy showModalDialog() API"
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(IOS_FAMILY)": WebKit::defaultShowModalDialogEnabled()
+      default: false
+    WebKit:
+      default: WebKit::defaultShowModalDialogEnabled()
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 SpeakerSelectionRequiresUserGesture:
   type: bool

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -67,6 +67,7 @@ enum class SDKAlignedBehavior {
     NoLaBanquePostaleQuirks,
     NoMoviStarPlusCORSPreflightQuirk,
     NoPokerBrosBuiltInTagQuirk,
+    NoShowModalDialog,
     NoTheSecretSocietyHiddenMysteryWindowOpenQuirk,
     NoTypedArrayAPIQuirk,
     NoUnconditionalUniversalSandboxExtension,

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -64,6 +64,10 @@
 #include "ChromeClient.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 
 namespace WebCore {
 using namespace JSC;
@@ -128,7 +132,8 @@ void JSDOMWindowBase::finishCreation(VM& vm, JSWindowProxy* proxy)
     if (m_wrapped && m_wrapped->frame() && m_wrapped->frame()->settings().needsSiteSpecificQuirks())
         setNeedsSiteSpecificQuirks(true);
 
-    putDirectCustomAccessor(vm, builtinNames(vm).showModalDialogPublicName(), CustomGetterSetter::create(vm, showModalDialogGetter, nullptr), static_cast<unsigned>(PropertyAttribute::CustomValue));
+    if (m_wrapped && m_wrapped->frame() && m_wrapped->frame()->settings().showModalDialogEnabled())
+        putDirectCustomAccessor(vm, builtinNames(vm).showModalDialogPublicName(), CustomGetterSetter::create(vm, showModalDialogGetter, nullptr), static_cast<unsigned>(PropertyAttribute::CustomValue));
 }
 
 void JSDOMWindowBase::destroy(JSCell* cell)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -163,4 +163,14 @@ bool defaultMediaSessionCoordinatorEnabled()
 }
 #endif
 
+bool defaultShowModalDialogEnabled()
+{
+#if PLATFORM(COCOA)
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoShowModalDialog);
+    return !newSDK;
+#else
+    return false;
+#endif
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -83,4 +83,6 @@ bool defaultVisualTranslationEnabled();
 bool defaultRemoveBackgroundEnabled();
 #endif
 
+bool defaultShowModalDialogEnabled();
+
 } // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -43,6 +43,7 @@ bool defaultInlineMediaPlaybackRequiresPlaysInlineAttribute();
 bool defaultJavaScriptCanOpenWindowsAutomatically();
 bool defaultPassiveTouchListenersAsDefaultOnDocument();
 bool defaultRequiresUserGestureToLoadVideo();
+bool defaultShowModalDialogEnabled();
 bool defaultWebSQLEnabled();
 bool defaultAllowContentSecurityPolicySourceStarToMatchAnyProtocol();
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -75,6 +75,12 @@ bool defaultPassiveTouchListenersAsDefaultOnDocument()
     return result;
 }
 
+bool defaultShowModalDialogEnabled()
+{
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoShowModalDialog);
+    return !newSDK;
+}
+
 bool defaultRequiresUserGestureToLoadVideo()
 {
     static bool shouldRequireUserGestureToLoadVideo = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::RequiresUserGestureToLoadVideo);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -623,47 +623,6 @@ TEST(WebKit, PointerLock)
     TestWebKitAPI::Util::run(&done);
 }
 
-static bool resizableSet;
-
-@interface ModalDelegate : NSObject <WKUIDelegatePrivate>
-@end
-
-@implementation ModalDelegate
-
-- (void)_webViewRunModal:(WKWebView *)webView
-{
-    EXPECT_TRUE(resizableSet);
-    EXPECT_EQ(webView, createdWebView.get());
-    done = true;
-}
-
-- (void)_webView:(WKWebView *)webView setResizable:(BOOL)isResizable
-{
-    EXPECT_FALSE(isResizable);
-    resizableSet = true;
-}
-
-- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
-{
-    createdWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-    [createdWebView setUIDelegate:self];
-    return createdWebView.get();
-}
-
-@end
-
-TEST(WebKit, RunModal)
-{
-    auto delegate = adoptNS([[ModalDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    [webView setUIDelegate:delegate.get()];
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"simple" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
-    NSString *html = [NSString stringWithFormat:@"%@%@%@", @"<script> function openModal() { window.showModalDialog('", url, @"'); } </script> <input type='button' value='Click to open modal' onclick='openModal();'>"];
-    [webView synchronouslyLoadHTMLString:html];
-    [webView sendClicksAtPoint:NSMakePoint(20, 600 - 20) numberOfClicks:1];
-    TestWebKitAPI::Util::run(&done);
-}
-
 static bool receivedWindowFrame;
 
 @interface WindowFrameDelegate : NSObject <WKUIDelegatePrivate>

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -630,37 +630,6 @@ public:
     }
 };
 
-static void testWebViewAllowModalDialogs(ModalDialogsTest* test, gconstpointer)
-{
-    WebKitSettings* settings = webkit_web_view_get_settings(test->m_webView);
-    webkit_settings_set_allow_modal_dialogs(settings, TRUE);
-    webkit_settings_set_allow_top_navigation_to_data_urls(settings, TRUE);
-
-    test->loadHtml("<html><body onload=\"window.showModalDialog('data:text/html,<html><body/><script>window.close();</script></html>')\"></body></html>", 0);
-    test->waitUntilMainLoopFinishes();
-
-    Vector<UIClientTest::WebViewEvents>& events = test->m_webViewEvents;
-    g_assert_cmpint(events.size(), ==, 4);
-    g_assert_cmpint(events[0], ==, UIClientTest::Create);
-    g_assert_cmpint(events[1], ==, UIClientTest::ReadyToShow);
-    g_assert_cmpint(events[2], ==, UIClientTest::RunAsModal);
-    g_assert_cmpint(events[3], ==, UIClientTest::Close);
-}
-
-static void testWebViewDisallowModalDialogs(ModalDialogsTest* test, gconstpointer)
-{
-    WebKitSettings* settings = webkit_web_view_get_settings(test->m_webView);
-    webkit_settings_set_allow_modal_dialogs(settings, FALSE);
-
-    test->loadHtml("<html><body onload=\"window.showModalDialog('data:text/html,<html><body/><script>window.close();</script></html>')\"></body></html>", 0);
-    // We need to use a timeout here because the viewClose() function
-    // won't ever be called as the dialog won't be created.
-    test->wait(1);
-
-    Vector<UIClientTest::WebViewEvents>& events = test->m_webViewEvents;
-    g_assert_cmpint(events.size(), ==, 0);
-}
-
 static void testWebViewJavaScriptDialogs(UIClientTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -1488,8 +1457,6 @@ void beforeAll()
 #if PLATFORM(GTK)
     CreateNavigationDataTest::add("WebKitWebView", "create-navigation-data", testWebViewCreateNavigationData);
 #endif
-    ModalDialogsTest::add("WebKitWebView", "allow-modal-dialogs", testWebViewAllowModalDialogs);
-    ModalDialogsTest::add("WebKitWebView", "disallow-modal-dialogs", testWebViewDisallowModalDialogs);
     UIClientTest::add("WebKitWebView", "javascript-dialogs", testWebViewJavaScriptDialogs);
     UIClientTest::add("WebKitWebView", "window-properties", testWebViewWindowProperties);
 #if PLATFORM(GTK)

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -118,6 +118,7 @@ const TestFeatures& TestOptions::defaults()
             { "RequiresUserGestureForAudioPlayback", false },
             { "RequiresUserGestureForMediaPlayback", false },
             { "RequiresUserGestureForVideoPlayback", false },
+            { "ShowModalDialogEnabled", false },
             { "SpeakerSelectionRequiresUserGesture", false },
             { "SubpixelAntialiasedLayerTextEnabled", false },
             { "TabsToLinks", false },


### PR DESCRIPTION
#### c4bb4d1af89e1ef5f57ef1b1cf7b65ce62c30ba5
<pre>
Stop exposing showModalDialog(), behind a linked-on-after check
<a href="https://bugs.webkit.org/show_bug.cgi?id=243099">https://bugs.webkit.org/show_bug.cgi?id=243099</a>
&lt;rdar://97441232&gt;

Reviewed by Ryosuke Niwa and Darin Adler.

Now that we support the dialog element, drop support for showModalDialog(),
behind a linked-on-after check. Blink and Gecko have already dropped their
support for showModalDialog() a long time ago.

* LayoutTests/editing/execCommand/show-modal-dialog-during-execCommand.html:
* LayoutTests/fast/animation/request-animation-frame-during-modal.html:
* LayoutTests/fast/dom/Window/delete-operations.html:
* LayoutTests/fast/dom/Window/forbid-showModalDialog.html:
* LayoutTests/fast/dom/Window/open-window-min-size.html:
* LayoutTests/fast/dom/Window/showModalDialog-mandatory-parameter.html:
* LayoutTests/fast/dom/Window/window-function-frame-getter-precedence.html:
* LayoutTests/fast/dom/Window/window-function-name-getter-precedence.html:
* LayoutTests/fast/dom/Window/window-lookup-precedence.html:
* LayoutTests/fast/dom/Window/window-property-shadowing.html:
* LayoutTests/fast/dom/null-page-show-modal-dialog-crash.html:
* LayoutTests/fast/dom/wrapper-identity.html:
* LayoutTests/fast/events/beforeunload-showModalDialog.html:
* LayoutTests/fast/events/pagehide-showModalDialog.html:
* LayoutTests/fast/events/scroll-event-during-modal-dialog.html:
* LayoutTests/fast/events/show-modal-dialog-onblur-onfocus.html:
* LayoutTests/fast/events/unload-showModalDialog.html:
* LayoutTests/fast/harness/show-modal-dialog.html:
* LayoutTests/http/tests/cookies/document-cookie-after-showModalDialog.html:
* LayoutTests/http/tests/security/cross-frame-access-call.html:
* LayoutTests/http/tests/security/cross-frame-access-get.html:
* LayoutTests/http/tests/security/cross-frame-access-getOwnPropertyDescriptor.html:
* LayoutTests/http/tests/security/cross-frame-access-put.html:
* LayoutTests/http/tests/security/cross-origin-modal-dialog-base.html:
* LayoutTests/http/tests/security/navigate-when-restoring-cached-page.html:
* LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load.html:
* LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load2.html:
* LayoutTests/js/dom/function-length.html:
* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::finishCreation):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultShowModalDialogEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm:
(WebKit::defaultShowModalDialogEnabled):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[ModalDelegate _webViewRunModal:]): Deleted.
(-[ModalDelegate _webView:setResizable:]): Deleted.
(-[ModalDelegate webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
(beforeAll):
(testWebViewAllowModalDialogs): Deleted.
(testWebViewDisallowModalDialogs): Deleted.
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/252759@main">https://commits.webkit.org/252759@main</a>
</pre>
