### PR TITLE
[JSC] Remove typedArrayStorageType

### DIFF
--- a/Source/JavaScriptCore/API/JSTypedArray.cpp
+++ b/Source/JavaScriptCore/API/JSTypedArray.cpp
@@ -44,34 +44,33 @@ using namespace JSC;
 
 // Helper functions.
 
-inline JSTypedArrayType toJSTypedArrayType(TypedArrayType type)
+inline JSTypedArrayType toJSTypedArrayType(JSC::JSType type)
 {
     switch (type) {
-    case JSC::TypeDataView:
-    case NotTypedArray:
-        return kJSTypedArrayTypeNone;
-    case TypeInt8:
+    case JSC::Int8ArrayType:
         return kJSTypedArrayTypeInt8Array;
-    case TypeUint8:
+    case JSC::Uint8ArrayType:
         return kJSTypedArrayTypeUint8Array;
-    case TypeUint8Clamped:
+    case JSC::Uint8ClampedArrayType:
         return kJSTypedArrayTypeUint8ClampedArray;
-    case TypeInt16:
+    case JSC::Int16ArrayType:
         return kJSTypedArrayTypeInt16Array;
-    case TypeUint16:
+    case JSC::Uint16ArrayType:
         return kJSTypedArrayTypeUint16Array;
-    case TypeInt32:
+    case JSC::Int32ArrayType:
         return kJSTypedArrayTypeInt32Array;
-    case TypeUint32:
+    case JSC::Uint32ArrayType:
         return kJSTypedArrayTypeUint32Array;
-    case TypeFloat32:
+    case JSC::Float32ArrayType:
         return kJSTypedArrayTypeFloat32Array;
-    case TypeFloat64:
+    case JSC::Float64ArrayType:
         return kJSTypedArrayTypeFloat64Array;
-    case TypeBigInt64:
+    case JSC::BigInt64ArrayType:
         return kJSTypedArrayTypeBigInt64Array;
-    case TypeBigUint64:
+    case JSC::BigUint64ArrayType:
         return kJSTypedArrayTypeBigUint64Array;
+    default:
+        return kJSTypedArrayTypeNone;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -163,7 +162,7 @@ JSTypedArrayType JSValueGetTypedArrayType(JSContextRef ctx, JSValueRef valueRef,
     if (jsDynamicCast<JSArrayBuffer*>(object))
         return kJSTypedArrayTypeArrayBuffer;
 
-    return toJSTypedArrayType(object->classInfo()->typedArrayStorageType);
+    return toJSTypedArrayType(object->type());
 }
 
 JSObjectRef JSObjectMakeTypedArray(JSContextRef ctx, JSTypedArrayType arrayType, size_t length, JSValueRef* exception)
@@ -287,7 +286,7 @@ size_t JSObjectGetTypedArrayByteLength(JSContextRef, JSObjectRef objectRef, JSVa
     JSObject* object = toJS(objectRef);
 
     if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object))
-        return typedArray->length() * elementSize(typedArray->classInfo()->typedArrayStorageType);
+        return typedArray->length() * elementSize(typedArray->type());
 
     return 0;
 }

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -1856,32 +1856,31 @@ JSCTypedArrayType jsc_value_typed_array_get_type(JSCValue *value)
     if (!jsValue.isObject())
         return JSC_TYPED_ARRAY_NONE;
 
