### PR TITLE
[WebGPU] Fix texture format resolution during texture view creation

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -74,7 +74,11 @@ public:
     static bool isValidImageCopySource(WGPUTextureFormat, WGPUTextureAspect);
     static bool isValidImageCopyDestination(WGPUTextureFormat, WGPUTextureAspect);
     static bool validateLinearTextureData(const WGPUTextureDataLayout&, uint64_t, WGPUTextureFormat, WGPUExtent3D);
+    static MTLPixelFormat pixelFormat(WGPUTextureFormat);
+    static std::optional<MTLPixelFormat> depthOnlyAspectMetalFormat(WGPUTextureFormat);
+    static std::optional<MTLPixelFormat> stencilOnlyAspectMetalFormat(WGPUTextureFormat);
     static WGPUTextureFormat removeSRGBSuffix(WGPUTextureFormat);
+    static std::optional<WGPUTextureFormat> resolveTextureFormat(WGPUTextureFormat, WGPUTextureAspect);
 
     WGPUExtent3D logicalMiplevelSpecificTextureExtent(uint32_t mipLevel);
     WGPUExtent3D physicalMiplevelSpecificTextureExtent(uint32_t mipLevel);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1399,7 +1399,7 @@ static MTLTextureUsage usage(WGPUTextureUsageFlags usage)
     return result;
 }
 
