### PR TITLE
WKWebView's scrollView.bounces=false is not working

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -908,7 +908,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         horizontalOverscrollBehavior = rootNode->horizontalOverscrollBehavior();
         verticalOverscrollBehavior = rootNode->verticalOverscrollBehavior();
     }
-
+    
     WebKit::ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(_scrollView.get(), horizontalOverscrollBehavior, verticalOverscrollBehavior, WebKit::ScrollingTreeScrollingNodeDelegateIOS::AllowOverscrollToPreventScrollPropagation::No);
 
     bool hasDockedInputView = !CGRectIsEmpty(_inputViewBoundsInWindow);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -33,6 +33,7 @@
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "RemoteScrollingTree.h"
 #import "UIKitSPI.h"
+#import "WKScrollView.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIPanGestureRecognizer.h>
@@ -223,8 +224,12 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren(const Scro
 
 void ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(UIScrollView *scrollView, const WebCore::OverscrollBehavior horizontalOverscrollBehavior, WebCore::OverscrollBehavior verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation allowPropogation)
 {
-    scrollView.bouncesHorizontally = horizontalOverscrollBehavior != OverscrollBehavior::None;
-    scrollView.bouncesVertically = verticalOverscrollBehavior != OverscrollBehavior::None;
+    if ([scrollView isKindOfClass:[WKScrollView class]])
+        [(WKScrollView*)scrollView _setBouncesInternal:horizontalOverscrollBehavior != WebCore::OverscrollBehavior::None vertical: verticalOverscrollBehavior != WebCore::OverscrollBehavior::None];
+    else {
+        scrollView.bouncesHorizontally = horizontalOverscrollBehavior != OverscrollBehavior::None;
+        scrollView.bouncesVertically = verticalOverscrollBehavior != OverscrollBehavior::None;
+    }
     if (allowPropogation == AllowOverscrollToPreventScrollPropagation::Yes) {
 #if HAVE(UIKIT_OVERSCROLL_BEHAVIOR_SUPPORT)
         scrollView._allowsParentToBeginHorizontally = horizontalOverscrollBehavior == OverscrollBehavior::Auto;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -38,6 +38,7 @@
 - (void)_setContentSizePreservingContentOffsetDuringRubberband:(CGSize)contentSize;
 - (void)_setScrollEnabledInternal:(BOOL)enabled;
 - (void)_setZoomEnabledInternal:(BOOL)enabled;
+- (void)_setBouncesInternal:(BOOL)horizontal vertical:(BOOL)vertical;
 - (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -141,6 +141,9 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     BOOL _scrollEnabledInternal;
     BOOL _zoomEnabledByClient;
     BOOL _zoomEnabledInternal;
+    BOOL _bouncesSetByClient;
+    BOOL _bouncesHorizontalInternal;
+    BOOL _bouncesVerticalInternal;
     std::optional<UIEdgeInsets> _contentScrollInsetFromClient;
     std::optional<UIEdgeInsets> _contentScrollInsetInternal;
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
@@ -159,6 +162,9 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     _scrollEnabledInternal = YES;
     _zoomEnabledByClient = YES;
     _zoomEnabledInternal = YES;
+    _bouncesSetByClient = YES;
+    _bouncesHorizontalInternal = YES;
+    _bouncesVerticalInternal = YES;
 
     self.alwaysBounceVertical = YES;
     self.directionalLockEnabled = YES;
@@ -471,6 +477,25 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 - (void)_updateScrollability
 {
     [super setScrollEnabled:(_scrollEnabledByClient && _scrollEnabledInternal)];
+}
+
+- (void)setBounces:(BOOL)value
+{
+    _bouncesSetByClient = value;
+    [self _updateBouncability];
+}
+
+- (void)_setBouncesInternal:(BOOL)horizontal vertical:(BOOL)vertical
+{
+    _bouncesHorizontalInternal = horizontal;
+    _bouncesVerticalInternal = vertical;
+    [self _updateBouncability];
+}
+
+- (void)_updateBouncability
+{
+    [super setBouncesHorizontally:(_bouncesSetByClient && _bouncesHorizontalInternal)];
+    [super setBouncesVertically:(_bouncesSetByClient && _bouncesVerticalInternal)];
 }
 
 - (void)setZoomEnabled:(BOOL)value

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		1A77BAA31D9AFFFC005FC568 /* OptionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE50D8C81C8665CE0072EA5A /* OptionSet.cpp */; };
 		1A7E8B3618120B2F00AEB74A /* FragmentNavigation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1A7E8B351812093600AEB74A /* FragmentNavigation.html */; };
 		1A9E52C913E65EF4006917F5 /* 18-characters.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = C045F9461385C2F800C0F3CD /* 18-characters.html */; };
+		1AD7343D28D2A78400797100 /* ScrollViewBouncesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AD7343C28D2A78400797100 /* ScrollViewBouncesTests.mm */; };
 		1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ADAD14E1D77A9F600212586 /* BlockPtr.mm */; };
 		1ADBEFE3130C6AA100D61D19 /* simple-accelerated-compositing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1ADBEFBC130C6A0100D61D19 /* simple-accelerated-compositing.html */; };
 		1AEDE22613E5E7E700E62FE8 /* InjectedBundleControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */; };
