### PR TITLE
[PlayStation] Fix build after https://commits.webkit.org/251493@main

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1184,8 +1184,10 @@ void NetworkResourceLoader::didFinishWithRedirectResponse(WebCore::ResourceReque
     networkLoadMetrics.responseBodyBytesReceived = 0;
     networkLoadMetrics.responseBodyDecodedSize = 0;
 
+#if ENABLE(SERVICE_WORKER)
     if (m_serviceWorkerFetchTask)
         networkLoadMetrics.fetchStart = m_serviceWorkerFetchTask->startTime();
+#endif
     send(Messages::WebResourceLoader::DidFinishResourceLoad { networkLoadMetrics });
 
     cleanup(LoadResult::Success);


### PR DESCRIPTION
#### 91727129ca4a8e022ec7d0ee3302763c70978565
<pre>
[PlayStation] Fix build after <a href="https://commits.webkit.org/251493@main">https://commits.webkit.org/251493@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=243304">https://bugs.webkit.org/show_bug.cgi?id=243304</a>

Unreviewed build fix.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishWithRedirectResponse):

Canonical link: <a href="https://commits.webkit.org/252927@main">https://commits.webkit.org/252927@main</a>
</pre>
