### PR TITLE
html/semantics/forms/the-input-element/type-change-state.html is failing in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
@@ -160,8 +160,8 @@ PASS change state from datetime-local to time
 PASS change state from datetime-local to number
 PASS change state from datetime-local to range
 PASS change state from datetime-local to color
-FAIL change state from datetime-local to checkbox assert_equals: input.value should be 'on' after change of state expected "on" but got ""
-FAIL change state from datetime-local to radio assert_equals: input.value should be 'on' after change of state expected "on" but got ""
+PASS change state from datetime-local to checkbox
+PASS change state from datetime-local to radio
 PASS change state from datetime-local to file
 PASS change state from datetime-local to submit
 PASS change state from datetime-local to image
@@ -265,8 +265,8 @@ PASS change state from number to week
 PASS change state from number to time
 PASS change state from number to range
 PASS change state from number to color
-FAIL change state from number to checkbox assert_equals: input.value should be 'on' after change of state expected "on" but got ""
-FAIL change state from number to radio assert_equals: input.value should be 'on' after change of state expected "on" but got ""
+PASS change state from number to checkbox
+PASS change state from number to radio
 PASS change state from number to file
 PASS change state from number to submit
 PASS change state from number to image

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1007,7 +1007,7 @@ String HTMLInputElement::value() const
         return m_valueIfDirty;
 
     if (auto& valueString = attributeWithoutSynchronization(valueAttr); !valueString.isNull()) {
-        if (auto sanitizedValue = sanitizeValue(valueString); !sanitizedValue.isNull())
+        if (auto sanitizedValue = sanitizeValue(valueString); !sanitizedValue.isEmpty())
             return sanitizedValue;
     }
 


### PR DESCRIPTION
#### e0ed2700ba471fc29c216a0202bd97e8e2910fb3
<pre>
html/semantics/forms/the-input-element/type-change-state.html is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243311">https://bugs.webkit.org/show_bug.cgi?id=243311</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

The value attribute of inputs with `type=checkbox` and `type=radio` is supposed to return &quot;on&quot;
when there is no value. We use to return &quot;&quot; when the sanitized value was the empty string.
We would only return &quot;on&quot; when the value was actually a null String. This mismatch was causing
us to fail this test. We end up an empty String because the sanitization of some inputs
(e.g. number) sometimes return the empty string.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::value const):
</pre>