### PR TITLE
XPath: Some operators / functions are using the wrong EvaluationContext for non-first arguments

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/booleans-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/booleans-expected.txt
@@ -1,11 +1,11 @@
 
 
 
-FAIL "or" operator depending on the context node assert_true: expected true got false
-FAIL "=" operator depending on the context node assert_true: expected true got false
-FAIL "!=" operator depending on the context node assert_false: expected false got true
-FAIL "<" operator depending on the context node assert_true: expected true got false
-FAIL ">" operator depending on the context node assert_false: expected false got true
-FAIL ">=" operator depending on the context node assert_false: expected false got true
-FAIL "<=" operator depending on the context node assert_true: expected true got false
+PASS "or" operator depending on the context node
+PASS "=" operator depending on the context node
+PASS "!=" operator depending on the context node
+PASS "<" operator depending on the context node
+PASS ">" operator depending on the context node
+PASS ">=" operator depending on the context node
+PASS "<=" operator depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-concat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-concat-expected.txt
@@ -1,4 +1,4 @@
 foobarber
 
-FAIL concat() arguments depending on the context node assert_equals: expected "barber" but got "bar"
+PASS concat() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-contains-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-contains-expected.txt
@@ -1,4 +1,4 @@
 bar barbarberbar
 
-FAIL contains() arguments depending on the context node assert_true: expected true got false
+PASS contains() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-starts-with-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-starts-with-expected.txt
@@ -1,4 +1,4 @@
 foobarberbar
 
-FAIL starts-with() arguments depending on the context node assert_true: expected true got false
+PASS starts-with() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-after-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-after-expected.txt
@@ -1,4 +1,4 @@
 ^^^bar$$$bar^bar
 
-FAIL substring-after() arguments depending on the context node assert_equals: expected "$$$" but got "^^bar$$$"
+PASS substring-after() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-before-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-before-expected.txt
@@ -1,4 +1,4 @@
 ^^^bar$$$bar$bar
 
-FAIL substring-before() arguments depending on the context node assert_equals: expected "^^^" but got "^^^bar"
+PASS substring-before() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-expected.txt
@@ -3,5 +3,5 @@
 
 
 
-FAIL substring() arguments depending on the context node assert_equals: expected "bar$$$" but got "^^^bar$$$"
+PASS substring() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-translate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-translate-expected.txt
@@ -1,4 +1,4 @@
 ^^^bar$$$^^^barfoo
 
-FAIL translate() arguments depending on the context node assert_equals: expected "^^^foo$$$" but got "bar$$$"
+PASS translate() arguments depending on the context node
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/numbers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/numbers-expected.txt
@@ -1,9 +1,9 @@
 
 
 
-FAIL "+" operator depending on the context node assert_equals: expected 3 but got 1
-FAIL "-" operator depending on the context node assert_equals: expected -1 but got 1
-FAIL "*" operator depending on the context node assert_equals: expected 2 but got 0
-FAIL "div" operator depending on the context node assert_equals: expected 0.5 but got Infinity
-FAIL "mod" operator depending on the context node assert_equals: expected 1 but got NaN
+PASS "+" operator depending on the context node
+PASS "-" operator depending on the context node
+PASS "*" operator depending on the context node
+PASS "div" operator depending on the context node
+PASS "mod" operator depending on the context node
 

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -37,6 +37,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/SetForScope.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -434,8 +435,9 @@ Value FunConcat::evaluate() const
     result.reserveCapacity(1024);
 
     for (unsigned i = 0, count = argumentCount(); i < count; ++i) {
-        String str(argument(i).evaluate().toString());
-        result.append(str);
+        EvaluationContext clonedContext(Expression::evaluationContext());
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        result.append(argument(i).evaluate().toString());
     }
 
     return result.toString();
@@ -443,8 +445,14 @@ Value FunConcat::evaluate() const
 
 Value FunStartsWith::evaluate() const
 {
+    auto clonedContext = Expression::evaluationContext();
+
     String s1 = argument(0).evaluate().toString();
-    String s2 = argument(1).evaluate().toString();
+    String s2;
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        s2 = argument(1).evaluate().toString();
+    }
 
     if (s2.isEmpty())
         return true;
@@ -454,8 +462,14 @@ Value FunStartsWith::evaluate() const
 
 Value FunContains::evaluate() const
 {
+    auto clonedContext = Expression::evaluationContext();
+
     String s1 = argument(0).evaluate().toString();
-    String s2 = argument(1).evaluate().toString();
+    String s2;
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        s2 = argument(1).evaluate().toString();
+    }
 
     if (s2.isEmpty()) 
         return true;
@@ -465,8 +479,15 @@ Value FunContains::evaluate() const
 
 Value FunSubstringBefore::evaluate() const
 {
+    auto clonedContext = Expression::evaluationContext();
+
     String s1 = argument(0).evaluate().toString();
-    String s2 = argument(1).evaluate().toString();
+    String s2;
+
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        s2 = argument(1).evaluate().toString();
+    }
 
     if (s2.isEmpty())
         return emptyString();
