### PR TITLE
REGRESSION (246051@main): Legacy videoFrameToImage path is always taken

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -6143,7 +6143,7 @@ RefPtr<Image> WebGLRenderingContextBase::videoFrameToImage(HTMLVideoElement* vid
             return nullptr;
         }
         FloatRect imageRect { { }, imageSize };
-        ImageBuffer* imageBuffer = m_generatedImageCache.imageBuffer(imageSize, nativeImage->colorSpace(), CompositeOperator::Copy);
+        imageBuffer = m_generatedImageCache.imageBuffer(imageSize, nativeImage->colorSpace(), CompositeOperator::Copy);
         if (!imageBuffer) {
             synthesizeGLError(GraphicsContextGL::OUT_OF_MEMORY, functionName, "out of memory");
             return nullptr;


### PR DESCRIPTION
#### 47319060e06f7cb7bb037a606c334dcdc036b09f
<pre>
REGRESSION (246051@main): Legacy videoFrameToImage path is always taken
<a href="https://bugs.webkit.org/show_bug.cgi?id=243202">https://bugs.webkit.org/show_bug.cgi?id=243202</a>
&lt;rdar://97591186&gt;

Reviewed by Jean-Yves Avenard.

Due to a small name shadowing/scope bug with `imageBuffer`, the `if (!imageBuffer)`
legacy fallback path would always be taken since the outer scoped `imageBuffer`
would not be defined within the `nativeImage` path. This leads to drawing
the same frame twice and doubling the frame memory usage at best.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::videoFrameToImage):

Canonical link: <a href="https://commits.webkit.org/252831@main">https://commits.webkit.org/252831@main</a>
</pre>
