### PR TITLE
[JSC] Use ARM64 jcvt if __ARM_FEATURE_JCVT is defined

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -259,7 +259,7 @@
 #define HAVE_COMPUTED_GOTO 1
 #endif
 
-#if CPU(ARM64E) && OS(DARWIN)
+#if (CPU(ARM64E) && OS(DARWIN)) || (COMPILER(CLANG) && defined(__ARM_FEATURE_JCVT))
 #define HAVE_FJCVTZS_INSTRUCTION 1
 #endif
 


### PR DESCRIPTION
#### 0b2cbf5c3f275eb8acc722356167c40ffa22845b
<pre>
[JSC] Use ARM64 jcvt if __ARM_FEATURE_JCVT is defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=243158">https://bugs.webkit.org/show_bug.cgi?id=243158</a>

Reviewed by Justin Michaud.

We can detect whether jcvt is available via __ARM_FEATURE_JCVT macro in clang.
It is defined when the compilation target is Armv8.3-A or later[1].

[1]: <a href="https://reviews.llvm.org/D64495">https://reviews.llvm.org/D64495</a>

* Source/WTF/wtf/PlatformHave.h:

Canonical link: <a href="https://commits.webkit.org/252795@main">https://commits.webkit.org/252795@main</a>
</pre>
