### PR TITLE
Make new pseudo to allow Mail to turn off attachment controls.

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -282,7 +282,7 @@ CSSSelector::PseudoElementType CSSSelector::parsePseudoElementType(StringView na
 
     auto type = parsePseudoElementString(name);
     if (type == PseudoElementUnknown) {
-        if (name.startsWith("-webkit-"_s))
+        if (name.startsWith("-webkit-"_s) || name.startsWith("-apple-"_s))
             type = PseudoElementWebKitCustom;
     }
 

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -45,6 +45,7 @@
 #include "MouseEvent.h"
 #include "RenderAttachment.h"
 #include "RenderImage.h"
+#include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
 #include "UserAgentStyleSheets.h"
 #include <wtf/text/AtomString.h>
@@ -105,6 +106,7 @@ void createImageControls(HTMLElement& element)
     auto button = HTMLButtonElement::create(HTMLNames::buttonTag, element.document(), nullptr);
     button->setIdAttribute(imageControlsButtonIdentifier());
     controlLayer->appendChild(button);
+    controlLayer->setPseudo(ShadowPseudoIds::appleAttachmentControlsContainer());
     
     if (auto* renderObject = element.renderer(); is<RenderImage>(renderObject))
         downcast<RenderImage>(*renderObject).setHasShadowControls(true);

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
@@ -327,6 +327,12 @@ const AtomString& webkitValidationBubbleBody()
     return webkitValidationBubbleBody;
 }
 
+const AtomString& appleAttachmentControlsContainer()
+{
+    static MainThreadNeverDestroyed<const AtomString> appleAttachmentControlsContainer("-apple-attachment-controls-container"_s);
+    return appleAttachmentControlsContainer;
+}
+
 } // namespace ShadowPseudoId
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.h
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.h
@@ -103,6 +103,8 @@ const AtomString& webkitValidationBubbleTextBlock();
 const AtomString& webkitValidationBubbleHeading();
 const AtomString& webkitValidationBubbleBody();
 
+const AtomString& appleAttachmentControlsContainer();
+
 } // namespace ShadowPseudoId
 
 } // namespace WebCore


### PR DESCRIPTION
#### 607499977734f77ef66a84a9df7f9b2bf4a03278
<pre>
Make new pseudo to allow Mail to turn off attachment controls.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243229">https://bugs.webkit.org/show_bug.cgi?id=243229</a>

Reviewed by Wenson Hsieh and Devin Rousso.

Mail would like to have the option to turn off attachment controls for some images.
Since this is stored in the shadowdom, we need to add a pseudo to allow mail to change
the style of the controls, to make them invisible.

We also need to expand the prefixes for custom pseudo to keep the compartmentalization
of these pseudos correct.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementType):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::createImageControls):
* Source/WebCore/html/shadow/ShadowPseudoIds.cpp:
(WebCore::ShadowPseudoIds::appleAttachmentControlsContainer):
* Source/WebCore/html/shadow/ShadowPseudoIds.h:

Canonical link: <a href="https://commits.webkit.org/252862@main">https://commits.webkit.org/252862@main</a>
</pre>
