### PR TITLE
xhr/json.any.html WPT test is failing in WebKit

### DIFF
--- a/LayoutTests/fast/xmlhttprequest/xmlhttprequest-responsetype-json-utf16-expected.txt
+++ b/LayoutTests/fast/xmlhttprequest/xmlhttprequest-responsetype-json-utf16-expected.txt
@@ -3,7 +3,7 @@ Tests XMLHttpRequest.responseType of "json" fails to parse if the payload was en
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-FAIL jsonXHR.response should be null. Was [object Object].
+PASS jsonXHR.response is null
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/json.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/json.any-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Ensure the correct JSON parser is used
-FAIL Ensure UTF-16 results in an error assert_equals: expected null but got object "[object Object]"
+PASS Ensure UTF-16 results in an error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/json.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/json.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Ensure the correct JSON parser is used
-FAIL Ensure UTF-16 results in an error assert_equals: expected null but got object "[object Object]"
+PASS Ensure UTF-16 results in an error
 

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -68,6 +68,8 @@ public:
     void useLenientXMLDecoding() { m_useLenientXMLDecoding = true; }
     bool sawError() const { return m_sawError; }
 
+    void setAlwaysUseUTF8() { ASSERT(!strcmp(m_encoding.name(), "UTF-8")); m_alwaysUseUTF8 = true; }
+
 private:
     TextResourceDecoder(const String& mimeType, const PAL::TextEncoding& defaultEncoding, bool usesEncodingDetector);
 
@@ -95,6 +97,7 @@ private:
     bool m_useLenientXMLDecoding { false }; // Don't stop on XML decoding errors.
     bool m_sawError { false };
     bool m_usesEncodingDetector { false };
+    bool m_alwaysUseUTF8 { false };
 };
 
 inline void TextResourceDecoder::setHintEncoding(const TextResourceDecoder* parentFrameDecoder)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1017,8 +1017,12 @@ Ref<TextResourceDecoder> XMLHttpRequest::createDecoder() const
         }
         FALLTHROUGH;
     case ResponseType::Text:
-    case ResponseType::Json:
-        return TextResourceDecoder::create("text/plain"_s, "UTF-8");
+    case ResponseType::Json: {
+        auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8");
+        if (responseType() == ResponseType::Json)
+            decoder->setAlwaysUseUTF8();
+        return decoder;
+    }
     case ResponseType::Document: {
         if (equalLettersIgnoringASCIICase(responseMIMEType(), "text/html"_s))
             return TextResourceDecoder::create("text/html"_s, "UTF-8");


### PR DESCRIPTION
#### c74e2dd4d5886b9a328977a6b46b98a7830b7128
<pre>
xhr/json.any.html WPT test is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243109">https://bugs.webkit.org/show_bug.cgi?id=243109</a>

Reviewed by Darin Adler.

Force UTF-8 decoding for XHR response when responseType is json.
This aligns our behavior with Blink and Gecko.

* LayoutTests/imported/w3c/web-platform-tests/xhr/json.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/json.any.worker-expected.txt:
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::setEncoding):
(WebCore::TextResourceDecoder::checkForBOM):
* Source/WebCore/loader/TextResourceDecoder.h:
(WebCore::TextResourceDecoder::setAlwaysUseUTF8):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createDecoder const):

Canonical link: <a href="https://commits.webkit.org/252838@main">https://commits.webkit.org/252838@main</a>
</pre>
