### PR TITLE
[ iOS15 ] 3X TestWebKitAPI.WebKit.LockdownMode (API tests) are constantly failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -395,7 +395,7 @@ TEST(WebKit, InjectedBundleNodeHandleIsSelectElement)
     TestWebKitAPI::Util::run(&done);
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
 
 static int presentViewControllerCallCount = 0;
 
@@ -540,7 +540,7 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebKitCaptivePortalModeAlertShownKey];
 }
 
-#endif
+#endif // PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
 
 #if PLATFORM(MAC)
 


### PR DESCRIPTION
#### 73456e51b9ec60308f77d2bc147fb6f6810bb158
<pre>
[ iOS15 ] 3X TestWebKitAPI.WebKit.LockdownMode (API tests) are constantly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243214">https://bugs.webkit.org/show_bug.cgi?id=243214</a>
&lt;rdar://97609613&gt;

Unreviewed, the lock down mode API is new in iOS 16 and thus we should only
run these API tests on iOS16+.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:

Canonical link: <a href="https://commits.webkit.org/252830@main">https://commits.webkit.org/252830@main</a>
</pre>
