### PR TITLE
[iOS] Dispatch active "touchmove" events without sending synchronous IPC messages

### DIFF
--- a/LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling-expected.txt
@@ -1,0 +1,12 @@
+Panning over this element should not cause scrolling.
+This test verifies that panning up and down over an element that prevents 'touchmove' events does not allow scrolling to happen, even if the touchmove event handler temporarily hangs the web process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Prevented touchmove
+PASS observedTouchEnd became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling.html
+++ b/LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+#scroller {
+    width: 300px;
+    height: 300px;
+    background-color: tomato;
+    border: solid 2px red;
+    color: white;
+    top: 0;
+    left: 0;
+    overflow: scroll;
+    font-size: 1.5em;
+    text-align: center;
+}
+
+#column {
+    width: 100%;
+    height: 1000px;
+}
+</style>
+</head>
+<body>
+<div id="scroller">
+    Panning over this element should not cause scrolling.
+    <div id="column"></div>
+</div>
+<div id="console"></div>
+<script>
+jsTestIsAsync = true;
+scroller = document.getElementById("scroller");
+observedFirstTouchMove = false;
+observedTouchEnd = false;
+scroller.addEventListener("scroll", () => testFailed("Observed unexpected scroll event"), { once: true });
+scroller.addEventListener("touchstart", () => observedFirstTouchMove = false, { passive: true });
+scroller.addEventListener("touchend", () => observedTouchEnd = true, { passive: true });
+scroller.addEventListener("touchmove", event => {
+    if (observedFirstTouchMove)
+        return;
+
+    const startTime = Date.now();
+    while (true) {
+        if (Date.now() - startTime > 100)
+            break;
+    }
+    event.preventDefault();
+    testPassed("Prevented touchmove");
+    observedFirstTouchMove = true;
+});
+
+description("This test verifies that panning up and down over an element that prevents 'touchmove' events does not allow scrolling to happen, even if the touchmove event handler temporarily hangs the web process.");
+
+if (window.testRunner) {
+    (async function() {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(150, 150)
+            .move(150, 10, 0.5)
+            .move(150, 290, 1)
+            .move(150, 150, 0.5)
+            .end()
+            .takeResult());
+        await shouldBecomeEqual("observedTouchEnd", "true");
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt
@@ -1,0 +1,13 @@
+Panning over this element should allow scrolling.
+This test verifies that panning up and down over an element that has an active 'touchmove' event listener allows scrolling to happen, even if the event handler temporarily hangs the web process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Observed first touchmove
+PASS Observed scroll event
+PASS observedTouchEnd became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html
+++ b/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+#scroller {
+    width: 300px;
+    height: 300px;
+    background-color: tomato;
+    border: solid 2px red;
+    color: white;
+    top: 0;
+    left: 0;
+    overflow: scroll;
+    font-size: 1.5em;
+    text-align: center;
+}
+
+#column {
+    width: 100%;
+    height: 1000px;
+}
+</style>
+</head>
+<body>
+<div id="scroller">
+    Panning over this element should allow scrolling.
+    <div id="column"></div>
+</div>
+<div id="console"></div>
+<script>
+jsTestIsAsync = true;
+scroller = document.getElementById("scroller");
+observedFirstTouchMove = false;
+observedTouchEnd = false;
+scroller.addEventListener("scroll", () => testPassed("Observed scroll event"), { once: true });
+scroller.addEventListener("touchstart", () => observedFirstTouchMove = false, { passive: true });
+scroller.addEventListener("touchend", () => observedTouchEnd = true, { passive: true });
+scroller.addEventListener("touchmove", event => {
+    if (observedFirstTouchMove)
+        return;
+
+    const startTime = Date.now();
+    while (true) {
+        if (Date.now() - startTime > 100)
+            break;
+    }
+    testPassed("Observed first touchmove");
+    observedFirstTouchMove = true;
+});
+
+description("This test verifies that panning up and down over an element that has an active 'touchmove' event listener allows scrolling to happen, even if the event handler temporarily hangs the web process.");
+
+if (window.testRunner) {
+    (async function() {
+        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+            .begin(150, 150)
+            .move(150, 10, 0.5)
+            .move(150, 290, 1)
+            .move(150, 150, 0.5)
+            .end()
+            .takeResult());
+        await shouldBecomeEqual("observedTouchEnd", "true");
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -365,6 +365,7 @@ public:
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
     virtual void doneDeferringTouchStart(bool preventNativeGestures) = 0;
+    virtual void doneDeferringTouchMove(bool preventNativeGestures) = 0;
     virtual void doneDeferringTouchEnd(bool preventNativeGestures) = 0;
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1929,6 +1929,7 @@ public:
 #endif
 
     bool isHandlingPreventableTouchStart() const { return m_handlingPreventableTouchStartCount; }
+    bool isHandlingPreventableTouchMove() const { return m_touchMovePreventionState == TouchMovePreventionState::Waiting; }
     bool isHandlingPreventableTouchEnd() const { return m_handlingPreventableTouchEndCount; }
 
     bool hasQueuedKeyEvent() const;
@@ -2981,9 +2982,10 @@ private:
     Deque<QueuedTouchEvents> m_touchEventQueue;
 #endif
 
-    bool m_handledSynchronousTouchEventWhileDispatchingPreventableTouchStart { false };
     uint64_t m_handlingPreventableTouchStartCount { 0 };
     uint64_t m_handlingPreventableTouchEndCount { 0 };
+    enum class TouchMovePreventionState : uint8_t { NotWaiting, Waiting, ReceivedReply };
+    TouchMovePreventionState m_touchMovePreventionState { TouchMovePreventionState::NotWaiting };
 
 #if ENABLE(INPUT_TYPE_COLOR)
     RefPtr<WebColorPicker> m_colorPicker;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -118,6 +118,7 @@ private:
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
     void doneDeferringTouchStart(bool preventNativeGestures) override;
+    void doneDeferringTouchMove(bool preventNativeGestures) override;
     void doneDeferringTouchEnd(bool preventNativeGestures) override;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -455,6 +455,11 @@ void PageClientImpl::doneDeferringTouchStart(bool preventNativeGestures)
     [m_contentView _doneDeferringTouchStart:preventNativeGestures];
 }
 
+void PageClientImpl::doneDeferringTouchMove(bool preventNativeGestures)
+{
+    [m_contentView _doneDeferringTouchMove:preventNativeGestures];
+}
+
 void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 {
     [m_contentView _doneDeferringTouchEnd:preventNativeGestures];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -291,6 +291,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WKDeferringGestureRecognizer> _touchEndDeferringGestureRecognizerForImmediatelyResettableGestures;
     RetainPtr<WKDeferringGestureRecognizer> _touchEndDeferringGestureRecognizerForDelayedResettableGestures;
     RetainPtr<WKDeferringGestureRecognizer> _touchEndDeferringGestureRecognizerForSyntheticTapGestures;
+    RetainPtr<WKDeferringGestureRecognizer> _touchMoveDeferringGestureRecognizer;
     std::optional<HashSet<RetainPtr<WKDeferringGestureRecognizer>>> _failedTouchStartDeferringGestures;
 #if ENABLE(IMAGE_ANALYSIS)
     RetainPtr<WKDeferringGestureRecognizer> _imageAnalysisDeferringGestureRecognizer;
@@ -640,6 +641,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #endif
 #if ENABLE(IOS_TOUCH_EVENTS)
 - (void)_doneDeferringTouchStart:(BOOL)preventNativeGestures;
+- (void)_doneDeferringTouchMove:(BOOL)preventNativeGestures;
 - (void)_doneDeferringTouchEnd:(BOOL)preventNativeGestures;
 #endif
 - (void)_commitPotentialTapFailed;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1364,7 +1364,7 @@ public:
     template<typename T>
     SendSyncResult sendSyncWithDelayedReply(T&& message, typename T::Reply&& reply, OptionSet<IPC::SendSyncOption> sendSyncOptions = { })
     {
-        cancelGesturesBlockedOnSynchronousReplies();
+        cancelCurrentInteractionInformationRequest();
         sendSyncOptions = sendSyncOptions | IPC::SendSyncOption::InformPlatformProcessWillSuspend;
         return sendSync(WTFMove(message), WTFMove(reply), Seconds::infinity(), sendSyncOptions);
     }
@@ -1996,7 +1996,7 @@ private:
 
     bool canShowMIMEType(const String&, const Function<bool(const String&, WebCore::PluginData::AllowedPluginTypes)>& supportsPlugin) const;
 
-    void cancelGesturesBlockedOnSynchronousReplies();
+    void cancelCurrentInteractionInformationRequest();
 
     bool shouldDispatchUpdateAfterFocusingElement(const WebCore::Element&) const;
 
@@ -2299,10 +2299,6 @@ private:
         ScheduledDuringAccessibilitySelectionChange,
     };
     PendingEditorStateUpdateStatus m_pendingEditorStateUpdateStatus { PendingEditorStateUpdateStatus::NotScheduled };
-
-#if ENABLE(IOS_TOUCH_EVENTS)
-    CompletionHandler<void(bool)> m_pendingSynchronousTouchEventReply;
-#endif
 
 #if ENABLE(META_VIEWPORT)
     WebCore::ViewportConfiguration m_viewportConfiguration;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -146,7 +146,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     ResetPotentialTapSecurityOrigin()
-    TouchEventSync(WebKit::WebTouchEvent event) -> (bool handled) Synchronous
 #endif
 #if !ENABLE(IOS_TOUCH_EVENTS) && ENABLE(TOUCH_EVENTS)
     TouchEvent(WebKit::WebTouchEvent event)


### PR DESCRIPTION
#### b7a998fb59f59222ea76fe60141f38cfd2fc8cde
<pre>
[iOS] Dispatch active &quot;touchmove&quot; events without sending synchronous IPC messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=243250">https://bugs.webkit.org/show_bug.cgi?id=243250</a>
rdar://78840792

Reviewed by Tim Horton and Devin Rousso.

Dispatch active &quot;touchmove&quot; events asynchronously, by introducing a new deferring gesture recognizer
that defers pan and pinch gesture recognition until after the first &quot;touchmove&quot; event has been
handled by the page.

Compatibility-wise, this still allows pages to call `preventDefault()` on &quot;touchmove&quot; events in
order to prevent scrolling and pinch-zooming, as long as the page (at least) prevents the initial
touchmove event. This roughly matches shipping behavior, but with the slight risk that in shipping
WebKit, calling prevent default on the second &quot;touchmove&quot; event *sometimes* prevents scrolling
(whereas after this patch, preventing the second &quot;touchmove&quot; event but not the first does not
prevent native gestures). It&apos;s important to note that this behavior is already inconsistent in
shipping software; before and after this patch, the only reliable way to prevent scrolling on
&quot;touchmove&quot; events is to (at least) prevent the first &quot;touchmove&quot; event that&apos;s dispatched when
performing a pan gesture.

See comments below for more details.

Tests:  fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling.html
        fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html

* LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/prevent-touchmove-with-slow-event-listener-prevents-scrolling.html: Added.
* LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html: Added.

Add a couple of tests to exercise cases where a page installs an active &quot;touchmove&quot; event listener
that spins for a significant amount of time (in this case, 100 ms), and then proceeds to either
prevent default (i.e. the former test), or not prevent default (the latter). In particular, this
exercises the ability for the new &quot;touchmove&quot; deferring gesture recognizer to prevent scroll view
pan gestures from firing, until the web page has at least handled the first &quot;touchmove&quot; event.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handlePreventableTouchEvent):

