### PR TITLE
[JSC] Fix Wasm::isI31ref

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -118,7 +118,8 @@ inline bool isFuncref(Type type)
 
 inline bool isI31ref(Type type)
 {
-    ASSERT(Options::useWebAssemblyGC());
+    if (!Options::useWebAssemblyGC())
+        return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::I31ref);
 }
 


### PR DESCRIPTION
#### 126af4f8105f6ef1f75f69395eac6d8efae24441
<pre>
[JSC] Fix Wasm::isI31ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=243193">https://bugs.webkit.org/show_bug.cgi?id=243193</a>

Reviewed by Mark Lam.

Wasm::isI31ref function can be called even when WasmGC is disabled.

* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isI31ref):

Canonical link: <a href="https://commits.webkit.org/252815@main">https://commits.webkit.org/252815@main</a>
</pre>
