### PR TITLE
Dynamically inserted stylesheets cannot be accessed via document.styleSheets

### DIFF
--- a/LayoutTests/fast/dom/document-style-sheets-dynamic-insertion-expected.txt
+++ b/LayoutTests/fast/dom/document-style-sheets-dynamic-insertion-expected.txt
@@ -1,0 +1,12 @@
+This tests inserting a style element dynamically. document.styleSheets should immediately list the element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.styleSheets.length is 1
+PASS document.head.appendChild(styleElement); document.styleSheets.length is 2
+PASS styleElement.sheet is document.styleSheets[1]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/document-style-sheets-dynamic-insertion.html
+++ b/LayoutTests/fast/dom/document-style-sheets-dynamic-insertion.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('This tests inserting a style element dynamically. document.styleSheets should immediately list the element.');
+
+const styleElement = document.createElement('style');
+styleElement.type = 'text/css';
+styleElement.rel = 'stylesheet';
+
+shouldBe('document.styleSheets.length', '1');
+shouldBe('document.head.appendChild(styleElement); document.styleSheets.length', '2');
+shouldBe('styleElement.sheet', 'document.styleSheets[1]');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### dc0078a2b47f3ba71733d01464d93d5ce44b441d
<pre>
Dynamically inserted stylesheets cannot be accessed via document.styleSheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=14586">https://bugs.webkit.org/show_bug.cgi?id=14586</a>

Reviewed by Wenson Hsieh.

Add a test case now that it&apos;s working.

* LayoutTests/fast/dom/document-style-sheets-dynamic-insertion-expected.txt: Added.
* LayoutTests/fast/dom/document-style-sheets-dynamic-insertion.html: Added.

Canonical link: <a href="https://commits.webkit.org/252816@main">https://commits.webkit.org/252816@main</a>
</pre>
