### PR TITLE
[WebGPU] Add scaffolding to represent WGSL types during semantic analysis

### DIFF
--- a/Source/WebGPU/WGSL/Semantics/Types/AbstractFloat.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/AbstractFloat.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class AbstractFloat : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return makeUniqueRef<AbstractFloat>(span);
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isAbstractFloat();
+    }
+
+    String string() const override
+    {
+        return "AbstractFloat"_s;
+    }
+
+private:
+    AbstractFloat(SourceSpan span)
+        : Type(Type::Kind::AbstractFloat, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(AbstractFloat, isAbstractFloat())

--- a/Source/WebGPU/WGSL/Semantics/Types/AbstractInt.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/AbstractInt.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class AbstractInt : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return makeUniqueRef<AbstractInt>(span);
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isAbstractInt();
+    }
+
+    String string() const override
+    {
+        return "AbstractInt"_s;
+    }
+
+private:
+    AbstractInt(SourceSpan span)
+        : Type(Type::Kind::AbstractInt, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(AbstractInt, isAbstractInt())

--- a/Source/WebGPU/WGSL/Semantics/Types/Array.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Array.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Array.h"
+
+namespace WGSL::Semantics::Types {
+
+static std::optional<Error> checkValidElementType(const Type& type, SourceSpan span)
+{
+    // An array element type MUST be one of:
+
+    // a scalar type
+    if (type.isScalar())
+        return { };
+
+    // a vector type with concrete components
+    if (type.isVector()) {
+        const Vector& vectorType = downcast<Vector>(type);
+        const Type& componentType = vectorType.componentType();
+
+        if (!componentType.isConcrete()) {
+            auto errorMsg = makeString(
+                "element type '",
+                type.string(),
+                "' is a vector with component of type '",
+                componentType.string(),
+                "', which is not concrete"
+            );
+
+            return Error { WTFMove(errorMsg), componentType.span() };
+        }
+
+        return { };
+    }
+
+    // a matrix type with concrete components
+    if (type.isMatrix()) {
+        const Matrix& matrixType = downcast<Matrix>(type);
+        const Type& componentType = matrixType.componentType();
+
+        if (!componentType.isConcrete()) {
+            auto errorMsg = makeString(
+                "element type '",
+                type.string(),
+                "' is a matrix with component of type '",
+                componentType.string(),
+                "', which is not concrete"
+            );
+
+            return Error { WTFMove(errorMsg), componentType.span() };
+        }
+
+        return { };
+    }
+
+    // an atomic type
+    if (type.isAtomic())
+        return { };
+
+    // an array having a creation-fixed footprint.
+    if (type.isArray()) {
+        if (!type.hasCreationFixedFootprint()) {
+            auto errorMsg = makeString(
+                "element type '",
+                type.string(),
+                "' is an array with non-creation-fixed footprint"
+            );
+
+            return Error { WTFMove(errorMsg), type.span() };
+        }
+
+        return { };
+    }
+
+    if (type.isStruct()) {
+        if (!type.hasCreationFixedFootprint()) {
+            auto errorMsg = makeString(
+                "element type '",
+                type.string(),
+                "' is a struct with non-creation-fixed footprint"
+            );
+
+            return Error { WTFMove(errorMsg), type.span() };
+        }
+
+        return { };
+    }
+
+    auto errorMsg = makeString(
+        "element type '",
+        type.string(),
+        "' is not valid as a array element type"
+    );
+
+    return Error { WTFMove(errorMsg), span };
+}
+
+Array::Array(SourceSpan span, UniqueRef<Type> elementType, size_t count)
+    : Type(Type::Kind::Array, span)
+    , m_elementType(WTFMove(elementType))
+    , m_count(count)
+{
+}
+
+Expected<UniqueRef<Type>, Error> Array::tryCreate(SourceSpan span, UniqueRef<Type> elementType, size_t count)
+{
+    if (auto err = checkValidElementType(elementType, span))
+        return makeUnexpected(*err);
+
+    if (!count)
+        return makeUnexpected(Error { "array size must be non-zero"_s, span });
+
+    return { UniqueRef(*new Array(span, WTFMove(elementType), count)) };
+}
+
+bool Array::operator==(const Type &other) const
+{
+    if (!other.isArray())
+        return false;
+
+    const auto& arrayOther = downcast<Array>(other);
+    return (m_elementType.get() == arrayOther.m_elementType.get())
+        && (m_count == arrayOther.m_count);
+}
+
+String Array::string() const
+{
+    return makeString("array<", m_elementType->string(), ",", toString(m_count), ">");
+}
+
+
+} // namespace WGSL::Semantics::Types

--- a/Source/WebGPU/WGSL/Semantics/Types/Array.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Array.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Matrix.h"
+#include "Type.h"
+#include "Vector.h"
+
+namespace WGSL::Semantics::Types {
+
+// Array type.
+// https://gpuweb.github.io/gpuweb/wgsl/#array-types
+// Currently does not support runtime-sized arrays.
+class Array : public Type {
+public:
+    static Expected<UniqueRef<Type>, Error> tryCreate(SourceSpan, UniqueRef<Type> elementType, size_t count);
+
+    bool operator==(const Type &other) const override;
+    String string() const override;
+
+    const Type& elementType() const { return m_elementType; }
+    size_t count() const { return m_count; }
+
+private:
+    Array(SourceSpan, UniqueRef<Type> elementType, size_t count);
+
+    UniqueRef<Type> m_elementType;
+    size_t m_count;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Array, isArray())

--- a/Source/WebGPU/WGSL/Semantics/Types/Atomic.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Atomic.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Atomic.h"
+
+namespace WGSL::Semantics::Types {
+
+static std::optional<Error> checkValidInnerType(const Type& type, SourceSpan span)
+{
+    if (!type.isIntegerScalar()) {
+        auto err = makeString(
+            "'",
+            type.string(),
+            "' is not a integer scalar, required by 'atomic'"
+        );
+
+        return Error { WTFMove(err), span };
+    }
+
+    return { };
+}
+
+Atomic::Atomic(SourceSpan span, UniqueRef<Type> innerType)
+    : Type(Type::Kind::Atomic, span)
+    , m_innerType(WTFMove(innerType))
+{
+}
+
+Expected<UniqueRef<Atomic>, Error> Atomic::tryCreate(SourceSpan span, UniqueRef<Type> innerType)
+{
+    if (auto err = checkValidInnerType(innerType, span))
+        return makeUnexpected(*err);
+
+    // return makeUniqueRef<Atomic>(WTFMove(innerType));
+    return { UniqueRef(*new Atomic(span, WTFMove(innerType))) };
+}
+
+bool Atomic::operator==(const Type& other) const
+{
+    if (!is<Atomic>(other))
+        return false;
+
+    const Atomic& atomicOther = downcast<Atomic>(other);
+
+    return m_innerType.get() == atomicOther.m_innerType.get();
+}
+
+String Atomic::string() const
+{
+    return makeString("atomic<", m_innerType->string(), ">");
+}
+
+} // namespace WGSL::Semantics::Types

--- a/Source/WebGPU/WGSL/Semantics/Types/Atomic.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Atomic.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompilationMessage.h"
+#include "Type.h"
+#include <wtf/Expected.h>
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class Atomic : public Type {
+public:
+    static Expected<UniqueRef<Atomic>, Error> tryCreate(SourceSpan, UniqueRef<Type> innerType);
+
+    bool operator==(const Type& other) const override;
+    String string() const override;
+
+    const Type& innerType() const { return m_innerType; }
+
+private:
+    Atomic(SourceSpan, UniqueRef<Type> innerType);
+
+    UniqueRef<Type> m_innerType;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Atomic, isAtomic());

--- a/Source/WebGPU/WGSL/Semantics/Types/Bool.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Bool.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class Bool : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return UniqueRef(*new Bool(span));
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isBool();
+    }
+
+    String string() const override
+    {
+        return "bool"_s;
+    }
+
+private:
+    Bool(SourceSpan span)
+        : Type(Type::Kind::Bool, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Bool, isBool())

--- a/Source/WebGPU/WGSL/Semantics/Types/F16.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/F16.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class F16 : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return UniqueRef(*new F16(span));
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isF16();
+    }
+
+    String string() const override
+    {
+        return "f16"_s;
+    }
+
+private:
+    F16(SourceSpan span)
+        : Type(Type::Kind::F16, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(F16, isF16())

--- a/Source/WebGPU/WGSL/Semantics/Types/F32.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/F32.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class F32 : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return UniqueRef(*new F32(span));
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isF32();
+    }
+
+    String string() const override
+    {
+        return "f32"_s;
+    }
+
+private:
+    F32(SourceSpan span)
+        : Type(Type::Kind::F32, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(F32, isF32())

--- a/Source/WebGPU/WGSL/Semantics/Types/I32.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/I32.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class I32 : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return UniqueRef(*new I32(span));
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isI32();
+    }
+
+    String string() const override
+    {
+        return "i32"_s;
+    }
+
+private:
+    I32(SourceSpan span)
+        : Type(Type::Kind::I32, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(I32, isU32())

--- a/Source/WebGPU/WGSL/Semantics/Types/Matrix.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Matrix.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Matrix.h"
+
+namespace WGSL::Semantics::Types {
+
+static std::optional<Error> checkValidComponentType(const Type& type, SourceSpan span)
+{
+    if (!type.isF32() && !type.isF16() && !type.isAbstractFloat()) {
+        auto err = makeString(
+            "matrix component type '",
+            type.string(),
+            "' is neither f32, f15, nor abstract float"
+        );
+
+        return Error { WTFMove(err), span };
+    }
+
+    return { };
+}
+
+static std::optional<Error> checkValidColCount(uint8_t size, SourceSpan span)
+{
+    if (size != 2 && size != 3 && size != 4)
+        return { Error { "matrix column size must either be 2, 3, or 4"_s, span } };
+
+    return { };
+}
+
+static std::optional<Error> checkValidRowCount(uint8_t size, SourceSpan span)
+{
+    if (size != 2 && size != 3 && size != 4)
+        return { Error { "matrix row size must either be 2, 3, or 4"_s, span } };
+
+    return { };
+}
+
+Matrix::Matrix(SourceSpan span, UniqueRef<Type> componentType, uint8_t colCount, uint8_t rowCount)
+    : Type(Type::Kind::Matrix, span)
+    , m_componentType(WTFMove(componentType))
+    , m_colCount(colCount)
+    , m_rowCount(rowCount)
+{
+}
+
+Expected<UniqueRef<Type>, Error> Matrix::tryCreate(SourceSpan span, UniqueRef<Type> componentType, uint8_t colCount, uint8_t rowCount)
+{
+    if (auto err = checkValidComponentType(componentType, span))
+        return makeUnexpected(*err);
+
+    if (auto err = checkValidColCount(colCount, span))
+        return makeUnexpected(*err);
+
+    if (auto err = checkValidRowCount(rowCount, span))
+        return makeUnexpected(*err);
+
+    // return { makeUniqueRef<Matrix>(span, WTFMove(componentType), colCount, rowCount) };
+    return { UniqueRef(*new Matrix(span, WTFMove(componentType), colCount, rowCount)) };
+}
+
+bool Matrix::operator==(const Type& other) const
+{
+    if (!other.isMatrix())
+        return false;
+
+    const auto& matrixOther = downcast<Matrix>(other);
+    return (m_componentType.get() == matrixOther.m_componentType.get())
+        && (m_colCount == matrixOther.m_colCount)
+        && (m_rowCount == matrixOther.m_rowCount);
+}
+
+String Matrix::string() const
+{
+    return makeString("mat", toString(m_colCount), "x", toString(m_rowCount), "<", m_componentType->string(), ">");
+}
+
+}

--- a/Source/WebGPU/WGSL/Semantics/Types/Matrix.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Matrix.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompilationMessage.h"
+#include "Type.h"
+#include <wtf/StringPrintStream.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace WGSL::Semantics::Types {
+
+class Matrix : public Type {
+public:
+    static Expected<UniqueRef<Type>, Error> tryCreate(SourceSpan, UniqueRef<Type> componentType, uint8_t colCount, uint8_t rowCount);
+
+    bool operator==(const Type& other) const override;
+    String string() const override;
+
+    const Type& componentType() const { return m_componentType; }
+    uint8_t colCount() const { return m_colCount; }
+    uint8_t rowCount() const { return m_rowCount; }
+
+private:
+    Matrix(SourceSpan, UniqueRef<Type> componentType, uint8_t colCount, uint8_t rowCount);
+
+    UniqueRef<Type> m_componentType;
+    uint8_t m_colCount;
+    uint8_t m_rowCount;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Matrix, isMatrix())

--- a/Source/WebGPU/WGSL/Semantics/Types/Struct.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Struct.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Struct.h"
+
+namespace WGSL::Semantics::Types {
+
+static std::optional<Error> checkStructMemberType(SourceSpan span, const Type& type)
+{
+    if (type.isScalar() || type.isVector() || type.isMatrix() || type.isAtomic())
+        return { };
+
+    // TODO: support runtime-sized array
+    if (type.isArray()) {
+        if (!type.hasCreationFixedFootprint()) {
+            auto err = makeString(
+                "struct member type '",
+                type.string(),
+                "' is an array, but does not have creation-fixed footprint"
+            );
+
+            return Error { WTFMove(err), type.span() };
+        }
+
+        return { };
+    }
+
+    if (type.isStruct()) {
+        if (!type.hasCreationFixedFootprint()) {
+            auto err = makeString(
+                "struct member type '",
+                type.string(),
+                "' is a struct, but does not have creation-fixed footprint"
+            );
+
+            return Error { WTFMove(err), type.span() };
+        }
+
+        return { };
+    }
+
+    auto err = makeString(
+        "'",
+        type.string(),
+        "' can't be used as struct member type"
+    );
+
+    return Error { WTFMove(err), span };
+}
+
+StructMember::StructMember(SourceSpan span, UniqueRef<Type> type)
+    : m_span(span)
+    , m_type(WTFMove(type))
+{
+}
+
+Expected<StructMember, Error> StructMember::tryCreate(SourceSpan span, UniqueRef<Type> type)
+{
+    if (auto err = checkStructMemberType(span, type))
+        return makeUnexpected(*err);
+
+    return StructMember { span, WTFMove(type) };
+}
+
+Struct::Struct(SourceSpan span, String name, Vector<StructMember>&& members)
+    : Type(Type::Kind::Struct, span)
+    , m_name(WTFMove(name))
+    , m_members(WTFMove(members))
+{
+}
+
+UniqueRef<Type> Struct::create(SourceSpan span, String name, Vector<StructMember>&& members)
+{
+    // return makeUniqueRef<Struct>(span, WTFMove(name), WTFMove(members));
+    return { UniqueRef(*new Struct(span, WTFMove(name), WTFMove(members))) };
+}
+
+bool Struct::operator==(const Type &other) const
+{
+    if (!other.isStruct())
+        return false;
+
+    const auto& structOther = downcast<Struct>(other);
+
+    // TODO: assume that all structs have unique name, so comparing
+    // name is enough. Check if assumption is true.
+    return m_name == structOther.m_name;
+}
+
+String Struct::string() const
+{
+    return makeString("struct ", m_name);
+}
+
+} // namespace WGSL::Semantics::Types

--- a/Source/WebGPU/WGSL/Semantics/Types/Struct.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Struct.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
+
+namespace WGSL::Semantics::Types {
+
+class StructMember {
+    static Expected<StructMember, Error> tryCreate(SourceSpan, UniqueRef<Type>);
+
+    SourceSpan span() const { return m_span; }
+    const Type& type() const { return m_type; }
+
+private:
+    StructMember(SourceSpan, UniqueRef<Type>);
+
+    // TODO: member attributes.
+    SourceSpan m_span;
+    UniqueRef<Type> m_type;
+};
+
+class Struct : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan, String name, Vector<StructMember>&& m_members);
+
+    bool operator==(const Type &other) const override;
+    String string() const override;
+
+    const String& name() const { return m_name; }
+    const Vector<StructMember>& members() const { return m_members; }
+
+private:
+    Struct(SourceSpan, String name, Vector<StructMember>&& members);
+
+    String m_name;
+    Vector<StructMember> m_members;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Struct, isStruct())

