### PR TITLE
Store in UIProcess whether VTB supports VP9 decode to query it only once in GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -279,12 +279,23 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     // reply from the GPU process, which would be unsafe.
     m_connection->setOnlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage(true);
     m_connection->open();
+
+#if ENABLE(VP9)
+    bool hasVP9HardwareDecoder;
+    if (parameters.hasVP9HardwareDecoder)
+        hasVP9HardwareDecoder = *parameters.hasVP9HardwareDecoder;
+    else {
+        hasVP9HardwareDecoder = WebCore::vp9HardwareDecoderAvailable();
+        gpuProcess.send(Messages::GPUProcessProxy::SetHasVP9HardwareDecoder(hasVP9HardwareDecoder));
+    }
+#endif
+
     WebKit::GPUProcessConnectionInfo info {
 #if HAVE(AUDIT_TOKEN)
         gpuProcess.parentProcessConnection()->getAuditToken(),
 #endif
 #if ENABLE(VP9)
-        WebCore::vp9HardwareDecoderAvailable()
+        hasVP9HardwareDecoder
 #endif
     };
     m_connection->send(Messages::GPUProcessConnection::DidInitialize(info), 0);

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -43,6 +43,9 @@ struct GPUProcessConnectionParameters {
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> presentingApplicationAuditToken;
 #endif
+#if ENABLE(VP9)
+    std::optional<bool> hasVP9HardwareDecoder;
+#endif
 
     void encode(IPC::Encoder& encoder) const
     {
@@ -54,6 +57,9 @@ struct GPUProcessConnectionParameters {
 #endif
 #if HAVE(AUDIT_TOKEN)
         encoder << presentingApplicationAuditToken;
+#endif
+#if ENABLE(VP9)
+        encoder << hasVP9HardwareDecoder;
 #endif
     }
 
@@ -68,6 +74,9 @@ struct GPUProcessConnectionParameters {
 #if HAVE(AUDIT_TOKEN)
         auto presentingApplicationAuditToken = decoder.decode<std::optional<audit_token_t>>();
 #endif
+#if ENABLE(VP9)
+        auto hasVP9HardwareDecoder = decoder.decode<std::optional<bool>>();
+#endif
         if (!decoder.isValid())
             return std::nullopt;
 
@@ -80,6 +89,9 @@ struct GPUProcessConnectionParameters {
 #endif
 #if HAVE(AUDIT_TOKEN)
             WTFMove(*presentingApplicationAuditToken),
+#endif
+#if ENABLE(VP9)
+            WTFMove(*hasVP9HardwareDecoder),
 #endif
         };
     }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -381,8 +381,16 @@ void GPUProcessProxy::processWillShutDown(IPC::Connection& connection)
         singleton() = nullptr;
 }
 
+#if ENABLE(VP9)
+std::optional<bool> GPUProcessProxy::s_hasVP9HardwareDecoder;
+#endif
+
 void GPUProcessProxy::createGPUProcessConnection(WebProcessProxy& webProcessProxy, IPC::Attachment&& connectionIdentifier, GPUProcessConnectionParameters&& parameters)
 {
+#if ENABLE(VP9)
+    parameters.hasVP9HardwareDecoder = s_hasVP9HardwareDecoder;
+#endif
+
     if (auto* store = webProcessProxy.websiteDataStore())
         addSession(*store);
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -152,6 +152,10 @@ private:
     void didCreateContextForVisibilityPropagation(WebPageProxyIdentifier, WebCore::PageIdentifier, LayerHostingContextID);
 #endif
 
+#if ENABLE(VP9)
+    void setHasVP9HardwareDecoder(bool hasVP9HardwareDecoder) { s_hasVP9HardwareDecoder = hasVP9HardwareDecoder; }
+#endif
+
     GPUProcessCreationParameters processCreationParameters();
     void platformInitializeGPUProcessParameters(GPUProcessCreationParameters&);
 
@@ -170,6 +174,9 @@ private:
 
 #if HAVE(SCREEN_CAPTURE_KIT)
     bool m_hasEnabledScreenCaptureKit { false };
+#endif
+#if ENABLE(VP9)
+    static std::optional<bool> s_hasVP9HardwareDecoder;
 #endif
 
     HashSet<PAL::SessionID> m_sessionIDs;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -28,6 +28,10 @@ messages -> GPUProcessProxy {
     DidCreateContextForVisibilityPropagation(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, WebKit::LayerHostingContextID contextID)
 #endif
 
+#if ENABLE(VP9)
+    SetHasVP9HardwareDecoder(bool hasVP9HardwareDecoder)
+#endif
+
     ProcessIsReadyToExit()
     TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier)
 }


### PR DESCRIPTION
#### 76c46a7cbb12097740c470f949f8ae19604d993c
<pre>
Store in UIProcess whether VTB supports VP9 decode to query it only once in GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=243251">https://bugs.webkit.org/show_bug.cgi?id=243251</a>

Reviewed by Eric Carlson.

WebCore::vp9HardwareDecoderAvailable might be an expensive operation, so it is best to do it as little as possible.
What we do is to add a parameter telling GPUProcess whether to query whether VP9 HW decoding is supported.
If query is needed, GPUProcess does it and sends the result to UIProcess, as well as WebProcess.
When UIProcess has it, UIProcess makes sure to no longer ask GPUProcess for querying it, and passes the stored value to let WebProcess knows it.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::GPUConnectionToWebProcess):
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
(WebKit::GPUProcessConnectionParameters::encode const):
(WebKit::GPUProcessConnectionParameters::decode):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::createGPUProcessConnection):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/252902@main">https://commits.webkit.org/252902@main</a>
</pre>
