### PR TITLE
link elements should be able to fire more than one load / error event

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -626,8 +626,6 @@ imported/w3c/web-platform-tests/html/browsers/origin/relaxing-the-same-origin-re
 imported/w3c/web-platform-tests/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.pattern.transform.infinity.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_navigate_ancestor-1.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/historical-search-event.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element.html [ Skip ]

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-preload-load-once.html, http method GET> redirectResponse (null)
+link-preload-load-once.html - didFinishLoading
+data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 200>
+data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 below:
+
+1

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once.html
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    testRunner.dumpResourceLoadCallbacks();
+}
+
+let loadCount = 0;
+function didLoad(element)
+{
+    if (!loadCount) {
+        document.querySelector('link').rel = 'preload';
+        setTimeout(() => {
+            document.querySelector('link').rel = 'PreLoad';          
+        }, 100);
+        setTimeout(() => {
+            document.querySelector('link').rel = 'PreLoad ';          
+        }, 200);
+        setTimeout(() => {
+            if (window.testRunner)
+              testRunner.notifyDone();
+        }, 300);
+    }
+    ++loadCount;
+    result.innerHTML = loadCount;
+}
+
+</script>
+<link rel="preload" as="style" href="data:text/css,div { background: green; width: 100px; height: 100px }" onload="didLoad(this)">
+</head>
+<body>
+<p>This tests overriding rel content attribute with the same value.<br>
+You should see 1 below:</p>
+<div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
+link-stylesheet-load-once.html - didFinishLoading
+data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 200>
+data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 in a green box below:
+
+1

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    testRunner.dumpResourceLoadCallbacks();
+}
+
+let loadCount = 0;
+function didLoad(element)
+{
+    if (!loadCount) {
+        document.querySelector('link').rel = 'stylesheet';
+        setTimeout(() => {
+            document.querySelector('link').rel = 'StyleSheet';          
+        }, 100);
+        setTimeout(() => {
+            document.querySelector('link').rel = '  StyleSheet';          
+        }, 200);
+        setTimeout(() => {
+            if (window.testRunner)
+              testRunner.notifyDone();
+        }, 300);
+    }
+    ++loadCount;
+    result.innerHTML = loadCount;
+}
+
+</script>
+<link rel="stylesheet" href="data:text/css,div { background: green; width: 100px; height: 100px }" onload="didLoad(this)">
+</head>
+<body>
+<p>This tests overriding rel content attribute with the same value.<br>
+You should see 1 in a green box below:</p>
+<div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-error-events-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Check if the <link>'s error event fires for each stylesheet it fails to load Test timed out
+PASS Check if the <link>'s error event fires for each stylesheet it fails to load
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-load-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-load-events-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Check if the <link>'s load event fires for each stylesheet it loads Test timed out
+PASS Check if the <link>'s load event fires for each stylesheet it loads
 

--- a/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - willSendRequest <NSURLRequest URL data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, main document URL link-preload-load-once.html, http method GET> redirectResponse (null)
+link-preload-load-once.html - didFinishLoading
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didReceiveResponse <NSURLResponse data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, http status code 0>
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 below:
+
+1

--- a/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - willSendRequest <NSURLRequest URL data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, main document URL (null), http method GET> redirectResponse (null)
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didReceiveResponse <NSURLResponse data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, http status code 0>
+data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didFinishLoading
+link-stylesheet-load-once.html - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 in a green box below:
+
+1

--- a/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-preload-load-once.html, http method GET> redirectResponse (null)
+link-preload-load-once.html - didFinishLoading
+data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 0>
+data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 below:
+
+1

--- a/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,0 +1,8 @@
+data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
+link-stylesheet-load-once.html - didFinishLoading
+data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 0>
+data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
+This tests overriding rel content attribute with the same value.
+You should see 1 in a green box below:
+
+1

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -151,7 +151,6 @@ private:
     LinkRelAttribute m_relAttribute;
     bool m_loading : 1;
     bool m_createdByParser : 1;
-    bool m_firedLoad : 1;
     bool m_loadedResource : 1;
     bool m_isHandlingBeforeLoad : 1;
     bool m_allowPrefetchLoadAndErrorForTesting : 1;

--- a/Source/WebCore/html/LinkRelAttribute.h
+++ b/Source/WebCore/html/LinkRelAttribute.h
@@ -58,4 +58,19 @@ struct LinkRelAttribute {
     static bool isSupported(Document&, StringView);
 };
 
+inline bool operator==(const LinkRelAttribute& left, const LinkRelAttribute& right)
+{
+    return left.iconType == right.iconType
+        && left.isStyleSheet == right.isStyleSheet
+        && left.isAlternate == right.isAlternate
+        && left.isDNSPrefetch == right.isDNSPrefetch
+        && left.isLinkPreload == right.isLinkPreload
+        && left.isLinkPreconnect == right.isLinkPreconnect
+        && left.isLinkPrefetch == right.isLinkPrefetch
+#if ENABLE(APPLICATION_MANIFEST)
+        && left.isApplicationManifest == right.isApplicationManifest
+#endif
+        ;
+}
+
 }


### PR DESCRIPTION
#### d19e2bc5b2348544278300e500d500dc3a105df3
<pre>
link elements should be able to fire more than one load / error event
<a href="https://bugs.webkit.org/show_bug.cgi?id=232309">https://bugs.webkit.org/show_bug.cgi?id=232309</a>

Reviewed by NOBODY (OOPS!).

Based on a patch written by Chris Dumez.

This patch makes link element emit more than one load event each time resource is loaded,
and fixes the bug that setting rel content attribute to the same value resulted in the resource to be reloaded.
New behavior matches that of Chrome and Firefox.

* LayoutTests/TestExpectations: Unskip now passing tests.
* LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt: Added.
* LayoutTests/fast/dom/HTMLLinkElement/link-preload-load-once.html: Added.
* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt: Added.
* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-error-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-multiple-load-events-expected.txt:
* LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt:
* LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-preload-load-once-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt:

* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::HTMLLinkElement):
(WebCore::HTMLLinkElement::parseAttribute):
(WebCore::HTMLLinkElement::notifyLoadedSheetAndAllCriticalSubresources):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/LinkRelAttribute.h:
(WebCore::operator==): Added.
</pre>