--- a/Source/WebGPU/WGSL/Semantics/Types/Texture.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Texture.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Texture.h"
+
+namespace WGSL::Semantics::Types {
+
+Texture::Texture(SourceSpan span, Dimension dimension, UniqueRef<Type> componentType)
+    : Type(Type::Kind::Texture, span)
+    , m_dimension(dimension)
+    , m_componentType(WTFMove(componentType))
+{
+}
+
+Expected<UniqueRef<Type>, Error> Texture::tryCreate(SourceSpan span, Dimension dimension, UniqueRef<Type> componentType)
+{
+    if (!componentType->isF32() && !componentType->isI32() && !componentType->isU32()) {
+        auto err = makeString(
+            "texture component type '",
+            componentType->string(),
+            "' is not f32, i32 or u32"
+        );
+
+        return makeUnexpected(Error { WTFMove(err), componentType->span() });
+    }
+
+    // return { makeUniqueRef<Texture>(span, dimension, WTFMove(componentType)) };
+    return { UniqueRef(*new Texture(span, dimension, WTFMove(componentType))) };
+}
+
+bool Texture::operator==(const Type &other) const
+{
+    if (!other.isTexture())
+        return false;
+
+    const auto& textureOther = downcast<Texture>(other);
+    return (m_dimension == textureOther.m_dimension)
+        && (m_componentType.get() == textureOther.m_componentType.get());
+}
+
+} // namespace WGSL::Semantics::Types

