### PR TITLE
Enable lazy iframe loading by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -830,11 +830,11 @@ LazyIframeLoadingEnabled:
   humanReadableDescription: "Enable lazy iframe loading support"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 LazyImageLoadingEnabled:
   type: bool


### PR DESCRIPTION
#### 461deb6c6dd76896c70a9196a2ad9cc78d07a054
<pre>
Enable lazy iframe loading by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=243199">https://bugs.webkit.org/show_bug.cgi?id=243199</a>
&lt;rdar://97565220&gt;

Reviewed by Simon Fraser.

Turn on lazy iframe loading by default as the implementation seems complete and is
passing most WPT tests.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:

Canonical link: <a href="https://commits.webkit.org/252848@main">https://commits.webkit.org/252848@main</a>
</pre>
