### PR TITLE
[JSC] TypedArray change-array-by-copy should be C++

### DIFF
--- a/JSTests/microbenchmarks/typed-array-subarray-hot.js
+++ b/JSTests/microbenchmarks/typed-array-subarray-hot.js
@@ -1,0 +1,6 @@
+var typedArray = new Uint8Array(1024);
+typedArray.fill(253);
+var output = typedArray.subarray();
+for (let i = 0; i < 100000; i++) {
+    output = output.subarray();
+}

--- a/JSTests/microbenchmarks/typed-array-to-reversed-hot.js
+++ b/JSTests/microbenchmarks/typed-array-to-reversed-hot.js
@@ -1,0 +1,6 @@
+var typedArray = new Uint8Array(1024);
+typedArray.fill(253);
+var output = typedArray.toReversed();
+for (let i = 0; i < 100000; i++) {
+    output = output.toReversed();
+}

--- a/JSTests/microbenchmarks/typed-array-to-sorted-hot.js
+++ b/JSTests/microbenchmarks/typed-array-to-sorted-hot.js
@@ -1,0 +1,6 @@
+var typedArray = new Uint8Array(1024);
+typedArray.fill(253);
+var output = typedArray.toSorted();
+for (let i = 0; i < 100000; i++) {
+    output = output.toSorted();
+}

--- a/JSTests/microbenchmarks/typed-array-with-hot.js
+++ b/JSTests/microbenchmarks/typed-array-with-hot.js
@@ -1,0 +1,6 @@
+var typedArray = new Uint8Array(1024);
+typedArray.fill(253);
+var output = typedArray.with(0, 1);
+for (let i = 0; i < 100000; i++) {
+    output = output.with(i & 1023, i);
+}

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -818,12 +818,12 @@ function toReversed()
     return result;
 }
 
-function toSorted(comparefn)
+function toSorted(comparator)
 {
     "use strict";
 
     // Step 1.
-    if (comparefn !== @undefined && !@isCallable(comparefn))
+    if (comparator !== @undefined && !@isCallable(comparator))
         @throwTypeError("Array.prototype.toSorted requires the comparator argument to be a function or undefined");
 
     // Step 2.
@@ -840,7 +840,7 @@ function toSorted(comparefn)
         @putByValDirect(result, k, array[k]);
 
     // Step 6.
-    @arraySort.@call(result, comparefn);
+    @arraySort.@call(result, comparator);
 
     return result;
 }

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -73,10 +73,10 @@ namespace JSC {
     macro(Map) \
     macro(throwTypeErrorFunction) \
     macro(typedArrayLength) \
+    macro(typedArrayClone) \
     macro(typedArrayContentType) \
     macro(typedArraySort) \
     macro(typedArrayGetOriginalConstructor) \
-    macro(typedArraySubarrayCreate) \
     macro(BuiltinLog) \
     macro(BuiltinDescribe) \
     macro(homeObject) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -50,6 +50,7 @@ class JSGlobalObject;
     v(makeTypeError, nullptr) \
     v(AggregateError, nullptr) \
     v(typedArrayLength, nullptr) \
+    v(typedArrayClone, nullptr) \
     v(typedArrayContentType, nullptr) \
     v(typedArrayGetOriginalConstructor, nullptr) \
     v(typedArraySort, nullptr) \
@@ -57,7 +58,6 @@ class JSGlobalObject;
     v(isSharedTypedArrayView, nullptr) \
     v(isDetached, nullptr) \
     v(typedArrayDefaultComparator, nullptr) \
-    v(typedArraySubarrayCreate, nullptr) \
     v(isBoundFunction, nullptr) \
     v(hasInstanceBoundFunction, nullptr) \
     v(instanceOf, nullptr) \

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1602,7 +1602,7 @@ const Vector<String>& intlAvailableCalendars()
         }
 
         // The AvailableCalendars abstract operation returns a List, ordered as if an Array of the same
