### PR TITLE
[iOS 16] 'Select All' appears in the edit menu after selecting a text range

### DIFF
--- a/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt
+++ b/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt
@@ -1,10 +1,11 @@
-This test verifies that the callout bar is shown after selecting a word in an editable element using the callout bar. To test manually, focus the editable area and tap 'Select' in the callout bar; the callout bar should appear again, with an option to 'Copy'.
+This test verifies that the callout bar is shown after selecting a word in an editable element using the callout bar. To test manually, focus the editable area and tap 'Select' in the callout bar; the callout bar should appear again, with an option to 'Copy'. The 'Select All' action should not be shown.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 PASS Showed menu by tapping
 PASS Selected word using menu action
 PASS Callout bar contains 'Copy' action
+PASS selectAllItemRect is null
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html
+++ b/LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html
@@ -39,7 +39,7 @@ addEventListener("load", async () => {
     if (!window.testRunner)
         return;
 
-    description("This test verifies that the callout bar is shown after selecting a word in an editable element using the callout bar. To test manually, focus the editable area and tap 'Select' in the callout bar; the callout bar should appear again, with an option to 'Copy'.");
+    description("This test verifies that the callout bar is shown after selecting a word in an editable element using the callout bar. To test manually, focus the editable area and tap 'Select' in the callout bar; the callout bar should appear again, with an option to 'Copy'. The 'Select All' action should not be shown.");
 
     const editor = document.querySelector("div[contenteditable]");
 
@@ -55,6 +55,9 @@ addEventListener("load", async () => {
 
     await waitUntilMenuContains("Copy");
     testPassed("Callout bar contains 'Copy' action");
+
+    selectAllItemRect = await UIHelper.rectForMenuAction("Select All");
+    shouldBeNull("selectAllItemRect");
 
     editor.remove();
     finishJSTest();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -477,6 +477,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _waitingForKeyboardToStartAnimatingInAfterElementFocus;
     BOOL _shouldZoomToFocusRectAfterShowingKeyboard;
     BOOL _isHidingKeyboard;
+    BOOL _isPreparingEditMenu;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;


### PR DESCRIPTION
#### dd3c292ca93c8499aab292ab26e6b71fcf5665b1
<pre>
[iOS 16] &apos;Select All&apos; appears in the edit menu after selecting a text range
<a href="https://bugs.webkit.org/show_bug.cgi?id=243136">https://bugs.webkit.org/show_bug.cgi?id=243136</a>

Reviewed by Ryosuke Niwa.

In iOS 16, when presenting the edit menu (either by right clicking with a trackpad or after
selecting text via gestures), the `sender` argument that&apos;s passed to `-canPerformAction:withSender:`
is no longer the shared `UIMenuController` instance. This breaks our existing logic to suppress
&quot;Select All&quot; in the callout bar when text is already selected. Furthermore, the `sender` in this
case is just a `UIKeyCommand`, making it indistinguishable from the `sender` in the case where the
user is using `⌘+A` with a hardware keyboard to insert text.

To fix this on iOS 16, instead of consulting the value of `sender`, we set a flag when the edit menu
is about to be presented (either via right click with trackpad, or via text interaction gestures)
and check the value of this flag instead.

Covered by augmenting an existing layout test.

* LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word-expected.txt:
* LayoutTests/editing/selection/ios/show-callout-bar-after-selecting-word.html:

Augment a layout test that already checks for the presence of &quot;Copy&quot; after making a text selection,
by additionally verifying that the &quot;Select All&quot; action is not also present.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):

Consult the new flag (`_isPreparingEditMenu`) when deciding whether to allow &quot;Select All&quot;.

(-[WKContentView requestRVItemInSelectedRangeWithCompletionHandler:]):

Set `_isPreparingEditMenu` when invoking the completion handler, right before showing the callout
bar after Reveal items have been requested. This is the final step before UIKit proceeds to show the
callout bar after selecting text via a long press or loupe gesture (querying
`-canPerformAction:withSender:` in the process).

(-[WKContentView prepareSelectionForContextMenuWithLocationInView:completionHandler:]):

Set `_isPreparingEditMenu` after preparing for the (editing) context menu. Similarly, this is the
final step before UIKit proceeds to show the edit menu after right clicking to select text, querying
`-canPerformAction:withSender:` in the process.

Canonical link: <a href="https://commits.webkit.org/252764@main">https://commits.webkit.org/252764@main</a>
</pre>
