### PR TITLE
[Playstation] Fix build break after 252799@main

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -834,7 +834,7 @@ String pathByAppendingComponents(StringView path, const Vector<StringView>& comp
 
 #endif
 
-#if !OS(WINDOWS) && !PLATFORM(COCOA)
+#if !OS(WINDOWS) && !PLATFORM(COCOA) && !PLATFORM(PLAYSTATION)
 
 String createTemporaryDirectory()
 {

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -213,7 +213,7 @@ WTF_EXPORT_PRIVATE std::optional<bool> allowsMaterializingDatalessFiles(PolicySc
 #endif
 
 // Impl for systems that do not already have createTemporaryDirectory
-#if !OS(WINDOWS) && !PLATFORM(COCOA)
+#if !OS(WINDOWS) && !PLATFORM(COCOA) && !PLATFORM(PLAYSTATION)
 WTF_EXPORT_PRIVATE String createTemporaryDirectory();
 #endif
 


### PR DESCRIPTION
#### 0165256e096498ad0b027e563ff854158c4d702c
<pre>
[Playstation] Fix build break after 252799@main

<a href="https://bugs.webkit.org/show_bug.cgi?id=243223">https://bugs.webkit.org/show_bug.cgi?id=243223</a>

Unreviewed build fix.
Skip createTemporaryDirectory() for PlayStation since temporary directory is not supported on PlayStation.

Canonical link: <a href="https://commits.webkit.org/252953@main">https://commits.webkit.org/252953@main</a>
</pre>
