### PR TITLE
Punycode a few more Canadian Aboriginal syllabics characters when mixed with Latin characters

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -96,6 +96,10 @@ template<> bool isLookalikeCharacterOfScriptType<USCRIPT_CANADIAN_ABORIGINAL>(UC
 {
     switch (codePoint) {
     case 0x15AF: /* CANADIAN SYLLABICS AIVILIK B */
+    case 0x15B4: /* CANADIAN SYLLABICS BLACKFOOT WE */
+    case 0x157C: /* CANADIAN SYLLABICS NUNAVUT H */
+    case 0x166D: /* CANADIAN SYLLABICS CHI SIGN */
+    case 0x166E: /* CANADIAN SYLLABICS FULL STOP */
         return true;
     default:
         return false;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -128,6 +128,14 @@ TEST(WTF_URLExtras, URLExtras_Spoof)
         "xn--o-10e"_s, // 'o' U+0BE6
         "xn--a-53i"_s, // U+15AF 'a'
         "xn--a-63i"_s, // 'a' U+15AF
+        "xn--a-g4i"_s, // U+15B4 'a'
+        "xn--a-h4i"_s, // 'a' U+15B4
+        "xn--a-80i"_s, // U+157C 'a'
+        "xn--a-90i"_s, // 'a' U+157C
+        "xn--a-0fj"_s, // U+166D 'a'
+        "xn--a-1fj"_s, // 'a' U+166D
+        "xn--a-2fj"_s, // U+166E 'a'
+        "xn--a-3fj"_s, // 'a' U+166E
     };
     for (auto& host : punycodedSpoofHosts) {
         auto url = makeString("http://", host, "/").utf8();
@@ -157,6 +165,10 @@ TEST(WTF_URLExtras, URLExtras_NotSpoofed)
 
     // Canadian aboriginal
     EXPECT_STREQ("https://\u15AF\u1401abc/", userVisibleString(literalURL("https://\u15AF\u1401abc/")));
+    EXPECT_STREQ("https://\u15B4\u1401abc/", userVisibleString(literalURL("https://\u15B4\u1401abc/")));
+    EXPECT_STREQ("https://\u157C\u1401abc/", userVisibleString(literalURL("https://\u157C\u1401abc/")));
+    EXPECT_STREQ("https://\u166D\u1401abc/", userVisibleString(literalURL("https://\u166D\u1401abc/")));
+    EXPECT_STREQ("https://\u166E\u1401abc/", userVisibleString(literalURL("https://\u166E\u1401abc/")));
 }
 
 TEST(WTF_URLExtras, URLExtras_DivisionSign)


### PR DESCRIPTION
#### 9173324f25ee3401ad8d27dc66d4e6274f8bd397
<pre>
Punycode a few more Canadian Aboriginal syllabics characters when mixed with Latin characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=243693">https://bugs.webkit.org/show_bug.cgi?id=243693</a>
rdar://98135919

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isLookalikeCharacterOfScriptType&lt;USCRIPT_CANADIAN_ABORIGINAL&gt;):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST):
</pre>