### PR TITLE
Account for larger sample spaces in WebAudioBufferList

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp
@@ -113,7 +113,7 @@ void SpeechRecognitionCaptureSourceImpl::pullSamplesAndCallDataCallback(const Me
 {
     ASSERT(isMainThread());
 
-    auto data = WebAudioBufferList { audioDescription, static_cast<uint32_t>(sampleCount) };
+    auto data = WebAudioBufferList { audioDescription, sampleCount };
     {
         Locker locker { m_dataSourceLock };
         m_dataSource->pullSamples(*data.list(), sampleCount, time.timeValue(), 0, AudioSampleDataSource::Copy);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -80,7 +80,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
         // Heap allocations are forbidden on the audio thread for performance reasons so we need to
         // explicitly allow the following allocation(s).
         DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-        m_audioBuffer = makeUnique<WebAudioBufferList>(description, safeCast<uint32_t>(numberOfFrames));
+        m_audioBuffer = makeUnique<WebAudioBufferList>(description, numberOfFrames);
         audioBuffer = &downcast<WebAudioBufferList>(*m_audioBuffer);
     } else
         audioBuffer->setSampleCount(numberOfFrames);

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -53,13 +53,13 @@ WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format)
     reset();
 }
 
-WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format, uint32_t sampleCount)
+WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format, size_t sampleCount)
     : WebAudioBufferList(format)
 {
     setSampleCount(sampleCount);
 }
 
-static inline std::optional<std::pair<size_t, size_t>> computeBufferSizes(uint32_t numberOfInterleavedChannels, uint32_t bytesPerFrame, uint32_t numberOfChannelStreams, uint32_t sampleCount)
+static inline std::optional<std::pair<size_t, size_t>> computeBufferSizes(uint32_t numberOfInterleavedChannels, uint32_t bytesPerFrame, uint32_t numberOfChannelStreams, size_t sampleCount)
 {
     size_t totalSampleCount;
     bool result = WTF::safeMultiply(sampleCount, numberOfInterleavedChannels, totalSampleCount);
@@ -79,12 +79,12 @@ static inline std::optional<std::pair<size_t, size_t>> computeBufferSizes(uint32
     return std::make_pair(bytesPerBuffer, flatBufferSize);
 }
 
-bool WebAudioBufferList::isSupportedDescription(const CAAudioStreamDescription& format, uint32_t sampleCount)
+bool WebAudioBufferList::isSupportedDescription(const CAAudioStreamDescription& format, size_t sampleCount)
 {
     return !!computeBufferSizes(format.numberOfInterleavedChannels(), format.bytesPerFrame(), format.numberOfChannelStreams(), sampleCount);
 }
 
-void WebAudioBufferList::setSampleCount(uint32_t sampleCount)
+void WebAudioBufferList::setSampleCount(size_t sampleCount)
 {
     if (!sampleCount || m_sampleCount == sampleCount)
         return;

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -42,11 +42,11 @@ class CAAudioStreamDescription;
 class WebAudioBufferList final : public PlatformAudioData {
 public:
     WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&);
-    WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&, uint32_t sampleCount);
+    WEBCORE_EXPORT WebAudioBufferList(const CAAudioStreamDescription&, size_t sampleCount);
     WebAudioBufferList(const CAAudioStreamDescription&, CMSampleBufferRef);
 
     void reset();
-    WEBCORE_EXPORT void setSampleCount(uint32_t);
+    WEBCORE_EXPORT void setSampleCount(size_t);
 
     AudioBufferList* list() const { return m_list.get(); }
     operator AudioBufferList&() const { return *m_list; }
@@ -56,7 +56,7 @@ public:
     AudioBuffer* buffer(uint32_t index) const;
     IteratorRange<AudioBuffer*> buffers() const;
 
-    WEBCORE_EXPORT static bool isSupportedDescription(const CAAudioStreamDescription&, uint32_t sampleCount);
+    WEBCORE_EXPORT static bool isSupportedDescription(const CAAudioStreamDescription&, size_t sampleCount);
 
     WEBCORE_EXPORT void zeroFlatBuffer();
 
@@ -66,7 +66,7 @@ private:
     size_t m_listBufferSize { 0 };
     uint32_t m_bytesPerFrame { 0 };
     uint32_t m_channelCount { 0 };
-    uint32_t m_sampleCount { 0 };
+    size_t m_sampleCount { 0 };
     std::unique_ptr<AudioBufferList> m_canonicalList;
     std::unique_ptr<AudioBufferList> m_list;
     RetainPtr<CMBlockBufferRef> m_blockBuffer;

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -137,7 +137,7 @@ private:
 
     std::unique_ptr<WebAudioBufferList> m_audioBufferList;
 
-    uint32_t m_maximiumFrameCount;
+    size_t m_maximiumFrameCount;
     uint64_t m_samplesEmitted { 0 };
     uint64_t m_samplesRendered { 0 };
 

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
@@ -54,7 +54,7 @@ private:
 
     Ref<WorkQueue> m_workQueue;
     RunLoop::Timer<MockAudioDestinationCocoa> m_timer;
-    uint32_t m_numberOfFramesToProcess { 384 };
+    size_t m_numberOfFramesToProcess { 384 };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 659f5b107515cfac3610d557b4c38a2ec0f00b57
<pre>
Account for larger sample spaces in WebAudioBufferList
<a href="https://bugs.webkit.org/show_bug.cgi?id=243181">https://bugs.webkit.org/show_bug.cgi?id=243181</a>
&lt;rdar://97391151&gt;

Reviewed by Chris Dumez.

Use size_t for sample count to account for larger sample spaces in WebAudioBufferList.

* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.cpp:
(WebCore::SpeechRecognitionCaptureSourceImpl::pullSamplesAndCallDataCallback):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
(WebCore::MediaStreamAudioSource::consumeAudio):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::WebAudioBufferList):
(WebCore::computeBufferSizes):
(WebCore::WebAudioBufferList::isSupportedDescription):
(WebCore::WebAudioBufferList::setSampleCount):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.h:

Canonical link: <a href="https://commits.webkit.org/252808@main">https://commits.webkit.org/252808@main</a>
</pre>
