### PR TITLE
Change RegionAllocator pointer fields to use ptrauth attributes instead of doing manual pac/auth.

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -830,10 +830,10 @@ private:
         {
             RELEASE_ASSERT(start < islandBegin);
             RELEASE_ASSERT(islandBegin <= end);
-            m_start = tagCodePtr<ExecutableMemoryPtrTag>(bitwise_cast<void*>(start));
-            m_islandBegin = tagCodePtr<ExecutableMemoryPtrTag>(bitwise_cast<void*>(islandBegin));
-            m_end = tagCodePtr<ExecutableMemoryPtrTag>(bitwise_cast<void*>(end));
-            RELEASE_ASSERT(!((this->end() - this->start()) % pageSize()));
+            m_start = bitwise_cast<void*>(start);
+            m_islandBegin = bitwise_cast<void*>(islandBegin);
+            m_end = bitwise_cast<void*>(end);
+            RELEASE_ASSERT(!((this->islandBegin() - this->start()) % pageSize()));
             RELEASE_ASSERT(!((this->end() - this->islandBegin()) % pageSize()));
             addFreshFreeSpace(bitwise_cast<void*>(this->start()), allocatorSize());
         }
@@ -842,9 +842,9 @@ private:
         //  | jit allocations -->   <-- islands |
         //  -------------------------------------
 
-        uintptr_t start() { return bitwise_cast<uintptr_t>(untagCodePtr<ExecutableMemoryPtrTag>(m_start)); }
-        uintptr_t islandBegin() { return bitwise_cast<uintptr_t>(untagCodePtr<ExecutableMemoryPtrTag>(m_islandBegin)); }
-        uintptr_t end() { return bitwise_cast<uintptr_t>(untagCodePtr<ExecutableMemoryPtrTag>(m_end)); }
+        uintptr_t start() { return bitwise_cast<uintptr_t>(m_start); }
+        uintptr_t islandBegin() { return bitwise_cast<uintptr_t>(m_islandBegin); }
+        uintptr_t end() { return bitwise_cast<uintptr_t>(m_end); }
 
         size_t maxIslandsInThisRegion() { return (end() - islandBegin()) / islandSizeInBytes; }
 
@@ -935,10 +935,13 @@ private:
         }
 
     private:
+#define REGION_ALLOCATOR_CODEPTR(field) \
+    WTF_FUNCPTR_PTRAUTH_STR("RegionAllocator." #field) field
+
         // Range: [start, end)
-        void* m_start;
-        void* m_islandBegin;
-        void* m_end;
+        void* REGION_ALLOCATOR_CODEPTR(m_start);
+        void* REGION_ALLOCATOR_CODEPTR(m_islandBegin);
+        void* REGION_ALLOCATOR_CODEPTR(m_end);
         FastBitVector islandBits;
     };
 #endif // ENABLE(JUMP_ISLANDS)

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -491,6 +491,10 @@ inline bool usesPointerTagging() { return true; }
 #define WTF_VTBL_FUNCPTR_PTRAUTH_STR(discriminatorStr) \
     __ptrauth(ptrauth_key_process_independent_code, 1, ptrauth_string_discriminator(discriminatorStr))
 
+#define WTF_FUNCPTR_PTRAUTH(discriminator) WTF_FUNCPTR_PTRAUTH_STR(#discriminator)
+#define WTF_FUNCPTR_PTRAUTH_STR(discriminatorStr) \
+    __ptrauth(ptrauth_key_process_dependent_code, 1, ptrauth_string_discriminator(discriminatorStr))
+
 #else // not CPU(ARM64E)
 
 inline const void* untagReturnPC(const void* pc, const void*)
@@ -554,6 +558,8 @@ inline bool usesPointerTagging() { return false; }
 
 #define WTF_VTBL_FUNCPTR_PTRAUTH(discriminator)
 #define WTF_VTBL_FUNCPTR_PTRAUTH_STR(discriminatorStr)
+#define WTF_FUNCPTR_PTRAUTH(discriminator)
+#define WTF_FUNCPTR_PTRAUTH_STR(discriminatorStr)
 
 #endif // CPU(ARM64E)
 


### PR DESCRIPTION
#### a8bf62165df0b9ae294a2b7e7f3539ed1373dd82
<pre>
Change RegionAllocator pointer fields to use ptrauth attributes instead of doing manual pac/auth.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243122">https://bugs.webkit.org/show_bug.cgi?id=243122</a>

Reviewed by Yusuke Suzuki.

This makes the code cleaner to read, less prone to human error, and increases PAC
hardness of those fields.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/wtf/PtrTag.h:

Canonical link: <a href="https://commits.webkit.org/252755@main">https://commits.webkit.org/252755@main</a>
</pre>
