### PR TITLE
Transmit CG display list surfaces out-of-line

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -944,6 +944,17 @@ UseARKitForModel:
     WebKit:
       default: true
 
+UseCGDisplayListOutOfLineSurfaces:
+  type: bool
+  humanReadableName: "CG Display Lists: Out-of-line Surfaces"
+  humanReadableDescription: "Encode surfaces out-of-line for CG Display List image buffers."
+  webcoreBinding: none
+  condition: ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: true
+
 UseCGDisplayListsForDOMRendering:
   type: bool
   humanReadableName: "CG Display Lists: DOM Rendering"

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -59,18 +59,28 @@ public:
 #endif
         bool avoidIOSurfaceSizeCheckInWebProcessForTesting = false;
 
+        enum class UseOutOfLineSurfaces : bool { No, Yes };
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+        UseOutOfLineSurfaces useOutOfLineSurfacesForCGDisplayLists;
+#endif
+
         CreationContext(HostWindow* window = nullptr
 #if HAVE(IOSURFACE)
             , IOSurfacePool* pool = nullptr
 #endif
             , bool avoidCheck = false
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+            , UseOutOfLineSurfaces useOutOfLineSurfacesForCGDisplayLists = UseOutOfLineSurfaces::No
+#endif
         )
             : hostWindow(window)
 #if HAVE(IOSURFACE)
             , surfacePool(pool)
 #endif
             , avoidIOSurfaceSizeCheckInWebProcessForTesting(avoidCheck)
-
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+            , useOutOfLineSurfacesForCGDisplayLists(useOutOfLineSurfacesForCGDisplayLists)
+#endif
         { }
     };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp
