### PR TITLE
[GTK4] WebKitWebView::context-menu errors out on GTK4

### DIFF
--- a/Source/WebCore/platform/gtk/GRefPtrGtk.cpp
+++ b/Source/WebCore/platform/gtk/GRefPtrGtk.cpp
@@ -89,6 +89,19 @@ template <> void derefGPtr(GskRenderNode* ptr)
     if (ptr)
         gsk_render_node_unref(ptr);
 }
+
+template <> GdkEvent* refGPtr(GdkEvent* ptr)
+{
+    if (ptr)
+        gdk_event_ref(ptr);
+    return ptr;
+}
+
+template <> void derefGPtr(GdkEvent* ptr)
+{
+    if (ptr)
+        gdk_event_unref(ptr);
+}
 #endif
 
 }

--- a/Source/WebCore/platform/gtk/GRefPtrGtk.h
+++ b/Source/WebCore/platform/gtk/GRefPtrGtk.h
@@ -46,6 +46,9 @@ template <> void derefGPtr(GtkWidgetPath* ptr);
 #if USE(GTK4)
 template <> GskRenderNode* refGPtr(GskRenderNode* ptr);
 template <> void derefGPtr(GskRenderNode* ptr);
+
+template <> GdkEvent* refGPtr(GdkEvent* ptr);
+template <> void derefGPtr(GdkEvent* ptr);
 #endif
 
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -1048,6 +1048,71 @@ static gboolean webkitWebViewAccumulatorObjectHandled(GSignalInvocationHint*, GV
     return !object;
 }
 
+#if PLATFORM(GTK) && USE(GTK4)
+static GdkEvent* gValueGetEvent(const GValue* value)
+{
+    g_return_val_if_fail(G_VALUE_HOLDS(value, GDK_TYPE_EVENT), NULL);
+
+    return reinterpret_cast<GdkEvent*>(value->data[0].v_pointer);
+}
+
+typedef gboolean (*ContextMenuCallback) (gpointer, WebKitContextMenu*, GdkEvent*, WebKitHitTestResult*, gpointer);
+
+static void webkitWebViewContextMenuMarshal(GClosure* closure, GValue* returnValue, guint nParams, const GValue* params, gpointer, gpointer marshalData)
+{
+    auto* cc = reinterpret_cast<GCClosure*>(closure);
+    gpointer data1, data2;
+
+    g_return_if_fail(returnValue);
+    g_return_if_fail(nParams == 4);
+
+    if (G_CCLOSURE_SWAP_DATA(closure)) {
+        data1 = closure->data;
+        data2 = g_value_peek_pointer(&params[0]);
+    } else {
+        data1 = g_value_peek_pointer(&params[0]);
+        data2 = closure->data;
+    }
+
+    auto* menu = WEBKIT_CONTEXT_MENU(g_value_get_object(&params[1]));
+    auto* event = gValueGetEvent(&params[2]);
+    auto* result = WEBKIT_HIT_TEST_RESULT(g_value_get_object(&params[3]));
+
+    auto callback = reinterpret_cast<ContextMenuCallback>(marshalData ? marshalData : cc->callback);
+    gboolean ret = callback(data1, menu, event, result, data2);
+    g_value_set_boolean(returnValue, ret);
+}
+
+static void webkitWebViewContextMenuMarshalVa(GClosure* closure, GValue* returnValue, gpointer instance, va_list args, gpointer marshalData, int, GType*)
+{
+    auto* cc = reinterpret_cast<GCClosure*>(closure);
+    gpointer data1, data2;
+
+    g_return_if_fail(returnValue);
+
+    if (G_CCLOSURE_SWAP_DATA(closure)) {
+        data1 = closure->data;
+        data2 = instance;
+    } else {
+        data1 = instance;
+        data2 = closure->data;
+    }
+
+    va_list argsCopy;
+    G_VA_COPY(argsCopy, args);
+
+    GRefPtr<WebKitContextMenu> menu = WEBKIT_CONTEXT_MENU(va_arg(argsCopy, gpointer));
+    GRefPtr<GdkEvent> event = reinterpret_cast<GdkEvent*>(va_arg(argsCopy, gpointer));
+    GRefPtr<WebKitHitTestResult> result = WEBKIT_HIT_TEST_RESULT(va_arg(argsCopy, gpointer));
+
+    va_end(argsCopy);
+
+    auto callback = reinterpret_cast<ContextMenuCallback>(marshalData ? marshalData : cc->callback);
+    gboolean ret = callback(data1, menu.get(), event.get(), result.get(), data2);
+    g_value_set_boolean(returnValue, ret);
+}
+#endif
+
 static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
 {
     GObjectClass* gObjectClass = G_OBJECT_CLASS(webViewClass);
@@ -2133,15 +2198,26 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
         G_SIGNAL_RUN_LAST,
         G_STRUCT_OFFSET(WebKitWebViewClass, context_menu),
         g_signal_accumulator_true_handled, nullptr,
+#if USE(GTK4)
+        webkitWebViewContextMenuMarshal,
+#else
         g_cclosure_marshal_generic,
+#endif
         G_TYPE_BOOLEAN, 3,
         WEBKIT_TYPE_CONTEXT_MENU,
 #if PLATFORM(GTK)
+#if USE(GTK4)
+        GDK_TYPE_EVENT,
+#else
         GDK_TYPE_EVENT | G_SIGNAL_TYPE_STATIC_SCOPE,
+#endif
 #elif PLATFORM(WPE)
         G_TYPE_POINTER, // FIXME: use a wpe thing here. I'm not sure we want to expose libwpe in the API.
 #endif
         WEBKIT_TYPE_HIT_TEST_RESULT);
+#if USE(GTK4)
+    g_signal_set_va_marshaller(signals[CONTEXT_MENU], G_TYPE_FROM_CLASS(webViewClass), webkitWebViewContextMenuMarshalVa);
+#endif
 
     /**
      * WebKitWebView::context-menu-dismissed:

--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
@@ -73,7 +73,8 @@ static inline void popdownMenuWidget(GtkWidget* widget)
 
 static inline bool menuWidgetHasItems(GtkWidget* widget)
 {
-    return g_menu_model_get_n_items(gtk_popover_menu_get_menu_model(GTK_POPOVER_MENU(widget)));
+    GMenuModel* model = gtk_popover_menu_get_menu_model(GTK_POPOVER_MENU(widget));
+    return model ? g_menu_model_get_n_items(model) : 0;
 }
 
 static inline void bindModelToMenuWidget(GtkWidget* widget, GMenuModel* model)


### PR DESCRIPTION
#### 7f793269519256ea5f2b8b420ed02578d4ce6f2c
<pre>
[GTK4] WebKitWebView::context-menu errors out on GTK4
<a href="https://bugs.webkit.org/show_bug.cgi?id=233785">https://bugs.webkit.org/show_bug.cgi?id=233785</a>

Reviewed by Michael Catanzaro.

GdkEvent is not a boxed type or an object, and so needs a custom marshaler.

Fix a separate crash in WebContextMenuProxyGtk, it had never been noticed
as the signal crash happened before that.

Add GdkEvent support to GRefPtr on GTK4.

* Source/WebCore/platform/gtk/GRefPtrGtk.cpp:
(WTF::refGPtr):
(WTF::derefGPtr):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(gValueGetEvent):
(webkitWebViewContextMenuMarshal):
(webkitWebViewContextMenuMarshalVa):
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp:
(WebKit::menuWidgetHasItems):

Canonical link: <a href="https://commits.webkit.org/252908@main">https://commits.webkit.org/252908@main</a>
</pre>