--- a/Source/WebGPU/WGSL/Semantics/Types/Texture.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Texture.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class Texture : public Type {
+public:
+    enum class Dimension {
+        _1d,
+        _2d,
+        _2dArray,
+        _3d,
+        Cube,
+        CubeArray
+    };
+
+    Expected<UniqueRef<Type>, Error> tryCreate(SourceSpan, Dimension, UniqueRef<Type> componentType);
+
+    bool operator==(const Type& other) const override;
+    String string() const override;
+
+    Dimension dimension() const { return m_dimension; }
+    const Type& componentType() const { return m_componentType; }
+
+private:
+    Texture(SourceSpan, Dimension, UniqueRef<Type> componentType);
+
+    Dimension m_dimension;
+    UniqueRef<Type> m_componentType;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Texture, isTexture())

--- a/Source/WebGPU/WGSL/Semantics/Types/Type.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Type.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Type.h"
+
+#include "Array.h"
+#include "Matrix.h"
+#include "Vector.h"
+
+namespace WGSL::Semantics::Types {
+
+Type::Type(Kind kind, SourceSpan span)
+    : m_kind(kind)
+    , m_span(span)
+{
+}
+
+bool Type::isIntegerScalar() const
+{
+    return isI32() || isU32();
+}
+
+// TODO for code review: should this logic be implemented entirely here,
+// or should we delegate the logic to individual types.
+bool Type::isConcrete() const
+{
+    // A concrete type is not a abstract numberic type...
+    if (isAbstractInt() || isAbstractFloat())
+        return false;
+
+    // nor a container type that contains an abstract numberic type...
+
+    // vector without abstract numeric elements.
+    if (isVector()) {
+        const auto& vectorThis = downcast<Vector>(*this);
+        return !vectorThis.componentType().isAbstractNumeric();
+    }
+
+    // Matrix without abstract numeric elements.
+    if (isMatrix()) {
+        const auto& matrixThis = downcast<Matrix>(*this);
+        return !matrixThis.componentType().isAbstractNumeric();
+    }
+
+    // atomic
+    if (isAtomic())
+        return true;
+
+    // fixed-size array without abstract numeric elements.
+    if (isArray()) {
+        const auto& arrayThis = downcast<Array>(*this);
+        return !arrayThis.elementType().isAbstractNumeric();
+    }
+
+    // structure, when all members are not abstract numeric elements.
+    // TODO: implement this.
+    if (isStruct())
+        return true;
+
+    return false;
+}
+
+bool Type::isScalar() const
+{
+    return isBool() || isI32() || isU32() || isF32() || isF16();
+}
+
+bool Type::isAbstractNumeric() const
+{
+    return isAbstractInt() || isAbstractFloat();
+}
+
+// TODO for code review: should this logic be implemented entirely here,
+// or should we delegate the logic to individual types.
+bool Type::hasCreationFixedFootprint() const
+{
+    // A type has creation-fixed footprint when it's a ...
+
+    // scalar type
+    if (isScalar())
+        return true;
+
+    // vector with concrete components
+    if (isVector()) {
+        const auto& vectorThis = downcast<Vector>(*this);
+        return vectorThis.componentType().isConcrete();
+    }
+
+    // matrix with concrete components
+    if (isMatrix()) {
+        const auto& matrixThis = downcast<Matrix>(*this);
+        return matrixThis.componentType().isConcrete();
+    }
+
+    // atomic
+    if (isAtomic())
+        return true;
+
+    // fixed-size array, when the element count is a creation-time
+    // expression.
+    // TODO: fix this when we support pipeline overridables as element count.
+    if (isArray())
+        return true;
+
+    // structure, when all members has creation-fixed footprint.
+    // TODO: implement this.
+    if (isStruct())
+        return true;
+
+    return false;
+}
+
+} // namespace WGSL::Semantics::Type

