### PR TITLE
[WebGPU] Implement various render pass encoder methods: creation, pipeline assignment, draw

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -84,6 +84,7 @@ private:
     bool validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
     bool validateFinish() const;
     bool validatePopDebugGroup() const;
+    bool validateRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
 
     void makeInvalid() { m_commandBuffer = nil; }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -39,6 +39,32 @@
 
 namespace WebGPU {
 
+static MTLLoadAction loadAction(WGPULoadOp loadOp)
+{
+    switch (loadOp) {
+    case WGPULoadOp_Load:
+        return MTLLoadActionLoad;
+    case WGPULoadOp_Clear:
+        return MTLLoadActionClear;
+    case WGPULoadOp_Force32:
+        ASSERT_NOT_REACHED();
+        return MTLLoadActionClear;
+    }
+}
+
+static MTLStoreAction storeAction(WGPUStoreOp storeOp)
+{
+    switch (storeOp) {
+    case WGPUStoreOp_Store:
+        return MTLStoreActionStore;
+    case WGPUStoreOp_Discard:
+        return MTLStoreActionDontCare;
+    case WGPUStoreOp_Force32:
+        ASSERT_NOT_REACHED();
+        return MTLStoreActionDontCare;
+    }
+}
+
 Ref<CommandEncoder> Device::createCommandEncoder(const WGPUCommandEncoderDescriptor& descriptor)
 {
     if (descriptor.nextInChain)
@@ -93,10 +119,79 @@ Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDe
     return ComputePassEncoder::createInvalid(m_device);
 }
 
+bool CommandEncoder::validateRenderPassDescriptor(const WGPURenderPassDescriptor& descriptor) const
+{
+    // FIXME: Fully implement this according to
+    // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-beginrenderpass.
+
+    // Some features are explicitly supported by WebGPU, however we do not have support for them.
+    // The following checks reject descriptors using such features.
+    // FIXME: remove the corresponding check once we support them.
+
+    // Do not support multisampling.
+    for (uint32_t i = 0; i < descriptor.colorAttachmentCount; ++i) {
+        if (descriptor.colorAttachments[i].resolveTarget)
+            return false;
+    }
+
+    // Do not support depth/stencil
+    if (descriptor.depthStencilAttachment)
+        return false;
+
+    // Do not support occlusion
+    if (descriptor.occlusionQuerySet)
+        return false;
+
+    if (descriptor.timestampWriteCount)
+        return false;
+
+    return true;
+}
+
 Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescriptor& descriptor)
 {
-    UNUSED_PARAM(descriptor);
-    return RenderPassEncoder::createInvalid(m_device);
+    if (descriptor.nextInChain)
+        return RenderPassEncoder::createInvalid(m_device);
+
+    if (!validateRenderPassDescriptor(descriptor))
+        return RenderPassEncoder::createInvalid(m_device);
+
+    MTLRenderPassDescriptor* mtlDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+
+    // FIXME: check maximum number of color attachments
+    // Apple1: 4, others: 8
+
+    for (uint32_t i = 0; i < descriptor.colorAttachmentCount; ++i) {
+        const auto& attachment = descriptor.colorAttachments[i];
+        const auto& mtlAttachment = mtlDescriptor.colorAttachments[i];
+
+        mtlAttachment.clearColor = MTLClearColorMake(
+            attachment.clearColor.r,
+            attachment.clearColor.g,
+            attachment.clearColor.b,
+            attachment.clearColor.a);
+
+        mtlAttachment.texture = fromAPI(attachment.view).texture();
+        mtlAttachment.level = 0;
+        mtlAttachment.slice = 0;
+        mtlAttachment.depthPlane = 0;
+        mtlAttachment.loadAction = loadAction(attachment.loadOp);
+        mtlAttachment.storeAction = storeAction(attachment.storeOp);
+
+        // FIXME: Multisampling support
+        // mtlDescriptor.colorAttachments[i].resolveTexture = fromAPI(attachment.resolveTarget).texture();
+        // mtlAttachment.resolveLevel = 0;
+        // mtlAttachment.resolveSlice = 0;
+        // mtlAttachment.resolveDepthPlane = 0;
+    }
+
+    // FIXME: Depth + stencil texture.
+
+    // other stuff are not important.
+
+    auto mtlRenderCommandEncoder = [m_commandBuffer renderCommandEncoderWithDescriptor:mtlDescriptor];
+
+    return RenderPassEncoder::create(mtlRenderCommandEncoder, m_device);
 }
 
 bool CommandEncoder::validateCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size)
