### PR TITLE
[Lockdown Mode] Chrome will not load past launch screen after install

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3016,13 +3016,9 @@ static bool isLockdownModeWarningNeeded()
     if (!lockdownModeWarningNeeded)
         return;
 
-    NSString *appDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(__bridge NSString *)_kCFBundleDisplayNameKey];
-    if (!appDisplayName)
-        appDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
-
     auto message = WEB_UI_NSSTRING(@"Certain experiences and features may not function as expected. You can turn off Lockdown Mode for this app in Settings.", "Lockdown Mode alert message");
 
-    auto decisionHandler = makeBlockPtr([appDisplayName, message, protectedSelf = retainPtr(self)](WKDialogResult result) mutable {
+    auto decisionHandler = makeBlockPtr([message, protectedSelf = retainPtr(self)](WKDialogResult result) mutable {
         if (result == WKDialogResultAskAgain) {
             lockdownModeWarningNeeded = true;
             return;
@@ -3034,17 +3030,20 @@ static bool isLockdownModeWarningNeeded()
             [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitCaptivePortalModeAlertShownKey];
             return;
         }
-    
-        UIAlertController *alert = [UIAlertController
-            alertControllerWithTitle:[NSString stringWithFormat:WEB_UI_NSSTRING(@"Lockdown Mode is Turned On For “%@“", "Lockdown Mode alert title"), appDisplayName]
-            message:message
-            preferredStyle:UIAlertControllerStyleAlert];
 
-        [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
+        RunLoop::main().dispatch([message = retainPtr(message), protectedSelf = WTFMove(protectedSelf)] {
+            NSString *appDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(__bridge NSString *)_kCFBundleDisplayNameKey];
+            if (!appDisplayName)
+                appDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
 
-        UIViewController *presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:protectedSelf.get()];
-        [presentationViewController presentViewController:alert animated:YES completion:nil];
-        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitCaptivePortalModeAlertShownKey];
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:WEB_UI_NSSTRING(@"Lockdown Mode is Turned On For “%@“", "Lockdown Mode alert title"), appDisplayName] message:message.get() preferredStyle:UIAlertControllerStyleAlert];
+
+            [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
+
+            UIViewController *presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:protectedSelf.get()];
+            [presentationViewController presentViewController:alert animated:YES completion:nil];
+            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitCaptivePortalModeAlertShownKey];
+        });
     });
     
 #if PLATFORM(IOS)


### PR DESCRIPTION
#### 45a7877d638bfbe43ffaac8a2b5f2a8ba26d604c
<pre>
[Lockdown Mode] Chrome will not load past launch screen after install
<a href="https://bugs.webkit.org/show_bug.cgi?id=243253">https://bugs.webkit.org/show_bug.cgi?id=243253</a>
rdar://95220110

Reviewed by Wenson Hsieh.

An app using WebKit, while the user has lockdown mode enabled, will display an
alert the first time the user opens the app. As of 252700@main, apps can
implement WKUIDelegate to customize the alert presentation. However, apps linked
before iOS 16 will always display an alert the first time a `WKWebView` is added
to the window.

Chrome adds a `WKWebView` to the window, and then attempts to present their own
view controller. When lockdown mode is enabled, the alert is displayed, and
Chrome&apos;s own view controller never appears. To present the alert, WebKit reaches
into the app&apos;s view controller hierarchy, and calls `-[UIViewController
presentViewController:animated:completion:]`.  Chrome&apos;s view controller never
appears since alert view controllers are presented modally, and view controllers
cannot be presented on top of a modal view controller.  This sequence of events
ends up leaving Chrome in a bad state, as they require users to interact with
the view controller they attempted to present, prior to unlocking access to the
rest of the app.

WebKit&apos;s current behavior is deeply problematic, frameworks should never attempt
to reach into an app&apos;s view controller hierarchy and modify its state. Apps
should have full control over view controller presentation and dismissal.
Consequently, the correct solution would be to stop reaching into the app&apos;s view
controller hierarchy, and instead, present a system level alert, using
SpringBoard.

However, the correct solution requires an additional entitlement and sandbox
extension, making it unviable at this time:
- The need for an entitlement means that the solution cannot be implemented in
  the the UI process.
- There is no desire to extend the WebContent and GPU process sandbox,
  especially for a security-focused feature.
- Bringing up a new process to handle alert display is not a small task.

Given current limitations, the next best solution is to simply delay WebKit&apos;s
attempt to display the alert. This solution gives Chrome an opportunity to
display their view controller first, mitigating the issue.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _presentCaptivePortalMode]):

Use `RunLoop::main().dispatch()` to delay the alert presentation until the next
runloop iteration. This ensures Chrome is able to present their view controller,
and does not leave the app in a bad state. Note that this solution will not fix
cases where an app also presents a view controller asynchronously, after adding
a `WKWebView` to the window. In this case, a view controller would still fail to
present, as the alert would be displayed. However, it is still believed this fix
is sufficient, given it fixes the most common failure scenario, and any failure
scenario is recoverable by relaunching the app.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:

Fix existing UIDelegate tests for lockdown mode alert UI. The tests added in
252700@main have never passed, since they were not being set up correctly.  The
lockdown-mode-enabled-for-testing state depends on the existence of a web
process, but the tests are currently attempting to enable the feature prior to
`WKWebView` creation. Logic has been re-ordered to ensure test set up is done
correctly.

No new tests were added as part of this fix, since TestWebKitAPI is not a UI
application, preventing testing of actual view controller presentation.
Instead, the existing tests are also reworked to account for the fact that the
alert is displayed asynchronously.

Canonical link: <a href="https://commits.webkit.org/252873@main">https://commits.webkit.org/252873@main</a>
</pre>
