### PR TITLE
[ews-app] Generate Github comment text for a given commit id

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -169,3 +169,13 @@ class Buildbot():
 
         _log.error('Failed to retry build: {}, http response code: {}'.format(build_url, response.status_code))
         return False
+
+    @classmethod
+    def is_tester_queue(self, queue):
+        icon = Buildbot.icons_for_queues_mapping.get(queue)
+        return icon in ['testOnly', 'buildAndTest']
+
+    @classmethod
+    def is_builder_queue(self, queue):
+        icon = Buildbot.icons_for_queues_mapping.get(queue)
+        return icon in ['buildOnly', 'buildAndTest']

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -84,8 +84,8 @@ class StatusBubble(View):
         bubble = {
             'name': queue,
         }
-        is_tester_queue = self._is_tester_queue(queue)
-        is_builder_queue = self._is_builder_queue(queue)
+        is_tester_queue = Buildbot.is_tester_queue(queue)
+        is_builder_queue = Buildbot.is_builder_queue(queue)
         if hide_icons == False:
             if is_tester_queue:
                 bubble['name'] = StatusBubble.TESTER_ICON + '  ' + bubble['name']
@@ -202,14 +202,6 @@ class StatusBubble(View):
                 bubble['details_message'] += '\n\n' + timestamp
 
         return bubble
-
-    def _is_tester_queue(self, queue):
-        icon = Buildbot.icons_for_queues_mapping.get(queue)
-        return icon in ['testOnly', 'buildAndTest']
-
-    def _is_builder_queue(self, queue):
-        icon = Buildbot.icons_for_queues_mapping.get(queue)
-        return icon in ['buildOnly', 'buildAndTest']
 
     def _get_parent_queue(self, queue):
         return StatusBubble.QUEUE_TRIGGERS.get(queue)


### PR DESCRIPTION
#### 440eea9e48a1d9176f6a11dfd65c750163192409
<pre>
[ews-app] Generate Github comment text for a given commit id
<a href="https://bugs.webkit.org/show_bug.cgi?id=243168">https://bugs.webkit.org/show_bug.cgi?id=243168</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
* Tools/CISupport/ews-app/ews/common/buildbot.py:
* Tools/CISupport/ews-app/ews/views/statusbubble.py:

Canonical link: <a href="https://commits.webkit.org/252790@main">https://commits.webkit.org/252790@main</a>
</pre>