-static MTLPixelFormat pixelFormat(WGPUTextureFormat textureFormat)
+MTLPixelFormat Texture::pixelFormat(WGPUTextureFormat textureFormat)
 {
     switch (textureFormat) {
     case WGPUTextureFormat_R8Unorm:
@@ -1776,7 +1776,7 @@ WGPUTextureFormat Texture::aspectSpecificFormat(WGPUTextureFormat format, WGPUTe
     }
 }
 
-static std::optional<MTLPixelFormat> depthOnlyAspectMetalFormat(WGPUTextureFormat textureFormat)
+std::optional<MTLPixelFormat> Texture::depthOnlyAspectMetalFormat(WGPUTextureFormat textureFormat)
 {
     switch (textureFormat) {
     case WGPUTextureFormat_R8Unorm:
@@ -1888,7 +1888,7 @@ static std::optional<MTLPixelFormat> depthOnlyAspectMetalFormat(WGPUTextureForma
     }
 }
 
-static std::optional<MTLPixelFormat> stencilOnlyAspectMetalFormat(WGPUTextureFormat textureFormat)
+std::optional<MTLPixelFormat> Texture::stencilOnlyAspectMetalFormat(WGPUTextureFormat textureFormat)
 {
     switch (textureFormat) {
     case WGPUTextureFormat_R8Unorm:
@@ -2103,7 +2103,7 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor, IOSu
         return Texture::createInvalid(*this);
     }
 
-    textureDescriptor.pixelFormat = pixelFormat(descriptor.format);
+    textureDescriptor.pixelFormat = Texture::pixelFormat(descriptor.format);
 
     textureDescriptor.mipmapLevelCount = descriptor.mipLevelCount;
 
@@ -2149,8 +2149,12 @@ std::optional<WGPUTextureViewDescriptor> Texture::resolveTextureViewDescriptorDe
 
     WGPUTextureViewDescriptor resolved = descriptor;
 
-    if (resolved.format == WGPUTextureFormat_Undefined)
-        resolved.format = m_descriptor.format;
+    if (resolved.format == WGPUTextureFormat_Undefined) {
+        if (auto format = resolveTextureFormat(m_descriptor.format, descriptor.aspect))
+            resolved.format = *format;
+        else
+            resolved.format = m_descriptor.format;
+    }
 
     if (resolved.mipLevelCount == WGPU_MIP_LEVEL_COUNT_UNDEFINED) {
         auto mipLevelCount = checkedDifference<uint32_t>(m_descriptor.mipLevelCount, resolved.baseMipLevel);
@@ -2205,6 +2209,21 @@ std::optional<WGPUTextureViewDescriptor> Texture::resolveTextureViewDescriptorDe
     return resolved;
 }
 
+std::optional<WGPUTextureFormat> Texture::resolveTextureFormat(WGPUTextureFormat format, WGPUTextureAspect aspect)
+{
+    switch (aspect) {
+    case WGPUTextureAspect_All:
+        return format;
+    case WGPUTextureAspect_DepthOnly:
+        return depthSpecificFormat(format);
+    case WGPUTextureAspect_StencilOnly:
+        return stencilSpecificFormat(format);
+    case WGPUTextureAspect_Force32:
+    default:
+        return { };
+    }
+}
+
 uint32_t Texture::arrayLayerCount() const
 {
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-array-layer-count
@@ -2227,20 +2246,12 @@ bool Texture::validateCreateView(const WGPUTextureViewDescriptor& descriptor) co
     if (!isValid())
         return false;
 
-    switch (descriptor.aspect) {
-    case WGPUTextureAspect_All:
-        break;
-    case WGPUTextureAspect_StencilOnly:
-        if (!containsStencilAspect(m_descriptor.format))
+    if (descriptor.aspect == WGPUTextureAspect_All) {
+        if (descriptor.format != m_descriptor.format && !m_viewFormats.contains(descriptor.format))
             return false;
-        break;
-    case WGPUTextureAspect_DepthOnly:
-        if (!containsDepthAspect(m_descriptor.format))
+    } else {
+        if (descriptor.format != resolveTextureFormat(m_descriptor.format, descriptor.aspect))
             return false;
-        break;
-    case WGPUTextureAspect_Force32:
-        ASSERT_NOT_REACHED();
-        return false;
     }
 
     if (!descriptor.mipLevelCount)
@@ -2257,8 +2268,10 @@ bool Texture::validateCreateView(const WGPUTextureViewDescriptor& descriptor) co
     if (endArrayLayer.hasOverflowed() || endArrayLayer.value() > arrayLayerCount())
         return false;
 
-    if (descriptor.format != m_descriptor.format && !m_viewFormats.contains(descriptor.format))
-        return false;
+    if (m_descriptor.sampleCount > 1) {
+        if (descriptor.dimension != WGPUTextureViewDimension_2D)
+            return false;
+    }
 
     switch (descriptor.dimension) {
     case WGPUTextureViewDimension_Undefined:
@@ -2345,26 +2358,8 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
         return TextureView::createInvalid(m_device);
     }
 
-    std::optional<MTLPixelFormat> pixelFormat;
-    if (isDepthOrStencilFormat(descriptor->format)) {
-        switch (descriptor->aspect) {
-        case WGPUTextureAspect_All:
-            pixelFormat = WebGPU::pixelFormat(descriptor->format);
-            break;
-        case WGPUTextureAspect_StencilOnly:
-            pixelFormat = stencilOnlyAspectMetalFormat(descriptor->format);
-            break;
-        case WGPUTextureAspect_DepthOnly:
-            pixelFormat = depthOnlyAspectMetalFormat(descriptor->format);
-            break;
-        case WGPUTextureAspect_Force32:
-            ASSERT_NOT_REACHED();
-            return TextureView::createInvalid(m_device);
-        }
-    }
-    if (!pixelFormat)
-        return TextureView::createInvalid(m_device);
-    ASSERT(*pixelFormat != MTLPixelFormatInvalid);
+    auto pixelFormat = Texture::pixelFormat(descriptor->format);
+    ASSERT(pixelFormat != MTLPixelFormatInvalid);
 
     MTLTextureType textureType;
     switch (descriptor->dimension) {
@@ -2411,7 +2406,7 @@ Ref<TextureView> Texture::createView(const WGPUTextureViewDescriptor& inputDescr
 
     auto slices = NSMakeRange(descriptor->baseArrayLayer, descriptor->arrayLayerCount);
 
-    id<MTLTexture> texture = [m_texture newTextureViewWithPixelFormat:*pixelFormat textureType:textureType levels:levels slices:slices];
+    id<MTLTexture> texture = [m_texture newTextureViewWithPixelFormat:pixelFormat textureType:textureType levels:levels slices:slices];
     if (!texture)
         return TextureView::createInvalid(m_device);
 


### PR DESCRIPTION
#### 0318aa1d8b4642b0c4365debb5656a0383ac7859
<pre>
[WebGPU] Fix texture format resolution during texture view creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243359">https://bugs.webkit.org/show_bug.cgi?id=243359</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::pixelFormat):
(WebGPU::Texture::depthOnlyAspectMetalFormat):
(WebGPU::Texture::stencilOnlyAspectMetalFormat):
(WebGPU::Device::createTexture):
(WebGPU::Texture::resolveTextureViewDescriptorDefaults const):
(WebGPU::Texture::resolveTextureFormat):
(WebGPU::Texture::validateCreateView const):
(WebGPU::Texture::createView):
(WebGPU::pixelFormat): Deleted.
(WebGPU::depthOnlyAspectMetalFormat): Deleted.
(WebGPU::stencilOnlyAspectMetalFormat): Deleted.
</pre>