### PR TITLE
Fix contain-size-button-001+002.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4853,11 +4853,6 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/animation-dis
 # Multicolumn does not paint the horizontal overflow area of a relative child.
 webkit.org/b/41796 imported/w3c/web-platform-tests/css/css-contain/contain-size-monolithic-002.html [ ImageOnlyFailure ]
 
-# Buttons with auto width and height has extra, intrinsic margins (see addIntrinsicMargins in StyleAdjuster).
-# webkit.org/b/238587 may address this.
-imported/w3c/web-platform-tests/css/css-contain/contain-size-button-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002.html [ ImageOnlyFailure ]
-
 # Scrollbar displays are different.
 imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-001.html
@@ -9,6 +9,7 @@
 button {
   border: 5px solid green;
   padding: 0;
+  margin: 0;
   contain: size;
   color: transparent;
   font-size: 2em;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-expected.html
@@ -7,6 +7,7 @@
   <style>
   button {
     border: 1em solid green;
+    margin: 0;
     /* In case the testcase's 'inner' text is taller than the button, don't let
        it influence its line-box's size.  This lets us more-easily compare
        sizing between empty buttons vs. contained nonempty buttons. */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-ref.html
@@ -7,6 +7,7 @@
   <style>
   button {
     border: 1em solid green;
+    margin: 0;
     /* In case the testcase's 'inner' text is taller than the button, don't let
        it influence its line-box's size.  This lets us more-easily compare
        sizing between empty buttons vs. contained nonempty buttons. */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002.html
@@ -9,6 +9,7 @@
   <style>
   button {
     contain: size;
+    margin: 0;
     border: 1em solid green;
     /* In case the testcase's 'inner' text is taller than the button, don't let
        it influence its line-box's size.  This lets us more-easily compare


### PR DESCRIPTION
#### b850aebbf296f19378b75bd248c52377234dee9c
<pre>
Fix contain-size-button-001+002.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=243300">https://bugs.webkit.org/show_bug.cgi?id=243300</a>

Reviewed by Tim Nguyen.

In WebKit buttons with auto width and height set intrinsic margins, causing these
tests to fail. Since margins do not affect size containment, set margins to zero
in order to exclusively test the size containment.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-button-002.html:

Canonical link: <a href="https://commits.webkit.org/252973@main">https://commits.webkit.org/252973@main</a>
</pre>
