### PR TITLE
REGRESSION (iOS 15.5): Angular Materials style triggers poor performance on a long scrolling page

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -691,6 +691,12 @@ Vector<ScrollUpdate> ScrollingTree::takePendingScrollUpdates()
     return std::exchange(m_pendingScrollUpdates, { });
 }
 
+bool ScrollingTree::hasPendingScrollUpdates()
+{
+    Locker locker { m_pendingScrollUpdatesLock };
+    return m_pendingScrollUpdates.size();
+}
+
 // Can be called from the main thread.
 void ScrollingTree::setScrollPinningBehavior(ScrollPinningBehavior pinning)
 {

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -233,8 +233,10 @@ public:
     
     WEBCORE_EXPORT void willProcessWheelEvent();
 
-    void addPendingScrollUpdate(ScrollUpdate&&);
-    Vector<ScrollUpdate> takePendingScrollUpdates();
+    WEBCORE_EXPORT void addPendingScrollUpdate(ScrollUpdate&&);
+    WEBCORE_EXPORT Vector<ScrollUpdate> takePendingScrollUpdates();
+    WEBCORE_EXPORT bool hasPendingScrollUpdates();
+
     virtual void removePendingScrollAnimationForNode(ScrollingNodeID) { }
 
 protected:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS UIScrollView;
 
@@ -50,7 +51,7 @@ class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
 class WebPageProxy;
 
-class RemoteScrollingCoordinatorProxy {
+class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(RemoteScrollingCoordinatorProxy);
 public:
@@ -124,6 +125,8 @@ private:
     std::pair<float, std::optional<unsigned>> closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis, float currentScrollOffset, WebCore::FloatPoint scrollDestination, float velocity) const;
 
     void sendUIStateChangedIfNecessary();
+    void sendScrollingTreeNodeDidScroll();
+    void receivedLastScrollingTreeNodeDidScrollReply();
 
     WebPageProxy& m_webPageProxy;
     RefPtr<RemoteScrollingTree> m_scrollingTree;
@@ -133,6 +136,7 @@ private:
     std::optional<unsigned> m_currentHorizontalSnapPointIndex;
     std::optional<unsigned> m_currentVerticalSnapPointIndex;
     bool m_propagatesMainFrameScrolls { true };
+    bool m_waitingForDidScrollReply { false };
     HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_layersWithScrollingRelations;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_fixedScrollingNodeLayerIDs;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -78,7 +78,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     
     // Respond to UI process changes.
-    void scrollPositionChangedForNode(WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, bool syncLayerPosition);
+    void scrollPositionChangedForNode(WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, bool syncLayerPosition, CompletionHandler<void()>&&);
     void animatedScrollDidEndForNode(WebCore::ScrollingNodeID);
     void currentSnapPointIndicesChangedForNode(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 messages -> RemoteScrollingCoordinator {
-    ScrollPositionChangedForNode(uint64_t nodeID, WebCore::FloatPoint scrollPosition, bool syncLayerPosition);
+    ScrollPositionChangedForNode(uint64_t nodeID, WebCore::FloatPoint scrollPosition, bool syncLayerPosition) -> ()
     AnimatedScrollDidEndForNode(uint64_t nodeID);
     CurrentSnapPointIndicesChangedForNode(uint64_t nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
     ScrollingStateInUIProcessChanged(WebKit::RemoteScrollingUIState uiState);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -105,10 +105,14 @@ void RemoteScrollingCoordinator::buildTransaction(RemoteScrollingCoordinatorTran
 }
 
 // Notification from the UI process that we scrolled.
-void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, bool syncLayerPosition)
+void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, bool syncLayerPosition, CompletionHandler<void()>&& completionHandler)
 {
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition);
+
     auto scrollUpdate = ScrollUpdate { nodeID, scrollPosition, { }, ScrollUpdateType::PositionUpdate, syncLayerPosition ? ScrollingLayerPositionAction::Sync : ScrollingLayerPositionAction::Set };
     applyScrollUpdate(WTFMove(scrollUpdate));
+
+    completionHandler();
 }
 
 void RemoteScrollingCoordinator::animatedScrollDidEndForNode(ScrollingNodeID nodeID)


### PR DESCRIPTION
#### e7b60434701b0440c0f2be49850e6769e9253c5b
<pre>
REGRESSION (iOS 15.5): Angular Materials style triggers poor performance on a long scrolling page
<a href="https://bugs.webkit.org/show_bug.cgi?id=241458">https://bugs.webkit.org/show_bug.cgi?id=241458</a>
&lt;rdar://95287714&gt;

Reviewed by Tim Horton.

Batch scrolling updates for sub-scrollers from the UI process to the web process to avoid getting
backed up doing expensive compositing updates when the web process receives a flood of scroll update
IPC messages.

RemoteScrollingCoordinatorProxy can use ScrollingTree&apos;s existing ability to coalesce updates,
relying on a reply to the async IPC to know when the web process has finished handling the previous
update.

I tried to make an API test for this, but failed; it would need to detect when the web process
handles a stream of &quot;did scroll&quot; IPC messages, and would need to scroll content that is very slow to
update. scroll events can&apos;t be used as a signal for how many scroll updates the web process
receives.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::hasPendingScrollUpdates):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollReply):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollPositionChangedForNode):

Canonical link: <a href="https://commits.webkit.org/253015@main">https://commits.webkit.org/253015@main</a>
</pre>
