### PR TITLE
WorkerGlobalScope.isSecureContext should be based on owner's top URL, not the owner's URL

### DIFF
--- a/LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-frame.html
+++ b/LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-frame.html
@@ -1,0 +1,7 @@
+<p>HTTPS iframe</p>
+<script>
+worker = new Worker("worker-iframe-owner-isSecureContext-worker.js");
+worker.onmessage = (message) => {
+    top.postMessage(message.data, "*");
+};
+</script>

--- a/LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-worker.js
+++ b/LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-worker.js
@@ -1,0 +1,1 @@
+postMessage(isSecureContext);

--- a/LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext-expected.txt
+++ b/LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext-expected.txt
@@ -1,0 +1,10 @@
+Tests that a worker's isSecureContext flag relies on the owner's top URL, not the owner's URL
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isSecureContext is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext.html
+++ b/LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that a worker's isSecureContext flag relies on the owner's top URL, not the owner's URL");
+jsTestIsAsync = true;
+
+// We need to explicitly mark the context as insecure, even though it has a HTTP URL. The reason is that '127.0.0.1'
+// host is treated as secure by default. Sadly, WebKitTestRunner only supports running tests over secure hosts at the
+// moment.
+if (window.internals)
+    internals.markContextAsInsecure();
+
+onload = () => {
+    var frame = document.createElement("iframe");
+    frame.src = "https://127.0.0.1:8443/workers/resources/worker-iframe-owner-isSecureContext-frame.html";
+    document.body.appendChild(frame);
+}
+
+onmessage = (message) => {
+    isSecureContext = message.data;
+    shouldBeFalse("isSecureContext");
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/local-url-inherit-controller.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/local-url-inherit-controller.https-expected.txt
@@ -4,6 +4,6 @@ PASS Same-origin blob URL iframe should intercept fetch().
 PASS Same-origin blob URL worker should inherit service worker controller.
 PASS Same-origin blob URL worker should intercept fetch().
 PASS Data URL iframe should not intercept fetch().
-FAIL Data URL worker should not inherit service worker controller. promise_test: Unhandled rejection with value: "TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.controller')"
+PASS Data URL worker should not inherit service worker controller.
 PASS Data URL worker should not intercept fetch().
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -181,7 +181,7 @@ bool WorkerGlobalScope::isSecureContext() const
     if (!DeprecatedGlobalSettings::secureContextChecksEnabled())
         return true;
 
-    return securityOrigin() && securityOrigin()->isPotentiallyTrustworthy();
+    return m_topOrigin->isPotentiallyTrustworthy();
 }
 
 void WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)


### PR DESCRIPTION
#### abdef0407a12c25977060aa7ca51c960d7d05c26
<pre>
WorkerGlobalScope.isSecureContext should be based on owner&apos;s top URL, not the owner&apos;s URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=243252">https://bugs.webkit.org/show_bug.cgi?id=243252</a>

Reviewed by Youenn Fablet.

WorkerGlobalScope.isSecureContext should be based on owner&apos;s top-level creation URL, not the owner&apos;s URL:
- <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a>

This means that if a worker created in a HTTPS iframe, under a HTTP top-level document should not be considered as secure.

This is causing us to fail the &quot;HTTPS worker from HTTPS subframe&quot; subtest on secure-contexts/basic-dedicated-worker.html WPT test. This test is passing in both Gecko and Blink.

I have verified manually that the subtest is now passing on:
- <a href="http://wpt.live/secure-contexts/basic-dedicated-worker.html">http://wpt.live/secure-contexts/basic-dedicated-worker.html</a>

Sadly, this test doesn&apos;t run as expected in our test infrastructure because we run tests over 127.0.0.1
&amp; localhost, both of which are treated as secure, even over HTTP (per specification). As a result, I
had to write my own test which relies on `internals.markContextAsInsecure()`.

* LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-frame.html: Added.
* LayoutTests/http/tests/workers/resources/worker-iframe-owner-isSecureContext-worker.js: Added.
* LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext-expected.txt: Added.
* LayoutTests/http/tests/workers/worker-iframe-owner-isSecureContext.html: Added.
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::isSecureContext const):

Canonical link: <a href="https://commits.webkit.org/252913@main">https://commits.webkit.org/252913@main</a>
</pre>
