### PR TITLE
Align the directionality of bdi and input elements with HTML5 spec

### DIFF
--- a/LayoutTests/fast/css/bdi-element-invalid-dir-expected.html
+++ b/LayoutTests/fast/css/bdi-element-invalid-dir-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#the-directionality">
+<style>
+div { width: 100px; height: 100px; background: green; }
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/bdi-element-invalid-dir.html
+++ b/LayoutTests/fast/css/bdi-element-invalid-dir.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#the-directionality">
+<style>
+div { position: relative; width: 100px; height: 100px; background: red; }
+bdi { width: 100px; height: 100px; display: block; }
+span { display: inline-block; width: 50px; height: 100px; background: green; color: green; }
+#left { background: green; position: absolute; left: 0px; top: 0px; }
+</style>
+</head>
+<body>
+<div><bdi dir="foo"><span id="left"></span><span>&#x05EA;</span></bdi></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-pseudo-on-bdi-element-expected.txt
+++ b/LayoutTests/fast/css/dir-pseudo-on-bdi-element-expected.txt
@@ -1,0 +1,7 @@
+
+PASS bdi element without dir content attribute
+PASS bdi element with invalid dir content attribute
+PASS bdi element with dir=auto content attribute
+PASS bdi element with dir=ltr content attribute
+PASS bdi element with dir=rtl content attribute
+

--- a/LayoutTests/fast/css/dir-pseudo-on-bdi-element.html
+++ b/LayoutTests/fast/css/dir-pseudo-on-bdi-element.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#the-directionality">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    const bdi = document.createElement('bdi');
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+
+    bdi.textContent = '\u05EA';
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+}, 'bdi element without dir content attribute');
+
+test(() => {
+    const bdi = document.createElement('bdi');
+    bdi.setAttribute('dir', 'foo');
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+
+    bdi.textContent = '\u05EA';
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+}, 'bdi element with invalid dir content attribute');
+
+test(() => {
+    const bdi = document.createElement('bdi');
+    bdi.setAttribute('dir', 'auto');
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+
+    bdi.textContent = '\u05EA';
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+
+    bdi.setAttribute('dir', 'AUTO');
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+}, 'bdi element with dir=auto content attribute');
+
+test(() => {
+    const bdi = document.createElement('bdi');
+    bdi.setAttribute('dir', 'ltr');
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+
+    bdi.setAttribute('dir', 'LTR');
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+
+    bdi.textContent = '\u05EA';
+    assert_true(bdi.matches(':dir(ltr)'));
+    assert_false(bdi.matches(':dir(rtl)'));
+}, 'bdi element with dir=ltr content attribute');
+
+test(() => {
+    const bdi = document.createElement('bdi');
+    bdi.setAttribute('dir', 'rtl');
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+
+    bdi.setAttribute('dir', 'RTL');
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+
+    bdi.textContent = '\u05EA';
+    assert_false(bdi.matches(':dir(ltr)'));
+    assert_true(bdi.matches(':dir(rtl)'));
+}, 'bdi element with dir=rtl content attribute');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-pseudo-on-input-element-expected.txt
+++ b/LayoutTests/fast/css/dir-pseudo-on-input-element-expected.txt
@@ -1,0 +1,20 @@
+
+PASS input element whose type attribute is in the telephone state
+PASS input element whose type attribute is in the telephone state in a RTL block
+PASS input element whose type attribute is in the text state
+PASS input element whose type attribute is in the search state
+PASS input element whose type attribute is in the url state
+PASS input element whose type attribute is in the email state
+PASS input element whose type attribute is in the password state
+PASS input element whose type attribute is in the date state
+PASS input element whose type attribute is in the time state
+PASS input element whose type attribute is in the number state
+PASS input element whose type attribute is in the range state
+PASS input element whose type attribute is in the color state
+PASS input element whose type attribute is in the checkbox state
+PASS input element whose type attribute is in the radio state
+PASS input element whose type attribute is in the submit state
+PASS input element whose type attribute is in the image state
+PASS input element whose type attribute is in the reset state
+PASS input element whose type attribute is in the button state
+