--- a/Source/WebGPU/WGSL/Semantics/Types/Type.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Type.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompilationMessage.h"
+#include <wtf/TypeCasts.h>
+#include <wtf/text/StringConcatenate.h>
+#include <wtf/text/WTFString.h>
+
+namespace WGSL::Semantics::Types {
+
+class Type {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    enum class Kind {
+        Bool,
+
+        // Creation-time constant types.
+        AbstractInt,
+        AbstractFloat,
+
+        // Integer types.
+        U32, // NOLINT
+        I32, // NOLINT
+
+        // Floating point types.
+        F32, // NOLINT
+        F16, // NOLINT
+
+        Atomic,
+
+        // Structure types.
+        Vector,
+        Matrix,
+        Array,
+        Struct,
+
+        // Textures.
+        Texture,
+        MultisampledTexture,
+        StorageTexture,
+        DepthTexture,
+
+        // Samplers.
+        Sampler,
+        ComparisonSampler,
+
+        Pointer
+    };
+
+    virtual ~Type() { }
+
+    virtual bool operator==(const Type &other) const = 0;
+    virtual String string() const = 0;
+
+    Kind kind() const { return m_kind; }
+
+    bool isBool() const { return kind() == Kind::Bool; }
+    bool isAbstractInt() const { return kind() == Kind::AbstractInt; }
+    bool isAbstractFloat() const { return kind() == Kind::AbstractFloat; }
+    bool isU32() const { return kind() == Kind::U32; }
+    bool isI32() const { return kind() == Kind::I32; }
+    bool isF32() const { return kind() == Kind::F32; }
+    bool isF16() const { return kind() == Kind::F16; }
+    bool isAtomic() const { return kind() == Kind::Atomic; }
+    bool isVector() const { return kind() == Kind::Vector; }
+    bool isMatrix() const { return kind() == Kind::Matrix; }
+    bool isArray() const { return kind() == Kind::Array; }
+    bool isStruct() const { return kind() == Kind::Struct; }
+    bool isTexture() const { return kind() == Kind::Texture; }
+    bool isMultisampledTexture() const { return kind() == Kind::MultisampledTexture; }
+    bool isStorageTexture() const { return kind() == Kind::StorageTexture; }
+    bool isDepthTexture() const { return kind() == Kind::DepthTexture; }
+    bool isSampler() const { return kind() == Kind::Sampler; }
+    bool isComparisonSampler() const { return kind() == Kind::ComparisonSampler; }
+    bool isPointer() const { return kind() == Kind::Pointer; }
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#integer-scalar
+    bool isIntegerScalar() const;
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#concrete
+    bool isConcrete() const;
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#scalar
+    bool isScalar() const;
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#abstract-numeric-types
+    bool isAbstractNumeric() const;
+
+    // https://gpuweb.github.io/gpuweb/wgsl/#creation-fixed-footprint
+    bool hasCreationFixedFootprint() const;
+
+    SourceSpan span() const { return m_span; }
+
+protected:
+    Type(Kind, SourceSpan);
+
+    Kind m_kind;
+
+    // The source span where the type is defined. This is intended to be used
+    // to produce diagnostic messages.
+    // For example:
+    //   * The span of an Abstract(Float|Int) is the constant literal
+    //   * The span of a type of an identifier type is either the type declaration,
+    //     or the initial value of that identifier when it's declared.
+    //   * The span of a type of an expression is the entire expression.
+    SourceSpan m_span;
+};
+
+} // namespace WGSL::Semantics::Types
+
+namespace WTF {
+
+using WGSL::Semantics::Types::Type;
+
+template<> class StringTypeAdapter<const Type&, void> : public StringTypeAdapter<String, void> {
+public:
+    StringTypeAdapter(const Type& type)
+        : StringTypeAdapter<String, void>(type.string())
+    {
+    }
+};
+
+} // namespace WTF
+
+#define SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::Semantics::Types::ToValueTypeName) \
+    static bool isType(const WGSL::Semantics::Types::Type& type) { return type.predicate; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebGPU/WGSL/Semantics/Types/U32.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/U32.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+#include <wtf/UniqueRef.h>
+
+namespace WGSL::Semantics::Types {
+
+class U32 : public Type {
+public:
+    static UniqueRef<Type> create(SourceSpan span)
+    {
+        return UniqueRef(*new U32(span));
+    }
+
+    bool operator==(const Type &other) const override
+    {
+        return other.isU32();
+    }
+
+    String string() const override
+    {
+        return "u32"_s;
+    }
+
+private:
+    U32(SourceSpan span)
+        : Type(Type::Kind::U32, span)
+    {
+    }
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(U32, isU32())

--- a/Source/WebGPU/WGSL/Semantics/Types/Vector.cpp
+++ b/Source/WebGPU/WGSL/Semantics/Types/Vector.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Vector.h"
+
+namespace WGSL::Semantics::Types {
+
+static std::optional<Error> checkValidComponentType(const Type& type, SourceSpan span)
+{
+    if (!type.isScalar() && !type.isAbstractNumeric()) {
+        auto err = makeString(
+            "vector component type '",
+            type.string(),
+            "' is neither a scalar nor abstract numeric type");
+
+        return Error { WTFMove(err), span };
+    }
+
+    return { };
+}
+
+static std::optional<Error> checkValidSize(uint8_t size, SourceSpan span)
+{
+    if (size != 2 && size != 3 && size != 4)
+        return Error { "vector size must either be 2, 3, or 4"_s, span };
+
+    return { };
+}
+
+Vector::Vector(SourceSpan span, UniqueRef<Type> componentType, uint8_t size)
+    : Type(Type::Kind::Vector, span)
+    , m_componentType(WTFMove(componentType))
+    , m_size(size)
+{
+}
+
+Expected<UniqueRef<Type>, Error> Vector::tryCreate(SourceSpan span, UniqueRef<Type> componentType, uint8_t size)
+{
+    if (auto err = checkValidComponentType(componentType, span))
+        return makeUnexpected(*err);
+
+    if (auto err = checkValidSize(size, span))
+        return makeUnexpected(*err);
+
+    // return { makeUniqueRef<Vector>(span, WTFMove(componentType), size) };
+    return { UniqueRef(*new Vector(span, WTFMove(componentType), size)) };
+}
+
+bool Vector::operator==(const Type& other) const
+{
+    if (!other.isVector())
+        return false;
+
+    const auto& vectorOther = downcast<Vector>(other);
+    return (m_componentType.get() == vectorOther.m_componentType.get())
+        && (m_size == vectorOther.m_size);
+}
+
+String Vector::string() const
+{
+    return makeString("vec", toString(m_size), "<", m_componentType->string(), ">");
+}
+
+} // namespace WGSL::Semantics::Types

--- a/Source/WebGPU/WGSL/Semantics/Types/Vector.h
+++ b/Source/WebGPU/WGSL/Semantics/Types/Vector.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompilationMessage.h"
+#include "Type.h"
+#include <wtf/StringPrintStream.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace WGSL::Semantics::Types {
+
+class Vector : public Type {
+public:
+    static Expected<UniqueRef<Type>, Error> tryCreate(SourceSpan, UniqueRef<Type> componentType, uint8_t size);
+
+    bool operator==(const Type& other) const override;
+    String string() const override;
+
+    const Type& componentType() const { return m_componentType; }
+    uint8_t size() const { return m_size; }
+
+private:
+    Vector(SourceSpan, UniqueRef<Type> componentType, uint8_t size);
+
+    UniqueRef<Type> m_componentType;
+    uint8_t m_size;
+};
+
+} // namespace WGSL::Semantics::Types
+
+SPECIALIZE_TYPE_TRAITS_WGSL_SEMANTICS_TYPES(Vector, isVector())

--- a/Source/WebGPU/WGSLUnitTests/Semantics/Types/ArrayTest.mm
+++ b/Source/WebGPU/WGSLUnitTests/Semantics/Types/ArrayTest.mm
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Array.h"
+
+#import "Bool.h"
+#import "F16.h"
+#import "F32.h"
+#import "I32.h"
+#import "U32.h"
+#import "Vector.h"
+#import <XCTest/XCTest.h>
+
+using namespace WGSL::Semantics;
+
+@interface ArrayTest : XCTestCase
+
+@end
+
+@implementation ArrayTest
+
+- (void)setUp {
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)testCreateScalarElement {
+    WGSL::SourceSpan span { 0, 1, 2, 3 };
+
+    auto boolArray = Types::Array::tryCreate(span, Types::Bool::create(span), 10);
+    auto i32Array = Types::Array::tryCreate(span, Types::I32::create(span), 10);
+    auto u32Array = Types::Array::tryCreate(span, Types::U32::create(span), 10);
+    auto f32Array = Types::Array::tryCreate(span, Types::F32::create(span), 10);
+    auto f16Array = Types::Array::tryCreate(span, Types::F16::create(span), 10);
+
+    XCTAssert(boolArray);
+    XCTAssert(i32Array);
+    XCTAssert(u32Array);
+    XCTAssert(f32Array);
+    XCTAssert(f16Array);
+}
+
+- (void)testCreateVectorWithConcreteElements {
+    WGSL::SourceSpan span { 0, 1, 2, 3 };
+
+    {
+        auto vectorOfI32 = Types::Vector::tryCreate(span, Types::I32::create(span), 4);
+        XCTAssert(vectorOfI32);
+
+        auto vectorOfI32Array = Types::Array::tryCreate(span, WTFMove(*vectorOfI32), 10);
+        XCTAssert(vectorOfI32Array);
+    }
+
+    {
+        auto vectorOfI32 = Types::Vector::tryCreate(span, Types::I32::create(span), 4);
+        XCTAssert(vectorOfI32);
+
+        auto vectorOfVectorOfI32 = Types::Vector::tryCreate(span, WTFMove(*vectorOfI32), 4);
+        XCTAssert(vectorOfVectorOfI32);
+
+        auto vectorOfI32Array = Types::Array::tryCreate(span, WTFMove(*vectorOfVectorOfI32), 10);
+        XCTAssert(vectorOfI32Array);
+    }
+}
+
+@end

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -78,9 +78,31 @@
 		33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* StructureAccess.h */; };
 		33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* CallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* LiteralExpressions.h */; };
