### PR TITLE
[Xcode] Building a single-project scheme builds its dependencies

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1400"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,10 +14,24 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1CEBD7E22716AFBA00A5254D"
-               BuildableName = "WebGPU.framework"
-               BlueprintName = "WebGPU"
-               ReferencedContainer = "container:WebGPU.xcodeproj">
+               BlueprintIdentifier = "932F5B3E0822A1C700736975"
+               BuildableName = "JavaScriptCore.framework"
+               BlueprintName = "JavaScriptCore"
+               ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "932F5BE30822A1C700736975"
+               BuildableName = "All"
+               BlueprintName = "All"
+               ReferencedContainer = "container:JavaScriptCore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -50,10 +64,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1CEBD7E22716AFBA00A5254D"
-            BuildableName = "WebGPU.framework"
-            BlueprintName = "WebGPU"
-            ReferencedContainer = "container:WebGPU.xcodeproj">
+            BlueprintIdentifier = "932F5B3E0822A1C700736975"
+            BuildableName = "JavaScriptCore.framework"
+            BlueprintName = "JavaScriptCore"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme
+++ b/Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme
+++ b/Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1400"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
+++ b/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme
+++ b/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme
+++ b/Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme
+++ b/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/MiniBrowserSwiftUI.xcscheme
+++ b/Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/MiniBrowserSwiftUI.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/_WebKit_SwiftUI.xcscheme
+++ b/Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/_WebKit_SwiftUI.xcscheme
@@ -4,7 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -223,6 +223,11 @@ sub buildUpToProject
         if (!configuredXcodeWorkspace()) {
             system("$FindBin::Bin/set-webkit-configuration", "--workspace=" . sourceDir() . "/WebKit.xcworkspace") == 0 or die;
         }
+        # By convention, projects that support this build workflow
+        # (JavaScriptCore, WebGPU) have a scheme which builds that project
+        # and its implicit dependencies.
+        my $schemeName = "Everything up to $projectName";
+
         my $compilerFlags = 'GCC_PREPROCESSOR_ADDITIONS="';
         if ($forceCLoop) {
             $compilerFlags .= "ENABLE_JIT=0 ENABLE_C_LOOP=1";
@@ -241,7 +246,7 @@ sub buildUpToProject
             $extraCommands .= " " . $arg;
         }
 
-        my $command = "make USE_WORKSPACE=YES " . (lc configuration()) . " " . $compilerFlags . " " . $extraCommands;
+        my $command = "make SCHEME=\"$schemeName\" " . (lc configuration()) . " " . $compilerFlags . " " . $extraCommands;
 
         print "\n";
         print "building ", $projectName, "\n";

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
+++ b/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
#### 56fd2f7529a1486a37feb4bcf19a5217d440debf
<pre>
[Xcode] Building a single-project scheme builds its dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=243228">https://bugs.webkit.org/show_bug.cgi?id=243228</a>

Reviewed by Alexey Proskuryakov.

Turn off &quot;Find Implicit Dependencies&quot; in each single-project scheme.
Create new &quot;Everything up to &lt;project&gt;&quot; schemes in JavaScriptCore and
WebGPU to power the build-jsc and build-webgpu scripts.

--

With the switch to workspace builds, engineers have no way to build an
individual project. This was an intentional change, with the idea that
we should make it easier to build &quot;up to&quot; a target of choice, and that
we shouldn&apos;t support build workflows which make it easy to produce an
incorrect build (by letting you build a project when its dependencies
are out of date).

However, since we&apos;ve rolled out workspace build and begun receiving
feedback, I think this was wrongly decided:

- It&apos;s perfectly valid to build a testing project (TestWebKitAPI or
  WebKitTestRunner) without building the entire stack.
- Sometimes an engineer is working on unrelated or staged changes in
  separate parts of the workspace, and doesn&apos;t want changes in one
  project to cause heavy rebuilds of the other project.
- It&apos;s unintuitive that running Make in a specific directory (e.g. `make
  -C Source/WebCore`) will build projects in other directories.
- We have scripts that run redundantly, so a null build of the full
  stack is slower than a null build of a single project, sometimes by
  10-15 sec.

The exception that proves the rule is in JavaScriptCore and WebGPU,
where engineers *do* often want to only build up to the respective
project. Traditionally, the build-jsc and build-webgpu scripts did this
by building individual projects one-at-a-time, and going back to that
build workflow would be a significant performance regression. My
intention with adding new &quot;Everything up to&quot; schemes is to establish a
pattern for other projects to adopt as needed.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme: Copied from Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme.
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme:
* Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme:
* Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme: Copied from Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WebGPU.xcscheme.
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WebGPU.xcscheme:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme:
* Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme:
* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme:
* Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme:
* Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/MiniBrowserSwiftUI.xcscheme:
* Tools/MiniBrowserSwiftUI/MiniBrowserSwiftUI.xcodeproj/xcshareddata/xcschemes/_WebKit_SwiftUI.xcscheme:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme:
* Tools/Scripts/webkitperl/BuildSubproject.pm:
(buildUpToProject):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme:
* Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme:

Canonical link: <a href="https://commits.webkit.org/252924@main">https://commits.webkit.org/252924@main</a>
</pre>
