### PR TITLE
Move logic to determine effective text alignment into RenderStyle and support text-justify: none

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2913,8 +2913,6 @@ imported/w3c/web-platform-tests/secure-contexts/basic-dedicated-worker.https.htm
 imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests.https.html [ Skip ]
 
 # text-justify
-webkit.org/b/99945 fast/css3-text/css3-text-justify/text-justify-none.html [ ImageOnlyFailure ]
-webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-001.html [ ImageOnlyFailure ]
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-006.html [ ImageOnlyFailure ]
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-and-trailing-spaces-002.html [ ImageOnlyFailure ]
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-and-trailing-spaces-003.html [ ImageOnlyFailure ]
@@ -2924,7 +2922,6 @@ webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/tex
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-distribute-001.html [ ImageOnlyFailure ]
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-inter-character-001.html [ ImageOnlyFailure ]
 webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-inter-word-001.html [ ImageOnlyFailure ]
-webkit.org/b/99945 imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-none-001.html [ ImageOnlyFailure ]
 
 # Link prefetch is disabled by default (needs ENABLE_LINK_PREFETCH)
 webkit.org/b/3652 fast/dom/HTMLLinkElement/link-and-subresource-test.html [ Skip ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -90,14 +90,17 @@ void Line::resetTrailingContent()
     m_trailingSoftHyphenWidth = { };
 }
 
