### PR TITLE
Allow for disabling building of interaction regions

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1105,7 +1105,15 @@ bool Page::shouldBuildInteractionRegions() const
 {
     return m_settings->interactionRegionsEnabled();
 }
-#endif
+
+void Page::setInteractionRegionsEnabled(bool enable)
+{
+    bool needsUpdate = enable && !shouldBuildInteractionRegions();
+    m_settings->setInteractionRegionsEnabled(enable);
+    if (needsUpdate)
+        mainFrame().invalidateContentEventRegionsIfNeeded(Frame::InvalidateContentEventRegionsReason::Layout);
+}
+#endif // ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
 
 const VisibleSelection& Page::selection() const
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -913,6 +913,7 @@ public:
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     bool shouldBuildInteractionRegions() const;
+    WEBCORE_EXPORT void setInteractionRegionsEnabled(bool);
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1693,6 +1693,16 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+- (void)_setInteractionRegionsEnabled:(BOOL)enabled
+{
+    WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _setInteractionRegionsEnabled] page - %p", self, _page.get());
+    if (_page && _page->preferences().interactionRegionsEnabled())
+        _page->setInteractionRegionsEnabled(enabled);
+}
+#endif // ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+
+
 - (void)_setOpaqueInternal:(BOOL)opaque
 {
     [super setOpaque:opaque];

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11600,6 +11600,15 @@ void WebPageProxy::setIsWindowResizingEnabled(bool hasResizableWindows)
 
 #endif
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+
+void WebPageProxy::setInteractionRegionsEnabled(bool enable)
+{
+    send(Messages::WebPage::SetInteractionRegionsEnabled(enable));
+}
+
+#endif // ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+
 bool WebPageProxy::shouldAvoidSynchronouslyWaitingToPreventDeadlock() const
 {
     if (m_isRunningModalJavaScriptDialog)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2138,6 +2138,9 @@ public:
 #if ENABLE(NOTIFICATIONS)
     void clearNotificationPermissionState();
 #endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    void setInteractionRegionsEnabled(bool);
+#endif
 
     void queryPermission(const WebCore::ClientOrigin&, const WebCore::PermissionDescriptor&, CompletionHandler<void(std::optional<WebCore::PermissionState>, bool shouldCache)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8162,6 +8162,19 @@ void WebPage::setIsWindowResizingEnabled(bool value)
 
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+
+void WebPage::setInteractionRegionsEnabled(bool enable)
+{
+    WEBPAGE_RELEASE_LOG(Process, "setInteractionRegionsEnabled: enable state = %d for page %p", (int)enable, (void*)m_page.get());
+    if (!m_page)
+        return;
+
+    m_page->setInteractionRegionsEnabled(enable);
+}
+
+#endif // ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+
 bool WebPage::handlesPageScaleGesture()
 {
 #if !ENABLE(PDFKIT_PLUGIN)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1554,6 +1554,10 @@ public:
     void setIsWindowResizingEnabled(bool);
 #endif
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    void setInteractionRegionsEnabled(bool);
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -696,4 +696,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     SetIsWindowResizingEnabled(bool hasResizableWindows)
 #endif
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    SetInteractionRegionsEnabled(bool enable)
+#endif
 }


### PR DESCRIPTION
#### 8622054d0540eb32ccc440c1c97e2bb22a55be6c
<pre>
Allow for disabling building of interaction regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=243128">https://bugs.webkit.org/show_bug.cgi?id=243128</a>

Reviewed by Tim Horton.

Allow for disabling building of interaction regions.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setInteractionRegionsEnabled):

* Source/WebCore/page/Page.h:
Add function to disable building interaction regions.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setIsLinkPreview:]):
Disable building interaction regions for link preview web views,
it is not possible to interact with them.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setInteractionRegionsEnabled):
Send message to the webpage.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setInteractionRegionsEnabled):
Forward call to Page::setInteractionRegionsEnabled

* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Add new message to enable / disable building interaction regions.

Canonical link: <a href="https://commits.webkit.org/253307@main">https://commits.webkit.org/253307@main</a>
</pre>
