### PR TITLE
[Cocoa] Allow decoding the animated AVIF image whose image type is "public.avis"

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -60,6 +60,7 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageType
 #endif
 #if HAVE(AVIF)
             "public.avif"_s,
+            "public.avis"_s,
 #endif
         };
 


### PR DESCRIPTION
#### 7cb2a0410253831d82c23e9306a9d0c0af85e774
<pre>
[Cocoa] Allow decoding the animated AVIF image whose image type is &quot;public.avis&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243330">https://bugs.webkit.org/show_bug.cgi?id=243330</a>
rdar://97757110

Reviewed by Simon Fraser.

The image type of the static AVIF image which is &quot;public.avif&quot; was added to the
list of supported image formats in bug 241904. We need also to add the image type
of the animated AVIF image which is &quot;public.avis&quot;.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::animationPropertiesFromProperties):
(WebCore::ImageDecoderCG::frameDurationAtIndex const):
(WebCore::animationHEICSPropertiesFromProperties): Deleted.
* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::defaultSupportedImageTypes):

Canonical link: <a href="https://commits.webkit.org/253002@main">https://commits.webkit.org/253002@main</a>
</pre>
