### PR TITLE
[JSC] The fast path for JSONP should handle TDZ

### DIFF
--- a/JSTests/stress/jsonp-program-evaluate-path-must-consider-global-lexical-environment.js
+++ b/JSTests/stress/jsonp-program-evaluate-path-must-consider-global-lexical-environment.js
@@ -13,6 +13,20 @@ let b = {f: 22};
 loadString("b.f = 42");
 assert(b.f === 42);
 
+let c = [1,2,3];
+loadString("c[0] = 42;");
+assert(c[0] === 42);
+
+let d = {
+    foo: [[1,2,3]]
+};
+loadString("d.foo[0][0] = 42;");
+assert(d.foo[0][0] === 42);
+
+let e = [[[1,2,3]]];
+loadString("e[0][0][0] = 42;");
+assert(e[0][0][0] === 42);
+
 let foo = null;
 let bar = 42;
 loadString("foo = 'root'; bar = 5")

--- a/JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js
+++ b/JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js
@@ -1,0 +1,106 @@
+disableRichSourceInfo();
+
+expectedError = "ReferenceError: Cannot access uninitialized variable.";
+
+function shouldThrow(func) {
+    var actualError = false;
+    try {
+        func();
+        throw new Error('func should have thrown');
+    } catch (e) {
+        actualError = e;
+    }
+    if (String(actualError) !== expectedError)
+        throw new Error('\nActual Value:' + actualError + '\nExpected Value:' + expectedError);
+}
+
+function test1() {
+    loadString("a = 42");
+}
+
+function test2() {
+    loadString("a.f = 42");
+}
+
+function test3() {
+    loadString("a[0] = 42;");
+}
+
+function test4() {
+    loadString("a = 'root'; b = 5;")
+}
+
+function test4() {
+    loadString("a({'foo':20})");
+}
+
+function test5() {
+    loadString("a(0)");
+}
+
+function test6() {
+    loadString("a.bar({'foo':20})");
+}
+
+function test7() {
+    loadString("a.foo[0][0] = 42;");
+}
+
+function test8() {
+    loadString("a[0][0][0] = 42;");
+}
+
+function test9() {
+    loadString("c = 42");
+}
+
+function test10() {
+    loadString("c.f = 42");
+}
+
+function test11() {
+    loadString("c[0] = 42;");
+}
+
+function test12() {
+    loadString("c = 'root'; d = 5;")
+}
+
+function test13() {
+    loadString("c({'foo':20})");
+}
+
+function test14() {
+    loadString("c(0)");
+}
+
+function test15() {
+    loadString("c.bar({'foo':20})");
+}
+
+function test16() {
+    loadString("c.foo[0][0] = 42;");
+}
+
+shouldThrow(test1);
+shouldThrow(test2);
+shouldThrow(test3);
+shouldThrow(test4);
+shouldThrow(test5);
+shouldThrow(test6);
+shouldThrow(test7);
+shouldThrow(test8);
+
+shouldThrow(test9);
+shouldThrow(test10);
+shouldThrow(test11);
+shouldThrow(test12);
+shouldThrow(test13);
+shouldThrow(test14);
+shouldThrow(test15);
+shouldThrow(test16);
+
+let a;
+let b;
+const c = 0;
+const d = 0;

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -831,6 +831,8 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
         parseResult = literalParser.tryJSONPParse(JSONPData, globalObject->globalObjectMethodTable()->supportsRichSourceInfo(globalObject));
     }
 
+    // FIXME: The patterns to trigger JSONP fast path should be more idiomatic.
+    // https://bugs.webkit.org/show_bug.cgi?id=243578
     RETURN_IF_EXCEPTION(throwScope, { });
     if (parseResult) {
         JSValue result;
@@ -896,18 +898,24 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
                 }
             }
 
+            const Identifier& ident = JSONPPath.last().m_pathEntryName;
             if (JSONPPath.size() == 1 && JSONPPath.last().m_type != JSONPPathEntryTypeLookup) {
                 RELEASE_ASSERT(baseObject == globalObject);
                 JSGlobalLexicalEnvironment* scope = globalObject->globalLexicalEnvironment();
-                if (scope->hasProperty(globalObject, JSONPPath.last().m_pathEntryName))
+                if (scope->hasProperty(globalObject, ident)) {
+                    RETURN_IF_EXCEPTION(throwScope, JSValue());
+                    PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
+                    JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
+                    if (slot.getValue(globalObject, ident) == jsTDZValue())
+                        return throwException(globalObject, throwScope, createTDZError(globalObject));
                     baseObject = scope;
-                RETURN_IF_EXCEPTION(throwScope, JSValue());
+                }
             }
 
             PutPropertySlot slot(baseObject);
             switch (JSONPPath.last().m_type) {
             case JSONPPathEntryTypeCall: {
-                JSValue function = baseObject.get(globalObject, JSONPPath.last().m_pathEntryName);
+                JSValue function = baseObject.get(globalObject, ident);
                 RETURN_IF_EXCEPTION(throwScope, JSValue());
                 auto callData = JSC::getCallData(function);
                 if (callData.type == CallData::Type::None)
@@ -921,7 +929,7 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
                 break;
             }
             case JSONPPathEntryTypeDot: {
-                baseObject.put(globalObject, JSONPPath.last().m_pathEntryName, JSONPValue, slot);
+                baseObject.put(globalObject, ident, JSONPValue, slot);
                 RETURN_IF_EXCEPTION(throwScope, JSValue());
                 break;
             }


### PR DESCRIPTION
#### 303ef67fea1e5cc1a71d7510579ad2e41e07d533
<pre>
[JSC] The fast path for JSONP should handle TDZ
<a href="https://bugs.webkit.org/show_bug.cgi?id=243578">https://bugs.webkit.org/show_bug.cgi?id=243578</a>
rdar://95963298

Reviewed by Alexey Shvayka.

TDZ are misuses for const/let in JSONP. If we don&apos;t want to abandon the benefits of the JSONP
fast path for const/let, we should throw exceptions for handling TDZ.

* JSTests/stress/jsonp-program-evaluate-path-must-consider-global-lexical-environment.js:
* JSTests/stress/jsonp-program-evaluate-path-must-handle-tdz.js: Added.
(shouldThrow):
(test1):
(test2):
(test3):
(test4):
(test5):
(test6):
(test7):
(test8):
(test9):
(test10):
(test11):
(test12):
(test13):
(test14):
(test15):
(test16):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):

Canonical link: <a href="https://commits.webkit.org/253157@main">https://commits.webkit.org/253157@main</a>
</pre>
