### PR TITLE
ASSERTION FAILED: bytecodeIndex.offset() < instructions().size()

### DIFF
--- a/JSTests/stress/stack-frame-code-block-offset.js
+++ b/JSTests/stress/stack-frame-code-block-offset.js
@@ -1,0 +1,16 @@
+//@ skip if $memoryLimited
+class __c_0 {
+  constructor() { return __v_20 }
+}
+class __c_1 extends __c_0 {
+  #x
+}
+try {
+  __v_20 = __c_1
+  try {
+    for (;;)
+      new __c_1
+  } catch {
+  }
+} catch {
+}

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -67,7 +67,7 @@ JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorType, const String
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension, const String&);
 
 std::unique_ptr<Vector<StackFrame>> getStackTrace(JSGlobalObject*, VM&, JSObject*, bool useCurrentFrame);
-void getBytecodeIndex(VM&, CallFrame*, Vector<StackFrame>*, CallFrame*&, BytecodeIndex&);
+std::tuple<CallFrame*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
 bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL);
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -133,9 +133,7 @@ void ErrorInstance::finishCreation(VM& vm, JSGlobalObject* globalObject, const S
 
     String messageWithSource = message;
     if (m_stackTrace && !m_stackTrace->isEmpty() && hasSourceAppender()) {
-        BytecodeIndex bytecodeIndex;
-        CallFrame* callFrame;
-        getBytecodeIndex(vm, vm.topCallFrame, m_stackTrace.get(), callFrame, bytecodeIndex);
+        auto [callFrame, bytecodeIndex] = getBytecodeIndex(vm, vm.topCallFrame);
         if (callFrame && callFrame->codeBlock() && !callFrame->callee().isWasm())
             messageWithSource = appendSourceToErrorMessage(callFrame, this, bytecodeIndex, message);
     }


### PR DESCRIPTION
#### 87b1e4a822c70b75fa2c8379e9b2423431574c32
<pre>
ASSERTION FAILED: bytecodeIndex.offset() &lt; instructions().size()
<a href="https://bugs.webkit.org/show_bug.cgi?id=243103">https://bugs.webkit.org/show_bug.cgi?id=243103</a>
&lt;rdar://97445560&gt;

Reviewed by Mark Lam.

We crash since FindFirstCallerFrameWithCodeblockFunctor in getBytecodeIndex is not skipping ImplementationVisibility::Private etc.
frames. But we compute index, and using it for Vector&lt;StackFrame&gt; which is skipping ImplementationVisibility::Private etc. frames.
So, we got wrong StackFrame &amp; CallFrame pair. Since bytecodeIndex from that is not the one of CallFrame::codeBlock(), we hit an assertion.

In this patch, we refactor getBytecodeIndex so that it does not rely on Vector&lt;StackFrame&gt; anymore. Using index obtained from different
functor is too fragile. Instead, we just get BytecodeIndex too.

* JSTests/stress/stack-frame-code-block-offset.js: Added.
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::FindFirstUserCallerFrameWithCodeblockFunctor::FindFirstUserCallerFrameWithCodeblockFunctor):
(JSC::FindFirstUserCallerFrameWithCodeblockFunctor::operator() const):
(JSC::FindFirstUserCallerFrameWithCodeblockFunctor::bytecodeIndex const):
(JSC::getBytecodeIndex):
(JSC::FindFirstCallerFrameWithCodeblockFunctor::FindFirstCallerFrameWithCodeblockFunctor): Deleted.
(JSC::FindFirstCallerFrameWithCodeblockFunctor::operator() const): Deleted.
(JSC::FindFirstCallerFrameWithCodeblockFunctor::foundCallFrame const): Deleted.
(JSC::FindFirstCallerFrameWithCodeblockFunctor::index const): Deleted.
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::finishCreation):

Canonical link: <a href="https://commits.webkit.org/252751@main">https://commits.webkit.org/252751@main</a>
</pre>
