### PR TITLE
update1

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -81,17 +81,6 @@ std::optional<GPRReg> linkRegister()
 #endif
 }
 
-std::optional<GPRReg> dataTempRegister()
-{
-#if CPU(ARM64) || CPU(RISCV64)
-    return MacroAssembler::dataTempRegister;
-#elif CPU(X86_64)
-    return std::nullopt;
-#else
-#error Unhandled architecture.
-#endif
-}
-
 } } // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -70,7 +70,18 @@ bool shouldSaveIRBeforePhase()
     return Options::verboseValidationFailure();
 }
 
-std::optional<GPRReg> pinnedExtendedOffsetAddrRegister()
+std::optional<GPRReg> linkRegister()
+{
+#if CPU(ARM64)
+    return MacroAssembler::linkRegister;
+#elif CPU(X86_64)
+    return std::nullopt;
+#else
+#error Unhandled architecture.
+#endif
+}
+
+std::optional<GPRReg> dataTempRegister()
 {
 #if CPU(ARM64) || CPU(RISCV64)
     return MacroAssembler::dataTempRegister;

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -207,8 +207,6 @@ inline unsigned defaultOptLevel()
 
 std::optional<GPRReg> linkRegister();
 
-std::optional<GPRReg> dataTempRegister();
-
 } } // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -205,7 +205,9 @@ inline unsigned defaultOptLevel()
     return Options::defaultB3OptLevel();
 }
 
-std::optional<GPRReg> pinnedExtendedOffsetAddrRegister();
+std::optional<GPRReg> linkRegister();
+
+std::optional<GPRReg> dataTempRegister();
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -144,11 +144,11 @@ static ALWAYS_INLINE CCallHelpers::Address callFrameAddr(CCallHelpers& jit, intp
         return CCallHelpers::Address(GPRInfo::callFrameRegister, offsetFromFP);
     }
 
-    ASSERT(pinnedExtendedOffsetAddrRegister());
+    ASSERT(linkRegister());
     auto addr = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
     if (addr.isValidForm(Width64))
         return CCallHelpers::Address(GPRInfo::callFrameRegister, offsetFromFP);
-    GPRReg reg = *pinnedExtendedOffsetAddrRegister();
+    GPRReg reg = *linkRegister();
     jit.move(CCallHelpers::TrustedImmPtr(offsetFromFP), reg);
     jit.add64(GPRInfo::callFrameRegister, reg);
     return CCallHelpers::Address(reg);

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -93,7 +93,7 @@ Code::Code(Procedure& proc)
             setRegsInPriorityOrder(bank, result);
         });
 
-    if (auto reg = pinnedExtendedOffsetAddrRegister())
+    if (auto reg = dataTempRegister())
         pinRegister(*reg);
 
     m_pinnedRegs.set(MacroAssembler::framePointerRegister);

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -93,7 +93,7 @@ Code::Code(Procedure& proc)
             setRegsInPriorityOrder(bank, result);
         });
 
-    if (auto reg = dataTempRegister())
+    if (auto reg = linkRegister())
         pinRegister(*reg);
 
     m_pinnedRegs.set(MacroAssembler::framePointerRegister);

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -78,8 +78,7 @@ void lowerStackArgs(Code& code)
                     if (Arg::isValidImmForm(offset))
                         inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, Arg::imm(offset), base, inst.args[1]);
                     else {
-                        ASSERT(pinnedExtendedOffsetAddrRegister());
-                        Air::Tmp tmp = Air::Tmp(*pinnedExtendedOffsetAddrRegister());
+                        Air::Tmp tmp = Air::Tmp(*linkRegister());
                         Arg offsetArg = Arg::bigImm(offset);
                         insertionSet.insert(instIndex, Move, inst.origin, offsetArg, tmp);
                         inst = Inst(inst.kind.opcode == Lea32 ? Add32 : Add64, inst.origin, tmp, base, inst.args[1]);
@@ -128,8 +127,7 @@ void lowerStackArgs(Code& code)
                         if (result.isValidForm(width))
                             return result;
 #if CPU(ARM64) || CPU(RISCV64)
-                        ASSERT(pinnedExtendedOffsetAddrRegister());
-                        Air::Tmp tmp = Air::Tmp(*pinnedExtendedOffsetAddrRegister());
+                        Air::Tmp tmp = Air::Tmp(*linkRegister());
 
                         Arg largeOffset = Arg::isValidImmForm(offsetFromSP) ? Arg::imm(offsetFromSP) : Arg::bigImm(offsetFromSP);
                         insertionSet.insert(instIndex, Move, inst.origin, largeOffset, tmp);


### PR DESCRIPTION
#### 201d00c3707dc30cb2e67073a2cedb5119586076
<pre>
update1
</pre>
----------------------------------------------------------------------
#### b40f931fdc0bece7e4edfe4852b2265f723191b2
<pre>
[ARM64] Use link register instead of pinning a register for materializing big load constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=228710">https://bugs.webkit.org/show_bug.cgi?id=228710</a>

Reviewed by NOBODY (OOPS!).

Previously, we pin a register as a temp for materializing a large constant that cannot fit in
Load/Store imm form. This is not efficient since the register allocator has one less register
to allocate from. To solve this problem, we should switch to using the link register as the temp
on ARM64.

* Source/JavaScriptCore/b3/B3Common.cpp:
(JSC::B3::linkRegister):
(JSC::B3::dataTempRegister):
(JSC::B3::pinnedExtendedOffsetAddrRegister): Deleted.
* Source/JavaScriptCore/b3/B3Common.h:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::callFrameAddr):
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::Code):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
</pre>