### PR TITLE
[commits.webkit.org] Add fallback for redirects

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 4)
+version = Version(0, 7, 5)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
@@ -40,10 +40,13 @@ class Redirector(object):
             if not isinstance(obj, Redirector):
                 return super(Checkout.Encoder, self).default(obj)
 
-            return dict(
+            result = dict(
                 name=obj.name,
                 url=obj.url,
             )
+            if obj.fallback:
+                result['fallback'] = self.default(obj.fallback)
+            return result
 
     @classmethod
     def bitbucket_generator(cls, base):
@@ -106,9 +109,10 @@ class Redirector(object):
             return [cls(**node) for node in data]
         return cls(**data)
 
-    def __init__(self, url, name=None):
+    def __init__(self, url, name=None, fallback=None):
         self.url = url
         self.type = None
+        self.fallback = self.from_json(fallback) if isinstance(fallback, dict) else fallback
         self._redirect = None
 
         for key, params in dict(
@@ -119,8 +123,25 @@ class Redirector(object):
             regex, generator, compare = params
             if regex.match(url):
                 self.type = key
-                self._redirect = generator(url)
-                self.compare = compare(url)
+                if self.fallback:
+                    redirect = generator(url)
+                    compare = compare(url)
+
+                    def fallback_generator(commit):
+                        if not commit or commit.message:
+                            return redirect(commit)
+                        return self.fallback(commit)
+
+                    def fallback_compare(head, base):
+                        if not head or not base or (head.message and base.message):
+                            return compare(head, base)
+                        return self.fallback.compare(head, base)
+
+                    self._redirect = fallback_generator
+                    self.compare = fallback_compare
+                else:
+                    self._redirect = generator(url)
+                    self.compare = compare(url)
                 break
         if not self.type:
             raise TypeError("'{}' is not a recognized redirect base")

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
@@ -97,6 +97,36 @@ class RedirectorUnittest(unittest.TestCase):
             transfered(Commit(hash='deadbeef')).headers.get('location'),
         )
 
+    def test_fallback(self):
+        redir = Redirector('https://github.com/WebKit/WebKit', fallback=Redirector('https://github.com/WebKit/WebKit-security'))
+        self.assertEqual(
+            redir(None).headers.get('location'),
+            'https://github.com/WebKit/WebKit/commits',
+        )
+        self.assertEqual(
+            redir(Commit(hash='deadbeef', message='defined')).headers.get('location'),
+            'https://github.com/WebKit/WebKit/commit/deadbeef',
+        )
+        self.assertEqual(
+            redir(Commit(hash='deadbeef')).headers.get('location'),
+            'https://github.com/WebKit/WebKit-security/commit/deadbeef',
+        )
+
+    def test_fallback_compare(self):
+        redir = Redirector('https://github.com/WebKit/WebKit', fallback=Redirector('https://github.com/WebKit/WebKit-security'))
+        self.assertEqual(
+            redir(None).headers.get('location'),
+            'https://github.com/WebKit/WebKit/commits',
+        )
+        self.assertEqual(
+            redir.compare(Commit(hash='deadbeef', message='defined'), Commit(hash='beefdead', message='defined')).headers.get('location'),
+            'https://github.com/WebKit/WebKit/compare/beefdead...deadbeef',
+        )
+        self.assertEqual(
+            redir.compare(Commit(hash='deadbeef'), Commit(hash='beefdead')).headers.get('location'),
+            'https://github.com/WebKit/WebKit-security/compare/beefdead...deadbeef',
+        )
+
 
 class CheckoutRouteUnittest(testing.PathTestCase):
     basepath = 'mock/repository'

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.4',
+    version='0.7.5',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 1112fba78559afce2508f659ba4f0d12daf4a810
<pre>
[commits.webkit.org] Add fallback for redirects
<a href="https://bugs.webkit.org/show_bug.cgi?id=243116">https://bugs.webkit.org/show_bug.cgi?id=243116</a>
&lt;rdar://97457723&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(Redirector.Encoder.default): Encode fallback object, if it exists.
(Redirector.__init__): Decode fallbak as Redirectory, if it exists. If fallback
is defined, use the fallback when message is not defined.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py:
(RedirectorUnittest.test_fallback):
(RedirectorUnittest.test_fallback_compare):
* Tools/Scripts/libraries/reporelaypy/setup.py: Bump version.

Canonical link: <a href="https://commits.webkit.org/252748@main">https://commits.webkit.org/252748@main</a>
</pre>
