### PR TITLE
REGRESSION (iOS 16 Beta 3) Video and audio are broken for WebRTC call after intervention if User enables Siri, receives PSTN call or navigates to Youtube

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -143,7 +143,12 @@ static void runWithoutAnimations(const WTF::Function<void()>& function)
 
 std::unique_ptr<LocalSampleBufferDisplayLayer> LocalSampleBufferDisplayLayer::create(Client& client)
 {
-    auto sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
+    RetainPtr<AVSampleBufferDisplayLayer> sampleBufferDisplayLayer;
+    @try {
+        sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
+    } @catch(id exception) {
+        RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::create failed to allocate display layer");
+    }
     if (!sampleBufferDisplayLayer)
         return nullptr;
 
@@ -317,7 +322,12 @@ void LocalSampleBufferDisplayLayer::flush()
 void LocalSampleBufferDisplayLayer::flushAndRemoveImage()
 {
     m_processingQueue->dispatch([this] {
-        [m_sampleBufferDisplayLayer flushAndRemoveImage];
+        @try {
+            [m_sampleBufferDisplayLayer flushAndRemoveImage];
+        } @catch(id exception) {
+            RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::flushAndRemoveImage failed");
+            layerErrorDidChange();
+        }
     });
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -415,6 +415,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
     if (!didSucceed) {
         ERROR_LOG(LOGIDENTIFIER, "Initializing the SampleBufferDisplayLayer failed.");
         m_sampleBufferDisplayLayer = nullptr;
+        updateLayersAsNeeded();
         return;
     }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -61,7 +61,7 @@ public:
         virtual void delaySamples(Seconds) { }
     };
 
-    static CoreAudioSharedUnit& unit();
+    WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
     static BaseAudioSharedUnit& singleton()  { return unit(); }
     CoreAudioSharedUnit();
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/CoreAudioCaptureSource.h>
+#include <WebCore/CoreAudioSharedUnit.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/WeakPtr.h>
 
@@ -260,7 +261,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitIs
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitHasStopped()
 {
     // Capture unit has stopped and audio will no longer be rendered through it so start the local unit.
-    if (m_isPlaying)
+    if (m_isPlaying && !CoreAudioSharedUnit::unit().isSuspended())
         m_localUnit->start();
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -77,6 +77,10 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
 {
     callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier, hideRootLayer, size, callback = WTFMove(callback)]() mutable {
         auto layer = RemoteSampleBufferDisplayLayer::create(m_connectionToWebProcess, identifier, m_connection.copyRef());
+        if (!layer) {
+            callback({ });
+            return;
+        }
         auto& layerReference = *layer;
         layerReference.initialize(hideRootLayer, size, [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = WTFMove(layer)](auto layerId) mutable {
             m_queue->dispatch([this, protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), identifier, layer = WTFMove(layer), layerId = WTFMove(layerId)]() mutable {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -99,6 +99,7 @@ public:
     void audioUnitWillStart() final
     {
         AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, RouteSharingPolicy::Default);
+        AudioSession::sharedSession().tryToSetActive(true);
     }
 
     void start()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11215,6 +11215,9 @@ void WebPageProxy::gpuProcessExited(ProcessTerminationReason)
     if (activeAudioCapture || activeVideoCapture) {
         auto& gpuProcess = process().processPool().ensureGPUProcess();
         gpuProcess.updateCaptureAccess(activeAudioCapture, activeVideoCapture, activeDisplayCapture, m_process->coreProcessIdentifier(), [] { });
+#if PLATFORM(IOS_FAMILY)
+        gpuProcess.setOrientationForMediaCapture(m_deviceOrientation);
+#endif
     }
 #endif
 }


### PR DESCRIPTION
#### 78614b1c3235c130d92d8df8379a9862aa098a64
<pre>
REGRESSION (iOS 16 Beta 3) Video and audio are broken for WebRTC call after intervention if User enables Siri, receives PSTN call or navigates to Youtube
<a href="https://bugs.webkit.org/show_bug.cgi?id=242828">https://bugs.webkit.org/show_bug.cgi?id=242828</a>
rdar://problem/97103335

Reviewed by Eric Carlson.

When there is an audio interruption (Siri or phone call), we sometimes try to uninterrupt by either activating the audio session or starting remote IOs.
This messes up the audio interruption states and we end up not receiving end of interruptions.
We fix the cases where we wrongly try to unterrupt too early.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive):
tryToSetActive is sometimes called with active=false. In that case, we should just not uninterrupt.
Also tryToSetActive might be called while we are looping over clients to being interruption.
To prevent uninterrupting wrongly, we uninterrupt asynchronously if the AudioSession is active but still interrupted.
(WebCore::AudioSession::beginInterruption):
We sometimes call beginInterruption even if already interrupted.
Bail out early in that case, like we do for endInterruption.
(WebCore::AudioSession::endInterruption):
Add logging to cover the case of endInterruption being called while not interrupted.
Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
When being interrupted, AVSBDL sometimes throw an exception. This could trigger GPU process crash.
In that case, we catch the exceptions and mark the display layer as failing.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
Retry initializing layers if it failed.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
Export unit() getter.
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitHasStopped):
When CoreAudio shared unit is suspended, captureUnitHasStopped is called.
In that case, we should not start the local audio render unit since we are suspending.
Starting to play the local audio render can break Siri or will end up failing in phone call cases.
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
Bail out early if we failed creating a LocalSampleBufferDisplayLayer.
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
Make sure to activate the session, if we are about to start capture.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::gpuProcessExited):
Drive-by fix: in case of GPUProcess crash, we need to send the device orientation for the camera video frame orientation to be correctly computed.

Canonical link: <a href="https://commits.webkit.org/252807@main">https://commits.webkit.org/252807@main</a>
</pre>