@@ -35,11 +35,14 @@ namespace WebKit {
 void CGDisplayList::encode(IPC::Encoder& encoder) const
 {
     encoder << m_displayList;
+    encoder << m_surfaces;
 }
 
-bool CGDisplayList::decode(IPC::Decoder& decoder, CGDisplayList& handle)
+bool CGDisplayList::decode(IPC::Decoder& decoder, CGDisplayList& displayList)
 {
-    if (!decoder.decode(handle.m_displayList))
+    if (!decoder.decode(displayList.m_displayList))
+        return false;
+    if (!decoder.decode(displayList.m_surfaces))
         return false;
     return true;
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
@@ -35,8 +35,9 @@ class CGDisplayList {
     WTF_MAKE_NONCOPYABLE(CGDisplayList);
 public:
     CGDisplayList() = default;
-    explicit CGDisplayList(WebCore::SharedBuffer& displayList)
+    CGDisplayList(WebCore::SharedBuffer& displayList, Vector<MachSendRight>&& surfaces)
         : m_displayList(&displayList)
+        , m_surfaces(WTFMove(surfaces))
     {
     }
 
@@ -44,12 +45,14 @@ public:
     CGDisplayList& operator=(CGDisplayList&&) = default;
 
     RefPtr<WebCore::SharedBuffer> buffer() const { return m_displayList; }
+    Vector<MachSendRight> takeSurfaces() { return std::exchange(m_surfaces, { }); }
 
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, CGDisplayList&);
 
 private:
     RefPtr<WebCore::SharedBuffer> m_displayList;
+    Vector<MachSendRight> m_surfaces;
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -34,13 +34,14 @@
 
 namespace WebKit {
 
+using UseOutOfLineSurfaces = WebCore::ImageBuffer::CreationContext::UseOutOfLineSurfaces;
+
 class CGDisplayListImageBufferBackend final : public WebCore::ImageBufferCGBackend, public ImageBufferBackendHandleSharing {
     WTF_MAKE_ISO_ALLOCATED(CGDisplayListImageBufferBackend);
     WTF_MAKE_NONCOPYABLE(CGDisplayListImageBufferBackend);
 public:
     static size_t calculateMemoryCost(const Parameters&);
 
-    static std::unique_ptr<CGDisplayListImageBufferBackend> create(const Parameters&);
     static std::unique_ptr<CGDisplayListImageBufferBackend> create(const Parameters&, const WebCore::ImageBuffer::CreationContext&);
 
     WebCore::GraphicsContext& context() const final;
@@ -53,7 +54,7 @@ public:
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
 protected:
-    CGDisplayListImageBufferBackend(const Parameters&, std::unique_ptr<WebCore::GraphicsContext>&&);
+    CGDisplayListImageBufferBackend(const Parameters&, std::unique_ptr<WebCore::GraphicsContext>&&, UseOutOfLineSurfaces);
 
     unsigned bytesPerRow() const final;
 
@@ -61,6 +62,7 @@ protected:
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
     std::unique_ptr<WebCore::GraphicsContext> m_context;
+    UseOutOfLineSurfaces m_useOutOfLineSurfaces;
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -47,6 +47,8 @@ class PlatformCALayerRemote;
 class RemoteLayerBackingStoreCollection;
 enum class SwapBuffersDisplayRequirement : uint8_t;
 
+using UseOutOfLineSurfaces = WebCore::ImageBuffer::CreationContext::UseOutOfLineSurfaces;
+
 class RemoteLayerBackingStore {
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStore);
     WTF_MAKE_FAST_ALLOCATED;
@@ -60,7 +62,7 @@ public:
     };
 
     enum class IncludeDisplayList : bool { No, Yes };
-    void ensureBackingStore(Type, WebCore::FloatSize, float scale, bool deepColor, bool isOpaque, IncludeDisplayList);
+    void ensureBackingStore(Type, WebCore::FloatSize, float scale, bool deepColor, bool isOpaque, IncludeDisplayList, UseOutOfLineSurfaces);
 
     void setNeedsDisplay(const WebCore::IntRect);
     void setNeedsDisplay();
@@ -174,6 +176,7 @@ private:
 
     Type m_type;
     IncludeDisplayList m_includeDisplayList { IncludeDisplayList::No };
+    UseOutOfLineSurfaces m_useOutOfLineSurfaces { UseOutOfLineSurfaces::No };
     bool m_deepColor { false };
 
     WebCore::RepaintRectList m_paintingRects;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -242,7 +242,7 @@ Shared/mac/MediaFormatReader/MediaSampleCursor.cpp
 Shared/mac/MediaFormatReader/MediaTrackReader.cpp
 
 Shared/RemoteLayerTree/CGDisplayList.cpp
-Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.cpp
+Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
 Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
@@ -33,7 +33,7 @@
 @interface WKCompositingLayer : CALayer
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-- (void)_setWKContents:(id)contents withDisplayList:(CFDataRef)data replayForTesting:(BOOL)replay;
+- (void)_setWKContents:(id)contents withDisplayList:(WebKit::CGDisplayList&&)data replayForTesting:(BOOL)replay;
 #endif
 
 @end

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6372,7 +6372,7 @@
 		BCE469571214EDF4000B98EB /* WKFormSubmissionListener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKFormSubmissionListener.cpp; sourceTree = "<group>"; };
 		BCE469581214EDF4000B98EB /* WKFormSubmissionListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKFormSubmissionListener.h; sourceTree = "<group>"; };
 		BCE579A42634836700F5C5E9 /* CGDisplayListImageBufferBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CGDisplayListImageBufferBackend.h; sourceTree = "<group>"; };
-		BCE579A52634836700F5C5E9 /* CGDisplayListImageBufferBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CGDisplayListImageBufferBackend.cpp; sourceTree = "<group>"; };
+		BCE579A52634836700F5C5E9 /* CGDisplayListImageBufferBackend.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CGDisplayListImageBufferBackend.mm; sourceTree = "<group>"; };
 		BCE81D8A1319F7EF00241910 /* FontInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontInfo.cpp; sourceTree = "<group>"; };
 		BCE81D8B1319F7EF00241910 /* FontInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontInfo.h; sourceTree = "<group>"; };
 		BCE9C0CF1485965D00E33D61 /* WebConnectionToUIProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebConnectionToUIProcess.cpp; sourceTree = "<group>"; };
@@ -8776,8 +8776,8 @@
 			children = (
 				2D478B90288F333500F3B73A /* CGDisplayList.cpp */,
 				2D478B8F288F333500F3B73A /* CGDisplayList.h */,
-				BCE579A52634836700F5C5E9 /* CGDisplayListImageBufferBackend.cpp */,
 				BCE579A42634836700F5C5E9 /* CGDisplayListImageBufferBackend.h */,
+				BCE579A52634836700F5C5E9 /* CGDisplayListImageBufferBackend.mm */,
 				2D47B56B1810714E003A3AEE /* RemoteLayerBackingStore.h */,
 				2D47B56A1810714E003A3AEE /* RemoteLayerBackingStore.mm */,
 				2DDF731318E95060004F5A66 /* RemoteLayerBackingStoreCollection.h */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -237,11 +237,14 @@ void PlatformCALayerRemote::updateBackingStore()
 
     auto type = m_acceleratesDrawing ? RemoteLayerBackingStore::Type::IOSurface : RemoteLayerBackingStore::Type::Bitmap;
     auto includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::No;
+    auto useOutOfLineSurfaces = UseOutOfLineSurfaces::No;
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     if (m_context->useCGDisplayListsForDOMRendering())
         includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::Yes;
+    if (m_context->useCGDisplayListOutOfLineSurfaces())
+        useOutOfLineSurfaces = UseOutOfLineSurfaces::Yes;
 #endif
-    m_properties.backingStore->ensureBackingStore(type, m_properties.bounds.size(), m_properties.contentsScale, m_wantsDeepColorBackingStore, m_properties.opaque, includeDisplayList);
+    m_properties.backingStore->ensureBackingStore(type, m_properties.bounds.size(), m_properties.contentsScale, m_wantsDeepColorBackingStore, m_properties.opaque, includeDisplayList, useOutOfLineSurfaces);
 }
 
 void PlatformCALayerRemote::setNeedsDisplayInRect(const FloatRect& rect)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -79,6 +79,9 @@ public:
 
     bool useCGDisplayListsForDOMRendering() const { return m_useCGDisplayListsForDOMRendering; }
     void setUseCGDisplayListsForDOMRendering(bool useCGDisplayLists) { m_useCGDisplayListsForDOMRendering = useCGDisplayLists; }
+
+    bool useCGDisplayListOutOfLineSurfaces() const { return m_useCGDisplayListOutOfLineSurfaces; }
+    void setUseCGDisplayListOutOfLineSurfaces(bool useOutOfLineSurfaces) { m_useCGDisplayListOutOfLineSurfaces = useOutOfLineSurfaces; }
     
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const;
@@ -106,6 +109,7 @@ private:
 
     bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };
     bool m_useCGDisplayListsForDOMRendering { false };
+    bool m_useCGDisplayListOutOfLineSurfaces { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -173,6 +173,7 @@ void RemoteLayerTreeDrawingArea::updatePreferences(const WebPreferencesStore& pr
     m_rootLayer->setShowDebugBorder(settings.showDebugBorders());
 
     m_remoteLayerTreeContext->setUseCGDisplayListsForDOMRendering(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListsForDOMRenderingKey()));
+    m_remoteLayerTreeContext->setUseCGDisplayListOutOfLineSurfaces(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListOutOfLineSurfacesKey()) && !preferences.getBoolValueForKey(WebPreferencesKey::replayCGDisplayListsIntoBackingStoreKey()));
 
     DebugPageOverlays::settingsChanged(*m_webPage.corePage());
 }


