### PR TITLE
REGRESSION (252540@main): Lockdown Mode alert contains "localized string not found"

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -697,11 +697,11 @@
 /* Option in segmented control for inserting a numbered list in text editing */
 "Numbered list" = "Numbered list";
 
+/* Label for OK button in alerts */
+"OK" = "OK";
+
 /* Title of the OK button for the number pad in zoomed form controls. */
 "OK (OK button title in extra zoomed number pad)" = "OK";
-
-/* OK button label in document password failure alert */
-"OK (document password failure alert)" = "OK";
 
 /* Menu item label for the track that represents disabling closed captions. */
 "Off (text track)" = "Off";

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3039,9 +3039,9 @@ static bool isLockdownModeWarningNeeded()
             alertControllerWithTitle:[NSString stringWithFormat:WEB_UI_NSSTRING(@"Lockdown Mode is Turned On For “%@“", "Lockdown Mode alert title"), appDisplayName]
             message:message
             preferredStyle:UIAlertControllerStyleAlert];
-            
-        [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Captive Portal Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
-        
+
+        [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
+
         UIViewController *presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:protectedSelf.get()];
         [presentationViewController presentViewController:alert animated:YES completion:nil];
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitCaptivePortalModeAlertShownKey];

--- a/Source/WebKit/UIProcess/ios/WKPasswordView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPasswordView.mm
@@ -131,7 +131,7 @@ const CGFloat passwordEntryFieldPadding = 10;
     [[_passwordView passwordField] setText:@""];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:WEB_UI_STRING("The document could not be opened with that password.", "document password failure alert message") message:@"" preferredStyle:UIAlertControllerStyleAlert];
 
-    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("OK", "OK (document password failure alert)", "OK button label in document password failure alert") style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
+    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING("OK", "OK button label in document password failure alert") style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
 
     [alert addAction:defaultAction];
 


### PR DESCRIPTION
#### 5b2c23580d5c05fe3bfd4669a8df0538089d4eb5
<pre>
REGRESSION (252540@main): Lockdown Mode alert contains &quot;localized string not found&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243169">https://bugs.webkit.org/show_bug.cgi?id=243169</a>
rdar://97555448

Reviewed by Wenson Hsieh.

252540@main upstreamed Lockdown Mode code into open source, but incorrectly
omitted the localized string for the Lockdown Mode alert button.

* Source/WebCore/en.lproj/Localizable.strings:

Consolidate the &quot;OK&quot; alert button label into a single localizable string.

&quot;OK (OK button title in extra zoomed number pad)&quot; is kept as a separate string
since it receives different translations due to the compact nature of the UI.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _presentCaptivePortalMode]):
* Source/WebKit/UIProcess/ios/WKPasswordView.mm:
(-[WKPasswordView showPasswordFailureAlert]):

Canonical link: <a href="https://commits.webkit.org/252792@main">https://commits.webkit.org/252792@main</a>
</pre>
