### PR TITLE
[Gardening]:Migrate iOS16 expectations to OpenSource. Lint/Clean no longer needed expectations.]

### DIFF
--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -10,13 +10,10 @@ fast/forms/ios/ipad [ Pass ]
 # iPads don't zoom when form elements are focused
 fast/forms/ios/accessory-bar-navigation.html [ Skip ]
 fast/forms/ios/choose-select-option.html [ Skip ]
-fast/forms/ios/delete-in-input-in-iframe.html [ Skip ]
 fast/forms/ios/focus-input-in-fixed.html [ Skip ]
-fast/forms/ios/focus-input-in-iframe.html [ Skip ]
 fast/forms/ios/focus-input-via-button-no-scaling.html [ Skip ]
 fast/forms/ios/focus-input-via-button.html [ Skip ]
 fast/forms/ios/focus-long-textarea.html [ Skip ]
-fast/forms/ios/typing-in-input-in-iframe.html [ Skip ]
 fast/forms/ios/user-scalable-does-not-scale-for-keyboard-focus-with-author-defined-scale.html [ Skip ]
 fast/forms/ios/user-scalable-does-not-scale-for-keyboard-focus-with-user-scalable-no.html [ Skip ]
 fast/forms/ios/zoom-after-input-tap-wide-input.html [ Skip ]
@@ -25,9 +22,7 @@ fast/forms/ios/zoom-after-input-tap.html [ Skip ]
 media/video-background-playback.html [ Pass Crash ]
 fast/forms/ios/scroll-to-reveal-focused-select.html [ Crash Failure ]
 fast/forms/ios/time-picker-value-change.html [ Failure ]
-fast/forms/ios/delete-in-input-in-iframe.html [ Timeout ]
 [ Debug ] fast/forms/ios/form-control-refresh/select/focus-select-in-touchend.html [ Timeout ]
-fast/forms/ios/typing-in-input-in-iframe.html [ Timeout ]
 fast/forms/ios/user-scalable-does-not-scale-for-keyboard-focus-with-author-defined-scale.html [ Timeout ]
 fast/forms/ios/user-scalable-does-not-scale-for-keyboard-focus-with-user-scalable-no.html [ Timeout ]
 fast/events/ios/should-be-able-to-dismiss-form-accessory-after-tapping-outside-iframe-with-focused-field.html [ Timeout ]
@@ -82,9 +77,6 @@ fast/scrolling/ios/overflow-scrolling-touch-enabled-stacking.html [ ImageOnlyFai
 
 # This test relies on the numeric keyboard having a different size than regular keyboard. This is not the case on iPad.
 fast/forms/ios/inputmode-change-update-keyboard.html [ Skip ]
-
-# <rdar://problem/51869921> REGRESSION (iOS 13) [ iPad Sim ] Layout Test http/tests/adClickAttribution/anchor-tag-attributes-validation.html is failing
-http/tests/adClickAttribution/anchor-tag-attributes-validation.html [ Failure ]
 
 # <rdar://problem/51865126> [ iPad Simulator ] 2 New Layout tests are failing on iOS 13 iPad Simulator testers fast/scrolling/ios/body-overflow-hidden-height-100-percent-zoomed-*
 fast/scrolling/ios/body-overflow-hidden-height-100-percent-zoomed-2.html [ Skip ]


### PR DESCRIPTION
#### 2ddeb950f78d75a7d2102c8315bd1d0563c305bc
<pre>
[Gardening]:Migrate iOS16 expectations to OpenSource. Lint/Clean no longer needed expectations.]
<a href="https://bugs.webkit.org/show_bug.cgi?id=242650">https://bugs.webkit.org/show_bug.cgi?id=242650</a>

Unreviewed test gardening.

* LayoutTests/platform/ipad/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/252931@main">https://commits.webkit.org/252931@main</a>
</pre>
