### PR TITLE
Add webpushd IPC to query for all domains with active Web Push subscriptions

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -670,6 +670,26 @@ void PushDatabase::getTopics(CompletionHandler<void(PushTopics&&)>&& completionH
     });
 }
 
+void PushDatabase::getOriginsWithPushSubscriptions(const String& bundleID, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
+{
+    dispatchOnWorkQueue([this, bundleID = crossThreadCopy(bundleID), completionHandler = WTFMove(completionHandler)]() mutable {
+        auto sql = cachedStatementOnQueue(
+            "SELECT securityOrigin "
+            "FROM SubscriptionSets "
+            "WHERE bundleID = ? AND state = 0"_s);
+        if (!sql || sql->bindText(1, bundleID) != SQLITE_OK) {
+            PUSHDB_RELEASE_LOG_BIND_ERROR();
+            return completeOnMainQueue(WTFMove(completionHandler), Vector<String> { });
+        }
+
+        Vector<String> origins;
+        while (sql->step() == SQLITE_ROW)
+            origins.append(sql->columnText(0));
+
+        completeOnMainQueue(WTFMove(completionHandler), WTFMove(origins));
+    });
+}
+
 void PushDatabase::incrementSilentPushCount(const String& bundleID, const String& securityOrigin, CompletionHandler<void(unsigned)>&& completionHandler)
 {
     dispatchOnWorkQueue([this, bundleID = crossThreadCopy(bundleID), securityOrigin = crossThreadCopy(securityOrigin), completionHandler = WTFMove(completionHandler)]() mutable {

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -96,6 +96,8 @@ public:
     WEBCORE_EXPORT void getIdentifiers(CompletionHandler<void(HashSet<PushSubscriptionIdentifier>&&)>&&);
     WEBCORE_EXPORT void getTopics(CompletionHandler<void(PushTopics&&)>&&);
 
+    WEBCORE_EXPORT void getOriginsWithPushSubscriptions(const String& bundleID, CompletionHandler<void(Vector<String>&&)>&&);
+
     WEBCORE_EXPORT void incrementSilentPushCount(const String& bundleID, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
 
     WEBCORE_EXPORT void removeRecordsByBundleIdentifier(const String& bundleID, CompletionHandler<void(Vector<RemovedPushRecord>&&)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2414,6 +2414,17 @@ void NetworkProcess::getOriginsWithPushAndNotificationPermissions(PAL::SessionID
     callback({ });
 }
 
+void NetworkProcess::getOriginsWithPushSubscriptions(PAL::SessionID sessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&& callback)
+{
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    if (auto* session = networkSession(sessionID)) {
+        session->notificationManager().getOriginsWithPushSubscriptions(WTFMove(callback));
+        return;
+    }
+#endif
+    callback({ });
+}
+
 void NetworkProcess::hasPushSubscriptionForTesting(PAL::SessionID sessionID, URL&& scopeURL, CompletionHandler<void(bool)>&& callback)
 {
 #if ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -385,6 +385,7 @@ public:
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
+    void getOriginsWithPushSubscriptions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, URL&&, CompletionHandler<void(bool)>&&);
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -218,6 +218,7 @@ messages -> NetworkProcess LegacyReceiver {
     SetPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin, bool enabled) -> ()
     DeletePushAndNotificationRegistration(PAL::SessionID sessionID, struct WebCore::SecurityOriginData origin) -> (String errorMessage)
     GetOriginsWithPushAndNotificationPermissions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
+    GetOriginsWithPushSubscriptions(PAL::SessionID sessionID) -> (Vector<WebCore::SecurityOriginData> origins)
     HasPushSubscriptionForTesting(PAL::SessionID sessionID, URL scopeURL) -> (bool hasSubscription)
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -95,6 +95,18 @@ void NetworkNotificationManager::getOriginsWithPushAndNotificationPermissions(Co
     sendMessageWithReply<WebPushD::MessageType::GetOriginsWithPushAndNotificationPermissions>(WTFMove(replyHandler));
 }
 
+void NetworkNotificationManager::getOriginsWithPushSubscriptions(CompletionHandler<void(const Vector<SecurityOriginData>&)>&& completionHandler)
+{
+    CompletionHandler<void(Vector<String>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<String> originStrings) mutable {
+        auto origins = originStrings.map([](auto& originString) {
+            return SecurityOriginData::fromURL({ { }, originString });
+        });
+        completionHandler(WTFMove(origins));
+    };
+
+    sendMessageWithReply<WebPushD::MessageType::GetOriginsWithPushSubscriptions>(WTFMove(replyHandler));
+}
+
 void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
 {
     CompletionHandler<void(Vector<WebPushMessage>&&)> replyHandler = [completionHandler = WTFMove(completionHandler)] (Vector<WebPushMessage>&& messages) mutable {

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -57,6 +57,7 @@ public:
     void setPushAndNotificationsEnabledForOrigin(const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
+    void getOriginsWithPushSubscriptions(CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
 
     void subscribeToPushService(URL&& scopeURL, Vector<uint8_t>&& applicationServerKey, CompletionHandler<void(Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -58,6 +58,7 @@ enum class MessageType : uint8_t {
     RemovePushSubscriptionsForOrigin,
     SetPublicTokenForTesting,
     SetPushAndNotificationsEnabledForOrigin,
+    GetOriginsWithPushSubscriptions,
 };
 
 enum class RawXPCMessageType : uint8_t {
@@ -83,6 +84,7 @@ inline bool messageTypeSendsReply(MessageType messageType)
     case MessageType::RemovePushSubscriptionsForOrigin:
     case MessageType::SetPublicTokenForTesting:
     case MessageType::SetPushAndNotificationsEnabledForOrigin:
+    case MessageType::GetOriginsWithPushSubscriptions:
         return true;
     case MessageType::SetDebugModeIsEnabled:
     case MessageType::UpdateConnectionConfiguration:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -902,6 +902,18 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     });
 }
 
+- (void)_getOriginsWithPushSubscriptions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler {
+    auto completionHandlerCopy = makeBlockPtr(completionHandler);
+    _websiteDataStore->networkProcess().getOriginsWithPushSubscriptions(_websiteDataStore->sessionID(), [completionHandlerCopy](const Vector<WebCore::SecurityOriginData>& origins) {
+        auto set = adoptNS([[NSMutableSet alloc] initWithCapacity:origins.size()]);
+        for (auto& origin : origins) {
+            auto apiOrigin = API::SecurityOrigin::create(origin);
+            [set addObject:wrapper(apiOrigin.get())];
+        }
+        completionHandlerCopy(set.get());
+    });
+}
+
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler
 {
     auto completionHandlerCopy = makeBlockPtr(completionHandler);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -116,6 +116,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_processPersistentNotificationClose:(NSDictionary *)notificationDictionaryRepresentation completionHandler:(void(^)(bool))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_deletePushAndNotificationRegistration:(WKSecurityOrigin *)securityOrigin completionHandler:(void(^)(NSError *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_getOriginsWithPushAndNotificationPermissions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+-(void)_getOriginsWithPushSubscriptions:(void(^)(NSSet<WKSecurityOrigin *> *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_originDirectoryForTesting:(NSURL *)origin topOrigin:(NSURL *)topOrigin type:(NSString *)dataType completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1792,6 +1792,11 @@ void NetworkProcessProxy::getOriginsWithPushAndNotificationPermissions(PAL::Sess
     sendWithAsyncReply(Messages::NetworkProcess::GetOriginsWithPushAndNotificationPermissions { sessionID }, WTFMove(callback));
 }
 
+void NetworkProcessProxy::getOriginsWithPushSubscriptions(PAL::SessionID sessionID, CompletionHandler<void(const Vector<SecurityOriginData>&)>&& callback)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::GetOriginsWithPushSubscriptions { sessionID }, WTFMove(callback));
+}
+
 void NetworkProcessProxy::hasPushSubscriptionForTesting(PAL::SessionID sessionID, const URL& scopeURL, CompletionHandler<void(bool)>&& callback)
 {
     sendWithAsyncReply(Messages::NetworkProcess::HasPushSubscriptionForTesting { sessionID, scopeURL }, WTFMove(callback));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -290,6 +290,7 @@ public:
     void setPushAndNotificationsEnabledForOrigin(PAL::SessionID, const WebCore::SecurityOriginData&, bool, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(PAL::SessionID, const WebCore::SecurityOriginData&, CompletionHandler<void(const String&)>&&);
     void getOriginsWithPushAndNotificationPermissions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
+    void getOriginsWithPushSubscriptions(PAL::SessionID, CompletionHandler<void(const Vector<WebCore::SecurityOriginData>&)>&&);
     void hasPushSubscriptionForTesting(PAL::SessionID, const URL&, CompletionHandler<void(bool)>&&);
 
     void dataTaskReceivedChallenge(DataTaskIdentifier, WebCore::AuthenticationChallenge&&, CompletionHandler<void(AuthenticationChallengeDisposition, WebCore::Credential&&)>&&);

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -64,6 +64,8 @@ public:
     void subscribe(const String& bundleIdentifier, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);
     void unsubscribe(const String& bundleIdentifier, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
 
+    void getOriginsWithPushSubscriptions(const String& bundleIdentifier, CompletionHandler<void(Vector<String>&&)>&&);
+
     void setPushesEnabledForBundleIdentifierAndOrigin(const String& bundleIdentifier, const String& securityOrigin, bool, CompletionHandler<void()>&&);
 
     void removeRecordsForBundleIdentifier(const String& bundleIdentifier, CompletionHandler<void(unsigned)>&&);

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -501,6 +501,11 @@ void PushService::didCompleteUnsubscribeRequest(UnsubscribeRequest& request)
     finishedPushServiceRequest(m_unsubscribeRequests, request);
 }
 
+void PushService::getOriginsWithPushSubscriptions(const String& bundleIdentifier, CompletionHandler<void(Vector<String>&&)>&& handler)
+{
+    m_database->getOriginsWithPushSubscriptions(bundleIdentifier, WTFMove(handler));
+}
+
 void PushService::incrementSilentPushCount(const String& bundleIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&& handler)
 {
     if (bundleIdentifier.isEmpty() || securityOrigin.isEmpty()) {

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -75,6 +75,7 @@ public:
     void echoTwice(ClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
     void requestSystemNotificationPermission(ClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
     void getOriginsWithPushAndNotificationPermissions(ClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
+    void getOriginsWithPushSubscriptions(ClientConnection*, CompletionHandler<void(Vector<String>&&)>&&);
     void setPushAndNotificationsEnabledForOrigin(ClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
     void deletePushRegistration(const String&, const String&, CompletionHandler<void()>&&);
     void deletePushAndNotificationRegistration(ClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp
@@ -347,6 +347,25 @@ public:
         return result;
     }
 
+    Vector<String> getOriginsWithPushSubscriptions(const String& bundleID)
+    {
+        bool done = false;
+        Vector<String> result;
+
+        db->getOriginsWithPushSubscriptions(bundleID, [&done, &result](Vector<String>&& origins) mutable {
+            result = WTFMove(origins);
+            done = true;
+        });
+        Util::run(&done);
+
+        // Sort to make comparison easier.
+        std::sort(result.begin(), result.end(), [](const String& lhs, const String& rhs) {
+            return codePointCompare(lhs, rhs) < 0;
+        });
+
+        return result;
+    }
+
     void SetUp() final
     {
         db = createDatabaseSync(SQLiteDatabase::inMemoryPath());
@@ -519,7 +538,7 @@ TEST_F(PushDatabaseTest, IncrementSilentPushCount)
     EXPECT_EQ(count, 0u);
 }
 
-TEST_F(PushDatabaseTest, setPushesEnabledForOrigin)
+TEST_F(PushDatabaseTest, SetPushesEnabledForOrigin)
 {
     bool result = setPushesEnabledForOrigin("com.apple.Safari"_s, "https://www.apple.com"_s, false);
     EXPECT_TRUE(result);
@@ -537,6 +556,32 @@ TEST_F(PushDatabaseTest, setPushesEnabledForOrigin)
 
     result = setPushesEnabledForOrigin("com.apple.nonexistent"_s, "https://www.apple.com"_s, false);
     EXPECT_FALSE(result);
+}
+
+TEST_F(PushDatabaseTest, GetOriginsWithPushSubscriptions)
+{
+    {
+        auto result = getOriginsWithPushSubscriptions("com.apple.webapp"_s);
+        auto expected = Vector<String> { "https://www.apple.com"_s };
+        EXPECT_EQ(result, expected);
+    }
+
+    {
+        auto result = getOriginsWithPushSubscriptions("com.apple.Safari"_s);
+        Vector<String> expected { "https://www.apple.com"_s, "https://www.webkit.org"_s };
+        EXPECT_EQ(result, expected);
+    }
+
+    {
+        bool result = setPushesEnabledForOrigin("com.apple.Safari"_s, "https://www.apple.com"_s, false);
+        EXPECT_TRUE(result);
+    }
+
+    {
+        auto result = getOriginsWithPushSubscriptions("com.apple.Safari"_s);
+        auto expected = Vector<String> { "https://www.webkit.org"_s };
+        EXPECT_EQ(result, expected);
+    }
 }
 
 TEST(PushDatabase, ManyInFlightOps)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -427,6 +427,21 @@ protected:
         return result;
     }
 
+    Vector<String> getOriginsWithPushSubscriptions()
+    {
+        __block bool done = false;
+        __block Vector<String> result;
+
+        [m_dataStore _getOriginsWithPushSubscriptions:^(NSSet<WKSecurityOrigin *> *origins) {
+            for (WKSecurityOrigin *origin in origins)
+                result.append(makeString(String(origin.protocol), "://"_s, String(origin.host), ":"_s, String::number(origin.port)));
+            done = true;
+        }];
+
+        TestWebKitAPI::Util::run(&done);
+        return result;
+    }
+
     ~WebPushDTest()
     {
         cleanUpTestWebPushD(m_tempDirectory.get());
@@ -769,6 +784,10 @@ TEST_F(WebPushDTest, SubscribeTest)
     ASSERT_EQ([subscription[@"keys"][@"p256dh"] length], 87u);
 
     ASSERT_TRUE(hasPushSubscription());
+
+    auto result = getOriginsWithPushSubscriptions();
+    EXPECT_EQ(result.size(), 1u);
+    EXPECT_EQ(result.first(), m_server->origin());
 }
 
 TEST_F(WebPushDTest, SubscribeFailureTest)


### PR DESCRIPTION
#### bc1e128089c0d6569702b2232aef9100f82fb78a
<pre>
Add webpushd IPC to query for all domains with active Web Push subscriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=243347">https://bugs.webkit.org/show_bug.cgi?id=243347</a>
rdar://93193992

Reviewed by Alex Christensen.

Some parts of WebKit (e.g. ITP) need the ability to query for all domains with active Web Push
subscriptions. We should add an IPC to webpushd to facilitate this.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::getOriginsWithPushSubscriptions):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getOriginsWithPushSubscriptions):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getOriginsWithPushSubscriptions):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::messageTypeSendsReply):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getOriginsWithPushSubscriptions:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getOriginsWithPushSubscriptions):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::getOriginsWithPushSubscriptions):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::MessageInfo::getOriginsWithPushSubscriptions::encodeReply):
(WebPushD::handleWebPushDMessageWithReply):
(WebPushD::Daemon::decodeAndHandleMessage):
(WebPushD::Daemon::getOriginsWithPushSubscriptions):
* Tools/TestWebKitAPI/Tests/WebCore/PushDatabase.cpp:
(TestWebKitAPI::PushDatabaseTest::getOriginsWithPushSubscriptions):
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/252970@main">https://commits.webkit.org/252970@main</a>
</pre>