+		661D45E92852D7C600F1F751 /* Vector.h in Headers */ = {isa = PBXBuildFile; fileRef = 661D45E82852D7C600F1F751 /* Vector.h */; };
 		6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6634666A285F0140002ABE8E /* ConstLiteralTests.mm */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
+		66B361EE285748F800C4CCE9 /* Array.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361E2285748F700C4CCE9 /* Array.cpp */; };
+		66B361F1285748F800C4CCE9 /* Atomic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361E5285748F800C4CCE9 /* Atomic.cpp */; };
+		66B361F2285748F800C4CCE9 /* Struct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361E6285748F800C4CCE9 /* Struct.cpp */; };
+		66B361F3285748F800C4CCE9 /* Texture.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B361E7285748F800C4CCE9 /* Texture.h */; };
+		66B361F5285748F800C4CCE9 /* Vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361E9285748F800C4CCE9 /* Vector.cpp */; };
+		66B361F6285748F800C4CCE9 /* Matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361EA285748F800C4CCE9 /* Matrix.cpp */; };
+		66B361F7285748F800C4CCE9 /* Struct.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B361EB285748F800C4CCE9 /* Struct.h */; };
+		66B361F8285748F800C4CCE9 /* Texture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66B361EC285748F800C4CCE9 /* Texture.cpp */; };
+		66B361FC28574D6300C4CCE9 /* ArrayTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 66B361FB28574D6300C4CCE9 /* ArrayTest.mm */; };
+		66B361FF2857513C00C4CCE9 /* F16.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B361FD2857513C00C4CCE9 /* F16.h */; };
+		66B362002857513C00C4CCE9 /* F32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66B361FE2857513C00C4CCE9 /* F32.h */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
+		66F2810E2852BBC500E4D4B1 /* Type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66F2810C2852BBC500E4D4B1 /* Type.cpp */; };
+		66F2810F2852BBC500E4D4B1 /* Type.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2810D2852BBC500E4D4B1 /* Type.h */; };
+		66F281112852C1E700E4D4B1 /* Bool.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F281102852C1E700E4D4B1 /* Bool.h */; };
+		66F281132852C66700E4D4B1 /* U32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F281122852C66700E4D4B1 /* U32.h */; };
+		66F281152852C6AE00E4D4B1 /* I32.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F281142852C6AE00E4D4B1 /* I32.h */; };
+		66F281182852C9E100E4D4B1 /* AbstractInt.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F281162852C9E100E4D4B1 /* AbstractInt.h */; };
+		66F281192852C9E100E4D4B1 /* AbstractFloat.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F281172852C9E100E4D4B1 /* AbstractFloat.h */; };
+		66F2811E2852CDB800E4D4B1 /* Atomic.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2811A2852CDB800E4D4B1 /* Atomic.h */; };
+		66F2811F2852CDB800E4D4B1 /* Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2811B2852CDB800E4D4B1 /* Array.h */; };
+		66F281202852CDB800E4D4B1 /* Matrix.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F2811C2852CDB800E4D4B1 /* Matrix.h */; };
 		DD05A35C27BF09C60096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1CEBD8292716CAE700A5254D /* libWTF.a */; };
 /* End PBXBuildFile section */
 
