### PR TITLE
[JSC] Make species constructor for TypedArray fast

### DIFF
--- a/JSTests/microbenchmarks/typed-array-slice-hot.js
+++ b/JSTests/microbenchmarks/typed-array-slice-hot.js
@@ -1,0 +1,6 @@
+var typedArray = new Uint8Array(1024);
+typedArray.fill(253);
+var output = typedArray.slice();
+for (let i = 0; i < 1000000; i++) {
+    output = output.slice();
+}

--- a/JSTests/stress/typed-array-slice-before-watchpoint-insertion.js
+++ b/JSTests/stress/typed-array-slice-before-watchpoint-insertion.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+Uint8Array.__proto__ = {
+    __proto__: Uint16Array.__proto__,
+    [Symbol.species]: Uint16Array,
+};
+
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-constructor-replace.js
+++ b/JSTests/stress/typed-array-slice-constructor-replace.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+array.constructor = Uint16Array;
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-own-extend-but-fast.js
+++ b/JSTests/stress/typed-array-slice-own-extend-but-fast.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+uint8.hello = "Hello";
+var uint8_2 = array.slice();
+shouldBe(uint8_2 instanceof Uint8Array, true);
+shouldBe(uint8_2.length, 1024);

--- a/JSTests/stress/typed-array-slice-parent-replace.js
+++ b/JSTests/stress/typed-array-slice-parent-replace.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+
+function Middle() { }
+Middle.__proto__ = Uint8Array.__proto__;
+Reflect.defineProperty(Middle, Symbol.species, {
+    value: Uint16Array,
+    writable: true,
+});
+Uint8Array.__proto__ = Middle;
+
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-parent-species-replace.js
+++ b/JSTests/stress/typed-array-slice-parent-species-replace.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+
+Reflect.defineProperty(Uint8Array.__proto__, Symbol.species, {
+    writable: true,
+    value: Uint16Array,
+});
+
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-proto-constructor-replace.js
+++ b/JSTests/stress/typed-array-slice-proto-constructor-replace.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+Uint8Array.prototype.constructor = Uint16Array;
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-proto-replace.js
+++ b/JSTests/stress/typed-array-slice-proto-replace.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+
+array.__proto__ = {
+    __proto__: Uint8Array.prototype,
+    constructor: Uint16Array,
+};
+
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/JSTests/stress/typed-array-slice-species-define.js
+++ b/JSTests/stress/typed-array-slice-species-define.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = new Uint8Array(1024);
+var uint8 = array.slice();
+shouldBe(uint8 instanceof Uint8Array, true);
+shouldBe(uint8.length, 1024);
+Reflect.defineProperty(Uint8Array, Symbol.species, {
+    value: Uint16Array,
+    writable: true,
+});
+var uint16 = array.slice();
+shouldBe(uint16 instanceof Uint16Array, true);
+shouldBe(uint16.length, 1024);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1977,6 +1977,7 @@
 		E3893A1D2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */; };
 		E38DB2E727F588F80027BD3F /* ScriptExecutableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */; };
 		E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9788FC221471AD0C0068CE2D /* JSDateMath.cpp */; };
+		E38F091A288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */; };
 		E39006212208BFC4001019CF /* SubspaceAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = E39006202208BFC3001019CF /* SubspaceAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E392E6F824D25FA600B20767 /* B3BottomTupleValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392E6F624D25FA600B20767 /* B3BottomTupleValue.cpp */; };
 		E392E6F924D25FA900B20767 /* B3BottomTupleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E392E6F724D25FA600B20767 /* B3BottomTupleValue.h */; };
@@ -5465,6 +5466,7 @@
 		E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060D1F8E814100649CF2 /* JSScriptFetchParameters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSScriptFetchParameters.cpp; sourceTree = "<group>"; };
 		E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptExecutableInlines.h; sourceTree = "<group>"; };
+		E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectAdaptiveStructureWatchpoint.h; sourceTree = "<group>"; };
 		E39006202208BFC3001019CF /* SubspaceAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SubspaceAccess.h; sourceTree = "<group>"; };
 		E3915C062309682900CB2561 /* WasmContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmContext.cpp; sourceTree = "<group>"; };
 		E392E6F624D25FA600B20767 /* B3BottomTupleValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3BottomTupleValue.cpp; path = b3/B3BottomTupleValue.cpp; sourceTree = "<group>"; };
@@ -8128,6 +8130,7 @@
 				BC2680C40E16D4E900A06E92 /* NumberPrototype.cpp */,
 				BC2680C50E16D4E900A06E92 /* NumberPrototype.h */,
 				142D3938103E4560007DCB52 /* NumericStrings.h */,