@@ -1931,6 +1932,7 @@
 		1A9FB6CC1CA34BE500966124 /* EarlyKVOCrash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EarlyKVOCrash.mm; sourceTree = "<group>"; };
 		1AAD19F51C7CE20300831E47 /* Coding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Coding.mm; sourceTree = "<group>"; };
 		1ABC3DED1899BE6D004F0626 /* Navigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Navigation.mm; sourceTree = "<group>"; };
+		1AD7343C28D2A78400797100 /* ScrollViewBouncesTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewBouncesTests.mm; sourceTree = "<group>"; };
 		1ADAD14E1D77A9F600212586 /* BlockPtr.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BlockPtr.mm; sourceTree = "<group>"; };
 		1ADBEFAD130C689C00D61D19 /* ForceRepaint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ForceRepaint.cpp; sourceTree = "<group>"; };
 		1ADBEFBC130C6A0100D61D19 /* simple-accelerated-compositing.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "simple-accelerated-compositing.html"; sourceTree = "<group>"; };
@@ -4214,6 +4216,7 @@
 				F4010B7F24DA24AC00A876E2 /* NavigationSwipeTests.mm */,
 				0F34077523037FDC0060A1A0 /* OverflowScrollViewTests.mm */,
 				F464AF9120BB66EA007F9B18 /* RenderingProgressTests.mm */,
+				1AD7343C28D2A78400797100 /* ScrollViewBouncesTests.mm */,
 				F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */,
 				0FF1134D22D68679009A81DA /* ScrollViewScrollabilityTests.mm */,
 				1C90420B2326E03C00BEF91E /* SelectionByWord.mm */,
@@ -6183,6 +6186,7 @@
 				CDC0932B21C872C10030C4B0 /* ScrollingDoesNotPauseMedia.mm in Sources */,
 				7CCE7F121A411AE600447C4C /* ScrollPinningBehaviors.cpp in Sources */,
 				F434CA1A22E65BCA005DDB26 /* ScrollToRevealSelection.mm in Sources */,
+				1AD7343D28D2A78400797100 /* ScrollViewBouncesTests.mm in Sources */,
 				F4C8797F2059D8D3009CD00B /* ScrollViewInsetTests.mm in Sources */,
 				0FF1134E22D68679009A81DA /* ScrollViewScrollabilityTests.mm in Sources */,
 				CE06DF9B1E1851F200E570C9 /* SecurityOrigin.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewBouncesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewBouncesTests.mm
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "PlatformUtilities.h"
+#import "TestInputDelegate.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import <UIKit/UIKit.h>
+#import <WebKit/WKWebViewPrivate.h>
+
+namespace TestWebKitAPI {
+
+static const CGFloat viewHeight = 500;
+
+static NSString *overscrollBehaviorAuto = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior: auto;'>";
+static NSString *overscrollBehaviorNone = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior: none;'>";
+static NSString *overscrollBehaviorContain = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior: contain;'>";
+
+static NSString *overscrollBehaviorAutoX = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-x: auto;'>";
+static NSString *overscrollBehaviorNoneX = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-x: none;'>";
+static NSString *overscrollBehaviorContainX = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-x: contain;'>";
+
+static NSString *overscrollBehaviorAutoY = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-y: auto;'>";
+static NSString *overscrollBehaviorNoneY = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-y: none;'>";
+static NSString *overscrollBehaviorContainY = @"<meta name='viewport' content='width=device-width, initial-scale=1'><html style='width: 100%; height: 5000px; overscroll-behavior-y: contain;'>";
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSet)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSet)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetDynamicallyChange)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+    [webView stringByEvaluatingJavaScript:@"document.documentElement.style.overscrollBehavior = 'auto'"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetDynamicallyChange)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+    [webView stringByEvaluatingJavaScript:@"document.documentElement.style.overscrollBehavior = 'auto'"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneDynamicallyChange)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+    [webView objectByEvaluatingJavaScript:@"document.documentElement.style.overscrollBehavior = 'none'"];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSet)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSet)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContain];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSet)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContain];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoX];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoX];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneNotSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneX];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneX];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContainX];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSetX)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContainX];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetY)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoY];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSety)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoY];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneNotSetY)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneY];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetY)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneY];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSetY)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContainY];
+    EXPECT_EQ([[webView scrollView] bounces], YES);
+}
+
+TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSetY)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    [webView synchronouslyLoadHTMLString:overscrollBehaviorContainY];
+    [[webView scrollView] setBounces:NO];
+    EXPECT_EQ([[webView scrollView] bounces], NO);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(IOS_FAMILY)
+


### PR DESCRIPTION
#### b40f80bcf189b67147eb79d9e0ca3c00dc8f8ea0
<pre>
WKWebView&apos;s scrollView.bounces=false is not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=243270">https://bugs.webkit.org/show_bug.cgi?id=243270</a>
&lt;rdar://96024524&gt;

Reviewed by Simon Fraser.

Keep track if bounces is set by client to make sure it is not overwritten by overscroll behavior.
Currently setting bounces = True on a page with overscroll-behavior:none will result in the client
setting to be ignored.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior):

Canonical link: <a href="https://commits.webkit.org/254582@main">https://commits.webkit.org/254582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401e301ae59fa5c763ebbccb2fc694ba98ffabb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/89485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/98798 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/155105 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/93493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/32540 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/81843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/93211 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/25850 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76376 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/25784 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/80728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/68775 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/30299 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/14696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/30041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/15633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/33488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/38589 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/32198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/34724 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->