### PR TITLE
RTCDtlsTransport should get closed when its peer connection gets closed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDtlsTransport-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDtlsTransport-state-expected.txt
@@ -1,6 +1,6 @@
 
 PASS DTLS transport goes to connected state
-FAIL close() causes the local transport to close immediately assert_equals: expected "closed" but got "connected"
+PASS close() causes the local transport to close immediately
 PASS close() causes the other end's DTLS transport to close
 FAIL stop bundled transceiver retains dtls transport state assert_equals: getReceivers does not expose a receiver of a stopped transceiver expected 1 but got 2
 

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -54,6 +54,8 @@ public:
 
     const RTCDtlsTransportBackend& backend() const { return m_backend.get(); }
 
+    void close() { stop(); }
+
 private:
     RTCDtlsTransport(ScriptExecutionContext&, UniqueRef<RTCDtlsTransportBackend>&&, Ref<RTCIceTransport>&&);
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -577,6 +577,9 @@ bool RTCPeerConnection::doClose()
     }
     m_operations.clear();
 
+    for (auto& transport : m_dtlsTransports)
+        transport->close();
+
     return true;
 }
 


### PR DESCRIPTION
#### 61a20216a8a6f1fa648c28483eeec24eb209d8e0
<pre>
RTCDtlsTransport should get closed when its peer connection gets closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=243337">https://bugs.webkit.org/show_bug.cgi?id=243337</a>

Reviewed by Eric Carlson.

As per <a href="https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-close">https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-close</a>, we should set the DTLS transport state to closed
when peer connection gets closed.
Covered by WPT test.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDtlsTransport-state-expected.txt:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::doClose):
* Source/WebCore/Modules/mediastream/RTCSctpTransport.h:

Canonical link: <a href="https://commits.webkit.org/252948@main">https://commits.webkit.org/252948@main</a>
</pre>
