### PR TITLE
[Gardening]: [ iOS ] http/tests/media/media-source/mediasource-rvfc.html is a flaky timeout and text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3667,7 +3667,7 @@ webkit.org/b/242270 fast/encoding/char-after-fast-path-ascii-decoding.html [ Pas
 webkit.org/b/242273 fast/events/ios/dragstart-on-image-by-long-pressing.html [ Pass Failure ]
 
 # Requires platform support (see rdar://94324932).
-http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
+http/tests/media/media-source/mediasource-rvfc.html [ Failure Timeout ]
 
 webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable.html [ Pass Failure ]
 


### PR DESCRIPTION
#### ba2276891702a094be895483058b49f533523e48
<pre>
[Gardening]: [ iOS ] http/tests/media/media-source/mediasource-rvfc.html is a flaky timeout and text failure
&lt;rdar://problem/94324932&gt;

Unreviewed test gardening. 

Adding expectation for current bug.

* LayoutTests/platform/ios/TestExpectations:
</pre>