### PR TITLE
[iOS Mail] Selection does not change when tapping in compose when keyboard is not already shown

### DIFF
--- a/LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view-expected.txt
+++ b/LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view-expected.txt
@@ -1,0 +1,14 @@
+This test verifies that the selection changes when initially focusing an editable web view by tapping, if the WebKit client unconditionally allows programmatic focus to show the keyboard. To manually test, tap the red square above and verify that the selection is set
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS clickedTarget became true
+PASS getSelection().rangeCount is 1
+PASS getSelection().type is 'Caret'
+PASS target.contains(selectionRange.startContainer) is true
+PASS target.contains(selectionRange.endContainer) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view.html
+++ b/LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true focusStartsInputSessionPolicy=allow ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+clickedTarget = false;
+
+addEventListener("load", async () => {
+    description("This test verifies that the selection changes when initially focusing an editable web view by tapping, if the WebKit client unconditionally allows programmatic focus to show the keyboard. To manually test, tap the red square above and verify that the selection is set ");
+
+    target = document.getElementById("target");
+    target.addEventListener("mouseover", () => target.style.opacity = 0.8);
+    target.addEventListener("click", () => clickedTarget = true);
+
+    if (!window.testRunner || !window.internals)
+        return;
+
+    internals.settings.setContentChangeObserverEnabled(true);
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.addChromeInputField();
+    await UIHelper.selectChromeInputField();
+    await UIHelper.setWebViewEditable(true);
+    getSelection().removeAllRanges();
+    await UIHelper.activateElementAndWaitForInputSession(target);
+
+    await shouldBecomeEqual("clickedTarget", "true");
+    shouldBe("getSelection().rangeCount", "1");
+    shouldBe("getSelection().type", "'Caret'");
+    selectionRange = getSelection().getRangeAt(0);
+    shouldBeTrue("target.contains(selectionRange.startContainer)");
+    shouldBeTrue("target.contains(selectionRange.endContainer)");
+
+    document.activeElement.blur();
+    document.getElementById("content").remove();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+<style>
+body {
+    font-size: 20px;
+}
+#target {
+    margin: 4px;
+    display: inline-block;
+    background-color: rgba(255, 0, 0, 0.5);
+}
+</style>
+</head>
+<body>
+<div id="content">
+    <div>Here's to the crazy ones.</div>
+    <div>The misfits.</div>
+    <div>The rebels.</div>
+    <div>The troublemakers.</div>
+    <div>The round pegs in the square holes.</div>
+    <div>The ones who see things differently.</div>
+    <div id="target">They're not fond of rules.</div>
+    <div>And they have no respect for the status quo.</div>
+    <div>You can quote them, disagree with them, glorify or vilify them.</div>
+    <div>About the only thing you can't do is ignore them.</div>
+    <div>Because they change things.</div>
+    <div>They push the human race forward.</div>
+    <div>And while some may see them as the crazy ones, we see genius.</div>
+    <div>Because the people who are crazy enough to think they can change the world, are the ones who do.</div>
+</div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -104,9 +104,7 @@ void WebEditorClient::subFrameScrollPositionChanged()
 
 bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
 {
-    // The text selection assistant will handle selection in the case where we are already editing the node
-    auto* editableRoot = newSelection.rootEditableElement();
-    return !editableRoot || editableRoot != targetNode.rootEditableElement() || !m_page->isShowingInputViewForFocusedElement();
+    return m_page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection);
 }
 
 bool WebEditorClient::shouldRevealCurrentSelectionAfterInsertion() const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -859,6 +859,7 @@ public:
 
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
     void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest, CompletionHandler<void(WebKit::DocumentEditingContext)>&&);
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
 #endif
 
     void willChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = true; }
@@ -2317,6 +2318,8 @@ private:
     WebCore::IntPoint m_lastInteractionLocation;
 
     bool m_isShowingInputViewForFocusedElement { false };
