### PR TITLE
Turn macOS smooth keyboard scrolling on by default

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
+++ b/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ScrollAnimatorEnabled=false ] -->
+<!DOCTYPE html>
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/repaint/fixed-move-after-keyboard-scroll.html
+++ b/LayoutTests/fast/repaint/fixed-move-after-keyboard-scroll.html
@@ -5,7 +5,7 @@
       function runTest()
       {
           if (window.internals)
-              internals.settings.setScrollAnimatorEnabled(false);
+              internals.settings.setScrollAnimatorEnabled(true);
           frames[0].focus();
           if (window.eventSender) {
               window.eventSender.keyDown("pageDown");

--- a/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
+++ b/LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html
@@ -23,9 +23,6 @@
             testRunner.waitUntilDone();
         }
 
-        if (window.internals)
-            internals.settings.setScrollAnimatorEnabled(false);
-
         function checkForScroll()
         {
             var expectedScrollLeft = -120;

--- a/LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar-expected.txt
+++ b/LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar-expected.txt
@@ -3,7 +3,7 @@ Test that scrolling backward by page excludes the area taken by fixed element co
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Scrolled to 520
+PASS Scrolled to 440
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html
+++ b/LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html
@@ -56,14 +56,14 @@
 
                     failTimeoutId = setTimeout(function() {
                         testFailed("The scrollview failed to scroll in response to the event.");
-                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (1000 - (window.innerHeight - 120)));
+                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (1000 - (window.innerHeight - 40)));
                         finishJSTest();
                     }, 1000);
                 }
             }
 
             window.addEventListener("scroll", function() {
-                if (window.scrollY == 1000 - (window.innerHeight - 120)) {
+                if (window.scrollY == 1000 - (window.innerHeight - 40)) {
                     testPassed("Scrolled to " + window.scrollY);
                     clearTimeout(failTimeoutId);
                     finishJSTest();

--- a/LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar-expected.txt
+++ b/LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar-expected.txt
@@ -3,7 +3,7 @@ Test scrolling with page granularity by using the space bar excludes the height 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Scrolled to 480
+PASS Scrolled to 560
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar.html
+++ b/LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar.html
@@ -64,14 +64,14 @@
 
                     failTimeoutId = setTimeout(function() {
                         testFailed("The scrollview failed to scroll in response to the event.");
-                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (window.innerHeight - 120));
+                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (window.innerHeight - 40));
                         finishJSTest();
                     }, 1000);
                 }
             }
 
             window.addEventListener("scroll", function() {
-                if (window.scrollY == window.innerHeight - 120) {
+                if (window.scrollY == window.innerHeight - 40) {
                     testPassed("Scrolled to " + window.scrollY);
                     clearTimeout(failTimeoutId);
                     finishJSTest();

--- a/LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar-expected.txt
+++ b/LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar-expected.txt
@@ -3,7 +3,7 @@ Test scrolling with page granularity by using the space bar excludes the height 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Scrolled to 480
+PASS Scrolled to 560
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar.html
+++ b/LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar.html
@@ -55,14 +55,14 @@
 
                     failTimeoutId = setTimeout(function() {
                         testFailed("The scrollview failed to scroll in response to the event.");
-                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (window.innerHeight - 120));
+                        debug("window.scrollY = " + window.scrollY + " excepted value around " + (window.innerHeight - 40));
                         finishJSTest();
                     }, 1000);
                 }
             }
 
             window.addEventListener("scroll", function() {
-                if (window.scrollY == window.innerHeight - 120) {
+                if (window.scrollY == window.innerHeight - 40) {
                     testPassed("Scrolled to " + window.scrollY);
                     clearTimeout(failTimeoutId);
                     finishJSTest();

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -276,7 +276,7 @@ EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   WebKitLegacy:
    default: false
   WebKit:
-   default: false
+   default: true
   WebCore:
    default: false
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4395,8 +4395,12 @@ bool EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer(Sc
 
     if (node) {
         auto renderer = node->renderer();
+        if (!renderer)
+            return false;
+
         RenderBox& renderBox = renderer->enclosingBox();
-        if (renderer && !renderer->isListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox))
+
+        if (!renderer->isListBox() && startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(direction, granularity, &renderBox))
             return true;
     }
     return false;


### PR DESCRIPTION
#### ff58815ac252d13c99f1fb7626e28a680c947663
<pre>
Turn macOS smooth keyboard scrolling on by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=228159">https://bugs.webkit.org/show_bug.cgi?id=228159</a>
rdar://80912063

Reviewed by NOBODY (OOPS!).

No tests added.

Set the default value for EventHandlerDrivenSmoothKeyboardScrollingEnabled to true in WebKit.

Rebased tests:

LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
LayoutTests/fast/repaint/fixed-move-after-keyboard-scroll.html
LayoutTests/fast/scrolling/arrow-key-scroll-in-rtl-document.html

These tests now require ScrollAnimator to be enabled.

LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar-expected.txt
LayoutTests/scrollbars/scrolling-backward-by-page-accounting-bottom-fixed-elements-on-keyboard-spacebar.html

LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar-expected.txt
LayoutTests/scrollbars/scrolling-by-page-accounting-oversized-fixed-elements-on-keyboard-spacebar.html

LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar-expected.txt
LayoutTests/scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar.html

Updated these tests to reflect the new distance scrolled.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
EventHandlerDrivenSmoothKeyboardScrollingEnabled is now true on default for WebKit.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
Added check if renderer is null to fix crash in LayoutTests/fast/forms/select/select-change-type-on-focus.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff58815ac252d13c99f1fb7626e28a680c947663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95843 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29432 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25726 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91016 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23757 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73812 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23764 "Found 1 new test failure: css3/scroll-snap/scroll-padding-overflow-paging.html") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78746 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79037 "Found 1 new API test failure: TestWebKitAPI.WebKit.SpacebarScrolling") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66776 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27166 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12878 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72535 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27107 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13892 "Found 4 new test failures: css3/scroll-snap/scroll-padding-overflow-paging.html, fast/repaint/fixed-move-after-keyboard-scroll.html, fast/scrolling/arrow-key-scroll-in-rtl-document.html, scrollbars/scrolling-by-page-accounting-top-fixed-elements-with-negative-top-on-keyboard-spacebar.html") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25863 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28790 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36740 "Found 3 new test failures: css3/scroll-snap/scroll-padding-overflow-paging.html, fast/repaint/fixed-move-after-keyboard-scroll.html, scrollbars/scrolling-by-page-accounting-top-fixed-elements-with-negative-top-on-keyboard-spacebar.html") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75332 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33169 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16672 "Passed tests") | 
<!--EWS-Status-Bubble-End-->