### PR TITLE
createDataChannel should not LegacyNullToEmptyString

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt
@@ -4,7 +4,7 @@ PASS createDataChannel with closed connection should throw InvalidStateError
 FAIL createDataChannel attribute default values assert_equals: expected "blob" but got "arraybuffer"
 FAIL createDataChannel with provided parameters should initialize attributes to provided values assert_equals: expected "blob" but got "arraybuffer"
 PASS createDataChannel with label "foo" should succeed
-FAIL createDataChannel with label null should succeed assert_equals: expected "null" but got ""
+PASS createDataChannel with label null should succeed
 PASS createDataChannel with label undefined should succeed
 PASS createDataChannel with label lone surrogate should succeed
 PASS createDataChannel with ordered false should succeed

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -133,7 +133,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     // 6.1 Peer-to-peer data API
     readonly attribute RTCSctpTransport? sctp;
 
-    RTCDataChannel createDataChannel([LegacyNullToEmptyString] USVString label, optional RTCDataChannelInit options);
+    RTCDataChannel createDataChannel(USVString label, optional RTCDataChannelInit options);
     attribute EventHandler ondatachannel;
 
 


### PR DESCRIPTION
#### 65e2837a04b395fb0ba10e33a1bb4565ceed2995
<pre>
createDataChannel should not LegacyNullToEmptyString
<a href="https://bugs.webkit.org/show_bug.cgi?id=243295">https://bugs.webkit.org/show_bug.cgi?id=243295</a>

Reviewed by Eric Carlson.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel-expected.txt:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.idl:

Canonical link: <a href="https://commits.webkit.org/252944@main">https://commits.webkit.org/252944@main</a>
</pre>
