### PR TITLE
[JSC] Remove ordering check for range parameters of Intl DateTimeFormat, NumberFormat, and PluralRules

### DIFF
--- a/JSTests/stress/intl-datetimeformat-formatrange.js
+++ b/JSTests/stress/intl-datetimeformat-formatrange.js
@@ -37,9 +37,7 @@ shouldThrow(() => {
     fmt0.formatRange();
 }, `TypeError: startDate or endDate is undefined`);
 
-shouldThrow(() => {
-    fmt0.formatRange(new Date(Date.UTC(2008, 0, 20, 10, 0, 0)), new Date(Date.UTC(2007, 0, 10, 10, 0, 0)));
-}, `RangeError: startDate is larger than endDate`);
+shouldBe(fmt0.formatRange(new Date(Date.UTC(2008, 0, 20, 10, 0, 0)), new Date(Date.UTC(2007, 0, 10, 10, 0, 0))), `1/20/08, 2:00 AM – 1/10/07, 2:00 AM`);
 
 function test() {
     let date1 = new Date(Date.UTC(2007, 0, 10, 10, 0, 0));

--- a/JSTests/stress/intl-datetimeformat-formatrangetoparts.js
+++ b/JSTests/stress/intl-datetimeformat-formatrangetoparts.js
@@ -53,9 +53,31 @@ function test() {
             fmt0.formatRangeToParts();
         }, `TypeError: startDate or endDate is undefined`);
 
-        shouldThrow(() => {
-            fmt0.formatRangeToParts(new Date(Date.UTC(2008, 0, 20, 10, 0, 0)), new Date(Date.UTC(2007, 0, 10, 10, 0, 0)));
-        }, `RangeError: startDate is larger than endDate`);
+        compareParts(fmt0.formatRangeToParts(new Date(Date.UTC(2008, 0, 20, 10, 0, 0)), new Date(Date.UTC(2007, 0, 10, 10, 0, 0))), [
+            {"type":"month","value":"1","source":"startRange"},
+            {"type":"literal","value":"/","source":"startRange"},
+            {"type":"day","value":"20","source":"startRange"},
+            {"type":"literal","value":"/","source":"startRange"},
+            {"type":"year","value":"08","source":"startRange"},
+            {"type":"literal","value":", ","source":"startRange"},
+            {"type":"hour","value":"2","source":"startRange"},
+            {"type":"literal","value":":","source":"startRange"},
+            {"type":"minute","value":"00","source":"startRange"},
+            {"type":"literal","value":" ","source":"startRange"},
+            {"type":"dayPeriod","value":"AM","source":"startRange"},
+            {"type":"literal","value":" – ","source":"shared"},
+            {"type":"month","value":"1","source":"endRange"},
+            {"type":"literal","value":"/","source":"endRange"},
+            {"type":"day","value":"10","source":"endRange"},
+            {"type":"literal","value":"/","source":"endRange"},
+            {"type":"year","value":"07","source":"endRange"},
+            {"type":"literal","value":", ","source":"endRange"},
+            {"type":"hour","value":"2","source":"endRange"},
+            {"type":"literal","value":":","source":"endRange"},
+            {"type":"minute","value":"00","source":"endRange"},
+            {"type":"literal","value":" ","source":"endRange"},
+            {"type":"dayPeriod","value":"AM","source":"endRange"}
+        ]);
     }
 
     {

--- a/JSTests/stress/intl-number-format-range-order.js
+++ b/JSTests/stress/intl-number-format-range-order.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    // Tolerate different space characters used by different ICU versions.
+    // Older ICU uses U+2009 Thin Space in ranges, whereas newer ICU uses
+    // regular old U+0020. Let's ignore these differences.
+    if (typeof actual === 'string')
+        actual = actual.replaceAll(' ', ' ');
+
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected value: ' + expected);
+}
+
+function compareParts(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < actual.length; ++i) {
+        shouldBe(actual[i].type, expected[i].type);
+        shouldBe(actual[i].value, expected[i].value);
+        shouldBe(actual[i].source, expected[i].source);
+    }
+}
+
+var fmt = new Intl.NumberFormat('en-US');
+if (fmt.formatRange) {
+    shouldBe(fmt.formatRange(20, -20), `20–-20`);
+    shouldBe(fmt.formatRange(0, -0), `0–-0`);
+}
+if (fmt.formatRangeToParts) {
+    compareParts(fmt.formatRangeToParts(20, -20), [
+        {"type":"integer","value":"20","source":"startRange"},
+        {"type":"literal","value":"–","source":"shared"},
+        {"type":"minusSign","value":"-","source":"endRange"},
+        {"type":"integer","value":"20","source":"endRange"}
+    ]);
+    compareParts(fmt.formatRangeToParts(0, -0), [
+        {"type":"integer","value":"0","source":"startRange"},
+        {"type":"literal","value":"–","source":"shared"},
+        {"type":"minusSign","value":"-","source":"endRange"},
+        {"type":"integer","value":"0","source":"endRange"}
+    ]);
+}

