### PR TITLE
html/semantics/forms/the-input-element/type-change-state.html is failing in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
@@ -144,8 +144,8 @@ PASS change state from datetime-local to time
 PASS change state from datetime-local to number
 PASS change state from datetime-local to range
 PASS change state from datetime-local to color
-FAIL change state from datetime-local to checkbox assert_equals: input.value should be 'on' after change of state expected "on" but got ""
-FAIL change state from datetime-local to radio assert_equals: input.value should be 'on' after change of state expected "on" but got ""
+PASS change state from datetime-local to checkbox
+PASS change state from datetime-local to radio
 PASS change state from datetime-local to file
 PASS change state from datetime-local to submit
 PASS change state from datetime-local to image
@@ -201,8 +201,8 @@ PASS change state from number to date
 PASS change state from number to time
 PASS change state from number to range
 PASS change state from number to color
-FAIL change state from number to checkbox assert_equals: input.value should be 'on' after change of state expected "on" but got ""
-FAIL change state from number to radio assert_equals: input.value should be 'on' after change of state expected "on" but got ""
+PASS change state from number to checkbox
+PASS change state from number to radio
 PASS change state from number to file
 PASS change state from number to submit
 PASS change state from number to image

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt
@@ -201,8 +201,8 @@ FAIL change state from number to date assert_implements: Support for input type 
 FAIL change state from number to time assert_implements: Support for input type time is required for this test. undefined
 PASS change state from number to range
 FAIL change state from number to color assert_implements: Support for input type color is required for this test. undefined
-FAIL change state from number to checkbox assert_equals: input.value should be 'on' after change of state expected "on" but got ""
-FAIL change state from number to radio assert_equals: input.value should be 'on' after change of state expected "on" but got ""
+PASS change state from number to checkbox
+PASS change state from number to radio
 PASS change state from number to file
 PASS change state from number to submit
 PASS change state from number to image

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -525,8 +525,10 @@ void HTMLInputElement::updateType()
     bool didRespectHeightAndWidth = m_inputType->shouldRespectHeightAndWidthAttributes();
     bool wasSuccessfulSubmitButtonCandidate = m_inputType->canBeSuccessfulSubmitButton();
 
-    if (didStoreValue && !willStoreValue && hasDirtyValue())
-        setAttributeWithoutSynchronization(valueAttr, AtomString { std::exchange(m_valueIfDirty, { }) });
+    if (didStoreValue && !willStoreValue) {
+        if (auto dirtyValue = std::exchange(m_valueIfDirty, { }); !dirtyValue.isEmpty())
+            setAttributeWithoutSynchronization(valueAttr, AtomString { WTFMove(dirtyValue) });
+    }
 
     m_inputType->destroyShadowSubtree();
     m_inputType->detachFromElement();


### PR DESCRIPTION
#### 3763b9dfd24051056b3218d862d8a908b8f5ab0e
<pre>
html/semantics/forms/the-input-element/type-change-state.html is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243311">https://bugs.webkit.org/show_bug.cgi?id=243311</a>

Reviewed by Darin Adler.

Per the specification [1]:
```
If the previous state of the element&apos;s type attribute put the value IDL
attribute in the value mode, and the element&apos;s value is not the empty string,
and the new state of the element&apos;s type attribute puts the value IDL attribute
in either the default mode or the default/on mode, then set the element&apos;s value
content attribute to the element&apos;s value.
```

In our implementation, we were missing the `and the element&apos;s value is not the
empty string` part of the check. As a result, when changing the type from
&quot;number&quot; to &quot;checkbox&quot; (for example) and if m_valueIfDirty was the emptyString,
we would set the &quot;value&quot; content attribute to the empty string. In general, this
is not very observable because input.value would return the empty string if
whether the &quot;value&quot; content attribute is missing or the empty string. However,
for input types such as &quot;checkbox&quot; and &quot;radio&quot;, it is observable since
`input.value` is expected to &quot;on&quot; when the &quot;value&quot; content attribute is missing.
This bug would cause `input.value` to return &quot;&quot; instead of &quot;on&quot; in such case.

[1] <a href="https://html.spec.whatwg.org/#the-input-element">https://html.spec.whatwg.org/#the-input-element</a>:attr-input-type-37 (step 1)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-expected.txt:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):

Canonical link: <a href="https://commits.webkit.org/252967@main">https://commits.webkit.org/252967@main</a>
</pre>
