### PR TITLE
Implement ElementInternals

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
@@ -9,15 +9,15 @@ PASS customElements.define must throw a NotSupportedError when element definitio
 PASS customElements.define must check IsConstructor on the constructor before checking the element definition is running flag
 PASS customElements.define must validate the custom element name before checking the element definition is running flag
 PASS customElements.define unset the element definition is running flag before upgrading custom elements
-FAIL customElements.define must not throw when defining another custom element in a different global object during Get(constructor, "prototype") assert_array_equals: customElements.define must get "prototype", "disabledFeatures", and "formAssociated" on the constructor lengths differ, expected array ["prototype", "disabledFeatures", "formAssociated"] length 3, got ["prototype", "disabledFeatures"] length 2
+PASS customElements.define must not throw when defining another custom element in a different global object during Get(constructor, "prototype")
 PASS Custom Elements: CustomElementRegistry interface
-FAIL customElements.define must get "prototype", "disabledFeatures", and "formAssociated" property of the constructor assert_array_equals: lengths differ, expected array ["prototype", "disabledFeatures", "formAssociated"] length 3, got ["prototype", "disabledFeatures"] length 2
+PASS customElements.define must get "prototype", "disabledFeatures", and "formAssociated" property of the constructor
 PASS customElements.define must rethrow an exception thrown while getting "prototype" property of the constructor
 PASS customElements.define must throw when "prototype" property of the constructor is not an object
 PASS customElements.define must get callbacks of the constructor prototype
 PASS customElements.define must rethrow an exception thrown while getting callbacks on the constructor prototype
 PASS customElements.define must rethrow an exception thrown while converting a callback value to Function callback type
-FAIL customElements.define must get "observedAttributes" property on the constructor prototype when "attributeChangedCallback" is present assert_array_equals: lengths differ, expected array [0, "prototype", 5, "observedAttributes", 6, "disabledFeatures", 7, "formAssociated"] length 8, got [0, "prototype", 5, "observedAttributes", 6, "disabledFeatures"] length 6
+PASS customElements.define must get "observedAttributes" property on the constructor prototype when "attributeChangedCallback" is present
 PASS customElements.define must rethrow an exception thrown while getting observedAttributes on the constructor prototype
 PASS customElements.define must rethrow an exception thrown while converting the value of observedAttributes to sequence<DOMString>
 PASS customElements.define must rethrow an exception thrown while iterating over observedAttributes to sequence<DOMString>
@@ -27,9 +27,9 @@ PASS customElements.define must rethrow an exception thrown while getting disabl
 PASS customElements.define must rethrow an exception thrown while converting the value of disabledFeatures to sequence<DOMString>
 PASS customElements.define must rethrow an exception thrown while iterating over disabledFeatures to sequence<DOMString>
 PASS customElements.define must rethrow an exception thrown while retrieving Symbol.iterator on disabledFeatures
-FAIL customElements.define must rethrow an exception thrown while getting formAssociated on the constructor prototype assert_throws_exactly: function "() => customElements.define('element-with-throwing-form-associated', proxy)" did not throw
-FAIL customElements.define must get four additional callbacks on the prototype if formAssociated is converted to true assert_array_equals: customElements.define must get "prototype", "disabledFeatures", and "formAssociated" on the constructor lengths differ, expected array ["prototype", "disabledFeatures", "formAssociated"] length 3, got ["prototype", "disabledFeatures"] length 2
-FAIL customElements.define must rethrow an exception thrown while getting additional formAssociated callbacks on the constructor prototype assert_throws_exactly: function "() => customElements.define('element-with-throwing-callback-2', proxy)" did not throw
+PASS customElements.define must rethrow an exception thrown while getting formAssociated on the constructor prototype
+PASS customElements.define must get four additional callbacks on the prototype if formAssociated is converted to true
+PASS customElements.define must rethrow an exception thrown while getting additional formAssociated callbacks on the constructor prototype
 PASS customElements.define must define an instantiatable custom element
 PASS customElements.define must upgrade elements in the shadow-including tree order
 PASS CustomElementRegistry interface must have get as a method

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-attachInternals-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-attachInternals-expected.txt
@@ -1,8 +1,6 @@
 
