### PR TITLE
Rename FrameView::m_size to m_lastUsedSizeForLayout

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -323,7 +323,7 @@ void FrameView::init()
 {
     reset();
 
-    m_size = LayoutSize();
+    m_lastUsedSizeForLayout = { };
 
     // Propagate the scrolling mode to the view.
     auto* ownerElement = frame().ownerElement();
@@ -1268,11 +1268,11 @@ void FrameView::willDoLayout(WeakPtr<RenderElement> layoutRoot)
     }
     adjustScrollbarsForLayout(firstLayout);
         
-    auto oldSize = m_size;
-    LayoutSize newSize = layoutSize();
+    auto oldSize = m_lastUsedSizeForLayout;
+    auto newSize = layoutSize();
     if (oldSize != newSize) {
-        m_size = newSize;
-        LOG_WITH_STREAM(Layout, stream << "  layout size changed from " << oldSize << " to " << newSize);
+        m_lastUsedSizeForLayout = newSize;
+        LOG_WITH_STREAM(Layout, stream << "  size for layout changed from " << oldSize << " to " << newSize);
         layoutContext().setNeedsFullRepaint();
         if (!firstLayout)
             markRootOrBodyRendererDirty();
@@ -2733,7 +2733,7 @@ void FrameView::updateScriptedAnimationsAndTimersThrottlingState(const IntRect& 
         return;
 
     // We don't throttle zero-size or display:none frames because those are usually utility frames.
-    bool shouldThrottle = visibleRect.isEmpty() && !m_size.isEmpty() && frame().ownerRenderer();
+    bool shouldThrottle = visibleRect.isEmpty() && !m_lastUsedSizeForLayout.isEmpty() && frame().ownerRenderer();
     document->setTimerThrottlingEnabled(shouldThrottle);
 
     auto* page = frame().page();

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -918,7 +918,7 @@ private:
 
     MonotonicTime m_lastPaintTime;
 
-    LayoutSize m_size;
+    LayoutSize m_lastUsedSizeForLayout;
 
     Color m_baseBackgroundColor { Color::white };
     IntSize m_lastViewportSize;


### PR DESCRIPTION
#### 56bc3a69c714260a2c0de11763429618429e8db4
<pre>
Rename FrameView::m_size to m_lastUsedSizeForLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=179579">https://bugs.webkit.org/show_bug.cgi?id=179579</a>

Reviewed by Alan Bujtas.

Rename FrameView::m_size to m_lastUsedSizeForLayout.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::init):
(WebCore::FrameView::willDoLayout):
(WebCore::FrameView::updateScriptedAnimationsAndTimersThrottlingState):
* Source/WebCore/page/FrameView.h:

Canonical link: <a href="https://commits.webkit.org/252894@main">https://commits.webkit.org/252894@main</a>
</pre>
