### PR TITLE
Add SPI to request that a WKWebView ignores mouse move events

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -644,6 +644,7 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 @property (nonatomic, readonly) WKPageRef _pageRefForTransitionToWKWebView  WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, readonly) BOOL _hasActiveVideoForControlsManager WK_API_AVAILABLE(macos(10.12));
 @property (nonatomic, readwrite, setter=_setIgnoresNonWheelEvents:) BOOL _ignoresNonWheelEvents WK_API_AVAILABLE(macos(10.13.4));
+@property (nonatomic, readwrite, setter=_setIgnoresMouseMoveEvents:) BOOL _ignoresMouseMoveEvents WK_API_AVAILABLE(macos(13.0));
 
 /*! @abstract A Boolean value indicating whether drawing clips to the visibleRect.
 @discussion When YES, the view will use its -visibleRect when determining which areas of the WKWebView to draw. This may improve performance for large WKWebViews which are mostly clipped out by enclosing views.  The default value is NO.

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1289,6 +1289,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _impl->setIgnoresNonWheelEvents(ignoresNonWheelEvents);
 }
 
+- (BOOL)_ignoresMouseMoveEvents
+{
+    return _impl->ignoresMouseMoveEvents();
+}
+
+- (void)_setIgnoresMouseMoveEvents:(BOOL)ignoresMouseMoveEvents
+{
+    _impl->setIgnoresMouseMoveEvents(ignoresMouseMoveEvents);
+}
+
 - (NSView *)_safeBrowsingWarning
 {
     return _impl->safeBrowsingWarning();

--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.h
@@ -435,6 +435,8 @@ public:
 
     void setIgnoresNonWheelEvents(bool);
     bool ignoresNonWheelEvents() const { return m_ignoresNonWheelEvents; }
+    void setIgnoresMouseMoveEvents(bool ignoresMouseMoveEvents) { m_ignoresMouseMoveEvents = ignoresMouseMoveEvents; }
+    bool ignoresMouseMoveEvents() const { return m_ignoresMouseMoveEvents; }
     void setIgnoresAllEvents(bool);
     bool ignoresAllEvents() const { return m_ignoresAllEvents; }
     void setIgnoresMouseDraggedEvents(bool);
@@ -829,6 +831,7 @@ private:
     RetainPtr<NSEvent> m_lastPressureEvent;
 
     bool m_ignoresNonWheelEvents { false };
+    bool m_ignoresMouseMoveEvents { false };
     bool m_ignoresAllEvents { false };
     bool m_ignoresMouseDraggedEvents { false };
 

--- a/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm
@@ -5582,11 +5582,17 @@ void WebViewImpl::nativeMouseEventHandlerInternal(NSEvent *event)
 
 void WebViewImpl::mouseEntered(NSEvent *event)
 {
+    if (m_ignoresMouseMoveEvents)
+        return;
+
     nativeMouseEventHandler(event);
 }
 
 void WebViewImpl::mouseExited(NSEvent *event)
 {
+    if (m_ignoresMouseMoveEvents)
+        return;
+
     nativeMouseEventHandler(event);
 }
 
@@ -5642,7 +5648,7 @@ void WebViewImpl::mouseDraggedInternal(NSEvent *event)
 
 void WebViewImpl::mouseMoved(NSEvent *event)
 {
-    if (m_ignoresNonWheelEvents)
+    if (m_ignoresNonWheelEvents || m_ignoresMouseMoveEvents)
         return;
 
 #if ENABLE(UI_PROCESS_PDF_HUD)


### PR DESCRIPTION
#### 4bdd79779dacc345a52b134e09c2a66d5b4a8310
<pre>
Add SPI to request that a WKWebView ignores mouse move events
<a href="https://bugs.webkit.org/show_bug.cgi?id=243231">https://bugs.webkit.org/show_bug.cgi?id=243231</a>
&lt;rdar://95823990&gt;

Reviewed by Tim Horton.

Add SPI to request that a WKWebView ignores mouse move events. Before r290743,
the client app could override [WKWebView mouseMoved:] and drop events. However,
this no longer works since r290743 since WKWebView now gets its mouse move
events via another mechanism.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _ignoresMouseMoveEvents]):
(-[WKWebView _setIgnoresMouseMoveEvents:]):
* Source/WebKit/UIProcess/Cocoa/WebViewImpl.h:
(WebKit::WebViewImpl::setIgnoresMouseMoveEvents):
(WebKit::WebViewImpl::ignoresMouseMoveEvents const):
* Source/WebKit/UIProcess/Cocoa/WebViewImpl.mm:
(-[WKMouseTrackingObserver mouseMoved:]):
(-[WKMouseTrackingObserver mouseEntered:]):
(-[WKMouseTrackingObserver mouseExited:]):

Canonical link: <a href="https://commits.webkit.org/252850@main">https://commits.webkit.org/252850@main</a>
</pre>