-void Line::applyRunExpansion(InlineLayoutUnit horizontalAvailableSpace)
+void Line::applyRunExpansion(InlineLayoutUnit horizontalAvailableSpace, bool isLastLine)
 {
-    ASSERT(formattingContext().root().style().textAlign() == TextAlignMode::Justify || formattingContext().root().style().textAlignLast() == TextAlignLast::Justify);
     // Text is justified according to the method specified by the text-justify property,
     // in order to exactly fill the line box. Unless otherwise specified by text-align-last,
     // the last line before a forced break or the end of the block is start-aligned.
+
+    ASSERT_UNUSED(isLastLine, formattingContext().root().style().effectiveTextAlignForLine(isLastLine) == TextAlignMode::Justify);
+
     if (m_runs.isEmpty() || m_runs.last().isLineBreak())
         return;
+
     // A hanging glyph is still enclosed inside its parent inline box and still participates in text justification:
     // its character advance is just not measured when determining how much content fits on the line, how much the line’s contents
     // need to be expanded or compressed for justification, or how to position the content within the line box for text alignment.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -67,7 +67,7 @@ public:
     void removeTrailingTrimmableContent(ShouldApplyTrailingWhiteSpaceFollowedByBRQuirk);
     void removeHangingGlyphs();
     void resetBidiLevelForTrailingWhitespace(UBiDiLevel rootBidiLevel);
-    void applyRunExpansion(InlineLayoutUnit horizontalAvailableSpace);
+    void applyRunExpansion(InlineLayoutUnit horizontalAvailableSpace, bool isLastLine);
 
     struct Run {
         enum class Type : uint8_t {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -570,10 +570,10 @@ LineBuilder::InlineItemRange LineBuilder::close(const InlineItemRange& needsLayo
     // On each line, reset the embedding level of any sequence of whitespace characters at the end of the line
     // to the paragraph embedding level
     m_line.resetBidiLevelForTrailingWhitespace(rootStyle.isLeftToRightDirection() ? UBIDI_LTR : UBIDI_RTL);
-    auto runsExpandHorizontally = isLastLine ? rootStyle.textAlignLast() == TextAlignLast::Justify
-        : rootStyle.textAlign() == TextAlignMode::Justify;
-    if (runsExpandHorizontally)
-        m_line.applyRunExpansion(horizontalAvailableSpace);
+
+    if (rootStyle.effectiveTextAlignForLine(isLastLine) == TextAlignMode::Justify)
+        m_line.applyRunExpansion(horizontalAvailableSpace, isLastLine);
+
     auto lineEndsWithHyphen = false;
     if (m_line.hasContent()) {
         auto& lastTextContent = m_line.runs().last().textContent();

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -359,33 +359,9 @@ TextAlignMode LegacyLineLayout::textAlignmentForLine(bool endsWithSoftBreak) con
     if (auto overrideAlignment = m_flow.overrideTextAlignmentForLine(endsWithSoftBreak))
         return *overrideAlignment;
 
-    TextAlignMode alignment = style().textAlign();
-
-    if (endsWithSoftBreak)
-        return alignment;
-
-    TextAlignLast alignmentLast = style().textAlignLast();
-    switch (alignmentLast) {
-    case TextAlignLast::Start:
-        return TextAlignMode::Start;
-    case TextAlignLast::End:
-        return TextAlignMode::End;
-    case TextAlignLast::Left:
-        return TextAlignMode::Left;
-    case TextAlignLast::Right:
-        return TextAlignMode::Right;
-    case TextAlignLast::Center:
-        return TextAlignMode::Center;
-    case TextAlignLast::Justify:
-        return TextAlignMode::Justify;
-    case TextAlignLast::Auto:
-        if (alignment == TextAlignMode::Justify)
-            return TextAlignMode::Start;
-        return alignment;
-    }
-
-    ASSERT_NOT_REACHED();
-    return TextAlignMode::Start;
+    // Line ending with soft break means it's not the last line. effectiveTextAlignForLine
+    // expects a bool indicating if this is the last line or not.
+    return style().effectiveTextAlignForLine(!endsWithSoftBreak);
 }
 
 static void updateLogicalWidthForLeftAlignedBlock(bool isLeftToRightDirection, BidiRun* trailingSpaceRun, float& logicalLeft, float& totalLogicalWidth, float availableLogicalWidth)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2949,4 +2949,45 @@ UserSelect RenderStyle::effectiveUserSelect() const
     return value;
 }
 
+TextAlignMode RenderStyle::effectiveTextAlignForLine(bool isLastLine) const
+{
+    // Text alignment always follows text-align...
+    TextAlignMode alignment = textAlign();
+
+    // ...except when it's the last line in a block, in which case
+    // text-align-last takes precedence.
+    if (isLastLine) {
+        switch (textAlignLast()) {
+        case TextAlignLast::Auto:
+            if (alignment == TextAlignMode::Justify)
+                alignment = TextAlignMode::Start;
+            break;
+        case TextAlignLast::Start:
+            alignment = TextAlignMode::Start;
+            break;
+        case TextAlignLast::End:
+            alignment = TextAlignMode::End;
+            break;
+        case TextAlignLast::Left:
+            alignment = TextAlignMode::Left;
+            break;
+        case TextAlignLast::Right:
+            alignment = TextAlignMode::Right;
+            break;
+        case TextAlignLast::Center:
+            alignment = TextAlignMode::Center;
+            break;
+        case TextAlignLast::Justify:
+            alignment = TextAlignMode::Justify;
+            break;
+        }
+    }
+
+    // text-justify: none forces disable justification, even when text-align(-last) is justify.
+    if (alignment == TextAlignMode::Justify && textJustify() == TextJustify::None)
+        alignment = initialTextAlign();
+
+    return alignment;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -381,6 +381,8 @@ public:
     const Length& textIndent() const { return m_rareInheritedData->indent; }
     TextAlignMode textAlign() const { return static_cast<TextAlignMode>(m_inheritedFlags.textAlign); }
     TextAlignLast textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
+    // Return the effective text alignment for a line based on text-align, text-align-last and text-justify.
+    TextAlignMode effectiveTextAlignForLine(bool isLastLine) const;
     TextTransform textTransform() const { return static_cast<TextTransform>(m_inheritedFlags.textTransform); }
     OptionSet<TextDecorationLine> textDecorationsInEffect() const { return OptionSet<TextDecorationLine>::fromRaw(m_inheritedFlags.textDecorationLines); }
     OptionSet<TextDecorationLine> textDecorationLine() const { return OptionSet<TextDecorationLine>::fromRaw(m_visualData->textDecorationLine); }


### PR DESCRIPTION
#### f1406f73ab89eb2f56a9bb92f39071b518182d1a
<pre>
Move logic to determine effective text alignment into RenderStyle and support text-justify: none
<a href="https://bugs.webkit.org/show_bug.cgi?id=243335">https://bugs.webkit.org/show_bug.cgi?id=243335</a>

Reviewed by NOBODY (OOPS!).

The effective (or actual) text alignment of a line depends on the value of
text-align and text-align-last, and whether the line is the last line in a
block. Previously, the logic to determine the effective  alignment is
duplicated in the legacy layout engine and IFC. This commit moves this logic
into RenderStyle instead to avoid duplication.

One side effect of this change is it makes it easy to implement
&quot;text-justify: none&quot;: when text-justify is none, force the effective
alignment to be the initial value, regardless of the specified alignment
in CSS.

Tests: fast/css3-text/css3-text-justify/text-justify-none.html
       imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-001.html
       imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-none-001.html

* LayoutTests/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::applyRunExpansion):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::horizontalAlignmentOffset):
(WebCore::Layout::LineBoxBuilder::build):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::close):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::textAlignmentForLine const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::effectiveTextAlignForLine const): Add method to determine
the effective text alignment of a line.
* Source/WebCore/rendering/style/RenderStyle.h:
</pre>