### PR TITLE
Non-unified build fixes, late July 2022 edition

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -39,6 +39,7 @@
 #include "JSCellInlines.h"
 #include "JSDataView.h"
 #include "JSFunction.h"
+#include "JSGenericTypedArrayView.h"
 #include "JSMap.h"
 #include "JSSet.h"
 #include "JSWeakMap.h"

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "CCallHelpers.h"
+#include "JSCJSValueInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "LinkBuffer.h"
 #include "MaxFrameExtentForSlowPathCall.h"

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -30,6 +30,7 @@
 
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPropertyParser.h"
+#include "Document.h"
 #include "Element.h"
 #include "RenderStyle.h"
 #include "StylePropertyShorthand.h"

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -47,6 +47,7 @@
 #include "FloatRect.h"
 #include "FocusController.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "HTMLIFrameElement.h"
 #include "HitTestResult.h"
 #include "InspectorController.h"

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -27,6 +27,7 @@
 #include "InteractionRegion.h"
 
 #include "Document.h"
+#include "ElementInlines.h"
 #include "Frame.h"
 #include "FrameSnapshotting.h"
 #include "FrameView.h"

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -28,6 +28,7 @@
 
 #include "GeometryUtilities.h"
 #include "SVGElement.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGPathData.h"
 #include "SVGPathElement.h"
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -33,6 +33,7 @@
 #include "MediaFeatureNames.h"
 #include "MediaList.h"
 #include "MediaQuery.h"
+#include "NodeRenderStyle.h"
 #include "RenderView.h"
 #include "StyleRule.h"
 #include "StyleScope.h"

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -25,6 +25,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "SVGElement.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGUseElement.h"
 #include "XLinkNames.h"
 #include <wtf/URL.h>


### PR DESCRIPTION
#### 19c49cf8315e01cec9894d2233f7179e60e9664a
<pre>
Non-unified build fixes, late July 2022 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=243344">https://bugs.webkit.org/show_bug.cgi?id=243344</a>

Reviewed by Ross Kirsling.

* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/rendering/PathOperation.cpp:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
* Source/WebCore/svg/SVGURIReference.cpp:

Canonical link: <a href="https://commits.webkit.org/252956@main">https://commits.webkit.org/252956@main</a>
</pre>