-    switch (jsValue.getObject()->classInfo()->typedArrayStorageType) {
-    case JSC::TypeDataView:
-    case JSC::NotTypedArray:
-        return JSC_TYPED_ARRAY_NONE;
-    case JSC::TypeInt8:
+    switch (jsValue.getObject()->type()) {
+    case JSC::Int8ArrayType:
         return JSC_TYPED_ARRAY_INT8;
-    case JSC::TypeUint8:
+    case JSC::Uint8ArrayType:
         return JSC_TYPED_ARRAY_UINT8;
-    case JSC::TypeUint8Clamped:
+    case JSC::Uint8ClampedArrayType:
         return JSC_TYPED_ARRAY_UINT8_CLAMPED;
-    case JSC::TypeInt16:
+    case JSC::Int16ArrayType:
         return JSC_TYPED_ARRAY_INT16;
-    case JSC::TypeUint16:
+    case JSC::Uint16ArrayType:
         return JSC_TYPED_ARRAY_UINT16;
-    case JSC::TypeInt32:
+    case JSC::Int32ArrayType:
         return JSC_TYPED_ARRAY_INT32;
-    case JSC::TypeUint32:
+    case JSC::Uint32ArrayType:
         return JSC_TYPED_ARRAY_UINT32;
-    case JSC::TypeFloat32:
+    case JSC::Float32ArrayType:
         return JSC_TYPED_ARRAY_FLOAT32;
-    case JSC::TypeFloat64:
+    case JSC::Float64ArrayType:
         return JSC_TYPED_ARRAY_FLOAT64;
-    case JSC::TypeBigInt64:
+    case JSC::BigInt64ArrayType:
         return JSC_TYPED_ARRAY_INT64;
-    case JSC::TypeBigUint64:
+    case JSC::BigUint64ArrayType:
         return JSC_TYPED_ARRAY_UINT64;
+    default:
+        return JSC_TYPED_ARRAY_NONE;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -84,8 +84,8 @@ inline bool GetByVariant::canMergeIntrinsicStructures(const GetByVariant& other)
     switch (intrinsic()) {
     case TypedArrayByteLengthIntrinsic: {
         // We can merge these sets as long as the element size of the two sets is the same.
-        TypedArrayType thisType = (*m_structureSet.begin())->classInfoForCells()->typedArrayStorageType;
-        TypedArrayType otherType = (*other.m_structureSet.begin())->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType thisType = typedArrayType((*m_structureSet.begin())->typeInfo().type());
+        TypedArrayType otherType = typedArrayType((*other.m_structureSet.begin())->typeInfo().type());
 
         ASSERT(isTypedView(thisType) && isTypedView(otherType));
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -616,39 +616,39 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
             accessType = AccessCase::IndexedScopedArgumentsLoad;
         else if (base->type() == StringType)
             accessType = AccessCase::IndexedStringLoad;
-        else if (isTypedView(base->classInfo()->typedArrayStorageType)) {
-            switch (base->classInfo()->typedArrayStorageType) {
-            case TypeInt8:
+        else if (isTypedView(base->type())) {
+            switch (base->type()) {
+            case Int8ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt8Load;
                 break;
-            case TypeUint8:
+            case Uint8ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint8Load;
                 break;
-            case TypeUint8Clamped:
+            case Uint8ClampedArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint8ClampedLoad;
                 break;
-            case TypeInt16:
+            case Int16ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt16Load;
                 break;
-            case TypeUint16:
+            case Uint16ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint16Load;
                 break;
-            case TypeInt32:
+            case Int32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt32Load;
                 break;
-            case TypeUint32:
+            case Uint32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint32Load;
                 break;
-            case TypeFloat32:
+            case Float32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayFloat32Load;
                 break;
-            case TypeFloat64:
+            case Float64ArrayType:
                 accessType = AccessCase::IndexedTypedArrayFloat64Load;
                 break;
             // FIXME: Optimize BigInt64Array / BigUint64Array in IC
             // https://bugs.webkit.org/show_bug.cgi?id=221183
-            case TypeBigInt64:
-            case TypeBigUint64:
+            case BigInt64ArrayType:
+            case BigUint64ArrayType:
                 return GiveUpOnCache;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -1029,39 +1029,39 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
         JSCell* base = baseValue.asCell();
 
         AccessCase::AccessType accessType;
-        if (isTypedView(base->classInfo()->typedArrayStorageType)) {
-            switch (base->classInfo()->typedArrayStorageType) {
-            case TypeInt8:
+        if (isTypedView(base->type())) {
+            switch (base->type()) {
+            case Int8ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt8Store;
                 break;
-            case TypeUint8:
+            case Uint8ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint8Store;
                 break;
-            case TypeUint8Clamped:
+            case Uint8ClampedArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint8ClampedStore;
                 break;
-            case TypeInt16:
+            case Int16ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt16Store;
                 break;
-            case TypeUint16:
+            case Uint16ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint16Store;
                 break;
-            case TypeInt32:
+            case Int32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayInt32Store;
                 break;
-            case TypeUint32:
+            case Uint32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayUint32Store;
                 break;
-            case TypeFloat32:
+            case Float32ArrayType:
                 accessType = AccessCase::IndexedTypedArrayFloat32Store;
                 break;
-            case TypeFloat64:
+            case Float64ArrayType:
                 accessType = AccessCase::IndexedTypedArrayFloat64Store;
                 break;
             // FIXME: Optimize BigInt64Array / BigUint64Array in IC
             // https://bugs.webkit.org/show_bug.cgi?id=221183
-            case TypeBigInt64:
-            case TypeBigUint64:
+            case BigInt64ArrayType:
+            case BigUint64ArrayType:
                 return GiveUpOnCache;
             default:
                 RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -522,9 +522,14 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
     if (classInfo->isSubClassOf(JSPromise::info()))
         return SpecPromiseObject;
     
-    if (isTypedView(classInfo->typedArrayStorageType))
-        return speculationFromTypedArrayType(classInfo->typedArrayStorageType);
-    
+#define JSC_TYPED_ARRAY_CHECK(type) do { \
+        static_assert(std::is_final<JS ## type ## Array>::value); \
+        if (classInfo == JS ## type ## Array::info()) \
+            return Spec ## type ## Array; \
+    } while (0);
+    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_CHECK)
+#undef JSC_TYPED_ARRAY_CHECK
+
     if (classInfo->isSubClassOf(JSObject::info()))
         return SpecObjectOther;
     

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1537,7 +1537,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setConstant(node, jsBoolean(child.value().isEmpty()));
                 break;
             case IsTypedArrayView:
-                setConstant(node, jsBoolean(child.value().isObject() && isTypedView(child.value().getObject()->classInfo()->typedArrayStorageType)));
+                setConstant(node, jsBoolean(child.value().isObject() && isTypedView(child.value().getObject()->type())));
                 break;
             default:
                 constantWasSet = false;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3832,12 +3832,12 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
 #endif
         insertChecks();
 
-        TypedArrayType type = (*variant.structureSet().begin())->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType type = typedArrayType((*variant.structureSet().begin())->typeInfo().type());
         Array::Type arrayType = toArrayType(type);
         size_t logSize = logElementSize(type);
 
         variant.structureSet().forEach([&] (Structure* structure) {
-            TypedArrayType curType = structure->classInfoForCells()->typedArrayStorageType;
+            TypedArrayType curType = typedArrayType(structure->typeInfo().type());
             ASSERT(logSize == logElementSize(curType));
             arrayType = refineTypedArrayType(arrayType, curType);
             ASSERT(arrayType != Array::Generic);
@@ -3869,11 +3869,11 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
 #endif
         insertChecks();
 
-        TypedArrayType type = (*variant.structureSet().begin())->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType type = typedArrayType((*variant.structureSet().begin())->typeInfo().type());
         Array::Type arrayType = toArrayType(type);
 
         variant.structureSet().forEach([&] (Structure* structure) {
-            TypedArrayType curType = structure->classInfoForCells()->typedArrayStorageType;
+            TypedArrayType curType = typedArrayType(structure->typeInfo().type());
             arrayType = refineTypedArrayType(arrayType, curType);
             ASSERT(arrayType != Array::Generic);
         });
@@ -3893,11 +3893,11 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
 #endif
         insertChecks();
 
-        TypedArrayType type = (*variant.structureSet().begin())->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType type = typedArrayType((*variant.structureSet().begin())->typeInfo().type());
         Array::Type arrayType = toArrayType(type);
 
         variant.structureSet().forEach([&] (Structure* structure) {
-            TypedArrayType curType = structure->classInfoForCells()->typedArrayStorageType;
+            TypedArrayType curType = typedArrayType(structure->typeInfo().type());
             arrayType = refineTypedArrayType(arrayType, curType);
             ASSERT(arrayType != Array::Generic);
         });

--- a/Source/JavaScriptCore/jit/IntrinsicEmitter.cpp
+++ b/Source/JavaScriptCore/jit/IntrinsicEmitter.cpp
@@ -60,9 +60,7 @@ bool IntrinsicGetterAccessCase::canEmitIntrinsicGetter(StructureStubInfo& stubIn
     case TypedArrayByteOffsetIntrinsic:
     case TypedArrayByteLengthIntrinsic:
     case TypedArrayLengthIntrinsic: {
-        TypedArrayType type = structure->classInfoForCells()->typedArrayStorageType;
-
-        if (!isTypedView(type))
+        if (!isTypedView(structure->typeInfo().type()))
             return false;
         
         return true;
@@ -98,7 +96,7 @@ void IntrinsicGetterAccessCase::emitIntrinsicGetter(AccessGenerationState& state
     }
 
     case TypedArrayByteLengthIntrinsic: {
-        TypedArrayType type = structure()->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType type = typedArrayType(structure()->typeInfo().type());
 #if USE(LARGE_TYPED_ARRAYS)
         jit.load64(MacroAssembler::Address(state.baseGPR, JSArrayBufferView::offsetOfLength()), valueGPR);
         if (elementSize(type) > 1)

--- a/Source/JavaScriptCore/runtime/ClassInfo.h
+++ b/Source/JavaScriptCore/runtime/ClassInfo.h
@@ -176,7 +176,6 @@ struct MethodTable {
         &ClassName::visitOutputConstraints, \
         &ClassName::visitOutputConstraints, \
     }, \
-    ClassName::TypedArrayStorageType, \
     sizeof(ClassName),
 
 struct CLASS_INFO_ALIGNMENT ClassInfo {
@@ -191,7 +190,6 @@ struct CLASS_INFO_ALIGNMENT ClassInfo {
     CheckJSCastSnippetFunctionPtr checkSubClassSnippet;
     const std::optional<JSTypeRange> inheritsJSTypeRange; // This is range of JSTypes for doing inheritance checking. Has the form: [firstJSType, lastJSType] (inclusive).
     MethodTable methodTable;
-    const TypedArrayType typedArrayStorageType;
     const unsigned staticClassSize;
 
     static ptrdiff_t offsetOfParentClass()

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -220,23 +220,9 @@ void JSArrayBufferView::detach()
     m_vector.clear();
 }
 
-static const constexpr size_t ElementSizeData[] = {
-#define FACTORY(type) sizeof(typename type ## Adaptor::Type),
-    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(FACTORY)
-#undef FACTORY
-    1, // DataViewType
-};
-
 #define FACTORY(type) static_assert(std::is_final<JS ## type ## Array>::value);
 FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(FACTORY)
 #undef FACTORY
-
-static inline size_t elementSize(JSType type)
-{
-    ASSERT(type >= Int8ArrayType && type <= DataViewType);
-    static_assert(BigUint64ArrayType + 1 == DataViewType);
-    return ElementSizeData[type - Int8ArrayType];
-}
 
 size_t JSArrayBufferView::byteLength() const
 {
@@ -349,7 +335,7 @@ JSArrayBufferView* validateTypedArray(JSGlobalObject* globalObject, JSValue type
     }
 
     JSCell* typedArrayCell = typedArrayValue.asCell();
-    if (!isTypedView(typedArrayCell->classInfo()->typedArrayStorageType)) {
+    if (!isTypedView(typedArrayCell->type())) {
         throwTypeError(globalObject, scope, "Argument needs to be a typed array."_s);
         return nullptr;
     }

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -66,7 +66,47 @@ struct JSTypeRange {
 };
 
 // Specific type overloads.
-#define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(macro) \
+
+template<typename>
+class JSGenericTypedArrayView;
+struct Int8Adaptor;
+struct Int16Adaptor;
+struct Int32Adaptor;
+struct Uint8Adaptor;
+struct Uint16Adaptor;
+struct Uint32Adaptor;
+struct Uint8ClampedAdaptor;
+struct Float32Adaptor;
+struct Float64Adaptor;
+struct BigInt64Adaptor;
+struct BigUint64Adaptor;
+
+using JSInt8Array = JSGenericTypedArrayView<Int8Adaptor>;
+using JSInt16Array = JSGenericTypedArrayView<Int16Adaptor>;
+using JSInt32Array = JSGenericTypedArrayView<Int32Adaptor>;
+using JSUint8Array = JSGenericTypedArrayView<Uint8Adaptor>;
+using JSUint8ClampedArray = JSGenericTypedArrayView<Uint8ClampedAdaptor>;
+using JSUint16Array = JSGenericTypedArrayView<Uint16Adaptor>;
+using JSUint32Array = JSGenericTypedArrayView<Uint32Adaptor>;
+using JSFloat32Array = JSGenericTypedArrayView<Float32Adaptor>;
+using JSFloat64Array = JSGenericTypedArrayView<Float64Adaptor>;
+using JSBigInt64Array = JSGenericTypedArrayView<BigInt64Adaptor>;
+using JSBigUint64Array = JSGenericTypedArrayView<BigUint64Adaptor>;
+
+#define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_NON_FORWARD_DECLARED(macro) \
+    /* TypedArrays are typedef, thus, we cannot use `class` forward declaration */ \
+    macro(JSInt8Array, JSType::Int8ArrayType, JSType::Int8ArrayType) \
+    macro(JSUint8Array, JSType::Uint8ArrayType, JSType::Uint8ArrayType) \
+    macro(JSInt16Array, JSType::Int16ArrayType, JSType::Int16ArrayType) \
+    macro(JSUint16Array, JSType::Uint16ArrayType, JSType::Uint16ArrayType) \
+    macro(JSInt32Array, JSType::Int32ArrayType, JSType::Int32ArrayType) \
+    macro(JSUint32Array, JSType::Uint32ArrayType, JSType::Uint32ArrayType) \
+    macro(JSFloat32Array, JSType::Float32ArrayType, JSType::Float32ArrayType) \
+    macro(JSFloat64Array, JSType::Float64ArrayType, JSType::Float64ArrayType) \
+    macro(JSBigInt64Array, JSType::BigInt64ArrayType, JSType::BigInt64ArrayType) \
+    macro(JSBigUint64Array, JSType::BigUint64ArrayType, JSType::BigUint64ArrayType) \
+
+#define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_FORWARD_DECLARED(macro) \
     macro(JSImmutableButterfly, JSType::JSImmutableButterflyType, JSType::JSImmutableButterflyType) \
     macro(JSStringIterator, JSType::JSStringIteratorType, JSType::JSStringIteratorType) \
     macro(JSObject, FirstObjectType, LastObjectType) \
@@ -101,11 +141,15 @@ struct JSTypeRange {
     macro(JSScope, JSType::GlobalObjectType, JSType::WithScopeType) \
     macro(StringObject, JSType::StringObjectType, JSType::DerivedStringObjectType) \
     macro(ShadowRealmObject, JSType::ShadowRealmType, JSType::ShadowRealmType) \
+    macro(JSDataView, JSType::DataViewType, JSType::DataViewType) \
 
+#define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(macro) \
+    FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_FORWARD_DECLARED(macro) \
+    FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_NON_FORWARD_DECLARED(macro) \
 
 // Forward declare the classes because they may not already exist.
 #define FORWARD_DECLARE_OVERLOAD_CLASS(className, jsType, op) class className;
-FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD(FORWARD_DECLARE_OVERLOAD_CLASS)
+FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_FORWARD_DECLARED(FORWARD_DECLARE_OVERLOAD_CLASS)
 #undef FORWARD_DECLARE_OVERLOAD_CLASS
 
 namespace JSCastingHelpers {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -147,7 +147,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     if (JSObject* object = jsDynamicCast<JSObject*>(firstValue)) {
         size_t length;
 
-        if (isTypedView(object->classInfo()->typedArrayStorageType)) {
+        if (isTypedView(object->type())) {
             auto* view = jsCast<JSArrayBufferView*>(object);
 
             if (view->isDetached()) {
@@ -155,7 +155,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
                 return nullptr;
             }
 
-            if (contentType(object->classInfo()->typedArrayStorageType) != ViewClass::contentType) {
+            if (contentType(object->type()) != ViewClass::contentType) {
                 throwTypeError(globalObject, scope, "Content types of source and new typed array are different"_s);
                 return nullptr;
             }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -264,26 +264,26 @@ bool JSGenericTypedArrayView<Adaptor>::set(
         if (!success)
             return false;
 
-        RELEASE_ASSERT(JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(other->classInfo()->typedArrayStorageType));
+        RELEASE_ASSERT(JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(other->type()));
         memmove(typedVector() + offset, bitwise_cast<typename Adaptor::Type*>(other->vector()) + objectOffset, length * elementSize);
         return true;
     };
 
-    const ClassInfo* ci = object->classInfo();
-    if (ci->typedArrayStorageType == Adaptor::typeValue)
+    TypedArrayType typedArrayType = JSC::typedArrayType(object->type());
+    if (typedArrayType == Adaptor::typeValue)
         return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
 
     auto isSomeUint8 = [] (TypedArrayType type) {
         return type == TypedArrayType::TypeUint8 || type == TypedArrayType::TypeUint8Clamped;
     };
 
-    if (isSomeUint8(ci->typedArrayStorageType) && isSomeUint8(Adaptor::typeValue))
+    if (isSomeUint8(typedArrayType) && isSomeUint8(Adaptor::typeValue))
         return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
 
-    if (isInt(Adaptor::typeValue) && isInt(ci->typedArrayStorageType) && !isClamped(Adaptor::typeValue) && JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(ci->typedArrayStorageType))
+    if (isInt(Adaptor::typeValue) && isInt(typedArrayType) && !isClamped(Adaptor::typeValue) && JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(typedArrayType))
         return memmoveFastPath(jsCast<JSArrayBufferView*>(object));
 
-    switch (ci->typedArrayStorageType) {
+    switch (typedArrayType) {
     case TypeInt8:
         RELEASE_AND_RETURN(scope, setWithSpecificType<Int8Adaptor>(
             globalObject, offset, jsCast<JSInt8Array*>(object), objectOffset, length, type));

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -158,7 +158,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSet(VM& vm, JSGlobalO
     RETURN_IF_EXCEPTION(scope, { });
 
     size_t length;
-    if (isTypedView(sourceArray->classInfo()->typedArrayStorageType)) {
+    if (isTypedView(sourceArray->type())) {
         JSArrayBufferView* sourceView = jsCast<JSArrayBufferView*>(sourceArray);
         if (UNLIKELY(sourceView->isDetached()))
             return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
@@ -601,7 +601,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
 
     // https://tc39.es/ecma262/#typedarray-species-create
     // If result.[[ContentType]] ≠ exemplar.[[ContentType]], throw a TypeError exception.
-    if (contentType(result->classInfo()->typedArrayStorageType) != ViewClass::contentType)
+    if (contentType(result->type()) != ViewClass::contentType)
         return throwVMTypeError(globalObject, scope, "Content types of source and created typed arrays are different"_s);
 
     // We return early here since we don't allocate a backing store if length is 0 and memmove does not like nullptrs
@@ -615,48 +615,48 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
     if (result->length() < length)
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.slice constructed typed array of insufficient length"_s);
 
-    switch (result->classInfo()->typedArrayStorageType) {
-    case TypeInt8:
+    switch (result->type()) {
+    case Int8ArrayType:
         scope.release();
         jsCast<JSInt8Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeInt16:
+    case Int16ArrayType:
         scope.release();
         jsCast<JSInt16Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeInt32:
+    case Int32ArrayType:
         scope.release();
         jsCast<JSInt32Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeUint8:
+    case Uint8ArrayType:
         scope.release();
         jsCast<JSUint8Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeUint8Clamped:
+    case Uint8ClampedArrayType:
         scope.release();
         jsCast<JSUint8ClampedArray*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeUint16:
+    case Uint16ArrayType:
         scope.release();
         jsCast<JSUint16Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeUint32:
+    case Uint32ArrayType:
         scope.release();
         jsCast<JSUint32Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeFloat32:
+    case Float32ArrayType:
         scope.release();
         jsCast<JSFloat32Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeFloat64:
+    case Float64ArrayType:
         scope.release();
         jsCast<JSFloat64Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeBigInt64:
+    case BigInt64ArrayType:
         scope.release();
         jsCast<JSBigInt64Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
-    case TypeBigUint64:
+    case BigUint64ArrayType:
         scope.release();
         jsCast<JSBigUint64Array*>(result)->set(globalObject, 0, thisObject, begin, length, CopyType::LeftToRight);
         return JSValue::encode(result);
@@ -730,7 +730,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncSubarrayCreate(VM& 
 
     JSArrayBufferView* validated = validateTypedArray(globalObject, result);
     RETURN_IF_EXCEPTION(scope, { });
-    if (contentType(validated->classInfo()->typedArrayStorageType) != ViewClass::contentType)
+    if (contentType(validated->type()) != ViewClass::contentType)
         return throwVMTypeError(globalObject, scope, "TypedArray.prototype.subarray constructed typed array of different content type from |this|"_s);
 
     return JSValue::encode(validated);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1040,7 +1040,7 @@ public:
     }
     bool isOriginalTypedArrayStructure(Structure* structure)
     {
-        TypedArrayType type = structure->classInfoForCells()->typedArrayStorageType;
+        TypedArrayType type = typedArrayType(structure->typeInfo().type());
         if (type == NotTypedArray)
             return false;
         return typedArrayStructureConcurrently(type) == structure;

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -557,7 +557,7 @@ public:
 
     bool hijacksIndexingHeader() const
     {
-        return isTypedView(m_classInfo->typedArrayStorageType);
+        return isTypedView(m_blob.type());
     }
     
     bool couldHaveIndexingHeader() const

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -255,7 +255,7 @@ inline bool Structure::hasIndexingHeader(const JSCell* cell) const
     if (hasIndexedProperties(indexingType()))
         return true;
     
-    if (!isTypedView(typedArrayTypeForType(m_blob.type())))
+    if (!isTypedView(m_blob.type()))
         return false;
 
     return jsCast<const JSArrayBufferView*>(cell)->mode() == WastefulTypedArray;

--- a/Source/JavaScriptCore/runtime/TypedArrayType.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayType.h
@@ -82,6 +82,43 @@ inline TypedArrayType indexToTypedArrayType(unsigned index)
     return result;
 }
 
+inline constexpr TypedArrayType typedArrayType(JSType type)
+{
+    switch (type) {
+    case Int8ArrayType:
+        return TypeInt8;
+    case Uint8ArrayType:
+        return TypeUint8;
+    case Uint8ClampedArrayType:
+        return TypeUint8Clamped;
+    case Int16ArrayType:
+        return TypeInt16;
+    case Uint16ArrayType:
+        return TypeUint16;
+    case Int32ArrayType:
+        return TypeInt32;
+    case Uint32ArrayType:
+        return TypeUint32;
+    case Float32ArrayType:
+        return TypeFloat32;
+    case Float64ArrayType:
+        return TypeFloat64;
+    case BigInt64ArrayType:
+        return TypeBigInt64;
+    case BigUint64ArrayType:
+        return TypeBigUint64;
+    case DataViewType:
+        return TypeDataView;
+    default:
+        return NotTypedArray;
+    }
+}
+
+inline bool isTypedView(JSType type)
+{
+    return type >= FirstTypedArrayType && type <= LastTypedArrayTypeExcludingDataView;
+}
+
 inline bool isTypedView(TypedArrayType type)
 {
     switch (type) {
@@ -133,6 +170,11 @@ inline unsigned logElementSize(TypedArrayType type)
 inline size_t elementSize(TypedArrayType type)
 {
     return static_cast<size_t>(1) << logElementSize(type);
+}
+
+inline size_t elementSize(JSType type)
+{
+    return static_cast<size_t>(1) << logElementSize(typedArrayType(type));
 }
 
 const ClassInfo* constructorClassInfoForType(TypedArrayType);
@@ -209,6 +251,27 @@ inline bool isSigned(TypedArrayType type)
 inline bool isClamped(TypedArrayType type)
 {
     return type == TypeUint8Clamped;
+}
+
+inline constexpr TypedArrayContentType contentType(JSType type)
+{
+    switch (type) {
+    case BigInt64ArrayType:
+    case BigUint64ArrayType:
+        return TypedArrayContentType::BigInt;
+    case Int8ArrayType:
+    case Int16ArrayType:
+    case Int32ArrayType:
+    case Uint8ArrayType:
+    case Uint16ArrayType:
+    case Uint32ArrayType:
+    case Float32ArrayType:
+    case Float64ArrayType:
+    case Uint8ClampedArrayType:
+        return TypedArrayContentType::Number;
+    default:
+        return TypedArrayContentType::None;
+    }
 }
 
 inline constexpr TypedArrayContentType contentType(TypedArrayType type)


### PR DESCRIPTION
#### e98e128329464e856b7fb19d157b4432a9eb69f3
<pre>
[JSC] Remove typedArrayStorageType
<a href="https://bugs.webkit.org/show_bug.cgi?id=243147">https://bugs.webkit.org/show_bug.cgi?id=243147</a>

Reviewed by Alexey Shvayka.

Sampling profiler showed that dispatching typed-array&apos;s derived types in typed array method is costly.
And we are using typedArrayStorageType from ClassInfo from Structure from object. But this is not necessary at all
since JSType of object can represent the necessary information completely.
This patch removes typedArrayStorageType from ClassInfo. And we get the same information from JSType of the object.

* Source/JavaScriptCore/API/JSTypedArray.cpp:
(toJSTypedArrayType):
(JSValueGetTypedArrayType):
(JSObjectGetTypedArrayByteLength):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_typed_array_get_type):
* Source/JavaScriptCore/bytecode/GetByVariant.cpp:
(JSC::GetByVariant::canMergeIntrinsicStructures const):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):
(JSC::tryCacheArrayPutByVal):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromClassInfoInheritance):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
* Source/JavaScriptCore/jit/IntrinsicEmitter.cpp:
(JSC::IntrinsicGetterAccessCase::canEmitIntrinsicGetter):
(JSC::IntrinsicGetterAccessCase::emitIntrinsicGetter):
* Source/JavaScriptCore/runtime/ClassInfo.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::validateTypedArray):
(JSC::elementSize): Deleted.
* Source/JavaScriptCore/runtime/JSCast.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArguments):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::set):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSet):
(JSC::genericTypedArrayViewProtoFuncSlice):
(JSC::genericTypedArrayViewPrivateFuncSubarrayCreate):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::isOriginalTypedArrayStructure):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::hijacksIndexingHeader const):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::hasIndexingHeader const):
* Source/JavaScriptCore/runtime/TypedArrayType.h:
(JSC::typedArrayType):
(JSC::isTypedView):
(JSC::elementSize):
(JSC::contentType):

Canonical link: <a href="https://commits.webkit.org/252772@main">https://commits.webkit.org/252772@main</a>
</pre>
