### PR TITLE
[Gardening]: [ BigSur Release ] 4X webgl/2.0.0/deqp/functional/gles3/ tests are constantly failing

### DIFF
--- a/LayoutTests/webgl/TestExpectations
+++ b/LayoutTests/webgl/TestExpectations
@@ -21,11 +21,6 @@ webgl/2.0.0/deqp/functional/gles3/vertexarrays/multiple_attributes.stride.html [
 webgl/2.0.0/deqp/functional/gles3/builtinprecision/ [ Skip ]
 webgl/2.0.0/conformance2/textures/misc/tex-srgb-mipmap.html [ Skip ]
 
-webkit.org/b/228703 webgl/2.0.0/deqp/functional/gles3/fbomultisample.2_samples.html [ Failure ]
-webkit.org/b/228703 webgl/2.0.0/deqp/functional/gles3/fbomultisample.4_samples.html [ Failure ]
-webkit.org/b/228703 webgl/2.0.0/deqp/functional/gles3/fbomultisample.8_samples.html [ Failure ]
-webkit.org/b/228703 webgl/2.0.0/deqp/functional/gles3/shadertexturefunction/texturegrad.html [ Failure ]
-
 # Explicitly enable tests which we have fixed. These expectations will be removed when 1.0.x/2.0.y is enabled.
 webgl/1.0.x/conformance/extensions/webgl-compressed-texture-etc.html [ Pass ]
 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-etc.html [ Pass ]


### PR DESCRIPTION
#### fa7620b947b664ce4f9fe0111d044b77e2c69af0
<pre>
[Gardening]: [ BigSur Release ] 4X webgl/2.0.0/deqp/functional/gles3/ tests are constantly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=228703">https://bugs.webkit.org/show_bug.cgi?id=228703</a>

Unreviewed test gardening.

* LayoutTests/webgl/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252835@main">https://commits.webkit.org/252835@main</a>
</pre>
