### PR TITLE
Make some iokit-get-properties sandbox violations quieter

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -916,6 +916,17 @@
 #endif
 )
 
+;; <rdar://97677559>
+(deny iokit-get-properties
+    (iokit-property "AppleDiagnosticDataSysCfg")
+    (iokit-property "AppleJPEGNumCores")
+    (iokit-property "als-colorCfg")
+    (iokit-property "ean-storage-present")
+    (iokit-property "noMultiColorSupport")
+    (iokit-property "product-id")
+    (iokit-property "syscfg-v2-data")
+    (with no-report))
+
 ;; <rdar://problem/60088861>
 (if (equal? (param "CPU") "arm64")
     (allow iokit-get-properties


### PR DESCRIPTION
#### 634d6d0ba6296b3931cbfa9747db0019399fa342
<pre>
Make some iokit-get-properties sandbox violations quieter
<a href="https://bugs.webkit.org/show_bug.cgi?id=243261">https://bugs.webkit.org/show_bug.cgi?id=243261</a>

Reviewed by Per Arne Vollan.

Some iokit-get-properties sandbox denials are relatively common and harmless but cause CPU usage for
violation reporting in sandboxd. We should make these denials quieter with the no-report option.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in

Canonical link: <a href="https://commits.webkit.org/252925@main">https://commits.webkit.org/252925@main</a>
</pre>
