### PR TITLE
Add a quirk for nfl.com on Permissions API

### DIFF
--- a/Source/WebCore/Modules/permissions/Navigator+Permissions.idl
+++ b/Source/WebCore/Modules/permissions/Navigator+Permissions.idl
@@ -27,7 +27,8 @@
 
 [
     EnabledBySetting=PermissionsAPIEnabled,
-    ImplementedBy=NavigatorPermissions
+    ImplementedBy=NavigatorPermissions,
+    DisabledByQuirk=hasBrokenPermissionsAPISupport
 ] partial interface Navigator {
     [SameObject] readonly attribute Permissions permissions;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1494,4 +1494,17 @@ bool Quirks::allowLayeredFullscreenVideos() const
 }
 #endif
 
+bool Quirks::hasBrokenPermissionsAPISupportQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_hasBrokenPermissionsAPISupportQuirk) {
+        auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+        m_hasBrokenPermissionsAPISupportQuirk = domain.endsWith(".nfl.com"_s);
+    }
+
+    return m_hasBrokenPermissionsAPISupportQuirk.value();
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -162,6 +162,7 @@ public:
 #if PLATFORM(IOS)
     WEBCORE_EXPORT bool allowLayeredFullscreenVideos() const;
 #endif
+    bool hasBrokenPermissionsAPISupportQuirk() const;
     
 private:
     bool needsQuirks() const;
@@ -212,6 +213,7 @@ private:
 #if PLATFORM(IOS)
     mutable std::optional<bool> m_allowLayeredFullscreenVideos;
 #endif
+    mutable std::optional<bool> m_hasBrokenPermissionsAPISupportQuirk;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f408a57b194026f71dc9bdeb7d76ea6224a28dc3
<pre>
Add a quirk for nfl.com on Permissions API
<a href="https://bugs.webkit.org/show_bug.cgi?id=243180">https://bugs.webkit.org/show_bug.cgi?id=243180</a>

Reviewed by Chris Dumez.

Disable Permissions API on nfl.com until they fix rdar://91915995.

* Source/WebCore/Modules/permissions/Navigator+Permissions.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::hasBrokenPermissionsAPISupportQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/252812@main">https://commits.webkit.org/252812@main</a>
</pre>
