### PR TITLE
REGRESSION (Safari 16): Dynamic viewport units (dvh) not matching viewport height

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5869,7 +5869,7 @@ FloatSize FrameView::sizeForCSSDynamicViewportUnits() const
         return fixedLayoutSize();
 
     if (frame().settings().visualViewportEnabled())
-        return size();
+        return unobscuredContentRectIncludingScrollbars().size();
 
     return viewportConstrainedVisibleContentRect().size();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1605,7 +1605,13 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 {
     auto frame = WebCore::FloatSize(self.frame.size);
 
-    auto maximumViewportInsetSize = WebCore::FloatSize(maximumViewportInset.left + maximumViewportInset.right, maximumViewportInset.top + maximumViewportInset.bottom);
+#if PLATFORM(MAC)
+    CGFloat additionalTopInset = self._topContentInset;
+#else
+    CGFloat additionalTopInset = 0;
+#endif
+
+    auto maximumViewportInsetSize = WebCore::FloatSize(maximumViewportInset.left + maximumViewportInset.right, maximumViewportInset.top + additionalTopInset + maximumViewportInset.bottom);
     auto minimumUnobscuredSize = frame - maximumViewportInsetSize;
     if (minimumUnobscuredSize.isEmpty()) {
         if (!maximumViewportInsetSize.isEmpty()) {
@@ -1620,7 +1626,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
         minimumUnobscuredSize = frame;
     }
 
-    auto minimumViewportInsetSize = WebCore::FloatSize(minimumViewportInset.left + minimumViewportInset.right, minimumViewportInset.top + minimumViewportInset.bottom);
+    auto minimumViewportInsetSize = WebCore::FloatSize(minimumViewportInset.left + minimumViewportInset.right, minimumViewportInset.top + additionalTopInset + minimumViewportInset.bottom);
     auto maximumUnobscuredSize = frame - minimumViewportInsetSize;
     if (maximumUnobscuredSize.isEmpty()) {
         if (!minimumViewportInsetSize.isEmpty()) {

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -52,6 +52,8 @@ public:
 
     void pageClosed() override;
 
+    void topContentInsetDidChange() final;
+
 #if ENABLE(GPU_PROCESS)
     void gpuProcessDidFinishLaunching() override;
     void gpuProcessDidExit() override;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -44,6 +44,11 @@ PageClientImplCocoa::PageClientImplCocoa(WKWebView *webView)
 
 PageClientImplCocoa::~PageClientImplCocoa() = default;
 
+void PageClientImplCocoa::topContentInsetDidChange()
+{
+    [m_webView _recalculateViewportSizesWithMinimumViewportInset:[m_webView minimumViewportInset] maximumViewportInset:[m_webView maximumViewportInset] throwOnInvalidInput:NO];
+}
+
 void PageClientImplCocoa::themeColorWillChange()
 {
     [m_webView willChangeValueForKey:@"themeColor"];

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -279,6 +279,8 @@ public:
 
     virtual void didChangeContentSize(const WebCore::IntSize&) = 0;
 
+    virtual void topContentInsetDidChange() { }
+
     virtual void showSafeBrowsingWarning(const SafeBrowsingWarning&, CompletionHandler<void(std::variant<ContinueUnsafeLoad, URL>&&)>&& completionHandler) { completionHandler(ContinueUnsafeLoad::Yes); }
     virtual void clearSafeBrowsingWarning() { }
     virtual void clearSafeBrowsingWarningIfForMainFrameNavigation() { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2033,6 +2033,8 @@ void WebPageProxy::setTopContentInset(float contentInset)
 
     m_topContentInset = contentInset;
 
+    pageClient().topContentInsetDidChange();
+
     if (!hasRunningProcess())
         return;
 #if PLATFORM(COCOA)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
@@ -794,6 +794,156 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithBounds)
     }
 }
 
+#if PLATFORM(MAC)
+
+TEST(CSSViewportUnits, TopContentInset)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+
+    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    [[window contentView] addSubview:webView.get()];
+    [window makeKeyAndOrderFront:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
+
+    [webView _setAutomaticallyAdjustsContentInsets:NO];
+    [webView _setTopContentInset:10];
+
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vi"));
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"svw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"svmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"svi"));
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
+
+    {
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedHeight = heightOfElementWithID(webView, @"fixed");
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvmax"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvb"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvi"));
+    }
+}
+
+TEST(CSSViewportUnits, MinimumViewportInsetWithTopContentInset)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+
+    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    [[window contentView] addSubview:webView.get()];
+    [window makeKeyAndOrderFront:nil];
+
+    [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
+    [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
+
+    [webView _setAutomaticallyAdjustsContentInsets:NO];
+    [webView _setTopContentInset:10];
+
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vi"));
+
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svw"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svmin"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svi"));
+
+    EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvw"));
+    EXPECT_FLOAT_EQ(448, viewportUnitLength(webView, @"lvh"));
+    EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvmin"));
+    EXPECT_FLOAT_EQ(448, viewportUnitLength(webView, @"lvmax"));
+    EXPECT_FLOAT_EQ(448, viewportUnitLength(webView, @"lvb"));
+    EXPECT_FLOAT_EQ(258, viewportUnitLength(webView, @"lvi"));
+
+    {
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedHeight = heightOfElementWithID(webView, @"fixed");
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvmax"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvb"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvi"));
+    }
+}
+
+TEST(CSSViewportUnits, MaximumViewportInsetWithTopContentInset)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+
+    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    [[window contentView] addSubview:webView.get()];
+    [window makeKeyAndOrderFront:nil];
+
+    [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
+    [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
+
+    [webView _setAutomaticallyAdjustsContentInsets:NO];
+    [webView _setTopContentInset:10];
+
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"vb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"vi"));
+
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svw"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svh"));
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svmin"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svmax"));
+    EXPECT_FLOAT_EQ(446, viewportUnitLength(webView, @"svb"));
+    EXPECT_FLOAT_EQ(256, viewportUnitLength(webView, @"svi"));
+
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvw"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvh"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvmin"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvmax"));
+    EXPECT_FLOAT_EQ(490, viewportUnitLength(webView, @"lvb"));
+    EXPECT_FLOAT_EQ(320, viewportUnitLength(webView, @"lvi"));
+
+    {
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
+        double fixedHeight = heightOfElementWithID(webView, @"fixed");
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvmin"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvmax"));
+        EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvb"));
+        EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvi"));
+    }
+}
+
+#endif // PLATFORM(MAC)
+
 #if PLATFORM(IOS_FAMILY)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithContentInset)


