### PR TITLE
Add SPI to store SKAdNetwork attribution for navigations handled outside of WebKit

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1822,7 +1822,7 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
     config.get().sourceWebRegistrableDomain = pcm.sourceSite().registrableDomain.string();
     config.get().version = @"3";
     config.get().attributionContext = AttributionTypeDefault;
-    [[ASDInstallAttribution sharedInstance] addInstallWebAttributionParamsWithConfig:config.get() completionHandler:nil];
+    [[ASDInstallAttribution sharedInstance] addInstallWebAttributionParamsWithConfig:config.get() completionHandler:^(NSError *) { }];
 #endif
 
     if (!m_privateClickMeasurementDebugModeEnabled)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -219,4 +219,22 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEvent::Synthe
     return wrapper(_navigationAction->mainFrameNavigation());
 }
 
+
+- (void)_storeSKAdNetworkAttribution
+{
+    auto* mainFrameNavigation = _navigationAction->mainFrameNavigation();
+    if (!mainFrameNavigation)
+        return;
+    auto& privateClickMeasurement = mainFrameNavigation->privateClickMeasurement();
+    if (!privateClickMeasurement || !privateClickMeasurement->isSKAdNetworkAttribution())
+        return;
+    auto* sourceFrame = _navigationAction->sourceFrame();
+    if (!sourceFrame)
+        return;
+    auto* page = sourceFrame->page();
+    if (!page)
+        return;
+    page->websiteDataStore().storePrivateClickMeasurement(*privateClickMeasurement);
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
@@ -60,5 +60,6 @@ typedef NS_ENUM(NSInteger, WKSyntheticClickType) {
 
 @property (nonatomic, readonly) BOOL _isRedirect WK_API_AVAILABLE(macos(10.13), ios(11.0));
 @property (nonatomic, readonly) WKNavigation *_mainFrameNavigation WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
+- (void)_storeSKAdNetworkAttribution WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5137,7 +5137,7 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
             privateClickMeasurement = navigation->privateClickMeasurement();
         if (privateClickMeasurement) {
             if (privateClickMeasurement->destinationSite().matches(frame->url()) || privateClickMeasurement->isSKAdNetworkAttribution())
-                websiteDataStore().networkProcess().send(Messages::NetworkProcess::StorePrivateClickMeasurement(m_websiteDataStore->sessionID(), *privateClickMeasurement), 0);
+                websiteDataStore().storePrivateClickMeasurement(*privateClickMeasurement);
         }
     }
     m_privateClickMeasurement.reset();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1689,6 +1689,11 @@ void WebsiteDataStore::setPrivateClickMeasurementDebugMode(bool enabled)
     networkProcess().setPrivateClickMeasurementDebugMode(sessionID(), enabled);
 }
 
+void WebsiteDataStore::storePrivateClickMeasurement(const WebCore::PrivateClickMeasurement& privateClickMeasurement)
+{
+    networkProcess().send(Messages::NetworkProcess::StorePrivateClickMeasurement(sessionID(), privateClickMeasurement), 0);
+}
+
 void WebsiteDataStore::closeDatabases(CompletionHandler<void()>&& completionHandler)
 {
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -75,6 +75,7 @@ class CertificateInfo;
 class RegistrableDomain;
 class SecurityOrigin;
 class LocalWebLockRegistry;
+class PrivateClickMeasurement;
 
 struct MockWebAuthenticationConfiguration;
 struct NotificationData;
@@ -153,6 +154,7 @@ public:
     void isResourceLoadStatisticsEphemeral(CompletionHandler<void(bool)>&&) const;
 
     void setPrivateClickMeasurementDebugMode(bool);
+    void storePrivateClickMeasurement(const WebCore::PrivateClickMeasurement&);
 
     uint64_t perOriginStorageQuota() const { return m_resolvedConfiguration->perOriginStorageQuota(); }
     uint64_t perThirdPartyOriginStorageQuota() const;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -36,6 +36,7 @@
 #import "Utilities.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKMain.h>
+#import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKPage.h>
 #import <WebKit/WKPageInjectedBundleClient.h>
 #import <WebKit/WKPreferencesPrivate.h>
@@ -560,7 +561,7 @@ TEST(PrivateClickMeasurement, DaemonDebugMode)
     cleanUpDaemon(tempDir);
 }
 
-TEST(PrivateClickMeasurement, SKAdNetwork)
+static void setupSKAdNetworkTest(Vector<String>& consoleMessages, id<WKNavigationDelegate> navigationDelegate)
 {
     HTTPServer server({ { "/app/apple-store/id1234567890"_s, { "hello"_s } } }, HTTPServer::Protocol::HttpsProxy);
 
@@ -581,7 +582,6 @@ TEST(PrivateClickMeasurement, SKAdNetwork)
         }
     }
 
