### PR TITLE
Fix retain cycle when snapshotting a PDF

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1244,7 +1244,7 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     RetainPtr<WKWebView> strongSelf = self;
     BOOL afterScreenUpdates = snapshotConfiguration && snapshotConfiguration.afterScreenUpdates;
     auto callSnapshotRect = [strongSelf, afterScreenUpdates, rectInViewCoordinates, imageWidth, deviceScale, handler] {
-        [strongSelf _snapshotRectAfterScreenUpdates:afterScreenUpdates rectInViewCoordinates:rectInViewCoordinates intoImageOfWidth:imageWidth completionHandler:[strongSelf, handler, deviceScale](CGImageRef snapshotImage) {
+        [strongSelf _snapshotRectAfterScreenUpdates:afterScreenUpdates rectInViewCoordinates:rectInViewCoordinates intoImageOfWidth:imageWidth completionHandler:[handler, deviceScale](CGImageRef snapshotImage) {
             RetainPtr<NSError> error;
             RetainPtr<UIImage> image;
             


### PR DESCRIPTION
#### b16d7efbd2b6d89e4c7522a571a9db1bb757da23
<pre>
Fix retain cycle when snapshotting a PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=243264">https://bugs.webkit.org/show_bug.cgi?id=243264</a>

Reviewed by Tim Horton.

In -[WKWebView takeSnapshotWithConfiguration:completionHandler:],
the completion handler passed to _snapshotRectAfterScreenUpdates
captures a strong reference to the WKWebView even though it
doesn&apos;t need one. When a 3rd-party embedder calls this method
while the WKWebView is displaying a PDF, this callback is
passed through PDFKit SPI to PDFHostViewController, which
doesn&apos;t release the callback even after taking the snapshot.
This creates a retain cycle which can only be broken by
navigating the WKWebView to another site, which results in
both the WKPDFView and PDFHostViewController being released. If,
instead, the WKWebView is released by the embedder before
navigating away, there is no way to break the retain cycle, and
the WKWebView is permanently leaked.

Prevent this leak by not capturing a strong reference to the
WKWebView in the completion handler passed to
_snapshotRectAfterScreenUpdates.

Tested manually since a PDFHostViewController does not get
created when loading a PDF in TestWebKitAPI, so the retain
cycle cannot be reproduced in that environment.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/252966@main">https://commits.webkit.org/252966@main</a>
</pre>
