### PR TITLE
[WebGPU] Introduce WebGPUSurface and implement GPUCanvasContext on top of it

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1689,6 +1689,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/filters/SourceGraphic.h
     platform/graphics/filters/SpotLightSource.h
 
+    platform/graphics/gpu/WebGPUSurface.h
+
     platform/graphics/iso/ISOBox.h
     platform/graphics/iso/ISOOriginalFormatBox.h
     platform/graphics/iso/ISOProtectionSchemeInfoBox.h

--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -27,6 +27,11 @@
 #include "GPU.h"
 
 #include "JSGPUAdapter.h"
+#if PLATFORM(COCOA)
+#include "WebGPUSurfaceCocoa.h"
+#else
+#include "WebGPUSurface.h"
+#endif
 
 namespace WebCore {
 
@@ -65,7 +70,11 @@ void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options,
 
 GPUTextureFormat GPU::getPreferredCanvasFormat()
 {
-    return GPUTextureFormat::Rgba8unorm;
+#if PLATFORM(COCOA)
+    return WebGPUSurfaceCocoa::preferredTextureFormat();
+#else
+    return WebGPUSurface::preferredTextureFormat();
+#endif
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl
@@ -26,6 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucanvascontext
 
 [
+    ActiveDOMObject,
     EnabledBySetting=WebGPU,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
@@ -65,6 +65,9 @@ private:
 
     Ref<Buffer> createBuffer(const BufferDescriptor&) final;
     Ref<Texture> createTexture(const TextureDescriptor&) final;
+#if HAVE(IOSURFACE)
+    Ref<Texture> createIOSurfaceBackedTexture(const TextureDescriptor&, IOSurfaceRef) final;
+#endif
     Ref<Sampler> createSampler(const SamplerDescriptor&) final;
     Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
@@ -38,6 +38,10 @@
 #include <wtf/Ref.h>
 #include <wtf/text/WTFString.h>
 
+#if HAVE(IOSURFACE)
+#include <IOSurface/IOSurfaceRef.h>
+#endif
+
 namespace PAL::WebGPU {
 
 class BindGroup;
@@ -93,6 +97,9 @@ public:
 
     virtual Ref<Buffer> createBuffer(const BufferDescriptor&) = 0;
     virtual Ref<Texture> createTexture(const TextureDescriptor&) = 0;
+#if HAVE(IOSURFACE)
+    virtual Ref<Texture> createIOSurfaceBackedTexture(const TextureDescriptor&, IOSurfaceRef) = 0;
+#endif
     virtual Ref<Sampler> createSampler(const SamplerDescriptor&) = 0;
     virtual Ref<ExternalTexture> importExternalTexture(const ExternalTextureDescriptor&) = 0;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -90,6 +90,7 @@
 #include "FrameView.h"
 #include "FullscreenManager.h"
 #include "GCReachableRef.h"
+#include "GPUCanvasContext.h"
 #include "GenericCachedHTMLCollection.h"
 #include "HTMLAllCollection.h"
 #include "HTMLAnchorElement.h"
@@ -6585,6 +6586,9 @@ std::optional<RenderingContext> Document::getCSSCanvasContext(const String& type
 
     if (is<ImageBitmapRenderingContext>(*context))
         return RenderingContext { RefPtr<ImageBitmapRenderingContext> { &downcast<ImageBitmapRenderingContext>(*context) } };
+
+    if (is<GPUCanvasContext>(*context))
+        return RenderingContext { RefPtr<GPUCanvasContext> { &downcast<GPUCanvasContext>(*context) } };
 
     return RenderingContext { RefPtr<CanvasRenderingContext2D> { &downcast<CanvasRenderingContext2D>(*context) } };
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -327,7 +327,8 @@ using RenderingContext = std::variant<
     RefPtr<WebGL2RenderingContext>,
 #endif
     RefPtr<ImageBitmapRenderingContext>,
-    RefPtr<CanvasRenderingContext2D>
+    RefPtr<CanvasRenderingContext2D>,
+    RefPtr<GPUCanvasContext>
 >;
 
 class DocumentParserYieldToken {

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -26,7 +26,8 @@ typedef (
     WebGL2RenderingContext or
 #endif
     ImageBitmapRenderingContext or 
-    CanvasRenderingContext2D) RenderingContext;
+    CanvasRenderingContext2D or
+    GPUCanvasContext) RenderingContext;
 
 typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
 

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -91,6 +91,10 @@ public:
     ImageBitmapRenderingContext* createContextBitmapRenderer(const String&, ImageBitmapRenderingContextSettings&&);
     ImageBitmapRenderingContext* getContextBitmapRenderer(const String&, ImageBitmapRenderingContextSettings&&);
 
+    static bool isWebGPUType(const String&);
+    GPUCanvasContext* createContextWebGPU(const String&);
+    GPUCanvasContext* getContextWebGPU(const String&);
+
     WEBCORE_EXPORT ExceptionOr<UncachedString> toDataURL(const String& mimeType, JSC::JSValue quality);
     WEBCORE_EXPORT ExceptionOr<UncachedString> toDataURL(const String& mimeType);
     ExceptionOr<void> toBlob(Ref<BlobCallback>&&, const String& mimeType, JSC::JSValue quality);

--- a/Source/WebCore/html/HTMLCanvasElement.idl
+++ b/Source/WebCore/html/HTMLCanvasElement.idl
@@ -32,7 +32,8 @@ typedef (
     WebGL2RenderingContext or
 #endif
     ImageBitmapRenderingContext or 
-    CanvasRenderingContext2D) RenderingContext;
+    CanvasRenderingContext2D or
+    GPUCanvasContext) RenderingContext;
 
 [
     ExportMacro=WEBCORE_EXPORT,

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -64,6 +64,7 @@ public:
     virtual bool isWebGL1() const { return false; }
     virtual bool isWebGL2() const { return false; }
     bool isWebGL() const { return isWebGL1() || isWebGL2(); }
+    virtual bool isWebGPU() const { return false; }
     virtual bool isGPUBased() const { return false; }
     virtual bool isAccelerated() const { return false; }
     virtual bool isBitmapRenderer() const { return false; }

--- a/Source/WebCore/platform/graphics/gpu/WebGPUSurface.h
+++ b/Source/WebCore/platform/graphics/gpu/WebGPUSurface.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GPUTextureFormat.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "PixelFormat.h"
+#include "pal/graphics/WebGPU/WebGPUTexture.h"
+
+namespace WebCore {
+
+class WebGPUSurface : public GraphicsLayerContentsDisplayDelegate {
+public:
+    virtual ~WebGPUSurface() = default;
+
+    virtual DestinationColorSpace colorSpace() const = 0;
+    virtual Ref<PAL::WebGPU::Texture> currentTexture() = 0;
+    virtual PixelFormat pixelFormat() const = 0;
+    virtual void present() = 0;
+
+    static GPUTextureFormat preferredTextureFormat()
+    {
+        return GPUTextureFormat::Rgba8unorm;
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.cpp
+++ b/Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebGPUSurfaceCocoa.h"
+
+#include "PlatformCALayer.h"
+#include "pal/graphics/WebGPU/WebGPUCanvasConfiguration.h"
+#include "pal/graphics/WebGPU/WebGPUDevice.h"
+#include "pal/graphics/WebGPU/WebGPUTextureDescriptor.h"
+
+namespace WebCore {
+
+static bool validateSurfaceCreation(IntSize, const PAL::WebGPU::CanvasConfiguration& configuration)
+{
+    // FIXME: Support RGBA8 or RGBA16Float if possible.
+    if (configuration.format != PAL::WebGPU::TextureFormat::Bgra8unorm) {
+        // FIXME: this generates a device validation error.
+        return false;
+    }
+
+    // FIXME: Support view formats
+    if (!configuration.viewFormats.isEmpty())
+        return false;
+
+    return true;
+}
+
+RefPtr<WebGPUSurfaceCocoa> WebGPUSurfaceCocoa::create(IntSize size, PAL::WebGPU::CanvasConfiguration configuration)
+{
+    if (!validateSurfaceCreation(size, configuration))
+        return nullptr;
+
+    return adoptRef(*new WebGPUSurfaceCocoa(WTFMove(size), WTFMove(configuration)));
+}
+
+WebGPUSurfaceCocoa::WebGPUSurfaceCocoa(IntSize size, PAL::WebGPU::CanvasConfiguration configuration)
+    : m_size(WTFMove(size))
+    , m_configuration(WTFMove(configuration))
+{
+    ASSERT(validateSurfaceCreation(size, configuration));
+}
+
+void WebGPUSurfaceCocoa::prepareToDelegateDisplay(PlatformCALayer&)
+{
+}
+
+void WebGPUSurfaceCocoa::display(PlatformCALayer& layer)
+{
+    if (m_frontBuffer)
+        layer.setContents(m_frontBuffer->surface());
+}
+
+GraphicsLayer::CompositingCoordinatesOrientation WebGPUSurfaceCocoa::orientation() const
+{
+    return GraphicsLayer::CompositingCoordinatesOrientation::TopDown;
+}
+
+void WebGPUSurfaceCocoa::present()
+{
+    std::swap(m_frontBuffer, m_backBuffer);
+    m_backBufferTexture = nullptr;
+    std::swap(m_backBuffer, m_secondaryBackBuffer);
+}
+
+bool WebGPUSurfaceCocoa::isValidBuffer(const IOSurface* buffer)
+{
+    if (!buffer)
+        return false;
+
+    if (buffer->size() != m_size)
+        return false;
+
+    if (buffer->isInUse())
+        return false;
+
+    return true;
+}
+
+void WebGPUSurfaceCocoa::ensureValidBackBuffer()
+{
+    if (isValidBuffer(m_backBuffer.get()))
+        return;
+
+    // The back buffer is not valid, so we should not reuse it and the back buffer texture.
+    // Destroy the back buffer texture here.
+    if (m_backBufferTexture) {
+        m_backBufferTexture->destroy();
+        m_backBufferTexture = nullptr;
+    }
+
+    // Then try to recycle the secondary back buffer as the new back buffer.
+    m_backBuffer = WTFMove(m_secondaryBackBuffer);
+
+    if (isValidBuffer(m_backBuffer.get()))
+        return;
+
+    // Can't use the secondary back buffer, so destroy it and create a new one.
+    m_backBuffer = IOSurface::create(nullptr, m_size, colorSpace());
+    ASSERT(isValidBuffer(m_backBuffer.get()));
+}
+
+Ref<PAL::WebGPU::Texture> WebGPUSurfaceCocoa::currentTexture()
+{
+    ensureValidBackBuffer();
+
+    if (!m_backBufferTexture) {
+        PAL::WebGPU::TextureDescriptor textureDescriptor {
+            { "WebGPU Display texture"_s },
+            PAL::WebGPU::Extent3DDict { static_cast<unsigned>(m_size.width()), static_cast<unsigned>(m_size.height()), 1 },
+            1 /* mipMapCount */,
+            1 /* sampleCount */,
+            PAL::WebGPU::TextureDimension::_2d,
+            m_configuration.format,
+            m_configuration.usage,
+            m_configuration.viewFormats
+        };
+
+        m_backBufferTexture = m_configuration.device.createIOSurfaceBackedTexture(textureDescriptor, m_backBuffer->surface());
+    }
+
+    return Ref { *m_backBufferTexture };
+}
+
+PixelFormat WebGPUSurfaceCocoa::pixelFormat() const
+{
+    switch (m_configuration.format) {
+    case PAL::WebGPU::TextureFormat::Rgba8snorm:
+        return PixelFormat::RGBA8;
+    case PAL::WebGPU::TextureFormat::Bgra8unorm:
+        return PixelFormat::BGRA8;
+    default:
+        ASSERT_NOT_REACHED();
+        return PixelFormat::RGBA8;
+    }
+}
+
+DestinationColorSpace WebGPUSurfaceCocoa::colorSpace() const
+{
+    switch (m_configuration.colorSpace) {
+    case PAL::WebGPU::PredefinedColorSpace::SRGB:
+        return DestinationColorSpace::SRGB();
+    }
+}
+
+} // namespace WebCore.

--- a/Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.h
+++ b/Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IOSurface.h"
+#include "WebGPUSurface.h"
+#include "pal/graphics/WebGPU/WebGPUCanvasConfiguration.h"
+
+namespace WebCore {
+
+class WebGPUSurfaceCocoa final: public WebGPUSurface {
+public:
+    static RefPtr<WebGPUSurfaceCocoa> create(IntSize, PAL::WebGPU::CanvasConfiguration);
+
+    ~WebGPUSurfaceCocoa() = default;
+
+    // GraphicsLayerContentsDisplayDelegate overrides:
+    void prepareToDelegateDisplay(PlatformCALayer&) override;
+    void display(PlatformCALayer&) override;
+    GraphicsLayer::CompositingCoordinatesOrientation orientation() const override;
+
+    // WebGPUSurface overrides:
+    Ref<PAL::WebGPU::Texture> currentTexture() override;
+    PixelFormat pixelFormat() const override;
+    DestinationColorSpace colorSpace() const override;
+    void present() override;
+    static GPUTextureFormat preferredTextureFormat()
+    {
+        return GPUTextureFormat::Bgra8unorm;
+    }
+
+private:
+    WebGPUSurfaceCocoa(IntSize, PAL::WebGPU::CanvasConfiguration);
+
+    IntSize m_size;
+    PAL::WebGPU::CanvasConfiguration m_configuration;
+
+    // Validate an IOSurface (not null, and its size matched the surface size)
+    bool isValidBuffer(const IOSurface*);
+
+    // Ensures that the back buffer can be used, and recreate them if necessary.
+    void ensureValidBackBuffer();
+
+    // Buffer that's currently used for presentation. The web process has access to
+    // this buffer for presentation.
+    std::unique_ptr<IOSurface> m_frontBuffer;
+
+    // Buffer for drawing stuff. When it's time for presentation, this is swapped with
+    // m_frontBuffer to become the front buffer.
+    std::unique_ptr<IOSurface> m_backBuffer;
+    RefPtr<PAL::WebGPU::Texture> m_backBufferTexture;
+
+    // Standby secondary back buffer in case something else is using the primary back buffer
+    // and we need a buffer now.
+    std::unique_ptr<IOSurface> m_secondaryBackBuffer;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -990,6 +990,21 @@ void RenderLayerBacking::updateConfigurationAfterStyleChange()
     updateContentsScalingFilters(style);
 }
 
+bool RenderLayerBacking::shouldSetContentsDisplayDelegate() const
+{
+    if (!renderer().isCanvas())
+        return false;
+
+    if (canvasCompositingStrategy(renderer()) != CanvasAsLayerContents)
+        return false;
+
+#if ENABLE(WEBGL) || ENABLE(OFFSCREEN_CANVAS)
+    return true;
+#else
+    return renderer().settings().webGPU();
+#endif
+}
+
 bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAncestor)
 {
     ASSERT(!m_owningLayer.normalFlowListDirty());
@@ -1095,15 +1110,13 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         updateContentsRects();
     }
 #endif
-#if ENABLE(WEBGL) || ENABLE(OFFSCREEN_CANVAS)
-    else if (renderer().isCanvas() && canvasCompositingStrategy(renderer()) == CanvasAsLayerContents) {
-        const HTMLCanvasElement* canvas = downcast<HTMLCanvasElement>(renderer().element());
+    else if (shouldSetContentsDisplayDelegate()) {
+        auto* canvas = downcast<HTMLCanvasElement>(renderer().element());
         if (auto* context = canvas->renderingContext())
             m_graphicsLayer->setContentsDisplayDelegate(context->layerContentsDisplayDelegate(), GraphicsLayer::ContentsLayerPurpose::Canvas);
 
         layerConfigChanged = true;
     }
-#endif
 #if ENABLE(MODEL_ELEMENT)
     else if (is<RenderModel>(renderer())) {
         auto element = downcast<HTMLModelElement>(renderer().element());

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -398,6 +398,8 @@ private:
     LayoutRect computeParentGraphicsLayerRect(const RenderLayer* compositedAncestor) const;
     LayoutRect computePrimaryGraphicsLayerRect(const RenderLayer* compositedAncestor, const LayoutRect& parentGraphicsLayerRect) const;
 
+    bool shouldSetContentsDisplayDelegate() const;
+
 #if USE(OWNING_LAYER_BEAR_TRAP)
     uintptr_t m_owningLayerBearTrap { BEAR_TRAP_VALUE }; // webkit.org/b.206915
 #endif

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -85,7 +85,7 @@ public:
     Ref<Sampler> createSampler(const WGPUSamplerDescriptor&);
     Ref<ShaderModule> createShaderModule(const WGPUShaderModuleDescriptor&);
     Ref<SwapChain> createSwapChain(const Surface&, const WGPUSwapChainDescriptor&);
-    Ref<Texture> createTexture(const WGPUTextureDescriptor&, IOSurfaceRef = nullptr);
+    Ref<Texture> createTexture(const WGPUTextureDescriptor&);
     void destroy();
     size_t enumerateFeatures(WGPUFeatureName* features);
     bool getLimits(WGPUSupportedLimits&);

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -26,6 +26,8 @@
 #ifndef WEBGPUEXT_H_
 #define WEBGPUEXT_H_
 
+#include <IOSurface/IOSurfaceRef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +49,7 @@ typedef enum WGPUSTypeExtended {
     WGPUSTypeExtended_ShaderModuleDescriptorHints = 0x348970F3, // Random
     WGPUSTypeExtended_TextureDescriptorViewFormats = 0x1D5BC57, // Random
     WGPUSTypeExtended_InstanceCocoaDescriptor = 0x151BBC00, // Random
+    WGPUSTypeExtended_TextureDescriptorIOSurfaceBacking = 0x017E9710, // Random
     WGPUSTypeExtended_Force32 = 0x7FFFFFFF
 } WGPUSTypeExtended;
 
@@ -83,6 +86,11 @@ typedef struct WGPUTextureDescriptorViewFormats {
     uint32_t viewFormatsCount;
     WGPUTextureFormat const * viewFormats;
 } WGPUTextureDescriptorViewFormats;
+
+typedef struct WGPUTextureDescriptorIOSurfaceBacking {
+    WGPUChainedStruct chain;
+    IOSurfaceRef surface;
+} WGPUTextureDescriptorIOSurfaceBacking;
 
 #if !defined(WGPU_SKIP_PROCS)
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -33,6 +33,7 @@
 #include "WebGPUIdentifier.h"
 #include <pal/graphics/WebGPU/WebGPUErrorFilter.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/MachSendRight.h>
 #include <wtf/Ref.h>
 #include <wtf/text/WTFString.h>
 
@@ -95,6 +96,9 @@ private:
 
     void createBuffer(const WebGPU::BufferDescriptor&, WebGPUIdentifier);
     void createTexture(const WebGPU::TextureDescriptor&, WebGPUIdentifier);
+#if HAVE(IOSURFACE)
+    void createIOSurfaceBackedTexture(const WebGPU::TextureDescriptor&, MachSendRight, WebGPUIdentifier);
+#endif
     void createSampler(const WebGPU::SamplerDescriptor&, WebGPUIdentifier);
     void importExternalTexture(const WebGPU::ExternalTextureDescriptor&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -27,6 +27,9 @@ messages -> RemoteDevice NotRefCounted Stream {
     void Destroy()
     void CreateBuffer(WebKit::WebGPU::BufferDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateTexture(WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
+#if HAVE(IOSURFACE)
+    void CreateIOSurfaceBackedTexture(WebKit::WebGPU::TextureDescriptor descriptor, MachSendRight backing, WebKit::WebGPUIdentifier identifier) NotStreamEncodable
+#endif
     void CreateSampler(WebKit::WebGPU::SamplerDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void ImportExternalTexture(WebKit::WebGPU::ExternalTextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateBindGroupLayout(WebKit::WebGPU::BindGroupLayoutDescriptor descriptor, WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -81,6 +81,9 @@ private:
 
     Ref<PAL::WebGPU::Buffer> createBuffer(const PAL::WebGPU::BufferDescriptor&) final;
     Ref<PAL::WebGPU::Texture> createTexture(const PAL::WebGPU::TextureDescriptor&) final;
+#if HAVE(IOSURFACE)
+    Ref<PAL::WebGPU::Texture> createIOSurfaceBackedTexture(const PAL::WebGPU::TextureDescriptor&, IOSurfaceRef) final;
+#endif
     Ref<PAL::WebGPU::Sampler> createSampler(const PAL::WebGPU::SamplerDescriptor&) final;
     Ref<PAL::WebGPU::ExternalTexture> importExternalTexture(const PAL::WebGPU::ExternalTextureDescriptor&) final;
 


### PR DESCRIPTION
#### 53198d81a9e7bc8762b40d7782cb24260a1f8ba6
<pre>
[WebGPU] Introduce WebGPUSurface and implement GPUCanvasContext on top of it
<a href="https://bugs.webkit.org/show_bug.cgi?id=241881">https://bugs.webkit.org/show_bug.cgi?id=241881</a>
&lt;rdar://96172732&gt;

Reviewed by NOBODY (OOPS!).

This commit introduces WebGPUSurface, representing a WebGPU surface / swapchain that
can be drawn into by JavaScript applications using WebGPU. GPUCanvasContext is then
implemented by delegating to WebGPUSurface.

WebGPUSurface represents a generic WebGPU surface / swapchain. The available interfaces allows
for getting the current WebGPU texture to draw into, and presenting the current texture. The
intention is for different platforms to have their own WebGPUSurface implementation. One
concrete implementation is provided: WebGPUSurfaceCocoa for Apple platforms. Because
WebGPUSurfaceCocoa uses IOSurfaces under the hood, WebGPU.framework and PAL is extended to allow
creating IOSurface-backed textures.

GPUCanvasContext is then implemented as a thin wrapper above WebGPUSurface. When a GPUCanvasContext is
configured or resized, a new WebGPUSurface is created. When a JavaScript application requests the current
texture from GPUCanvasContext, GPUCanvasContext delegates this to the underlying WebGPUSurface.
When a GPUCanvasContext is unconfigured/tear down, the WebGPUSurface is destroyed.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::getPreferredCanvasFormat):
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.cpp:
(WebCore::getCanvasSizeAsIntSize):
(WebCore::GPUCanvasContext::create):
(WebCore::GPUCanvasContext::GPUCanvasContext):
(WebCore::GPUCanvasContext::reshape):
(WebCore::GPUCanvasContext::canvas):
(WebCore::GPUCanvasContext::configure):
(WebCore::GPUCanvasContext::getCurrentTexture):
(WebCore::GPUCanvasContext::unconfigure):
(WebCore::GPUCanvasContext::pixelFormat const):
(WebCore::GPUCanvasContext::colorSpace const):
(WebCore::GPUCanvasContext::layerContentsDisplayDelegate):
(WebCore::GPUCanvasContext::prepareForDisplay):
(WebCore::GPUCanvasContext::markContextChangedAndNotifyCanvasObservers):
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.h:
(WebCore::GPUCanvasContext::create): Deleted.
* Source/WebCore/Modules/WebGPU/GPUCanvasContext.idl:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createIOSurfaceBackedTexture):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::getCSSCanvasContext):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::isWebGPUType):
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::getContextWebGPU):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCanvasElement.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::isWebGPU const):
* Source/WebCore/platform/graphics/gpu/WebGPUSurface.h: Copied from Source/WebCore/Modules/WebGPU/GPUCanvasContext.cpp.
(WebCore::WebGPUSurface::preferredTextureFormat):
* Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.cpp: Added.
(WebCore::WebGPUSurfaceCocoa::WebGPUSurfaceCocoa):
(WebCore::WebGPUSurfaceCocoa::prepareToDelegateDisplay):
(WebCore::WebGPUSurfaceCocoa::display):
(WebCore::WebGPUSurfaceCocoa::orientation const):
(WebCore::WebGPUSurfaceCocoa::present):
(WebCore::WebGPUSurfaceCocoa::isValidBuffer):
(WebCore::WebGPUSurfaceCocoa::ensureValidBackBuffer):
(WebCore::WebGPUSurfaceCocoa::createNewSurface):
(WebCore::WebGPUSurfaceCocoa::currentTexture):
(WebCore::WebGPUSurfaceCocoa::pixelFormat const):
(WebCore::WebGPUSurfaceCocoa::colorSpace const):
* Source/WebCore/platform/graphics/gpu/cocoa/WebGPUSurfaceCocoa.h: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::shouldSetContentsDisplayDelegate const):
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Device::createTexture):
(WebGPU::pixelFormat): Deleted.
(WebGPU::depthOnlyAspectMetalFormat): Deleted.
(WebGPU::stencilOnlyAspectMetalFormat): Deleted.
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createIOSurfaceBackedTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createIOSurfaceBackedTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
</pre>