### PR TITLE
[iOS] Microphone sometimes fails to capture shortly after Siri interruption - for iOS only

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -77,6 +77,8 @@ void BaseAudioSharedUnit::forEachClient(const Function<void(CoreAudioCaptureSour
     }
 }
 
+const static OSStatus lowPriorityError1 = 560557684;
+const static OSStatus lowPriorityError2 = 561017449;
 void BaseAudioSharedUnit::startProducingData()
 {
     ASSERT(isMainThread());
@@ -98,8 +100,6 @@ void BaseAudioSharedUnit::startProducingData()
     }
     auto error = startUnit();
     if (error) {
-        const OSStatus lowPriorityError1 = 560557684;
-        const OSStatus lowPriorityError2 = 561017449;
         if (error == lowPriorityError1 || error == lowPriorityError2) {
             RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::startProducingData failed due to not high enough priority, suspending unit");
             suspend();
@@ -114,6 +114,13 @@ OSStatus BaseAudioSharedUnit::startUnit()
         client.audioUnitWillStart();
     });
     ASSERT(!DeprecatedGlobalSettings::shouldManageAudioSessionCategory() || AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
+
+#if PLATFORM(IOS_FAMILY)
+    if (AudioSession::sharedSession().category() != AudioSession::CategoryType::PlayAndRecord) {
+        RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::startUnit cannot call startInternal if category is not set to PlayAndRecord");
+        return lowPriorityError2;
+    }
+#endif
 
     return startInternal();
 }

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -82,12 +82,12 @@ public:
     void devicesChanged(const Vector<CaptureDevice>&);
     void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     bool isRenderingAudio() const { return m_isRenderingAudio; }
+    bool hasClients() const { return !m_clients.isEmpty(); }
 
     const String& persistentIDForTesting() const { return m_capturingDevice ? m_capturingDevice->first : emptyString(); }
 
 protected:
     void forEachClient(const Function<void(CoreAudioCaptureSource&)>&) const;
-    bool hasClients() const { return !m_clients.isEmpty(); }
     void captureFailed();
 
     virtual void cleanupAudioUnit() = 0;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -210,7 +210,9 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(const S
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
-        if (WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning())
+        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning()
+            || (WebCore::CoreAudioSharedUnit::unit().hasClients() && WebCore::CoreAudioSharedUnit::unit().isSuspended());
+        if (shouldNotStartLocalUnit)
             return;
     }
 


### PR DESCRIPTION
#### 58755a28bbd27408ef46ec5280a1e303b0abf250
<pre>
[iOS] Microphone sometimes fails to capture shortly after Siri interruption - for iOS only
<a href="https://bugs.webkit.org/show_bug.cgi?id=243245">https://bugs.webkit.org/show_bug.cgi?id=243245</a>
rdar://97262695

Reviewed by Eric Carlson.

We might restart capture very quickly after a phone call or Siri interruption.
In that case, the call to set the PlayAndRecord category might fail.
If it fails, instead of trying to start microphone capture, we use the suspend code path.
We only do this for iOS since this is iOS specific behavior and, on macOS, speech recognition may be done in UIProcess without the audio category set appropriately.

We also do not want to start the local audio renderer unit in case we are suspended.
This messes up the interruption state and we might no longer receive the end of interruption signal.
To do so, we return early in case the audio renderer is registered with the shared unit and the shared unit is suspended.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::startProducingData):
(WebCore::BaseAudioSharedUnit::startUnit):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
(WebCore::BaseAudioSharedUnit::hasClients const):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitHasStopped):

Canonical link: <a href="https://commits.webkit.org/252868@main">https://commits.webkit.org/252868@main</a>
</pre>
