### PR TITLE
Remove sysctl sandbox telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -539,7 +539,7 @@
 ;;; End UIKit-apps.sb content
 ;;;
 
-(deny sysctl* (with telemetry))
+(deny sysctl*)
 (allow sysctl-read
     (sysctl-name
         "hw.activecpu"


### PR DESCRIPTION
#### db0f03c7d7d72947180c25cbfe41ae8eb5735d82
<pre>
Remove sysctl sandbox telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=243212">https://bugs.webkit.org/show_bug.cgi?id=243212</a>
&lt;rdar://problem/97606762&gt;

Reviewed by Chris Dumez.

Remove sysctl sandbox telemetry in the GPU process on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/252826@main">https://commits.webkit.org/252826@main</a>
</pre>
