### PR TITLE
[WebIDL] @@iterator of a setlike<> interface should be its "values" method

### DIFF
--- a/LayoutTests/highlight/highlight-interfaces-expected.txt
+++ b/LayoutTests/highlight/highlight-interfaces-expected.txt
@@ -7,6 +7,7 @@ Testing Highlight:
 PASS Highlight instanceof Function is true
 PASS typeof Highlight is "function"
 PASS new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})) instanceof Highlight is true
+PASS Highlight.prototype[Symbol.iterator] is Highlight.prototype.values
 PASS HighlightRegister instanceof Function is true
 PASS typeof HighlightRegister is "function"
 PASS new HighlightRegister() instanceof HighlightRegister is true

--- a/LayoutTests/highlight/highlight-interfaces.html
+++ b/LayoutTests/highlight/highlight-interfaces.html
@@ -10,6 +10,7 @@ debug("Testing Highlight:");
 shouldBeTrue("Highlight instanceof Function");
 shouldBeEqualToString("typeof Highlight", "function");
 shouldBeTrue("new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})) instanceof Highlight");
+shouldBe("Highlight.prototype[Symbol.iterator]", "Highlight.prototype.values");
 shouldBeTrue("HighlightRegister instanceof Function");
 shouldBeEqualToString("typeof HighlightRegister", "function");
 shouldBeTrue("new HighlightRegister() instanceof HighlightRegister");

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -401,7 +401,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     push(@{$forEachOperation->arguments}, ($forEachArgument));
     $forEachOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($forEachOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    # FIXME: The WebIDL spec says that the forEach operation should be enumerable.
     $forEachOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $forEachOperation);
 
@@ -4656,8 +4655,10 @@ sub GenerateImplementation
 
         if (InterfaceNeedsIterator($interface)) {
             AddToImplIncludes("<JavaScriptCore/BuiltinNames.h>");
-            if (IsKeyValueIterableInterface($interface) or $interface->mapLike or $interface->setLike) {
+            if (IsKeyValueIterableInterface($interface) or $interface->mapLike) {
                 push(@implContent, "    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));\n");
+            } elsif ($interface->setLike) {
+                push(@implContent, "    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().valuesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));\n");
             } else {
                 AddToImplIncludes("<JavaScriptCore/ArrayPrototype.h>");
                 push(@implContent, "    putDirect(vm, vm.propertyNames->iteratorSymbol, globalObject()->arrayPrototype()->getDirect(vm, vm.propertyNames->builtinNames().valuesPrivateName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));\n");

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -134,7 +134,7 @@ void JSTestReadOnlySetLikePrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTestReadOnlySetLike::info(), JSTestReadOnlySetLikePrototypeTableValues, *this);
-    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().valuesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -140,7 +140,7 @@ void JSTestSetLikePrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTestSetLike::info(), JSTestSetLikePrototypeTableValues, *this);
-    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().valuesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -144,7 +144,7 @@ void JSTestSetLikeWithOverriddenOperationsPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSTestSetLikeWithOverriddenOperations::info(), JSTestSetLikeWithOverriddenOperationsPrototypeTableValues, *this);
-    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().valuesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 


### PR DESCRIPTION
#### 7a065485d2f19a25311e51a57b78a5210e3518f4
<pre>
[WebIDL] @@iterator of a setlike&lt;&gt; interface should be its &quot;values&quot; method
<a href="https://bugs.webkit.org/show_bug.cgi?id=243153">https://bugs.webkit.org/show_bug.cgi?id=243153</a>

Reviewed by Yusuke Suzuki.

Before this change, @@iterator was its &quot;entries&quot; method, which didn&apos;t match
the spec [1] nor Chrome.

Also, this change removes FIXME about enumerability of setlike&lt;&gt; interface&apos;s
&quot;forEach&quot;, which should be non-enumerable [2] like other similar methods.

[1] <a href="https://webidl.spec.whatwg.org/#es-set-iterator">https://webidl.spec.whatwg.org/#es-set-iterator</a>
[2] <a href="https://webidl.spec.whatwg.org/#es-set-forEach">https://webidl.spec.whatwg.org/#es-set-forEach</a>

* LayoutTests/highlight/highlight-interfaces-expected.txt:
* LayoutTests/highlight/highlight-interfaces.html:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(AddSetLikeAttributesAndOperationIfNeeded):
(GenerateImplementation):
* Source/WebCore/bindings/scripts/test/JS/*: Updated.

Canonical link: <a href="https://commits.webkit.org/252782@main">https://commits.webkit.org/252782@main</a>
</pre>
