### PR TITLE
Unreviewed, fix the build after `252742@main`

### DIFF
--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -47,7 +47,6 @@
 
 OBJC_CLASS NSString;
 OBJC_CLASS UIKeyboardInputMode;
-OBJC_CLASS UIEditMenuInteraction;
 OBJC_CLASS UIPasteboardConsistencyEnforcer;
 OBJC_CLASS WKWebViewConfiguration;
 
@@ -382,11 +381,6 @@ public:
     bool denyNotificationPermissionOnPrompt(WKStringRef origin);
 
     PlatformWebView* createOtherPlatformWebView(PlatformWebView* parentView, WKPageConfigurationRef, WKNavigationActionRef, WKWindowFeaturesRef);
-
-#if HAVE(UI_EDIT_MENU_INTERACTION)
-    void didPresentEditMenuInteraction(UIEditMenuInteraction *);
-    void didDismissEditMenuInteraction(UIEditMenuInteraction *);
-#endif
 
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);


### PR DESCRIPTION
#### ad7bda55ab84879f805963b52e67266b1be74245
<pre>
Unreviewed, fix the build after `252742@main`

These methods are unused after the changes in `252742@main`.

* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/252754@main">https://commits.webkit.org/252754@main</a>
</pre>
