### PR TITLE
User style sheets should also apply pseudo-element styles

### DIFF
--- a/LayoutTests/userscripts/insert-stylesheets-with-pseudo-expected.txt
+++ b/LayoutTests/userscripts/insert-stylesheets-with-pseudo-expected.txt
@@ -1,0 +1,13 @@
+PASS getComputedStyle(testElement).backgroundColor is not 'rgb(255, 0, 0)'
+
+Adding author CSS...
+PASS getComputedStyle(testElement).backgroundColor is 'rgb(255, 0, 0)'
+
+Adding user CSS...
+PASS getComputedStyle(testElement).backgroundColor is 'rgb(0, 0, 255)'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test requires testRunner and window.internals.
+
+

--- a/LayoutTests/userscripts/insert-stylesheets-with-pseudo.html
+++ b/LayoutTests/userscripts/insert-stylesheets-with-pseudo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<p>This test requires testRunner and window.internals.</p>
+<input id="test" type="range">
+<script>
+function test()
+{
+    if (!window.internals)
+      return;
+
+    window.testRunner?.dumpAsText();
+
+    let shadow = internals.shadowRoot(document.getElementById("test"));
+
+    window.testElement = shadow.querySelector("[pseudo='-webkit-slider-runnable-track']");
+    shouldNotBe("getComputedStyle(testElement).backgroundColor", "'rgb(255, 0, 0)'");
+
+    debug("");
+
+    debug("Adding author CSS...");
+    internals.insertAuthorCSS("input[type=\"range\"]::-webkit-slider-runnable-track { background-color: red; }");
+    shouldBe("getComputedStyle(testElement).backgroundColor", "'rgb(255, 0, 0)'");
+
+    debug("");
+
+    debug("Adding user CSS...");
+    internals.insertUserCSS("input[type=\"range\"]::-webkit-slider-runnable-track { background-color: blue !important; }");
+    shouldBe("getComputedStyle(testElement).backgroundColor", "'rgb(0, 0, 255)'");
+}
+
+test();
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -36,6 +36,7 @@ namespace WebCore::Style {
 class MatchRequest;
 class ScopeRuleSets;
 struct SelectorMatchingState;
+enum class CascadeLevel : uint8_t;
 
 class PseudoElementRequest {
 public:
@@ -100,17 +101,17 @@ private:
 
     void matchUARules(const RuleSet&);
 
-    void collectMatchingAuthorRules();
     void addElementInlineStyleProperties(bool includeSMILProperties);
 
-    void matchAuthorShadowPseudoElementRules();
-    void matchHostPseudoClassRules();
-    void matchSlottedPseudoElementRules();
-    void matchPartPseudoElementRules();
-    void matchPartPseudoElementRulesForScope(const Element& partMatchingElement);
+    void matchShadowPseudoElementRules(CascadeLevel);
+    void matchHostPseudoClassRules(CascadeLevel);
+    void matchSlottedPseudoElementRules(CascadeLevel);
+    void matchPartPseudoElementRules(CascadeLevel);
+    void matchPartPseudoElementRulesForScope(const Element& partMatchingElement, CascadeLevel);
 
     void collectMatchingShadowPseudoElementRules(const MatchRequest&);
 
+    void collectMatchingRules(CascadeLevel);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
     bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal);

--- a/Source/WebCore/style/StyleInvalidationFunctions.h
+++ b/Source/WebCore/style/StyleInvalidationFunctions.h
@@ -39,11 +39,16 @@ inline void traverseRuleFeaturesInShadowTree(Element& element, TraverseFunction&
 {
     if (!element.shadowRoot())
         return;
+
     auto& shadowRuleSets = element.shadowRoot()->styleScope().resolver().ruleSets();
-    auto& authorStyle = shadowRuleSets.authorStyle();
-    bool hasHostPseudoClassRulesMatchingInShadowTree = authorStyle.hasHostPseudoClassRulesMatchingInShadowTree();
-    if (authorStyle.hostPseudoClassRules().isEmpty() && !hasHostPseudoClassRulesMatchingInShadowTree)
+    bool hasHostPseudoClassRulesMatchingInShadowTree = false;
+    bool hasHostPseudoClassRule = shadowRuleSets.hasMatchingUserOrAuthorStyle([&] (auto& style) {
+        hasHostPseudoClassRulesMatchingInShadowTree = style.hasHostPseudoClassRulesMatchingInShadowTree();
+        return !style.hostPseudoClassRules().isEmpty();
+    });
+    if (!hasHostPseudoClassRule && !hasHostPseudoClassRulesMatchingInShadowTree)
         return;
+
     function(shadowRuleSets.features(), hasHostPseudoClassRulesMatchingInShadowTree);
 }
 
@@ -53,8 +58,9 @@ inline void traverseRuleFeaturesForSlotted(Element& element, TraverseFunction&& 
     auto assignedShadowRoots = assignedShadowRootsIfSlotted(element);
     for (auto& assignedShadowRoot : assignedShadowRoots) {
         auto& ruleSets = assignedShadowRoot->styleScope().resolver().ruleSets();
-        if (ruleSets.authorStyle().slottedPseudoElementRules().isEmpty())
+        if (!ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); }))
             continue;
+
         function(ruleSets.features(), false);
     }
 }