@@ -481,8 +502,15 @@ Value FunSubstringBefore::evaluate() const
 
 Value FunSubstringAfter::evaluate() const
 {
+    auto clonedContext = Expression::evaluationContext();
+
     String s1 = argument(0).evaluate().toString();
-    String s2 = argument(1).evaluate().toString();
+    String s2;
+
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        s2 = argument(1).evaluate().toString();
+    }
 
     size_t i = s1.find(s2);
     if (i == notFound)
@@ -493,8 +521,21 @@ Value FunSubstringAfter::evaluate() const
 
 Value FunSubstring::evaluate() const
 {
-    String s = argument(0).evaluate().toString();
-    double doublePos = argument(1).evaluate().toNumber();
+    EvaluationContext clonedContext1(Expression::evaluationContext());
+    EvaluationContext clonedContext2(Expression::evaluationContext());
+
+    String s;
+    double doublePos;
+
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext1);
+        s = argument(0).evaluate().toString();
+    }
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext2);
+        doublePos = argument(1).evaluate().toNumber();
+    }
+
     if (std::isnan(doublePos))
         return emptyString();
     long pos = static_cast<long>(FunRound::round(doublePos));
@@ -542,9 +583,20 @@ Value FunNormalizeSpace::evaluate() const
 
 Value FunTranslate::evaluate() const
 {
+    EvaluationContext clonedContext1(Expression::evaluationContext());
+    EvaluationContext clonedContext2(Expression::evaluationContext());
+
     String s1 = argument(0).evaluate().toString();
-    String s2 = argument(1).evaluate().toString();
-    String s3 = argument(2).evaluate().toString();
+    String s2, s3;
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext1);
+        s2 = argument(1).evaluate().toString();
+    }
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext2);
+        s3 = argument(2).evaluate().toString();
+    }
+
     StringBuilder result;
 
     for (unsigned i1 = 0; i1 < s1.length(); ++i1) {

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -32,6 +32,7 @@
 #include "XPathUtil.h"
 #include <math.h>
 #include <wtf/MathExtras.h>
+#include <wtf/SetForScope.h>
 
 namespace WebCore {
 namespace XPath {
@@ -75,8 +76,15 @@ NumericOp::NumericOp(Opcode opcode, std::unique_ptr<Expression> lhs, std::unique
 
 Value NumericOp::evaluate() const
 {
+    EvaluationContext clonedContext(Expression::evaluationContext());
+
     double leftVal = subexpression(0).evaluate().toNumber();
-    double rightVal = subexpression(1).evaluate().toNumber();
+    double rightVal;
+
+    {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        rightVal = subexpression(1).evaluate().toNumber();
+    }
 
     switch (m_opcode) {
         case OP_Add:
@@ -199,8 +207,14 @@ bool EqTestOp::compare(const Value& lhs, const Value& rhs) const
 
 Value EqTestOp::evaluate() const
 {
+    EvaluationContext clonedContext(Expression::evaluationContext());
+
     Value lhs(subexpression(0).evaluate());
-    Value rhs(subexpression(1).evaluate());
+    Value rhs = [&] {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        return subexpression(1).evaluate();
+    }();
+
     return compare(lhs, rhs);
 }
 
@@ -218,12 +232,15 @@ inline bool LogicalOp::shortCircuitOn() const
 
 Value LogicalOp::evaluate() const
 {
+    EvaluationContext clonedContext(Expression::evaluationContext());
+
     // This is not only an optimization, http://www.w3.org/TR/xpath
     // dictates that we must do short-circuit evaluation
     bool lhsBool = subexpression(0).evaluate().toBoolean();
     if (lhsBool == shortCircuitOn())
         return lhsBool;
 
+    SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
     return subexpression(1).evaluate().toBoolean();
 }
 


### PR DESCRIPTION
#### 0d8b57602412587e0775e329f3031589976ecfdb
<pre>
XPath: Some operators / functions are using the wrong EvaluationContext for non-first arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=243184">https://bugs.webkit.org/show_bug.cgi?id=243184</a>

Reviewed by Darin Adler.

Make sure to backup the EvaluationContext before evaluating the first argument, so that
we can evaluate the non-first parameters with this same initial EvaluationContext.

This is a cherry-pick from Blink&apos;s:
<a href="https://chromium-review.googlesource.com/c/chromium/src/+/1977884">https://chromium-review.googlesource.com/c/chromium/src/+/1977884</a>

* LayoutTests/imported/w3c/web-platform-tests/domxpath/booleans-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-concat-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-contains-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-starts-with-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-after-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-before-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-substring-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-translate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/domxpath/numbers-expected.txt:
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::FunConcat::evaluate const):
(WebCore::XPath::FunStartsWith::evaluate const):
(WebCore::XPath::FunContains::evaluate const):
(WebCore::XPath::FunSubstringBefore::evaluate const):
(WebCore::XPath::FunSubstringAfter::evaluate const):
(WebCore::XPath::FunSubstring::evaluate const):
(WebCore::XPath::FunTranslate::evaluate const):
* Source/WebCore/xml/XPathPredicate.cpp:
(WebCore::XPath::NumericOp::evaluate const):
(WebCore::XPath::EqTestOp::evaluate const):
(WebCore::XPath::LogicalOp::evaluate const):

Canonical link: <a href="https://commits.webkit.org/252846@main">https://commits.webkit.org/252846@main</a>
</pre>
