### PR TITLE
Temporal.Duration#toString should use BigInt#toString for values beyond MAX_SAFE_INTEGER

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1056,12 +1056,6 @@ test/built-ins/Temporal/Duration/prototype/subtract/timezone-string-leap-second.
 test/built-ins/Temporal/Duration/prototype/subtract/timezone-wrong-type.js:
   default: 'Test262Error: symbol is not a valid object and does not convert to a string Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: symbol is not a valid object and does not convert to a string Expected a TypeError but got a RangeError'
-test/built-ins/Temporal/Duration/prototype/toString/precision-formatted-as-decimal-number.js:
-  default: 'Test262Error: Expected SameValue(«P10000000000000004000W», «P10000000000000004096W») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«P10000000000000004000W», «P10000000000000004096W») to be true'
-test/built-ins/Temporal/Duration/prototype/toString/throws-when-rounded-duration-is-invalid.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone, calendar)')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(0n, timeZone, calendar)')"

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -563,7 +563,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
     RETURN_IF_EXCEPTION(scope, { });
 
     if (!options)
-        return toString();
+        RELEASE_AND_RETURN(scope, toString(globalObject));
 
     PrecisionData data = secondsStringPrecision(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
@@ -577,18 +577,43 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
 
     // No need to make a new object if we were given explicit defaults.
     if (std::get<0>(data.precision) == Precision::Auto && roundingMode == RoundingMode::Trunc)
-        return toString();
+        RELEASE_AND_RETURN(scope, toString(globalObject));
 
     ISO8601::Duration newDuration = m_duration;
     round(newDuration, data.increment, data.unit, roundingMode);
-    return toString(newDuration, data.precision);
+    RELEASE_AND_RETURN(scope, toString(globalObject, newDuration, data.precision));
+}
+
+static void appendInteger(JSGlobalObject* globalObject, StringBuilder& builder, double value)
+{
+    ASSERT(std::isfinite(value));
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    double absValue = std::abs(value);
+    if (LIKELY(absValue <= maxSafeInteger())) {
+        builder.append(absValue);
+        return;
+    }
+
+    auto* bigint = JSBigInt::createFrom(globalObject, absValue);
+    RETURN_IF_EXCEPTION(scope, void());
+
+    String string = bigint->toString(globalObject, 10);
+    RETURN_IF_EXCEPTION(scope, void());
+
+    builder.append(string);
 }
 
 // TemporalDurationToString ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, precision )
 // https://tc39.es/proposal-temporal/#sec-temporal-temporaldurationtostring
