### PR TITLE
CoreAudioSharedUnit needs to reconfigure in case of kParamError only once

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -145,6 +145,7 @@ private:
     uint64_t m_microphoneProcsCalledLastTime { 0 };
     Timer m_verifyCapturingTimer;
 
+    bool m_shouldUpdateMicrophoneSampleBufferSize { false };
     bool m_isReconfiguring { false };
     mutable Lock m_speakerSamplesProducerLock;
     CoreAudioSpeakerSamplesProducer* m_speakerSamplesProducer WTF_GUARDED_BY_LOCK(m_speakerSamplesProducerLock) { nullptr };


### PR DESCRIPTION
#### b8ccca81decfb83b5eed4a71c98b39bda14521ea
<pre>
CoreAudioSharedUnit needs to reconfigure in case of kParamError only once
<a href="https://bugs.webkit.org/show_bug.cgi?id=243211">https://bugs.webkit.org/show_bug.cgi?id=243211</a>

Reviewed by Eric Carlson.

In case of kParamError, we reconfigure the audio unit asynchronously on main thread.
There might be several kParamError cases before the audio unit is reconfigured.
But we only need to reconfigure the audio unit once.
Introduce m_shouldUpdateMicrophoneSampleBufferSize to limit reconfiguration.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::configureMicrophoneProc):
(WebCore::CoreAudioSharedUnit::processMicrophoneSamples):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/252864@main">https://commits.webkit.org/252864@main</a>
</pre>