-FAIL Successful attachInternals() and the second call. element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)
-FAIL attachInternals() throws a NotSupportedError if it is called for a customized built-in element assert_throws_dom: function "() => { customizedBuiltin.attachInternals() }" threw object "TypeError: customizedBuiltin.attachInternals is not a function. (In 'customizedBuiltin.attachInternals()', 'customizedBuiltin.attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
-FAIL If a custom element definition for the local name of the element doesn't exist, throw an NotSupportedError assert_throws_dom: function "() => { builtin.attachInternals() }" threw object "TypeError: builtin.attachInternals is not a function. (In 'builtin.attachInternals()', 'builtin.attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
-FAIL If a custom element definition for the local name of the element has disable internals flag, throw a NotSupportedError assert_throws_dom: function "() => {
-    (new MyElement2).attachInternals();
-  }" threw object "TypeError: (new MyElement2).attachInternals is not a function. (In '(new MyElement2).attachInternals()', '(new MyElement2).attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+PASS Successful attachInternals() and the second call.
+PASS attachInternals() throws a NotSupportedError if it is called for a customized built-in element
+PASS If a custom element definition for the local name of the element doesn't exist, throw an NotSupportedError
+PASS If a custom element definition for the local name of the element has disable internals flag, throw a NotSupportedError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-shadowroot-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-shadowroot-expected.txt
@@ -1,15 +1,9 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
-FAIL ElementInternals.shadowRoot allows access to open shadow root assert_true: expected true got false
-FAIL ElementInternals.shadowRoot allows access to closed shadow root assert_true: expected true got false
-FAIL ElementInternals cannot be called before constructor, upgrade case assert_throws_dom: attachInternals cannot be called before definition exists function "() => element.attachInternals()" threw object "TypeError: element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
-FAIL ElementInternals *can* be called after constructor, upgrade case assert_throws_dom: attachInternals cannot be called before constructor function "() => element.attachInternals()" threw object "TypeError: element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
-FAIL ElementInternals cannot be called after constructor calls it, create case assert_true: expected true got false
-FAIL ElementInternals disabled by disabledFeatures assert_throws_dom: attachInternals forbidden by disabledFeatures, pre-upgrade function "() => element.attachInternals()" threw object "TypeError: element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
-FAIL ElementInternals.shadowRoot doesn't reveal pre-attached closed shadowRoot assert_true: Failed to construct - test failed expected true got false
+PASS ElementInternals.shadowRoot allows access to open shadow root
+PASS ElementInternals.shadowRoot allows access to closed shadow root
+PASS ElementInternals cannot be called before constructor, upgrade case
+PASS ElementInternals *can* be called after constructor, upgrade case
+PASS ElementInternals cannot be called after constructor calls it, create case
+PASS ElementInternals disabled by disabledFeatures
+PASS ElementInternals.shadowRoot doesn't reveal pre-attached closed shadowRoot
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-NotSupportedError-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-NotSupportedError-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Form-related operations and attributes should throw NotSupportedErrors for non-form-associated custom elements. element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)
+FAIL Form-related operations and attributes should throw NotSupportedErrors for non-form-associated custom elements. assert_throws_dom: function "() => i.setFormValue('')" threw object "TypeError: i.setFormValue is not a function. (In 'i.setFormValue('')', 'i.setFormValue' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt
@@ -1,5 +1,48 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
+FAIL role is defined in ElementInternals assert_inherits: property "role" not found in prototype chain
+FAIL ariaActiveDescendantElement is defined in ElementInternals assert_inherits: property "ariaActiveDescendantElement" not found in prototype chain
+FAIL ariaAtomic is defined in ElementInternals assert_inherits: property "ariaAtomic" not found in prototype chain
+FAIL ariaAutoComplete is defined in ElementInternals assert_inherits: property "ariaAutoComplete" not found in prototype chain
+FAIL ariaBusy is defined in ElementInternals assert_inherits: property "ariaBusy" not found in prototype chain
+FAIL ariaChecked is defined in ElementInternals assert_inherits: property "ariaChecked" not found in prototype chain
+FAIL ariaColCount is defined in ElementInternals assert_inherits: property "ariaColCount" not found in prototype chain
+FAIL ariaColIndex is defined in ElementInternals assert_inherits: property "ariaColIndex" not found in prototype chain
+FAIL ariaColSpan is defined in ElementInternals assert_inherits: property "ariaColSpan" not found in prototype chain
+FAIL ariaControlsElements is defined in ElementInternals assert_inherits: property "ariaControlsElements" not found in prototype chain
+FAIL ariaCurrent is defined in ElementInternals assert_inherits: property "ariaCurrent" not found in prototype chain
+FAIL ariaDescribedByElements is defined in ElementInternals assert_inherits: property "ariaDescribedByElements" not found in prototype chain
+FAIL ariaDetailsElements is defined in ElementInternals assert_inherits: property "ariaDetailsElements" not found in prototype chain
+FAIL ariaDisabled is defined in ElementInternals assert_inherits: property "ariaDisabled" not found in prototype chain
+FAIL ariaErrorMessageElement is defined in ElementInternals assert_inherits: property "ariaErrorMessageElement" not found in prototype chain
+FAIL ariaExpanded is defined in ElementInternals assert_inherits: property "ariaExpanded" not found in prototype chain
+FAIL ariaFlowToElements is defined in ElementInternals assert_inherits: property "ariaFlowToElements" not found in prototype chain
+FAIL ariaHasPopup is defined in ElementInternals assert_inherits: property "ariaHasPopup" not found in prototype chain
+FAIL ariaHidden is defined in ElementInternals assert_inherits: property "ariaHidden" not found in prototype chain
+FAIL ariaInvalid is defined in ElementInternals assert_inherits: property "ariaInvalid" not found in prototype chain
+FAIL ariaKeyShortcuts is defined in ElementInternals assert_inherits: property "ariaKeyShortcuts" not found in prototype chain
+FAIL ariaLabel is defined in ElementInternals assert_inherits: property "ariaLabel" not found in prototype chain
+FAIL ariaLabelledByElements is defined in ElementInternals assert_inherits: property "ariaLabelledByElements" not found in prototype chain
+FAIL ariaLevel is defined in ElementInternals assert_inherits: property "ariaLevel" not found in prototype chain
+FAIL ariaLive is defined in ElementInternals assert_inherits: property "ariaLive" not found in prototype chain
+FAIL ariaModal is defined in ElementInternals assert_inherits: property "ariaModal" not found in prototype chain
+FAIL ariaMultiLine is defined in ElementInternals assert_inherits: property "ariaMultiLine" not found in prototype chain
+FAIL ariaMultiSelectable is defined in ElementInternals assert_inherits: property "ariaMultiSelectable" not found in prototype chain
+FAIL ariaOrientation is defined in ElementInternals assert_inherits: property "ariaOrientation" not found in prototype chain
+FAIL ariaOwnsElements is defined in ElementInternals assert_inherits: property "ariaOwnsElements" not found in prototype chain
+FAIL ariaPlaceholder is defined in ElementInternals assert_inherits: property "ariaPlaceholder" not found in prototype chain
+FAIL ariaPosInSet is defined in ElementInternals assert_inherits: property "ariaPosInSet" not found in prototype chain
+FAIL ariaPressed is defined in ElementInternals assert_inherits: property "ariaPressed" not found in prototype chain
+FAIL ariaReadOnly is defined in ElementInternals assert_inherits: property "ariaReadOnly" not found in prototype chain
+FAIL ariaRelevant is defined in ElementInternals assert_inherits: property "ariaRelevant" not found in prototype chain
+FAIL ariaRequired is defined in ElementInternals assert_inherits: property "ariaRequired" not found in prototype chain
+FAIL ariaRoleDescription is defined in ElementInternals assert_inherits: property "ariaRoleDescription" not found in prototype chain
+FAIL ariaRowCount is defined in ElementInternals assert_inherits: property "ariaRowCount" not found in prototype chain
+FAIL ariaRowIndex is defined in ElementInternals assert_inherits: property "ariaRowIndex" not found in prototype chain
+FAIL ariaRowSpan is defined in ElementInternals assert_inherits: property "ariaRowSpan" not found in prototype chain
+FAIL ariaSelected is defined in ElementInternals assert_inherits: property "ariaSelected" not found in prototype chain
+FAIL ariaSort is defined in ElementInternals assert_inherits: property "ariaSort" not found in prototype chain
+FAIL ariaValueMax is defined in ElementInternals assert_inherits: property "ariaValueMax" not found in prototype chain
+FAIL ariaValueMin is defined in ElementInternals assert_inherits: property "ariaValueMin" not found in prototype chain
+FAIL ariaValueNow is defined in ElementInternals assert_inherits: property "ariaValueNow" not found in prototype chain
+FAIL ariaValueText is defined in ElementInternals assert_inherits: property "ariaValueText" not found in prototype chain
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-form-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-form-expected.txt
@@ -1,6 +1,5 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
+FAIL ElementInternals.form should return the target element's form owner assert_equals: expected (object) Element node <form id="custom-form">
+  <custom-input-parser id="custom... but got (undefined) undefined
+FAIL ElementInternals.form should throws NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => i.form" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-labels-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-labels-expected.txt
@@ -1,9 +1,5 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
 FAIL LABEL association assert_equals: expected Element node <my-control></my-control> but got null
 FAIL LABEL click assert_equals: expected 1 but got 0
-FAIL ElementInternals.labels should throw NotSupportedError if the target element is not a form-associated custom element element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)
+FAIL ElementInternals.labels should throw NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => i.labels" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-expected.txt
@@ -1,117 +1,58 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
-
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
 PASS Single value - name is missing
