### PR TITLE
[Gardening]: (r278618) media/modern-media-controls/overflow-support/chapters.html is timing out since introduction

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3302,9 +3302,6 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/canva
 imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/canvas_transformations_scale_001.htm [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/transform_a.html [ ImageOnlyFailure ]
 
-# rdar://79084756 ((r278618) media/modern-media-controls /overflow-support/chapters.html is timing out since introduction (226828))
-media/modern-media-controls/overflow-support/chapters.html [ Timeout ]
-
 # rdar://80345578 ([ Mac iOS Debug ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html is flaky crashing)
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html [ Pass Failure Crash ]
 


### PR DESCRIPTION
#### 8a3641cefd0d601fc2c1b15365f707b4a53d25d7
<pre>
[Gardening]: (r278618) media/modern-media-controls/overflow-support/chapters.html is timing out since introduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=226828">https://bugs.webkit.org/show_bug.cgi?id=226828</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252842@main">https://commits.webkit.org/252842@main</a>
</pre>
