### PR TITLE
Unreviewed, remove workaround for EWS JSC test failures after 252861@main fix

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -530,6 +530,12 @@ public:
     InlineWatchpointSet m_structureCacheClearedWatchpoint { IsWatched };
     InlineWatchpointSet m_arrayBufferSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_sharedArrayBufferSpeciesWatchpointSet { ClearWatchpoint };
+    InlineWatchpointSet m_typedArrayConstructorSpeciesWatchpointSet { IsWatched };
+#define DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET(name) \
+    InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint };
+    FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET)
+#undef DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET
+
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayConstructorSpeciesWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayPrototypeConstructorWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayPrototypeSymbolIteratorWatchpoint;
@@ -546,6 +552,12 @@ public:
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_numberPrototypeToStringWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayBufferConstructorSpeciesWatchpoints[2];
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayBufferPrototypeConstructorWatchpoints[2];
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayConstructorSpeciesWatchpoint;
+#define DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT(name) \
+    std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## ConstructorSpeciesAbsenceWatchpoint; \
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArray ## name ## PrototypeConstructorWatchpoint;
+    FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
+#undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
 
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayConstructorSpeciesAbsenceWatchpoint(TypedArrayType type)
     {
@@ -1284,18 +1296,6 @@ private:
     void fixupPrototypeChainWithObjectPrototype(VM&);
 
     JS_EXPORT_PRIVATE static void clearRareData(JSCell*);
-
-    InlineWatchpointSet m_typedArrayConstructorSpeciesWatchpointSet { IsWatched };
-#define DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET(name) \
-    InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint };
-    FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET)
-#undef DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET
-    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayConstructorSpeciesWatchpoint;
-#define DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT(name) \
-    std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## ConstructorSpeciesAbsenceWatchpoint; \
-    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArray ## name ## PrototypeConstructorWatchpoint;
-    FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
-#undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
 
 #if JSC_OBJC_API_ENABLED
     RetainPtr<JSWrapperMap> m_wrapperMap;


### PR DESCRIPTION
#### 0d6e2a2ccd27ddebcf06fd38725f0223f9711e9f
<pre>
Unreviewed, remove workaround for EWS JSC test failures after 252861@main fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=243268">https://bugs.webkit.org/show_bug.cgi?id=243268</a>

* Source/JavaScriptCore/runtime/JSGlobalObject.h:

Canonical link: <a href="https://commits.webkit.org/252888@main">https://commits.webkit.org/252888@main</a>
</pre>
