### PR TITLE
[iOS] fast/events/touch/ios/long-press-on-(link|image).html fail after 251828@main

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11526,7 +11526,7 @@ constexpr auto analysisTypesForFullscreenVideo = VKAnalysisTypeAll & ~VKAnalysis
 #if HAVE(LINK_PREVIEW)
     if ([userInterfaceItem isEqualToString:@"contextMenu"]) {
         auto itemTitles = adoptNS([NSMutableArray<NSString *> new]);
-        [_contextMenuInteraction updateVisibleMenuWithBlock:[&itemTitles](UIMenu *menu) -> UIMenu * {
+        [self.contextMenuInteraction updateVisibleMenuWithBlock:[&itemTitles](UIMenu *menu) -> UIMenu * {
             for (UIMenuElement *child in menu.children)
                 [itemTitles addObject:child.title];
             return menu;


### PR DESCRIPTION
#### 1c032700aac4f419369112427362cf51fe99d5af
<pre>
[iOS] fast/events/touch/ios/long-press-on-(link|image).html fail after 251828@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243114">https://bugs.webkit.org/show_bug.cgi?id=243114</a>

Reviewed by Aditya Keerthi.

After `251828@main`, the `_contextMenuInteraction` is no longer used to present the context menu
when long pressing images and links; instead, we rely on the text interaction assistant&apos;s context
menu interaction.

As a result, the testing hook `-[WKContentView _contentsOfUserInterfaceItem:]` no longer works,
since it still calls `_contextMenuInteraction` directly; fix this by replacing it with a call to the
`-contextMenuInteraction` helper method.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _contentsOfUserInterfaceItem:]):

Canonical link: <a href="https://commits.webkit.org/252750@main">https://commits.webkit.org/252750@main</a>
</pre>
