### PR TITLE
Update find UI when ImageAnalysisQueue empties

### DIFF
--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -38,6 +38,7 @@ enum class HysteresisState {
 };
 
 class HysteresisActivity {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit HysteresisActivity(Function<void(HysteresisState)>&& callback = [](HysteresisState) { }, Seconds hysteresisSeconds = defaultHysteresisDuration)
         : m_callback(WTFMove(callback))

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -33,6 +33,10 @@
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 
+namespace PAL {
+class HysteresisActivity;
+}
+
 namespace WebCore {
 
 class Document;
@@ -46,10 +50,13 @@ public:
     ImageAnalysisQueue(Page&);
     ~ImageAnalysisQueue();
 
-    WEBCORE_EXPORT void enqueueAllImages(Document&, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
+    WEBCORE_EXPORT void enqueueAllImagesIfNeeded(Document&, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
     void clear();
 
     void enqueueIfNeeded(HTMLImageElement&);
+
+    WEBCORE_EXPORT void setDidBecomeEmptyCallback(Function<void()>&&);
+    WEBCORE_EXPORT void clearDidBecomeEmptyCallback();
 
 private:
     void resumeProcessingSoon();
@@ -76,6 +83,8 @@ private:
     PriorityQueue<Task, firstIsHigherPriority> m_queue;
     unsigned m_pendingRequestCount { 0 };
     unsigned m_currentTaskNumber { 0 };
+    std::unique_ptr<PAL::HysteresisActivity> m_imageQueueEmptyHysteresis;
+    bool m_analysisOfAllImagesOnPageHasStarted { false };
 };
 
 inline bool ImageAnalysisQueue::firstIsHigherPriority(const Task& first, const Task& second)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -807,11 +807,12 @@ bool Page::findString(const String& target, FindOptions options, DidWrap* didWra
 }
 
 #if ENABLE(IMAGE_ANALYSIS)
-void Page::analyzeImagesForFindInPage()
+void Page::analyzeImagesForFindInPage(Function<void()>&& callback)
 {
     if (settings().imageAnalysisDuringFindInPageEnabled()) {
-        if (RefPtr mainDocument = m_mainFrame->document(); mainDocument && !m_imageAnalysisQueue)
-            imageAnalysisQueue().enqueueAllImages(*mainDocument, { }, { });
+        imageAnalysisQueue().setDidBecomeEmptyCallback(WTFMove(callback));
+        if (RefPtr mainDocument = m_mainFrame->document())
+            imageAnalysisQueue().enqueueAllImagesIfNeeded(*mainDocument, { }, { });
     }
 }
 #endif

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -86,6 +86,10 @@ namespace JSC {
 class Debugger;
 }
 
+namespace PAL {
+class HysteresisActivity;
+}
+
 namespace WTF {
 class TextStream;
 }
@@ -973,7 +977,7 @@ public:
     WEBCORE_EXPORT void forceRepaintAllFrames();
 
 #if ENABLE(IMAGE_ANALYSIS)
-    WEBCORE_EXPORT void analyzeImagesForFindInPage();
+    WEBCORE_EXPORT void analyzeImagesForFindInPage(Function<void()>&& callback);
 #endif
 private:
     struct Navigation {

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -233,14 +233,10 @@ void FindController::updateFindUIAfterPageScroll(bool found, const String& strin
         hideFindIndicator();
 }
 
-void FindController::findString(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, CompletionHandler<void(bool)>&& completionHandler)
+void FindController::findString(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, TriggerImageAnalysis canTriggerImageAnalysis, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if ENABLE(PDFKIT_PLUGIN)
     auto* pluginView = mainFramePlugIn();
-#endif
-
-#if ENABLE(IMAGE_ANALYSIS)
-    m_webPage->corePage()->analyzeImagesForFindInPage();
 #endif
 
     WebCore::FindOptions coreOptions = core(options);
@@ -291,13 +287,22 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
                 m_foundStringMatchIndex++;
         }
     }
+#if ENABLE(IMAGE_ANALYSIS)
+    if (canTriggerImageAnalysis == TriggerImageAnalysis::Yes) {
+        m_webPage->corePage()->analyzeImagesForFindInPage([weakPage = WeakPtr { m_webPage }, string, options, maxMatchCount] {
+            if (weakPage)
+                weakPage->findController().findString(string, options, maxMatchCount, TriggerImageAnalysis::No); 
+        });
+    }
+#endif
 
     RefPtr<WebPage> protectedWebPage = m_webPage;
     m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage, found, string, options, maxMatchCount, didWrap] () {
         protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, didWrap, FindUIOriginator::FindString);
     });
 
