### PR TITLE
[ARM64] Use link register instead of pinning a register for materializing big load constants

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -70,12 +70,13 @@ bool shouldSaveIRBeforePhase()
     return Options::verboseValidationFailure();
 }
 
-std::optional<GPRReg> pinnedExtendedOffsetAddrRegister()
+GPRReg extendedOffsetAddrRegister()
 {
+    RELEASE_ASSERT(isARM64() || isRISCV64());
 #if CPU(ARM64) || CPU(RISCV64)
-    return MacroAssembler::dataTempRegister;
+    return MacroAssembler::linkRegister;
 #elif CPU(X86_64)
-    return std::nullopt;
+    return GPRReg::InvalidGPRReg;
 #else
 #error Unhandled architecture.
 #endif

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -205,7 +205,7 @@ inline unsigned defaultOptLevel()
     return Options::defaultB3OptLevel();
 }
 
-std::optional<GPRReg> pinnedExtendedOffsetAddrRegister();
+GPRReg extendedOffsetAddrRegister();
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -144,11 +144,10 @@ static ALWAYS_INLINE CCallHelpers::Address callFrameAddr(CCallHelpers& jit, intp
         return CCallHelpers::Address(GPRInfo::callFrameRegister, offsetFromFP);
     }
 
-    ASSERT(pinnedExtendedOffsetAddrRegister());
     auto addr = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
     if (addr.isValidForm(Width64))
         return CCallHelpers::Address(GPRInfo::callFrameRegister, offsetFromFP);
-    GPRReg reg = *pinnedExtendedOffsetAddrRegister();
+    GPRReg reg = extendedOffsetAddrRegister();
     jit.move(CCallHelpers::TrustedImmPtr(offsetFromFP), reg);
     jit.add64(GPRInfo::callFrameRegister, reg);
     return CCallHelpers::Address(reg);

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -93,9 +93,6 @@ Code::Code(Procedure& proc)
             setRegsInPriorityOrder(bank, result);
         });
 
-    if (auto reg = pinnedExtendedOffsetAddrRegister())
-        pinRegister(*reg);
-
     m_pinnedRegs.set(MacroAssembler::framePointerRegister);
 }
 

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -78,8 +78,7 @@ void lowerStackArgs(Code& code)
                     if (Arg::isValidImmForm(offset))
                         inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, Arg::imm(offset), base, inst.args[1]);
                     else {
-                        ASSERT(pinnedExtendedOffsetAddrRegister());
-                        Air::Tmp tmp = Air::Tmp(*pinnedExtendedOffsetAddrRegister());
+                        Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
                         Arg offsetArg = Arg::bigImm(offset);
                         insertionSet.insert(instIndex, Move, inst.origin, offsetArg, tmp);
                         inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, tmp, base, inst.args[1]);
@@ -128,8 +127,7 @@ void lowerStackArgs(Code& code)
                         if (result.isValidForm(width))
                             return result;
 #if CPU(ARM64) || CPU(RISCV64)
-                        ASSERT(pinnedExtendedOffsetAddrRegister());
-                        Air::Tmp tmp = Air::Tmp(*pinnedExtendedOffsetAddrRegister());
+                        Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
 
                         Arg largeOffset = Arg::isValidImmForm(offsetFromSP) ? Arg::imm(offsetFromSP) : Arg::bigImm(offsetFromSP);
                         insertionSet.insert(instIndex, Move, inst.origin, largeOffset, tmp);

--- a/Source/JavaScriptCore/ftl/FTLThunks.cpp
+++ b/Source/JavaScriptCore/ftl/FTLThunks.cpp
@@ -107,8 +107,6 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> genericGenerationThunkGenerator(
     // ensures that the return address is out of the way of register restoration.
     jit.restoreReturnAddressBeforeReturn(GPRInfo::regT0);
 
-    restoreAllRegisters(jit, buffer);
-
 #if CPU(ARM64E)
     jit.untagPtr(resultTag, AssemblyHelpers::linkRegister);
     jit.validateUntaggedPtr(AssemblyHelpers::linkRegister);
@@ -116,6 +114,9 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> genericGenerationThunkGenerator(
 #else
     UNUSED_PARAM(resultTag);
 #endif
+
+    restoreAllRegisters(jit, buffer);
+
     jit.ret();
     
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::FTLThunk);


### PR DESCRIPTION
#### fb402aa86c16383969af124c016231a45898ec32
<pre>
[ARM64] Use link register instead of pinning a register for materializing big load constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=228710">https://bugs.webkit.org/show_bug.cgi?id=228710</a>

Reviewed by Saam Barati.

Previously, we pin a register as a temp for materializing a large constant that cannot fit in
Load/Store imm form. This is not efficient since the register allocator has one less register
to allocate from. To solve this problem, we should switch to using the link register as the temp
on ARM64.

* Source/JavaScriptCore/b3/B3Common.cpp:
(JSC::B3::linkRegister):
(JSC::B3::pinnedExtendedOffsetAddrRegister): Deleted.
* Source/JavaScriptCore/b3/B3Common.h:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::callFrameAddr):
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::Code):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/ftl/FTLThunks.cpp:
(JSC::FTL::genericGenerationThunkGenerator):

Canonical link: <a href="https://commits.webkit.org/253105@main">https://commits.webkit.org/253105@main</a>
</pre>
