### PR TITLE
[JSC] Add Uint8ClampedArray for JSCast fast path

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -97,6 +97,7 @@ using JSBigUint64Array = JSGenericTypedArrayView<BigUint64Adaptor>;
     /* TypedArrays are typedef, thus, we cannot use `class` forward declaration */ \
     macro(JSInt8Array, JSType::Int8ArrayType, JSType::Int8ArrayType) \
     macro(JSUint8Array, JSType::Uint8ArrayType, JSType::Uint8ArrayType) \
+    macro(JSUint8ClampedArray, JSType::Uint8ClampedArrayType, JSType::Uint8ClampedArrayType) \
     macro(JSInt16Array, JSType::Int16ArrayType, JSType::Int16ArrayType) \
     macro(JSUint16Array, JSType::Uint16ArrayType, JSType::Uint16ArrayType) \
     macro(JSInt32Array, JSType::Int32ArrayType, JSType::Int32ArrayType) \


### PR DESCRIPTION
#### 08750d9e173ff619aebaabaa55e9d943805102de
<pre>
[JSC] Add Uint8ClampedArray for JSCast fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=243157">https://bugs.webkit.org/show_bug.cgi?id=243157</a>

Reviewed by Ross Kirsling.

252772@main missed this optimization. This patch adds it.

* Source/JavaScriptCore/runtime/JSCast.h:

Canonical link: <a href="https://commits.webkit.org/252774@main">https://commits.webkit.org/252774@main</a>
</pre>