### PR DESCRIPTION
#### cd186d735bf27331c2b5c4928a679f3dde57ed0e
<pre>
REGRESSION (Safari 16): Dynamic viewport units (dvh) not matching viewport height
<a href="https://bugs.webkit.org/show_bug.cgi?id=242758">https://bugs.webkit.org/show_bug.cgi?id=242758</a>
&lt;rdar://problem/97031866&gt;

Reviewed by Simon Fraser.

This is likely a regression from two different commits.

248939@main started *always* setting an override for `sv*`/`lv*` based on `-[WKWebView setFrame:]`
whereas before they&apos;d fall back to `FrameView::viewportConstrainedVisibleContentRect`, which takes
into account the `topContentInset`.

251232@main switched from using `RenderView::size` for `dvh` to using `FrameView::size` instead,
which does not take into account the `topContentInset`.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::sizeForCSSDynamicViewportUnits const):
Use a different method that takes into account the `topContentInset`. This also matches the fallback
behavior for `sv*`/`lv*`.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):
Include the `_topContentInset` when calculating the viewport sizes on macOS.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setTopContentInset):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::topContentInsetDidChange): Added.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::topContentInsetDidChange): Added.
Recalculate the viewport sizes whenever the `_topContentInset` changes (including `_automaticallyAdjustsContentInsets`).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm:
(TEST.CSSViewportUnits.TopContentInset): Added.
(TEST.CSSViewportUnits.MinimumViewportInsetWithTopContentInset): Added.
(TEST.CSSViewportUnits.MaximumViewportInsetWithTopContentInset): Added.

Canonical link: <a href="https://commits.webkit.org/252878@main">https://commits.webkit.org/252878@main</a>
</pre>
