### PR TITLE
[PlayStation] Fix build after 252739@main

### DIFF
--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -198,7 +198,7 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
     if (result == MAP_FAILED)
         return nullptr;
     if (result)
-        while (madvise(address, bytes, MADV_DONTNEED) == -1 && errno == EAGAIN) { }
+        while (madvise(result, bytes, MADV_DONTNEED) == -1 && errno == EAGAIN) { }
     return result;
 #else
 


### PR DESCRIPTION
#### 2f1d37b20d5b5012c78fb495ff847c11cd9492f6
<pre>
[PlayStation] Fix build after 252739@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243275">https://bugs.webkit.org/show_bug.cgi?id=243275</a>

Unreviewed build fix.

* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveUncommittedAligned):

Canonical link: <a href="https://commits.webkit.org/252917@main">https://commits.webkit.org/252917@main</a>
</pre>
