### PR TITLE
Verify DOM and Render text lengths are in sync in RenderTextLineBoxes::dirtyRange()

### DIFF
--- a/Source/WebCore/rendering/RenderTextLineBoxes.cpp
+++ b/Source/WebCore/rendering/RenderTextLineBoxes.cpp
@@ -158,6 +158,14 @@ bool RenderTextLineBoxes::dirtyRange(RenderText& renderer, unsigned start, unsig
     LegacyRootInlineBox* firstRootBox = nullptr;
     LegacyRootInlineBox* lastRootBox = nullptr;
 
+    // Verify the DOM and RenderText lengths are in sync. Certain text operations, like upper casing,
+    // may be reflected only on the Render side causing the DOM and Render lengths to differ.
+    if (renderer.style().textTransform() != TextTransform::None && renderer.textNode()
+        && renderer.length() != renderer.textNode()->wholeText().length()) {
+        dirtyAll();
+        return true;
+    }
+
     // Dirty all text boxes that include characters in between offset and offset+len.
     bool dirtiedLines = false;
     for (auto* current = m_first; current; current = current->nextTextBox()) {


### PR DESCRIPTION
#### 22aafa30b9a20ef9f3fd850b995ffabcc52679c2
<pre>
Verify DOM and Render text lengths are in sync in RenderTextLineBoxes::dirtyRange()
<a href="https://bugs.webkit.org/show_bug.cgi?id=237376">https://bugs.webkit.org/show_bug.cgi?id=237376</a>

Reviewed by Alan Bujtas.

Ensure that the DOM and Render text lengths are in sync when calling dirtyRange().
An edge case can occur when performing certain text operations like upper casing of text,
which will result in these two having differing results. This is ultimately caused by the Render
text having the modifications performed on it, while the DOM remains unchanged.

* Source/WebCore/rendering/RenderTextLineBoxes.cpp:
(WebCore::RenderTextLineBoxes::dirtyRange):

Canonical link: <a href="https://commits.webkit.org/252736@main">https://commits.webkit.org/252736@main</a>
</pre>
