### PR TITLE
[Alternate WebM Player] Re-enqueue samples on decompression session instantiation

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1265,6 +1265,9 @@ void MediaPlayerPrivateWebM::ensureDecompressionSession()
             setHasAvailableVideoFrame(true);
     });
     
+    if (m_enabledVideoTrackID != notFound)
+        reenqueSamples(m_enabledVideoTrackID);
+    
     m_player->renderingModeChanged();
 }
 


### PR DESCRIPTION
#### eabd5658eb2c30e188f91fa76fd5e53bd8e6a73a
<pre>
[Alternate WebM Player] Re-enqueue samples on decompression session instantiation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243200">https://bugs.webkit.org/show_bug.cgi?id=243200</a>
&lt;rdar://97589026&gt;

Reviewed by Jean-Yves Avenard.

As part of the effort to bring the alternate WebM player to an experimental
feature, this patch fixes a race condition with WebGL painting once a new
decompression session is created. If the session isn&apos;t created fast enough,
the first few frames will only be enqueued on the AVSBDL rather than the
decompression session and result in lost frames when painting.

The fix is to just re-enqueue samples once a new decompression session is created.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):

Canonical link: <a href="https://commits.webkit.org/252829@main">https://commits.webkit.org/252829@main</a>
</pre>
