### PR TITLE
Allow parsing of overflow-anchor behind flag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -219,6 +219,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -216,6 +216,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inheritance-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Property overflow-anchor has initial value auto assert_true: overflow-anchor doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-anchor does not inherit assert_true: expected true got false
+PASS Property overflow-anchor has initial value auto
+PASS Property overflow-anchor does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-computed-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Property overflow-anchor value 'auto' assert_true: overflow-anchor doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-anchor value 'none' assert_true: overflow-anchor doesn't seem to be supported in the computed style expected true got false
+PASS Property overflow-anchor value 'auto'
+PASS Property overflow-anchor value 'none'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-valid-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL e.style['overflow-anchor'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['overflow-anchor'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['overflow-anchor'] = "auto" should set the property value
+PASS e.style['overflow-anchor'] = "none" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 391
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 391
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 392
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 392
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -219,6 +219,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 390
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 390
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 390
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 390
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 391
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 391
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 391
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 391
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -219,6 +219,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 393
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 393
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 393
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 394
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -219,6 +219,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -216,6 +216,7 @@ PASS outline-color
 PASS outline-offset
 PASS outline-style
 PASS outline-width
+PASS overflow-anchor
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -405,6 +405,18 @@ CSSRelativeColorSyntaxEnabled:
     WebCore:
       default: false
 
+CSSScrollAnchoringEnabled:
+  type: bool
+  humanReadableName: "CSS Scroll Anchoring"
+  humanReadableDescription: "Enable CSS Scroll Anchoring"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextAlignLastEnabled:
   type: bool
   humanReadableName: "CSS text-align-last property"

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3306,6 +3306,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<TransformStyle3D>(CSSPropertyTransformStyle, &RenderStyle::transformStyle3D, &RenderStyle::setTransformStyle3D),
         new DiscretePropertyWrapper<WhiteSpace>(CSSPropertyWhiteSpace, &RenderStyle::whiteSpace, &RenderStyle::setWhiteSpace),
         new DiscretePropertyWrapper<WordBreak>(CSSPropertyWordBreak, &RenderStyle::wordBreak, &RenderStyle::setWordBreak),
+        new DiscretePropertyWrapper<OverflowAnchor>(CSSPropertyOverflowAnchor, &RenderStyle::overflowAnchor, &RenderStyle::setOverflowAnchor),
 
 #if ENABLE(CSS_BOX_DECORATION_BREAK)
         new DiscretePropertyWrapper<BoxDecorationBreak>(CSSPropertyWebkitBoxDecorationBreak, &RenderStyle::boxDecorationBreak, &RenderStyle::setBoxDecorationBreak),

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -4126,7 +4126,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(style.scrollSnapStop());
         case CSSPropertyScrollSnapType:
             return valueForScrollSnapType(style.scrollSnapType());
-
+        case CSSPropertyOverflowAnchor:
+            return cssValuePool.createValue(style.overflowAnchor());
 #if ENABLE(CSS_TRAILING_WORD)
         case CSSPropertyAppleTrailingWord:
             return cssValuePool.createValue(style.trailingWord());

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1907,6 +1907,37 @@ template<> inline CSSPrimitiveValue::operator OverscrollBehavior() const
     return OverscrollBehavior::Auto;
 }
 
+template<> inline CSSPrimitiveValue::CSSPrimitiveValue(OverflowAnchor anchor)
+    : CSSValue(PrimitiveClass)
+{
+    setPrimitiveUnitType(CSSUnitType::CSS_VALUE_ID);
+    switch (anchor) {
+    case OverflowAnchor::None:
+        m_value.valueID = CSSValueNone;
+        break;
+    case OverflowAnchor::Auto:
+        m_value.valueID = CSSValueAuto;
+        break;
+    }
+}
+
+template<> inline CSSPrimitiveValue::operator OverflowAnchor() const
+{
+    ASSERT(isValueID());
+
+    switch (m_value.valueID) {
+    case CSSValueNone:
+        return OverflowAnchor::None;
+    case CSSValueAuto:
+        return OverflowAnchor::Auto;
+    default:
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return OverflowAnchor::Auto;
+}
+
 template<> inline CSSPrimitiveValue::CSSPrimitiveValue(BreakBetween e)
     : CSSValue(PrimitiveClass)
 {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3832,6 +3832,19 @@
                 "url": "https://www.w3.org/TR/css-overflow-3/#propdef-overflow"
             }
         },
+        "overflow-anchor": {
+            "codegen-properties": {
+                "settings-flag": "cssScrollAnchoringEnabled"
+            },
+            "values": [
+                "none",
+                "auto"
+            ],
+            "specification": {
+                "category": "css-scroll-anchoring",
+                "url": "https://www.w3.org/TR/css-scroll-anchoring-1/#propdef-overflow-anchor"
+            }
+        },
         "overflow-wrap": {
             "codegen-properties": {
                 "aliases": [
@@ -7969,6 +7982,11 @@
             "shortname": "CSS Ruby",
             "longname": "CSS Ruby Layout Module",
             "url": "https://www.w3.org/TR/css-ruby-1/"
+        },
+        "css-scroll-anchoring": {
+            "shortname": "CSS Scroll Anchoring",
+            "longname": "CSS Scroll Anchoring Module",
+            "url": "https://www.w3.org/TR/css-scroll-anchoring-1/"
         },
         "css-scroll-snap": {
             "shortname": "CSS Scroll Snap",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1605,3 +1605,7 @@ sides
 and
 or
 not
+
+// overflow-anchor
+// none
+// auto

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2544,6 +2544,14 @@ static RefPtr<CSSValue> consumeOverscrollBehavior(CSSParserTokenRange& range)
     return consumeIdent(range);
 }
 
+static RefPtr<CSSValue> consumeOverflowAnchor(CSSParserTokenRange& range)
+{
+    auto valueID = range.peek().id();
+    if (valueID != CSSValueAuto && valueID != CSSValueNone)
+        return nullptr;
+    return consumeIdent(range);
+}
+
 static RefPtr<CSSValue> consumeBorderRadiusCorner(CSSParserTokenRange& range, CSSParserMode cssParserMode)
 {
     RefPtr<CSSPrimitiveValue> parsedValue1 = consumeLengthOrPercent(range, cssParserMode, ValueRange::NonNegative);
@@ -4755,6 +4763,8 @@ RefPtr<CSSValue> CSSPropertyParser::parseSingleValue(CSSPropertyID property, CSS
     case CSSPropertyContainIntrinsicBlockSize:
     case CSSPropertyContainIntrinsicInlineSize:
         return consumeContainIntrinsicSize(m_range);
+    case CSSPropertyOverflowAnchor:
+        return consumeOverflowAnchor(m_range);
     default:
         return nullptr;
     }

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -94,4 +94,17 @@ TextStream& operator<<(TextStream& ts, ScrollbarMode behavior)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, OverflowAnchor behavior)
+{
+    switch (behavior) {
+    case OverflowAnchor::Auto:
+        ts << 0;
+        break;
+    case OverflowAnchor::None:
+        ts << 1;
+        break;
+    }
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -77,6 +77,11 @@ enum class ScrollIsAnimated : uint8_t {
     Yes
 };
 
+enum class OverflowAnchor : uint8_t {
+    Auto,
+    None
+};
+
 inline ScrollDirection logicalToPhysical(ScrollLogicalDirection direction, bool isVertical, bool isFlipped)
 {
     switch (direction) {
@@ -323,6 +328,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollClamping);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehaviorForFixedElements);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollElasticity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
 
 struct ScrollPositionChangeOptions {
     ScrollType type;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1958,6 +1958,10 @@ public:
     static OffsetRotation initialOffsetRotate() { return OffsetRotation(true, 0); }
 
     bool borderAndBackgroundEqual(const RenderStyle&) const;
+    
+    OverflowAnchor overflowAnchor() const { return static_cast<OverflowAnchor>(m_rareNonInheritedData->overflowAnchor); }
+    void setOverflowAnchor(OverflowAnchor a) { SET_VAR(m_rareNonInheritedData, overflowAnchor, static_cast<unsigned>(a)); }
+    static OverflowAnchor initialOverflowAnchor() { return OverflowAnchor::Auto; }
 
 private:
     struct NonInheritedFlags {

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -116,6 +116,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , containIntrinsicWidthType(static_cast<unsigned>(RenderStyle::initialContainIntrinsicWidthType()))
     , containIntrinsicHeightType(static_cast<unsigned>(RenderStyle::initialContainIntrinsicHeightType()))
     , containerType(static_cast<unsigned>(RenderStyle::initialContainerType()))
+    , overflowAnchor(static_cast<unsigned>(RenderStyle::initialOverflowAnchor()))
     , columnGap(RenderStyle::initialColumnGap())
     , rowGap(RenderStyle::initialRowGap())
     , offsetDistance(RenderStyle::initialOffsetDistance())
@@ -224,6 +225,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , containIntrinsicWidthType(o.containIntrinsicWidthType)
     , containIntrinsicHeightType(o.containIntrinsicHeightType)
     , containerType(o.containerType)
+    , overflowAnchor(o.overflowAnchor)
     , containerNames(o.containerNames)
     , columnGap(o.columnGap)
     , rowGap(o.rowGap)
@@ -346,7 +348,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && offsetDistance == o.offsetDistance
         && offsetPosition == o.offsetPosition
         && offsetAnchor == o.offsetAnchor
-        && offsetRotate == o.offsetRotate;
+        && offsetRotate == o.offsetRotate
+        && overflowAnchor == o.overflowAnchor;
 }
 
 bool StyleRareNonInheritedData::contentDataEquivalent(const StyleRareNonInheritedData& other) const

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -243,6 +243,8 @@ public:
 
     unsigned containerType : 2; // ContainerType
 
+    unsigned overflowAnchor : 1; // Scroll Anchoring- OverflowAnchor
+
     Vector<AtomString> containerNames;
 
     GapLength columnGap;


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=242973
<rdar://97694545>

Reviewed by NOBODY (OOPS!).

Add flag for scroll anchoring and allow parsing of overflow-anchor behind
that flag.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/parsing/overflow-anchor-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::operator OverflowAnchor const):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeOverflowAnchor):
(WebCore::CSSPropertyParser::parseSingleValue):
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator<<):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::overflowAnchor const):
(WebCore::RenderStyle::setOverflowAnchor):
(WebCore::RenderStyle::initialOverflowAnchor):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