-    completionHandler(found);
+    if (completionHandler)
+        completionHandler(found);
 }
 
 void FindController::findStringMatches(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount)
@@ -405,6 +410,11 @@ void FindController::hideFindUI()
     
     hideFindIndicator();
     resetMatchIndex();
+
+#if ENABLE(IMAGE_ANALYSIS)
+    if (auto imageAnalysisQueue = m_webPage->corePage()->imageAnalysisQueueIfExists())
+        imageAnalysisQueue->clearDidBecomeEmptyCallback();
+#endif
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -56,10 +56,12 @@ class FindController final : private WebCore::PageOverlay::Client {
     WTF_MAKE_NONCOPYABLE(FindController);
 
 public:
+    enum class TriggerImageAnalysis : bool { No, Yes };
+
     explicit FindController(WebPage*);
     virtual ~FindController();
 
-    void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
+    void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, TriggerImageAnalysis, CompletionHandler<void(bool)>&& = { });
     void findStringMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount);
     void findRectsForStringMatches(const String&, OptionSet<WebKit::FindOptions>, unsigned maxMatchCount, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&);
     void getImageForFindMatch(uint32_t matchIndex);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4859,7 +4859,7 @@ void WebPage::replaceStringMatchesFromInjectedBundle(const Vector<uint32_t>& mat
 
 void WebPage::findString(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(bool)>&& completionHandler)
 {
-    findController().findString(string, options, maxMatchCount, WTFMove(completionHandler));
+    findController().findString(string, options, maxMatchCount, FindController::TriggerImageAnalysis::Yes, WTFMove(completionHandler));
 }
 
 void WebPage::findStringMatches(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount)
@@ -7912,7 +7912,7 @@ void WebPage::updateWithTextRecognitionResult(const TextRecognitionResult& resul
 void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
     if (RefPtr document = m_mainFrame->coreFrame()->document())
-        corePage()->imageAnalysisQueue().enqueueAllImages(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
+        corePage()->imageAnalysisQueue().enqueueAllImagesIfNeeded(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		1D67BFDC2433E0A7006B5047 /* PreemptVideoFullscreen.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1D67BFDB2433E0A7006B5047 /* PreemptVideoFullscreen.mm */; };
 		1D67BFDD2433EE66006B5047 /* two-videos.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1D67BFD92433DFD8006B5047 /* two-videos.html */; };
 		1DAA52CC243BE805001A3159 /* one-video.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1DAA52CB243BE621001A3159 /* one-video.html */; };
+		1F0559E52890A11B002E279C /* image-with-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1F0559E42890A09D002E279C /* image-with-text.html */; };
 		26DF5A6315A2A27E003689C2 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26DF5A6115A2A22B003689C2 /* CancelLoadFromResourceLoadDelegate.html */; };
 		26F52EAD1828827B0023D412 /* geolocationGetCurrentPosition.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAC1828820E0023D412 /* geolocationGetCurrentPosition.html */; };
 		26F52EAF18288C230023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 26F52EAE18288C040023D412 /* geolocationGetCurrentPositionWithHighAccuracy.html */; };
@@ -1439,6 +1440,7 @@
 				F491DBAE281DE0E80081705F /* image-controls.html in Copy Resources */,
 				F4DEF6ED1E9B4DB60048EF61 /* image-in-link-and-input.html in Copy Resources */,
 				F45B63FB1F197F4A009D38B9 /* image-map.html in Copy Resources */,
+				1F0559E52890A11B002E279C /* image-with-text.html in Copy Resources */,
 				3128A8152376413300D90D40 /* image.html in Copy Resources */,
 				71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */,
 				1C9C7F512891238500C4649E /* ImmediateFont.html in Copy Resources */,
