### PR TITLE
Revert [252581@main] Disable attachment element setting when lock down mode is enabled

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10453,7 +10453,6 @@ void WebPageProxy::writePromisedAttachmentToPasteboard(WebCore::PromisedAttachme
 void WebPageProxy::requestAttachmentIcon(const String& identifier, const String& contentType, const String& fileName, const String& title, const FloatSize& requestedSize)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
 
     FloatSize size = requestedSize;
     ShareableBitmap::Handle handle;
@@ -10514,7 +10513,6 @@ void WebPageProxy::updateAttachmentThumbnail(const String& identifier, const Ref
 void WebPageProxy::registerAttachmentIdentifierFromData(const String& identifier, const String& contentType, const String& preferredFileName, const IPC::SharedBufferReference& data)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     if (attachmentForIdentifier(identifier))
@@ -10530,7 +10528,6 @@ void WebPageProxy::registerAttachmentIdentifierFromData(const String& identifier
 void WebPageProxy::registerAttachmentIdentifierFromFilePath(const String& identifier, const String& contentType, const String& filePath)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     if (attachmentForIdentifier(identifier))
@@ -10549,7 +10546,6 @@ void WebPageProxy::registerAttachmentIdentifierFromFilePath(const String& identi
 void WebPageProxy::registerAttachmentIdentifier(const String& identifier)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     if (!attachmentForIdentifier(identifier))
@@ -10559,7 +10555,6 @@ void WebPageProxy::registerAttachmentIdentifier(const String& identifier)
 void WebPageProxy::registerAttachmentsFromSerializedData(Vector<WebCore::SerializedAttachmentData>&& data)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
 
     for (auto& serializedData : data) {
         auto identifier = WTFMove(serializedData.identifier);
@@ -10576,7 +10571,6 @@ void WebPageProxy::registerAttachmentsFromSerializedData(Vector<WebCore::Seriali
 void WebPageProxy::cloneAttachmentData(const String& fromIdentifier, const String& toIdentifier)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(fromIdentifier));
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(toIdentifier));
 
@@ -10608,7 +10602,6 @@ void WebPageProxy::serializedAttachmentDataForIdentifiers(const Vector<String>& 
     Vector<WebCore::SerializedAttachmentData> serializedData;
 
     MESSAGE_CHECK_COMPLETION(m_process, m_preferences->attachmentElementEnabled(), completionHandler(WTFMove(serializedData)));
-    MESSAGE_CHECK_COMPLETION(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled, completionHandler(WTFMove(serializedData)));
 
     for (const auto& identifier : identifiers) {
         auto attachment = attachmentForIdentifier(identifier);
@@ -10653,7 +10646,6 @@ void WebPageProxy::platformCloneAttachment(Ref<API::Attachment>&&, Ref<API::Atta
 void WebPageProxy::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, bool hasEnclosingImage)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     auto attachment = ensureAttachment(identifier);
@@ -10668,7 +10660,6 @@ void WebPageProxy::didInsertAttachmentWithIdentifier(const String& identifier, c
 void WebPageProxy::didRemoveAttachmentWithIdentifier(const String& identifier)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
-    MESSAGE_CHECK(m_process, m_process->captivePortalMode() == WebProcessProxy::CaptivePortalMode::Disabled);
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     if (auto attachment = attachmentForIdentifier(identifier))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4135,10 +4135,6 @@ static void adjustSettingsForCaptivePortal(Settings& settings, const WebPreferen
     settings.setSystemPreviewEnabled(false);
 #endif
 
-#if ENABLE(ATTACHMENT_ELEMENT)
-    DeprecatedGlobalSettings::setAttachmentElementEnabled(false);
-#endif
-
     settings.setAllowedMediaContainerTypes(store.getStringValueForKey(WebPreferencesKey::mediaContainerTypesAllowedInCaptivePortalModeKey()));
     settings.setAllowedMediaCodecTypes(store.getStringValueForKey(WebPreferencesKey::mediaCodecTypesAllowedInCaptivePortalModeKey()));
     settings.setAllowedMediaVideoCodecIDs(store.getStringValueForKey(WebPreferencesKey::mediaVideoCodecIDsAllowedInCaptivePortalModeKey()));


### PR DESCRIPTION
#### 88ccd8f0141f27776261ab5ccc4aa8147decb6ea
<pre>
Revert [252581@main] Disable attachment element setting when lock down mode is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=243305">https://bugs.webkit.org/show_bug.cgi?id=243305</a>
&lt;rdar://97724768&gt;

Unreviewed revert.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromData):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentIdentifier):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
(WebKit::WebPageProxy::cloneAttachmentData):
(WebKit::WebPageProxy::serializedAttachmentDataForIdentifiers):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachmentWithIdentifier):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::adjustSettingsForCaptivePortal):

Canonical link: <a href="https://commits.webkit.org/252919@main">https://commits.webkit.org/252919@main</a>
</pre>
