### PR TITLE
Fix more missing exception checks in JSGenericTypedArrayViewPrototypeFunctions.h.

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -623,6 +623,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncToReversed(VM& vm, JS
 
     Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
     ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
+    RETURN_IF_EXCEPTION(scope, { });
 
     const typename ViewClass::ElementType* from = thisObject->typedVector();
     typename ViewClass::ElementType* to = result->typedVector();
@@ -645,6 +646,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncClone(VM& vm, JSGlo
     size_t length = thisObject->length();
     Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
     ViewClass* result = ViewClass::createUninitialized(globalObject, structure, length);
+    RETURN_IF_EXCEPTION(scope, { });
 
     typename ViewClass::ElementType* from = thisObject->typedVector();
     typename ViewClass::ElementType* to = result->typedVector();
@@ -893,6 +895,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncWith(VM& vm, JSGlobal
 
     Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType);
     ViewClass* result = ViewClass::createUninitialized(globalObject, structure, thisLength);
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (UNLIKELY(thisLength != thisObject->length())) {
         for (unsigned index = 0; index < thisLength; ++index) {


### PR DESCRIPTION
#### 1b9e51c7647a26f2fbbebc4e9fdfe9e9a3b7328b
<pre>
Fix more missing exception checks in JSGenericTypedArrayViewPrototypeFunctions.h.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243351">https://bugs.webkit.org/show_bug.cgi?id=243351</a>
&lt;rdar://problem/97796738&gt;

Reviewed by Yusuke Suzuki.

These were detected by a Debug build run on JSC stress tests.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncToReversed):
(JSC::genericTypedArrayViewPrivateFuncClone):
(JSC::genericTypedArrayViewProtoFuncWith):

Canonical link: <a href="https://commits.webkit.org/252958@main">https://commits.webkit.org/252958@main</a>
</pre>
