### PR TITLE
xhr/overridemimetype-blob.html WPT test is failing in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-blob-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-blob-expected.txt
@@ -3,7 +3,7 @@ PASS Use text/xml as fallback MIME type
 PASS Use text/xml as fallback MIME type, 2
 PASS Loading data…
 PASS 1) MIME types need to be parsed and serialized: text/html;charset=gbk
-FAIL 2) MIME types need to be parsed and serialized: TEXT/HTML;CHARSET=GBK assert_equals: expected "text/html;charset=GBK" but got "text/html;charset=gbk"
+PASS 2) MIME types need to be parsed and serialized: TEXT/HTML;CHARSET=GBK
 PASS 3) MIME types need to be parsed and serialized: text/html;charset=gbk(
 PASS 4) MIME types need to be parsed and serialized: text/html;x=(;charset=gbk
 PASS 5) MIME types need to be parsed and serialized: text/html;charset=gbk;charset=windows-1255
@@ -27,8 +27,8 @@ PASS 22) MIME types need to be parsed and serialized: text/html;';charset=gbk
 PASS 23) MIME types need to be parsed and serialized: text/html;";charset=gbk
 PASS 24) MIME types need to be parsed and serialized: text/html ; ; charset=gbk
 PASS 25) MIME types need to be parsed and serialized: text/html;;;;charset=gbk
-FAIL 26) MIME types need to be parsed and serialized: text/html;charset= ";charset=GBK assert_equals: expected "text/html;charset=GBK" but got "text/html;charset=gbk"
-FAIL 27) MIME types need to be parsed and serialized: text/html;charset=";charset=foo";charset=GBK assert_equals: expected "text/html;charset=GBK" but got "text/html;charset=gbk"
+PASS 26) MIME types need to be parsed and serialized: text/html;charset= ";charset=GBK
+PASS 27) MIME types need to be parsed and serialized: text/html;charset=";charset=foo";charset=GBK
 PASS 28) MIME types need to be parsed and serialized: text/html;charset="gbk"
 PASS 29) MIME types need to be parsed and serialized: text/html;charset="gbk
 PASS 30) MIME types need to be parsed and serialized: text/html;charset=gbk"
@@ -38,12 +38,12 @@ PASS 33) MIME types need to be parsed and serialized: text/html;charset="\ gbk"
 PASS 34) MIME types need to be parsed and serialized: text/html;charset="\g\b\k"
 PASS 35) MIME types need to be parsed and serialized: text/html;charset="gbk"x
 PASS 36) MIME types need to be parsed and serialized: text/html;charset="";charset=GBK
-FAIL 37) MIME types need to be parsed and serialized: text/html;charset=";charset=GBK assert_equals: expected "text/html;charset=\";charset=GBK\"" but got "text/html;charset=\";charset=gbk\""
+PASS 37) MIME types need to be parsed and serialized: text/html;charset=";charset=GBK
 PASS 38) MIME types need to be parsed and serialized: text/html;charset={gbk}
 PASS 39) MIME types need to be parsed and serialized: text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk
 PASS 40) MIME types need to be parsed and serialized: 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-FAIL 41) MIME types need to be parsed and serialized: !#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz assert_equals: expected "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" but got "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
-FAIL 42) MIME types need to be parsed and serialized: x/x;x="	 !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ" assert_equals: expected "x/x;x=\"\t !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ\"" but got ""
+PASS 41) MIME types need to be parsed and serialized: !#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+PASS 42) MIME types need to be parsed and serialized: x/x;x="	 !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
 PASS 43) MIME types need to be parsed and serialized: x/x;test
 PASS 44) MIME types need to be parsed and serialized: x/x;test="\
 PASS 45) MIME types need to be parsed and serialized: x/x;x=
@@ -56,7 +56,7 @@ PASS 48) MIME types need to be parsed and serialized:
 PASS 49) MIME types need to be parsed and serialized: x/x;
 \r	 x=x
 \r	 ;x=y
-FAIL 50) MIME types need to be parsed and serialized: text/html;test=ÿ;charset=gbk assert_equals: expected "text/html;test=\"ÿ\";charset=gbk" but got ""
+PASS 50) MIME types need to be parsed and serialized: text/html;test=ÿ;charset=gbk
 PASS 51) MIME types need to be parsed and serialized: x/x;test=�;x=x
 PASS 52) MIME types need to be parsed and serialized: x/x
 PASS 53) MIME types need to be parsed and serialized: x/x

--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -39,7 +39,6 @@ namespace WebCore {
 BlobData::BlobData(const String& contentType)
     : m_contentType(contentType)
 {
-    ASSERT(Blob::isNormalizedContentType(contentType));
 }
 
 const long long BlobDataItem::toEndOfFile = -1;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -210,8 +210,7 @@ Ref<Blob> XMLHttpRequest::createResponseBlob()
     Vector<uint8_t> data;
     if (m_binaryResponseBuilder)
         data = m_binaryResponseBuilder.take()->extractData();
-    String normalizedContentType = Blob::normalizedContentType(responseMIMEType(FinalMIMEType::Yes)); // responseMIMEType defaults to text/xml which may be incorrect.
-    return Blob::create(scriptExecutionContext(), WTFMove(data), normalizedContentType);
+    return Blob::create(scriptExecutionContext(), WTFMove(data), responseMIMEType(FinalMIMEType::Yes)); // responseMIMEType defaults to text/xml which may be incorrect.
 }
 
 RefPtr<ArrayBuffer> XMLHttpRequest::createResponseArrayBuffer()


### PR DESCRIPTION
#### d631af92dc8ea7e82a1daf50401740c2fcbd7a9c
<pre>
xhr/overridemimetype-blob.html WPT test is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243115">https://bugs.webkit.org/show_bug.cgi?id=243115</a>

Reviewed by Darin Adler.

WebKit had some logic to normalize the Blob content type, which wasn&apos;t part of
the specification, didn&apos;t match the behavior of Gecko and causing us to fail
a WPT test. This patch drops the content-type normalization logic for better
standards compliance.

* LayoutTests/imported/w3c/web-platform-tests/xhr/overridemimetype-blob-expected.txt:
* Source/WebCore/platform/network/BlobData.cpp:
(WebCore::BlobData::BlobData):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createResponseBlob):

Canonical link: <a href="https://commits.webkit.org/252832@main">https://commits.webkit.org/252832@main</a>
</pre>