+				E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */,
 				BC2680C60E16D4E900A06E92 /* ObjectConstructor.cpp */,
 				BC2680C70E16D4E900A06E92 /* ObjectConstructor.h */,
 				E374166D26912BC700C80789 /* ObjectConstructorInlines.h */,
@@ -10895,6 +10898,7 @@
 				C4F4B6F61A05C984005CAB76 /* objc_generator_templates.py in Headers */,
 				86F3EEBD168CDE930077B92A /* ObjCCallbackFunction.h in Headers */,
 				86F3EEBF168CDE930077B92A /* ObjcRuntimeExtras.h in Headers */,
+				E38F091A288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h in Headers */,
 				14CA958D16AB50FA00938A06 /* ObjectAllocationProfile.h in Headers */,
 				79AC30FF1F99536400484FD7 /* ObjectAllocationProfileInlines.h in Headers */,
 				BC18C4450E16F5CD00B34460 /* ObjectConstructor.h in Headers */,

--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -33,6 +33,7 @@
 #include "FunctionRareData.h"
 #include "HeapInlines.h"
 #include "LLIntPrototypeLoadAdaptiveStructureWatchpoint.h"
+#include "ObjectAdaptiveStructureWatchpoint.h"
 #include "StructureRareDataInlines.h"
 #include "StructureStubClearingWatchpoint.h"
 #include "VM.h"

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -110,6 +110,7 @@ class WatchpointSet;
     macro(FunctionRareDataAllocationProfileClearing, FunctionRareData::AllocationProfileClearingWatchpoint) \
     macro(CachedSpecialPropertyAdaptiveStructure, CachedSpecialPropertyAdaptiveStructureWatchpoint) \
     macro(StructureChainInvalidation, StructureChainInvalidationWatchpoint) \
+    macro(ObjectAdaptiveStructure, ObjectAdaptiveStructureWatchpoint) \
 
 #if ENABLE(JIT)
 #define JSC_WATCHPOINT_TYPES_WITHOUT_DFG(macro) \

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
@@ -49,6 +49,7 @@ void JSTypedArrayViewConstructor::finishCreation(VM& vm, JSGlobalObject* globalO
 
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->of, typedArrayConstructorOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->from, typedArrayConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    globalObject->installTypedArrayConstructorSpeciesWatchpoint(this);
 }
 
 Structure* JSTypedArrayViewConstructor::createStructure(

--- a/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ObjectPropertyCondition.h"
+#include "PackedCellPtr.h"
+#include "Watchpoint.h"
+
+namespace JSC {
+
+class ObjectAdaptiveStructureWatchpoint final : public Watchpoint {
+public:
+    ObjectAdaptiveStructureWatchpoint(JSCell* owner, const ObjectPropertyCondition& key, InlineWatchpointSet& watchpointSet)
+        : Watchpoint(Watchpoint::Type::ObjectAdaptiveStructure)
+        , m_key(key)
+        , m_owner(owner)
+        , m_watchpointSet(watchpointSet)
+    {
+        RELEASE_ASSERT(key.kind() != PropertyCondition::Equivalence);
+        RELEASE_ASSERT(key.watchingRequiresStructureTransitionWatchpoint());
+        RELEASE_ASSERT(!key.watchingRequiresReplacementWatchpoint());
+        RELEASE_ASSERT(watchpointSet.state() == IsWatched);
+    }
+
+    const ObjectPropertyCondition& key() const { return m_key; }
+
+    void install(VM&);
+
+    void fireInternal(VM&, const FireDetail&);
+
+private:
+    // Own destructor may not be called. Keep members trivially destructible.
+    JSC_WATCHPOINT_FIELD(ObjectPropertyCondition, m_key);
+    JSC_WATCHPOINT_FIELD(JSCell*, m_owner);
+    JSC_WATCHPOINT_FIELD(InlineWatchpointSet&, m_watchpointSet);
+};
+
+inline void ObjectAdaptiveStructureWatchpoint::install(VM&)
+{
+    RELEASE_ASSERT(m_key.isWatchable(PropertyCondition::MakeNoChanges));
+
+    m_key.object()->structure()->addTransitionWatchpoint(this);
+}
+
+inline void ObjectAdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail&)
+{
+    if (!m_owner->isLive())
+        return;
+
+    if (m_key.isWatchable(PropertyCondition::EnsureWatchability)) {
+        install(vm);
+        return;
+    }
+
+    m_watchpointSet.fireAll(vm, StringFireDetail("Object Property is added."));
+}
+
+} // namespace JSC