--- a/JSTests/stress/intl-numberformat-format-range-v3.js
+++ b/JSTests/stress/intl-numberformat-format-range-v3.js
@@ -107,22 +107,19 @@ if (nf.formatRange || nf.formatRangeToParts) {
         shouldThrow(() => { nf[method](12, "NaN") }, RangeError);
         shouldThrow(() => { nf[method](12, "xyz") }, RangeError);
 
-        // 7. If x is a non-finite Number ..., throw a RangeError exception.
         shouldNotThrow(() => { nf[method](-12/0, 12/0) });
-        shouldThrow(() => { nf[method](12/0, -12/0) }, RangeError);
+        shouldNotThrow(() => { nf[method](12/0, -12/0) });
 
-        // 8. If x is greater than y, throw a RangeError exception.
-        // neither x nor y are bigint.
-        shouldThrow(() => { nf[method](23, 12) }, RangeError);
+        shouldNotThrow(() => nf[method](23, 12));
         shouldNotThrow(() => nf[method](12, 23));
         // x is not bigint but y is.
-        shouldThrow(() => { nf[method](23, 12n) }, RangeError);
+        shouldNotThrow(() => { nf[method](23, 12n) });
         shouldNotThrow(() => nf[method](12, 23n));
         // x is bigint but y is not.
-        shouldThrow(() => { nf[method](23n, 12) }, RangeError);
+        shouldNotThrow(() => { nf[method](23n, 12) });
         shouldNotThrow(() => nf[method](12n, 23));
         // both x and y are bigint.
-        shouldThrow(() => { nf[method](23n, 12n) }, RangeError);
+        shouldNotThrow(() => { nf[method](23n, 12n) });
         shouldNotThrow(() => nf[method](12n, 23n));
 
         validRanges.forEach(

--- a/JSTests/stress/intl-pluralrules-select-range-validate-inputs.js
+++ b/JSTests/stress/intl-pluralrules-select-range-validate-inputs.js
@@ -1,3 +1,8 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
 function shouldThrow(func, errorMessage) {
     var errorThrown = false;
     var error = null;
@@ -36,7 +41,6 @@ if (Intl.PluralRules.prototype.selectRange) {
     shouldThrow(() => {
         pl.selectRange(NaN, NaN);
     }, `RangeError: Passed numbers are out of range`);
-    shouldThrow(() => {
-        pl.selectRange(0, -0);
-    }, `RangeError: start is larger than end`);
+    shouldBe(pl.selectRange(0, -0), `other`);
+    shouldBe(pl.selectRange(20, -20), `other`);
 }

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1161,9 +1161,6 @@ test/harness/temporalHelpers-one-shift-time-zone.js:
 test/intl402/DateTimeFormat/prototype/format/temporal-objects-timezone-getoffsetnanosecondsfor-not-callable.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"
-test/intl402/DateTimeFormat/prototype/formatRange/date-x-greater-than-y-not-throws.js:
-  default: 'RangeError: startDate is larger than endDate'
-  strict mode: 'RangeError: startDate is larger than endDate'
 test/intl402/DateTimeFormat/prototype/formatRange/en-US.js:
   default: 'Test262Error: Expected SameValue(«1/3/2019 – 1/5/2019», «1/3/2019 – 1/5/2019») to be true'
   strict mode: 'Test262Error: Expected SameValue(«1/3/2019 – 1/5/2019», «1/3/2019 – 1/5/2019») to be true'
@@ -1173,9 +1170,6 @@ test/intl402/DateTimeFormat/prototype/formatRange/fractionalSecondDigits.js:
 test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-timezone-getoffsetnanosecondsfor-not-callable.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"
-test/intl402/DateTimeFormat/prototype/formatRangeToParts/date-x-greater-than-y-not-throws.js:
-  default: 'RangeError: startDate is larger than endDate'
-  strict mode: 'RangeError: startDate is larger than endDate'
 test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-timezone-getoffsetnanosecondsfor-not-callable.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789)')"

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -199,8 +199,6 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRange, (JSGlobalOb
     RETURN_IF_EXCEPTION(scope, { });
     double endDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, endDateValue);
     RETURN_IF_EXCEPTION(scope, { });
-    if (startDate > endDate)
-        return throwVMRangeError(globalObject, scope, "startDate is larger than endDate"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRange(globalObject, startDate, endDate)));
 }
