### PR TITLE
[Cocoa][MSE] Remove excessive updateLastPixelBuffer logging

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -674,7 +674,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer()
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     if (isCopyDisplayedPixelBufferAvailable()) {
         if (auto pixelBuffer = adoptCF([m_sampleBufferDisplayLayer copyDisplayedPixelBuffer])) {
-            ALWAYS_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentMediaTime());
+            INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentMediaTime());
             m_lastPixelBuffer = WTFMove(pixelBuffer);
             return true;
         }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -401,7 +401,7 @@ bool MediaPlayerPrivateWebM::updateLastPixelBuffer()
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     if (isCopyDisplayedPixelBufferAvailable()) {
         if (auto pixelBuffer = adoptCF([m_displayLayer copyDisplayedPixelBuffer])) {
-            ALWAYS_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentMediaTime());
+            INFO_LOG(LOGIDENTIFIER, "displayed pixelbuffer copied for time ", currentMediaTime());
             m_lastPixelBuffer = WTFMove(pixelBuffer);
             return true;
         }


### PR DESCRIPTION
#### aacf08a6e5c950a328b3fdbbff5b1bc2daa53f3a
<pre>
[Cocoa][MSE] Remove excessive updateLastPixelBuffer logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=243175">https://bugs.webkit.org/show_bug.cgi?id=243175</a>
&lt;rdar://97565008&gt;

Reviewed by Wenson Hsieh.

Since `updateLastPixelBuffer` is called every 1/60th of a second through
requestVideoFrameCallback, this log ends up dominating the other logs
and spins the main thread excessively.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateLastPixelBuffer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateLastPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/252801@main">https://commits.webkit.org/252801@main</a>
</pre>
