### PR TITLE
Quip print from NSMenuItem shows up as an empty page

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2794,6 +2794,13 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
     });
 }
 
+- (void)_generateSyntheticCommandP:(void (^)(BOOL))completionBlock
+{
+    _page->generateSyntheticCommandP([completionBlock = makeBlockPtr(completionBlock)](bool wasHandled) {
+        completionBlock(wasHandled);
+    });
+}
+
 - (NSData *)_sessionStateData
 {
     // FIXME: This should not use the legacy session state encoder.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -268,6 +268,8 @@ for this property.
 
 - (void)_doAfterNextVisibleContentRectUpdate:(void (^)(void))updateBlock WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+- (void)_generateSyntheticCommandP:(void (^)(BOOL))completionBlock WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 - (void)_executeEditCommand:(NSString *)command argument:(NSString *)argument completion:(void (^)(BOOL))completion WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
 - (void)_isJITEnabled:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(10.14.4), ios(12.2));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -974,6 +974,16 @@ bool WebPageProxy::shouldUseBackForwardCache() const
     return m_preferences->usesBackForwardCache() && backForwardCache().capacity() > 0;
 }
 
+void WebPageProxy::generateSyntheticCommandP(CompletionHandler<void(bool)>&& callbackFunction)
+{
+    if (!hasRunningProcess()) {
+        callbackFunction(false);
+        return;
+    }
+    
+    sendWithAsyncReply(Messages::WebPage::GenerateSyntheticCommandP(), WTFMove(callbackFunction));
+}
+
 void WebPageProxy::swapToProvisionalPage(std::unique_ptr<ProvisionalPageProxy> provisionalPage)
 {
     ASSERT(!m_isClosed);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -820,6 +820,9 @@ public:
 #if ENABLE(UI_SIDE_COMPOSITING)
     void updateVisibleContentRects(const VisibleContentRectUpdateInfo&, bool sendEvenIfUnchanged);
 #endif
+        
+    void generateSyntheticCommandP(CompletionHandler<void(bool)>&& callbackFunction);
+        
 
 #if PLATFORM(IOS_FAMILY)
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3280,6 +3280,22 @@ void WebPage::validateCommand(const String& commandName, CompletionHandler<void(
     completionHandler(isEnabled, state);
 }
 
+void WebPage::generateSyntheticCommandP(CompletionHandler<void(bool)>&& completion)
+{
+    OptionSet<PlatformEvent::Modifier> modifiers;
+    modifiers.add(PlatformEvent::Modifier::MetaKey);
+    
+    PlatformKeyboardEvent keyEvent = PlatformKeyboardEvent(PlatformEvent::KeyDown, "p"_s, "p"_s, "p"_s, "KeyP"_s, "U+0050"_s, 80, false, false, false, modifiers, WallTime::now());
+    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+
+    keyEvent.setIsSyntheticEvent();
+    
+    PlatformKeyboardEvent::setCurrentModifierState(modifiers);
+    
+    bool wasHandled = frame->eventHandler().keyEvent(keyEvent);
+    completion(wasHandled);
+}
+
 void WebPage::executeEditCommand(const String& commandName, const String& argument)
 {
     executeEditingCommand(commandName, argument);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1584,6 +1584,8 @@ private:
     void updateSizeForCSSSmallViewportUnits();
     void updateSizeForCSSLargeViewportUnits();
 
+    void generateSyntheticCommandP(CompletionHandler<void(bool)>&&);
+
 #if PLATFORM(IOS_FAMILY)
     std::optional<FocusedElementInformation> focusedElementInformation();
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -47,6 +47,7 @@ messages -> WebPage LegacyReceiver {
     ExecuteEditCommandWithCallback(String name, String argument) -> ()
     KeyEvent(WebKit::WebKeyboardEvent event)
     MouseEvent(WebKit::WebMouseEvent event, std::optional<Vector<WebKit::SandboxExtension::Handle>> sandboxExtensions)
+    GenerateSyntheticCommandP() -> (bool wasHandled)
 #if PLATFORM(IOS_FAMILY)
     SetViewportConfigurationViewLayoutSize(WebCore::FloatSize size, double scaleFactor, double minimumEffectiveDeviceWidth)
     SetDeviceOrientation(int32_t deviceOrientation)


### PR DESCRIPTION
#### 30ffd1a680bacaf1f0e1b2ecdcc658b3a61d7e90
<pre>
Quip print from NSMenuItem shows up as an empty page
<a href="https://bugs.webkit.org/show_bug.cgi?id=243218">https://bugs.webkit.org/show_bug.cgi?id=243218</a>
rdar://90054391

Reviewed by NOBODY (OOPS!).

When a user pressed Cmd+P, some websites (Quip, Google Docs, etc)
intercept this event and do their own processing before sending a print
event. However, when doing `File &gt; Print`, the default print behavior
is used. This causes discrepancies for how these websites are printed
between the two different methods.

This PR addresses this by synthesizing a Cmd+P event whenever
`File &gt; Print` is invoked or when `Print` is selected from the context
menu, which allows for consistent behavior.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _generateSyntheticCommandP:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::generateSyntheticCommandP):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::generateSyntheticEditingCommand): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::generateSyntheticCommandP):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre>