### PR TITLE
Make repatchable call lifecycle simpler.

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -307,7 +307,7 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
                 target = codeOutData + to - offset; // Compensate for what we have collapsed so far
             else
                 target = codeOutData + to - executableOffsetFor(to);
-                
+
             JumpLinkType jumpLinkType = MacroAssembler::computeJumpType(jumpsToLink[i], codeOutData + writePtr, target);
             // Compact branch if we can...
             if (MacroAssembler::canCompact(jumpsToLink[i].type())) {
@@ -411,7 +411,7 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
 void LinkBuffer::linkCode(MacroAssembler& macroAssembler, JITCompilationEffort effort)
 {
     // Ensure that the end of the last invalidation point does not extend beyond the end of the buffer.
-    macroAssembler.label();
+    macroAssembler.padBeforePatch();
 
 #if !ENABLE(BRANCH_COMPACTION)
 #if defined(ASSEMBLER_HAS_CONSTANT_POOL) && ASSEMBLER_HAS_CONSTANT_POOL

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -425,41 +425,49 @@ public:
 #if !CPU(ARM_THUMB2) && !CPU(ARM64)
     PatchableJump patchableBranchPtr(RelationalCondition cond, Address left, TrustedImmPtr right = TrustedImmPtr(nullptr))
     {
+        padBeforePatch();
         return PatchableJump(branchPtr(cond, left, right));
     }
     
     PatchableJump patchableBranchPtrWithPatch(RelationalCondition cond, Address left, DataLabelPtr& dataLabel, TrustedImmPtr initialRightValue = TrustedImmPtr(nullptr))
     {
+        padBeforePatch();
         return PatchableJump(branchPtrWithPatch(cond, left, dataLabel, initialRightValue));
     }
 
     PatchableJump patchableBranch32WithPatch(RelationalCondition cond, Address left, DataLabel32& dataLabel, TrustedImm32 initialRightValue = TrustedImm32(0))
     {
+        padBeforePatch();
         return PatchableJump(branch32WithPatch(cond, left, dataLabel, initialRightValue));
     }
 
     PatchableJump patchableJump()
     {
+        padBeforePatch();
         return PatchableJump(jump());
     }
 
     PatchableJump patchableBranchTest32(ResultCondition cond, RegisterID reg, TrustedImm32 mask = TrustedImm32(-1))
     {
+        padBeforePatch();
         return PatchableJump(branchTest32(cond, reg, mask));
     }
 
     PatchableJump patchableBranch32(RelationalCondition cond, RegisterID reg, TrustedImm32 imm)
     {
+        padBeforePatch();
         return PatchableJump(branch32(cond, reg, imm));
     }
 
     PatchableJump patchableBranch8(RelationalCondition cond, Address address, TrustedImm32 imm)
     {
+        padBeforePatch();
         return PatchableJump(branch8(cond, address, imm));
     }
 
     PatchableJump patchableBranch32(RelationalCondition cond, Address address, TrustedImm32 imm)
     {
+        padBeforePatch();
         return PatchableJump(branch32(cond, address, imm));
     }
 #endif

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
@@ -206,7 +206,7 @@ public:
         } else
 #endif
             m_assembler.blrab(targetGPR, tagGPR);
-        return Call(m_assembler.label(), Call::None);
+        return Call(m_assembler.labelIgnoringWatchpoints(), Call::None);
     }
 
     ALWAYS_INLINE Call call(RegisterID targetGPR, PtrTag tag)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -268,6 +268,7 @@ public:
 
     Call threadSafePatchableNearCall()
     {
+        padBeforePatch();
         const size_t nearCallOpcodeSize = 1;
         const size_t nearCallRelativeLocationSize = sizeof(int32_t);
         // We want to make sure the 32-bit near call immediate is 32-bit aligned.
@@ -1573,11 +1574,13 @@ public:
 
     PatchableJump patchableBranch64(RelationalCondition cond, RegisterID reg, TrustedImm64 imm)
     {
+        padBeforePatch();
         return PatchableJump(branch64(cond, reg, imm));
     }
 
     PatchableJump patchableBranch64(RelationalCondition cond, RegisterID left, RegisterID right)
     {
+        padBeforePatch();
         return PatchableJump(branch64(cond, left, right));
     }
     

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -135,7 +135,7 @@ void CallLinkInfo::clearCallee()
     if (isDataIC()) {
         u.dataIC.m_codeBlock = nullptr;
         u.dataIC.m_monomorphicCallDestination = nullptr;
-    } else if (!clearedByJettison()) {
+    } else {
 #if ENABLE(JIT)
         MacroAssembler::repatchPointer(u.codeIC.m_codeBlockLocation, nullptr);
         MacroAssembler::repatchPointer(u.codeIC.m_calleeLocation, nullptr);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -265,19 +265,9 @@ public:
         return m_clearedByVirtual;
     }
 
-    bool clearedByJettison()
-    {
-        return m_clearedByJettison;
-    }
-
     void setClearedByVirtual()
     {
         m_clearedByVirtual = true;
-    }
-
-    void setClearedByJettison()
-    {
-        m_clearedByJettison = true;
     }
     
     void setCallType(CallType callType)
@@ -379,7 +369,6 @@ protected:
         , m_clearedByGC(false)
         , m_clearedByVirtual(false)
         , m_allowStubs(true)
-        , m_clearedByJettison(false)
         , m_callType(None)
         , m_useDataIC(static_cast<unsigned>(useDataIC))
         , m_type(static_cast<unsigned>(type))
@@ -422,7 +411,6 @@ protected:
     bool m_clearedByGC : 1;
     bool m_clearedByVirtual : 1;
     bool m_allowStubs : 1;
-    bool m_clearedByJettison : 1;
     unsigned m_callType : 4; // CallType
     unsigned m_useDataIC : 1; // UseDataIC
     unsigned m_type : 1; // Type

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2285,21 +2285,6 @@ void CodeBlock::jettison(Profiler::JettisonReason reason, ReoptimizationMode mod
     if (vm.heap.currentThreadIsDoingGCWork() && !vm.heap.isMarked(ownerExecutable()))
         return;
 
-    {
-        ConcurrentJSLocker locker(m_lock);
-        if (JITCode::isOptimizingJIT(jitType())) {
-#if ENABLE(DFG_JIT)
-            DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
-            for (auto* callLinkInfo : dfgCommon->m_callLinkInfos)
-                callLinkInfo->setClearedByJettison();
-#endif
-        } else {
-            forEachLLIntOrBaselineCallLinkInfo([&](BaselineCallLinkInfo& callLinkInfo) {
-                callLinkInfo.setClearedByJettison();
-            });
-        }
-    }
-
     // This accomplishes (2).
     ownerExecutable()->installCode(vm, alternative(), codeType(), specializationKind());
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -141,16 +141,13 @@ static void revertCall(VM& vm, CallLinkInfo& callLinkInfo, MacroAssemblerCodeRef
     if (callLinkInfo.isDirect()) {
 #if ENABLE(JIT)
         callLinkInfo.clearCodeBlock();
-        if (!callLinkInfo.clearedByJettison())
-            static_cast<OptimizingCallLinkInfo&>(callLinkInfo).initializeDirectCall();
+        static_cast<OptimizingCallLinkInfo&>(callLinkInfo).initializeDirectCall();
 #endif
     } else {
-        if (!callLinkInfo.clearedByJettison()) {
-            linkSlowPathTo(vm, callLinkInfo, codeRef);
+        linkSlowPathTo(vm, callLinkInfo, codeRef);
 
-            if (callLinkInfo.stub())
-                callLinkInfo.revertCallToStub();
-        }
+        if (callLinkInfo.stub())
+            callLinkInfo.revertCallToStub();
         callLinkInfo.clearCallee(); // This also clears the inline cache both for data and code-based caches.
     }
     callLinkInfo.clearSeen();

--- a/Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp
@@ -43,6 +43,8 @@ void JumpReplacement::fire()
 
 void JumpReplacement::installVMTrapBreakpoint()
 {
+    dataLogLnIf(Options::dumpDisassembly(),
+        "Inserting VMTrap breakpoint at ", RawPointer(m_source.dataLocation()));
 #if ENABLE(SIGNAL_BASED_VM_TRAPS)
     MacroAssembler::replaceWithVMHalt(m_source);
 #else

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -723,7 +723,7 @@ void SpeculativeJIT::emitCall(Node* node)
     unsigned numAllocatedArgs = 0;
 
     auto* callLinkInfo = m_jit.jitCode()->common.addCallLinkInfo(m_currentNode->origin.semantic, m_graph.m_plan.isUnlinked() ? CallLinkInfo::UseDataIC::Yes : CallLinkInfo::UseDataIC::No);
-    
+
     // Gotta load the arguments somehow. Varargs is trickier.
     if (isVarargs || isForwardVarargs) {
         RELEASE_ASSERT(!isDirect);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1352,6 +1352,7 @@ public:
     void jitAssertArgumentCountSane();
     inline void jitAssertNoException(VM& vm) { jitReleaseAssertNoException(vm); }
     void jitAssertCodeBlockOnCallFrameWithType(GPRReg scratchGPR, JITType);
+    void jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(GPRReg scratchGPR, GPRReg scratchGPR2, UnlinkedCodeBlock&);
     void jitAssertCodeBlockOnCallFrameIsOptimizingJIT(GPRReg scratchGPR);
 #else
     void jitAssertIsInt32(GPRReg) { }
@@ -1366,6 +1367,7 @@ public:
     void jitAssertNoException(VM&) { }
     void jitAssertCodeBlockOnCallFrameWithType(GPRReg, JITType) { }
     void jitAssertCodeBlockOnCallFrameIsOptimizingJIT(GPRReg) { }
+    void jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(GPRReg, GPRReg, UnlinkedCodeBlock&) { }
 #endif
 
     void jitReleaseAssertNoException(VM&);

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -772,6 +772,7 @@ void JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
 
     emitFunctionPrologue();
     jitAssertCodeBlockOnCallFrameWithType(regT2, JITType::BaselineJIT);
+    jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(regT1, regT2, *m_unlinkedCodeBlock);
 
     Label beginLabel(this);
 
@@ -840,6 +841,7 @@ void JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
         emitFunctionPrologue();
         RELEASE_ASSERT(m_unlinkedCodeBlock->codeType() == FunctionCode);
         jitAssertCodeBlockOnCallFrameWithType(regT2, JITType::BaselineJIT);
+        jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame(regT1, regT2, *m_unlinkedCodeBlock);
         emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, regT0);
         store8(TrustedImm32(0), Address(regT0, CodeBlock::offsetOfShouldAlwaysBeInlined()));
 


### PR DESCRIPTION
#### 2b0e24b7e532633654c7828054a5003b22f07be8
<pre>
Make repatchable call lifecycle simpler.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243152">https://bugs.webkit.org/show_bug.cgi?id=243152</a>
rdar://90362880

Reviewed by Saam Barati.

Revert <a href="https://commits.webkit.org/210646@main">https://commits.webkit.org/210646@main</a> (CodeBlock::jettison()
should disallow repatching its own calls) and fix it the cleaner way.

21064 made the lifecycle of repatchable calls more complex, so
let&apos;s revert it and fix it by inserting labels before patchable things.

It did this to try to stop us from re-patching call ICs that were inside
InvalidationPoints. That is, we would write the InvalidationPoint exit ramp
jump, then later the code in jettison would re-patch the call IC breaking
the jump.

Any patchable place should never be overlapping with an InvalidationPoint, and
label() already handles this correctly because we don&apos;t want OSR exit jumps to
destroy loops. We just make sure, once and for all, that we always have a label
before a patchable thing.

This ensures that there is always room to write an InvalidationPoint&apos;s
OSR exit ramp jump without that jump being overwritten later, and this
makes the code much simpler.

Also, we fix a few places where we emitted a branch condition and then a
branch with a regular label in between. In practice this can never pose
an issue, but it made branch compaction fail when I increased the size of
maxJumpReplacementSize() to double-check that we weren&apos;t missing any labels.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::copyCompactAndLinkCode):
(JSC::LinkBuffer::linkCode):
* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::patchableBranchPtr):
(JSC::MacroAssembler::patchableBranchPtrWithPatch):
(JSC::MacroAssembler::patchableBranch32WithPatch):
(JSC::MacroAssembler::patchableJump):
(JSC::MacroAssembler::patchableBranchTest32):
(JSC::MacroAssembler::patchableBranch32):
(JSC::MacroAssembler::patchableBranch8):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::call):
(JSC::MacroAssemblerARM64::nearCall):
(JSC::MacroAssemblerARM64::threadSafePatchableNearCall):
(JSC::MacroAssemblerARM64::makeBranch):
(JSC::MacroAssemblerARM64::makeCompareAndBranch):
(JSC::MacroAssemblerARM64::makeTestBitAndBranch):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h:
(JSC::MacroAssemblerARM64E::callRegister):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::threadSafePatchableNearCall):
(JSC::MacroAssemblerX86_64::patchableBranch64):
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::clearCallee):
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::setClearedByVirtual):
(JSC::CallLinkInfo::CallLinkInfo):
(JSC::CallLinkInfo::clearedByJettison): Deleted.
(JSC::CallLinkInfo::setClearedByJettison): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::jettison):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::revertCall):
* Source/JavaScriptCore/dfg/DFGJumpReplacement.cpp:
(JSC::DFG::JumpReplacement::installVMTrapBreakpoint):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileAndLinkWithoutFinalizing):

Canonical link: <a href="https://commits.webkit.org/252789@main">https://commits.webkit.org/252789@main</a>
</pre>