+    bool m_wasShowingInputViewForFocusedElementDuringLastPotentialTap { false };
+    bool m_completingSyntheticClick { false };
     bool m_hasHandledSyntheticClick { false };
     
     enum SelectionAnchor { Start, End };

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -189,6 +189,7 @@ const TestFeatures& TestOptions::defaults()
             { "contentMode", { } },
             { "contentSecurityPolicyExtensionMode", { } },
             { "dragInteractionPolicy", { } },
+            { "focusStartsInputSessionPolicy", { } },
             { "jscOptions", { } },
             { "standaloneWebApplicationURL", { } },
         };
@@ -242,6 +243,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "contentMode", TestHeaderKeyType::StringTestRunner },
         { "contentSecurityPolicyExtensionMode", TestHeaderKeyType::StringTestRunner },
         { "dragInteractionPolicy", TestHeaderKeyType::StringTestRunner },
+        { "focusStartsInputSessionPolicy", TestHeaderKeyType::StringTestRunner },
         { "jscOptions", TestHeaderKeyType::StringTestRunner },
         { "standaloneWebApplicationURL", TestHeaderKeyType::StringURLTestRunner },
 

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -84,6 +84,7 @@ public:
     std::string contentMode() const { return stringTestRunnerFeatureValue("contentMode"); }
     std::string contentSecurityPolicyExtensionMode() const { return stringTestRunnerFeatureValue("contentSecurityPolicyExtensionMode"); }
     std::string dragInteractionPolicy() const { return stringTestRunnerFeatureValue("dragInteractionPolicy"); }
+    std::string focusStartsInputSessionPolicy() const { return stringTestRunnerFeatureValue("focusStartsInputSessionPolicy"); }
     std::string jscOptions() const { return stringTestRunnerFeatureValue("jscOptions"); }
     std::string standaloneWebApplicationURL() const { return stringTestRunnerFeatureValue("standaloneWebApplicationURL"); }
     std::vector<std::string> overrideLanguages() const { return stringVectorTestRunnerFeatureValue("language"); }

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -24,6 +24,7 @@
  */
 
 #import <WebKit/WebKit.h>
+#import <WebKit/_WKInputDelegate.h>
 
 @class UIEditMenuInteraction;
 @class UITextEffectsWindow;
@@ -68,6 +69,7 @@
 @property (nonatomic, readonly, getter=isShowingPopover) BOOL showingPopover;
 @property (nonatomic, assign) BOOL usesSafariLikeRotation;
 @property (nonatomic, readonly, getter=isInteractingWithFormControl) BOOL interactingWithFormControl;
+@property (nonatomic) _WKFocusStartsInputSessionPolicy focusStartsInputSessionPolicy;
 
 #endif
 

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -30,7 +30,6 @@
 #import "WebKitTestRunnerDraggingInfo.h"
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
-#import <WebKit/_WKInputDelegate.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -119,6 +118,7 @@ IGNORE_WARNINGS_END
         [center addObserver:self selector:@selector(_didDismissPopover) name:@"UIPopoverControllerDidDismissPopoverNotification" object:nil];
         self.UIDelegate = self;
         self._inputDelegate = self;
+        self.focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyAuto;
 #endif
     }
     return self;
@@ -526,6 +526,11 @@ static bool isQuickboardViewController(UIViewController *viewController)
 {
     if (self.willStartInputSessionCallback)
         self.willStartInputSessionCallback();
+}
+
+- (_WKFocusStartsInputSessionPolicy)_webView:(WKWebView *)webView decidePolicyForFocusedElement:(id<_WKFocusedElementInfo>)info
+{
+    return self.focusStartsInputSessionPolicy;
 }
 
 #pragma mark - UIGestureRecognizerDelegate

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -154,6 +154,16 @@ static _WKDragInteractionPolicy dragInteractionPolicy(const TestOptions& options
     return _WKDragInteractionPolicyDefault;
 }
 
