### PR TITLE
Stop restricting iframe lazy loading to http(s) URLs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-expected.txt
@@ -3,7 +3,7 @@
 
 PASS In-viewport iframes load eagerly
 PASS Below-viewport iframes load lazily
-FAIL Below-viewport srcdoc iframes load lazily assert_true: The window load event should have fired before the below-viewport srcdoc iframe's subresource loads expected true got false
-FAIL Below-viewport data: url iframes load lazily assert_true: The window load event should have fired before the below-viewport data url iframe loads expected true got false
+PASS Below-viewport srcdoc iframes load lazily
+PASS Below-viewport data: url iframes load lazily
 FAIL Below-viewport blob url iframes load lazily assert_true: The window load event should have fired before the below-viewport blob url iframe loads expected true got false
 

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -166,11 +166,8 @@ void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
     setAttributeWithoutSynchronization(loadingAttr, value);
 }
 
-static bool isFrameLazyLoadable(const Document& document, const URL& completeURL, const AtomString& loadingAttributeValue)
+static bool isFrameLazyLoadable(const Document& document, const AtomString& loadingAttributeValue)
 {
-    if (!completeURL.protocolIsInHTTPFamily())
-        return false;
-
     if (!document.frame() || !document.frame()->script().canExecuteScripts(NotAboutToExecuteScript))
         return false;
 
@@ -180,9 +177,9 @@ static bool isFrameLazyLoadable(const Document& document, const URL& completeURL
 bool HTMLIFrameElement::shouldLoadFrameLazily()
 {
     if (!m_lazyLoadFrameObserver && document().settings().lazyIframeLoadingEnabled()) {
-        URL completeURL = document().completeURL(frameURL());
-        if (isFrameLazyLoadable(document(), completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
+        if (isFrameLazyLoadable(document(), attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
             auto currentReferrerPolicy = referrerPolicy();
+            URL completeURL = document().completeURL(frameURL());
             lazyLoadFrameObserver().observe(AtomString { completeURL.string() }, currentReferrerPolicy);
             return true;
         }


### PR DESCRIPTION
#### fb16c32ad4fc21ecc04a45b295cdde23dd605d2a
<pre>
Stop restricting iframe lazy loading to http(s) URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=243225">https://bugs.webkit.org/show_bug.cgi?id=243225</a>

Reviewed by Simon Fraser.

Stop restricting iframe lazy loading to http(s) URLs so we can pass a few more WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-expected.txt:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::isFrameLazyLoadable):
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):

Canonical link: <a href="https://commits.webkit.org/252852@main">https://commits.webkit.org/252852@main</a>
</pre>
