### PR TITLE
Revert [252822@main] [iOS] Microphone sometimes fails to capture shortly after Siri interruption

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -77,8 +77,6 @@ void BaseAudioSharedUnit::forEachClient(const Function<void(CoreAudioCaptureSour
     }
 }
 
-const static OSStatus lowPriorityError1 = 560557684;
-const static OSStatus lowPriorityError2 = 561017449;
 void BaseAudioSharedUnit::startProducingData()
 {
     ASSERT(isMainThread());
@@ -100,6 +98,8 @@ void BaseAudioSharedUnit::startProducingData()
     }
     auto error = startUnit();
     if (error) {
+        const OSStatus lowPriorityError1 = 560557684;
+        const OSStatus lowPriorityError2 = 561017449;
         if (error == lowPriorityError1 || error == lowPriorityError2) {
             RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::startProducingData failed due to not high enough priority, suspending unit");
             suspend();
@@ -114,11 +114,6 @@ OSStatus BaseAudioSharedUnit::startUnit()
         client.audioUnitWillStart();
     });
     ASSERT(!DeprecatedGlobalSettings::shouldManageAudioSessionCategory() || AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
-
-    if (AudioSession::sharedSession().category() != AudioSession::CategoryType::PlayAndRecord) {
-        RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::startUnit cannot call startInternal if category is not set to PlayAndRecord");
-        return lowPriorityError2;
-    }
 
     return startInternal();
 }

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -82,12 +82,12 @@ public:
     void devicesChanged(const Vector<CaptureDevice>&);
     void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     bool isRenderingAudio() const { return m_isRenderingAudio; }
-    bool hasClients() const { return !m_clients.isEmpty(); }
 
     const String& persistentIDForTesting() const { return m_capturingDevice ? m_capturingDevice->first : emptyString(); }
 
 protected:
     void forEachClient(const Function<void(CoreAudioCaptureSource&)>&) const;
+    bool hasClients() const { return !m_clients.isEmpty(); }
     void captureFailed();
 
     virtual void cleanupAudioUnit() = 0;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -210,9 +210,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(const S
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
-        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning()
-            || (WebCore::CoreAudioSharedUnit::unit().hasClients() && WebCore::CoreAudioSharedUnit::unit().isSuspended());
-        if (shouldNotStartLocalUnit)
+        if (WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning())
             return;
     }
 


### PR DESCRIPTION
#### a8b0c4257e42b2e1280c92ab544431f4f56b3c3e
<pre>
Revert [252822@main] [iOS] Microphone sometimes fails to capture shortly after Siri interruption
<a href="https://bugs.webkit.org/show_bug.cgi?id=243206">https://bugs.webkit.org/show_bug.cgi?id=243206</a>
rdar://97262695

Unreviewed, revert 252822@main because it caused two API test failures.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::startProducingData):
(WebCore::BaseAudioSharedUnit::startUnit):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::isRenderingAudio const):
(WebCore::BaseAudioSharedUnit::hasClients const):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):

Canonical link: <a href="https://commits.webkit.org/252853@main">https://commits.webkit.org/252853@main</a>
</pre>
