### PR TITLE
Remove Element::focusDelegate()

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -383,11 +383,6 @@ bool Element::supportsFocus() const
     return !!tabIndexSetExplicitly();
 }
 
-RefPtr<Element> Element::focusDelegate()
-{
-    return this;
-}
-
 int Element::tabIndexForBindings() const
 {
     return valueOrCompute(tabIndexSetExplicitly(), [&] { return defaultTabIndex(); });

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -371,7 +371,6 @@ public:
 
     virtual int tabIndexForBindings() const;
     WEBCORE_EXPORT void setTabIndexForBindings(int);
-    virtual RefPtr<Element> focusDelegate();
 
     // Used by the HTMLElement and SVGElement IDLs.
     WEBCORE_EXPORT const AtomString& nonce() const;
@@ -511,6 +510,7 @@ public:
     virtual bool isOutOfRange() const { return false; }
     virtual bool isUploadButton() const { return false; }
     virtual bool isSliderContainerElement() const { return false; }
+    virtual bool isSliderThumbElement() const { return false; }
     virtual bool isHTMLTablePartElement() const { return false; }
 
     bool canContainRangeEndPoint() const override;

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -206,11 +206,6 @@ bool SliderThumbElement::matchesReadWritePseudoClass() const
     return input && input->matchesReadWritePseudoClass();
 }
 
-RefPtr<Element> SliderThumbElement::focusDelegate()
-{
-    return hostInput();
-}
-
 void SliderThumbElement::dragFrom(const LayoutPoint& point)
 {
     Ref<SliderThumbElement> protectedThis(*this);

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -58,11 +58,11 @@ public:
 
 private:
     SliderThumbElement(Document&);
+    bool isSliderThumbElement() const final { return true; }
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) final;
     bool isDisabledFormControl() const final;
     bool matchesReadWritePseudoClass() const final;
-    RefPtr<Element> focusDelegate() final;
 
     void defaultEventHandler(Event&) final;
     bool willRespondToMouseMoveEvents() const final;
@@ -118,6 +118,11 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SliderThumbElement)
+    static bool isType(const WebCore::Element& element) { return element.isSliderThumbElement(); }
+    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SliderContainerElement)
     static bool isType(const WebCore::Element& element) { return element.isSliderContainerElement(); }

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -60,6 +60,7 @@
 #import "RenderSlider.h"
 #import "RenderView.h"
 #import "SharedBuffer.h"
+#import "SliderThumbElement.h"
 #import "StringTruncator.h"
 #import "ThemeMac.h"
 #import "TimeRanges.h"
@@ -1805,8 +1806,11 @@ bool RenderThemeMac::paintSliderThumb(const RenderObject& o, const PaintInfo& pa
 
     // Update the various states we respond to.
     updateEnabledState(sliderThumbCell, o);
-    auto focusDelegate = is<Element>(o.node()) ? downcast<Element>(*o.node()).focusDelegate() : nullptr;
-    updateFocusedState(sliderThumbCell, focusDelegate ? focusDelegate->renderer() : nullptr);
+    RefPtr element = dynamicDowncast<Element>(o.node());
+    RefPtr delegate = element;
+    if (is<SliderThumbElement>(element))
+        delegate = downcast<SliderThumbElement>(*element).hostInput();
+    updateFocusedState(sliderThumbCell, delegate ? delegate->renderer() : nullptr);
 
     // Update the pressed state using the NSCell tracking methods, since that's how NSSliderCell keeps track of it.
     bool oldPressed;


### PR DESCRIPTION
#### 511a0e0ebba7fb2e622ee067d6ed9773dc39c838
<pre>
Remove Element::focusDelegate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=233777">https://bugs.webkit.org/show_bug.cgi?id=233777</a>
&lt;rdar://86287159&gt;

Reviewed by Wenson Hsieh.

It does not match what the HTML spec calls a &quot;focus delegate&quot;. Just inline the code in the two places instead.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focusDelegate): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::isSliderThumbElement const):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::focusDelegate): Deleted.
* Source/WebCore/html/shadow/SliderThumbElement.h:
(isType):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::isFocused const):
(WebCore::RenderTheme::disabledTextColor const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintSliderThumb):

Canonical link: <a href="https://commits.webkit.org/252926@main">https://commits.webkit.org/252926@main</a>
</pre>
