### PR TITLE
REGRESSION (252627@main): [iOS] fast/attachment/attachment-thumbnail-preserves-aspect-ratio.html is timing out

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2428,7 +2428,7 @@ fast/attachment/attachment-truncated-action.html [ Pass ]
 fast/attachment/attachment-wrapping-action.html [ Pass ]
 fast/attachment/attachment-borderless.html [ Pass ]
 fast/attachment/attachment-dynamic-type.html [ Pass ]
-fast/attachment/attachment-thumbnail-preserves-aspect-ratio.html [ Pass ]
+webkit.org/b/243126 fast/attachment/attachment-thumbnail-preserves-aspect-ratio.html [ Skip ]
 fast/images/pdf-as-image-dest-rect-change.html [ Pass ]
 
 fast/events/page-visibility-iframe-move-test.html [ Skip ]


### PR DESCRIPTION
#### 1ee0b00a35c1a598c878034bbd1c8043bb47e655
<pre>
REGRESSION (252627@main): [iOS] fast/attachment/attachment-thumbnail-preserves-aspect-ratio.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=243126">https://bugs.webkit.org/show_bug.cgi?id=243126</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations: Skip the test.

Canonical link: <a href="https://commits.webkit.org/252753@main">https://commits.webkit.org/252753@main</a>
</pre>
