### PR TITLE
WebRTC calls without microphone capture might be permmanently muted in case of AudioSession interruptions like Siri

### DIFF
--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -138,6 +138,8 @@ public:
     virtual void setHostProcessAttribution(audit_token_t) { };
     virtual void setPresentingProcesses(Vector<audit_token_t>&&) { };
 
+    bool isInterrupted() const { return m_isInterrupted; }
+
 protected:
     friend class NeverDestroyed<AudioSession>;
     AudioSession();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -49,7 +49,8 @@ namespace WebKit {
 
 class RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit
     : public CanMakeWeakPtr<RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit>
-    , public WebCore::CoreAudioSpeakerSamplesProducer {
+    , public WebCore::CoreAudioSpeakerSamplesProducer
+    , public WebCore::AudioSession::InterruptionObserver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     Unit(AudioMediaStreamTrackRendererInternalUnitIdentifier, Ref<IPC::Connection>&&, bool shouldRegisterAsSpeakerSamplesProducer, CompletionHandler<void(const WebCore::CAAudioStreamDescription&, size_t)>&&);
@@ -63,6 +64,9 @@ public:
 
     void setShouldRegisterAsSpeakerSamplesProducer(bool);
 
+    using WebCore::AudioSession::InterruptionObserver::weakPtrFactory;
+    using WeakValueType = WebCore::AudioSession::InterruptionObserver::WeakValueType;
+
 private:
     void storageChanged(SharedMemory*, const WebCore::CAAudioStreamDescription&, size_t);
 
@@ -72,6 +76,10 @@ private:
     void captureUnitHasStopped() final;
     // Background thread.
     OSStatus produceSpeakerSamples(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) final;
+
+    // WebCore::AudioSession::InterruptionObserver
+    void beginAudioSessionInterruption() final;
+    void endAudioSessionInterruption(WebCore::AudioSession::MayResume) final;
 
     AudioMediaStreamTrackRendererInternalUnitIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
@@ -156,6 +164,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit(AudioMediaStr
     , m_localUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::createLocalInternalUnit(renderCallback(*this), resetCallback(*this)))
     , m_shouldRegisterAsSpeakerSamplesProducer(shouldRegisterAsSpeakerSamplesProducer)
 {
+    WebCore::AudioSession::sharedSession().addInterruptionObserver(*this);
     m_localUnit->retrieveFormatDescription([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)](auto&& description) mutable {
         if (!weakThis || !description) {
             RELEASE_LOG_IF(!description, WebRTC, "RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit unable to get format description");
@@ -170,6 +179,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit(AudioMediaStr
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::~Unit()
 {
+    WebCore::AudioSession::sharedSession().removeInterruptionObserver(*this);
     stop();
 }
 
@@ -210,8 +220,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(const S
 
     if (m_shouldRegisterAsSpeakerSamplesProducer) {
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
-        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning()
-            || (WebCore::CoreAudioSharedUnit::unit().hasClients() && WebCore::CoreAudioSharedUnit::unit().isSuspended());
+        bool shouldNotStartLocalUnit = WebCore::CoreAudioCaptureSourceFactory::singleton().isAudioCaptureUnitRunning() || WebCore::AudioSession::sharedSession().isInterrupted();
         if (shouldNotStartLocalUnit)
             return;
     }
@@ -271,6 +280,23 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::captureUnitHa
 OSStatus RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::produceSpeakerSamples(size_t sampleCount, AudioBufferList& list, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags& flags)
 {
     return render(sampleCount, list, sampleTime, hostTime, flags);
+}
+
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::beginAudioSessionInterruption()
+{
+    if (m_isPlaying)
+        m_localUnit->stop();
+}
+
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::endAudioSessionInterruption(WebCore::AudioSession::MayResume)
+{
+    if (!m_isPlaying)
+        return;
+
+    if (m_shouldRegisterAsSpeakerSamplesProducer && (WebCore::CoreAudioSharedUnit::unit().isRunning() || WebCore::CoreAudioSharedUnit::unit().isSuspended()))
+        return;
+
+    m_localUnit->start();
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 4f10966211e8fe3e069d9888794bce65ec6b233d
<pre>
WebRTC calls without microphone capture might be permmanently muted in case of AudioSession interruptions like Siri
<a href="https://bugs.webkit.org/show_bug.cgi\?id\=243249">https://bugs.webkit.org/show_bug.cgi\?id\=243249</a>
rdar://97612139

Reviewed by Eric Carlson.

Expose whether an AudioSession is interrupted or not.
Make use of this state to not start a local audio render unit in that case, as AudioUnitInitialize might fail and this will error audio rendering.
To be able to restart audio on end of interruption, make RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit and audio session interruption observer, and play/pause accordingly.

Manually tested on iOS.

* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::~Unit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::beginAudioSessionInterruption):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::endAudioSessionInterruption):

Canonical link: <a href="https://commits.webkit.org/252907@main">https://commits.webkit.org/252907@main</a>
</pre>
