### PR TITLE
Add support for RTCIceCredentialType

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt
@@ -5,14 +5,14 @@ FAIL new RTCPeerConnection(config) - with turns server, credentialType oauth, an
       credentialType: 'oauth',
       username: 'user',
       credential: 'cred'
-    }] })" did not throw
+    }] })" threw object "TypeError: Type error" that is not a DOMException InvalidAccessError: property "code" is equal to undefined, expected 15
 FAIL setConfiguration(config) - with turns server, credentialType oauth, and string credential should throw InvalidAccessError assert_throws_dom: function "() =>
     makePc({ iceServers: [{
       urls: 'turns:turn.example.org',
       credentialType: 'oauth',
       username: 'user',
       credential: 'cred'
-    }] })" did not throw
-FAIL new RTCPeerConnection(config) - with turns server, credential type and credential from spec should not throw assert_equals: expected (string) "oauth" but got (undefined) undefined
-FAIL setConfiguration(config) - with turns server, credential type and credential from spec should not throw assert_equals: expected (string) "oauth" but got (undefined) undefined
+    }] })" threw object "TypeError: Type error" that is not a DOMException InvalidAccessError: property "code" is equal to undefined, expected 15
+FAIL new RTCPeerConnection(config) - with turns server, credential type and credential from spec should not throw Type error
+FAIL setConfiguration(config) - with turns server, credential type and credential from spec should not throw Type error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt
@@ -14,22 +14,22 @@ PASS new RTCPeerConnection(config) - { iceServers: [undefined] } should throw Ty
 PASS setConfiguration(config) - { iceServers: [undefined] } should throw TypeError
 PASS new RTCPeerConnection(config) - { iceServers: [{}] } should throw TypeError
 PASS setConfiguration(config) - { iceServers: [{}] } should throw TypeError
-FAIL new RTCPeerConnection(config) - with stun server should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL setConfiguration(config) - with stun server should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL new RTCPeerConnection(config) - with stun server array should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL setConfiguration(config) - with stun server array should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL new RTCPeerConnection(config) - with 2 stun servers should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL setConfiguration(config) - with 2 stun servers should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL new RTCPeerConnection(config) - with turn server, username, credential should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL setConfiguration(config) - with turn server, username, credential should succeed assert_equals: expected (string) "password" but got (undefined) undefined
+PASS new RTCPeerConnection(config) - with stun server should succeed
+PASS setConfiguration(config) - with stun server should succeed
+PASS new RTCPeerConnection(config) - with stun server array should succeed
+PASS setConfiguration(config) - with stun server array should succeed
+PASS new RTCPeerConnection(config) - with 2 stun servers should succeed
+PASS setConfiguration(config) - with 2 stun servers should succeed
+PASS new RTCPeerConnection(config) - with turn server, username, credential should succeed
+PASS setConfiguration(config) - with turn server, username, credential should succeed
 FAIL new RTCPeerConnection(config) - with turns server and empty string username, credential should succeed Bad Configuration Parameters
 FAIL setConfiguration(config) - with turns server and empty string username, credential should succeed Bad Configuration Parameters
 FAIL new RTCPeerConnection(config) - with turn server and empty string username, credential should succeed Bad Configuration Parameters
 FAIL setConfiguration(config) - with turn server and empty string username, credential should succeed Bad Configuration Parameters
 PASS new RTCPeerConnection(config) - with one turns server, one turn server, username, credential should succeed
 PASS setConfiguration(config) - with one turns server, one turn server, username, credential should succeed
-FAIL new RTCPeerConnection(config) - with stun server and credentialType password should succeed assert_equals: expected (string) "password" but got (undefined) undefined
-FAIL setConfiguration(config) - with stun server and credentialType password should succeed assert_equals: expected (string) "password" but got (undefined) undefined
+PASS new RTCPeerConnection(config) - with stun server and credentialType password should succeed
+PASS setConfiguration(config) - with stun server and credentialType password should succeed
 PASS new RTCPeerConnection(config) - with turn server and no credentials should throw InvalidAccessError
 PASS setConfiguration(config) - with turn server and no credentials should throw InvalidAccessError
 PASS new RTCPeerConnection(config) - with turn server and only username should throw InvalidAccessError
@@ -42,38 +42,14 @@ PASS new RTCPeerConnection(config) - with turns server and only username should 
 PASS setConfiguration(config) - with turns server and only username should throw InvalidAccessError
 PASS new RTCPeerConnection(config) - with turns server and only credential should throw InvalidAccessError
 PASS setConfiguration(config) - with turns server and only credential should throw InvalidAccessError