--- a/LayoutTests/fast/css/dir-pseudo-on-input-element.html
+++ b/LayoutTests/fast/css/dir-pseudo-on-input-element.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#the-directionality">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    const input = document.createElement('input');
+    input.type = 'tel';
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'foo');
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'rtl');
+    assert_false(input.matches(':dir(ltr)'));
+    assert_true(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'RTL');
+    assert_false(input.matches(':dir(ltr)'));
+    assert_true(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'ltr');
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'LTR');
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'auto');
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+
+    input.value = '\u05EA';
+    assert_false(input.matches(':dir(ltr)'));
+    assert_true(input.matches(':dir(rtl)'));
+
+    input.setAttribute('dir', 'AUTO');
+    assert_false(input.matches(':dir(ltr)'));
+    assert_true(input.matches(':dir(rtl)'));
+
+    input.removeAttribute('dir');
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+}, 'input element whose type attribute is in the telephone state');
+
+test(() => {
+    const input = document.createElement('input');
+    input.type = 'tel';
+
+    const container = document.createElement('div');
+    container.setAttribute('dir', 'rtl');
+    container.appendChild(input);
+
+    assert_true(input.matches(':dir(ltr)'));
+    assert_false(input.matches(':dir(rtl)'));
+}, 'input element whose type attribute is in the telephone state in a RTL block');
+
+for (let type of ['text', 'search', 'url', 'email']) {
+    test(() => {
+        const input = document.createElement('input');
+        input.type = type;
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'foo');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'rtl');
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'RTL');
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'ltr');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'LTR');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'auto');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.value = '\u05EA';
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'AUTO');
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'))
+
+        input.removeAttribute('dir');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+    }, `input element whose type attribute is in the ${type} state`);
+}
+
+for (let type of ['password', 'date', 'time', 'number', 'range', 'color',
+    'checkbox', 'radio', 'submit', 'image', 'reset', 'button']) {
+    test(() => {
+        const input = document.createElement('input');
+        input.type = type;
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'foo');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'rtl');
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'RTL');
+        assert_false(input.matches(':dir(ltr)'));
+        assert_true(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'ltr');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'LTR');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'auto');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.value = '\u05EA';
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+
+        input.setAttribute('dir', 'AUTO');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'))
+
+        input.removeAttribute('dir');
+        assert_true(input.matches(':dir(ltr)'));
+        assert_false(input.matches(':dir(rtl)'));
+    }, `input element whose type attribute is in the ${type} state`);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt
@@ -1,31 +1,5 @@
 
