### PR TITLE
[git-webkit] Handle invalid git remote

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.3.5',
+    version='5.3.6',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 3, 5)
+version = Version(5, 3, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -490,6 +490,8 @@ class Git(Scm):
     @decorators.Memoize()
     def remote(self, name=None):
         url = self.url(name=name)
+        if not url:
+            return None
         ssh_match = self.SSH_REMOTE.match(url)
         http_match = self.HTTP_REMOTE.match(url)
         if ssh_match:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py
@@ -64,7 +64,7 @@ class Clean(Command):
         match = cls.PR_RE.match(argument)
         if match:
             if not rmt:
-                sys.stderr.write("'{}' doesn't have a recognized remote\n".format(repository.root_path))
+                sys.stderr.write("'{}' doesn't have a recognized remote named '{}'\n".format(repository.root_path, remote_target or repository.default_remote))
                 return 1
             if not rmt.pull_requests:
                 sys.stderr.write("'{}' cannot generate pull-requests\n".format(rmt.url))
@@ -138,6 +138,9 @@ class DeletePRBranches(Command):
             return 1
 
         rmt = repository.remote(name=args.remote)
+        if not rmt:
+            sys.stderr.write("'{}' doesn't have a recognized remote named '{}'\n".format(repository.root_path, args.remote or repository.default_remote))
+            return 1
         if not rmt.pull_requests:
             sys.stderr.write("'{}' does not have associated pull-requests\n".format(rmt.url))
             return 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py
@@ -106,3 +106,16 @@ class TestClean(testing.PathTestCase):
                 path=self.path,
             ))
             self.assertNotIn('eng/pr-branch', repo.commits)
+
+    def test_delete_pr_branches_invalid_remote(self):
+        with OutputCapture() as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ), mocks.local.Svn():
+            self.assertEqual(1, program.main(
+                args=('delete-pr-branches', '-v', '--remote=all'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), "'{}' doesn't have a recognized remote named 'all'\n".format(self.path))


### PR DESCRIPTION
#### 9269904fddaeff45c22f6d8350e2b48c6a9e6a67
<pre>
[git-webkit] Handle invalid git remote
<a href="https://bugs.webkit.org/show_bug.cgi?id=243118">https://bugs.webkit.org/show_bug.cgi?id=243118</a>
&lt;rdar://problem/97460586&gt;

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.remote): If no URL found with the specified name, return None.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py:
(Clean.cleanup): Log remote when remote is invalid.
(DeletePRBranches.main): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clean_unittest.py:
(TestClean.test_delete_pr_branches_invalid_remote):

Canonical link: <a href="https://commits.webkit.org/253688@main">https://commits.webkit.org/253688@main</a>
</pre>


















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57fa17742aa2757f13bf12d815a8953fbc5e29b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86828 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/69/builds/30904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95660 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/90808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29271 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92444 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/90431 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27032 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/85927 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26954 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1026 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28582 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->