@@ -1861,6 +1863,7 @@
 		1D67BFD92433DFD8006B5047 /* two-videos.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "two-videos.html"; sourceTree = "<group>"; };
 		1D67BFDB2433E0A7006B5047 /* PreemptVideoFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PreemptVideoFullscreen.mm; sourceTree = "<group>"; };
 		1DAA52CB243BE621001A3159 /* one-video.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "one-video.html"; sourceTree = "<group>"; };
+		1F0559E42890A09D002E279C /* image-with-text.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "image-with-text.html"; sourceTree = "<group>"; };
 		1F83571A1D3FFB0E00E3967B /* WKBackForwardList.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKBackForwardList.mm; path = Tests/WebKit/WKBackForwardList.mm; sourceTree = SOURCE_ROOT; };
 		260BA5781B1D2E7B004FA07C /* DFACombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DFACombiner.cpp; sourceTree = "<group>"; };
 		260BA57A1B1D2EE2004FA07C /* DFAHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DFAHelpers.h; sourceTree = "<group>"; };
@@ -4278,6 +4281,7 @@
 				F491DBAD281DE0980081705F /* image-controls.html */,
 				F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */,
 				F45B63FA1F197F33009D38B9 /* image-map.html */,
+				1F0559E42890A09D002E279C /* image-with-text.html */,
 				3128A814237640FD00D90D40 /* image.html */,
 				1C9C7F4F2891234500C4649E /* ImmediateFont.html */,
 				49D7FBA7241FDDDA00AB67FA /* in-app-browser-privacy-local-file.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-with-text.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-with-text.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <meta name='viewport' content='initial-scale=1'>
+    </head>
+    <body style='margin: 0px;'>
+        <p>text</p>
+        <img style='display: block; height: 100%;' src="large-red-square.png">
+    </body>
+</html>
+


### PR DESCRIPTION
#### ce5226e9d21450f6ee5ed21e8969f81bc4dccdb9
<pre>
Update find UI when ImageAnalysisQueue empties
<a href="https://bugs.webkit.org/show_bug.cgi?id=243071">https://bugs.webkit.org/show_bug.cgi?id=243071</a>
rdar://97396153

Reviewed by Wenson Hsieh.

Test:
Updated FindInPageAPI.FindAPITextInImage to check that the first
Find-in-page operation on a webpage occurs twice.

This patch improves the internal setting ImageAnalysisForFindInPage.
Now the find ui is updated once the ImageAnalysisQueue is empty, so
matches from images show up shortly after other text matches without
the need for user interaction to update the ui. This is accomplished
by re-doing the most recent find-in-page when the image queue is newly
empty.

* Source/WebCore/PAL/pal/HysteresisActivity.h:

Added WTF_MAKE_FAST_ALLOCATED.

* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::enqueueAllImages): Deleted.
(WebCore::ImageAnalysisQueue::enqueueAllImagesIfNeeded): Added.

Changed name of function and added m_analysisOfAllImagesOnPageHasStarted
Check.

(WebCore::ImageAnalysisQueue::resumeProcessing):

Now checks if the image queue is empty, and if so, triggers
m_imageQueueEmptyHysteresis.

(WebCore::ImageAnalysisQueue::setDidBecomeEmptyCallback): Added.

Initializes m_imageQueueEmptyHysteresis with given callback to be called
When the HysteresisActivity goes off.

(WebCore::ImageAnalysisQueue::clearDidBecomeEmptyCallback): Added.

(WebCore::ImageAnalysisQueue::clear):

Reset m_analysisOfAllImagesOnPageHasStarted and m_imageQueueEmptyHysteresis.

Sets m_imageQueueEmptyHysteresis to nullptr.

* Source/WebCore/page/ImageAnalysisQueue.h:

* Source/WebCore/page/Page.cpp:
(WebCore::Page::analyzeImagesForFindInPage):

If setting is enabled, calls ImageAnalysisQueue::setImageQueueEmptyHysteresis
with given callback, then enqueues all images on page
to be analyzed if they have not begun to be analyzed yet.

* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):

Calls page::analyzeImagesForFindInPagee with a
callback function that calls FindController::findString with
Arguments configured to re-find the current string. Therefore there is a second
search for matches on the page and a UI update after the text from the images
has been added to the page.

findString has also been changed so that its completionHandler argument
Has a default value of { } and to take an enum shouldTriggerImageAnalysis.

(WebKit::FindController::hideFindUI):

Now also calls ImageAnalysisQueue::endImageQueueEmptyHysteresis.

* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp
(WebKit::WebPage::findString):

Now passes TriggerImageAnalysis::Yes to FindController::findString.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
(-[FindDelegate didFindMatches:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/image-with-text.html: Added.

Canonical link: <a href="https://commits.webkit.org/253244@main">https://commits.webkit.org/253244@main</a>
</pre>
