### PR TITLE
[Gardening]: Run tests in fast/forms/ios by default in EWS

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2226,3 +2226,5 @@ webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ P
 
 # The Notifications API is not supported on iOS
 imported/w3c/web-platform-tests/permissions/all-permissions.html [ Failure ]
+
+webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass Timeout ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -33,7 +33,6 @@ fast/forms/ios/inputmode-none-with-hardware-keyboard.html [ Pass Failure ]
 fast/forms/ios/dismiss-picker-using-keyboard.html [ Pass Timeout ]
 fast/forms/ios/drag-range-thumb.html [ Pass Timeout Timeout ]
 fast/forms/ios/inputmode-change-update-keyboard.html [ Pass Timeout ]
-fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass Timeout ]
 
 fast/css/appearance-apple-pay-button.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-radius.html [ Pass ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -51,8 +51,6 @@ media/video-element-fullscreen-not-in-dom-accelerated-iphone.html [ Skip ]
 # This test is iPad-specific
 media/modern-media-controls/media-documents/media-document-video-ipad-sizing.html [ Pass ]
 
-webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass Timeout ]
-
 webkit.org/b/194221 fast/forms/datalist/datalist-textinput-suggestions-order.html [ Failure ]
 webkit.org/b/194221 fast/forms/datalist/datalist-show-hide.html [ Skip ]
 


### PR DESCRIPTION
#### 979a571e5974637fde5eebdb74b202d1dbb3da18
<pre>
[Gardening]: Run tests in fast/forms/ios by default in EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=229656">https://bugs.webkit.org/show_bug.cgi?id=229656</a>

Unreviewed test gardening.

* LayoutTests/platform/ipad/TestExpectations:
</pre>