### PR TITLE
Fix installsrc defaulting to USE_WORKSPACE=YES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(MAKECMDGOALS),installsrc)
+USE_WORKSPACE = NO
+endif
+
 ifneq ($(USE_WORKSPACE),NO)
 
 SCHEME = All Modules

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(MAKECMDGOALS),installsrc)
+USE_WORKSPACE = NO
+endif
+
 ifneq ($(USE_WORKSPACE),NO)
 
 include ../Makefile.shared

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(MAKECMDGOALS),installsrc)
+USE_WORKSPACE = NO
+endif
+
 ifneq ($(USE_WORKSPACE),NO)
 
 include ../Makefile.shared


### PR DESCRIPTION
#### c4b4ccde34912340c0e4c90f5b1c0827f24558ed
<pre>
Fix installsrc defaulting to USE_WORKSPACE=YES
<a href="https://bugs.webkit.org/show_bug.cgi?id=242625">https://bugs.webkit.org/show_bug.cgi?id=242625</a>

Unreviewed build fix.

Unlike building, `make installsrc` does need to install
project-by-project. Explicitly set USE_WORKSPACE=NO when running
installsrc.

* Makefile:
* Source/Makefile:
* Tools/Makefile:

Canonical link: <a href="https://commits.webkit.org/252800@main">https://commits.webkit.org/252800@main</a>
</pre>