@@ -335,9 +357,31 @@
 		33EA188327BC268600A1DD52 /* StructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructureAccess.h; sourceTree = "<group>"; };
 		33EA188527BC26DF00A1DD52 /* CallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* LiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LiteralExpressions.h; sourceTree = "<group>"; };
+		661D45E82852D7C600F1F751 /* Vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vector.h; sourceTree = "<group>"; };
 		6634666A285F0140002ABE8E /* ConstLiteralTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConstLiteralTests.mm; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		66B361E2285748F700C4CCE9 /* Array.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Array.cpp; sourceTree = "<group>"; };
+		66B361E5285748F800C4CCE9 /* Atomic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Atomic.cpp; sourceTree = "<group>"; };
+		66B361E6285748F800C4CCE9 /* Struct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Struct.cpp; sourceTree = "<group>"; };
+		66B361E7285748F800C4CCE9 /* Texture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Texture.h; sourceTree = "<group>"; };
+		66B361E9285748F800C4CCE9 /* Vector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Vector.cpp; sourceTree = "<group>"; };
+		66B361EA285748F800C4CCE9 /* Matrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Matrix.cpp; sourceTree = "<group>"; };
+		66B361EB285748F800C4CCE9 /* Struct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Struct.h; sourceTree = "<group>"; };
+		66B361EC285748F800C4CCE9 /* Texture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Texture.cpp; sourceTree = "<group>"; };
+		66B361FB28574D6300C4CCE9 /* ArrayTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ArrayTest.mm; sourceTree = "<group>"; };
+		66B361FD2857513C00C4CCE9 /* F16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = F16.h; sourceTree = "<group>"; };
+		66B361FE2857513C00C4CCE9 /* F32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = F32.h; sourceTree = "<group>"; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
+		66F2810C2852BBC500E4D4B1 /* Type.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Type.cpp; sourceTree = "<group>"; };
+		66F2810D2852BBC500E4D4B1 /* Type.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Type.h; sourceTree = "<group>"; };
+		66F281102852C1E700E4D4B1 /* Bool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bool.h; sourceTree = "<group>"; };
+		66F281122852C66700E4D4B1 /* U32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = U32.h; sourceTree = "<group>"; };
+		66F281142852C6AE00E4D4B1 /* I32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = I32.h; sourceTree = "<group>"; };
+		66F281162852C9E100E4D4B1 /* AbstractInt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AbstractInt.h; sourceTree = "<group>"; };
+		66F281172852C9E100E4D4B1 /* AbstractFloat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AbstractFloat.h; sourceTree = "<group>"; };
+		66F2811A2852CDB800E4D4B1 /* Atomic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Atomic.h; sourceTree = "<group>"; };
+		66F2811B2852CDB800E4D4B1 /* Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Array.h; sourceTree = "<group>"; };
+		66F2811C2852CDB800E4D4B1 /* Matrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Matrix.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -383,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				6664847F28596A3E008FB60E /* Parser */,
+				66B361F928574C8800C4CCE9 /* Semantics */,
 				1C023D3E27449070001DB734 /* WGSLLexerTests.mm */,
 				339B7B1C27D80A1C0072BF9A /* WGSLParserTests.mm */,
 			);
@@ -646,6 +691,7 @@
 			isa = PBXGroup;
 			children = (
 				33EA185C27BC193D00A1DD52 /* AST */,
+				66F2810A2852B98200E4D4B1 /* Semantics */,
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
@@ -744,6 +790,58 @@
 			path = Parser;
 			sourceTree = "<group>";
 		};
