### PR TITLE
RemoteLayerTreeTransaction sometimes encodes changed layer properties multiple times

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -223,7 +223,7 @@ public:
     Vector<WebCore::GraphicsLayer::PlatformLayerID> destroyedLayers() const { return m_destroyedLayerIDs; }
     Vector<WebCore::GraphicsLayer::PlatformLayerID> layerIDsWithNewlyUnreachableBackingStore() const { return m_layerIDsWithNewlyUnreachableBackingStore; }
 
-    Vector<RefPtr<PlatformCALayerRemote>>& changedLayers() { return m_changedLayers; }
+    HashSet<RefPtr<PlatformCALayerRemote>>& changedLayers() { return m_changedLayers; }
 
     const LayerPropertiesMap& changedLayerProperties() const { return m_changedLayerProperties; }
     LayerPropertiesMap& changedLayerProperties() { return m_changedLayerProperties; }
@@ -315,7 +315,7 @@ public:
 
 private:
     WebCore::GraphicsLayer::PlatformLayerID m_rootLayerID;
-    Vector<RefPtr<PlatformCALayerRemote>> m_changedLayers; // Only used in the Web process.
+    HashSet<RefPtr<PlatformCALayerRemote>> m_changedLayers; // Only used in the Web process.
     LayerPropertiesMap m_changedLayerProperties; // Only used in the UI process.
 
     Vector<LayerCreationProperties> m_createdLayers;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -799,7 +799,7 @@ void RemoteLayerTreeTransaction::setRootLayerID(WebCore::GraphicsLayer::Platform
 
 void RemoteLayerTreeTransaction::layerPropertiesChanged(PlatformCALayerRemote& remoteLayer)
 {
-    m_changedLayers.append(&remoteLayer);
+    m_changedLayers.add(&remoteLayer);
 }
 
 void RemoteLayerTreeTransaction::setCreatedLayers(Vector<LayerCreationProperties> createdLayers)


### PR DESCRIPTION
#### b0e6f172161178435fda6fa94b14de262e2a9e38
<pre>
RemoteLayerTreeTransaction sometimes encodes changed layer properties multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=243327">https://bugs.webkit.org/show_bug.cgi?id=243327</a>

Reviewed by Simon Fraser.

Originally, `layerPropertiesChanged` could get away with using a vector of layers,
because it was only called from one place inside the transaction-building tree-walk,
so there would never be duplicates.

Recent changes (e.g. 248692@main) have introduced calls to `layerPropertiesChanged`
out of the flow of the tree-walk, causing duplicates to sometimes appear
in `m_changedLayers`, which, when iterated, causes properties to be needlessly
re-encoded in the transaction.

Switch to using a HashSet of layers instead.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::changedLayers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::layerPropertiesChanged):

Canonical link: <a href="https://commits.webkit.org/252955@main">https://commits.webkit.org/252955@main</a>
</pre>
