### PR TITLE
Add a quirk for gmail on ApplicationCache

### DIFF
--- a/Source/WebCore/loader/appcache/DOMApplicationCache.idl
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.idl
@@ -30,7 +30,7 @@
     GenerateIsReachable=ReachableFromDOMWindow,
     InterfaceName=ApplicationCache,
     Exposed=Window,
-    EnabledBySetting=OfflineWebApplicationCacheEnabled
+    EnabledByQuirk=shouldEnableApplicationCache
 ] interface DOMApplicationCache : EventTarget {
     // update status
     const unsigned short UNCACHED = 0;

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -78,7 +78,7 @@
     // the user agent
     readonly attribute Navigator navigator;
     // FIXME: This is specified to be [SecureContext]
-    [EnabledBySetting=OfflineWebApplicationCacheEnabled] readonly attribute DOMApplicationCache applicationCache;
+    [EnabledByQuirk=shouldEnableApplicationCache] readonly attribute DOMApplicationCache applicationCache;
 
     // user prompts
     undefined alert();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1488,4 +1488,25 @@ bool Quirks::hasBrokenPermissionsAPISupportQuirk() const
     return m_hasBrokenPermissionsAPISupportQuirk.value();
 }
 
+bool Quirks::shouldEnableApplicationCacheQuirk() const
+{
+    bool shouldEnableBySetting = m_document && m_document->settings().offlineWebApplicationCacheEnabled();
+#if PLATFORM(IOS_FAMILY)
+    if (!needsQuirks())
+        return shouldEnableBySetting;
+
+    if (!m_shouldEnableApplicationCacheQuirk) {
+        auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+        if (domain.endsWith("mail.google.com"_s))
+            m_shouldEnableApplicationCacheQuirk = true;
+        else
+            m_shouldEnableApplicationCacheQuirk = shouldEnableBySetting;
+    }
+
+    return m_shouldEnableApplicationCacheQuirk.value();
+#else
+    return shouldEnableBySetting;
+#endif
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -161,6 +161,7 @@ public:
     WEBCORE_EXPORT bool allowLayeredFullscreenVideos() const;
 #endif
     bool hasBrokenPermissionsAPISupportQuirk() const;
+    bool shouldEnableApplicationCacheQuirk() const;
     
 private:
     bool needsQuirks() const;
@@ -211,6 +212,9 @@ private:
     mutable std::optional<bool> m_allowLayeredFullscreenVideos;
 #endif
     mutable std::optional<bool> m_hasBrokenPermissionsAPISupportQuirk;
+#if PLATFORM(IOS_FAMILY)
+    mutable std::optional<bool> m_shouldEnableApplicationCacheQuirk;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ba526d288906723d792880e7b1a803f19cf80006
<pre>
Add a quirk for gmail on ApplicationCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=243298">https://bugs.webkit.org/show_bug.cgi?id=243298</a>
rdar://97351877

Reviewed by Chris Dumez.

Enable window.applicationcache on gmail until they fix rdar://97727706.

* Source/WebCore/loader/appcache/DOMApplicationCache.idl:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnableApplicationCacheQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/252942@main">https://commits.webkit.org/252942@main</a>
</pre>
