### PR TITLE
[Gardening]: rdar://83910715 ([ iOS ] fast/events/ios/rotation/la you…

### DIFF
--- a/LayoutTests/platform/ios-15/fast/events/ios/rotation/layout-viewport-during-safari-type-rotation-expected.txt
+++ b/LayoutTests/platform/ios-15/fast/events/ios/rotation/layout-viewport-during-safari-type-rotation-expected.txt
@@ -1,0 +1,21 @@
+Before rotation
+layoutViewport: 0, 0 - 390 x 797
+visualViewport: 0, 0 - 390 x 797
+client rect of fixed object:0, 0 - 390 x 797
+
+In orientationchange event handler:
+(This will trigger the resize handler by forcing a layout.)
+layoutViewport: 0, 0 - 844 x 390
+visualViewport: 0, 0 - 844 x 390
+client rect of fixed object:0, 0 - 844 x 390
+
+In resize event handler:
+layoutViewport: 0, 0 - 844 x 390
+visualViewport: 0, 0 - 844 x 390
+client rect of fixed object:0, 0 - 844 x 390
+
+After rotation
+layoutViewport: 0, 0 - 844 x 390
+visualViewport: 0, 0 - 844 x 390
+client rect of fixed object:0, 0 - 844 x 390
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3628,8 +3628,6 @@ swipe/main-frame-pinning-requirement.html
 
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
 
-webkit.org/b/231266 fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html [ Pass Failure ]
-
 webkit.org/b/227845 [ Debug ] webaudio/audioworket-out-of-memory.html [ Pass Timeout DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/240918 [ Debug ]  fast/loader/create-frame-in-DOMContentLoaded.html [ Pass Failure ]


### PR DESCRIPTION
…t-viewport-during-safari -type-rotation.html is a constant text failure

https://bugs.webkit.org/show_bug.cgi?id=231266

Unreviewed test gardening.

* LayoutTests/platform/ios-15/fast/events/ios/rotation/layout-viewport-during-safari-type-rotation-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
