### PR TITLE
[Xcode] `build-dumprendertree` and other scripts do not support workspace builds

### DIFF
--- a/Tools/Scripts/build-api-tests
+++ b/Tools/Scripts/build-api-tests
@@ -63,15 +63,8 @@ chdirWebKit();
 
 my $result;
 if (isAppleCocoaWebKit()) {
-    chdir "Source/ThirdParty/gtest";
-    buildXCodeProject("xcode/gtest", $clean, XcodeOptions(), @ARGV);
-    chdir "../../../Tools/TestWebKitAPI" or die;
-
-    my @options = XcodeOptions();
-    if ($wtfOnly) {
-        push @options, ("-target", "TestWTF");
-    }
-    $result = buildXCodeProject("TestWebKitAPI", $clean, @options, @ARGV);
+    my $scheme = $wtfOnly ? "TestWTF" : "TestWebKitAPI";
+    $result = buildXcodeScheme($scheme, $clean, XcodeOptions(), @ARGV);
 } else {
     die "TestWebKitAPI is not supported on this platform.\n";
 }

--- a/Tools/Scripts/build-dumprendertree
+++ b/Tools/Scripts/build-dumprendertree
@@ -65,7 +65,7 @@ chdir File::Spec->catdir("Tools", "DumpRenderTree") or die;
 
 my $result;
 if (isAppleCocoaWebKit()) {
-    $result = buildXCodeProject("DumpRenderTree", $clean, XcodeOptions(), @ARGV);
+    $result = buildXcodeScheme("DumpRenderTree", $clean, XcodeOptions(), @ARGV);
 } elsif (isGtk() || isWPE() || isAnyWindows()) {
     # GTK, WPE and Windows build everything in one shot. No need to build anything here.
     $result = 0;

--- a/Tools/Scripts/build-imagediff
+++ b/Tools/Scripts/build-imagediff
@@ -61,6 +61,8 @@ checkRequiredSystemConfig();
 setConfiguration();
 chdirWebKit();
 
+# ImageDiff is not part of any workspace.
+overrideConfiguredXcodeWorkspace("");
 my @xcodeOptions = ("-target", "ImageDiff");
 push @xcodeOptions, XcodeOptions();
 

--- a/Tools/Scripts/build-lldbwebkittester
+++ b/Tools/Scripts/build-lldbwebkittester
@@ -67,13 +67,5 @@ chdirWebKit();
 
 my @xcodeOptions = XcodeOptions();
 
-buildProjectOrDie("Tools/lldb/lldbWebKitTester", "lldbWebKitTester");
-
-sub buildProjectOrDie($$)
-{
-    my ($path, $project) = @_;
-    chdir($path) or die;
-    $result = exitStatus(buildXCodeProject($project, $clean, @xcodeOptions, @ARGV));
-    exit $result if $result;
-    chdirWebKit();
-}
+$result = exitStatus(buildXcodeScheme("lldbWebKitTester", $clean, @xcodeOptions, @ARGV));
+exit $result if $result;

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -226,11 +226,9 @@ if ((isAppleWebKit() || isWinCairo() || isPlayStation() || isFTW()) && !-d "WebK
 my @options = ();
 
 if (isAppleCocoaWebKit()) {
-    # Ignore any workspace set by set-webkit-configuration
     if (!$useWorkspace) {
+        # Ignore any workspace set by set-webkit-configuration
         overrideConfiguredXcodeWorkspace("");
-    } else {
-        overrideConfiguredXcodeWorkspace("WebKit.xcworkspace");
     }
     push @options, XcodeOptions();
 

--- a/Tools/Scripts/build-webkittestrunner
+++ b/Tools/Scripts/build-webkittestrunner
@@ -61,7 +61,7 @@ chdir "Tools/WebKitTestRunner" or die;
 
 my $result;
 if (isAppleCocoaWebKit()) {
-    $result = buildXCodeProject("WebKitTestRunner", $clean, XcodeOptions(), @ARGV);
+    $result = buildXcodeScheme("WebKitTestRunner", $clean, XcodeOptions(), @ARGV);
 } elsif (isGtk() || isWPE() || isPlayStation() || isAnyWindows()) {
     # GTK+, WPE, PlayStation, and Windows build everything in one shot. No need to build anything here.
     $result = 0;

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1055,8 +1055,9 @@ sub XcodeOptions
     my @options;
     push @options, "-UseSanitizedBuildSystemEnvironment=YES";
     push @options, "-ShowBuildOperationDuration=YES";
-    if ($configuredXcodeWorkspace && !checkForArgumentAndRemoveFromARGV("--no-use-workspace")) {
-        push @options, ("-workspace", $configuredXcodeWorkspace);
+    if (!checkForArgumentAndRemoveFromARGV("--no-use-workspace")) {
+        my $workspace = $configuredXcodeWorkspace // sourceDir() . "/WebKit.xcworkspace";
+        push @options, ("-workspace", $workspace) if $workspace;
     }
     push @options, ("-configuration", $configuration);
     if ($asanIsEnabled) {

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-               BuildableName = "TestWebKitAPI"
-               BlueprintName = "TestWebKitAPI"
+               BlueprintIdentifier = "7C83DF951D0A5AE400FEBCF3"
+               BuildableName = "TestWTF"
+               BlueprintName = "TestWTF"
                ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -58,9 +58,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-            BuildableName = "TestWebKitAPI"
-            BlueprintName = "TestWebKitAPI"
+            BlueprintIdentifier = "7C83DF951D0A5AE400FEBCF3"
+            BuildableName = "TestWTF"
+            BlueprintName = "TestWTF"
             ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -75,9 +75,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-            BuildableName = "TestWebKitAPI"
-            BlueprintName = "TestWebKitAPI"
+            BlueprintIdentifier = "7C83DF951D0A5AE400FEBCF3"
+            BuildableName = "TestWTF"
+            BlueprintName = "TestWTF"
             ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
+++ b/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,24 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-               BuildableName = "TestWebKitAPI"
-               BlueprintName = "TestWebKitAPI"
-               ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8D07F2BC0486CC7A007CD1D0"
-               BuildableName = "gtest.framework"
-               BlueprintName = "gtest-framework"
-               ReferencedContainer = "container:../../Source/ThirdParty/gtest/xcode/gtest.xcodeproj">
+               BlueprintIdentifier = "7C4AB3A01AF0276C003FC8D1"
+               BuildableName = "lldbWebKitTester"
+               BlueprintName = "lldbWebKitTester"
+               ReferencedContainer = "container:lldbWebKitTester.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -58,10 +44,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-            BuildableName = "TestWebKitAPI"
-            BlueprintName = "TestWebKitAPI"
-            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+            BlueprintIdentifier = "7C4AB3A01AF0276C003FC8D1"
+            BuildableName = "lldbWebKitTester"
+            BlueprintName = "lldbWebKitTester"
+            ReferencedContainer = "container:lldbWebKitTester.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -75,10 +61,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-            BuildableName = "TestWebKitAPI"
-            BlueprintName = "TestWebKitAPI"
-            ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
+            BlueprintIdentifier = "7C4AB3A01AF0276C003FC8D1"
+            BuildableName = "lldbWebKitTester"
+            BlueprintName = "lldbWebKitTester"
+            ReferencedContainer = "container:lldbWebKitTester.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>


### PR DESCRIPTION
#### b03221eccffc484cc8ba7d889fd03f595f5449e6
<pre>
[Xcode] `build-dumprendertree` and other scripts do not support workspace builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=243233">https://bugs.webkit.org/show_bug.cgi?id=243233</a>
rdar://97615725

Reviewed by Alexey Proskuryakov.

Adjust the build-* family of scripts to call buildXcodeScheme, instead
of building individual projects. They now build a scheme in the WebKit
workspace. These schemes (DumpRenderTree, TestWebKitAPI, etc.) do not
build their implicit dependencies, so it&apos;s still possible to build these
tools without implicitly building the entire WebKit stack.

* Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme:
* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme:
* Tools/Scripts/build-api-tests:
* Tools/Scripts/build-dumprendertree:
* Tools/Scripts/build-imagediff: The only exception: it&apos;s not part of
  any workspace and never has been, so call
  overrideConfiguredXcodeWorkspace to ensure we never try to build it in
  a workspace.
* Tools/Scripts/build-lldbwebkittester:
(buildProjectOrDie): Deleted.
* Tools/Scripts/build-webkit:
* Tools/Scripts/build-webkittestrunner:
* Tools/Scripts/webkitdirs.pm:
(XcodeOptions): Instead of the previous behavior, where webkitdirs would
not build in a workspace _at all_ if one hadn&apos;t been set, now fall back
to WebKit.xcworkspace by default. Scripts can still opt-out of building
in a workspace by calling overrideConfiguredXcodeWorkspace(&quot;&quot;).
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme: Added, builds TestWTF and gtest.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme: Also build gtest in addition to TestWebKitAPI.
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme:
* Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme: Added.

Canonical link: <a href="https://commits.webkit.org/252857@main">https://commits.webkit.org/252857@main</a>
</pre>