-FAIL new RTCPeerConnection(config) - with "" url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: ''
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL setConfiguration(config) - with "" url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: ''
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL new RTCPeerConnection(config) - with ["stun:stun1.example.net", ""] url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: ['stun:stun1.example.net', '']
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL setConfiguration(config) - with ["stun:stun1.example.net", ""] url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: ['stun:stun1.example.net', '']
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL new RTCPeerConnection(config) - with relative url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: 'relative-url'
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL setConfiguration(config) - with relative url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: 'relative-url'
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL new RTCPeerConnection(config) - with http url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: 'http://example.com'
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
-FAIL setConfiguration(config) - with http url should throw SyntaxError assert_throws_dom: function "() =>
-      makePc({ iceServers: [{
-        urls: 'http://example.com'
-      }] })" threw object "NotSupportedError: ICE server protocol not supported" that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
+PASS new RTCPeerConnection(config) - with "" url should throw SyntaxError
+PASS setConfiguration(config) - with "" url should throw SyntaxError
+PASS new RTCPeerConnection(config) - with ["stun:stun1.example.net", ""] url should throw SyntaxError
+PASS setConfiguration(config) - with ["stun:stun1.example.net", ""] url should throw SyntaxError
+PASS new RTCPeerConnection(config) - with relative url should throw SyntaxError
+PASS setConfiguration(config) - with relative url should throw SyntaxError
+PASS new RTCPeerConnection(config) - with http url should throw SyntaxError
+PASS setConfiguration(config) - with http url should throw SyntaxError
 FAIL new RTCPeerConnection(config) - with invalid turn url should throw SyntaxError assert_throws_dom: function "() =>
       makePc({ iceServers: [{
         urls: 'turn://example.org/foo?x=y'
@@ -98,26 +74,10 @@ FAIL setConfiguration(config) - with empty urls should throw SyntaxError assert_
       makePc({ iceServers: [{
         urls: []
       }] })" did not throw
-FAIL new RTCPeerConnection(config) - with invalid credentialType should throw TypeError assert_throws_js: function "() =>
-      makePc({ iceServers: [{
-        urls: [],
-        credentialType: 'invalid'
-      }] })" did not throw
-FAIL setConfiguration(config) - with invalid credentialType should throw TypeError assert_throws_js: function "() =>
-      makePc({ iceServers: [{
-        urls: [],
-        credentialType: 'invalid'
-      }] })" did not throw
-FAIL new RTCPeerConnection(config) - with credentialType token should throw TypeError assert_throws_js: function "() =>
-      makePc({ iceServers: [{
-        urls: [],
-        credentialType: 'token'
-      }] })" did not throw
-FAIL setConfiguration(config) - with credentialType token should throw TypeError assert_throws_js: function "() =>
-      makePc({ iceServers: [{
-        urls: [],
-        credentialType: 'token'
-      }] })" did not throw
+PASS new RTCPeerConnection(config) - with invalid credentialType should throw TypeError
+PASS setConfiguration(config) - with invalid credentialType should throw TypeError
+PASS new RTCPeerConnection(config) - with credentialType token should throw TypeError
+PASS setConfiguration(config) - with credentialType token should throw TypeError
 PASS new RTCPeerConnection(config) - with url field should throw TypeError
 PASS setConfiguration(config) - with url field should throw TypeError
 FAIL new RTCPeerConnection(config) - with turns server, credentialType password, and object credential should throw InvalidAccessError assert_throws_dom: function "() =>

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.h
@@ -34,9 +34,12 @@
 namespace WebCore {
 
 struct RTCIceServer {
+    enum class CredentialType { Password };
+
     std::variant<String, Vector<String>> urls;
-    String credential;
     String username;
+    String credential;
+    CredentialType credentialType { CredentialType::Password };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.idl
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+enum RTCIceCredentialType {
+  "password"
+};
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -31,5 +35,5 @@
     required (DOMString or sequence<DOMString>) urls;
     DOMString username;
     DOMString credential;
-    // FIXME 169662: missing credentialType
+    RTCIceCredentialType credentialType = "password";
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -426,7 +426,7 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
                             return Exception { TypeError, "TURN/TURNS username and/or credential are too long"_s };
                     }
                 } else if (!serverURL.protocolIs("stun"_s))
-                    return Exception { NotSupportedError, "ICE server protocol not supported"_s };
+                    return Exception { SyntaxError, "ICE server protocol not supported"_s };
             }
             if (serverURLs.size())
                 servers.uncheckedAppend({ WTFMove(serverURLs), server.credential, server.username });


### PR DESCRIPTION
#### c4f553bbe1c7b9b4a1956b5ae3265106dd1f789e
<pre>
Add support for RTCIceCredentialType
<a href="https://bugs.webkit.org/show_bug.cgi?id=243293">https://bugs.webkit.org/show_bug.cgi?id=243293</a>

Reviewed by Eric Carlson.

Update WebIDL to match the webrtc-pc spec.
Update an exception to match the webrtc-pc spec and tests.

Covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt:
* Source/WebCore/Modules/mediastream/RTCIceServer.h:
* Source/WebCore/Modules/mediastream/RTCIceServer.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::iceServersFromConfiguration):

Canonical link: <a href="https://commits.webkit.org/253514@main">https://commits.webkit.org/253514@main</a>
</pre>