-FAIL ':dir(rtl)' matches all elements whose directionality is 'rtl'. assert_array_equals: lengths differ, expected array [Element node <bdo dir="rtl" id="bdo1">WERBEH</bdo>, Element node <bdi dir="rtl" id="bdi2">WERBEH</bdi>, Element node <bdi id="bdi4">إيان</bdi>, Element node <span dir="rtl" id="span2">WERBEH</span>, Element node <span dir="rtl" id="span5">WERBEH</span>, Element node <span dir="rtl" id="span7">
-     <input type="tel" id="in..., Element node <input type="tel" id="input-tel3" dir="rtl"></input>, Element node <bdo dir="auto" id="bdo4">إيان</bdo>] length 8, got [Element node <bdo dir="rtl" id="bdo1">WERBEH</bdo>, Element node <bdi dir="rtl" id="bdi2">WERBEH</bdi>, Element node <bdi id="bdi4">إيان</bdi>, Element node <span dir="rtl" id="span2">WERBEH</span>, Element node <span dir="rtl" id="span5">WERBEH</span>, Element node <span dir="rtl" id="span7">
-     <input type="tel" id="in..., Element node <input type="tel" id="input-tel1"></input>, Element node <input type="tel" id="input-tel2" dir="invalid"></input>, Element node <input type="tel" id="input-tel3" dir="rtl"></input>, Element node <bdo dir="auto" id="bdo4">إيان</bdo>] length 10
-FAIL ':dir(ltr)' matches all elements whose directionality is 'ltr'. assert_array_equals: lengths differ, expected array […, Element node <link rel="author" title="Denis Ah-Kang" href="mailto:den..., Element node <link rel="help" href="https://html.spec.whatwg.org/multi..., Element node <script src="/resources/testharness.js" id="script1"></sc..., Element node <script src="/resources/testharnessreport.js" id="script2..., Element node <script src="utils.js" id="script3"></script>, Element node <style id="style">
-      #span1 {direction: rtl;}
-      #..., Element node <body id="body">
-    <div id="log"></div>
-    <bdo dir="r..., Element node <div id="log"></div>, Element node <bdo dir="ltr" id="bdo2">HEBREW</bdo>, Element node <bdi id="bdi1">HEBREW</bdi>, Element node <bdi dir="ltr" id="bdi3">HEBREW</bdi>, Element node <span id="span1">WERBEH</span>, Element node <span dir="ltr" id="span3">HEBREW</span>, Element node <span id="span4">WERBEH</span>, Element node <span dir="ltr" id="span6">HEBREW</span>, Element node <input type="tel" id="input-tel1"></input>, Element node <input type="tel" id="input-tel2" dir="invalid"></input>, Element node <bdo dir="auto" id="bdo3">HEBREW</bdo>, Element node <bdo dir="ltr" id="bdo5">עברית</bdo>, Element node <script id="script4">
-      const rtlElements = [
-       ...] length 24, got […, Element node <meta charset="utf-8" id="meta"></meta>, Element node <title id="title">Selector: pseudo-classes (:dir(ltr), :d..., Element node <link rel="author" title="Denis Ah-Kang" href="mailto:den..., Element node <link rel="help" href="https://html.spec.whatwg.org/multi..., Element node <script src="/resources/testharness.js" id="script1"></sc..., Element node <script src="/resources/testharnessreport.js" id="script2..., Element node <script src="utils.js" id="script3"></script>, Element node <style id="style">
-      #span1 {direction: rtl;}
-      #..., Element node <body id="body">
-    <div id="log"></div>
-    <bdo dir="r..., Element node <div id="log"></div>, Element node <bdo dir="ltr" id="bdo2">HEBREW</bdo>, Element node <bdi id="bdi1">HEBREW</bdi>, Element node <bdi dir="ltr" id="bdi3">HEBREW</bdi>, Element node <span id="span1">WERBEH</span>, Element node <span dir="ltr" id="span3">HEBREW</span>, Element node <span id="span4">WERBEH</span>, Element node <span dir="ltr" id="span6">HEBREW</span>, Element node <bdo dir="auto" id="bdo3">HEBREW</bdo>, Element node <bdo dir="ltr" id="bdo5">עברית</bdo>, Element node <script id="script4">
-      const rtlElements = [
-       ...] length 22
-FAIL ':dir(ltr)' doesn't match elements not in the document. assert_array_equals: lengths differ, expected array […, Element node <link rel="author" title="Denis Ah-Kang" href="mailto:den..., Element node <link rel="help" href="https://html.spec.whatwg.org/multi..., Element node <script src="/resources/testharness.js" id="script1"></sc..., Element node <script src="/resources/testharnessreport.js" id="script2..., Element node <script src="utils.js" id="script3"></script>, Element node <style id="style">
-      #span1 {direction: rtl;}
-      #..., Element node <body id="body">
-    <div id="log"></div>
-    <bdo dir="r..., Element node <div id="log"></div>, Element node <bdo dir="ltr" id="bdo2">HEBREW</bdo>, Element node <bdi id="bdi1">HEBREW</bdi>, Element node <bdi dir="ltr" id="bdi3">HEBREW</bdi>, Element node <span id="span1">WERBEH</span>, Element node <span dir="ltr" id="span3">HEBREW</span>, Element node <span id="span4">WERBEH</span>, Element node <span dir="ltr" id="span6">HEBREW</span>, Element node <input type="tel" id="input-tel1"></input>, Element node <input type="tel" id="input-tel2" dir="invalid"></input>, Element node <bdo dir="auto" id="bdo3">HEBREW</bdo>, Element node <bdo dir="ltr" id="bdo5">עברית</bdo>, Element node <script id="script4">
-      const rtlElements = [
-       ...] length 24, got […, Element node <meta charset="utf-8" id="meta"></meta>, Element node <title id="title">Selector: pseudo-classes (:dir(ltr), :d..., Element node <link rel="author" title="Denis Ah-Kang" href="mailto:den..., Element node <link rel="help" href="https://html.spec.whatwg.org/multi..., Element node <script src="/resources/testharness.js" id="script1"></sc..., Element node <script src="/resources/testharnessreport.js" id="script2..., Element node <script src="utils.js" id="script3"></script>, Element node <style id="style">
-      #span1 {direction: rtl;}
-      #..., Element node <body id="body">
-    <div id="log"></div>
-    <bdo dir="r..., Element node <div id="log"></div>, Element node <bdo dir="ltr" id="bdo2">HEBREW</bdo>, Element node <bdi id="bdi1">HEBREW</bdi>, Element node <bdi dir="ltr" id="bdi3">HEBREW</bdi>, Element node <span id="span1">WERBEH</span>, Element node <span dir="ltr" id="span3">HEBREW</span>, Element node <span id="span4">WERBEH</span>, Element node <span dir="ltr" id="span6">HEBREW</span>, Element node <bdo dir="auto" id="bdo3">HEBREW</bdo>, Element node <bdo dir="ltr" id="bdo5">עברית</bdo>, Element node <script id="script4">
-      const rtlElements = [
-       ...] length 22
+PASS ':dir(rtl)' matches all elements whose directionality is 'rtl'.
+PASS ':dir(ltr)' matches all elements whose directionality is 'ltr'.
+PASS ':dir(ltr)' doesn't match elements not in the document.
 WERBEH HEBREW HEBREW WERBEH HEBREW إيان WERBEH WERBEH HEBREW ‮WERBEH‬      HEBREW إيان עברית

--- a/LayoutTests/platform/mac-wk1/fast/css/dir-pseudo-on-input-element-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/css/dir-pseudo-on-input-element-expected.txt
@@ -1,0 +1,20 @@
+
+PASS input element whose type attribute is in the telephone state
+PASS input element whose type attribute is in the telephone state in a RTL block
+PASS input element whose type attribute is in the text state
+PASS input element whose type attribute is in the search state
+PASS input element whose type attribute is in the url state
+PASS input element whose type attribute is in the email state
+PASS input element whose type attribute is in the password state
+FAIL input element whose type attribute is in the date state assert_true: expected true got false
+FAIL input element whose type attribute is in the time state assert_true: expected true got false
+PASS input element whose type attribute is in the number state
+PASS input element whose type attribute is in the range state
+FAIL input element whose type attribute is in the color state assert_true: expected true got false
+PASS input element whose type attribute is in the checkbox state
+PASS input element whose type attribute is in the radio state
+PASS input element whose type attribute is in the submit state
+PASS input element whose type attribute is in the image state
+PASS input element whose type attribute is in the reset state
+PASS input element whose type attribute is in the button state
+

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -2818,6 +2818,10 @@ webkit.org/b/150830 fast/text/woff2.html [ Skip ]
 
 webkit.org/b/162668 fast/text/woff2-totalsfntsize.html [ Skip ]
 
+# :dir pseudo class isn't enabled yet.
+fast/css/dir-pseudo-on-bdi-element.html [ Failure ]
+fast/css/dir-pseudo-on-input-element.html [ Failure ]
+
 ################################################################################
 ######################### Start list of UNREVIEWED failures ########################
 ################################################################################

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -113,6 +113,7 @@ public:
     // any unknown input type is treated as text. Consider, for example, isTextField or
     // isTextField && !isPasswordField.
     WEBCORE_EXPORT bool isText() const;
+    bool isTextType() const;
     WEBCORE_EXPORT bool isEmailField() const;
     WEBCORE_EXPORT bool isFileUpload() const;
     bool isImageButton() const;
@@ -429,7 +430,6 @@ private:
 
     bool supportsMinLength() const { return isTextType(); }
     bool supportsMaxLength() const { return isTextType(); }
-    bool isTextType() const;
     bool tooShort(StringView, NeedsToCheckDirtyFlag) const;
     bool tooLong(StringView, NeedsToCheckDirtyFlag) const;
 


### PR DESCRIPTION
#### 92c7ebfc2fbb17b42e983e554890966dce8469a2
<pre>
Align the directionality of bdi and input elements with HTML5 spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=243130">https://bugs.webkit.org/show_bug.cgi?id=243130</a>

Reviewed by Cameron McCormack.

Align WebKit&apos;s behavior with HTML5 specification:
<a href="https://html.spec.whatwg.org/multipage/dom.html#the-directionality">https://html.spec.whatwg.org/multipage/dom.html#the-directionality</a>

Specifically, bdi element with invalid dir content attribute should behave as if dir=auto is set,
and only input element whose type attribute is in text, search, telephone, URL, or email state
should examine its value to determine the directionality.

* LayoutTests/fast/css/bdi-element-invalid-dir-expected.html: Added.
* LayoutTests/fast/css/bdi-element-invalid-dir.html: Added. Firefox passes but Chrome fails.
* LayoutTests/fast/css/dir-pseudo-on-bdi-element-expected.txt: Added.
* LayoutTests/fast/css/dir-pseudo-on-bdi-element.html: Added. Firefox pass all test cases.
* LayoutTests/fast/css/dir-pseudo-on-input-element-expected.txt: Added.
* LayoutTests/fast/css/dir-pseudo-on-input-element.html: Added. Firefox passes all test cases
except the one with input element with type=tel inside a RTL block.
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1780917">https://bugzilla.mozilla.org/show_bug.cgi?id=1780917</a> tracks the bug in Gecko.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/dir-expected.txt:
* LayoutTests/platform/mac-wk1/fast/css/dir-pseudo-on-input-element-expected.txt: Added.
* LayoutTests/platform/win/TestExpectations:

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::isValidDirValue): Added.
(WebCore::HTMLElement::hasDirectionAuto const): Fixed the bug that bdi with an invalid dir
doesn&apos;t behave as if dir is omitted.
(WebCore::HTMLElement::computeDirectionality const): Added a special case for telephone.
(WebCore::HTMLElement::directionality const): Only use the input element&apos;s value to determine
the directionality of the element only if its type is text, search, telephone, URL, or email state.

* Source/WebCore/html/HTMLInputElement.h:
(WebCore::HTMLInputElement): Made isTextType() public to be called in HTMLElement::directionality.

Canonical link: <a href="https://commits.webkit.org/252779@main">https://commits.webkit.org/252779@main</a>
</pre>
