### PR TITLE
[iOS 16] 'Insert text from camera' action should not appear in the edit menu when a range is selected

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4096,10 +4096,12 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
         if (!mayContainSelectableText(_focusedElementInformation.elementType) || _focusedElementInformation.isReadOnly)
             return NO;
 
+        BOOL isPreparingEditMenu = _isPreparingEditMenu;
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        if ([sender isKindOfClass:UIMenuController.class] && editorState.selectionIsRange)
-            return NO;
+        isPreparingEditMenu |= [sender isKindOfClass:UIMenuController.class];
         ALLOW_DEPRECATED_DECLARATIONS_END
+        if (isPreparingEditMenu && editorState.selectionIsRange)
+            return NO;
     }
 #endif // ENABLE(IMAGE_ANALYSIS)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm
@@ -147,7 +147,7 @@ TEST(WebKit, CaptureTextFromCamera)
     [webView _setInputDelegate:inputDelegate.get()];
     auto contentView = [webView textInputContentView];
 
-    [webView synchronouslyLoadHTMLString:@"<input value='foo' autofocus><input value='bar' readonly>"];
+    [webView synchronouslyLoadHTMLString:@"<input style='display: block; font-size: 100px;' value='foo' autofocus><input value='bar' readonly>"];
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ([webView targetForAction:@selector(captureTextFromCamera:) withSender:nil], contentView);
     EXPECT_TRUE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:nil]);
@@ -170,6 +170,16 @@ TEST(WebKit, CaptureTextFromCamera)
     [webView objectByEvaluatingJavaScript:@"document.querySelector('input[readonly]').focus()"];
     [webView waitForNextPresentationUpdate];
     EXPECT_FALSE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:nil]);
+
+#if HAVE(UI_EDIT_MENU_INTERACTION)
+    __block bool done = false;
+    [contentView prepareSelectionForContextMenuWithLocationInView:CGPointMake(20, 20) completionHandler:^(BOOL shouldPresentMenu, RVItem *) {
+        EXPECT_TRUE(shouldPresentMenu);
+        EXPECT_FALSE([webView canPerformAction:@selector(captureTextFromCamera:) withSender:nil]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+#endif
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### c106e6ec944a7c96e99925e664a34914c87f8f06
<pre>
[iOS 16] &apos;Insert text from camera&apos; action should not appear in the edit menu when a range is selected
<a href="https://bugs.webkit.org/show_bug.cgi?id=243171">https://bugs.webkit.org/show_bug.cgi?id=243171</a>

Reviewed by Devin Rousso.

This is another platform behavior (similar to the one fixed in `252764@main`) that broke due to the
new edit menu in iOS 16. The &quot;Insert from camera&quot; action (which shows up as a Live Text button in
the edit menu) was intended to only show up when the selection is collapsed and editable; however,
WebKit diverges from this platform behavior, since our logic for special-casing the edit menu is
based around checking whether the `sender` in `canPerformActionForWebView:withSender:` is a
`UIMenuController`, which is not the case when the iOS 16+ edit menu is enabled.

To fix this, check the newly introduced `_isPreparingEditMenu` flag instead. Changes tested by
augmenting an existing API test: `WebKit.CaptureTextFromCamera`

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentViewEditingActions.mm:

Canonical link: <a href="https://commits.webkit.org/252805@main">https://commits.webkit.org/252805@main</a>
</pre>