### PR DESCRIPTION
#### 6b84b375f3c1660e48f8396904b1604c89e1fdb6
<pre>
Transmit CG display list surfaces out-of-line
<a href="https://bugs.webkit.org/show_bug.cgi?id=243232">https://bugs.webkit.org/show_bug.cgi?id=243232</a>
&lt;rdar://93852164&gt;

Reviewed by Simon Fraser.

Instead of encoding images into the display list data blob, allow the encoder
to send them as sidecar IOSurfaces.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
Add a preference to allow disabling out-of-line surfaces.

* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::CreationContext::CreationContext):
Add a bit to the ImageBuffer CreationContext to plumb the desire to use out-of-line
surfaces or not through to the backend. This is a slight layering oddity, but
seems to be the current state-of-the-art for passing parameters to backends.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp:
(WebKit::CGDisplayList::encode const):
(WebKit::CGDisplayList::decode):
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h:
(WebKit::CGDisplayList::CGDisplayList):
(WebKit::CGDisplayList::takeSurfaces):
Store and transmit a set of surfaces alongside the display list blob.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm: Renamed from Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.cpp.
(WTF::CFTypeTrait&lt;CAMachPortRef&gt;::typeID):
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
(WebKit::CGDisplayListImageBufferBackend::calculateMemoryCost):
(WebKit::CGDisplayListImageBufferBackend::create):
(WebKit::CGDisplayListImageBufferBackend::CGDisplayListImageBufferBackend):
(WebKit::CGDisplayListImageBufferBackend::createBackendHandle const):
If enabled, ask the encoder to store IOSurfaces out-of-line, and stick them in a
Vector of MachSendRights ready for IPC.

(WebKit::CGDisplayListImageBufferBackend::context const):
(WebKit::CGDisplayListImageBufferBackend::backendSize const):
(WebKit::CGDisplayListImageBufferBackend::bytesPerRow const):
(WebKit::CGDisplayListImageBufferBackend::copyNativeImage const):
(WebKit::CGDisplayListImageBufferBackend::getPixelBuffer const):
(WebKit::CGDisplayListImageBufferBackend::putPixelBuffer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::ensureBackingStore):
(WebKit::RemoteLayerBackingStore::ensureFrontBuffer):
(WebKit::RemoteLayerBackingStore::applyBackingStoreToLayer):
Because of the MachSendRights, we now actually steal the m_displayListBufferHandle
when applying backing store to a layer. This is not a problem in practice
because backing store is only applied to a layer once.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h:
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer _setWKContents:withDisplayList:replayForTesting:]):
Convert the MachSendRights back into CAMachPorts and hand them off to the layer.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::updateBackingStore):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::useCGDisplayListOutOfLineSurfaces const):
(WebKit::RemoteLayerTreeContext::setUseCGDisplayListOutOfLineSurfaces):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updatePreferences):
Disable out-of-line surfaces if we are replaying display lists ourselves
(because we have no API to replay with a set of surfaces), or if the setting
is disabled.

Canonical link: <a href="https://commits.webkit.org/252874@main">https://commits.webkit.org/252874@main</a>
</pre>