+		66B361F928574C8800C4CCE9 /* Semantics */ = {
+			isa = PBXGroup;
+			children = (
+				66B361FA28574C8D00C4CCE9 /* Types */,
+			);
+			path = Semantics;
+			sourceTree = "<group>";
+		};
+		66B361FA28574C8D00C4CCE9 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				66B361FB28574D6300C4CCE9 /* ArrayTest.mm */,
+			);
+			path = Types;
+			sourceTree = "<group>";
+		};
+		66F2810A2852B98200E4D4B1 /* Semantics */ = {
+			isa = PBXGroup;
+			children = (
+				66F2810B2852B99200E4D4B1 /* Types */,
+			);
+			path = Semantics;
+			sourceTree = "<group>";
+		};
+		66F2810B2852B99200E4D4B1 /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				66F281172852C9E100E4D4B1 /* AbstractFloat.h */,
+				66F281162852C9E100E4D4B1 /* AbstractInt.h */,
+				66B361E2285748F700C4CCE9 /* Array.cpp */,
+				66F2811B2852CDB800E4D4B1 /* Array.h */,
+				66B361E5285748F800C4CCE9 /* Atomic.cpp */,
+				66F2811A2852CDB800E4D4B1 /* Atomic.h */,
+				66F281102852C1E700E4D4B1 /* Bool.h */,
+				66B361FD2857513C00C4CCE9 /* F16.h */,
+				66B361FE2857513C00C4CCE9 /* F32.h */,
+				66F281142852C6AE00E4D4B1 /* I32.h */,
+				66B361EA285748F800C4CCE9 /* Matrix.cpp */,
+				66F2811C2852CDB800E4D4B1 /* Matrix.h */,
+				66B361E6285748F800C4CCE9 /* Struct.cpp */,
+				66B361EB285748F800C4CCE9 /* Struct.h */,
+				66B361EC285748F800C4CCE9 /* Texture.cpp */,
+				66B361E7285748F800C4CCE9 /* Texture.h */,
+				66F2810C2852BBC500E4D4B1 /* Type.cpp */,
+				66F2810D2852BBC500E4D4B1 /* Type.h */,
+				66F281122852C66700E4D4B1 /* U32.h */,
+				66B361E9285748F800C4CCE9 /* Vector.cpp */,
+				661D45E82852D7C600F1F751 /* Vector.h */,
+			);
+			path = Types;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -769,26 +867,40 @@
 				33EA185E27BC194F00A1DD52 /* ASTNode.h in Headers */,
 				33EA186A27BC1BE600A1DD52 /* Attribute.h in Headers */,
 				33EA188627BC26DF00A1DD52 /* CallableExpression.h in Headers */,
+				66F2811F2852CDB800E4D4B1 /* Array.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				33EA187B27BC230E00A1DD52 /* CompoundStatement.h in Headers */,
+				66F281132852C66700E4D4B1 /* U32.h in Headers */,
+				66F281202852CDB800E4D4B1 /* Matrix.h in Headers */,
+				66B361F3285748F800C4CCE9 /* Texture.h in Headers */,
+				66F281112852C1E700E4D4B1 /* Bool.h in Headers */,
 				33EA186C27BC1CBC00A1DD52 /* Expression.h in Headers */,
 				33EA187627BC216B00A1DD52 /* FunctionDecl.h in Headers */,
 				33EA186227BC19C100A1DD52 /* GlobalDecl.h in Headers */,
 				33EA186027BC198100A1DD52 /* GlobalDirective.h in Headers */,
 				33EA186427BC1A1D00A1DD52 /* GlobalVariableDecl.h in Headers */,
+				661D45E92852D7C600F1F751 /* Vector.h in Headers */,
+				66F2810F2852BBC500E4D4B1 /* Type.h in Headers */,
+				66F281192852C9E100E4D4B1 /* AbstractFloat.h in Headers */,
 				33EA188227BC25D000A1DD52 /* IdentifierExpression.h in Headers */,
+				66B362002857513C00C4CCE9 /* F32.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				33EA188827BC361E00A1DD52 /* LiteralExpressions.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
 				66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */,
+				66F281182852C9E100E4D4B1 /* AbstractInt.h in Headers */,
+				66B361FF2857513C00C4CCE9 /* F16.h in Headers */,
 				33EA187E27BC249000A1DD52 /* ReturnStatement.h in Headers */,
 				33EA187027BC1E8A00A1DD52 /* ShaderModule.h in Headers */,
+				66B361F7285748F800C4CCE9 /* Struct.h in Headers */,
 				338BB2D227B6B63F00E066AB /* SourceSpan.h in Headers */,
 				33EA187927BC22AA00A1DD52 /* Statement.h in Headers */,
 				33EA188427BC268600A1DD52 /* StructureAccess.h in Headers */,
 				33EA187427BC204900A1DD52 /* StructureDecl.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
+				66F2811E2852CDB800E4D4B1 /* Atomic.h in Headers */,
 				33EA186E27BC1D4C00A1DD52 /* TypeDecl.h in Headers */,
+				66F281152852C6AE00E4D4B1 /* I32.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* VariableQualifier.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
 			);
@@ -1000,6 +1112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6634666B285F0140002ABE8E /* ConstLiteralTests.mm in Sources */,
+				66B361FC28574D6300C4CCE9 /* ArrayTest.mm in Sources */,
 				1C023D3F27449070001DB734 /* WGSLLexerTests.mm in Sources */,
 				339B7B1D27D80A1C0072BF9A /* WGSLParserTests.mm in Sources */,
 			);
