### PR TITLE
Null check IOSurfaceRef when creating WebCore::IOSurface from IOSurfaceRef

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -78,6 +78,9 @@ std::unique_ptr<IOSurface> IOSurface::createFromSendRight(const MachSendRight&& 
 
 std::unique_ptr<IOSurface> IOSurface::createFromSurface(IOSurfaceRef surface, const DestinationColorSpace& colorSpace)
 {
+    if (!surface)
+        return nullptr;
+
     return std::unique_ptr<IOSurface>(new IOSurface(surface, colorSpace));
 }
 


### PR DESCRIPTION
#### a8fb29320ab86fe43d9ead073aeb8e8602f590a2
<pre>
Null check IOSurfaceRef when creating WebCore::IOSurface from IOSurfaceRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=243241">https://bugs.webkit.org/show_bug.cgi?id=243241</a>

Reviewed by NOBODY (OOPS!).

When creating a WebCore::IOSurface from an IOSurfaceRef, WebCore::IOSurface expects
the IOSurfaceRef to be non-null, so it can pull out the dimension and allocation
size of the IOSurfaceRef.

* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::createFromSurface):
</pre>