### PR TITLE
Revert tuning large heap growth factor

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -198,7 +198,7 @@ bool canUseWebAssemblyFastMemory();
     v(Double, smallHeapGrowthFactor, 2, Normal, nullptr) \
     v(Double, mediumHeapRAMFraction, 0.5, Normal, nullptr) \
     v(Double, mediumHeapGrowthFactor, 1.5, Normal, nullptr) \
-    v(Double, largeHeapGrowthFactor, 1.20, Normal, nullptr) \
+    v(Double, largeHeapGrowthFactor, 1.24, Normal, nullptr) \
     v(Double, miniVMHeapGrowthFactor, 1.20, Normal, nullptr) \
     v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold") \
     v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)") \


### PR DESCRIPTION
#### 63e29731f6ec05fa1eca26eabc0e4fcd7173207b
<pre>
Revert tuning large heap growth factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=243235">https://bugs.webkit.org/show_bug.cgi?id=243235</a>

Reviewed by Justin Michaud.

Lowering large heap growth factor might lead to the regression
in benchmark PLUM3. So, we should revert that change applied in
the previous commit(<a href="https://github.com/WebKit/WebKit/pull/2082).">https://github.com/WebKit/WebKit/pull/2082).</a>

* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/252860@main">https://commits.webkit.org/252860@main</a>
</pre>
