### PR TITLE
Skip JSTests/microbenchmarks/string-index-of-* tests on memory limited platforms

### DIFF
--- a/JSTests/microbenchmarks/string-index-of-10000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1000001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1000001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-100001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-100001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-10001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-10001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-end.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-1001-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-1001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-404.js
+++ b/JSTests/microbenchmarks/string-index-of-101-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-101-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-end.js
+++ b/JSTests/microbenchmarks/string-index-of-101-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-101-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-101-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-404.js
+++ b/JSTests/microbenchmarks/string-index-of-11-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-beg.js
+++ b/JSTests/microbenchmarks/string-index-of-11-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-end.js
+++ b/JSTests/microbenchmarks/string-index-of-11-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/string-index-of-11-mid.js
+++ b/JSTests/microbenchmarks/string-index-of-11-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)


### PR DESCRIPTION
#### 092abab148b58751f614a197fdf9dbca3280d625
<pre>
Skip JSTests/microbenchmarks/string-index-of-* tests on memory limited platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=243108">https://bugs.webkit.org/show_bug.cgi?id=243108</a>

Unreviewed test gardening.

* JSTests/microbenchmarks/string-index-of-10000001-beg.js:
* JSTests/microbenchmarks/string-index-of-10000001-end.js:
* JSTests/microbenchmarks/string-index-of-10000001-mid.js:
* JSTests/microbenchmarks/string-index-of-1000001-404.js:
* JSTests/microbenchmarks/string-index-of-1000001-beg.js:
* JSTests/microbenchmarks/string-index-of-1000001-end.js:
* JSTests/microbenchmarks/string-index-of-1000001-mid.js:
* JSTests/microbenchmarks/string-index-of-100001-404.js:
* JSTests/microbenchmarks/string-index-of-100001-beg.js:
* JSTests/microbenchmarks/string-index-of-100001-end.js:
* JSTests/microbenchmarks/string-index-of-100001-mid.js:
* JSTests/microbenchmarks/string-index-of-10001-404.js:
* JSTests/microbenchmarks/string-index-of-10001-beg.js:
* JSTests/microbenchmarks/string-index-of-10001-end.js:
* JSTests/microbenchmarks/string-index-of-10001-mid.js:
* JSTests/microbenchmarks/string-index-of-1001-404.js:
* JSTests/microbenchmarks/string-index-of-1001-beg.js:
* JSTests/microbenchmarks/string-index-of-1001-end.js:
* JSTests/microbenchmarks/string-index-of-1001-mid.js:
* JSTests/microbenchmarks/string-index-of-101-404.js:
* JSTests/microbenchmarks/string-index-of-101-beg.js:
* JSTests/microbenchmarks/string-index-of-101-end.js:
* JSTests/microbenchmarks/string-index-of-101-mid.js:
* JSTests/microbenchmarks/string-index-of-11-404.js:
* JSTests/microbenchmarks/string-index-of-11-beg.js:
* JSTests/microbenchmarks/string-index-of-11-end.js:
* JSTests/microbenchmarks/string-index-of-11-mid.js:

Canonical link: <a href="https://commits.webkit.org/252740@main">https://commits.webkit.org/252740@main</a>
</pre>