+static _WKFocusStartsInputSessionPolicy focusStartsInputSessionPolicy(const TestOptions& options)
+{
+    auto policy = options.focusStartsInputSessionPolicy();
+    if (policy == "allow")
+        return _WKFocusStartsInputSessionPolicyAllow;
+    if (policy == "disallow")
+        return _WKFocusStartsInputSessionPolicyDisallow;
+    return _WKFocusStartsInputSessionPolicyAuto;
+}
+
 static void restorePortraitOrientationIfNeeded(PlatformWebView* platformWebView, Seconds timeoutDuration)
 {
 #if HAVE(UI_WINDOW_SCENE_GEOMETRY_PREFERENCES)
@@ -260,6 +270,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
         [webView _clearInterfaceOrientationOverride];
         [webView setAllowedMenuActions:nil];
         webView._dragInteractionPolicy = dragInteractionPolicy(options);
+        webView.focusStartsInputSessionPolicy = focusStartsInputSessionPolicy(options);
 
         UIScrollView *scrollView = webView.scrollView;
         [scrollView _removeAllAnimations:YES];


### PR DESCRIPTION
#### 8d38f657f8eeec2823a753ac4b509cae9f4b70f1
<pre>
[iOS Mail] Selection does not change when tapping in compose when keyboard is not already shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=243356">https://bugs.webkit.org/show_bug.cgi?id=243356</a>
rdar://96609950

Reviewed by Aditya Keerthi.

When tapping in Mail compose when the keyboard is not already shown, we first
`-becomeFirstResponder` underneath `-_singleTapRecognized:` before proceeding to dispatch synthetic
click events to the page. Note that:

1.  The entire web view is treated as editable via `WKWebView` SPI, and
2.  Mail implements the `-_webView:decidePolicyForFocusedElement:` input delegate method and returns
    `_WKFocusStartsInputSessionPolicyAllow`

...which causes us to show the keyboard earlier than usual (before actually completing the synthetic
click and dispatching mouse events), due to setting the focused element underneath activity state
flag changes (specifically, `IsFocused`). This, in turn, causes us to send IPC from the UI process
back to the web process indicating that the keyboard is shown, which causes us to *not* set the
selection underneath WebKit2 editor client code, due to the fact that
`isShowingInputViewForFocusedElement()` is true:

```
bool WebEditorClient::shouldAllowSingleClickToChangeSelection(…) const
{
    …
    return !editableRoot || editableRoot != targetNode.rootEditableElement() || !m_page-&gt;isShowingInputViewForFocusedElement();
}
```

To fix this (and allow the selection to change when tapping), we add some new state flags to
`WebPage` to only consider whether or not the keyboard *was* shown during the potential tap when
determining whether a synthetic click should change the selection.

Test: editing/selection/ios/tap-to-set-selection-in-editable-web-view.html

* LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view-expected.txt: Added.
* LayoutTests/editing/selection/ios/tap-to-set-selection-in-editable-web-view.html: Added.

Add a layout test to exercise the bug; see above for more details.

* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::shouldAllowSingleClickToChangeSelection):

Move this logic out of `WebEditorClient` and into `WebPage` as a helper method; in the case where
we&apos;re completing a synthetic click (i.e. dispatching mousedown and click events when tapping), we
consult `m_wasShowingInputViewForFocusedElementDuringLastPotentialTap` rather than the current state
of `m_isShowingInputViewForFocusedElement`.

* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::focusStartsInputSessionPolicy const):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView initWithFrame:configuration:]):
(-[TestRunnerWKWebView _webView:decidePolicyForFocusedElement:]):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::focusStartsInputSessionPolicy):
(WTR::TestController::platformResetStateToConsistentValues):

Implement the input delegate method `-_webView:decidePolicyForFocusedElement:`, and add a new layout
test option to influence the return type of this delegate method.

Canonical link: <a href="https://commits.webkit.org/252972@main">https://commits.webkit.org/252972@main</a>
</pre>