-        // values had been sorted using %Array.prototype.sort% using undefined as comparefn
+        // values had been sorted using %Array.prototype.sort% using undefined as comparator
         std::sort(availableCalendars->begin(), availableCalendars->end(),
             [](const String& a, const String& b) {
                 return WTF::codePointCompare(a, b) < 0;
@@ -1676,7 +1676,7 @@ static JSArray* availableCollations(JSGlobalObject* globalObject)
     }
 
     // The AvailableCollations abstract operation returns a List, ordered as if an Array of the same
-    // values had been sorted using %Array.prototype.sort% using undefined as comparefn
+    // values had been sorted using %Array.prototype.sort% using undefined as comparator
     std::sort(elements.begin(), elements.end(),
         [](const String& a, const String& b) {
             return WTF::codePointCompare(a, b) < 0;
@@ -1732,7 +1732,7 @@ static JSArray* availableCurrencies(JSGlobalObject* globalObject)
     }
 
     // The AvailableCurrencies abstract operation returns a List, ordered as if an Array of the same
-    // values had been sorted using %Array.prototype.sort% using undefined as comparefn
+    // values had been sorted using %Array.prototype.sort% using undefined as comparator
     std::sort(elements.begin(), elements.end(),
         [](const String& a, const String& b) {
             return WTF::codePointCompare(a, b) < 0;
@@ -1782,7 +1782,7 @@ static JSArray* availableNumberingSystems(JSGlobalObject* globalObject)
     }
 
     // The AvailableNumberingSystems abstract operation returns a List, ordered as if an Array of the same
-    // values had been sorted using %Array.prototype.sort% using undefined as comparefn
+    // values had been sorted using %Array.prototype.sort% using undefined as comprator
     std::sort(elements.begin(), elements.end(),
         [](const String& a, const String& b) {
             return WTF::codePointCompare(a, b) < 0;
@@ -1840,7 +1840,7 @@ const Vector<String>& intlAvailableTimeZones()
         }
 
         // The AvailableTimeZones abstract operation returns a List, ordered as if an Array of the same
-        // values had been sorted using %Array.prototype.sort% using undefined as comparefn
+        // values had been sorted using %Array.prototype.sort% using undefined as comparator
         std::sort(temporary.begin(), temporary.end(),
             [](const String& a, const String& b) {
                 return WTF::codePointCompare(a, b) < 0;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -91,8 +91,8 @@ ALWAYS_INLINE bool speciesWatchpointIsValid(JSGlobalObject* globalObject, ViewCl
 // This implements 22.2.4.7 TypedArraySpeciesCreate
 // Note, that this function throws.
 // https://tc39.es/ecma262/#typedarray-species-create
-template<typename ViewClass, typename Functor>
-inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewClass* exemplar, MarkedArgumentBuffer& args, const Functor& defaultConstructor)
+template<typename ViewClass, typename Functor, typename SlowPathArgsConstructor>
+inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewClass* exemplar, const Functor& defaultConstructor, const SlowPathArgsConstructor& constructArgs)
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -132,6 +132,10 @@ inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewCla
     if (species == viewClassConstructor)
         RELEASE_AND_RETURN(scope, defaultConstructor());
 
+    MarkedArgumentBuffer args;
+    constructArgs(args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
     JSValue result = construct(globalObject, species, args, "species is not a constructor"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
@@ -157,6 +161,15 @@ inline size_t argumentClampedIndexFromStartOrEnd(JSGlobalObject* globalObject, J
     if (value.isUndefined())
         return undefinedValue;
 
+    if (LIKELY(value.isInt32())) {
+        int64_t indexInt = value.asInt32();
+        if (indexInt < 0) {
+            indexInt += length;
+            return indexInt < 0 ? 0 : static_cast<size_t>(indexInt);
+        }
+        return static_cast<size_t>(indexInt) > length ? length : static_cast<size_t>(indexInt);
+    }
+
     double indexDouble = value.toIntegerOrInfinity(globalObject);
     if (indexDouble < 0) {
         indexDouble += length;
@@ -179,7 +192,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSet(VM& vm, JSGlobalO
     size_t offset;
     if (callFrame->argumentCount() >= 2) {
         double offsetNumber = callFrame->uncheckedArgument(1).toIntegerOrInfinity(globalObject);
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        RETURN_IF_EXCEPTION(scope, { });
         if (UNLIKELY(offsetNumber < 0))
             return throwVMRangeError(globalObject, scope, "Offset should not be negative"_s);
         if (offsetNumber <= maxSafeInteger() && offsetNumber <= static_cast<double>(std::numeric_limits<size_t>::max()))
@@ -204,11 +217,11 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSet(VM& vm, JSGlobalO
         length = jsCast<JSArrayBufferView*>(sourceArray)->length();
     } else {
         JSValue lengthValue = sourceArray->get(globalObject, vm.propertyNames->length);
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        RETURN_IF_EXCEPTION(scope, { });
         length = lengthValue.toLength(globalObject);
     }
 
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
     scope.release();
     thisObject->set(globalObject, offset, sourceArray, 0, length, CopyType::Unobservable);
@@ -227,11 +240,11 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncCopyWithin(VM& vm, JS
 
     size_t length = thisObject->length();
     size_t to = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(0), length);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
     size_t from = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(1), length);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
     size_t final = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(2), length, length);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (final < from)
         return JSValue::encode(callFrame->thisValue());
@@ -266,7 +279,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIncludes(VM& vm, JSGl
     JSValue valueToFind = callFrame->argument(0);
 
     size_t index = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(1), length);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (UNLIKELY(thisObject->isDetached()))
         return JSValue::encode(jsBoolean(valueToFind.isUndefined()));
@@ -333,7 +346,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIndexOf(VM& vm, JSGlo
 
     JSValue valueToFind = callFrame->argument(0);
     size_t index = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(1), length);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (UNLIKELY(thisObject->isDetached()))
         return JSValue::encode(jsNumber(-1));
@@ -499,7 +512,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncLastIndexOf(VM& vm, J
     if (callFrame->argumentCount() >= 2) {
         JSValue fromValue = callFrame->uncheckedArgument(1);
         double fromDouble = fromValue.toIntegerOrInfinity(globalObject);
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        RETURN_IF_EXCEPTION(scope, { });
         if (fromDouble < 0) {
             fromDouble += length;
             if (fromDouble < 0)
@@ -585,6 +598,50 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReverse(VM& vm, JSGlo
 }
 
 template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncToReversed(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/proposal-change-array-by-copy/#sec-%typedarray%.prototype.toReversed
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    if (UNLIKELY(thisObject->isDetached()))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+
+    size_t length = thisObject->length();
+
+    Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
+    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
+
+    const typename ViewClass::ElementType* from = thisObject->typedVector();
+    typename ViewClass::ElementType* to = result->typedVector();
+
+    memmove(to, from, length * ViewClass::elementSize);
+    std::reverse(to, to + length);
+
+    return JSValue::encode(result);
+}
+
+template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncClone(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    if (UNLIKELY(thisObject->isDetached()))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+
+    size_t length = thisObject->length();
+    Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
+    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
+
+    typename ViewClass::ElementType* from = thisObject->typedVector();
+    typename ViewClass::ElementType* to = result->typedVector();
+    memmove(to, from, length * ViewClass::elementSize);
+    return JSValue::encode(result);
+}
+
+template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncSort(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -613,9 +670,9 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
     size_t thisLength = thisObject->length();
 
     size_t begin = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(0), thisLength);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
     size_t end = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(1), thisLength, thisLength);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (UNLIKELY(thisObject->isDetached()))
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
@@ -626,15 +683,14 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
     ASSERT(end >= begin);
     size_t length = end - begin;
 
-    MarkedArgumentBuffer args;
-    args.append(jsNumber(length));
-    ASSERT(!args.hasOverflowed());
-
-    JSArrayBufferView* result = speciesConstruct(globalObject, thisObject, args, [&]() {
+    JSArrayBufferView* result = speciesConstruct(globalObject, thisObject, [&]() {
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
         return ViewClass::createUninitialized(globalObject, structure, length);
+    }, [&](MarkedArgumentBuffer& args) {
+        args.append(jsNumber(length));
+        ASSERT(!args.hasOverflowed());
     });
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    RETURN_IF_EXCEPTION(scope, { });
     ASSERT(!result->isDetached());
 
     // https://tc39.es/ecma262/#typedarray-species-create
@@ -704,7 +760,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSlice(VM& vm, JSGloba
 }
 
 template<typename ViewClass>
-ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncSubarrayCreate(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSubarray(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     DeferTermination deferScope(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -718,17 +774,13 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncSubarrayCreate(VM& 
     // Get the length here; later assert that the length didn't change.
     size_t thisLength = thisObject->length();
 
-    // I would assert that the arguments are integers here but that's not true since
-    // https://tc39.github.io/ecma262/#sec-tointeger allows the result of the operation
-    // to be +/- Infinity and -0.
-    ASSERT(callFrame->argument(0).isNumber());
-    ASSERT(callFrame->argument(1).isUndefined() || callFrame->argument(1).isNumber());
     size_t begin = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(0), thisLength);
-    scope.assertNoException();
+    RETURN_IF_EXCEPTION(scope, { });
     size_t end = argumentClampedIndexFromStartOrEnd(globalObject, callFrame->argument(1), thisLength, thisLength);
-    scope.assertNoException();
+    RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_ASSERT(!thisObject->isDetached());
+    if (UNLIKELY(thisObject->isDetached()))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
     // Clamp end to begin.
     end = std::max(begin, end);
@@ -746,32 +798,94 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncSubarrayCreate(VM& 
 
     size_t newByteOffset = thisObject->byteOffset() + offset * ViewClass::elementSize;
 
-    JSObject* defaultConstructor = globalObject->typedArrayConstructor(ViewClass::TypedArrayStorageType);
-    JSValue species = callFrame->uncheckedArgument(2);
-    if (species == defaultConstructor) {
+    scope.release();
+    return JSValue::encode(speciesConstruct(globalObject, thisObject, [&]() {
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
-
-        RELEASE_AND_RETURN(scope, JSValue::encode(ViewClass::create(
+        return ViewClass::create(
             globalObject, structure, WTFMove(arrayBuffer),
             thisObject->byteOffset() + offset * ViewClass::elementSize,
-            length)));
+            length);
+    }, [&](MarkedArgumentBuffer& args) {
+        args.append(vm.m_typedArrayController->toJS(globalObject, thisObject->globalObject(), arrayBuffer.get()));
+        args.append(jsNumber(newByteOffset));
+        args.append(jsNumber(length));
+        ASSERT(!args.hasOverflowed());
+    }));
+}
+
+template<typename ViewClass>
+static inline void validateIntegerIndex(JSGlobalObject* globalObject, ViewClass* thisObject, double index)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+
+    if (UNLIKELY(thisObject->isDetached())) {
+        throwVMRangeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+        return;
+    }
+    if (UNLIKELY(!isInteger(index))) {
+        throwVMRangeError(globalObject, scope, "index should be integer"_s);
+        return;
+    }
+    if (UNLIKELY(index == 0 && std::signbit(index))) {
+        throwVMRangeError(globalObject, scope, "index should not be negative zero"_s);
+        return;
+    }
+    if (UNLIKELY(index < 0 || !thisObject->inBounds(index))) {
+        throwVMRangeError(globalObject, scope, "index is out of range"_s);
+        return;
+    }
+}
+
+template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncWith(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/proposal-change-array-by-copy/#sec-%typedarray%.prototype.with
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ViewClass* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    if (UNLIKELY(thisObject->isDetached()))
+        return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
+
+    // Get the length here; later assert that the length didn't change.
+    size_t thisLength = thisObject->length();
+
+    double relativeIndex = callFrame->argument(0).toIntegerOrInfinity(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    double actualIndex = 0;
+    if (relativeIndex >= 0)
+        actualIndex = relativeIndex;
+    else
+        actualIndex = thisLength + relativeIndex;
+
+    typename ViewClass::ElementType nativeValue = ViewClass::toAdaptorNativeFromValue(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    validateIntegerIndex(globalObject, thisObject, actualIndex);
+    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(!thisObject->isDetached());
+    size_t replaceIndex = static_cast<size_t>(actualIndex);
+
+    Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
+    ViewClass* result = ViewClass::createUninitialized(globalObject, structure, thisLength);
+
+    if (UNLIKELY(thisLength != thisObject->length())) {
+        for (unsigned index = 0; index < thisLength; ++index) {
+            typename ViewClass::ElementType fromValue = 0;
+            if (index == replaceIndex)
+                fromValue = nativeValue;
+            else if (thisObject->canGetIndexQuickly(index))
+                fromValue = thisObject->getIndexQuicklyAsNativeValue(index);
+            result->setIndexQuicklyToNativeValue(index, fromValue);
+        }
+    } else {
+        typename ViewClass::ElementType* from = thisObject->typedVector();
+        typename ViewClass::ElementType* to = result->typedVector();
+        memmove(to, from, thisLength * ViewClass::elementSize);
+        to[replaceIndex] = nativeValue;
     }
 
-    MarkedArgumentBuffer args;
-    args.append(vm.m_typedArrayController->toJS(globalObject, thisObject->globalObject(), arrayBuffer.get()));
-    args.append(jsNumber(newByteOffset));
-    args.append(jsNumber(length));
-    ASSERT(!args.hasOverflowed());
-
-    JSObject* result = construct(globalObject, species, args, "species is not a constructor"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    JSArrayBufferView* validated = validateTypedArray(globalObject, result);
-    RETURN_IF_EXCEPTION(scope, { });
-    if (contentType(validated->type()) != ViewClass::contentType)
-        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.subarray constructed typed array of different content type from |this|"_s);
-
-    return JSValue::encode(validated);
+    return JSValue::encode(result);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1431,6 +1431,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayGetOriginalConstructor)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), typedArrayViewPrivateFuncGetOriginalConstructor));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayClone)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), typedArrayViewPrivateFuncClone));
+        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayContentType)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), typedArrayViewPrivateFuncContentType));
         });
@@ -1448,9 +1451,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayDefaultComparator)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), typedArrayViewPrivateFuncDefaultComparator));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArraySubarrayCreate)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), typedArrayViewPrivateFuncSubarrayCreate));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isBoundFunction)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), isBoundFunction));

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -50,7 +50,7 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject, Abstr
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects
     // Quoted from the spec:
     //     A List containing the String values of the exported names exposed as own properties of this object.
