### PR TITLE
RTCDataChannel.binaryType setter should use SyntaxError

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
@@ -1,19 +1,9 @@
 
 PASS Setting binaryType to 'blob' should succeed
 PASS Setting binaryType to 'arraybuffer' should succeed
-FAIL Setting invalid binaryType 'jellyfish' should throw SyntaxError assert_throws_dom: function "() => {
-      dc.binaryType = binaryType;
-    }" threw object "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object." that is not a DOMException SyntaxError: property "code" is equal to 17, expected 12
-FAIL Setting invalid binaryType 'arraybuffer ' should throw SyntaxError assert_throws_dom: function "() => {
-      dc.binaryType = binaryType;
-    }" threw object "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object." that is not a DOMException SyntaxError: property "code" is equal to 17, expected 12
-FAIL Setting invalid binaryType '' should throw SyntaxError assert_throws_dom: function "() => {
-      dc.binaryType = binaryType;
-    }" threw object "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object." that is not a DOMException SyntaxError: property "code" is equal to 17, expected 12
-FAIL Setting invalid binaryType 'null' should throw SyntaxError assert_throws_dom: function "() => {
-      dc.binaryType = binaryType;
-    }" threw object "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object." that is not a DOMException SyntaxError: property "code" is equal to 17, expected 12
-FAIL Setting invalid binaryType 'undefined' should throw SyntaxError assert_throws_dom: function "() => {
-      dc.binaryType = binaryType;
-    }" threw object "TypeMismatchError: The type of an object was incompatible with the expected type of the parameter associated to the object." that is not a DOMException SyntaxError: property "code" is equal to 17, expected 12
+PASS Setting invalid binaryType 'jellyfish' should throw SyntaxError
+PASS Setting invalid binaryType 'arraybuffer ' should throw SyntaxError
+PASS Setting invalid binaryType '' should throw SyntaxError
+PASS Setting invalid binaryType 'null' should throw SyntaxError
+PASS Setting invalid binaryType 'undefined' should throw SyntaxError
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -135,7 +135,7 @@ ExceptionOr<void> RTCDataChannel::setBinaryType(const AtomString& binaryType)
         m_binaryType = BinaryType::ArrayBuffer;
         return { };
     }
-    return Exception { TypeMismatchError };
+    return Exception { SyntaxError };
 }
 
 ExceptionOr<void> RTCDataChannel::send(const String& data)


### PR DESCRIPTION
#### ac230b42042b3b00cf039fc155b078b603033ceb
<pre>
RTCDataChannel.binaryType setter should use SyntaxError
<a href="https://bugs.webkit.org/show_bug.cgi?id=243294">https://bugs.webkit.org/show_bug.cgi?id=243294</a>

Reviewed by Eric Carlson.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::setBinaryType):

Canonical link: <a href="https://commits.webkit.org/252946@main">https://commits.webkit.org/252946@main</a>
</pre>
