### PR TITLE
[JSC] Fix getBytecodeIndex and appendSourceToErrorMessage inconsistency for inlined CodeBlock

### DIFF
--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -143,19 +143,19 @@ public:
         if (codeBlock->ownerExecutable()->implementationVisibility() != ImplementationVisibility::Public)
             return IterationStatus::Continue;
 
-        m_foundCallFrame = visitor->callFrame();
+        m_codeBlock = codeBlock;
 
         if (!codeBlock->unlinkedCodeBlock()->isBuiltinFunction())
             m_bytecodeIndex = visitor->bytecodeIndex();
         return IterationStatus::Done;
     }
 
-    CallFrame* foundCallFrame() const { return m_foundCallFrame; }
+    CodeBlock* codeBlock() const { return m_codeBlock; }
     BytecodeIndex bytecodeIndex() const { return m_bytecodeIndex; }
 
 private:
     CallFrame* m_startCallFrame;
-    mutable CallFrame* m_foundCallFrame { nullptr };
+    mutable CodeBlock* m_codeBlock { nullptr };
     mutable bool m_foundStartCallFrame { false };
     mutable BytecodeIndex m_bytecodeIndex { 0 };
 };
@@ -172,11 +172,11 @@ std::unique_ptr<Vector<StackFrame>> getStackTrace(JSGlobalObject*, VM& vm, JSObj
     return stackTrace;
 }
 
-std::tuple<CallFrame*, BytecodeIndex> getBytecodeIndex(VM& vm, CallFrame* startCallFrame)
+std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM& vm, CallFrame* startCallFrame)
 {
     FindFirstCallerFrameWithCodeblockFunctor functor(startCallFrame);
     StackVisitor::visit(vm.topCallFrame, vm, functor);
-    return { functor.foundCallFrame(), functor.bytecodeIndex() };
+    return { functor.codeBlock(), functor.bytecodeIndex() };
 }
 
 bool getLineColumnAndSource(VM& vm, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL)

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -67,7 +67,7 @@ JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorType, const String
 JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension, const String&);
 
 std::unique_ptr<Vector<StackFrame>> getStackTrace(JSGlobalObject*, VM&, JSObject*, bool useCurrentFrame);
-std::tuple<CallFrame*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
+std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
 bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL);
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);


### PR DESCRIPTION
#### 4ba59125ace33e0c29fe196966a55f7a391feb48
<pre>
[JSC] Fix getBytecodeIndex and appendSourceToErrorMessage inconsistency for inlined CodeBlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=243194">https://bugs.webkit.org/show_bug.cgi?id=243194</a>

Reviewed by Mark Lam.

JSTests/stress/put-private-name-invalid-define.js crashes in debug build since getBytecodeIndex and appendSourceToErrorMessage
have inconsistency for inlined CodeBlock. While getBytecodeIndex returns bytecodeIndex for inlined CodeBlock, appendSourceToErrorMessage
is getting CodeOrigin from CallFrame, which will point to the top-level CodeBlock inlining multiple functions. This inconsistency ends up
using wrong BytecodeIndex for wrong CodeBlock.

In this patch, we return the correct CodeBlock from getBytecodeIndex and use it in appendSourceToErrorMessage instead of querying to
CallFrame by itself.

* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::FindFirstCallerFrameWithCodeblockFunctor::operator() const):
(JSC::FindFirstCallerFrameWithCodeblockFunctor::codeBlock const):
(JSC::getBytecodeIndex):
(JSC::FindFirstCallerFrameWithCodeblockFunctor::foundCallFrame const): Deleted.
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::appendSourceToErrorMessage):
(JSC::ErrorInstance::finishCreation):

Canonical link: <a href="https://commits.webkit.org/252814@main">https://commits.webkit.org/252814@main</a>
</pre>