-    //     The list is ordered as if an Array of those String values had been sorted using Array.prototype.sort using SortCompare as comparefn.
+    //     The list is ordered as if an Array of those String values had been sorted using Array.prototype.sort using SortCompare as comparator.
     //
     // Sort the exported names by the code point order.
     std::sort(resolutions.begin(), resolutions.end(), [] (const auto& lhs, const auto& rhs) {

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
@@ -57,8 +57,8 @@ JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncDefaultComparator);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncSort);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncLength);
+JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncClone);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncContentType);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncGetOriginalConstructor);
-JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncSubarrayCreate);
     
 } // namespace JSC


### PR DESCRIPTION
#### 9bbad8a7d16c16aa00440cb190b310e46a4ec5e2
<pre>
[JSC] TypedArray change-array-by-copy should be C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=243162">https://bugs.webkit.org/show_bug.cgi?id=243162</a>

Reviewed by Alexey Shvayka and Ross Kirsling.

This patch implements TypedArray change-array-by-copy in C++ to get performance boost.
TypedArray has a lot of characteristics of non-dynamic behavior. Since it is typed too,
then we can easily write super fast C++ implementations for these methods.
This patch keeps toSorted in JS while large part of it is implemented in C++ already.
And we also migrate subarray from JS to C++ since we have fast speciesConstruct now.

                                            ToT                     Patched

    typed-array-to-sorted-hot        131.0737+-0.0586     ^     79.5521+-0.1355        ^ definitely 1.6476x faster
    typed-array-subarray-hot           4.5564+-0.2404     ^      3.5946+-0.0116        ^ definitely 1.2676x faster
    typed-array-to-reversed-hot       93.7245+-0.1785     ^     28.5393+-0.1813        ^ definitely 3.2841x faster
    typed-array-with-hot              78.6775+-0.2573     ^     10.2874+-0.0542        ^ definitely 7.6479x faster

* JSTests/microbenchmarks/typed-array-subarray-hot.js: Added.
* JSTests/microbenchmarks/typed-array-to-reversed-hot.js: Added.
* JSTests/microbenchmarks/typed-array-to-sorted-hot.js: Added.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/TypedArrayPrototype.js:
(subarray): Deleted.
(toReversed): Deleted.
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):
(JSC::genericTypedArrayViewProtoFuncToReversed):
(JSC::genericTypedArrayViewProtoFuncToSorted):
(JSC::genericTypedArrayViewProtoFuncSlice):
(JSC::genericTypedArrayViewProtoFuncSubarray):
(JSC::genericTypedArrayViewPrivateFuncSubarrayCreate): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSTypedArrayViewPrototype::finishCreation):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h:

Canonical link: <a href="https://commits.webkit.org/252891@main">https://commits.webkit.org/252891@main</a>
</pre>
