### PR TITLE
[JSC] Support ARM64 Disassembly Comments.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -578,6 +578,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/AbstractMacroAssembler.h
     assembler/AssemblerBuffer.h
     assembler/AssemblerCommon.h
+    assembler/AssemblyComments.h
     assembler/CPU.h
     assembler/CodeLocation.h
     assembler/FastJITPermissions.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -871,7 +871,12 @@
 		4443AE3316E188D90076F110 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F0EB6105C86C6B00E6DF1B /* Foundation.framework */; };
 		451539B912DC994500EF7AC4 /* Yarr.h in Headers */ = {isa = PBXBuildFile; fileRef = 451539B812DC994500EF7AC4 /* Yarr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		473DA4A4764C45FE871B0485 /* DefinePropertyAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEB137561BB11EEE00CD5100 /* MacroAssemblerARM64.cpp */; };
+		4B46940428984FEE00512FDF /* MacroAssemblerX86Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A4AE0717973B26005612B1 /* MacroAssemblerX86Common.cpp */; };
 		4BAA07CEB81F49A296E02203 /* WasmTypeDefinitionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4BDF3004289324AC00AE1DE3 /* AssemblyComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4BE92D442898522400FA48E1 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
+		4BE92D452898522400FA48E1 /* LowLevelInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680C714BBB16900BFE272 /* LowLevelInterpreter.cpp */; };
 		520D99F12388CC81000509A3 /* GetByValHistory.h in Headers */ = {isa = PBXBuildFile; fileRef = 520D99F02388CC78000509A3 /* GetByValHistory.h */; };
 		521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 521131F61F82BF11007CCEEE /* PolyProtoAccessChain.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		521322461ECBCE8200F65615 /* WebAssemblyFunctionBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 521322441ECBCE8200F65615 /* WebAssemblyFunctionBase.h */; };
@@ -1084,7 +1089,6 @@
 		536B319B1F735E780037FC33 /* UnifiedSource2-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 536B31961F735E5B0037FC33 /* UnifiedSource2-mm.mm */; };
 		536B319C1F735E7D0037FC33 /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 536B31971F735E5B0037FC33 /* UnifiedSource134.cpp */; };
 		536B319D1F735E7D0037FC33 /* UnifiedSource135.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 536B31991F735E5D0037FC33 /* UnifiedSource135.cpp */; };
-		536B319E1F735F160037FC33 /* LowLevelInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680C714BBB16900BFE272 /* LowLevelInterpreter.cpp */; };
 		5370806B1FE232DF00299E44 /* JSArrayBufferView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66BB17B6B5AB00A7AE3F /* JSArrayBufferView.h */; };
 		5370B4F61BF26205005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5370B4F41BF25EA2005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h */; };
 		537FEEC92742BDA300C9EFEE /* StructureID.h in Headers */ = {isa = PBXBuildFile; fileRef = 537FEEC82742BDA300C9EFEE /* StructureID.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1826,7 +1830,6 @@
 		DCFDFBDA1D1F5D9E00FE3D72 /* B3TypeMap.h in Headers */ = {isa = PBXBuildFile; fileRef = DCFDFBD81D1F5D9800FE3D72 /* B3TypeMap.h */; };
 		DD41FA8627CDAD3200394D95 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
 		DD41FA8727CDAD4300394D95 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
-		DD41FA8927CDDDEF00394D95 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
 		DD5F74F9283EF58D0027A8C6 /* copy-profiling-data.sh in Headers */ = {isa = PBXBuildFile; fileRef = DD5F74F8283EF4380027A8C6 /* copy-profiling-data.sh */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDB04F41278E569A008D3678 /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 1498CAD3214656C400710879 /* libWTF.a */; };
 		DDB04F42278E56A2008D3678 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1498CAD3214656C400710879 /* libWTF.a */; };
