### PR TITLE
Remove feature flag for HTTP/3

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -687,17 +687,6 @@ HDRMediaCapabilitiesEnabled:
     WebCore:
       default: false
 
-HTTP3Enabled:
-  type: bool
-  humanReadableName: "HTTP/3"
-  humanReadableDescription: "Enable HTTP/3"
-  webcoreBinding: none
-  condition: HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
-  exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
-
 HasPseudoClassEnabled:
   type: bool
   humanReadableName: ":has() pseudo-class"

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -54,7 +54,6 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
 #if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
     encoder << alternativeServiceDirectory;
     encoder << alternativeServiceDirectoryExtensionHandle;
-    encoder << http3Enabled;
 #endif
     encoder << hstsStorageDirectory;
     encoder << hstsStorageDirectoryExtensionHandle;
@@ -166,11 +165,6 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     std::optional<SandboxExtension::Handle> alternativeServiceDirectoryExtensionHandle;
     decoder >> alternativeServiceDirectoryExtensionHandle;
     if (!alternativeServiceDirectoryExtensionHandle)
-        return std::nullopt;
-    
-    std::optional<bool> http3Enabled;
-    decoder >> http3Enabled;
-    if (!http3Enabled)
         return std::nullopt;
 #endif
 
@@ -442,7 +436,6 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
 #if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
         , WTFMove(*alternativeServiceDirectory)
         , WTFMove(*alternativeServiceDirectoryExtensionHandle)
-        , WTFMove(*http3Enabled)
 #endif
         , WTFMove(*hstsStorageDirectory)
         , WTFMove(*hstsStorageDirectoryExtensionHandle)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -69,7 +69,6 @@ struct NetworkSessionCreationParameters {
 #if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
     String alternativeServiceDirectory;
     SandboxExtension::Handle alternativeServiceDirectoryExtensionHandle;
-    bool http3Enabled { false };
 #endif
     String hstsStorageDirectory;
     SandboxExtension::Handle hstsStorageDirectoryExtensionHandle;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1286,8 +1286,6 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
         SandboxExtension::consumePermanently(parameters.alternativeServiceDirectoryExtensionHandle);
         configuration._alternativeServicesStorage = adoptNS([[_NSHTTPAlternativeServicesStorage alloc] initPersistentStoreWithURL:[[NSURL fileURLWithPath:parameters.alternativeServiceDirectory isDirectory:YES] URLByAppendingPathComponent:@"AlternativeService.sqlite" isDirectory:NO]]).get();
     }
-    if (parameters.http3Enabled)
-        configuration._allowsHTTP3 = YES;
 #endif
 
     configuration._preventsSystemHTTPProxyAuthentication = parameters.preventsSystemHTTPProxyAuthentication;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -168,7 +168,6 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
         httpsProxy = URL { [defaults stringForKey:(NSString *)WebKit2HTTPSProxyDefaultsKey] };
 
 #if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
-    bool http3Enabled = WebsiteDataStore::http3Enabled();
     SandboxExtension::Handle alternativeServiceStorageDirectoryExtensionHandle;
     String alternativeServiceStorageDirectory = resolvedAlternativeServicesStorageDirectory();
     createHandleFromResolvedPathIfPossible(alternativeServiceStorageDirectory, alternativeServiceStorageDirectoryExtensionHandle);
@@ -185,7 +184,6 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
 #if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
     parameters.networkSessionParameters.alternativeServiceDirectory = WTFMove(alternativeServiceStorageDirectory);
     parameters.networkSessionParameters.alternativeServiceDirectoryExtensionHandle = WTFMove(alternativeServiceStorageDirectoryExtensionHandle);
-    parameters.networkSessionParameters.http3Enabled = WTFMove(http3Enabled);
 #endif
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.shouldIncludeLocalhost = shouldIncludeLocalhostInResourceLoadStatistics;
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.enableDebugMode = enableResourceLoadStatisticsDebugMode;
@@ -206,15 +204,6 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
 
     parameters.uiProcessCookieStorageIdentifier = m_uiProcessCookieStorageIdentifier;
     parameters.networkSessionParameters.enablePrivateClickMeasurementDebugMode = experimentalFeatureEnabled(WebPreferencesKey::privateClickMeasurementDebugModeEnabledKey());
-}
-
-bool WebsiteDataStore::http3Enabled()
-{
-#if HAVE(CFNETWORK_ALTERNATIVE_SERVICE)
-    return experimentalFeatureEnabled(WebPreferencesKey::http3EnabledKey());
-#else
-    return false;
-#endif
 }
 
 bool WebsiteDataStore::useNetworkLoader()

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1960,11 +1960,6 @@ String WebsiteDataStore::defaultJavaScriptConfigurationDirectory()
     return String();
 }
 
-bool WebsiteDataStore::http3Enabled()
-{
-    return false;
-}
-
 bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String&)
 {
     return false;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -359,7 +359,6 @@ public:
     static WTF::String defaultMediaKeysStorageDirectory();
     static WTF::String defaultDeviceIdHashSaltsStorageDirectory();
     static WTF::String defaultJavaScriptConfigurationDirectory();
-    static bool http3Enabled();
     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
     static bool defaultShouldUseCustomStoragePaths();
 

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -104,7 +104,7 @@ const TestFeatures& TestOptions::defaults()
             { "XSSAuditorEnabled", false },
 
             // FIXME: These experimental features are currently the only ones not enabled for WebKitLegacy, we
-            // should either enable them or stop exposing them (as we do with with preferences like HTTP3Enabled).
+            // should either enable them or stop exposing them (as we do with with preferences).
             // All other experimental features are automatically enabled regardless of their specified defaults.
             { "AsyncClipboardAPIEnabled", false },
             { "CSSOMViewSmoothScrollingEnabled", false },

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -389,17 +389,12 @@ TEST(WebKit, AlternativeServicesDefaultDirectoryCreation)
     // We always create the path, even if HTTP/3 is turned off.
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultDirectory.path]);
 
-    NSString *key = @"WebKitExperimentalHTTP3Enabled";
-    [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithBool:YES] forKey:key];
-
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]).get()];
     auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 synchronouslyLoadHTMLString:@"start auxiliary processes" baseURL:nil];
 
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultDirectory.path]);
-
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
     [[NSFileManager defaultManager] removeItemAtURL:defaultDirectory error:nil];
 
 #endif // HAVE(CFNETWORK_ALTERNATIVE_SERVICE)


### PR DESCRIPTION
#### 6cfa94b8b6ad179efd600c3c5fc1bff474fa95e2
<pre>
Remove feature flag for HTTP/3
<a href="https://bugs.webkit.org/show_bug.cgi?id=243182">https://bugs.webkit.org/show_bug.cgi?id=243182</a>

Reviewed by Chris Dumez.

The feature flag was used to turn on HTTP/3, when it&apos;s off in the system by default. Now that HTTP/3 is on by default,
and networking layer will not respect the feature flag value, we should drop it to avoid confusion.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
(WebKit::WebsiteDataStore::http3Enabled): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::http3Enabled): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/252834@main">https://commits.webkit.org/252834@main</a>
</pre>