-String TemporalDuration::toString(const ISO8601::Duration& duration, std::tuple<Precision, unsigned> precision)
+String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::Duration& duration, std::tuple<Precision, unsigned> precision)
 {
     ASSERT(std::get<0>(precision) == Precision::Auto || std::get<1>(precision) < 10);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto balancedMicroseconds = duration.microseconds() + std::trunc(duration.nanoseconds() / 1000);
     auto balancedNanoseconds = std::fmod(duration.nanoseconds(), 1000);
@@ -597,14 +622,6 @@ String TemporalDuration::toString(const ISO8601::Duration& duration, std::tuple<
     auto balancedSeconds = duration.seconds() + std::trunc(balancedMilliseconds / 1000);
     balancedMilliseconds = std::fmod(balancedMilliseconds, 1000);
 
-    // TEMPORARY! (pending spec discussion about maximum values @ https://github.com/tc39/proposal-temporal/issues/1604)
-    // We *must* avoid printing a number in scientific notation, which is currently only possible for numbers < 1e21
-    // (a value originating in the Number#toFixed spec and upheld by our NumberToStringBuffer).
-    auto formatInteger = [](double value) -> double {
-        auto absValue = std::abs(value);
-        return LIKELY(absValue < 1e21) ? absValue : 1e21 - 65537;
-    };
-
     StringBuilder builder;
 
     auto sign = TemporalDuration::sign(duration);
@@ -612,14 +629,26 @@ String TemporalDuration::toString(const ISO8601::Duration& duration, std::tuple<
         builder.append('-');
 
     builder.append('P');
-    if (duration.years())
-        builder.append(formatInteger(duration.years()), 'Y');
-    if (duration.months())
-        builder.append(formatInteger(duration.months()), 'M');
-    if (duration.weeks())
-        builder.append(formatInteger(duration.weeks()), 'W');
-    if (duration.days())
-        builder.append(formatInteger(duration.days()), 'D');
+    if (duration.years()) {
+        appendInteger(globalObject, builder, duration.years());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('Y');
+    }
+    if (duration.months()) {
+        appendInteger(globalObject, builder, duration.months());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('M');
+    }
+    if (duration.weeks()) {
+        appendInteger(globalObject, builder, duration.weeks());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('W');
+    }
+    if (duration.days()) {
+        appendInteger(globalObject, builder, duration.days());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('D');
+    }
 
     // The zero value is displayed in seconds.
     auto usesSeconds = balancedSeconds || balancedMilliseconds || balancedMicroseconds || balancedNanoseconds || !sign || std::get<0>(precision) != Precision::Auto;
@@ -627,12 +656,28 @@ String TemporalDuration::toString(const ISO8601::Duration& duration, std::tuple<
         return builder.toString();
 
     builder.append('T');
-    if (duration.hours())
-        builder.append(formatInteger(duration.hours()), 'H');
-    if (duration.minutes())
-        builder.append(formatInteger(duration.minutes()), 'M');
+    if (duration.hours()) {
+        appendInteger(globalObject, builder, duration.hours());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('H');
+    }
+    if (duration.minutes()) {
+        appendInteger(globalObject, builder, duration.minutes());
+        RETURN_IF_EXCEPTION(scope, { });
+        builder.append('M');
+    }
     if (usesSeconds) {
-        builder.append(formatInteger(balancedSeconds));
+        // TEMPORARY! (pending spec discussion about rebalancing @ https://github.com/tc39/proposal-temporal/issues/2195)
+        // Although we must be able to display Number values beyond MAX_SAFE_INTEGER, it does not seem reasonable
+        // to require that calculations be performed outside of double space purely to support a case like
+        // `Temporal.Duration.from({ microseconds: Number.MAX_VALUE, nanoseconds: Number.MAX_VALUE }).toString()`.
+        if (UNLIKELY(!std::isfinite(balancedSeconds))) {
+            throwRangeError(globalObject, scope, "Cannot display infinite seconds!"_s);
+            return { };
+        }
+
+        appendInteger(globalObject, builder, balancedSeconds);
+        RETURN_IF_EXCEPTION(scope, { });
 
         auto fraction = std::abs(balancedMilliseconds) * 1e6 + std::abs(balancedMicroseconds) * 1e3 + std::abs(balancedNanoseconds);
         formatSecondsStringFraction(builder, fraction, precision);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -67,7 +67,7 @@ public:
     ISO8601::Duration round(JSGlobalObject*, JSValue options) const;
     double total(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject*, JSValue options) const;
-    String toString(std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const { return toString(m_duration, precision); }
+    String toString(JSGlobalObject* globalObject, std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const { return toString(globalObject, m_duration, precision); }
 
     static ISO8601::Duration fromDurationLike(JSGlobalObject*, JSObject*);
     static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
@@ -83,7 +83,7 @@ private:
     template<typename CharacterType>
     static std::optional<ISO8601::Duration> parse(StringParsingBuffer<CharacterType>&);
 
-    static String toString(const ISO8601::Duration&, std::tuple<Precision, unsigned> precision);
+    static String toString(JSGlobalObject*, const ISO8601::Duration&, std::tuple<Precision, unsigned> precision);
 
     ISO8601::Duration m_duration;
 };

--- a/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
@@ -245,7 +245,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToJSON, (JSGlobalObject* g
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toJSON called on value that's not a Duration"_s);
 
-    return JSValue::encode(jsString(vm, duration->toString()));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, duration->toString(globalObject))));
 }
 
 // This will be part of the ECMA-402 Intl.DurationFormat proposal; until then, we just follow ECMA-262 in mimicking toJSON.
@@ -258,7 +258,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToLocaleString, (JSGlobalO
     if (!duration)
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toLocaleString called on value that's not a Duration"_s);
 
-    return JSValue::encode(jsString(vm, duration->toString()));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, duration->toString(globalObject))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncValueOf, (JSGlobalObject* globalObject, CallFrame*))


### PR DESCRIPTION
#### 78b4ebbdfc351bea76965ea5562d5536d3783f17
<pre>
Temporal.Duration#toString should use BigInt#toString for values beyond MAX_SAFE_INTEGER
<a href="https://bugs.webkit.org/show_bug.cgi?id=243323">https://bugs.webkit.org/show_bug.cgi?id=243323</a>

Reviewed by Yusuke Suzuki.

Duration fields are currently specified as finite integral Numbers; unless a further bound is introduced in the future,
this means we&apos;ll need to use BigInt#toString for values beyond MAX_SAFE_INTEGER. (Until now we&apos;ve just being using 1e21
as a maximum, since this is the cutoff for Number#toFixed.) This is somewhat unfortunate since the use of BigInt incurs
a bunch of new exception logic.

Furthermore, TemporalDurationToString somehow expects us to display seconds as a decimal number in a case like
`Temporal.Duration.from({ microseconds: Number.MAX_VALUE, nanoseconds: Number.MAX_VALUE }).toString()`,
where calculating in the Number domain produces Infinity. I&apos;ve added this to my concerns in tc39/proposal-temporal#2195;
for now, I think it makes the most sense to implement this as a RangeError.

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::toString const):
(JSC::appendInteger):
(JSC::TemporalDuration::toString):
* Source/JavaScriptCore/runtime/TemporalDuration.h:
* Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/252935@main">https://commits.webkit.org/252935@main</a>
</pre>