-FAIL Single value - empty name exists undefined is not an object (evaluating 'this.internals_.setFormValue')
-FAIL Single value - Non-empty name exists undefined is not an object (evaluating 'this.internals_.setFormValue')
-FAIL Null value should submit nothing undefined is not an object (evaluating 'this.internals_.setFormValue')
-FAIL Multiple values - name content attribute is ignored undefined is not an object (evaluating 'this.internals_.setFormValue')
-FAIL setFormValue with an empty FormData should submit nothing undefined is not an object (evaluating 'this.internals_.setFormValue')
-FAIL Newline normalization - \n in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \r\n in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL Newline normalization - \n\r in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'this.internals_.setFormValue')"
-FAIL ElementInternals.setFormValue() should throw NotSupportedError if the target element is not a form-associated custom element element.attachInternals is not a function. (In 'element.attachInternals()', 'element.attachInternals' is undefined)
+FAIL Single value - empty name exists this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)
+FAIL Single value - Non-empty name exists this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)
+FAIL Null value should submit nothing this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)
+FAIL Multiple values - name content attribute is ignored this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)
+FAIL setFormValue with an empty FormData should submit nothing this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)
+FAIL Newline normalization - \n in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(v)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData name (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData name (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData value (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData value (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \r\n in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData filename (urlencoded) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL Newline normalization - \n\r in FormData filename (formdata) promise_test: Unhandled rejection with value: object "TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue(formData)', 'this.internals_.setFormValue' is undefined)"
+FAIL ElementInternals.setFormValue() should throw NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => i.setFormValue("test")" threw object "TypeError: i.setFormValue is not a function. (In 'i.setFormValue("test")', 'i.setFormValue' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Target element of ElementsInternals is held strongly and doesn't get GCed if there are no other references
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-target-element-is-held-strongly.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Target element of ElementsInternals is held strongly and doesn't get GCed if there are no other references</title>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/garbage-collect.js"></script>
+
+<script>
+customElements.define("x-foo", class extends HTMLElement {});
+
+promise_test(async t => {
+    const elementInternals = [];
+
+    for (let i = 0; i < 1e5; i++) {
+        const targetElement = document.createElement("x-foo");
+        targetElement.attachShadow({ mode: "open" });
+        elementInternals.push(targetElement.attachInternals());
+    }
+
+    await maybeGarbageCollectAsync();
+    await new Promise(r => t.step_timeout(r, 100));
+
+    const allShadowRootsAreAlive = elementInternals.every(eI => eI.shadowRoot instanceof ShadowRoot);
+    assert_true(allShadowRootsAreAlive);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -1,29 +1,16 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
 
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
-FAIL willValidate this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL willValidate after upgrade undefined is not an object (evaluating 'controls[0].i.willValidate')
-FAIL willValidate should throw NotSupportedError if the target element is not a form-associated custom element this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL validity and setValidity() undefined is not an object (evaluating 'control.i.validity')
+FAIL willValidate assert_true: default value is true expected true got undefined
+FAIL willValidate after upgrade assert_true: default value expected true got undefined
+FAIL willValidate should throw NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => element.i.willValidate" did not throw
+FAIL validity and setValidity() undefined is not an object (evaluating 'validity.valueMissing')
 FAIL "anchor" argument of setValidity() assert_throws_dom: Not a descendant function "() => {
     control.i.setValidity(flags, m, document.body);
-  }" threw object "TypeError: undefined is not an object (evaluating 'control.i.setValidity')" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
-FAIL checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL checkValidity() undefined is not an object (evaluating 'control.i.checkValidity')
-FAIL reportValidity() should throw NotSupportedError if the target element is not a form-associated custom element this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL reportValidity() undefined is not an object (evaluating 'control.i.reportValidity')
-FAIL Custom control affects validation at the owner form undefined is not an object (evaluating 'control.i.checkValidity')
+  }" threw object "TypeError: control.i.setValidity is not a function. (In 'control.i.setValidity(flags, m, document.body)', 'control.i.setValidity' is undefined)" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
+FAIL checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => element.i.checkValidity()" threw object "TypeError: element.i.checkValidity is not a function. (In 'element.i.checkValidity()', 'element.i.checkValidity' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL checkValidity() control.i.checkValidity is not a function. (In 'control.i.checkValidity()', 'control.i.checkValidity' is undefined)
+FAIL reportValidity() should throw NotSupportedError if the target element is not a form-associated custom element assert_throws_dom: function "() => element.i.reportValidity()" threw object "TypeError: element.i.reportValidity is not a function. (In 'element.i.reportValidity()', 'element.i.reportValidity' is undefined)" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL reportValidity() control.i.reportValidity is not a function. (In 'control.i.reportValidity()', 'control.i.reportValidity' is undefined)
+FAIL Custom control affects validation at the owner form control.i.checkValidity is not a function. (In 'control.i.checkValidity()', 'control.i.checkValidity' is undefined)
 FAIL Custom control affects :valid :invalid for FORM and FIELDSET assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-associated-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-associated-callback-expected.txt
@@ -1,15 +1,7 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
 
-
-
-
-
-
-
-
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-
+FAIL Associate by parser, customized at element creation assert_equals: expected 3 but got 2
+FAIL Parsed, connected, then upgraded assert_equals: form.elements.length expected 3 but got 2
+FAIL Disassociation assert_equals: form.elements.length before removal expected 3 but got 2
+FAIL Updating "form" content attribute assert_equals: expected (object) null but got (undefined) undefined
+FAIL Updating "id" attribute of form element assert_equals: expected (object) null but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt
@@ -1,17 +1,17 @@
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-CONSOLE MESSAGE: TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+CONSOLE MESSAGE: TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
+CONSOLE MESSAGE: TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
+CONSOLE MESSAGE: TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
+CONSOLE MESSAGE: TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
+CONSOLE MESSAGE: TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
 
 
 
-Harness Error (FAIL), message = TypeError: this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+Harness Error (FAIL), message = TypeError: this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
 
-FAIL Adding/removing disabled content attribute this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL Adding/removing disabled content attribute this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
 FAIL Relationship with FIELDSET assert_true: expected true got false
 PASS A disabled form-associated custom element should not provide an entry for it
 FAIL A disabled form-associated custom element should not submit an entry for it assert_not_equals: got disallowed value -1
-FAIL Disabled attribute affects focus-capability this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL Disabled attribute affects focus-capability this.internals_.setFormValue is not a function. (In 'this.internals_.setFormValue('my-control-value')', 'this.internals_.setFormValue' is undefined)
 FAIL Upgrading an element with disabled content attribute assert_array_equals: value is undefined, expected array
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/garbage-collect.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/garbage-collect.js
@@ -1,0 +1,19 @@
+async function maybeGarbageCollectAsync() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    // Use --expose_gc for V8 (and Node.js)
+    // to pass this flag at chrome launch use: --js-flags="--expose-gc"
+    // Exposed in SpiderMonkey shell as well
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    /* eslint-disable no-console */
+    console.warn('Tests are running without the ability to do manual ' +
+                 'garbage collection. They will still work, but ' +
+                 'coverage will be suboptimal.');
+    /* eslint-enable no-console */
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/ElementInternals-states-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/ElementInternals-states-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL DOMTokenList behavior of ElementInternals.states: Initial state this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL DOMTokenList behavior of ElementInternals.states: Exceptions this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL DOMTokenList behavior of ElementInternals.states: Modifications this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL DOMTokenList behavior of ElementInternals.states: Initial state assert_true: expected true got false
+FAIL DOMTokenList behavior of ElementInternals.states: Exceptions assert_throws_dom: function "() => { i.states.add(''); }" threw object "TypeError: undefined is not an object (evaluating 'i.states.add')" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+FAIL DOMTokenList behavior of ElementInternals.states: Modifications undefined is not an object (evaluating 'i.states.add')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt
@@ -1,8 +1,8 @@
 
 PASS :state() parsing failures
 FAIL :state() serialization undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].cssText')
-FAIL :state() in simple cases this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :state() and other pseudo classes this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :state() and ::part() this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :state() and :host() this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL :state() in simple cases The string did not match the expected pattern.
+FAIL :state() and other pseudo classes undefined is not an object (evaluating 'states.value = 'foo'')
+FAIL :state() and ::part() undefined is not an object (evaluating 'innerStates.add')
+FAIL :state() and :host() undefined is not an object (evaluating 'outer.i.states.toggle')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL CustomStateSet behavior of ElementInternals.states: Initial state this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL CustomStateSet behavior of ElementInternals.states: Exceptions this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL CustomStateSet behavior of ElementInternals.states: Modifications this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL Updating a CustomStateSet while iterating it should work this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL CustomStateSet behavior of ElementInternals.states: Initial state Can't find variable: CustomStateSet
+FAIL CustomStateSet behavior of ElementInternals.states: Exceptions assert_throws_dom: function "() => { i.states.add(''); }" threw object "TypeError: undefined is not an object (evaluating 'i.states.add')" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+FAIL CustomStateSet behavior of ElementInternals.states: Modifications undefined is not an object (evaluating 'i.states.add')
+FAIL Updating a CustomStateSet while iterating it should work undefined is not an object (evaluating 'i.states.add')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
@@ -2,8 +2,8 @@
 FAIL :--foo parsing passes The string did not match the expected pattern.
 PASS :--foo parsing failures
 FAIL :--foo serialization undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].cssText')
-FAIL :--foo in simple cases this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :--foo and other pseudo classes this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :--foo and ::part() this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
-FAIL :--foo and :host() this.attachInternals is not a function. (In 'this.attachInternals()', 'this.attachInternals' is undefined)
+FAIL :--foo in simple cases The string did not match the expected pattern.
+FAIL :--foo and other pseudo classes undefined is not an object (evaluating 'states.add')
+FAIL :--foo and ::part() undefined is not an object (evaluating 'innerStates.add')
+FAIL :--foo and :host() undefined is not an object (evaluating 'outer.i.states.add')
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -259,7 +259,7 @@ PASS HTMLElement interface: attribute spellcheck
 FAIL HTMLElement interface: attribute autocapitalize assert_true: The prototype object must have a property "autocapitalize" expected true got false
 PASS HTMLElement interface: attribute innerText
 PASS HTMLElement interface: attribute outerText
-FAIL HTMLElement interface: operation attachInternals() assert_own_property: interface prototype object missing non-static operation expected property "attachInternals" missing
+PASS HTMLElement interface: operation attachInternals()
 PASS HTMLElement interface: attribute onabort
 FAIL HTMLElement interface: attribute onauxclick assert_true: The prototype object must have a property "onauxclick" expected true got false
 PASS HTMLElement interface: attribute onblur
@@ -356,7 +356,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type assert_inherits: property "autocapitalize" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "outerText" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type assert_inherits: property "attachInternals" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type assert_inherits: property "onauxclick" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onblur" with the proper type
@@ -4344,22 +4344,22 @@ PASS CustomElementRegistry interface: operation define(DOMString, CustomElementC
 PASS CustomElementRegistry interface: operation get(DOMString)
 PASS CustomElementRegistry interface: operation whenDefined(DOMString)
 PASS CustomElementRegistry interface: operation upgrade(Node)
-FAIL ElementInternals interface: existence and properties of interface object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object length assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object name assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute shadowRoot assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute form assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute willValidate assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validity assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validationMessage assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation checkValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation reportValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute labels assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
+PASS ElementInternals interface: existence and properties of interface object
+PASS ElementInternals interface object length
+PASS ElementInternals interface object name
+PASS ElementInternals interface: existence and properties of interface prototype object
+PASS ElementInternals interface: existence and properties of interface prototype object's "constructor" property
+PASS ElementInternals interface: existence and properties of interface prototype object's @@unscopables property
+PASS ElementInternals interface: attribute shadowRoot
+FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: interface prototype object missing non-static operation expected property "setFormValue" missing
+FAIL ElementInternals interface: attribute form assert_true: The prototype object must have a property "form" expected true got false
+FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: interface prototype object missing non-static operation expected property "setValidity" missing
+FAIL ElementInternals interface: attribute willValidate assert_true: The prototype object must have a property "willValidate" expected true got false
+FAIL ElementInternals interface: attribute validity assert_true: The prototype object must have a property "validity" expected true got false
+FAIL ElementInternals interface: attribute validationMessage assert_true: The prototype object must have a property "validationMessage" expected true got false
+FAIL ElementInternals interface: operation checkValidity() assert_own_property: interface prototype object missing non-static operation expected property "checkValidity" missing
+FAIL ElementInternals interface: operation reportValidity() assert_own_property: interface prototype object missing non-static operation expected property "reportValidity" missing
+FAIL ElementInternals interface: attribute labels assert_true: The prototype object must have a property "labels" expected true got false
 PASS DataTransfer interface: existence and properties of interface object
 PASS DataTransfer interface object length
 PASS DataTransfer interface object name

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -259,7 +259,7 @@ PASS HTMLElement interface: attribute spellcheck
 PASS HTMLElement interface: attribute autocapitalize
 PASS HTMLElement interface: attribute innerText
 PASS HTMLElement interface: attribute outerText
-FAIL HTMLElement interface: operation attachInternals() assert_own_property: interface prototype object missing non-static operation expected property "attachInternals" missing
+PASS HTMLElement interface: operation attachInternals()
 PASS HTMLElement interface: attribute onabort
 FAIL HTMLElement interface: attribute onauxclick assert_true: The prototype object must have a property "onauxclick" expected true got false
 PASS HTMLElement interface: attribute onblur
@@ -356,7 +356,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "outerText" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type assert_inherits: property "attachInternals" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type assert_inherits: property "onauxclick" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onblur" with the proper type
@@ -4344,22 +4344,22 @@ PASS CustomElementRegistry interface: operation define(DOMString, CustomElementC
 PASS CustomElementRegistry interface: operation get(DOMString)
 PASS CustomElementRegistry interface: operation whenDefined(DOMString)
 PASS CustomElementRegistry interface: operation upgrade(Node)
-FAIL ElementInternals interface: existence and properties of interface object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object length assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object name assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute shadowRoot assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute form assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute willValidate assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validity assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validationMessage assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation checkValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation reportValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute labels assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
+PASS ElementInternals interface: existence and properties of interface object
+PASS ElementInternals interface object length
+PASS ElementInternals interface object name
+PASS ElementInternals interface: existence and properties of interface prototype object
+PASS ElementInternals interface: existence and properties of interface prototype object's "constructor" property
+PASS ElementInternals interface: existence and properties of interface prototype object's @@unscopables property
+PASS ElementInternals interface: attribute shadowRoot
+FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: interface prototype object missing non-static operation expected property "setFormValue" missing
+FAIL ElementInternals interface: attribute form assert_true: The prototype object must have a property "form" expected true got false
+FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: interface prototype object missing non-static operation expected property "setValidity" missing
+FAIL ElementInternals interface: attribute willValidate assert_true: The prototype object must have a property "willValidate" expected true got false
+FAIL ElementInternals interface: attribute validity assert_true: The prototype object must have a property "validity" expected true got false
+FAIL ElementInternals interface: attribute validationMessage assert_true: The prototype object must have a property "validationMessage" expected true got false
+FAIL ElementInternals interface: operation checkValidity() assert_own_property: interface prototype object missing non-static operation expected property "checkValidity" missing
+FAIL ElementInternals interface: operation reportValidity() assert_own_property: interface prototype object missing non-static operation expected property "reportValidity" missing
+FAIL ElementInternals interface: attribute labels assert_true: The prototype object must have a property "labels" expected true got false
 PASS DataTransfer interface: existence and properties of interface object
 PASS DataTransfer interface object length
 PASS DataTransfer interface object name

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -259,7 +259,7 @@ PASS HTMLElement interface: attribute spellcheck
 PASS HTMLElement interface: attribute autocapitalize
 PASS HTMLElement interface: attribute innerText
 PASS HTMLElement interface: attribute outerText
-FAIL HTMLElement interface: operation attachInternals() assert_own_property: interface prototype object missing non-static operation expected property "attachInternals" missing
+PASS HTMLElement interface: operation attachInternals()
 PASS HTMLElement interface: attribute onabort
 FAIL HTMLElement interface: attribute onauxclick assert_true: The prototype object must have a property "onauxclick" expected true got false
 PASS HTMLElement interface: attribute onblur
@@ -356,7 +356,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "outerText" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type assert_inherits: property "attachInternals" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type assert_inherits: property "onauxclick" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onblur" with the proper type
@@ -4334,22 +4334,22 @@ PASS CustomElementRegistry interface: operation define(DOMString, CustomElementC
 PASS CustomElementRegistry interface: operation get(DOMString)
 PASS CustomElementRegistry interface: operation whenDefined(DOMString)
 PASS CustomElementRegistry interface: operation upgrade(Node)
-FAIL ElementInternals interface: existence and properties of interface object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object length assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object name assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute shadowRoot assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute form assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute willValidate assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validity assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validationMessage assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation checkValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation reportValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute labels assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
+PASS ElementInternals interface: existence and properties of interface object
+PASS ElementInternals interface object length
+PASS ElementInternals interface object name
+PASS ElementInternals interface: existence and properties of interface prototype object
+PASS ElementInternals interface: existence and properties of interface prototype object's "constructor" property
+PASS ElementInternals interface: existence and properties of interface prototype object's @@unscopables property
+PASS ElementInternals interface: attribute shadowRoot
+FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: interface prototype object missing non-static operation expected property "setFormValue" missing
+FAIL ElementInternals interface: attribute form assert_true: The prototype object must have a property "form" expected true got false
+FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: interface prototype object missing non-static operation expected property "setValidity" missing
+FAIL ElementInternals interface: attribute willValidate assert_true: The prototype object must have a property "willValidate" expected true got false
+FAIL ElementInternals interface: attribute validity assert_true: The prototype object must have a property "validity" expected true got false
+FAIL ElementInternals interface: attribute validationMessage assert_true: The prototype object must have a property "validationMessage" expected true got false
+FAIL ElementInternals interface: operation checkValidity() assert_own_property: interface prototype object missing non-static operation expected property "checkValidity" missing
+FAIL ElementInternals interface: operation reportValidity() assert_own_property: interface prototype object missing non-static operation expected property "reportValidity" missing
+FAIL ElementInternals interface: attribute labels assert_true: The prototype object must have a property "labels" expected true got false
 PASS DataTransfer interface: existence and properties of interface object
 PASS DataTransfer interface object length
 PASS DataTransfer interface object name

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -259,7 +259,7 @@ PASS HTMLElement interface: attribute spellcheck
 FAIL HTMLElement interface: attribute autocapitalize assert_true: The prototype object must have a property "autocapitalize" expected true got false
 PASS HTMLElement interface: attribute innerText
 PASS HTMLElement interface: attribute outerText
-FAIL HTMLElement interface: operation attachInternals() assert_own_property: interface prototype object missing non-static operation expected property "attachInternals" missing
+PASS HTMLElement interface: operation attachInternals()
 PASS HTMLElement interface: attribute onabort
 FAIL HTMLElement interface: attribute onauxclick assert_true: The prototype object must have a property "onauxclick" expected true got false
 PASS HTMLElement interface: attribute onblur
@@ -356,7 +356,7 @@ PASS HTMLElement interface: document.createElement("noscript") must inherit prop
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "autocapitalize" with the proper type assert_inherits: property "autocapitalize" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "innerText" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "outerText" with the proper type
-FAIL HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type assert_inherits: property "attachInternals" not found in prototype chain
+PASS HTMLElement interface: document.createElement("noscript") must inherit property "attachInternals()" with the proper type
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onabort" with the proper type
 FAIL HTMLElement interface: document.createElement("noscript") must inherit property "onauxclick" with the proper type assert_inherits: property "onauxclick" not found in prototype chain
 PASS HTMLElement interface: document.createElement("noscript") must inherit property "onblur" with the proper type
@@ -4344,22 +4344,22 @@ PASS CustomElementRegistry interface: operation define(DOMString, CustomElementC
 PASS CustomElementRegistry interface: operation get(DOMString)
 PASS CustomElementRegistry interface: operation whenDefined(DOMString)
 PASS CustomElementRegistry interface: operation upgrade(Node)
-FAIL ElementInternals interface: existence and properties of interface object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object length assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface object name assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute shadowRoot assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute form assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute willValidate assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validity assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute validationMessage assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation checkValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: operation reportValidity() assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
-FAIL ElementInternals interface: attribute labels assert_own_property: self does not have own property "ElementInternals" expected property "ElementInternals" missing
+PASS ElementInternals interface: existence and properties of interface object
+PASS ElementInternals interface object length
+PASS ElementInternals interface object name
+PASS ElementInternals interface: existence and properties of interface prototype object
+PASS ElementInternals interface: existence and properties of interface prototype object's "constructor" property
+PASS ElementInternals interface: existence and properties of interface prototype object's @@unscopables property
+PASS ElementInternals interface: attribute shadowRoot
+FAIL ElementInternals interface: operation setFormValue((File or USVString or FormData)?, optional (File or USVString or FormData)?) assert_own_property: interface prototype object missing non-static operation expected property "setFormValue" missing
+FAIL ElementInternals interface: attribute form assert_true: The prototype object must have a property "form" expected true got false
+FAIL ElementInternals interface: operation setValidity(optional ValidityStateFlags, optional DOMString, optional HTMLElement) assert_own_property: interface prototype object missing non-static operation expected property "setValidity" missing
+FAIL ElementInternals interface: attribute willValidate assert_true: The prototype object must have a property "willValidate" expected true got false
+FAIL ElementInternals interface: attribute validity assert_true: The prototype object must have a property "validity" expected true got false
+FAIL ElementInternals interface: attribute validationMessage assert_true: The prototype object must have a property "validationMessage" expected true got false
+FAIL ElementInternals interface: operation checkValidity() assert_own_property: interface prototype object missing non-static operation expected property "checkValidity" missing
+FAIL ElementInternals interface: operation reportValidity() assert_own_property: interface prototype object missing non-static operation expected property "reportValidity" missing
+FAIL ElementInternals interface: attribute labels assert_true: The prototype object must have a property "labels" expected true got false
 PASS DataTransfer interface: existence and properties of interface object
 PASS DataTransfer interface object length
 PASS DataTransfer interface object name

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -659,6 +659,18 @@ FocusVisibleEnabled:
     WebCore:
       default: true
 
+FormAssociatedCustomElementsEnabled:
+  type: bool
+  humanReadableName: "Form-associated custom elements"
+  humanReadableDescription: "Support for form-associated custom elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 GenericCueAPIEnabled:
   type: bool

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -930,6 +930,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/Element+PointerLock.idl
     dom/Element.idl
     dom/ElementContentEditable.idl
+    dom/ElementInternals.idl
     dom/ErrorEvent.idl
     dom/Event.idl
     dom/EventInit.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1073,6 +1073,7 @@ $(PROJECT_DIR)/dom/Element+PointerEvents.idl
 $(PROJECT_DIR)/dom/Element+PointerLock.idl
 $(PROJECT_DIR)/dom/Element.idl
 $(PROJECT_DIR)/dom/ElementContentEditable.idl
+$(PROJECT_DIR)/dom/ElementInternals.idl
 $(PROJECT_DIR)/dom/ErrorEvent.idl
 $(PROJECT_DIR)/dom/Event.idl
 $(PROJECT_DIR)/dom/EventInit.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -830,6 +830,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCSSInlineStyle.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCSSInlineStyle.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementContentEditable.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementContentEditable.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementInternals.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementInternals.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEndingType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEndingType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSErrorCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -931,6 +931,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/Element+PointerLock.idl \
     $(WebCore)/dom/Element.idl \
     $(WebCore)/dom/ElementContentEditable.idl \
+    $(WebCore)/dom/ElementInternals.idl \
     $(WebCore)/dom/ErrorEvent.idl \
     $(WebCore)/dom/Event.idl \
     $(WebCore)/dom/EventInit.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -972,6 +972,7 @@ dom/DocumentType.cpp
 dom/DragEvent.cpp
 dom/Element.cpp
 dom/ElementData.cpp
+dom/ElementInternals.cpp
 dom/ElementRareData.cpp
 dom/ErrorEvent.cpp
 dom/Event.cpp
@@ -3166,6 +3167,7 @@ JSEcdsaParams.cpp
 JSEffectTiming.cpp
 JSElement.cpp
 JSElementCSSInlineStyle.cpp
+JSElementInternals.cpp
 JSEndingType.cpp
 JSErrorCallback.cpp
 JSErrorEvent.cpp

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -81,8 +81,17 @@ public:
     bool observesAttribute(const AtomString& name) const { return m_observedAttributes.contains(name); }
     void invokeAttributeChangedCallback(Element&, const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
 
+    void disableElementInternals() { m_isElementInternalsDisabled = true; }
+    bool isElementInternalsDisabled() const { return m_isElementInternalsDisabled; }
+
     void disableShadow() { m_isShadowDisabled = true; }
     bool isShadowDisabled() const { return m_isShadowDisabled; }
+
+    void setIsFormAssociated() { m_isFormAssociated = true; }
+    void setFormAssociatedCallback(JSC::JSObject*);
+    void setFormResetCallback(JSC::JSObject*);
+    void setFormDisabledCallback(JSC::JSObject*);
+    void setFormStateRestoreCallback(JSC::JSObject*);
 
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
     JSC::JSObject* constructor() { return m_constructor.get(); }
@@ -108,10 +117,16 @@ private:
     JSC::Weak<JSC::JSObject> m_disconnectedCallback;
     JSC::Weak<JSC::JSObject> m_adoptedCallback;
     JSC::Weak<JSC::JSObject> m_attributeChangedCallback;
+    JSC::Weak<JSC::JSObject> m_formAssociatedCallback;
+    JSC::Weak<JSC::JSObject> m_formResetCallback;
+    JSC::Weak<JSC::JSObject> m_formDisabledCallback;
+    JSC::Weak<JSC::JSObject> m_formStateRestoreCallback;
     Ref<DOMWrapperWorld> m_isolatedWorld;
     Vector<RefPtr<Element>, 1> m_constructionStack;
     MemoryCompactRobinHoodHashSet<AtomString> m_observedAttributes;
+    bool m_isElementInternalsDisabled : 1;
     bool m_isShadowDisabled : 1;
+    bool m_isFormAssociated : 1;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -95,9 +95,10 @@ ALWAYS_INLINE bool matchesEnabledPseudoClass(const Element& element)
     return is<HTMLElement>(element) && downcast<HTMLElement>(element).canBeActuallyDisabled() && !element.isDisabledFormControl();
 }
 
+// https://dom.spec.whatwg.org/#concept-element-defined
 ALWAYS_INLINE bool isDefinedElement(const Element& element)
 {
-    return !element.isUndefinedCustomElement();
+    return element.isDefinedCustomElement() || element.isUncustomizedCustomElement();
 }
 
 ALWAYS_INLINE bool isMediaDocument(const Element& element)

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -233,6 +233,21 @@ bool CustomElementReactionQueue::observesStyleAttribute() const
     return m_interface->observesAttribute(HTMLNames::styleAttr->localName());
 }
 
+bool CustomElementReactionQueue::isElementInternalsDisabled() const
+{
+    return m_interface->isElementInternalsDisabled();
+}
+
+bool CustomElementReactionQueue::isElementInternalsAttached() const
+{
+    return m_elementInternalsAttached;
+}
+
+void CustomElementReactionQueue::setElementInternalsAttached()
+{
+    m_elementInternalsAttached = true;
+}
+
 void CustomElementReactionQueue::invokeAll(Element& element)
 {
     while (!m_items.isEmpty()) {

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -78,6 +78,10 @@ public:
     static void enqueuePostUpgradeReactions(Element&);
 
     bool observesStyleAttribute() const;
+    bool isElementInternalsDisabled() const;
+    bool isElementInternalsAttached() const;
+    void setElementInternalsAttached();
+
     void invokeAll(Element&);
     void clear();
     bool isEmpty() const { return m_items.isEmpty(); }
@@ -92,6 +96,7 @@ private:
 
     Ref<JSCustomElementInterface> m_interface;
     Vector<CustomElementReactionQueueItem> m_items;
+    bool m_elementInternalsAttached { false };
 };
 
 class CustomElementReactionDisallowedScope {

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -54,6 +54,11 @@ CustomElementRegistry::CustomElementRegistry(DOMWindow& window, ScriptExecutionC
 
 CustomElementRegistry::~CustomElementRegistry() = default;
 
+Document* CustomElementRegistry::document() const
+{
+    return m_window.document();
+}
+
 // https://dom.spec.whatwg.org/#concept-shadow-including-tree-order
 static void enqueueUpgradeInShadowIncludingTreeOrder(ContainerNode& node, JSCustomElementInterface& elementInterface)
 {

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -44,6 +44,7 @@ namespace WebCore {
 class CustomElementRegistry;
 class DOMWindow;
 class DeferredPromise;
+class Document;
 class Element;
 class JSCustomElementInterface;
 class Node;
@@ -53,6 +54,8 @@ class CustomElementRegistry : public RefCounted<CustomElementRegistry>, public C
 public:
     static Ref<CustomElementRegistry> create(DOMWindow&, ScriptExecutionContext*);
     ~CustomElementRegistry();
+
+    Document* document() const;
 
     RefPtr<DeferredPromise> addElementDefinition(Ref<JSCustomElementInterface>&&);
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -336,7 +336,7 @@ public:
 
     void setIsDefinedCustomElement(JSCustomElementInterface&);
     void setIsFailedCustomElement();
-    void setIsFailedCustomElementWithoutClearingReactionQueue();
+    void setIsFailedOrPrecustomizedCustomElementWithoutClearingReactionQueue();
     void clearReactionQueueFromFailedCustomElement();
     void setIsCustomElementUpgradeCandidate();
     void enqueueToUpgrade(JSCustomElementInterface&);

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ElementInternals.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ElementInternals);
+
+ShadowRoot* ElementInternals::shadowRoot() const
+{
+    RefPtr element = m_element.get();
+    if (!element)
+        return nullptr;
+    auto* shadowRoot = element->shadowRoot();
+    if (!shadowRoot || !shadowRoot->isAvailableToElementInternals())
+        return nullptr;
+    return shadowRoot;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HTMLElement.h"
+#include "ScriptWrappable.h"
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class ElementInternals final : public ScriptWrappable, public RefCounted<ElementInternals> {
+    WTF_MAKE_ISO_ALLOCATED(ElementInternals);
+public:
+    static Ref<ElementInternals> create(HTMLElement& element)
+    {
+        return adoptRef(*new ElementInternals(element));
+    }
+
+    Element* element() const { return m_element.get(); }
+    ShadowRoot* shadowRoot() const;
+
+private:
+    ElementInternals(HTMLElement& element)
+        : m_element(element)
+    {
+    }
+
+    WeakPtr<HTMLElement> m_element;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    GenerateIsReachable=ImplElementRoot,
+    GenerateAddOpaqueRoot=element,
+    Exposed=Window,
+] interface ElementInternals {
+    readonly attribute ShadowRoot? shadowRoot;
+};

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -247,10 +247,13 @@ public:
     HTMLSlotElement* assignedSlot() const;
     HTMLSlotElement* assignedSlotForBindings() const;
 
-    bool isUndefinedCustomElement() const { return customElementState() == CustomElementState::Undefined || customElementState() == CustomElementState::Failed; }
+    bool isUncustomizedCustomElement() const { return customElementState() == CustomElementState::Uncustomized; }
     bool isCustomElementUpgradeCandidate() const { return customElementState() == CustomElementState::Undefined; }
     bool isDefinedCustomElement() const { return customElementState() == CustomElementState::Custom; }
-    bool isFailedCustomElement() const { return customElementState() == CustomElementState::Failed; }
+    bool isFailedCustomElement() const { return customElementState() == CustomElementState::FailedOrPrecustomized && isUnknownElement(); }
+    bool isFailedOrPrecustomizedCustomElement() const { return customElementState() == CustomElementState::FailedOrPrecustomized; }
+    bool isPrecustomizedCustomElement() const { return customElementState() == CustomElementState::FailedOrPrecustomized && !isUnknownElement(); }
+    bool isPrecustomizedOrDefinedCustomElement() const { return isPrecustomizedCustomElement() || isDefinedCustomElement(); }
 
     // Returns null, a child of ShadowRoot, or a legacy shadow root.
     Node* nonBoundaryShadowTreeRootNode();
@@ -601,7 +604,7 @@ protected:
         Uncustomized = 0,
         Undefined = 1,
         Custom = 2,
-        Failed = 3,
+        FailedOrPrecustomized = 3,
     };
 
     struct RareDataBitFields {

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -65,10 +65,11 @@ static_assert(sizeof(ShadowRoot) == sizeof(SameSizeAsShadowRoot), "shadowroot sh
 static_assert(sizeof(WeakPtr<Element>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
-ShadowRoot::ShadowRoot(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus)
+ShadowRoot::ShadowRoot(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, AvailableToElementInternals availableToElementInternals)
     : DocumentFragment(document, CreateShadowRoot)
     , TreeScope(*this, document)
     , m_delegatesFocus(delegatesFocus == DelegatesFocus::Yes)
+    , m_availableToElementInternals(availableToElementInternals == AvailableToElementInternals::Yes)
     , m_type(type)
     , m_slotAssignmentMode(assignmentMode)
     , m_styleScope(makeUnique<Style::Scope>(*this))

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -49,11 +49,12 @@ class ShadowRoot final : public DocumentFragment, public TreeScope {
 public:
 
     enum class DelegatesFocus : uint8_t { Yes, No };
+    enum class AvailableToElementInternals : uint8_t { Yes, No };
 
     static Ref<ShadowRoot> create(Document& document, ShadowRootMode type,
-        SlotAssignmentMode assignmentMode = SlotAssignmentMode::Named, DelegatesFocus delegatesFocus = DelegatesFocus::No)
+        SlotAssignmentMode assignmentMode = SlotAssignmentMode::Named, DelegatesFocus delegatesFocus = DelegatesFocus::No, AvailableToElementInternals availableToElementInternals = AvailableToElementInternals::No)
     {
-        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus));
+        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, availableToElementInternals));
     }
 
     static Ref<ShadowRoot> create(Document& document, std::unique_ptr<SlotAssignment>&& assignment)
@@ -75,6 +76,8 @@ public:
     bool delegatesFocus() const { return m_delegatesFocus; }
     bool containsFocusedElement() const { return m_containsFocusedElement; }
     void setContainsFocusedElement(bool flag) { m_containsFocusedElement = flag; }
+
+    bool isAvailableToElementInternals() const { return m_availableToElementInternals; }
 
     Element* host() const { return m_host.get(); }
     void setHost(WeakPtr<Element>&& host) { m_host = WTFMove(host); }
@@ -121,7 +124,7 @@ public:
     Vector<RefPtr<WebAnimation>> getAnimations();
 
 private:
-    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus);
+    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, AvailableToElementInternals);
     ShadowRoot(Document&, std::unique_ptr<SlotAssignment>&&);
 
     bool childTypeAllowed(NodeType) const override;
@@ -137,6 +140,7 @@ private:
     bool m_hasBegunDeletingDetachedChildren { false };
     bool m_delegatesFocus { false };
     bool m_containsFocusedElement { false };
+    bool m_availableToElementInternals { false };
     ShadowRootMode m_type { ShadowRootMode::UserAgent };
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class ElementInternals;
 class FormAssociatedElement;
 class FormNamedItem;
 class HTMLFormElement;
@@ -133,6 +134,8 @@ public:
     void setEnterKeyHint(const AtomString& value);
 
     WEBCORE_EXPORT static bool shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate);
+
+    WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -46,8 +46,7 @@
 
     [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
 
-    // FIXME: Implement 'attachInternals'.
-    // ElementInternals attachInternals();
+    [EnabledBySetting=FormAssociatedCustomElementsEnabled] ElementInternals attachInternals();
 
     // Experimental: https://github.com/WICG/inert/blob/master/README.md
     [CEReactions, Reflect, EnabledBySetting=InertAttributeEnabled] attribute boolean inert;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1775,9 +1775,9 @@ static Protocol::DOM::CustomElementState customElementState(const Element& eleme
 {
     if (element.isDefinedCustomElement())
         return Protocol::DOM::CustomElementState::Custom;
-    if (element.isFailedCustomElement())
+    if (element.isFailedOrPrecustomizedCustomElement())
         return Protocol::DOM::CustomElementState::Failed;
-    if (element.isUndefinedCustomElement() || element.isCustomElementUpgradeCandidate())
+    if (element.isCustomElementUpgradeCandidate())
         return Protocol::DOM::CustomElementState::Waiting;
     return Protocol::DOM::CustomElementState::Builtin;
 }


### PR DESCRIPTION
#### c51d445d35e1f4407bd8fe107ebe158363e7ae8f
<pre>
Implement ElementInternals
<a href="https://bugs.webkit.org/show_bug.cgi?id=197960">https://bugs.webkit.org/show_bug.cgi?id=197960</a>

Reviewed by Ryosuke Niwa.

This change implements ElementInternals interface [1] with a `shadowRoot` getter only,
as well as allowing to disable attachInternals() via `disabledFeatures` property.

To avoid breaking web sites and polyfills that rely on form-associated custom elements
being fully supported if attachInternals() is present, ElementInternals is carefully
hidden behind a runtime flag.

To ensure attachInternals() can be called in a custom element constructor but not if
upgrading fails, the spec introduced a fifth custom element state of &quot;precustomized&quot;,
which is very similar to &quot;failed&quot;.

This change avoids adding CustomElementState::Precustomized to preserve free bits in
Node::RareDataBitFields, and instead leverages that &quot;precustomized&quot; state is set
only in upgrade algorithm, is very similar to &quot;failed&quot;, and we can distinguish them
by checking Node::IsUnknownElement flag.

For the same reason, not to increase sizeof(ElementRareData), ElementInternals attached
flag is defined on CustomElementReactionQueue, which led to loosening up assertions in
Element::reactionQueue() as it now may be invoked on a built-in element.

Also, the introduction of CustomElementState::PrecustomizedOrFailed led to adjusting
custom element state checks, bringing us closer to the spec steps / terminology by
removing inverted checks in upgradeElement() / at isUndefinedCustomElement() call sites.

[1] <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface</a>

Tests: imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html
       imported/w3c/web-platform-tests/custom-elements/HTMLElement-attachInternals.html
       imported/w3c/web-platform-tests/custom-elements/element-internals-shadowroot.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/HTMLElement-attachInternals-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-shadowroot-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-NotSupportedError-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-accessibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-form-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-labels-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-associated-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/form-disabled-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/ElementInternals-states-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/ElementInternals-states-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::JSCustomElementInterface):
(WebCore::JSCustomElementInterface::upgradeElement):
(WebCore::JSCustomElementInterface::setFormAssociatedCallback):
(WebCore::JSCustomElementInterface::setFormResetCallback):
(WebCore::JSCustomElementInterface::setFormDisabledCallback):
(WebCore::JSCustomElementInterface::setFormStateRestoreCallback):
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
(WebCore::JSCustomElementInterface::disableElementInternals):
(WebCore::JSCustomElementInterface::isElementInternalsDisabled const):
(WebCore::JSCustomElementInterface::setIsFormAssociated):
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::JSCustomElementRegistry::define):
* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp: Added.
(WebCore::JSElementInternals::visitAdditionalChildren):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::isDefinedElement):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::isElementInternalsDisabled const):
(WebCore::CustomElementReactionQueue::isElementInternalsAttached const):
(WebCore::CustomElementReactionQueue::setElementInternalsAttached):
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::document const):
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setIsFailedCustomElement):
(WebCore::Element::setIsFailedOrPrecustomizedCustomElementWithoutClearingReactionQueue):
(WebCore::Element::clearReactionQueueFromFailedOrPrecustomizedCustomElement):
(WebCore::Element::enqueueToUpgrade):
(WebCore::Element::reactionQueue const):
(WebCore::Element::setIsFailedCustomElementWithoutClearingReactionQueue): Deleted.
(WebCore::Element::clearReactionQueueFromFailedCustomElement): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp: Added.
(WebCore::ElementInternals::shadowRoot const):
* Source/WebCore/dom/ElementInternals.h: Added.
* Source/WebCore/dom/ElementInternals.idl: Added.
* Source/WebCore/dom/Node.h:
(WebCore::Node::isUncustomizedCustomElement const):
(WebCore::Node::isFailedCustomElement const):
(WebCore::Node::isFailedOrPrecustomizedCustomElement const):
(WebCore::Node::isPrecustomizedCustomElement const):
(WebCore::Node::isPrecustomizedOrDefinedCustomElement const):
(WebCore::Node::isUndefinedCustomElement const): Deleted.
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::attachInternals):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLElement.idl:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::customElementState):

Canonical link: <a href="https://commits.webkit.org/253303@main">https://commits.webkit.org/253303@main</a>
</pre>