@@ -66,14 +72,14 @@ inline void traverseRuleFeatures(Element& element, TraverseFunction&& function)
 
     auto mayAffectShadowTree = [&] {
         if (element.shadowRoot() && element.shadowRoot()->isUserAgentShadowRoot()) {
-            if (ruleSets.authorStyle().hasShadowPseudoElementRules())
+            if (ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return style.hasShadowPseudoElementRules(); }))
                 return true;
 #if ENABLE(VIDEO)
-            if (element.isMediaElement() && !ruleSets.authorStyle().cuePseudoRules().isEmpty())
+            if (element.isMediaElement() && ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.cuePseudoRules().isEmpty(); }))
                 return true;
 #endif
         }
-        if (is<HTMLSlotElement>(element) && !ruleSets.authorStyle().slottedPseudoElementRules().isEmpty())
+        if (is<HTMLSlotElement>(element) && ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); }))
             return true;
         return false;
     };

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -441,22 +441,10 @@ void Invalidator::invalidateHostAndSlottedStyleIfNeeded(ShadowRoot& shadowRoot)
     auto& host = *shadowRoot.host();
     auto* resolver = shadowRoot.styleScope().resolverIfExists();
 
-    auto shouldInvalidateHost = [&] {
-        if (!resolver)
-            return true;
-        return !resolver->ruleSets().authorStyle().hostPseudoClassRules().isEmpty();
-    }();
-
-    if (shouldInvalidateHost)
+    if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
         host.invalidateStyleInternal();
 
-    auto shouldInvalidateHostChildren = [&] {
-        if (!resolver)
-            return true;
-        return !resolver->ruleSets().authorStyle().slottedPseudoElementRules().isEmpty();
-    }();
-
-    if (shouldInvalidateHostChildren) {
+    if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); })) {
         for (auto& shadowChild : childrenOfType<Element>(host))
             shadowChild.invalidateStyleInternal();
     }

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -36,6 +36,7 @@ class CSSStyleRule;
 class CSSStyleSheet;
 class ExtensionStyleSheets;
 class MediaQueryEvaluator;
