### PR TITLE
[JSC] Use libpas JITHeap in Linux if libpas is enabled

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -349,7 +349,7 @@
 
 #if !defined(USE_LIBPAS_JIT_HEAP) && !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
-#if BENABLE(LIBPAS) && OS(DARWIN)
+#if BENABLE(LIBPAS) && (OS(DARWIN) || OS(LINUX))
 #define USE_LIBPAS_JIT_HEAP 1
 #endif
 #endif

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -116,6 +116,9 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, bool writable,
 void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
 #if OS(LINUX)
+    UNUSED_PARAM(usage);
+    UNUSED_PARAM(jitCageEnabled);
+    UNUSED_PARAM(includesGuardPages);
     int protection = PROT_READ;
     if (writable)
         protection |= PROT_WRITE;

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h
@@ -83,6 +83,7 @@ static inline void pas_page_sharing_participant_set_index(pas_page_sharing_parti
     pas_page_sharing_participant_get_payload(*ptr)->index_in_sharing_pool_min_heap = (unsigned)index;
 }
 
+PAS_IGNORE_WARNINGS_BEGIN("missing-field-initializers")
 PAS_CREATE_MIN_HEAP(
     pas_page_sharing_pool_min_heap,
     pas_page_sharing_participant,
@@ -90,6 +91,7 @@ PAS_CREATE_MIN_HEAP(
     .compare = pas_page_sharing_participant_compare,
     .get_index = pas_page_sharing_participant_get_index,
     .set_index = pas_page_sharing_participant_set_index);
+PAS_IGNORE_WARNINGS_END
 
 struct PAS_ALIGNED(sizeof(pas_versioned_field)) pas_page_sharing_pool {
     pas_versioned_field first_delta;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -344,7 +344,7 @@ pas_segregated_page_deallocate_with_page(pas_segregated_page* page,
         pas_log("Freeing %p in %p(%s), num_non_empty_words = %llu\n",
                 (void*)begin, page,
                 pas_segregated_page_config_kind_get_string(page_config.kind),
-                (uint64_t)page->emptiness.num_non_empty_words);
+                (unsigned long long)page->emptiness.num_non_empty_words);
     }
 
     bit_index_unmasked = begin >> page_config.base.min_align_shift;


### PR DESCRIPTION
#### cb485aa954c5cfd455069d8ca7b4cbe411c0c37d
<pre>
[JSC] Use libpas JITHeap in Linux if libpas is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=243111">https://bugs.webkit.org/show_bug.cgi?id=243111</a>

Reviewed by Mark Lam.

This patch enables libpas JITHeap in Linux if libpas is enabled.
libpas is enabled on JSCOnly ports.

* Source/WTF/wtf/PlatformUse.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveUncommitted):
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_pool.h:
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
(pas_segregated_page_deallocate_with_page):

Canonical link: <a href="https://commits.webkit.org/252749@main">https://commits.webkit.org/252749@main</a>
</pre>
