### PR TITLE
Add `Set-Cookie` as a forbidden header name

### DIFF
--- a/LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isappinitiated.html
+++ b/LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isappinitiated.html
@@ -35,7 +35,7 @@ function runTest()
     try {
         var xhr = new XMLHttpRequest();
         xhr.open("GET", "../cookies/resources/setCookies.cgi", false);
-        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");
+        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");
         xhr.send(null);
         if (xhr.status != 200) {
             testFailed("cookie not set");

--- a/LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html
+++ b/LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html
@@ -35,7 +35,7 @@ function runTest()
     try {
         var xhr = new XMLHttpRequest();
         xhr.open("GET", "../cookies/resources/setCookies.cgi", false);
-        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");
+        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");
         xhr.send(null);
         if (xhr.status != 200) {
             testFailed("cookie not set");

--- a/LayoutTests/http/tests/blink/sendbeacon/beacon-cookie.html
+++ b/LayoutTests/http/tests/blink/sendbeacon/beacon-cookie.html
@@ -16,7 +16,7 @@ function test() {
     try {
         var xhr = new XMLHttpRequest();
         xhr.open("GET", "../../cookies/resources/setCookies.cgi", false);
-        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");
+        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");
         xhr.send(null);
         if (xhr.status != 200) {
             testFailed("cookie not set");

--- a/LayoutTests/http/tests/cookies/cookie-with-multiple-level-path.html
+++ b/LayoutTests/http/tests/cookies/cookie-with-multiple-level-path.html
@@ -45,7 +45,7 @@
         const url = '/cookies/resources/setCookies.cgi';
         const cookie = prepareCookieHeader(name, value, path, 60);
 
-        return fetch(url, {headers: {"Set-Cookie": cookie}});
+        return fetch(url, {headers: {"X-Set-Cookie": cookie}});
     }
 
     function prepareCookieHeader(name, value, path, maxAge = 30) {

--- a/LayoutTests/http/tests/cookies/resources/cookie-utilities.js
+++ b/LayoutTests/http/tests/cookies/resources/cookie-utilities.js
@@ -51,7 +51,7 @@ async function setCookie(name, value, additionalProperties={})
     let promise = new Promise((resolved, rejected) => {
         let xhr = new XMLHttpRequest;
         xhr.open("GET", "/cookies/resources/setCookies.cgi");
-        xhr.setRequestHeader("SET-COOKIE", cookie);
+        xhr.setRequestHeader("X-SET-COOKIE", cookie);
         xhr.onload = () => resolved(xhr.responseText);
         xhr.onerror = rejected;
         xhr.send(null);

--- a/LayoutTests/http/tests/cookies/resources/cookies-test-pre.js
+++ b/LayoutTests/http/tests/cookies/resources/cookies-test-pre.js
@@ -10,7 +10,7 @@ function setCookies(cookie)
     try {
         var xhr = new XMLHttpRequest();
         xhr.open("GET", "resources/setCookies.cgi", false);
-        xhr.setRequestHeader("SET-COOKIE", cookie);
+        xhr.setRequestHeader("X-SET-COOKIE", cookie);
         xhr.send(null);
         if (xhr.status == 200) {
             // This is to clear them later.

--- a/LayoutTests/http/tests/cookies/resources/setCookies.cgi
+++ b/LayoutTests/http/tests/cookies/resources/setCookies.cgi
@@ -3,9 +3,9 @@ use strict;
 
 print "Content-Type: text/plain\n";
 print "Access-Control-Allow-Origin: *\n";
-print "Access-Control-Allow-Headers: SET-COOKIE\n";
+print "Access-Control-Allow-Headers: X-SET-COOKIE\n";
 print "Cache-Control: no-store\n";
 print 'Cache-Control: no-cache="set-cookie"' . "\n";
 
-# We only map the SET_COOKIE request header to "Set-Cookie"
-print "Set-Cookie: " . $ENV{"HTTP_SET_COOKIE"} . "\n\n";
+# We only map the X-SET_COOKIE request header to "Set-Cookie"
+print "Set-Cookie: " . $ENV{"HTTP_X_SET_COOKIE"} . "\n\n";

--- a/LayoutTests/http/tests/cookies/sync-xhr-set-cookie-invalidates-cache.html
+++ b/LayoutTests/http/tests/cookies/sync-xhr-set-cookie-invalidates-cache.html
@@ -9,7 +9,7 @@ shouldBeEqualToString('normalizeCookie(document.cookie)', 'testKey=testValue');
 var xhr = new XMLHttpRequest();
 xhr.open('GET', 'resources/setCookies.cgi', false);
 var cookie = 'xhrKey=xhrValue; path=/';
-xhr.setRequestHeader('SET-COOKIE', cookie);
+xhr.setRequestHeader('X-SET-COOKIE', cookie);
 xhr.send();
 
 // This is so the cookie gets removed at the end of the test.

--- a/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
+++ b/LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js
@@ -3,7 +3,7 @@ function setCookie()
     try {
         var xhr = new XMLHttpRequest;
         xhr.open("GET", "../../cookies/resources/setCookies.cgi", false);
-        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");
+        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");
         xhr.send(null);
         if (xhr.status != 200) {
             document.getElementsByTagName("body")[0].appendChild(document.createTextNode("FAILED: cookie not set"));

--- a/LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html
@@ -54,7 +54,7 @@
             return;
         }
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
         checkCookies(false);
         testRunner.statisticsDeleteCookiesForHost("http://127.0.0.1", false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
@@ -196,7 +196,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
@@ -196,7 +196,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
@@ -195,7 +195,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
@@ -195,7 +195,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
@@ -195,7 +195,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
@@ -197,7 +197,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
@@ -200,7 +200,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration.html
@@ -196,7 +196,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
@@ -196,7 +196,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
@@ -200,7 +200,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
@@ -196,7 +196,7 @@
     async function writeWebsiteDataAndContinue() {
         // Write cookies.
         await fetch("/cookies/resources/set-http-only-cookie.py?cookieName=" + httpOnlyCookieName, { credentials: "same-origin" });
-        await fetch("/cookies/resources/setCookies.cgi", { headers: { "Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
+        await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
 
         checkCookies(false);

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py
@@ -18,7 +18,7 @@ sys.stdout.write(
     '    testRunner.setStatisticsShouldDowngradeReferrer(false, function () {\n'
     '        var xhr = new XMLHttpRequest();\n'
     '        xhr.open("GET", "http://localhost:8080/cookies/resources/setCookies.cgi", false);\n'
-    '        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");\n'
+    '        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");\n'
     '        xhr.send(null);\n'
     '\n'
     '        // This image will generate a CSP violation report.\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-toggled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-toggled.py
@@ -15,7 +15,7 @@ print('''<!DOCTYPE html>
     // Normal browsing mode
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "http://localhost:8080/cookies/resources/setCookies.cgi", false);
-    xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");
+    xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");
     xhr.send(null);
 
     if (window.testRunner)

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py
@@ -17,7 +17,7 @@ sys.stdout.write(
     '    testRunner.setStatisticsShouldDowngradeReferrer(false, function () {\n'
     '        var xhr = new XMLHttpRequest();\n'
     '        xhr.open("GET", "http://localhost:8080/cookies/resources/setCookies.cgi", false);\n'
-    '        xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");\n'
+    '        xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");\n'
     '        xhr.send(null);\n'
     '\n'
     '        // This image will generate a CSP violation report.\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-no-cookies-when-private-browsing-toggled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-no-cookies-when-private-browsing-toggled.py
@@ -12,7 +12,7 @@ sys.stdout.write(
     '    // Normal browsing mode\n'
     '    var xhr = new XMLHttpRequest();\n'
     '    xhr.open("GET", "/cookies/resources/setCookies.cgi", false);\n'
-    '    xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");\n'
+    '    xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");\n'
     '    xhr.send(null);\n'
     '\n'
     '    if (window.testRunner)\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies-when-private-browsing-enabled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies-when-private-browsing-enabled.py
@@ -12,7 +12,7 @@ sys.stdout.write(
     '<script>\n'
     '    var xhr = new XMLHttpRequest();\n'
     '    xhr.open("GET", "/cookies/resources/setCookies.cgi", false);\n'
-    '    xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");\n'
+    '    xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");\n'
     '    xhr.send(null);\n'
     '</script>\n'
     '\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py
@@ -11,7 +11,7 @@ sys.stdout.write(
     '<script>\n'
     '    var xhr = new XMLHttpRequest();\n'
     '    xhr.open("GET", "/cookies/resources/setCookies.cgi", false);\n'
-    '    xhr.setRequestHeader("SET-COOKIE", "hello=world;path=/");\n'
+    '    xhr.setRequestHeader("X-SET-COOKIE", "hello=world;path=/");\n'
     '    xhr.send(null);\n'
     '</script>\n'
     '\n'

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any-expected.txt
@@ -23,4 +23,5 @@ PASS Proxy- is a forbidden request header
 PASS Proxy-Test is a forbidden request header
 PASS Sec- is a forbidden request header
 PASS Sec-Test is a forbidden request header
+PASS Set-Cookie is a forbidden request header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.js
@@ -41,3 +41,4 @@ requestForbiddenHeaders("Proxy- is a forbidden request header", {"Proxy-": "valu
 requestForbiddenHeaders("Proxy-Test is a forbidden request header", {"Proxy-Test": "value"});
 requestForbiddenHeaders("Sec- is a forbidden request header", {"Sec-": "value"});
 requestForbiddenHeaders("Sec-Test is a forbidden request header", {"Sec-Test": "value"});
+requestForbiddenHeaders("Set-Cookie is a forbidden request header", {"Set-Cookie": "cookie=none"});

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.worker-expected.txt
@@ -23,4 +23,5 @@ PASS Proxy- is a forbidden request header
 PASS Proxy-Test is a forbidden request header
 PASS Sec- is a forbidden request header
 PASS Sec-Test is a forbidden request header
+PASS Set-Cookie is a forbidden request header
 

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -867,6 +867,7 @@ bool isForbiddenHeaderName(const String& name)
         case HTTPHeaderName::KeepAlive:
         case HTTPHeaderName::Origin:
         case HTTPHeaderName::Referer:
+        case HTTPHeaderName::SetCookie:
         case HTTPHeaderName::TE:
         case HTTPHeaderName::Trailer:
         case HTTPHeaderName::TransferEncoding:


### PR DESCRIPTION
#### 593162b00deb43c8f03cbf3b5471e0ddf3130155
<pre>
Add `Set-Cookie` as a forbidden header name
<a href="https://bugs.webkit.org/show_bug.cgi?id=241703">https://bugs.webkit.org/show_bug.cgi?id=241703</a>
&lt;rdar://95811508&gt;

Reviewed by J Pascoe.

Added Set-Cookie as a forbidden request header.
<a href="https://github.com/whatwg/fetch/pull/1453">https://github.com/whatwg/fetch/pull/1453</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.js:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/request-forbidden-headers.any.worker-expected.txt:
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::isForbiddenHeaderName):
* LayoutTests/http/tests/cookies/cookie-with-multiple-level-path.html:
* LayoutTests/http/tests/cookies/resources/cookie-utilities.js:
* LayoutTests/http/tests/cookies/resources/cookies-test-pre.js:
(setCookies):
* LayoutTests/http/tests/cookies/resources/setCookies.cgi:
* LayoutTests/http/tests/cookies/sync-xhr-set-cookie-invalidates-cache.html:
* LayoutTests/http/tests/navigation/ping-attribute/resources/utilities.js:
(setCookie):
* LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-toggled.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-no-cookies-when-private-browsing-toggled.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies-when-private-browsing-enabled.py:
* LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py:
* LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isappinitiated.html:
* LayoutTests/http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html:
* LayoutTests/http/tests/blink/sendbeacon/beacon-cookie.html:
* LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html:
* LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html:

Canonical link: <a href="https://commits.webkit.org/253325@main">https://commits.webkit.org/253325@main</a>
</pre>