Remove the codepath for dispatching sync touch events altogether, now that all preventable (active)
touch events no longer require synchronous dispatch in order to prevent default gestures from
recognizing. We introduce and use the `m_touchMovePreventionState` flag here to know when the first
preventable &quot;touchmove&quot; is being handled by the web page, and only prevent native gestures from
firing by &quot;lifting&quot; the gate for deferred &quot;touchmove&quot; gestures for the initial &quot;touchmove&quot;. This is
covered by the new test: `prevent-touchmove-with-slow-event-listener-prevents-scrolling.html`.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::doneDeferringTouchMove):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Add support for a new deferring gesture recognizer which prevents all pan and pinch gestures at (or
underneath) the web view from firing, until the web page has had a chance to prevent active
&quot;touchmove&quot; events. Note that we&apos;re able to forgo the need for separate &quot;immediately resettable&quot;
and &quot;delayed resettable&quot; deferring gestures here, since the only native gestures that can be
prevented by preventing &quot;touchmove&quot; events are pan and pinch gestures, which immediately reset in
the first place.

(-[WKContentView setUpInteraction]):
(-[WKContentView _webTouchEventsRecognized:]):
(-[WKContentView deferringGestures]):
(-[WKContentView _doneDeferringTouchMove:]):
(-[WKContentView deferringGestureRecognizer:didEndTouchesWithEvent:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::cancelCurrentInteractionInformationRequest):
(WebKit::WebPage::cancelGesturesBlockedOnSynchronousReplies): Deleted.
(WebKit::WebPage::touchEventSync): Deleted.

Delete more code (and hacks) around synchronous touch event dispatch.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/252909@main">https://commits.webkit.org/252909@main</a>
</pre>
