### PR TITLE
[libpas] Enable libpas on GTK / WPE

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -20,6 +20,7 @@ set(bmalloc_SOURCES
     bmalloc/Heap.cpp
     bmalloc/HeapConstants.cpp
     bmalloc/HeapKind.cpp
+    bmalloc/IsoHeap.cpp
     bmalloc/IsoHeapImpl.cpp
     bmalloc/IsoMallocFallback.cpp
     bmalloc/IsoPage.cpp

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -324,7 +324,7 @@
 
 /* BENABLE(LIBPAS) is enabling libpas build. But this does not mean we use libpas for bmalloc replacement. */
 #if !defined(BENABLE_LIBPAS)
-#if BCPU(ADDRESS64) && (BOS(DARWIN) || (BOS(LINUX) && !BPLATFORM(GTK) && !BPLATFORM(WPE))) || BPLATFORM(PLAYSTATION)
+#if BCPU(ADDRESS64) && (BOS(DARWIN) || (BOS(LINUX) && (BCPU(X86_64) || BCPU(ARM64))) || BPLATFORM(PLAYSTATION))
 #define BENABLE_LIBPAS 1
 #ifndef PAS_BMALLOC
 #define PAS_BMALLOC 1

--- a/Tools/WebKitTestRunner/CMakeLists.txt
+++ b/Tools/WebKitTestRunner/CMakeLists.txt
@@ -100,6 +100,9 @@ set(WebKitTestRunnerInjectedBundle_LIBRARIES
     WebKit::WebCoreTestSupport
     WebKit::WebKit
 )
+if (NOT USE_SYSTEM_MALLOC)
+    list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES bmalloc)
+endif ()
 
 set(WebKitTestRunnerInjectedBundle_IDL_FILES
     "${WebKitTestRunner_DIR}/InjectedBundle/Bindings/AccessibilityController.idl"


### PR DESCRIPTION
#### fd0426d0c812116d14e6c6b66f6ad07cd1d7b00e
<pre>
[libpas] Enable libpas on GTK / WPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=243201">https://bugs.webkit.org/show_bug.cgi?id=243201</a>

Reviewed by Michael Catanzaro.

This patch enables libpas on GTK and WPE Linux ports if they are X86_64 or ARM64.
This offers 1% improvement in JetStream2 (182.483 v.s. 184.102).
In RAMification score, we first observed regression, but it turned out that this
is because Linux RAMification is not correctly measuring footprint: it is using
RSS instead of private dirty memory, so it includes text region etc. And after using
smaps based footprint calculation, the result is roughly the same between libpas and
bmalloc. Also, we know that text size in WebKit / WebCore singificantly decreases
While text size in JavaScriptCore increases with libpas (because of isoheap implementation
improvement), we can say libpas enablement can be win in performance and memory.

* Source/bmalloc/bmalloc/BPlatform.h:
* Tools/WebKitTestRunner/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/252858@main">https://commits.webkit.org/252858@main</a>
</pre>
