### PR TITLE
REGRESSION(252518@main-252520@main): [ macOS iOS15 ] TestWebKitAPI.WKNavigation.AutomaticVisibleViewReloadAfterWebProcessCrash is a flaky crash

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1071,7 +1071,8 @@ void Connection::enqueueIncomingMessage(std::unique_ptr<Decoder> incomingMessage
 
 void Connection::dispatchMessage(Decoder& decoder)
 {
-    RELEASE_ASSERT(isValid());
+    ASSERT(RunLoop::isMain());
+    RELEASE_ASSERT(!m_didInvalidationOnMainThread);
     if (decoder.messageReceiverName() == ReceiverName::AsyncReply) {
         auto handler = takeAsyncReplyHandler(*this, decoder.destinationID());
         if (!handler) {


### PR DESCRIPTION
#### 1e3bfd0f884dc1ce2b46cb9810a51fec6d5249bc
<pre>
REGRESSION(252518@main-252520@main): [ macOS iOS15 ] TestWebKitAPI.WKNavigation.AutomaticVisibleViewReloadAfterWebProcessCrash is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=243098">https://bugs.webkit.org/show_bug.cgi?id=243098</a>
&lt;rdar://97440864&gt;

Reviewed by Darin Adler.

In 252520@main, I made it so that IPC::Connection::m_isValid can now get updated
on a background thread. This caused us to sometimes hit a `RELEASE_ASSERT(isValid())`
under IPC::Connection::dispatchMessage(). Since this function runs on the main
thread, the purpose of this assertion was to make sure that invalidation has not
yet occurred on the main thread. After 252520@main, this is tracked by
!m_didInvalidationOnMainThread, not m_isValid. Update the assertion accordingly.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessage):

Canonical link: <a href="https://commits.webkit.org/252760@main">https://commits.webkit.org/252760@main</a>
</pre>
