### PR TITLE
Add few sub-directories of public_html to .gitignore for CISupport

### DIFF
--- a/Tools/CISupport/.gitignore
+++ b/Tools/CISupport/.gitignore
@@ -6,3 +6,5 @@ twistd.pid
 state.sqlite
 passwords.json
 workers/
+archives/
+results/


### PR DESCRIPTION
#### 4d0d39d5fcbffb0242e526d89c385358805be612
<pre>
Add few sub-directories of public_html to .gitignore for CISupport
<a href="https://bugs.webkit.org/show_bug.cgi?id=243291">https://bugs.webkit.org/show_bug.cgi?id=243291</a>

Reviewed by Alexey Proskuryakov.

* Tools/CISupport/.gitignore:

Canonical link: <a href="https://commits.webkit.org/252912@main">https://commits.webkit.org/252912@main</a>
</pre>
