### PR TITLE
[iOS] Several FullscreenVideoTextRecognition API tests are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -44,10 +44,13 @@
 
 static void swizzledPresentViewController(UIViewController *, SEL, UIViewController *, BOOL, dispatch_block_t completion)
 {
-    dispatch_async(dispatch_get_main_queue(), completion);
+    RunLoop::main().dispatch([completion = makeBlockPtr(completion)] {
+        if (completion)
+            completion();
+    });
 }
 
-#endif
+#endif // PLATFORM(IOS_FAMILY)
 
 static int32_t swizzledProcessRequest(VKCImageAnalyzer *, SEL, id request, void (^)(double progress), void (^completion)(VKImageAnalysis *, NSError *))
 {
@@ -67,6 +70,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 @implementation FullscreenVideoTextRecognitionWebView {
     std::unique_ptr<InstanceMethodSwizzler> _imageAnalysisRequestSwizzler;
 #if PLATFORM(IOS_FAMILY)
+    std::unique_ptr<InstanceMethodSwizzler> _viewControllerPresentationSwizzler;
     std::unique_ptr<InstanceMethodSwizzler> _imageAnalysisInteractionSwizzler;
 #else
     std::unique_ptr<InstanceMethodSwizzler> _imageAnalysisOverlaySwizzler;
@@ -101,6 +105,14 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
         @selector(setAnalysis:),
         reinterpret_cast<IMP>(swizzledSetAnalysis)
     );
+    // Work around lack of a real UIApplication in TestWebKitAPIApp on iOS. Without this,
+    // -presentViewController:animated:completion: never calls the completion handler,
+    // which means we never transition into WKFullscreenStateInFullscreen.
+    _viewControllerPresentationSwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
+        UIViewController.class,
+        @selector(presentViewController:animated:completion:),
+        reinterpret_cast<IMP>(swizzledPresentViewController)
+    );
 #else
     _imageAnalysisOverlaySwizzler = WTF::makeUnique<InstanceMethodSwizzler>(
         PAL::getVKCImageAnalysisOverlayViewClass(),
@@ -125,17 +137,6 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 
 - (void)enterFullscreen
 {
-#if PLATFORM(IOS_FAMILY)
-    // Work around lack of a real UIApplication in TestWebKitAPIApp on iOS. Without this,
-    // -presentViewController:animated:completion: never calls the completion handler,
-    // which means we never transition into WKFullscreenStateInFullscreen.
-    InstanceMethodSwizzler presentationSwizzler {
-        UIViewController.class,
-        @selector(presentViewController:animated:completion:),
-        reinterpret_cast<IMP>(swizzledPresentViewController)
-    };
-#endif // PLATFORM(IOS_FAMILY)
-
     _doneEnteringFullscreen = false;
     [self evaluateJavaScript:@"enterFullscreen()" completionHandler:nil];
     TestWebKitAPI::Util::run(&_doneEnteringFullscreen);


### PR DESCRIPTION
#### d5d042efe221e77a15f793c7bf504f5ffb482eae
<pre>
[iOS] Several FullscreenVideoTextRecognition API tests are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=243273">https://bugs.webkit.org/show_bug.cgi?id=243273</a>
rdar://97567564

Reviewed by Tim Horton.

Address a couple sources of flaky crashes in these API tests on iOS:

1. It&apos;s possible for `-play` to trigger the video fullscreen presentation codepath (and thus, call
into `-presentViewController:animated:completion:` before the tests that call this method have
finished; in this scenario, the view controller presentation method isn&apos;t swizzled, so we end up
crashing in UIKit code due to lack of a UI application). Address this by pulling this logic out into
the common initializer of `FullscreenVideoTextRecognitionWebView` instead, to ensure that this call
into `UIViewController` remains swizzled throughout the entire duration of each test.

2. The swizzled implementation of `swizzledPresentViewController` are current unsafe, since nothing
guarantees that the completion handler is still alive by the time it is invoked on the next runloop
iteration. Address this by using `BlockPtr` to retain and release the completion block.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(swizzledPresentViewController):
(-[FullscreenVideoTextRecognitionWebView initWithFrame:configuration:]):
(-[FullscreenVideoTextRecognitionWebView enterFullscreen]):

Canonical link: <a href="https://commits.webkit.org/252892@main">https://commits.webkit.org/252892@main</a>
</pre>
