### PR TITLE
[Alternate WebM Player] Incorrect first frame paint

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -38,6 +38,7 @@
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 OBJC_CLASS AVSampleBufferAudioRenderer;
 OBJC_CLASS AVSampleBufferDisplayLayer;
@@ -227,6 +228,8 @@ private:
     void destroyAudioRenderers();
     void clearTracks();
         
+    void registerNotifyWhenHasAvailableVideoFrame();
+        
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
     std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }
@@ -281,6 +284,7 @@ private:
     uint64_t m_lastConvertedSampleCount { 0 };
     uint64_t m_sampleCount { 0 };
     ProcessIdentity m_resourceOwner;
+    std::unique_ptr<BinarySemaphore> m_hasAvailableVideoFrameSemaphore;
 
     FloatSize m_naturalSize;
     MediaTime m_currentTime;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -483,8 +483,15 @@ void MediaPlayerPrivateWebM::willBeAskedToPaintGL()
 
 RefPtr<VideoFrame> MediaPlayerPrivateWebM::videoFrameForCurrentTime()
 {
-    if (!m_isGatheringVideoFrameMetadata)
+    if (!m_isGatheringVideoFrameMetadata) {
+        // FIXME: This method is synchronous in order to
+        // work around https://bugs.webkit.org/show_bug.cgi?id=228997
+        // on builds without AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER
+        const auto shouldWaitForFrame = m_hasAvailableVideoFrameSemaphore && m_decompressionSession;
+        if (shouldWaitForFrame)
+            m_hasAvailableVideoFrameSemaphore->waitFor(100_ms);
         updateLastPixelBuffer();
+    }
     if (!m_lastPixelBuffer)
         return nullptr;
     return VideoFrameCV::create(currentMediaTime(), false, VideoFrame::Rotation::None, RetainPtr { m_lastPixelBuffer });
@@ -1181,10 +1188,9 @@ void MediaPlayerPrivateWebM::flushVideo()
     
     if (m_decompressionSession) {
         m_decompressionSession->flush();
-        m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, this] {
-            if (weakThis)
-                setHasAvailableVideoFrame(true);
-        });
+        if (!m_hasAvailableVideoFrameSemaphore)
+            m_hasAvailableVideoFrameSemaphore = makeUnique<BinarySemaphore>();
+        registerNotifyWhenHasAvailableVideoFrame();
     }
     setHasAvailableVideoFrame(false);
 }
@@ -1251,6 +1257,8 @@ void MediaPlayerPrivateWebM::ensureDecompressionSession()
 {
     if (m_decompressionSession)
         return;
+    
+    m_hasAvailableVideoFrameSemaphore = makeUnique<BinarySemaphore>();
 
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
     m_decompressionSession->setTimebase([m_synchronizer timebase]);
@@ -1259,10 +1267,7 @@ void MediaPlayerPrivateWebM::ensureDecompressionSession()
         if (weakThis)
             didBecomeReadyForMoreSamples(m_enabledVideoTrackID);
     });
-    m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, this] {
-        if (weakThis)
-            setHasAvailableVideoFrame(true);
-    });
+    registerNotifyWhenHasAvailableVideoFrame();
     
     if (m_enabledVideoTrackID != notFound)
         reenqueSamples(m_enabledVideoTrackID);
@@ -1352,6 +1357,7 @@ void MediaPlayerPrivateWebM::destroyDecompressionSession()
     
     m_decompressionSession->invalidate();
     m_decompressionSession = nullptr;
+    m_hasAvailableVideoFrameSemaphore = nullptr;
     setHasAvailableVideoFrame(false);
 }
 
@@ -1387,6 +1393,22 @@ void MediaPlayerPrivateWebM::clearTracks()
         m_player->removeAudioTrack(*track);
     }
     m_audioTracks.clear();
+}
+
+void MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame()
+{
+    if (!m_decompressionSession)
+        return;
+    
+    m_decompressionSession->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, this] {
+        if (weakThis) {
+            setHasAvailableVideoFrame(true);
+            if (m_hasAvailableVideoFrameSemaphore) {
+                m_hasAvailableVideoFrameSemaphore->signal();
+                m_hasAvailableVideoFrameSemaphore = nullptr;
+            }
+        }
+    });
 }
 
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()


### PR DESCRIPTION
#### 14204636ed8ad06e4d89b952f40b174d35a57f6f
<pre>
[Alternate WebM Player] Incorrect first frame paint
<a href="https://bugs.webkit.org/show_bug.cgi?id=243281">https://bugs.webkit.org/show_bug.cgi?id=243281</a>
&lt;rdar://97701232&gt;

Reviewed by Eric Carlson.

Currently there is a race condition when attempting to paint the first
video frame on builds that do not support AVSBDL -copyDisplayedPixelBuffer
directly related to the cause of <a href="https://bugs.webkit.org/show_bug.cgi?id=228997.">https://bugs.webkit.org/show_bug.cgi?id=228997.</a>

Due to the asynchronous nature of the WebCoreDecompressionSession and the
very short time between destroying the AVSBDL and creating a new decompression
session, we run into a scenario where the first video frame is requested by
WebGLRenderingContextBase::videoFrameToImage is not available causing us
to draw an empty black frame.

This also affected the legacy code path since the first frame sometimes
wasn&apos;t available for the call to `colorSpace` but was available for the
subsequent call to paint, resulting in a frame being painted with the
incorrect color space.

The fix is to make the already synchronous `nativeImageForCurrentTime`
call even more synchronous on the private player layer and wait for the
first frame to be decoded before attempting to fetch it.

This kills any chance of the legacy code path from being taken so there
is no need to make those calls synchronous as well.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::flushVideo):
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::destroyDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::registerNotifyWhenHasAvailableVideoFrame):

Canonical link: <a href="https://commits.webkit.org/253059@main">https://commits.webkit.org/253059@main</a>
</pre>
