### PR TITLE
Remove :role() pseudo-class implementation

### DIFF
--- a/LayoutTests/fast/css/css-selector-text-expected.txt
+++ b/LayoutTests/fast/css/css-selector-text-expected.txt
@@ -553,19 +553,7 @@ PASS parseThenSerializeRule(':lang(   *-1996   ,  *-1997   ) { }') threw excepti
 PASS parseThenSerializeRule(':lang(   *-1996   ,*-1997   ) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 PASS parseThenSerializeRule(':lang(   *-1996,*-1997   ) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 
-PASS parseThenSerializeRule(':role(a) { }') is ':role(a) { }'
-PASS parseThenSerializeRule(':role(button) { }') is ':role(button) { }'
-PASS parseThenSerializeRule(':role(LiNk) { }') is ':role(LiNk) { }'
-PASS parseThenSerializeRule(':role( a    ) { }') is ':role(a) { }'
-
-PASS parseThenSerializeRule(':role() { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(42) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(a, b) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(}) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role()) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(role()) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(:role()) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
-PASS parseThenSerializeRule(':role(:role(a)) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
+PASS parseThenSerializeRule(':role(a) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 
 PASS parseThenSerializeRule(':dir(ltr) { }') is ':dir(ltr) { }'
 PASS parseThenSerializeRule(':dir(rtl) { }') is ':dir(rtl) { }'

--- a/LayoutTests/fast/css/css-selector-text.html
+++ b/LayoutTests/fast/css/css-selector-text.html
@@ -703,21 +703,7 @@ shouldThrow("parseThenSerializeRule(':lang(   *-1996,*-1997   ) { }')");
 
 debug('');
 
-testSelectorRoundTrip(":role(a)");
-testSelectorRoundTrip(":role(button)");
-testSelectorRoundTrip(":role(LiNk)");
-shouldBe("parseThenSerializeRule(':role( a    ) { }')", "':role(a) { }'");
-
-debug('');
-
-shouldThrow("parseThenSerializeRule(':role() { }')");
-shouldThrow("parseThenSerializeRule(':role(42) { }')");
-shouldThrow("parseThenSerializeRule(':role(a, b) { }')");
-shouldThrow("parseThenSerializeRule(':role(}) { }')");
-shouldThrow("parseThenSerializeRule(':role()) { }')");
-shouldThrow("parseThenSerializeRule(':role(role()) { }')");
-shouldThrow("parseThenSerializeRule(':role(:role()) { }')");
-shouldThrow("parseThenSerializeRule(':role(:role(a)) { }')");
+shouldThrow("parseThenSerializeRule(':role(a) { }')");
 
 debug('');
 

--- a/LayoutTests/fast/css/css-set-selector-text-expected.txt
+++ b/LayoutTests/fast/css/css-set-selector-text-expected.txt
@@ -67,7 +67,6 @@ PASS setThenReadSelectorText(':dir(a)') is ':dir(a)'
 PASS setThenReadSelectorText(':lang("a")') is ':lang("a")'
 PASS setThenReadSelectorText(':lang(a)') is ':lang("a")'
 PASS setThenReadSelectorText(':not(a)') is ':not(a)'
-PASS setThenReadSelectorText(':role(a)') is ':role(a)'
 PASS setThenReadSelectorText(':-webkit-any(a, b, p)') is ':-webkit-any(a, b, p)'
 
 PASS setThenReadSelectorText('::after') is '::after'

--- a/LayoutTests/fast/css/css-set-selector-text.html
+++ b/LayoutTests/fast/css/css-set-selector-text.html
@@ -136,7 +136,6 @@ testSelectorRoundTrip(":dir(a)");
 testSelectorRoundTrip(":lang(\"a\")");
 testSelectorRoundTrip(":lang(a)");
 testSelectorRoundTrip(":not(a)");
-testSelectorRoundTrip(":role(a)");
 testSelectorRoundTrip(":-webkit-any(a, b, p)");
 
 debug('');

--- a/LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt
+++ b/LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt
@@ -419,58 +419,6 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
-PASS document.querySelectorAll(":role\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":role\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":role\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":role\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
-PASS document.styleSheets[1].cssRules.length is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/invalid-functional-pseudo-class.html
+++ b/LayoutTests/fast/selectors/invalid-functional-pseudo-class.html
@@ -71,7 +71,6 @@ var functionalPseudoClasses = [
     "nth-last-child",
     "nth-last-of-type",
     "nth-of-type",
-    "role",
 ];
 
 for (var functionalPseudoClass of functionalPseudoClasses)

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -343,9 +343,6 @@ static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelec
     case CSSSelector::PseudoClassNthLastChild:
     case CSSSelector::PseudoClassNthOfType:
     case CSSSelector::PseudoClassNthLastOfType:
-#if ENABLE(CSS_SELECTORS_LEVEL4)
-    case CSSSelector::PseudoClassRole:
-#endif
         builder.append(selector->argument());
         builder.append(')');
         break;
@@ -676,12 +673,6 @@ String CSSSelector::selectorText(const String& rightSide) const
             case CSSSelector::PseudoClassRequired:
                 builder.append(":required");
                 break;
-#if ENABLE(CSS_SELECTORS_LEVEL4)
-            case CSSSelector::PseudoClassRole:
-                builder.append(":role(");
-                appendPseudoClassFunctionTail(builder, cs);
-                break;
-#endif
             case CSSSelector::PseudoClassRoot:
                 builder.append(":root");
                 break;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -178,7 +178,6 @@ namespace WebCore {
 #endif
 #if ENABLE(CSS_SELECTORS_LEVEL4)
             PseudoClassDir,
-            PseudoClassRole,
 #endif
             PseudoClassHost,
             PseudoClassDefined,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1120,10 +1120,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 #if ENABLE(CSS_SELECTORS_LEVEL4)
         case CSSSelector::PseudoClassDir:
             return matchesDirPseudoClass(element, selector.argument());
-
-        // FIXME: Implement :role() selector.
-        case CSSSelector::PseudoClassRole:
-            return false;
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -64,9 +64,6 @@ placeholder-shown
 read-only
 read-write
 required
-#if ENABLE(CSS_SELECTORS_LEVEL4)
-role
-#endif
 root
 scope
 single-button

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -600,7 +600,6 @@ static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassTy
     case CSSSelector::PseudoClassAny:
 #if ENABLE(CSS_SELECTORS_LEVEL4)
     case CSSSelector::PseudoClassDir:
-    case CSSSelector::PseudoClassRole:
 #endif
         return true;
     default:
@@ -763,8 +762,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             return selector;
         }
 #if ENABLE(CSS_SELECTORS_LEVEL4)
-        case CSSSelector::PseudoClassDir:
-        case CSSSelector::PseudoClassRole: {
+        case CSSSelector::PseudoClassDir: {
             const CSSParserToken& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -974,7 +974,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClassRelativeScope:
 #if ENABLE(CSS_SELECTORS_LEVEL4)
     case CSSSelector::PseudoClassDir:
-    case CSSSelector::PseudoClassRole:
 #endif
         return FunctionType::CannotCompile;
 


### PR DESCRIPTION
#### 4f6fdd5fa416190cbc901af7dc4407c40ed9c03e
<pre>
Remove :role() pseudo-class implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243151">https://bugs.webkit.org/show_bug.cgi?id=243151</a>

Reviewed by Ryosuke Niwa.

The matching is not implemented, and it&apos;s not part of the spec: <a href="https://github.com/w3c/csswg-drafts/issues/3596.">https://github.com/w3c/csswg-drafts/issues/3596.</a>
Let&apos;s remove since it&apos;s confusing.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::appendPseudoClassFunctionTail):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isOnlyPseudoClassFunction):
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):

* LayoutTests/fast/css/css-selector-text-expected.txt:
* LayoutTests/fast/css/css-selector-text.html:
* LayoutTests/fast/css/css-set-selector-text-expected.txt:
* LayoutTests/fast/css/css-set-selector-text.html:
* LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt:
* LayoutTests/fast/selectors/invalid-functional-pseudo-class.html:

Canonical link: <a href="https://commits.webkit.org/252786@main">https://commits.webkit.org/252786@main</a>
</pre>
