### PR TITLE
Evict unused fonts after 4 rendering updates containing paint changes.

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -386,8 +386,14 @@ void RemoteRenderingBackendProxy::finalizeRenderingUpdate()
     if (!m_gpuProcessConnection)
         return;
     sendToStream(Messages::RemoteRenderingBackend::FinalizeRenderingUpdate(m_renderingUpdateID));
-    m_remoteResourceCacheProxy.finalizeRenderingUpdate();
     m_renderingUpdateID.increment();
+}
+
+void RemoteRenderingBackendProxy::didPaintLayers()
+{
+    if (!m_gpuProcessConnection)
+        return;
+    m_remoteResourceCacheProxy.didPaintLayers();
 }
 
 void RemoteRenderingBackendProxy::didCreateImageBufferBackend(ImageBufferBackendHandle handle, RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -116,6 +116,8 @@ public:
     Vector<SwapBuffersResult> prepareBuffersForDisplay(const Vector<LayerPrepareBuffersData>&);
 
     void finalizeRenderingUpdate();
+    void didPaintLayers();
+
     RenderingUpdateID renderingUpdateID() const { return m_renderingUpdateID; }
     unsigned delayedRenderingUpdateCount() const { return m_renderingUpdateID - m_didRenderingUpdateID; }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -56,7 +56,7 @@ public:
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
 
-    void finalizeRenderingUpdate();
+    void didPaintLayers();
 
     void remoteResourceCacheWasDestroyed();
     void releaseMemory();
@@ -66,7 +66,7 @@ public:
 private:
     using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::ImageBuffer>>;
     using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::NativeImage>>;
-    using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, RenderingUpdateID>;
+    using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
     using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::DecomposedGlyphs>>;
     
     void releaseNativeImage(WebCore::RenderingResourceIdentifier) override;
@@ -87,6 +87,7 @@ private:
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
 
     RemoteRenderingBackendProxy& m_remoteRenderingBackendProxy;
+    uint64_t m_renderingUpdateID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -378,6 +378,9 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     RefPtr<BackingStoreFlusher> backingStoreFlusher = BackingStoreFlusher::create(WebProcess::singleton().parentProcessConnection(), WTFMove(commitEncoder), WTFMove(flushers));
     m_pendingBackingStoreFlusher = backingStoreFlusher;
 
+    if (flushers.size())
+        m_webPage.didPaintLayers();
+
     auto pageID = m_webPage.identifier();
     dispatch_async(m_commitQueue.get(), [backingStoreFlusher = WTFMove(backingStoreFlusher), pageID] {
         backingStoreFlusher->flush();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4435,11 +4435,21 @@ void WebPage::updateRendering()
 
 void WebPage::didUpdateRendering()
 {
+    didPaintLayers();
+
     if (m_didUpdateRenderingAfterCommittingLoad)
         return;
 
     m_didUpdateRenderingAfterCommittingLoad = true;
     send(Messages::WebPageProxy::DidUpdateRenderingAfterCommittingLoad());
+}
+
+void WebPage::didPaintLayers()
+{
+#if ENABLE(GPU_PROCESS)
+    if (m_remoteRenderingBackendProxy)
+        m_remoteRenderingBackendProxy->didPaintLayers();
+#endif
 }
 
 bool WebPage::shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -670,6 +670,7 @@ public:
 #endif
 
     void didUpdateRendering();
+    void didPaintLayers();
 
     // A "platform rendering update" here describes the work done by the system graphics framework before work is submitted to the system compositor.
     // On macOS, this is a CoreAnimation commit.


### PR DESCRIPTION
#### 2da5f7dd5dd8835df69e5d489132dfc374c54c52
<pre>
Evict unused fonts after 4 rendering updates containing paint changes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243189">https://bugs.webkit.org/show_bug.cgi?id=243189</a>

Reviewed by Simon Fraser.

We previously evicted fonts from the resource cache if they hadn&apos;t been used
for 4 rendering updates. Many rendering updates don&apos;t contain any paint changes,
so always count all fonts as &apos;unused&apos;.

This changes us to only count rendering updates that contain painting towards
deciding if a font has been unused long enough to be evicted.

* ../../Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::finalizeRenderingUpdate):
(WebKit::RemoteRenderingBackendProxy::didPaintLayers):
* ../../Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* ../../Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordFontUse):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
(WebKit::RemoteResourceCacheProxy::didPaintLayers):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdate): Deleted.
* ../../Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* ../../Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* ../../Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didUpdateRendering):
(WebKit::WebPage::didPaintLayers):
* ../../Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/252844@main">https://commits.webkit.org/252844@main</a>
</pre>