@@ -804,7 +899,7 @@ void CommandEncoder::pushDebugGroup(String&& groupLabel)
 
     if (!prepareTheEncoderState())
         return;
-    
+
     finalizeBlitCommandEncoder();
 
     ++m_debugGroupStackSize;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -98,6 +98,7 @@ private:
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;
+    RefPtr<const RenderPipeline> m_renderPipeline;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -46,7 +46,11 @@ RenderPassEncoder::RenderPassEncoder(Device& device)
 {
 }
 
-RenderPassEncoder::~RenderPassEncoder() = default;
+RenderPassEncoder::~RenderPassEncoder()
+{
+    // FIXME: Metal driver requires the command encoder to end before being destroyed.
+    // Might have to explicitly end encoding here if the user forgets to?
+}
 
 void RenderPassEncoder::beginOcclusionQuery(uint32_t queryIndex)
 {
@@ -61,10 +65,14 @@ void RenderPassEncoder::beginPipelineStatisticsQuery(const QuerySet& querySet, u
 
 void RenderPassEncoder::draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance)
 {
-    UNUSED_PARAM(vertexCount);
-    UNUSED_PARAM(instanceCount);
-    UNUSED_PARAM(firstVertex);
-    UNUSED_PARAM(firstInstance);
+    // FIXME: validation according to
+    // https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw
+    [m_renderCommandEncoder
+        drawPrimitives:m_renderPipeline->primitiveType()
+        vertexStart:firstVertex
+        vertexCount:vertexCount
+        instanceCount:instanceCount
+        baseInstance:firstInstance];
 }
 
 void RenderPassEncoder::drawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance)
@@ -95,7 +103,7 @@ void RenderPassEncoder::endOcclusionQuery()
 
 void RenderPassEncoder::endPass()
 {
-
+    [m_renderCommandEncoder endEncoding];
 }
 
 void RenderPassEncoder::endPipelineStatisticsQuery()
@@ -176,7 +184,13 @@ void RenderPassEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat for
 
 void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
 {
-    UNUSED_PARAM(pipeline);
+    // FIXME: validation according to
+    // https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline.
+    m_renderPipeline = RefPtr(&pipeline);
+
+    [m_renderCommandEncoder setRenderPipelineState:pipeline.renderPipelineState()];
+    [m_renderCommandEncoder setCullMode:m_renderPipeline->cullMode()];
+    [m_renderCommandEncoder setFrontFacingWinding:m_renderPipeline->frontFace()];
 }
 
 void RenderPassEncoder::setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height)


### PR DESCRIPTION
#### 6a97f9eb92fbb6c1abc900ab8f2844dfee826a9e
<pre>
[WebGPU] Implement various render pass encoder methods: creation, pipeline assignment, draw
<a href="https://bugs.webkit.org/show_bug.cgi?id=243357">https://bugs.webkit.org/show_bug.cgi?id=243357</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::loadAction):
(WebGPU::storeAction):
(WebGPU::CommandEncoder::validateRenderPassDescriptor const):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::pushDebugGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::~RenderPassEncoder):
(WebGPU::RenderPassEncoder::draw):
(WebGPU::RenderPassEncoder::endPass):
(WebGPU::RenderPassEncoder::setPipeline):
</pre>