-    Vector<String> consoleMessages;
     setInjectedBundleClient(webView.get(), consoleMessages);
     [viewConfiguration.websiteDataStore _setPrivateClickMeasurementDebugModeEnabledForTesting:YES];
 
@@ -592,19 +592,42 @@ TEST(PrivateClickMeasurement, SKAdNetwork)
     while (consoleMessages.isEmpty())
         Util::spinRunLoop();
     EXPECT_WK_STREQ(consoleMessages[0], "[Private Click Measurement] Turned Debug Mode on.");
+    consoleMessages.clear();
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
-        EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
-        callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-    }];
-    webView.get().navigationDelegate = delegate.get();
+    webView.get().navigationDelegate = navigationDelegate;
 
     [webView clickOnElementID:@"anchorid"];
+}
 
-    while (consoleMessages.size() < 2)
+const char* expectedSKAdNetworkConsoleMessage = "Submitting potential install attribution for AdamId: 1234567890, adNetworkRegistrableDomain: destination, impressionId: MTIzNDU2Nzg5MDEyMzQ1Ng, sourceWebRegistrableDomain: example.com, version: 3";
+
+TEST(PrivateClickMeasurement, SKAdNetwork)
+{
+    Vector<String> consoleMessages;
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+    setupSKAdNetworkTest(consoleMessages, delegate.get());
+    while (consoleMessages.isEmpty())
         Util::spinRunLoop();
-    EXPECT_WK_STREQ(consoleMessages[1], "Submitting potential install attribution for AdamId: 1234567890, adNetworkRegistrableDomain: destination, impressionId: MTIzNDU2Nzg5MDEyMzQ1Ng, sourceWebRegistrableDomain: example.com, version: 3");
+    EXPECT_WK_STREQ(consoleMessages[0], expectedSKAdNetworkConsoleMessage);
+}
+
+TEST(PrivateClickMeasurement, SKAdNetworkWithoutNavigatingToAppStoreLink)
+{
+    Vector<String> consoleMessages;
+    auto delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        decisionHandler(WKNavigationActionPolicyCancel);
+        Util::sleep(0.1);
+        EXPECT_EQ(0u, consoleMessages.size());
+        [navigationAction _storeSKAdNetworkAttribution];
+    };
+    setupSKAdNetworkTest(consoleMessages, delegate.get());
+
+    while (consoleMessages.isEmpty())
+        Util::spinRunLoop();
+    EXPECT_WK_STREQ(consoleMessages[0], expectedSKAdNetworkConsoleMessage);
 }
 
 TEST(PrivateClickMeasurement, NetworkProcessDebugMode)

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -42,6 +42,7 @@
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKWebView *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *));
 @property (nonatomic, copy) void (^contentRuleListPerformedAction)(WKWebView *, NSString *, _WKContentRuleListAction *, NSURL *);
 
+- (void)allowAnyTLSCertificate;
 - (void)waitForDidStartProvisionalNavigation;
 - (void)waitForDidFinishNavigation;
 - (void)waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "TestNavigationDelegate.h"
 
+#import "PlatformUtilities.h"
 #import "Utilities.h"
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <wtf/RetainPtr.h>
@@ -96,6 +97,15 @@
         _didReceiveAuthenticationChallenge(webView, challenge, completionHandler);
     else
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+}
+
+- (void)allowAnyTLSCertificate
+{
+    EXPECT_FALSE(self.didReceiveAuthenticationChallenge);
+    self.didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
+        EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
+        callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    };
 }
 
 - (void)waitForDidStartProvisionalNavigation


### PR DESCRIPTION
#### 7cbb914de8291709c0d2aad547df0be22b86da02
<pre>
Add SPI to store SKAdNetwork attribution for navigations handled outside of WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243280">https://bugs.webkit.org/show_bug.cgi?id=243280</a>
rdar://97684535

Reviewed by Chris Dumez.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=237969">https://bugs.webkit.org/show_bug.cgi?id=237969</a> I implemented a way to give SKAdNetwork information about clicks on app store links, but that only works if WebKit navigates to the link.  Safari, however, tells WebKit not to navigate and handles the navigation elsewhere.  This adds a way for Safari to tell WebKit that it successfully navigated to the link.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::donateToSKAdNetwork):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _storeSKAdNetworkAttribution]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::storePrivateClickMeasurement):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::setupSKAdNetworkTest):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate allowAnyTLSCertificate]):

Canonical link: <a href="https://commits.webkit.org/252928@main">https://commits.webkit.org/252928@main</a>
</pre>