@@ -1049,11 +1162,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				66B361F1285748F800C4CCE9 /* Atomic.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
+				66B361F6285748F800C4CCE9 /* Matrix.cpp in Sources */,
+				66B361F5285748F800C4CCE9 /* Vector.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,
+				66B361F2285748F800C4CCE9 /* Struct.cpp in Sources */,
+				66F2810E2852BBC500E4D4B1 /* Type.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
+				66B361F8285748F800C4CCE9 /* Texture.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,
+				66B361EE285748F800C4CCE9 /* Array.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### 1ee3c21ca8b1a37ebac878217380aec185b20a30
<pre>
[WebGPU] Add scaffolding to represent WGSL types during semantic analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=243336">https://bugs.webkit.org/show_bug.cgi?id=243336</a>

Reviewed by NOBODY (OOPS!).

These classes are used to represent types in WGSL programs. Generally speaking,
types are divided into two groups:

* Primitive, non-parametric types: Types that don&apos;t accept parameters like i32,
f32, bool. Objects of these types are always valid, and can be created by calling
the ::create() static methods.

* Parametric types: Types that accepts parameters. For example, array&lt;&gt; or vec&lt;&gt;
accepts a type representing the element type. Because there are restrictions on
what value of parameters should be allowed (for example, element type of an array&lt;&gt;
must be concrete), these types are instead created by calling the ::tryCreate
static methods. ::tryCreate validates the parameter values and only creates the
type object if the parameters are valid. Otherwise, it returns an error message
that can be reported to the user.

&quot;Type&quot; is the root class that every other type classes inherit from.

* Source/WebGPU/WGSL/Semantics/Types/AbstractFloat.h: Added.
(WGSL::Semantics::Types::AbstractFloat::create):
(WGSL::Semantics::Types::AbstractFloat::AbstractFloat):
* Source/WebGPU/WGSL/Semantics/Types/AbstractInt.h: Added.
(WGSL::Semantics::Types::AbstractInt::create):
(WGSL::Semantics::Types::AbstractInt::AbstractInt):
* Source/WebGPU/WGSL/Semantics/Types/Array.cpp: Added.
(WGSL::Semantics::Types::checkValidElementType):
(WGSL::Semantics::Types::Array::Array):
(WGSL::Semantics::Types::Array::tryCreate):
(WGSL::Semantics::Types::Array::operator== const):
(WGSL::Semantics::Types::Array::string const):
* Source/WebGPU/WGSL/Semantics/Types/Array.h: Added.
(WGSL::Semantics::Types::Array::elementType const):
(WGSL::Semantics::Types::Array::count const):
* Source/WebGPU/WGSL/Semantics/Types/Atomic.cpp: Added.
(WGSL::Semantics::Types::checkValidInnerType):
(WGSL::Semantics::Types::Atomic::Atomic):
(WGSL::Semantics::Types::Atomic::tryCreate):
(WGSL::Semantics::Types::Atomic::operator== const):
(WGSL::Semantics::Types::Atomic::string const):
* Source/WebGPU/WGSL/Semantics/Types/Atomic.h: Added.
(WGSL::Semantics::Types::Atomic::innerType const):
* Source/WebGPU/WGSL/Semantics/Types/Bool.h: Added.
(WGSL::Semantics::Types::Bool::create):
(WGSL::Semantics::Types::Bool::Bool):
* Source/WebGPU/WGSL/Semantics/Types/F16.h: Added.
(WGSL::Semantics::Types::F16::create):
(WGSL::Semantics::Types::F16::F16):
* Source/WebGPU/WGSL/Semantics/Types/F32.h: Added.
(WGSL::Semantics::Types::F32::create):
(WGSL::Semantics::Types::F32::F32):
* Source/WebGPU/WGSL/Semantics/Types/I32.h: Added.
(WGSL::Semantics::Types::I32::create):
(WGSL::Semantics::Types::I32::I32):
* Source/WebGPU/WGSL/Semantics/Types/Matrix.cpp: Added.
(WGSL::Semantics::Types::checkValidComponentType):
(WGSL::Semantics::Types::checkValidColCount):
(WGSL::Semantics::Types::checkValidRowCount):
(WGSL::Semantics::Types::Matrix::Matrix):
(WGSL::Semantics::Types::Matrix::tryCreate):
(WGSL::Semantics::Types::Matrix::operator== const):
(WGSL::Semantics::Types::Matrix::string const):
* Source/WebGPU/WGSL/Semantics/Types/Matrix.h: Added.
(WGSL::Semantics::Types::Matrix::componentType const):
(WGSL::Semantics::Types::Matrix::colCount const):
(WGSL::Semantics::Types::Matrix::rowCount const):
* Source/WebGPU/WGSL/Semantics/Types/Struct.cpp: Added.
(WGSL::Semantics::Types::checkStructMemberType):
(WGSL::Semantics::Types::StructMember::StructMember):
(WGSL::Semantics::Types::StructMember::tryCreate):
(WGSL::Semantics::Types::Struct::Struct):
(WGSL::Semantics::Types::Struct::create):
(WGSL::Semantics::Types::Struct::operator== const):
(WGSL::Semantics::Types::Struct::string const):
* Source/WebGPU/WGSL/Semantics/Types/Struct.h: Added.
(WGSL::Semantics::Types::StructMember::span const):
(WGSL::Semantics::Types::StructMember::type const):
(WGSL::Semantics::Types::Struct::name const):
(WGSL::Semantics::Types::Struct::members const):
* Source/WebGPU/WGSL/Semantics/Types/Texture.cpp: Added.
(WGSL::Semantics::Types::Texture::Texture):
(WGSL::Semantics::Types::Texture::tryCreate):
(WGSL::Semantics::Types::Texture::operator== const):
* Source/WebGPU/WGSL/Semantics/Types/Texture.h: Added.
(WGSL::Semantics::Types::Texture::dimension const):
(WGSL::Semantics::Types::Texture::componentType const):
* Source/WebGPU/WGSL/Semantics/Types/Type.cpp: Added.
(WGSL::Semantics::Types::Type::Type):
(WGSL::Semantics::Types::Type::isIntegerScalar const):
(WGSL::Semantics::Types::Type::isConcrete const):
(WGSL::Semantics::Types::Type::isScalar const):
(WGSL::Semantics::Types::Type::isAbstractNumeric const):
(WGSL::Semantics::Types::Type::hasCreationFixedFootprint const):
* Source/WebGPU/WGSL/Semantics/Types/Type.h: Added.
(WGSL::Semantics::Types::Type::~Type):
(WGSL::Semantics::Types::Type::kind const):
(WGSL::Semantics::Types::Type::isBool const):
(WGSL::Semantics::Types::Type::isAbstractInt const):
(WGSL::Semantics::Types::Type::isAbstractFloat const):
(WGSL::Semantics::Types::Type::isU32 const):
(WGSL::Semantics::Types::Type::isI32 const):
(WGSL::Semantics::Types::Type::isF32 const):
(WGSL::Semantics::Types::Type::isF16 const):
(WGSL::Semantics::Types::Type::isAtomic const):
(WGSL::Semantics::Types::Type::isVector const):
(WGSL::Semantics::Types::Type::isMatrix const):
(WGSL::Semantics::Types::Type::isArray const):
(WGSL::Semantics::Types::Type::isStruct const):
(WGSL::Semantics::Types::Type::isTexture const):
(WGSL::Semantics::Types::Type::isMultisampledTexture const):
(WGSL::Semantics::Types::Type::isStorageTexture const):
(WGSL::Semantics::Types::Type::isDepthTexture const):
(WGSL::Semantics::Types::Type::isSampler const):
(WGSL::Semantics::Types::Type::isComparisonSampler const):
(WGSL::Semantics::Types::Type::isPointer const):
(WGSL::Semantics::Types::Type::span const):
* Source/WebGPU/WGSL/Semantics/Types/U32.h: Added.
(WGSL::Semantics::Types::U32::create):
(WGSL::Semantics::Types::U32::U32):
* Source/WebGPU/WGSL/Semantics/Types/Vector.cpp: Added.
(WGSL::Semantics::Types::checkValidComponentType):
(WGSL::Semantics::Types::checkValidSize):
(WGSL::Semantics::Types::Vector::Vector):
(WGSL::Semantics::Types::Vector::tryCreate):
(WGSL::Semantics::Types::Vector::operator== const):
(WGSL::Semantics::Types::Vector::string const):
* Source/WebGPU/WGSL/Semantics/Types/Vector.h: Added.
(WGSL::Semantics::Types::Vector::componentType const):
(WGSL::Semantics::Types::Vector::size const):
* Source/WebGPU/WGSLUnitTests/Semantics/Types/ArrayTest.mm: Added.
(-[ArrayTest setUp]):
(-[ArrayTest testCreateScalarElement]):
(-[ArrayTest testCreateVectorWithConcreteElements]):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
</pre>