### PR TITLE
constructJSWebAssemblyException needs overflow checks.

### DIFF
--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -63,6 +63,8 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     MarkedArgumentBuffer values;
     forEachInIterable(globalObject, tagParameters, [&] (VM&, JSGlobalObject*, JSValue nextValue) {
         values.append(nextValue);
+        if (UNLIKELY(values.hasOverflowed()))
+            throwOutOfMemoryError(globalObject, scope);
     });
     RETURN_IF_EXCEPTION(scope, { });
 


### PR DESCRIPTION
#### c948101f1850f61b4bfa48571da1725299e8f29e
<pre>
constructJSWebAssemblyException needs overflow checks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243217">https://bugs.webkit.org/show_bug.cgi?id=243217</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/252867@main">https://commits.webkit.org/252867@main</a>
</pre>
