### PR TITLE
Fix build-jsc not building test tools

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:JavaScriptCore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "932F5BE30822A1C700736975"
+               BuildableName = "All"
+               BlueprintName = "All"
+               ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
#### 2fe47ad4362fe32319c9adb392426106fe86d843
<pre>
Fix build-jsc not building test tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=242616">https://bugs.webkit.org/show_bug.cgi?id=242616</a>

Reviewed by Alexey Proskuryakov.

Build fix for changes introduced in
<a href="https://commits.webkit.org/252809@main.">https://commits.webkit.org/252809@main.</a> `build-jsc` needs to build
everything from the JSC project, not just the main framework.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme:
  Build the &quot;All&quot; aggregate as part of the scheme.

Canonical link: <a href="https://commits.webkit.org/252861@main">https://commits.webkit.org/252861@main</a>
</pre>
