### PR TITLE
Add UIDelegate API to observe text edit menu appearance and dismissal

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class WKContextMenuElementInfo;
 @class UIContextMenuConfiguration;
 @protocol UIContextMenuInteractionCommitAnimating;
+@protocol UIEditMenuInteractionAnimating;
 #endif
 
 typedef NS_ENUM(NSInteger, WKPermissionDecision) {
@@ -253,6 +254,22 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
  If you do not implement this method, the web view will display the default Lockdown Mode message.
  */
 - (void)webView:(WKWebView *)webView showLockdownModeFirstUseMessage:(NSString *)message completionHandler:(void (^)(WKDialogResult))completionHandler WK_API_AVAILABLE(ios(13.0));
+
+/**
+ * @abstract Called when the web view is about to present its edit menu.
+ *
+ * @param webView The web view displaying the menu.
+ * @param animator Appearance animator. Add animations to this object to run them alongside the appearance transition.
+ */
+- (void)webView:(WKWebView *)webView willPresentEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator WK_API_AVAILABLE(ios(WK_IOS_TBA));
+
+/**
+ * @abstract Called when the web view is about to dismiss its edit menu.
+ *
+ * @param webView The web view displaying the menu.
+ * @param animator Dismissal animator. Add animations to this object to run them alongside the dismissal transition.
+ */
+- (void)webView:(WKWebView *)webView willDismissEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
 #endif // TARGET_OS_IOS
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -256,9 +256,6 @@ struct UIEdgeInsets;
 - (NSArray<UIDragItem *> *)_webView:(WKWebView *)webView willPerformDropWithSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDropSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDragSession:(id <UIDragSession>)session WK_API_AVAILABLE(ios(11.0));
-// FIXME (243102): Expose these edit menu delegates as public API.
-- (void)_webView:(WKWebView *)webView willPresentEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator WK_API_AVAILABLE(ios(WK_IOS_TBA));
-- (void)_webView:(WKWebView *)webView willDismissEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator WK_API_AVAILABLE(ios(WK_IOS_TBA));
 #endif
 
 - (void)_webView:(WKWebView *)webView didChangeSafeAreaShouldAffectObscuredInsets:(BOOL)safeAreaShouldAffectObscuredInsets WK_API_AVAILABLE(ios(11.0));

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11365,20 +11365,20 @@ constexpr auto analysisTypesForFullscreenVideo = VKAnalysisTypeAll & ~VKAnalysis
 
 - (void)willPresentEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
 {
-    auto delegate = static_cast<id<WKUIDelegatePrivate>>(self.webView.UIDelegate);
-    if (![delegate respondsToSelector:@selector(_webView:willPresentEditMenuWithAnimator:)])
+    auto delegate = self.webView.UIDelegate;
+    if (![delegate respondsToSelector:@selector(webView:willPresentEditMenuWithAnimator:)])
         return;
 
-    [delegate _webView:self.webView willPresentEditMenuWithAnimator:animator];
+    [delegate webView:self.webView willPresentEditMenuWithAnimator:animator];
 }
 
 - (void)willDismissEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
 {
-    auto delegate = static_cast<id<WKUIDelegatePrivate>>(self.webView.UIDelegate);
-    if (![delegate respondsToSelector:@selector(_webView:willDismissEditMenuWithAnimator:)])
+    auto delegate = self.webView.UIDelegate;
+    if (![delegate respondsToSelector:@selector(webView:willDismissEditMenuWithAnimator:)])
         return;
 
-    [delegate _webView:self.webView willDismissEditMenuWithAnimator:animator];
+    [delegate webView:self.webView willDismissEditMenuWithAnimator:animator];
 }
 
 #endif // HAVE(UI_EDIT_MENU_INTERACTION)

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -504,14 +504,14 @@ static bool isQuickboardViewController(UIViewController *viewController)
 
 #if HAVE(UI_EDIT_MENU_INTERACTION)
 
-- (void)_webView:(WKWebView *)webView willPresentEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
+- (void)webView:(WKWebView *)webView willPresentEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
 {
     [animator addCompletion:[strongSelf = RetainPtr { self }] {
         [strongSelf _didShowMenu];
     }];
 }
 
-- (void)_webView:(WKWebView *)webView willDismissEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
+- (void)webView:(WKWebView *)webView willDismissEditMenuWithAnimator:(id<UIEditMenuInteractionAnimating>)animator
 {
     [animator addCompletion:[strongSelf = RetainPtr { self }] {
         [strongSelf _didHideMenu];


### PR DESCRIPTION
#### 0db83bab641f94f01a0c4a5a0a597687cda5b0d6
<pre>
Add UIDelegate API to observe text edit menu appearance and dismissal
<a href="https://bugs.webkit.org/show_bug.cgi?id=243102">https://bugs.webkit.org/show_bug.cgi?id=243102</a>
rdar://96239605

Reviewed by Aditya Keerthi.

Move the private UI delegate methods introduced in `252742@main` into the public API header,
`WKUIDelegate.h`, and adopt this new API in our own testing infrastructure, to observe edit menu
presentation and dismissal.

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView willPresentEditMenuWithAnimator:]):
(-[WKContentView willDismissEditMenuWithAnimator:]):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView webView:willPresentEditMenuWithAnimator:]):
(-[TestRunnerWKWebView webView:willDismissEditMenuWithAnimator:]):
(-[TestRunnerWKWebView _webView:willPresentEditMenuWithAnimator:]): Deleted.
(-[TestRunnerWKWebView _webView:willDismissEditMenuWithAnimator:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/252974@main">https://commits.webkit.org/252974@main</a>
</pre>
