### PR TITLE
Two platform/ios/fast/scrolling/find tests complete with unfinished UIScripts

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3617,8 +3617,6 @@ imported/w3c/web-platform-tests/clipboard-apis/async-raw-write-read.tentative.ht
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html
 imported/w3c/web-platform-tests/html/user-activation/no-activation-thru-escape-key.html
-platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit.html
-platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html
 swipe/main-frame-pinning-requirement.html
 
 

--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-expected.txt
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-expected.txt
@@ -6,10 +6,12 @@ layer at (0,0) size 800x262
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 722x19
           text run at (0,0) width 722: "Use iOS Find UI to search for the text \"match\" in the following overflow node. The result should be highlighted."
-layer at (8,52) size 202x202 clip at (9,53) size 200x200 scrollHeight 620
+layer at (8,52) size 202x202 clip at (9,53) size 200x200 scrollY 210 scrollHeight 620
   RenderBlock {DIV} at (0,36) size 202x202 [bgcolor=#808080] [border: (1px solid #000000)]
     RenderBlock {DIV} at (1,1) size 200x300
     RenderBlock {DIV} at (1,301) size 200x20
       RenderText {#text} at (0,0) size 40x19
         text run at (0,0) width 40: "match"
     RenderBlock {DIV} at (1,321) size 200x300
+selection start: position 0 of child 0 {#text} of child 3 {DIV} of child 3 {DIV} of body
+selection end:   position 5 of child 0 {#text} of child 3 {DIV} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit-expected.txt
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit-expected.txt
@@ -6,9 +6,11 @@ layer at (0,0) size 800x262
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 722x19
           text run at (0,0) width 722: "Use iOS Find UI to search for the text \"match\" in the following overflow node. The result should be highlighted."
-layer at (8,52) size 202x202 clip at (9,53) size 200x200 scrollHeight 320
+layer at (8,52) size 202x202 clip at (9,53) size 200x200 scrollY 120 scrollHeight 320
   RenderBlock {DIV} at (0,36) size 202x202 [bgcolor=#808080] [border: (1px solid #000000)]
     RenderBlock {DIV} at (1,1) size 200x300
     RenderBlock {DIV} at (1,301) size 200x20
       RenderText {#text} at (0,0) size 40x19
         text run at (0,0) width 40: "match"
+selection start: position 0 of child 0 {#text} of child 3 {DIV} of child 3 {DIV} of body
+selection end:   position 5 of child 0 {#text} of child 3 {DIV} of child 3 {DIV} of body

--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit.html
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit.html
@@ -6,17 +6,19 @@
     <script type="text/javascript">
       if (window.testRunner)
           testRunner.waitUntilDone();
-      function run() {
+      async function run() {
         if (!window.testRunner || !testRunner.runUIScript)
           return;
 
         var findOptions = 1 << 6; // show find indicator
         var maxCount = 1;
-        testRunner.runUIScript(`
-          uiController.findString("match", ${findOptions}, ${maxCount});
-          uiController.findString("match", ${findOptions}, ${maxCount});
-          uiController.uiScriptComplete("Done");
-        `);
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.findString("match", ${findOptions}, ${maxCount});
+                uiController.findString("match", ${findOptions}, ${maxCount});
+                uiController.uiScriptComplete("");
+            `, resolve);
+        });
 
         testRunner.notifyDone();
       }

--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html
@@ -6,17 +6,19 @@
     <script type="text/javascript">
       if (window.testRunner)
           testRunner.waitUntilDone();
-      function run() {
+      async function run() {
         if (!window.testRunner || !testRunner.runUIScript)
           return;
 
         var findOptions = 1 << 6; // show find indicator
         var maxCount = 1;
-        testRunner.runUIScript(`
-          uiController.findString("match", ${findOptions}, ${maxCount});
-          uiController.findString("match", ${findOptions}, ${maxCount});
-          uiController.uiScriptComplete("Done");
-        `);
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.findString("match", ${findOptions}, ${maxCount});
+                uiController.findString("match", ${findOptions}, ${maxCount});
+                uiController.uiScriptComplete("");
+            `, resolve);
+        });
 
         testRunner.notifyDone();
       }


### PR DESCRIPTION
#### 2e9ba87b684432464883db26efe8a55149ae5c93
<pre>
Two platform/ios/fast/scrolling/find tests complete with unfinished UIScripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=243318">https://bugs.webkit.org/show_bug.cgi?id=243318</a>

Reviewed by Ryosuke Niwa.

These tests need to wait for testRunner.runUIScript() to complete (see webkit.org/b/236794).

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-expected.txt:
* LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit-expected.txt:
* LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position-limit.html:
* LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node-indicator-position.html:

Canonical link: <a href="https://commits.webkit.org/252968@main">https://commits.webkit.org/252968@main</a>
</pre>
