### PR TITLE
Alternate stylesheets are not present in document.styleSheets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-title-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-title-expected.txt
@@ -2,5 +2,5 @@ Should be green
 
 
 PASS Preferred style sheet name
-FAIL StyleSheet.title assert_equals: expected 4 but got 3
+PASS StyleSheet.title
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/ttwf-cssom-doc-ext-load-tree-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/ttwf-cssom-doc-ext-load-tree-order-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL styleSheets.length must be 5 assert_equals: styleSheets.length is incorrect: expected 5 but got 1
+PASS styleSheets.length must be 5
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'document.styleSheets[1].disabled = false')
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x76

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'document.styleSheets[1].disabled = false')
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x82

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'document.styleSheets[1].disabled = false')
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x76

--- a/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
+++ b/LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'document.styleSheets[1].disabled = false')
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x76

--- a/LayoutTests/platform/wincairo/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
+++ b/LayoutTests/platform/wincairo/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'document.styleSheets[1].disabled = false')
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x82

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -60,7 +60,7 @@ public:
     Node* ownerNode() const final { return m_ownerNode; }
     MediaList* media() const final;
     String href() const final;
-    String title() const final { return m_title; }
+    String title() const final { return !m_title.isEmpty() ? m_title : String(); }
     bool disabled() const final { return m_isDisabled; }
     void setDisabled(bool) final;
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -154,7 +154,12 @@ private:
     WEBCORE_EXPORT void flushPendingSelfUpdate();
     WEBCORE_EXPORT void flushPendingDescendantUpdates();
 
-    void collectActiveStyleSheets(Vector<RefPtr<StyleSheet>>&);
+    struct ActiveStyleSheetCollection {
+        Vector<RefPtr<StyleSheet>> activeStyleSheets;
+        Vector<RefPtr<StyleSheet>> styleSheetsForStyleSheetList;
+    };
+
+    ActiveStyleSheetCollection collectActiveStyleSheets();
 
     enum class ResolverUpdateType {
         Reconstruct,

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -89,7 +89,7 @@ public:
     void setDisabled(bool b) override { m_isDisabled = b; }
     Node* ownerNode() const override { return m_ownerNode; }
     String href() const override { return m_originalURL; }
-    String title() const override { return emptyString(); }
+    String title() const override { return { }; }
 
     void clearOwnerNode() override { m_ownerNode = nullptr; }
     URL baseURL() const override { return m_finalURL; }


### PR DESCRIPTION
#### a39b520b8e0ca63489db7a45fe19181a33fac903
<pre>
Alternate stylesheets are not present in document.styleSheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=56932">https://bugs.webkit.org/show_bug.cgi?id=56932</a>

Reviewed by Cameron McCormack.

Align the behavior of WebKit with the spec and that of other browsers by always enumerating list of
stylesheets regardless of whether if title is specified or it is an alternate stylesheet.

Also fixed the bug that StyleSheet.title returns an empty string instead of null.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-title-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/ttwf-cssom-doc-ext-load-tree-order-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt:
* LayoutTests/platform/win/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt:
* LayoutTests/platform/wincairo/tables/mozilla_expected_failures/bugs/bug92868_1-expected.txt:

* Source/WebCore/css/CSSStyleSheet.h:
(WebCore::XSLStyleSheet::title): Return null if m_title is an empty string.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::collectActiveStyleSheets): This function now returns two vector&apos;s containing
the list of active stylesheets as well as ones for Document/ShadowRoot&apos;s styleSheets attribute.
(WebCore::Style::Scope::updateActiveStyleSheets):
* Source/WebCore/style/StyleScope.h:
(WebCore::Style::Scope::ActiveStyleSheetCollection):
* Source/WebCore/xml/XSLStyleSheet.h:
(WebCore::XSLStyleSheet::title): Return null.

Canonical link: <a href="https://commits.webkit.org/252781@main">https://commits.webkit.org/252781@main</a>
</pre>
