### PR TITLE
System colors do not always respect inherited color-scheme values

### DIFF
--- a/LayoutTests/css-dark-mode/color-scheme-inherited-expected.html
+++ b/LayoutTests/css-dark-mode/color-scheme-inherited-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.box {
+    color: CanvasText;
+    background-color: Canvas;
+}
+
+</style>
+</head>
+<body>
+
+<div class="box" style="color-scheme: dark">Dark</div>
+<div class="box" style="color-scheme: light">Light</div>
+
+</body>
+</html>

--- a/LayoutTests/css-dark-mode/color-scheme-inherited.html
+++ b/LayoutTests/css-dark-mode/color-scheme-inherited.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.box {
+    color: CanvasText;
+    background-color: Canvas;
+}
+
+</style>
+</head>
+<body>
+
+<div style="color-scheme: dark">
+<div class="box">Dark</div>
+</div>
+
+<div style="color-scheme: light">
+<div class="box">Light</div>
+</div>
+
+</body>
+</html>

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -80,6 +80,11 @@ bool MatchedDeclarationsCache::Entry::isUsableAfterHighPriorityProperties(const 
     if (style.effectiveZoom() != renderStyle->effectiveZoom())
         return false;
 
+#if ENABLE(DARK_MODE_CSS)
+    if (style.colorScheme() != renderStyle->colorScheme())
+        return false;
+#endif
+
     return CSSPrimitiveValue::equalForLengthResolution(style, *renderStyle);
 }
 


### PR DESCRIPTION
#### ae8a3909d3254aa6d08dee8098acab5082e2027d
<pre>
System colors do not always respect inherited color-scheme values
<a href="https://bugs.webkit.org/show_bug.cgi?id=240925">https://bugs.webkit.org/show_bug.cgi?id=240925</a>
rdar://94247591

Reviewed by Antti Koivisto.

The MatchedDeclarationsCache speeds up style computation by reusing by copying
non-inherited properties from an earlier style object built using the same
exact style declarations.

Since &apos;color-scheme&apos; is an inherited property, it is possible for two elements
to have the same &apos;background-color&apos; declaration, with different color schemes.
However, the computed value of a system color is dependent on the computed
style&apos;s &apos;color-scheme&apos; value. Consequently, the cache entry can only be used if
the styles have equivalent color schemes.

* LayoutTests/css-dark-mode/color-scheme-inherited-expected.html: Added.
* LayoutTests/css-dark-mode/color-scheme-inherited.html: Added.
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::Entry::isUsableAfterHighPriorityProperties const):

Canonical link: <a href="https://commits.webkit.org/253041@main">https://commits.webkit.org/253041@main</a>
</pre>
