### PR TITLE
WPT webrtc/RTCRtpTransceiver-setCodecPreferences.html last test is buggy in case of multiple codec variants

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt
@@ -17,5 +17,5 @@ PASS setCodecPreferences() with modified codec channel count should throw Invali
 PASS setCodecPreferences() with modified codec parameters should throw InvalidModificationError
 PASS setCodecPreferences() with modified codecs returned from getCapabilities() should throw InvalidModificationError
 PASS setCodecPreferences() modifies the order of audio codecs in createOffer
-FAIL setCodecPreferences() modifies the order of video codecs in createOffer assert_equals: expected "VP8" but got "H264"
+PASS setCodecPreferences() modifies the order of video codecs in createOffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences.html
@@ -291,7 +291,7 @@
     let i;
     for (i = 0; i < codecs.length; i++) {
       const codec = codecs[i];
-      if (codec.mimeType === 'video/VP8') {
+      if (codec.mimeType === 'video/VP8' && vp8 === -1) {
         vp8 = i;
         if (h264 !== -1) {
           codecs[vp8] = codecs[h264];
@@ -300,7 +300,7 @@
           break;
         }
       }
-      if (codec.mimeType === 'video/H264') {
+      if (codec.mimeType === 'video/H264' && h264 === -1) {
         h264 = i;
         if (vp8 !== -1) {
           codecs[h264] = codecs[vp8];


### PR DESCRIPTION
#### f987e4ff207694211ab0c2d42c01e2728c2a2443
<pre>
WPT webrtc/RTCRtpTransceiver-setCodecPreferences.html last test is buggy in case of multiple codec variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=243338">https://bugs.webkit.org/show_bug.cgi?id=243338</a>

Reviewed by Eric Carlson.

We should only swap the first H264 with the first VP8 entries.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences.html:

Canonical link: <a href="https://commits.webkit.org/252952@main">https://commits.webkit.org/252952@main</a>
</pre>