@@ -226,8 +224,6 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRangeToParts, (JSG
     RETURN_IF_EXCEPTION(scope, { });
     double endDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, endDateValue);
     RETURN_IF_EXCEPTION(scope, { });
-    if (startDate > endDate)
-        return throwVMRangeError(globalObject, scope, "startDate is larger than endDate"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRangeToParts(globalObject, startDate, endDate)));
 }

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -830,12 +830,6 @@ JSValue IntlNumberFormat::formatRange(JSGlobalObject* globalObject, double start
     if (std::isnan(start) || std::isnan(end))
         return throwRangeError(globalObject, scope, "Passed numbers are out of range"_s);
 
-    if (end < start)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
-
-    if (isNegativeZero(end) && start >= 0)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
-
     UErrorCode status = U_ZERO_ERROR;
     auto range = std::unique_ptr<UFormattedNumberRange, ICUDeleter<unumrf_closeResult>>(unumrf_openResult(&status));
     if (U_FAILURE(status))
@@ -1158,12 +1152,6 @@ JSValue IntlNumberFormat::formatRangeToParts(JSGlobalObject* globalObject, doubl
 
     if (std::isnan(start) || std::isnan(end))
         return throwRangeError(globalObject, scope, "Passed numbers are out of range"_s);
-
-    if (end < start)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
-
-    if (isNegativeZero(end) && start >= 0)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
 
     UErrorCode status = U_ZERO_ERROR;
     auto range = std::unique_ptr<UFormattedNumberRange, ICUDeleter<unumrf_closeResult>>(unumrf_openResult(&status));

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -282,12 +282,6 @@ JSValue IntlPluralRules::selectRange(JSGlobalObject* globalObject, double start,
     if (std::isnan(start) || std::isnan(end))
         return throwRangeError(globalObject, scope, "Passed numbers are out of range"_s);
 
-    if (end < start)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
-
-    if (isNegativeZero(end) && start >= 0)
-        return throwRangeError(globalObject, scope, "start is larger than end"_s);
-
     UErrorCode status = U_ZERO_ERROR;
     auto range = std::unique_ptr<UFormattedNumberRange, ICUDeleter<unumrf_closeResult>>(unumrf_openResult(&status));
     if (U_FAILURE(status))


### PR DESCRIPTION
#### d71535dfa06111c4fe0824f85523c7fc3e54d87e
<pre>
[JSC] Remove ordering check for range parameters of Intl DateTimeFormat, NumberFormat, and PluralRules
<a href="https://bugs.webkit.org/show_bug.cgi?id=243285">https://bugs.webkit.org/show_bug.cgi?id=243285</a>

Reviewed by Ross Kirsling.

We apply recent spec changes[1,2] to our implementation, not doing ordering check for
range parameters in Intl formatting functions, because there is legit use cases
where inverted range is useful[3].

[1]: <a href="https://github.com/tc39/ecma402/commit/769df4bd7b5a8af3784e681bbf7fee4f48827888">https://github.com/tc39/ecma402/commit/769df4bd7b5a8af3784e681bbf7fee4f48827888</a>
[2]: <a href="https://github.com/tc39/proposal-intl-numberformat-v3/commit/0c3d849ac7041860fa838e9c8d9d031c4b994f89">https://github.com/tc39/proposal-intl-numberformat-v3/commit/0c3d849ac7041860fa838e9c8d9d031c4b994f89</a>
[3]: <a href="https://docs.google.com/presentation/d/1UUvbf3FFu9PGtrPAKPdMad9DZuVFLIvkAsAxyJZyvxM/edit#slide=id.p">https://docs.google.com/presentation/d/1UUvbf3FFu9PGtrPAKPdMad9DZuVFLIvkAsAxyJZyvxM/edit#slide=id.p</a>

* JSTests/stress/intl-datetimeformat-formatrange.js:
* JSTests/stress/intl-datetimeformat-formatrangetoparts.js:
* JSTests/stress/intl-number-format-range-order.js: Added.
(shouldBe):
(compareParts):
(fmt.formatRangeToParts.compareParts.fmt.formatRangeToParts):
* JSTests/stress/intl-numberformat-format-range-v3.js:
(nf.formatRange.nf.formatRangeToParts.methods.forEach):
* JSTests/stress/intl-pluralrules-select-range-validate-inputs.js:
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::formatRange const):
(JSC::IntlNumberFormat::formatRangeToParts const):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::selectRange const):

Canonical link: <a href="https://commits.webkit.org/252911@main">https://commits.webkit.org/252911@main</a>
</pre>
