### PR TITLE
Re-import changes made while upstreaming bug 241048

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html
@@ -21,8 +21,12 @@ for (let [filenameBase, expectedPixels] of Object.entries(videoTests)) {
                         video.append(source);
                     }
 
+                    let loadedData = new Promise(resolver => video.onloadeddata = resolver);
+
                     document.body.append(video);
                     await video.play();
+                    await loadedData;
+                    await new Promise(requestAnimationFrame);
 
                     let imageBitmap;
                     if (cropSource)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html
@@ -21,8 +21,12 @@ for (let [filenameBase, expectedPixels] of Object.entries(videoTests)) {
                         video.append(source);
                     }
 
+                    let loadedData = new Promise(resolver => video.onloadeddata = resolver);
+
                     document.body.append(video);
                     await video.play();
+                    await loadedData;
+                    await new Promise(requestAnimationFrame);
 
                     let canvas = document.createElement("canvas");
                     canvas.width = 2;


### PR DESCRIPTION
#### fe8869a039c2279d9e68ef20a47106e2e15660ef
<pre>
Re-import changes made while upstreaming bug 241048
<a href="https://bugs.webkit.org/show_bug.cgi?id=243125">https://bugs.webkit.org/show_bug.cgi?id=243125</a>

Unreviewed test gardening.

Re-import some test tweaks that were made as part of
<a href="https://github.com/web-platform-tests/wpt/pull/34977">https://github.com/web-platform-tests/wpt/pull/34977</a>, which upstreamed
the test changes from <a href="https://bugs.webkit.org/show_bug.cgi?id=241048">https://bugs.webkit.org/show_bug.cgi?id=241048</a>, to
avoid the tests being flaky in Chrome.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html:

Canonical link: <a href="https://commits.webkit.org/252761@main">https://commits.webkit.org/252761@main</a>
</pre>