+enum class CascadeLevel : uint8_t;
 
 namespace Style {
 
@@ -58,6 +59,8 @@ public:
     RuleSet* userAgentMediaQueryStyle() const;
     RuleSet& authorStyle() const { return *m_authorStyle; }
     RuleSet* userStyle() const;
+    RuleSet* styleForCascadeLevel(CascadeLevel);
+
     const RuleFeatureSet& features() const;
     RuleSet* sibling() const { return m_siblingRuleSet.get(); }
     RuleSet* uncommonAttribute() const { return m_uncommonAttributeRuleSet.get(); }
@@ -86,6 +89,8 @@ public:
     RuleFeatureSet& mutableFeatures();
 
     bool& isInvalidatingStyleWithRuleSets() { return m_isInvalidatingStyleWithRuleSets; }
+
+    bool hasMatchingUserOrAuthorStyle(const Function<bool(RuleSet&)>&);
 
 private:
     void collectFeatures() const;

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -102,7 +102,7 @@ std::unique_ptr<RenderStyle> SharingResolver::resolve(const Styleable& searchSty
         return nullptr;
     if (elementHasDirectionAuto(element))
         return nullptr;
-    if (element.shadowRoot() && !element.shadowRoot()->styleScope().resolver().ruleSets().authorStyle().hostPseudoClassRules().isEmpty())
+    if (element.shadowRoot() && element.shadowRoot()->styleScope().resolver().ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
         return nullptr;
     if (auto* keyframeEffectStack = searchStyleable.keyframeEffectStack()) {
         if (keyframeEffectStack->hasEffectWithImplicitKeyframes())
@@ -281,7 +281,7 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
             return false;
     }
 
-    if (candidateElement.shadowRoot() && !candidateElement.shadowRoot()->styleScope().resolver().ruleSets().authorStyle().hostPseudoClassRules().isEmpty())
+    if (candidateElement.shadowRoot() && candidateElement.shadowRoot()->styleScope().resolver().ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
         return false;
 
 #if ENABLE(WHEEL_EVENT_REGIONS)


### PR DESCRIPTION
#### 62782a8855305e19a8039168935016bb1b7ecfcf
<pre>
User style sheets should also apply pseudo-element styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=243355">https://bugs.webkit.org/show_bug.cgi?id=243355</a>
&lt;rdar://problem/97623809&gt;

Reviewed by Antti Koivisto.

User style sheets are a common way for internal clients to override UA functionality without having
to worry about being overridden by Author style sheets, as an `!important` inside a User style sheet
is higher precedence than any Author style sheet. This currently works fine for &quot;regular&quot; styles,
but not styles that involve pseudo-classes. We should allow that, as that any style that works in an
Author style sheet should also work in a User style sheet.

* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/StyleInvalidationFunctions.h:
(WebCore::Style::traverseRuleFeaturesInShadowTree):
(WebCore::Style::traverseRuleFeaturesForSlotted):
(WebCore::Style::traverseRuleFeatures):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateHostAndSlottedStyleIfNeeded):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::resolve):
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
Also check to see if the `ScopeRuleSets::userStyle` matches the required conditions everywhere that
previously only checked the `ScopeRuleSets::authorStyle`.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::matchAuthorRules):
(WebCore::Style::ElementRuleCollector::matchesAnyAuthorRules):
(WebCore::Style::ElementRuleCollector::matchShadowPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
(WebCore::Style::ElementRuleCollector::matchSlottedPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRulesForScope):
(WebCore::Style::ElementRuleCollector::matchUserRules):
(WebCore::Style::ElementRuleCollector::matchAllRules):
(WebCore::Style::ElementRuleCollector::matchAuthorShadowPseudoElementRules): Deleted.
(WebCore::Style::ElementRuleCollector::collectMatchingAuthorRules): Deleted.
Rework how User and Author rules are collected and matched to use a common function based on a given
`CascadeLevel`. This also ensures that future changes for Author rules also affects User rules.

* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::styleForCascadeLevel): Added.
(WebCore::Style::ScopeRuleSets::hasMatchingUserOrAuthorStyle): Added.
Add a utility methods that
- return the `RuleSet` that matches the given `CascadeLevel`
- check to see if the given predicate matches the User or Author style sheet, allowing callers to
  not have to repeat the same logic over and over to check both.

* LayoutTests/userscripts/insert-stylesheets-with-pseudo.html: Added.
* LayoutTests/userscripts/insert-stylesheets-with-pseudo-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/253092@main">https://commits.webkit.org/253092@main</a>
</pre>
