### PR TITLE
[Cocoa][MSE] Fix canvas painting on older builds

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2278,9 +2278,6 @@ webkit.org/b/240989 http/tests/media/hls/hls-webvtt-flashing.html [ Pass Failure
 
 webkit.org/b/242249 [ BigSur+ ] webanimations/accelerated-animation-after-forward-filling-animation.html [ Pass ImageOnlyFailure ]
 
-# Requires platform support (see rdar://94324932).
-[ BigSur Monterey ] http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
-
 webkit.org/b/242481 fast/css/direct-adjacent-style-sharing-3.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242484 fast/css/display-contents-all.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5164,6 +5164,10 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSourceHelper(TexImageFuncti
         // elements' size for WebGL 1.0 as late as possible.
         bool sourceImageRectIsDefault = inputSourceImageRect == sentinelEmptyRect() || inputSourceImageRect == IntRect(0, 0, video->videoWidth(), video->videoHeight());
 
+#if PLATFORM(COCOA) && !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+        if (auto player = video->player())
+            player->willBeAskedToPaintGL();
+#endif
         // Go through the fast path doing a GPU-GPU textures copy without a readback to system memory if possible.
         // Otherwise, it will fall back to the normal SW path.
         // FIXME: The current restrictions require that format shoud be RGB or RGBA,
@@ -5173,9 +5177,6 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSourceHelper(TexImageFuncti
             && type == GraphicsContextGL::UNSIGNED_BYTE
             && !level) {
             if (auto player = video->player()) {
-#if PLATFORM(COCOA) && !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
-                player->willBeAskedToPaintGL();
-#endif
                 if (m_context->copyTextureFromMedia(*player, texture->object(), target, level, internalformat, format, type, m_unpackPremultiplyAlpha, m_unpackFlipY)) {
 #if !USE(ANGLE)
                     texture->setLevelInfo(target, level, internalformat, video->videoWidth(), video->videoHeight(), type);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -788,7 +788,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer() const
         return !m_player->playerContentBoxRect().isEmpty();
     }();
 #else
-    return !m_hasBeenAskedToPaintGL;
+    return !m_hasBeenAskedToPaintGL && !m_isGatheringVideoFrameMetadata;
 #endif
 }
 
@@ -1446,6 +1446,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering()
 {
     ASSERT(!m_videoFrameMetadataGatheringObserver || m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
+    acceleratedRenderingStateChanged();
 
     // FIXME: We should use a CADisplayLink to get updates on rendering, for now we emulate with addPeriodicTimeObserverForInterval.
     m_videoFrameMetadataGatheringObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::CMTimeMake(1, 60) queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }](CMTime currentTime) {
@@ -1477,6 +1478,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::checkNewVideoFrameMetadata(CMTime cur
 void MediaPlayerPrivateMediaSourceAVFObjC::stopVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = false;
+    acceleratedRenderingStateChanged();
     m_videoFrameMetadata = { };
 
     ASSERT(m_videoFrameMetadataGatheringObserver);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -610,7 +610,7 @@ bool MediaPlayerPrivateWebM::shouldEnsureLayer() const
         && ((m_displayLayer && !CGRectIsEmpty([m_displayLayer bounds]))
             || !m_player->playerContentBoxRect().isEmpty());
 #else
-    return !m_hasBeenAskedToPaintGL;
+    return !m_hasBeenAskedToPaintGL && !m_isGatheringVideoFrameMetadata;
 #endif
 }
 
@@ -1394,6 +1394,7 @@ void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
     ASSERT(!m_videoFrameMetadataGatheringObserver || m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
+    acceleratedRenderingStateChanged();
 
     // FIXME: We should use a CADisplayLink to get updates on rendering, for now we emulate with addPeriodicTimeObserverForInterval.
     m_videoFrameMetadataGatheringObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::CMTimeMake(1, 60) queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }](CMTime currentTime) {
@@ -1407,6 +1408,7 @@ void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 void MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = false;
+    acceleratedRenderingStateChanged();
     m_videoFrameMetadata = { };
 
     ASSERT(m_videoFrameMetadataGatheringObserver);


### PR DESCRIPTION
#### 02bb8a509f08174d0673b37f1ceef03cfd689824
<pre>
[Cocoa][MSE] Fix canvas painting on older builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=243163">https://bugs.webkit.org/show_bug.cgi?id=243163</a>
&lt;rdar://97532406&gt;

Reviewed by Eric Carlson and Wenson Hsieh.

After 252183@main, an alternate path was provided for older builds that
didn&apos;t support AVSBDL `-copyDisplayedPixelBuffer` by calling `willBeAskedToPaintGL`
before a canvas paint is attempted. The problem is that the location in
which `willBeAskedToPaintGL` was called is too late since valid frame metadata
is checked before `willBeAskedToPaintGL` is reached, however, on older builds
this method needs to be called in order to valid frame metadata to be generated.

The fix is to simply enable the decompression session if frame metadata
is being requested and notify WebGL is about to paint for the SW path as well.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::stopVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering):

* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252893@main">https://commits.webkit.org/252893@main</a>
</pre>
