### PR TITLE
On OS(DARWIN), enable ExecutableAllocator to use a constexpr page size instead of calling WTF::pageSize() repeatedly.

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -792,7 +792,7 @@ void SpeculativeJIT::emitCall(Node* node)
             loadArgumentsGPR(GPRInfo::returnValueGPR);
             m_jit.move(TrustedImm32(numUsedStackSlots), scratchGPR1);
             emitSetVarargsFrame(m_jit, GPRInfo::returnValueGPR, false, scratchGPR1, scratchGPR1);
-            m_jit.addPtr(TrustedImm32(-(sizeof(CallerFrameAndPC) + WTF::roundUpToMultipleOf(stackAlignmentBytes(), 5 * sizeof(void*)))), scratchGPR1, JITCompiler::stackPointerRegister);
+            m_jit.addPtr(TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + WTF::roundUpToMultipleOf(stackAlignmentBytes(), 5 * sizeof(void*)))), scratchGPR1, JITCompiler::stackPointerRegister);
             
             callOperation(operationSetupVarargsFrame, GPRInfo::returnValueGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), scratchGPR1, argumentsGPR, data->firstVarArgOffset, GPRInfo::returnValueGPR);
             m_jit.exceptionCheck();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,6 @@
 #include "JSCConfig.h"
 #include "JSCPtrTag.h"
 #include "Options.h"
-#include <stddef.h> // for ptrdiff_t
 #include <limits>
 #include <wtf/Assertions.h>
 #include <wtf/Gigacage.h>
@@ -49,8 +48,6 @@
 #if CPU(MIPS) && OS(LINUX)
 #include <sys/cachectl.h>
 #endif
-
-#define JIT_ALLOCATOR_LARGE_ALLOC_SIZE (pageSize() * 4)
 
 #define EXECUTABLE_POOL_WRITABLE true
 

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -130,7 +130,7 @@ JIT::compileSetupFrame(const Op& bytecode)
     }
 
 #if USE(JSVALUE64)
-    addPtr(TrustedImm32(-(sizeof(CallerFrameAndPC) + WTF::roundUpToMultipleOf(stackAlignmentBytes(), 5 * sizeof(void*)))), regT1, stackPointerRegister);
+    addPtr(TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + WTF::roundUpToMultipleOf(stackAlignmentBytes(), 5 * sizeof(void*)))), regT1, stackPointerRegister);
 #elif USE(JSVALUE32_64)
     addPtr(TrustedImm32(-(sizeof(CallerFrameAndPC) + WTF::roundUpToMultipleOf(stackAlignmentBytes(), 6 * sizeof(void*)))), regT1, stackPointerRegister);
 #endif

--- a/Source/WTF/wtf/PageBlock.cpp
+++ b/Source/WTF/wtf/PageBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,6 @@
 namespace WTF {
 
 static size_t s_pageSize;
-static size_t s_pageMask;
 
 #if OS(UNIX)
 
@@ -64,15 +63,9 @@ size_t pageSize()
         s_pageSize = systemPageSize();
         RELEASE_ASSERT(isPowerOfTwo(s_pageSize));
         RELEASE_ASSERT_WITH_MESSAGE(s_pageSize <= CeilingOnPageSize, "CeilingOnPageSize is too low, raise it in PageBlock.h!");
+        RELEASE_ASSERT(roundUpToMultipleOf(s_pageSize, CeilingOnPageSize) == CeilingOnPageSize);
     }
     return s_pageSize;
-}
-
-size_t pageMask()
-{
-    if (!s_pageMask)
-        s_pageMask = ~(pageSize() - 1);
-    return s_pageMask;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/PageBlock.h
+++ b/Source/WTF/wtf/PageBlock.h
@@ -57,10 +57,13 @@ constexpr size_t CeilingOnPageSize = 4 * KB;
 #endif
 
 WTF_EXPORT_PRIVATE size_t pageSize();
-WTF_EXPORT_PRIVATE size_t pageMask();
-inline bool isPageAligned(void* address) { return !(reinterpret_cast<intptr_t>(address) & (pageSize() - 1)); }
-inline bool isPageAligned(size_t size) { return !(size & (pageSize() - 1)); }
-inline bool isPowerOfTwo(size_t size) { return !(size & (size - 1)); }
+
+inline bool isPageAligned(size_t pageSize, void* address) { return !(reinterpret_cast<intptr_t>(address) & (pageSize - 1)); }
+inline bool isPageAligned(size_t pageSize, size_t size) { return !(size & (pageSize - 1)); }
+
+inline bool isPageAligned(void* address) { return isPageAligned(pageSize(), address); }
+inline bool isPageAligned(size_t size) { return isPageAligned(pageSize(), size); }
+
 
 class PageBlock {
     WTF_MAKE_FAST_ALLOCATED;


### PR DESCRIPTION
#### 733bed1be716b30a5630ba3f407094ea94530e19
<pre>
On OS(DARWIN), enable ExecutableAllocator to use a constexpr page size instead of calling WTF::pageSize() repeatedly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=242971">https://bugs.webkit.org/show_bug.cgi?id=242971</a>

Reviewed by Yusuke Suzuki.

1. On OS(DARWIN), the page size is fixed.  We already rely on this in MarkedBlock.
   Allow ExecutableAllocator to do the same and use the constexpr CeilingOnPageSize value as the
   page size instead of repeatedly calling WTF::pageSize().
2. Moved isPowerOfTwo() to StdLibExtra.h, and made it constexpr.
3. Made roundUpToMultipleOf() constexpr.

   The above working together allows many page size calculations to be constant folded.

4. Added a comment to clarify why each allocatable region in the RegionAllocators must be able to
   fit 2 jump islands in a 128M span (for ARM64), and not just one.  This is because the jumps in
   the jump islands can chain using relative jumps to adjacent islands as well.  Hence, any
   adjacent neighbor jump island needs to be within the ARM64 128M near jump range.

5. Removed some unused code.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileSetupFrame):
* Source/WTF/wtf/PageBlock.cpp:
(WTF::pageSize):
(WTF::pageMask): Deleted.
* Source/WTF/wtf/PageBlock.h:
(WTF::isPageAligned):
(WTF::isPowerOfTwo): Deleted.
* Source/WTF/wtf/StdLibExtras.h:
(WTF::isPowerOfTwo):
(WTF::roundUpToMultipleOfImpl):
(WTF::roundUpToMultipleOf):

Canonical link: <a href="https://commits.webkit.org/252775@main">https://commits.webkit.org/252775@main</a>
</pre>