@@ -3796,6 +3799,8 @@
 		442FBD852149D1E00073519C /* hasher.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = hasher.py; path = yarr/hasher.py; sourceTree = "<group>"; };
 		451539B812DC994500EF7AC4 /* Yarr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Yarr.h; path = yarr/Yarr.h; sourceTree = "<group>"; };
 		45E12D8806A49B0F00E9DF84 /* jsc.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsc.cpp; sourceTree = "<group>"; tabWidth = 4; };
+		4BDF3001289324AB00AE1DE3 /* AssemblyComments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AssemblyComments.cpp; sourceTree = "<group>"; };
+		4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AssemblyComments.h; sourceTree = "<group>"; };
 		4CE978E385A8498199052153 /* ModuleNamespaceAccessCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleNamespaceAccessCase.h; sourceTree = "<group>"; };
 		51F0EB6105C86C6B00E6DF1B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		51F0EC0705C86C9A00E6DF1B /* libobjc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libobjc.dylib; path = /usr/lib/libobjc.dylib; sourceTree = "<absolute>"; };
@@ -8830,6 +8835,8 @@
 		9688CB120ED12B4E001D649F /* assembler */ = {
 			isa = PBXGroup;
 			children = (
+				4BDF3001289324AB00AE1DE3 /* AssemblyComments.cpp */,
+				4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */,
 				0F1FE51B1922A3BC006987C5 /* AbortReason.h */,
 				0F2C63BF1E660EA500C13839 /* AbstractMacroAssembler.cpp */,
 				860161DF0F3A83C100F84710 /* AbstractMacroAssembler.h */,
@@ -10450,6 +10457,7 @@
 				0FB7F39B15ED8E4600F167B2 /* IndexingType.h in Headers */,
 				14386A791DD6989C008652C4 /* IndirectEvalExecutable.h in Headers */,
 				0FF8BDEB1AD4CF7100DFE884 /* InferredValue.h in Headers */,
+				4BDF3004289324AC00AE1DE3 /* AssemblyComments.h in Headers */,
 				0F4AE0431FE0D25700E20839 /* InferredValueInlines.h in Headers */,
 				BC18C4100E16F5CD00B34460 /* InitializeThreading.h in Headers */,
 				A513E5B8185B8BD3007E95AD /* InjectedScript.h in Headers */,
@@ -12250,6 +12258,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BE92D442898522400FA48E1 /* LowLevelInterpreter.asm in Sources */,
+				4BE92D452898522400FA48E1 /* LowLevelInterpreter.cpp in Sources */,
+				4B46940428984FEE00512FDF /* MacroAssemblerX86Common.cpp in Sources */,
+				4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */,
 				FE05FAFD1FE4CEDA00093230 /* DeprecatedInspectorValues.cpp in Sources */,
 				5333BBDC2110F7D9007618EC /* DFGSpeculativeJIT.cpp in Sources */,
 				5333BBDB2110F7D2007618EC /* DFGSpeculativeJIT32_64.cpp in Sources */,
@@ -12261,9 +12273,6 @@
 				E30873E7272559410053B601 /* IntlPluralRules.cpp in Sources */,
 				A3EE8543262514B000FC9B8D /* IntlWorkaround.cpp in Sources */,
 				E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */,
-				DD41FA8927CDDDEF00394D95 /* LowLevelInterpreter.asm in Sources */,
-				DD41FA8927CDDDEF00394D95 /* LowLevelInterpreter.asm in Sources */,
-				536B319E1F735F160037FC33 /* LowLevelInterpreter.cpp in Sources */,
 				DFBC2CA625E6D5B90081BDD1 /* SymbolStubsForSafariCompatibility.mm in Sources */,
 				E32F713F281B3C6600AFD21D /* UnifiedSource1-c.c in Sources */,
 				536B319A1F735E780037FC33 /* UnifiedSource1-mm.mm in Sources */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -46,17 +46,18 @@ API/OpaqueJSString.cpp
 
 assembler/AbstractMacroAssembler.cpp
 assembler/AssemblerBuffer.cpp
+assembler/AssemblyComments.cpp
 assembler/CPU.cpp
 assembler/JITOperationList.cpp
 assembler/LinkBuffer.cpp
 assembler/MacroAssembler.cpp
-assembler/MacroAssemblerARM64.cpp
-assembler/MacroAssemblerARMv7.cpp
+assembler/MacroAssemblerARM64.cpp @no-unify
+assembler/MacroAssemblerARMv7.cpp @no-unify
 assembler/MacroAssemblerCodeRef.cpp
-assembler/MacroAssemblerMIPS.cpp
+assembler/MacroAssemblerMIPS.cpp @no-unify
 assembler/MacroAssemblerPrinter.cpp
-assembler/MacroAssemblerRISCV64.cpp
-assembler/MacroAssemblerX86Common.cpp
+assembler/MacroAssemblerRISCV64.cpp @no-unify
+assembler/MacroAssemblerX86Common.cpp @no-unify
 assembler/PerfLog.cpp
 assembler/Printer.cpp
 assembler/ProbeContext.cpp

--- a/Source/JavaScriptCore/assembler/AssemblyComments.cpp
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AssemblyComments.h"
+
+#include <wtf/NeverDestroyed.h>
+
+namespace JSC {
+
+static LazyNeverDestroyed<AssemblyCommentRegistry> commentsRegistry;
+
+void AssemblyCommentRegistry::initialize()
+{
+    commentsRegistry.construct();
+}
+
+AssemblyCommentRegistry& AssemblyCommentRegistry::singleton()
+{
+    return commentsRegistry.get();
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/assembler/AssemblyComments.h
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "Options.h"
+
+#include <optional>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/StdMap.h>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+class AssemblyCommentRegistry {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(AssemblyCommentRegistry);
+public:
+    static AssemblyCommentRegistry& singleton();
+    static void initialize();
+
+    Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+
+    using CommentMap = HashMap<uintptr_t, String>;
+
+    void registerCodeRange(void* start, void* end, CommentMap&& map)
+    {
+        if (LIKELY(!Options::dumpDisassembly()) || !map.size())
+            return;
+        Locker locker { m_lock };
+
+        auto newStart = bitwise_cast<uintptr_t>(start);
+        auto newEnd = bitwise_cast<uintptr_t>(end);
+        RELEASE_ASSERT(newStart < newEnd);
+
+#if ASSERT_ENABLED
+        for (auto it : m_comments) {
+            auto thisStart = orderedKeyInverse(it.first);
+            auto& [thisEnd, _] = it.second;
+            ASSERT(newEnd <= thisStart
+                || thisEnd <= newStart);
+            ASSERT(thisStart < thisEnd);
+        }
+#else
+        (void) newStart;
+#endif
+
+        m_comments.emplace(orderedKey(start), std::pair { newEnd, WTFMove(map) });
+    }
+
+    void unregisterCodeRange(void* start, void* end)
+    {
+        if (LIKELY(!Options::dumpDisassembly()))
+            return;
+        Locker locker { m_lock };
+
+        auto it = m_comments.find(orderedKey(start));
+        if (it == m_comments.end())
+            return;
+
+        auto& [foundEnd, _] = it->second; 
+        RELEASE_ASSERT(foundEnd == bitwise_cast<uintptr_t>(end));
+        m_comments.erase(it);
+    }
+
+    inline std::optional<String> comment(void* in)
+    {
+        if (LIKELY(!Options::dumpDisassembly()))
+            return { };
+        Locker locker { m_lock };
+        auto it = m_comments.lower_bound(orderedKey(in));
+
+        if (it == m_comments.end())
+            return { };
+        
+        auto& [end, map] = it->second;
+        if (bitwise_cast<uintptr_t>(in) > bitwise_cast<uintptr_t>(end))
+            return { };
+
+        auto it2 = map.find(bitwise_cast<uintptr_t>(in));
+
+        if (it2 == map.end())
+            return { };
+
+        return { it2->value.isolatedCopy() };
+    }
+
+    AssemblyCommentRegistry() = default;
+
+private:
+
+    // Flip ordering for lower_bound comparator to work.
+    inline uintptr_t orderedKey(void* in) { return std::numeric_limits<uintptr_t>::max() - bitwise_cast<uintptr_t>(in); }
+    inline uintptr_t orderedKeyInverse(uintptr_t in) { return std::numeric_limits<uintptr_t>::max() - in; }
+
+    Lock m_lock;
+    StdMap<uintptr_t, std::pair<uintptr_t, CommentMap>> m_comments WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -374,6 +374,8 @@ private:
     {
         return m_code.dataLocation();
     }
+
+    void linkComments(MacroAssembler&);
     
     void allocate(MacroAssembler&, JITCompilationEffort);
 

--- a/Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#include "AssemblyComments.h"
 #include "Disassembler.h"
 
 #if ENABLE(ARM64_DISASSEMBLER)
@@ -49,7 +50,11 @@ bool tryToDisassemble(const MacroAssemblerCodePtr<DisassemblyPtrTag>& codePtr, s
             snprintf(pcInfo, sizeof(pcInfo) - 1, "<%u> %#llx", pcOffset, static_cast<unsigned long long>(bitwise_cast<uintptr_t>(currentPC)));
         else
             snprintf(pcInfo, sizeof(pcInfo) - 1, "%#llx", static_cast<unsigned long long>(bitwise_cast<uintptr_t>(currentPC)));
-        out.printf("%s%24s: %s\n", prefix, pcInfo, arm64Opcode.disassemble(currentPC));
+        out.printf("%s%24s: %s", prefix, pcInfo, arm64Opcode.disassemble(currentPC));
+        if (auto str = AssemblyCommentRegistry::singleton().comment(reinterpret_cast<void*>(currentPC)))
+            out.printf("; %s\n", str->ascii().data());
+        else
+            out.printf("\n");
         pcOffset += sizeof(uint32_t);
         currentPC++;
         byteCount -= sizeof(uint32_t);

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1288,6 +1288,7 @@ RefPtr<ExecutableMemoryHandle> ExecutableMemoryHandle::createImpl(size_t sizeInB
 
 ExecutableMemoryHandle::~ExecutableMemoryHandle()
 {
+    AssemblyCommentRegistry::singleton().unregisterCodeRange(start().untaggedPtr(), end().untaggedPtr());
     FixedVMPoolExecutableAllocator* allocator = g_jscConfig.fixedVMPoolExecutableAllocator;
     allocator->handleWillBeReleased(*this, sizeInBytes());
     jit_heap_deallocate(key());

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "InitializeThreading.h"
 
+#include "AssemblyComments.h"
 #include "ExecutableAllocator.h"
 #include "JITOperationList.h"
 #include "JSCConfig.h"
@@ -103,6 +104,7 @@ void initialize()
         if (Options::useSigillCrashAnalyzer())
             enableSigillCrashAnalyzer();
 
+        AssemblyCommentRegistry::initialize();
         LLInt::initialize();
         DisallowGC::initialize();
 


### PR DESCRIPTION
#### 739d9f24705c7b993d6517b428309b95211064c5
<pre>
[JSC] Support ARM64 Disassembly Comments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243358">https://bugs.webkit.org/show_bug.cgi?id=243358</a>

Reviewed by Yusuke Suzuki.

Add support for ARM64 disassembler comments in jit code. We use a global map of code
address -&gt; comments, which is updated during linking. Comments do nothing when
dumpDisassembly=0.

Also, we opt-out some MacroAssembler files from unified builds to fix build
errors caused by a RegisterID symbol conflict that this patch accidentally exposes.

Here is an example of a comment:

```
comment(scratchGPR, &quot; = callFrame-&gt;callee-&gt;executableOrRareData&quot;);
emitGetFromCallFrameHeaderPtr(CallFrameSlot::callee, scratchGPR);
loadPtr(Address(scratchGPR, JSFunction::offsetOfExecutableOrRareData()), scratchGPR);
auto hasExecutable = branchTestPtr(Zero, scratchGPR, TrustedImm32(JSFunction::rareDataTag));
loadPtr(Address(scratchGPR, FunctionRareData::offsetOfExecutable() - JSFunction::rareDataTag), scratchGPR);
hasExecutable.link(this);
comment(scratchGPR, &quot; = (&quot;, scratchGPR, &quot;: Executable)-&gt;codeBlock&quot;);
loadPtr(Address(scratchGPR, FunctionExecutable::offsetOfCodeBlockFor(kind)), scratchGPR);
```

becomes

```
&lt;44&gt; 0x12e51c02c:    ldur     x1, [fp, #24]; %x1 = callFrame-&gt;callee-&gt;executableOrRareData
&lt;48&gt; 0x12e51c030:    ldur     x1, [x1, #24]
&lt;52&gt; 0x12e51c034:    tbz      x1, #0, 0x12e51c03c -&gt; &lt;60&gt;
&lt;56&gt; 0x12e51c038:    ldur     x1, [x1, #47]
&lt;60&gt; 0x12e51c03c:    ldur     x1, [x1, #96]; %x1 = (%x1: Executable)-&gt;codeBlock
```

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::comment):
(JSC::AbstractMacroAssembler::lineComment):
(JSC::AbstractMacroAssembler::commentImpl):
* Source/JavaScriptCore/assembler/Comments.cpp: Copied from Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp.
(JSC::CommentRegistry::initialize):
(JSC::CommentRegistry::singleton):
* Source/JavaScriptCore/assembler/Comments.h: Added.
(JSC::CommentRegistry::WTF_RETURNS_LOCK):
(JSC::CommentRegistry::registerCodeRange):
(JSC::CommentRegistry::unregisterCodeRange):
(JSC::CommentRegistry::comment):
(JSC::CommentRegistry::orderedKey):
(JSC::CommentRegistry::orderedKeyInverse):
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::linkCode):
(JSC::LinkBuffer::linkComments):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/disassembler/ARM64Disassembler.cpp:
(JSC::tryToDisassemble):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::jitAssertCodeBlockOnCallFrameWithType):
(JSC::AssemblyHelpers::jitAssertCodeBlockMatchesCurrentCalleeCodeBlockOnCallFrame):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableMemoryHandle::~ExecutableMemoryHandle):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):

remove unified sources for macroasm

Canonical link: <a href="https://commits.webkit.org/253085@main">https://commits.webkit.org/253085@main</a>
</pre>
