### PR TITLE
REGRESSION(252481@main): [ iOS ] TestWebKitAPI.WebAuthenticationPanel.PanelHidCancel is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -721,8 +721,12 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&webAuthenticationPanelRan);
+    __block bool done = false;
+    [webView performAfterReceivingMessage:@"This request has been cancelled by the user." action:^{
+        done = true;
+    }];
     [[delegate panel] cancel];
-    [webView waitForMessage:@"This request has been cancelled by the user."];
+    Util::run(&done);
     EXPECT_TRUE(webAuthenticationPanelFailed);
 }
 


### PR DESCRIPTION
#### 83a6feae0199a933bd8f8c144ecbea1e2472e2d7
<pre>
REGRESSION(252481@main): [ iOS ] TestWebKitAPI.WebAuthenticationPanel.PanelHidCancel is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=243174">https://bugs.webkit.org/show_bug.cgi?id=243174</a>
rdar://97563724

Reviewed by Chris Dumez.

Currently, this test sometimes times out while waiting for a &quot;This request has been cancelled by the
user.&quot; message to be posted from the web process. In the case where this happens, the message
handlers haven&apos;t been registered yet in the page, which causes this JavaScript to throw an exception
due to `window.webkit` being `undefined`:

```
window.webkit.messageHandlers.testHandler.postMessage(error.message);
```

Mitigate this flaky test by ensuring that the IPC message from the UI process to the web process to
register message handlers (which is triggered by `-addScriptMessageHandler:`) always arrives before
the IPC messages to the web process propagated via `-[_WKWebAuthenticationPanel cancel]`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:

Canonical link: <a href="https://commits.webkit.org/252811@main">https://commits.webkit.org/252811@main</a>
</pre>
