### PR TITLE
CGDisplayList-image-buffer-backed tiles grow without bound when repainted

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -478,6 +478,12 @@ void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
         backend->setVolatilityState(volatilityState);
 }
 
+void ImageBuffer::clearContents()
+{
+    if (auto* backend = ensureBackendCreated())
+        backend->clearContents();
+}
+
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 {
     if (auto* backend = ensureBackendCreated())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -215,6 +215,8 @@ public:
     WEBCORE_EXPORT VolatilityState volatilityState() const;
     WEBCORE_EXPORT void setVolatilityState(VolatilityState);
 
+    WEBCORE_EXPORT void clearContents();
+
     WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
 
 protected:

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -164,6 +164,8 @@ public:
 
     virtual void setOwnershipIdentity(const ProcessIdentity&) { }
 
+    virtual void clearContents() { ASSERT_NOT_REACHED(); }
+
 protected:
     WEBCORE_EXPORT ImageBufferBackend(const Parameters&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -48,20 +48,22 @@ public:
     WebCore::IntSize backendSize() const final;
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
 
+    void clearContents() final;
+
     // NOTE: These all ASSERT_NOT_REACHED().
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
     RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& outputFormat, const WebCore::IntRect&, const WebCore::ImageBufferAllocator& = WebCore::ImageBufferAllocator()) const final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
 protected:
-    CGDisplayListImageBufferBackend(const Parameters&, std::unique_ptr<WebCore::GraphicsContext>&&, UseOutOfLineSurfaces);
+    CGDisplayListImageBufferBackend(const Parameters&, UseOutOfLineSurfaces);
 
     unsigned bytesPerRow() const final;
 
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
-    std::unique_ptr<WebCore::GraphicsContext> m_context;
+    mutable std::unique_ptr<WebCore::GraphicsContext> m_context;
     UseOutOfLineSurfaces m_useOutOfLineSurfaces;
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -131,9 +131,7 @@ private:
 
     struct Buffer {
         RefPtr<WebCore::ImageBuffer> imageBuffer;
-#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-        RefPtr<WebCore::ImageBuffer> displayListImageBuffer;
-#endif
+
         explicit operator bool() const
         {
             return !!imageBuffer;
@@ -169,6 +167,7 @@ private:
     std::optional<MachSendRight> m_contentsBufferHandle;
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    RefPtr<WebCore::ImageBuffer> m_displayListBuffer;
     std::optional<ImageBufferBackendHandle> m_displayListBufferHandle;
 #endif
 


### PR DESCRIPTION
#### 9c49b078b670fd395a2848edee0478c6cd21f4ca
<pre>
CGDisplayList-image-buffer-backed tiles grow without bound when repainted
<a href="https://bugs.webkit.org/show_bug.cgi?id=243307">https://bugs.webkit.org/show_bug.cgi?id=243307</a>

Reviewed by Simon Fraser.

When repainting a display-list-backed tile, we shouldn&apos;t continue using the
existing recorder, but rather start a fresh one. Otherwise, the display list
just piles up.

Similarly, there is no reason to &quot;swap&quot; between display list image buffers,
since we repaint them fully every time, and this will cause trouble for future
resource caching efforts.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::clearContents):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::clearContents):
Add a &quot;clearContents&quot; ImageBuffer and ImageBufferBackend method.
I don&apos;t implement it for bitmap image buffers, opting instead for an assertion,
but you could *imagine* an implementation, so it seems OK to add here.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
(WebKit::CGDisplayListImageBufferBackend::create):
Move platform context creation into the GraphicsContext constructor, so
that we can re-do both in one operation.

(WebKit::CGDisplayListImageBufferBackend::clearContents):
Implement clearContents as just swapping out the display list recorder.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::clearBackingStore):
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::swapToValidFrontBuffer):
(WebKit::RemoteLayerBackingStore::ensureFrontBuffer):
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::Buffer::discard):
Move the display list buffer to its own toplevel, instead of hanging off Buffer,
since swapping display lists doesn&apos;t make any sense.

Canonical link: <a href="https://commits.webkit.org/252936@main">https://commits.webkit.org/252936@main</a>
</pre>
