### PR TITLE
[Gardening]: REGRESSION (r281182?): [ BigSur wk2 ] 4X media/modern-media-controls/tracks-support (Layout Tests) are constantly timing out

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1520,11 +1520,6 @@ webkit.org/b/230056 [ BigSur Debug ] http/tests/inspector/network/har/har-page-a
 
 webkit.org/b/229472 [ BigSur Debug ] webgl/1.0.3/conformance/glsl/constructors/glsl-construct-bvec2.html [ Pass Timeout ]
 
-#webkit.org/b/229474
-[ BigSur+ ] media/modern-media-controls/tracks-support/auto-text-track.html [ Pass Timeout ]
-[ BigSur+ ] media/modern-media-controls/tracks-support/hidden-tracks.html [ Pass Timeout ]
-[ BigSur+ ] media/modern-media-controls/tracks-support/off-text-track.html [ Pass Failure Timeout ]
-
 webkit.org/b/229523 [ Debug ] fast/canvas/webgl/lose-context-on-timeout.html [ Pass Timeout ]
 
 webkit.org/b/229561 http/tests/navigation/page-cache-video.html [ Pass Failure ]
@@ -1681,8 +1676,6 @@ webkit.org/b/239574 [ Monterey Release ] webanimations/frame-rate/animation-fram
 webkit.org/b/195635 [ arm64 ] scrollingcoordinator/mac/multiple-fixed.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html [ Pass Failure ]
-
-webkit.org/b/239634 [ arm64 ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Failure ]
 
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 1c2334cf2453355df7d06e76fc46ced6a13849f2
<pre>
[Gardening]: REGRESSION (r281182?): [ BigSur wk2 ] 4X media/modern-media-controls/tracks-support (Layout Tests) are constantly timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=229474">https://bugs.webkit.org/show_bug.cgi?id=229474</a>

Unreviewed test gardening.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252841@main">https://commits.webkit.org/252841@main</a>
</pre>
