### PR TITLE
Three media query tests leave UIScripts running

### DIFF
--- a/LayoutTests/fast/media/mq-inverted-colors-live-update-for-listener.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-live-update-for-listener.html
@@ -15,26 +15,29 @@ let didCallListener = false;
 let timer;
 
 window.onload = () => {
-    requestAnimationFrame(() => {
-        window.matchMedia('(inverted-colors)').addListener((event) => {
-            didCallListener = true;
-            finalize();
-        });
+    window.matchMedia('(inverted-colors)').addListener((event) => {
+        didCallListener = true;
+    });
 
-        if (!window.internals || !testRunner.runUIScript) {
-            testFailed('This test requires runUIScript');
-            finishJSTest();
-            return;
-        }
+    if (!window.internals || !testRunner.runUIScript) {
+        testFailed('This test requires runUIScript');
+        finishJSTest();
+        return;
+    }
 
+    requestAnimationFrame(async () => {
         window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "on";
-        testRunner.runUIScript(`
-            uiController.simulateAccessibilitySettingsChangeNotification(() => {
-                uiController.uiScriptComplete("Done");
-            })`, () => {
-            if (!didCallListener)
-                timer = setTimeout(finalize, 1000);
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.simulateAccessibilitySettingsChangeNotification(() => {
+                    uiController.uiScriptComplete();
+                });`, resolve);
         });
+
+        if (didCallListener)
+            finalize();
+        else
+            timer = setTimeout(finalize, 1000);
     });
 }
 

--- a/LayoutTests/fast/media/mq-prefers-contrast-live-update-for-listener.html
+++ b/LayoutTests/fast/media/mq-prefers-contrast-live-update-for-listener.html
@@ -15,26 +15,29 @@ let didCallListener = false;
 let timer;
 
 window.onload = () => {
-    requestAnimationFrame(() => {
-        window.matchMedia('(prefers-contrast)').addListener((e) => {
-            didCallListener = true;
-            finalize();
-        });
+    window.matchMedia('(prefers-contrast)').addListener((e) => {
+        didCallListener = true;
+    });
 
-        if (!window.internals || !testRunner.runUIScript) {
-            testFailed('This test requires runUIScript');
-            finishJSTest();
-            return;
-        }
+    if (!window.internals || !testRunner.runUIScript) {
+        testFailed('This test requires runUIScript');
+        finishJSTest();
+        return;
+    }
 
+    requestAnimationFrame(async () => {
         window.internals.settings.forcedPrefersContrastAccessibilityValue = "on";
-        testRunner.runUIScript(`
-            uiController.simulateAccessibilitySettingsChangeNotification(() => {
-                uiController.uiScriptComplete("Done");
-            })`, () => {
-            if (!didCallListener)
-                timer = setTimeout(finalize, 1000);
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.simulateAccessibilitySettingsChangeNotification(() => {
+                    uiController.uiScriptComplete();
+                });`, resolve);
         });
+
+        if (didCallListener)
+            finalize();
+        else
+            timer = setTimeout(finalize, 1000);
     });
 }
 

--- a/LayoutTests/fast/media/mq-prefers-reduced-motion-live-update-for-listener.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-motion-live-update-for-listener.html
@@ -15,26 +15,29 @@ let didCallListener = false;
 let timer;
 
 window.onload = () => {
-    requestAnimationFrame(() => {
-        window.matchMedia('(prefers-reduced-motion)').addListener((e) => {
-            didCallListener = true;
-            finalize();
-        });
+    window.matchMedia('(prefers-reduced-motion)').addListener((e) => {
+        didCallListener = true;
+    });
 
-        if (!window.internals || !testRunner.runUIScript) {
-            testFailed('This test requires runUIScript');
-            finishJSTest();
-            return;
-        }
+    if (!window.internals || !testRunner.runUIScript) {
+        testFailed('This test requires runUIScript');
+        finishJSTest();
+        return;
+    }
 
+    requestAnimationFrame(async () => {
         window.internals.settings.forcedPrefersReducedMotionAccessibilityValue = "on";
-        testRunner.runUIScript(`
-            uiController.simulateAccessibilitySettingsChangeNotification(() => {
-                uiController.uiScriptComplete("Done");
-            })`, () => {
-            if (!didCallListener)
-                timer = setTimeout(finalize, 1000);
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.simulateAccessibilitySettingsChangeNotification(() => {
+                    uiController.uiScriptComplete();
+                });`, resolve);
         });
+
+        if (didCallListener)
+            finalize();
+        else
+            timer = setTimeout(finalize, 1000);
     });
 }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3614,9 +3614,6 @@ webkit.org/b/240579 http/wpt/push-api [ Skip ]
 # These tests finish with unfired UI script callbacks, causing crashes. See webkit.org/b/236794
 editing/spelling/editing-word-with-marker-1.html
 fast/events/ios/pdf-modifer-key-down-crash.html
-fast/media/mq-inverted-colors-live-update-for-listener.html
-fast/media/mq-prefers-contrast-live-update-for-listener.html
-fast/media/mq-prefers-reduced-motion-live-update-for-listener.html
 imported/w3c/web-platform-tests/clipboard-apis/async-raw-write-read.tentative.https.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html


### PR DESCRIPTION
#### c8cd14f0ca1889b4c33adfe23ebabeea63e84ac3
<pre>
Three media query tests leave UIScripts running
<a href="https://bugs.webkit.org/show_bug.cgi?id=243317">https://bugs.webkit.org/show_bug.cgi?id=243317</a>

Reviewed by Ryosuke Niwa.

These tests called testRunner.runUIScript() from requestAnimationFrame, but
called finishJSTest() from a media query callback that could fire before the
UIScript was complete, resulting in the test finishing with unfinished UI scripts
(see webkit.org/b/236794).

Fix by having the requestAnimationFrame() wait on the runUIScript().

* LayoutTests/fast/media/mq-inverted-colors-live-update-for-listener.html:
* LayoutTests/fast/media/mq-prefers-contrast-live-update-for-listener.html:
* LayoutTests/fast/media/mq-prefers-reduced-motion-live-update-for-listener.html:

Canonical link: <a href="https://commits.webkit.org/252962@main">https://commits.webkit.org/252962@main</a>
</pre>
