### PR TITLE
Fix missing exception check in JSGenericTypedArrayViewPrototypeFunctions.h's speciesConstruct().

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -99,7 +99,9 @@ inline JSArrayBufferView* speciesConstruct(JSGlobalObject* globalObject, ViewCla
 
     bool inSameRealm = exemplar->globalObject() == globalObject;
     if (LIKELY(inSameRealm)) {
-        if (LIKELY(speciesWatchpointIsValid(globalObject, exemplar)))
+        bool isValid = speciesWatchpointIsValid(globalObject, exemplar);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (LIKELY(isValid))
             RELEASE_AND_RETURN(scope, defaultConstructor());
     }
 


### PR DESCRIPTION
#### 6a77746466540335ffd3aa3266d37ac679d187af
<pre>
Fix missing exception check in JSGenericTypedArrayViewPrototypeFunctions.h&apos;s speciesConstruct().
<a href="https://bugs.webkit.org/show_bug.cgi?id=243348">https://bugs.webkit.org/show_bug.cgi?id=243348</a>

Reviewed by Yusuke Suzuki.

This issue was showing up as unchecked exception errors when doing Debug build JSC stress test runs.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):

Canonical link: <a href="https://commits.webkit.org/252954@main">https://commits.webkit.org/252954@main</a>
</pre>
