### PR TITLE
Web Inspector: Network: add a Path column

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -523,6 +523,9 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         case "domain":
             this._populateDomainCell(cell, entry);
             break;
+        case "path":
+            setTextContent((resourceEntry) => resourceEntry.path);
+            break;
         case "type":
             setTextContent((resourceEntry) => resourceEntry.displayType);
             break;
@@ -1057,6 +1060,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         switch (sortColumnIdentifier) {
         case "name":
         case "domain":
+        case "path":
         case "mimeType":
         case "method":
         case "scheme":
@@ -1188,6 +1192,13 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
             initialWidth: 150,
         });
 
+        this._pathColumn = new WI.TableColumn("path", WI.UIString("Path"), {
+            hidden: true,
+            minWidth: 120,
+            maxWidth: 400,
+            initialWidth: 150,
+        });
+
         this._typeColumn = new WI.TableColumn("type", WI.UIString("Type"), {
             minWidth: 70,
             maxWidth: 120,
@@ -1290,6 +1301,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
 
         this._table.addColumn(this._nameColumn);
         this._table.addColumn(this._domainColumn);
+        this._table.addColumn(this._pathColumn);
         this._table.addColumn(this._typeColumn);
         this._table.addColumn(this._mimeTypeColumn);
         this._table.addColumn(this._methodColumn);
@@ -1988,10 +2000,15 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
                 rowClassNames.push("initiated");
         }
 
+        let subpath = resource.urlComponents.path;
+        if (subpath && resource.urlComponents.lastPathComponent)
+            subpath = subpath.substring(0, subpath.length - resource.urlComponents.lastPathComponent.length);
+
         return {
             resource,
             name: WI.displayNameForURL(resource.url, resource.urlComponents),
             domain: WI.displayNameForHost(resource.urlComponents.host),
+            path: subpath || "",
             scheme: resource.urlComponents.scheme ? resource.urlComponents.scheme.toLowerCase() : "",
             method: resource.requestMethod,
             type: resource.type,


### PR DESCRIPTION
#### 49164c7925f98769b0dfe8d741b1314a1f818e97
<pre>
Web Inspector: Network: add a Path column
<a href="https://bugs.webkit.org/show_bug.cgi?id=243185">https://bugs.webkit.org/show_bug.cgi?id=243185</a>

Reviewed by Patrick Angle.

It&apos;s sometimes useful to know the full path of a resource, such as if two resources have the same
basename (though this specific example would ideally be fixed by &lt;<a href="https://webkit.org/b/143632">https://webkit.org/b/143632</a>&gt;).
This is probably not the most common thing, however, so don&apos;t show the Path column by default. But
still provide it to developers if they explicitly indicate a desire for it (i.e. showing the column).

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView.prototype.tablePopulateCell):
(WI.NetworkTableContentView.prototype._generateSortComparator):
(WI.NetworkTableContentView.prototype.initialLayout):
(WI.NetworkTableContentView.prototype._entryForResource):

Canonical link: <a href="https://commits.webkit.org/252827@main">https://commits.webkit.org/252827@main</a>
</pre>
