### PR TITLE
[iOS] editing/spelling/editing-word-with-marker-1.html causes the subsequent test to time out

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4986,9 +4986,6 @@ webkit.org/b/227086 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_construct
 # "Opacity on an inline element should apply on float child".
 webkit.org/b/234690 imported/w3c/web-platform-tests/css/css-color/inline-opacity-float-child.html [ ImageOnlyFailure ]
 
-# Interferes with following test
-webkit.org/b/237812 editing/spelling/editing-word-with-marker-1.html [ Skip ]
-
 # color-mix() doesn't work with currentcolor
 webkit.org/b/234691 imported/w3c/web-platform-tests/css/css-color/color-mix-basic-001.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/editing/spelling/editing-word-with-marker-1.html
+++ b/LayoutTests/editing/spelling/editing-word-with-marker-1.html
@@ -57,7 +57,7 @@ async function resetText()
 
 async function runTest()
 {
-    resetText();
+    await resetText();
     textarea.setSelectionRange(14, 15);
     execDeleteCommand();
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -68,7 +68,7 @@ async function runTest()
     }
 
     // Testing deletion at various location.
-    resetText();
+    await resetText();
     textarea.setSelectionRange(6, 6);
     execForwardDeleteCommand();
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -78,7 +78,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'ameagesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea.setSelectionRange(7, 7);
     execForwardDeleteCommand();
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -88,7 +88,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'eagesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea.setSelectionRange(10, 10);
     typeCharacterCommand(' ');
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -98,7 +98,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The segment 'mea gesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea.setSelectionRange(10, 13);
     execDeleteCommand();
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -108,7 +108,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'meaga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea.setSelectionRange(10, 13);
     typeCharacterCommand(' ');
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -119,7 +119,7 @@ async function runTest()
     }
 
     // Testing appending non-whitespace character.
-    resetText();
+    await resetText();
     textarea.setSelectionRange(7, 7);
     typeCharacterCommand('a');
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -129,7 +129,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'ameagesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea.setSelectionRange(15, 15);
     typeCharacterCommand('a');
     if (window.internals && window.internals.hasSpellingMarker) {
@@ -140,7 +140,7 @@ async function runTest()
     }
 
     // Testing pasting.
-    resetText();
+    await resetText();
     textarea = document.getElementById('test');
     textarea.setSelectionRange(0, 4);
     execCopyCommand();
@@ -153,7 +153,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'meagesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea = document.getElementById('test');
     textarea.setSelectionRange(0, 4);
     execCopyCommand();
@@ -168,7 +168,7 @@ async function runTest()
             document.getElementById('console').innerHTML += "FAILURE. The word 'meagesga' has underline.<br>";
     }
 
-    resetText();
+    await resetText();
     textarea = document.getElementById('test');
     textarea.setSelectionRange(0, 4);
     execCopyCommand();

--- a/LayoutTests/platform/ios-wk2/editing/spelling/editing-word-with-marker-1-expected.txt
+++ b/LayoutTests/platform/ios-wk2/editing/spelling/editing-word-with-marker-1-expected.txt
@@ -1,0 +1,15 @@
+The test verified that when a word is modified, its spelling markers are removed. When manually testing, type "it's a meagesga", then edit the word "meagesga". You should see the underline under the modified "meagesga" disppears after editing.
+
+
+SUCCESS
+SUCCESS
+FAILURE. The word 'eagesga' has underline.
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3612,7 +3612,6 @@ webkit.org/b/240579 http/tests/push-api [ Skip ]
 webkit.org/b/240579 http/wpt/push-api [ Skip ]
 
 # These tests finish with unfired UI script callbacks, causing crashes. See webkit.org/b/236794
-editing/spelling/editing-word-with-marker-1.html
 fast/events/ios/pdf-modifer-key-down-crash.html
 imported/w3c/web-platform-tests/clipboard-apis/async-raw-write-read.tentative.https.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html

--- a/LayoutTests/platform/mac-wk1/editing/spelling/editing-word-with-marker-1-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/spelling/editing-word-with-marker-1-expected.txt
@@ -1,0 +1,15 @@
+The test verified that when a word is modified, its spelling markers are removed. When manually testing, type "it's a meagesga", then edit the word "meagesga". You should see the underline under the modified "meagesga" disppears after editing.
+
+
+SUCCESS
+FAILURE. The word 'ameagesga' has underline.
+FAILURE. The word 'eagesga' has underline.
+FAILURE. The segment 'mea gesga' has underline.
+SUCCESS
+FAILURE. The segment 'mea ga' has underline.
+FAILURE. The word 'ameagesga' has underline.
+SUCCESS
+SUCCESS
+SUCCESS
+SUCCESS
+


### PR DESCRIPTION
#### e456d22e637ff422afbb19edf067600b9d4e537f
<pre>
[iOS] editing/spelling/editing-word-with-marker-1.html causes the subsequent test to time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=237812">https://bugs.webkit.org/show_bug.cgi?id=237812</a>
&lt;rdar://90529903&gt;

Reviewed by Ryosuke Niwa.

Fix the test to correctly `await` the resetText() function

Land failing results for iOS and WebKitLegacy (webkit.org/b/243315).

* LayoutTests/TestExpectations:
* LayoutTests/editing/spelling/editing-word-with-marker-1.html:
* LayoutTests/platform/ios-wk2/editing/spelling/editing-word-with-marker-1-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252963@main">https://commits.webkit.org/252963@main</a>
</pre>