### PR DESCRIPTION
#### b4e6f9389bc51b544479064285db2a538306cba8
<pre>
[JSC] Make species constructor for TypedArray fast
<a href="https://bugs.webkit.org/show_bug.cgi?id=243148">https://bugs.webkit.org/show_bug.cgi?id=243148</a>

Reviewed by Saam Barati.

This patch accelerates TypedArray species-construct operation since it is consuming much time in TypedArray#slice.
The concept is that we should do the same optimization to ArraySpeciesCreate. But difficulty is that TypedArray
constructor is a bit awkwardly designed. So we need to carefully ensure the invariants.

TypedArray constructor&apos;s inheritance chain is that,

    Uint8Array (It does *not* have @@species getter)
    |
    v
    TypedArray (This *has* @@species getter)
    |
    v
    Function
    |
    v
    Object

And prototype is,

    Uint8Array.prototype (which has &quot;constructor&quot; property to Uint8Array)
    |
    v
    TypedArray.prototype (which has various TypedArray functions)
    |
    v
    ...

And in species construct, we first get &quot;constructor&quot; property of the instance, which looks up Uint8Array.prototype.constructor.
Then, from this constructor, we get @@species field (invoking a getter). It looks up TypedArray[@@species] and it returns |this|,
in this case, Uint8Array. And this is how species constructor is obtained.

In this patch, we have two WatchpointSet.

1. typedArraySpeciesWatchpointSet. It ensures that (1) Uint8Array constructor does not have @@species getter, (2) Uint8Array constructor&apos;s __proto__
   is TypedArray constructor, (3) and Uint8Array.prototype.constructor is Uint8Array constructor.
2. typedArrayConstructorSpeciesWatchpointSet. It ensures that TypedArray constructor has the default @@species getter.

For 1&apos;s (1) and (2), we track Uint8Array&apos;s @@species absence and its __proto__ via ObjectPropertyCondition::absence. We introduce ObjectAdaptiveStructureWatchpoint,
which looks similar to ObjectPropertyChangeAdaptiveWatchpoint, but it is usable for absence and presence. And 1&apos;s (3) is ensured by using ObjectPropertyChangeAdaptiveWatchpoint.
For 2, we use ObjectPropertyChangeAdaptiveWatchpoint.

If these conditions are met, we can skip &quot;constructor&quot; and @@species property lookups if (1) the instance does not have properties (which can shadow &quot;constructor&quot;) and
(2) the instance&apos;s __proto__ is Uint8Array.prototype. speciesWatchpointIsValid checks them.

Attached microbenchmark showed 2x better score.

                                      ToT                     Patched

    typed-array-slice-hot      239.3897+-0.3691     ^    118.0493+-0.2077        ^ definitely 2.0279x faster

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/bytecode/Watchpoint.cpp:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesWatchpointIsValid):
(JSC::speciesConstruct):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
(JSC::JSGlobalObject::tryInstallSpeciesWatchpoint):
(JSC::JSGlobalObject::tryInstallArraySpeciesWatchpoint):
(JSC::JSGlobalObject::tryInstallArrayBufferSpeciesWatchpoint):
(JSC::JSGlobalObject::tryInstallTypedArraySpeciesWatchpoint):
(JSC::JSGlobalObject::installTypedArrayConstructorSpeciesWatchpoint):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::typedArrayConstructorSpeciesWatchpoint):
(JSC::JSGlobalObject::typedArrayPrototypeConstructorWatchpoint):
(JSC::JSGlobalObject::typedArraySpeciesWatchpointSet):
(JSC::JSGlobalObject::typedArrayConstructorSpeciesWatchpointSet):
(JSC::JSGlobalObject::typedArrayPrototype const):
* Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp:
(JSC::JSTypedArrayViewConstructor::finishCreation):
* Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h: Added.
(JSC::ObjectAdaptiveStructureWatchpoint::install):
(JSC::ObjectAdaptiveStructureWatchpoint::fireInternal):
* JSTests/stress/typed-array-slice-constructor-replace.js: Added.
(shouldBe):
* JSTests/stress/typed-array-slice-own-extend-but-fast.js: Added.
(shouldBe):
* JSTests/stress/typed-array-slice-parent-replace.js: Added.
(shouldBe):
(Middle):
* JSTests/stress/typed-array-slice-parent-species-replace.js: Added.
(shouldBe):
* JSTests/stress/typed-array-slice-proto-constructor-replace.js: Added.
(shouldBe):
* JSTests/stress/typed-array-slice-proto-replace.js: Added.
(shouldBe):
* JSTests/stress/typed-array-slice-species-define.js: Added.
(shouldBe):

Canonical link: <a href="https://commits.webkit.org/252847@main">https://commits.webkit.org/252847@main</a>
</pre>
