### PR TITLE
Web Inspector: support OffscreenCanvas for Canvas related operations

### DIFF
--- a/LayoutTests/inspector/canvas/create-context-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-2d-expected.txt
@@ -29,6 +29,13 @@ PASS: Canvas context should be Offscreen2D.
 
 PASS: Removed canvas has expected ID.
 
+-- Running test case: Canvas.CreateContext2D.Worker
+PASS: Canvas context should be Offscreen2D.
+  0: getContext - [native code]
+  1: createContext - inspector/canvas/resources/worker.js:4:36
+  2: (anonymous function) - inspector/canvas/resources/worker.js:14:21
+
+
 -- Running test case: Canvas.CreateContext2D.CSSCanvas
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be 2D.

--- a/LayoutTests/inspector/canvas/create-context-2d.html
+++ b/LayoutTests/inspector/canvas/create-context-2d.html
@@ -5,6 +5,8 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script src="resources/create-context-utilities.js"></script>
 <script>
+window.worker = new Worker("resources/worker.js");
+
 function test() {
     let suite = InspectorTest.CreateContextUtilities.initializeTestSuite("Canvas.CreateContext2D");
 
@@ -24,6 +26,13 @@ function test() {
         name: "Offscreen",
         expression: `createOffscreenCanvas("2d")`,
         contextType: WI.Canvas.ContextType.OffscreenCanvas2D,
+    });
+
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Worker",
+        expression: `worker.postMessage({name: "createContext", args: ["2d"]})`,
+        contextType: WI.Canvas.ContextType.OffscreenCanvas2D,
+        skipDestroy: true,
     });
 
     InspectorTest.CreateContextUtilities.addCSSCanvasTestCase(WI.Canvas.ContextType.Canvas2D);

--- a/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
@@ -21,3 +21,27 @@ PASS: Canvas context should be Bitmap Renderer.
 
 PASS: Removed canvas has expected ID.
 
+-- Running test case: Canvas.CreateContextBitmapRenderer.Offscreen
+PASS: Canvas context should be Bitmap Renderer.
+  0: getContext - [native code]
+  1: createOffscreenCanvas - inspector/canvas/resources/create-context-utilities.js:36:36
+  2: Global Code - [program code]
+
+PASS: Removed canvas has expected ID.
+
+-- Running test case: Canvas.CreateContextBitmapRenderer.Worker
+PASS: Canvas context should be Bitmap Renderer.
+  0: getContext - [native code]
+  1: createContext - inspector/canvas/resources/worker.js:4:36
+  2: (anonymous function) - inspector/canvas/resources/worker.js:14:21
+
+
+-- Running test case: Canvas.CreateContextBitmapRenderer.CSSCanvas
+Create CSS canvas from -webkit-canvas(css-canvas).
+PASS: Canvas context should be Bitmap Renderer.
+  0: getCSSCanvasContext - [native code]
+  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:22:47
+  2: Global Code - [program code]
+
+PASS: Canvas name should equal the identifier passed to -webkit-canvas.
+

--- a/LayoutTests/inspector/canvas/create-context-bitmaprenderer.html
+++ b/LayoutTests/inspector/canvas/create-context-bitmaprenderer.html
@@ -5,6 +5,8 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script src="resources/create-context-utilities.js"></script>
 <script>
+window.worker = new Worker("resources/worker.js");
+
 function test() {
     let suite = InspectorTest.CreateContextUtilities.initializeTestSuite("Canvas.CreateContextBitmapRenderer");
 
@@ -19,6 +21,21 @@ function test() {
         expression: `createDetachedCanvas("bitmaprenderer")`,
         contextType: WI.Canvas.ContextType.BitmapRenderer,
     });
+
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Offscreen",
+        expression: `createOffscreenCanvas("bitmaprenderer")`,
+        contextType: WI.Canvas.ContextType.BitmapRenderer,
+    });
+
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Worker",
+        expression: `worker.postMessage({name: "createContext", args: ["bitmaprenderer"]})`,
+        contextType: WI.Canvas.ContextType.BitmapRenderer,
+        skipDestroy: true,
+    });
+
+    InspectorTest.CreateContextUtilities.addCSSCanvasTestCase(WI.Canvas.ContextType.BitmapRenderer);
 
     suite.runTestCasesAndFinish();
 }

--- a/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
@@ -21,6 +21,14 @@ PASS: Canvas context should be WebGL.
 
 PASS: Removed canvas has expected ID.
 
+-- Running test case: Canvas.CreateContextWebGL.Offscreen
+PASS: Canvas context should be WebGL.
+  0: getContext - [native code]
+  1: createOffscreenCanvas - inspector/canvas/resources/create-context-utilities.js:36:36
+  2: Global Code - [program code]
+
+PASS: Removed canvas has expected ID.
+
 -- Running test case: Canvas.CreateContextWebGL.CSSCanvas
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be WebGL.

--- a/LayoutTests/inspector/canvas/create-context-webgl.html
+++ b/LayoutTests/inspector/canvas/create-context-webgl.html
@@ -20,6 +20,12 @@ function test() {
         contextType: WI.Canvas.ContextType.WebGL,
     });
 
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Offscreen",
+        expression: `createOffscreenCanvas("webgl")`,
+        contextType: WI.Canvas.ContextType.WebGL,
+    });
+
     InspectorTest.CreateContextUtilities.addCSSCanvasTestCase(WI.Canvas.ContextType.WebGL);
 
     suite.runTestCasesAndFinish();

--- a/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
@@ -21,6 +21,14 @@ PASS: Canvas context should be WebGL2.
 
 PASS: Removed canvas has expected ID.
 
+-- Running test case: Canvas.CreateContextWebGL2.Offscreen
+PASS: Canvas context should be WebGL2.
+  0: getContext - [native code]
+  1: createOffscreenCanvas - inspector/canvas/resources/create-context-utilities.js:36:36
+  2: Global Code - [program code]
+
+PASS: Removed canvas has expected ID.
+
 -- Running test case: Canvas.CreateContextWebGL2.CSSCanvas
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be WebGL2.

--- a/LayoutTests/inspector/canvas/create-context-webgl2.html
+++ b/LayoutTests/inspector/canvas/create-context-webgl2.html
@@ -20,6 +20,12 @@ function test() {
         contextType: WI.Canvas.ContextType.WebGL2,
     });
 
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Offscreen",
+        expression: `createOffscreenCanvas("webgl2")`,
+        contextType: WI.Canvas.ContextType.WebGL2,
+    });
+
     InspectorTest.CreateContextUtilities.addCSSCanvasTestCase(WI.Canvas.ContextType.WebGL2);
 
     suite.runTestCasesAndFinish();

--- a/LayoutTests/inspector/canvas/resources/create-context-utilities.js
+++ b/LayoutTests/inspector/canvas/resources/create-context-utilities.js
@@ -54,6 +54,8 @@ function destroyCanvases() {
 
     window.contexts = [];
 
+    window.worker?.postMessage({name: `destroyContexts`, args: []});
+
     // Force GC to make sure the canvas element is destroyed, otherwise the frontend
     // does not receive Canvas.canvasRemoved events.
     destroyCanvasesInterval = setInterval(() => { GCController.collect(); }, 0);
@@ -120,15 +122,14 @@ TestPage.registerInitializer(() => {
         return suite;
     };
 
-    InspectorTest.CreateContextUtilities.addSimpleTestCase = function({name, description, expression, contextType}) {
+    InspectorTest.CreateContextUtilities.addSimpleTestCase = function({name, description, expression, contextType, skipDestroy}) {
         suite.addTestCase({
             name: suite.name + "." + name,
             description,
             test(resolve, reject) {
                 awaitCanvasAdded(contextType)
                 .then((canvas) => {
-                    if (canvas.cssCanvasName) {
-                        InspectorTest.log("CSS canvas will not be destroyed");
+                    if (skipDestroy) {
                         resolve();
                         return;
                     }

--- a/LayoutTests/inspector/canvas/resources/worker.js
+++ b/LayoutTests/inspector/canvas/resources/worker.js
@@ -1,0 +1,16 @@
+globalThis.contexts = [];
+
+function createContext(contextType) {
+    let canvas = new OffscreenCanvas(10, 10);
+    let context = canvas.getContext(contextType);
+    globalThis.contexts.push(context);
+}
+
+function destroyContexts() {
+    globalThis.contexts = [];
+}
+
+addEventListener("message", (event) => {
+    let {name, args} = event.data;
+    globalThis[name](...args);
+});

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -2,7 +2,7 @@
     "domain": "Canvas",
     "description": "Canvas domain allows tracking of canvases that have an associated graphics context. Tracks canvases in the DOM and CSS canvases created with -webkit-canvas.",
     "debuggableTypes": ["page", "web-page"],
-    "targetTypes": ["page"],
+    "targetTypes": ["page", "worker"],
     "types": [
         {
             "id": "CanvasId",
@@ -62,6 +62,8 @@
             "properties": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." },
                 { "name": "contextType", "$ref": "ContextType", "description": "The type of rendering context backing the canvas." },
+                { "name": "width", "type": "number", "description": "Width of the canvas in pixels." },
+                { "name": "height", "type": "number", "description": "Height of the canvas in pixels." },
                 { "name": "nodeId", "$ref": "DOM.NodeId", "optional": true, "description": "The corresponding DOM node id." },
                 { "name": "cssCanvasName", "type": "string", "optional": true, "description": "The CSS canvas identifier, for canvases created with <code>document.getCSSCanvasContext</code>." },
                 { "name": "contextAttributes", "$ref": "ContextAttributes", "optional": true, "description": "Context attributes for rendering contexts." },
@@ -93,6 +95,7 @@
         {
             "name": "requestNode",
             "description": "Gets the NodeId for the canvas node with the given CanvasId.",
+            "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Canvas identifier." }
             ],
@@ -113,6 +116,7 @@
         {
             "name": "requestClientNodes",
             "description": "Gets all <code>-webkit-canvas</code> nodes or active <code>HTMLCanvasElement</code> for a <code>WebGPUDevice</code>.",
+            "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId" }
             ],
@@ -209,6 +213,14 @@
             ]
         },
         {
+            "name": "canvasSizeChanged",
+            "parameters": [
+                { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." },
+                { "name": "width", "type": "number", "description": "Width of the canvas in pixels." },
+                { "name": "height", "type": "number", "description": "Height of the canvas in pixels." }
+            ]
+        },
+        {
             "name": "canvasMemoryChanged",
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." },
@@ -224,6 +236,7 @@
         },
         {
             "name": "clientNodesChanged",
+            "targetTypes": ["page"],
             "parameters": [
                 { "name": "canvasId", "$ref": "CanvasId", "description": "Identifier of canvas that changed." }
             ]

--- a/Source/JavaScriptCore/inspector/protocol/Recording.json
+++ b/Source/JavaScriptCore/inspector/protocol/Recording.json
@@ -2,7 +2,7 @@
     "domain": "Recording",
     "description": "General types used for recordings of actions performed in the inspected page.",
     "debuggableTypes": ["page", "web-page"],
-    "targetTypes": ["page"],
+    "targetTypes": ["page", "worker"],
     "version": 2,
     "types": [
         {

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1675,6 +1675,7 @@ inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
+inspector/agents/page/PageCanvasAgent.cpp
 inspector/agents/page/PageConsoleAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageDebuggerAgent.cpp
@@ -1683,6 +1684,7 @@ inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
+inspector/agents/worker/WorkerCanvasAgent.cpp
 inspector/agents/worker/WorkerConsoleAgent.cpp
 inspector/agents/worker/WorkerDOMDebuggerAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -140,7 +140,7 @@ protected:
 
     virtual ScriptExecutionContext* canvasBaseScriptExecutionContext() const = 0;
 
-    virtual void setSize(const IntSize& size) { m_size = size; }
+    virtual void setSize(const IntSize&);
 
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
     virtual bool hasCreatedImageBuffer() const { return false; }

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -896,9 +896,13 @@ Ref<Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(bool capture
         return Protocol::Canvas::ContextType::Canvas2D;
     }();
 
+    const auto& size = m_context->canvasBase().size();
+
     auto canvas = Protocol::Canvas::Canvas::create()
         .setCanvasId(m_identifier)
         .setContextType(contextType)
+        .setWidth(size.width())
+        .setHeight(size.height())
         .release();
 
     if (auto* node = canvasElement()) {

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -40,7 +40,6 @@
 #include "InspectorApplicationCacheAgent.h"
 #include "InspectorCPUProfilerAgent.h"
 #include "InspectorCSSAgent.h"
-#include "InspectorCanvasAgent.h"
 #include "InspectorClient.h"
 #include "InspectorDOMAgent.h"
 #include "InspectorDOMStorageAgent.h"
@@ -63,6 +62,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "PageAuditAgent.h"
+#include "PageCanvasAgent.h"
 #include "PageConsoleAgent.h"
 #include "PageDOMDebuggerAgent.h"
 #include "PageDebugger.h"
@@ -183,7 +183,7 @@ void InspectorController::createLazyAgents()
 #endif
     m_agents.append(makeUnique<PageHeapAgent>(pageContext));
     m_agents.append(makeUnique<PageAuditAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorCanvasAgent>(pageContext));
+    m_agents.append(makeUnique<PageCanvasAgent>(pageContext));
     m_agents.append(makeUnique<InspectorTimelineAgent>(pageContext));
     m_agents.append(makeUnique<InspectorAnimationAgent>(pageContext));
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -57,6 +57,7 @@
 #include "LoaderStrategy.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
+#include "PageCanvasAgent.h"
 #include "PageDOMDebuggerAgent.h"
 #include "PageDebuggerAgent.h"
 #include "PageHeapAgent.h"
@@ -785,8 +786,8 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
     if (auto* pageRuntimeAgent = instrumentingAgents.enabledPageRuntimeAgent())
         pageRuntimeAgent->frameNavigated(frame);
 
-    if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
-        canvasAgent->frameNavigated(frame);
+    if (auto* pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent())
+        pageCanvasAgent->frameNavigated(frame);
 
     if (auto* animationAgent = instrumentingAgents.enabledAnimationAgent())
         animationAgent->frameNavigated(frame);
@@ -1126,14 +1127,20 @@ void InspectorInstrumentation::didSendWebSocketFrameImpl(InstrumentingAgents& in
 
 void InspectorInstrumentation::didChangeCSSCanvasClientNodesImpl(InstrumentingAgents& instrumentingAgents, CanvasBase& canvasBase)
 {
-    if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
-        canvasAgent->didChangeCSSCanvasClientNodes(canvasBase);
+    if (auto* pageCanvasAgent = instrumentingAgents.enabledPageCanvasAgent())
+        pageCanvasAgent->didChangeCSSCanvasClientNodes(canvasBase);
 }
 
 void InspectorInstrumentation::didCreateCanvasRenderingContextImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
 {
     if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
         canvasAgent->didCreateCanvasRenderingContext(context);
+}
+
+void InspectorInstrumentation::didChangeCanvasSizeImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
+{
+    if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
+        canvasAgent->didChangeCanvasSize(context);
 }
 
 void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -301,6 +301,7 @@ public:
 
     static void didChangeCSSCanvasClientNodes(CanvasBase&);
     static void didCreateCanvasRenderingContext(CanvasRenderingContext&);
+    static void didChangeCanvasSize(CanvasRenderingContext&);
     static void didChangeCanvasMemory(CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
@@ -513,6 +514,7 @@ private:
 
     static void didChangeCSSCanvasClientNodesImpl(InstrumentingAgents&, CanvasBase&);
     static void didCreateCanvasRenderingContextImpl(InstrumentingAgents&, CanvasRenderingContext&);
+    static void didChangeCanvasSizeImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didChangeCanvasMemoryImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrameImpl(InstrumentingAgents&, CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
@@ -1462,6 +1464,13 @@ inline void InspectorInstrumentation::didCreateCanvasRenderingContext(CanvasRend
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didCreateCanvasRenderingContextImpl(*agents, context);
+}
+
+inline void InspectorInstrumentation::didChangeCanvasSize(CanvasRenderingContext& context)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+        didChangeCanvasSizeImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::didChangeCanvasMemory(CanvasRenderingContext& context)

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -58,6 +58,7 @@ class InspectorNetworkAgent;
 class InspectorPageAgent;
 class InspectorTimelineAgent;
 class InspectorWorkerAgent;
+class PageCanvasAgent;
 class PageDOMDebuggerAgent;
 class PageDebuggerAgent;
 class PageHeapAgent;
@@ -70,6 +71,7 @@ class WebDebuggerAgent;
 #define DEFINE_INSPECTOR_AGENT_Animation(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorAnimationAgent, AnimationAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_ApplicationCache(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorApplicationCacheAgent, ApplicationCacheAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Canvas(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorCanvasAgent, CanvasAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_Canvas_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageCanvasAgent, PageCanvasAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_CSS(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorCSSAgent, CSSAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOM(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMAgent, DOMAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOMDebugger(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMDebuggerAgent, DOMDebuggerAgent, Getter, Setter)
@@ -117,6 +119,7 @@ class WebDebuggerAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Animation) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, ApplicationCache) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Canvas) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, Canvas_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, CSS) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Database) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Debugger_Page) \

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -33,6 +33,7 @@
 #include "WebInjectedScriptHost.h"
 #include "WebInjectedScriptManager.h"
 #include "WorkerAuditAgent.h"
+#include "WorkerCanvasAgent.h"
 #include "WorkerConsoleAgent.h"
 #include "WorkerDOMDebuggerAgent.h"
 #include "WorkerDebugger.h"
@@ -219,6 +220,7 @@ void WorkerInspectorController::createLazyAgents()
 
     m_agents.append(makeUnique<WorkerDOMDebuggerAgent>(workerContext, debuggerAgentPtr));
     m_agents.append(makeUnique<WorkerAuditAgent>(workerContext));
+    m_agents.append(makeUnique<WorkerCanvasAgent>(workerContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())
         commandLineAPIHost->init(m_instrumentingAgents.copyRef());

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -34,22 +34,17 @@
 #include "CanvasRenderingContext2D.h"
 #include "DOMMatrix2DInit.h"
 #include "DOMPointInit.h"
-#include "Document.h"
-#include "Element.h"
 #include "EventLoop.h"
-#include "FrameDestructionObserverInlines.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
 #include "ImageBitmap.h"
 #include "ImageBitmapRenderingContext.h"
 #include "ImageData.h"
-#include "InspectorDOMAgent.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorShaderProgram.h"
 #include "InstrumentingAgents.h"
 #include "JSExecState.h"
-#include "LocalFrame.h"
 #include "Path2D.h"
 #include "PlaceholderRenderingContext.h"
 #include "StringAdaptors.h"
@@ -93,12 +88,11 @@ namespace WebCore {
 
 using namespace Inspector;
 
-InspectorCanvasAgent::InspectorCanvasAgent(PageAgentContext& context)
+InspectorCanvasAgent::InspectorCanvasAgent(WebAgentContext& context)
     : InspectorAgentBase("Canvas"_s, context)
     , m_frontendDispatcher(makeUnique<Inspector::CanvasFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::CanvasBackendDispatcher::create(context.backendDispatcher, this))
     , m_injectedScriptManager(context.injectedScriptManager)
-    , m_inspectedPage(context.inspectedPage)
     , m_canvasDestroyedTimer(*this, &InspectorCanvasAgent::canvasDestroyedTimerFired)
 #if ENABLE(WEBGL)
     , m_programDestroyedTimer(*this, &InspectorCanvasAgent::programDestroyedTimerFired)
@@ -124,19 +118,31 @@ void InspectorCanvasAgent::discardAgent()
 
 Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
 {
-    if (m_instrumentingAgents.enabledCanvasAgent() == this)
-        return { };
+    if (enabled())
+        return makeUnexpected("Canvas domain already enabled"_s);
+
+    internalEnable();
+
+    return { };
+}
+
+Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
+{
+    internalDisable();
+
+    return { };
+}
+
+bool InspectorCanvasAgent::enabled() const
+{
+    return m_instrumentingAgents.enabledCanvasAgent() == this;
+}
+
+void InspectorCanvasAgent::internalEnable()
+{
+    ASSERT(!enabled());
 
     m_instrumentingAgents.setEnabledCanvasAgent(this);
-
-    const auto existsInCurrentPage = [&] (ScriptExecutionContext* scriptExecutionContext) {
-        if (!is<Document>(scriptExecutionContext))
-            return false;
-
-        // FIXME: <https://webkit.org/b/168475> Web Inspector: Correctly display iframe's WebSockets
-        auto* document = downcast<Document>(scriptExecutionContext);
-        return document->page() == &m_inspectedPage;
-    };
 
     {
         Locker locker { CanvasRenderingContext::instancesLock() };
@@ -145,7 +151,8 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
             if (is<PlaceholderRenderingContext>(context))
                 continue;
 #endif
-            if (existsInCurrentPage(context->canvasBase().scriptExecutionContext()))
+
+            if (matchesCurrentContext(context->canvasBase().scriptExecutionContext()))
                 bindCanvas(*context, false);
         }
     }
@@ -154,44 +161,20 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::enable()
     {
         Locker locker { WebGLProgram::instancesLock() };
         for (auto& [program, contextWebGLBase] : WebGLProgram::instances()) {
-            if (contextWebGLBase && existsInCurrentPage(contextWebGLBase->canvasBase().scriptExecutionContext()))
+            if (contextWebGLBase && matchesCurrentContext(contextWebGLBase->canvasBase().scriptExecutionContext()))
                 didCreateWebGLProgram(*contextWebGLBase, *program);
         }
     }
 #endif
-
-    return { };
 }
 
-Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
+void InspectorCanvasAgent::internalDisable()
 {
     m_instrumentingAgents.setEnabledCanvasAgent(nullptr);
 
     reset();
 
     m_recordingAutoCaptureFrameCount = std::nullopt;
-
-    return { };
-}
-
-Protocol::ErrorStringOr<Protocol::DOM::NodeId> InspectorCanvasAgent::requestNode(const Protocol::Canvas::CanvasId& canvasId)
-{
-    Protocol::ErrorString errorString;
-
-    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
-    if (!inspectorCanvas)
-        return makeUnexpected(errorString);
-
-    auto* node = inspectorCanvas->canvasElement();
-    if (!node)
-        makeUnexpected("Missing element of canvas for given canvasId"_s);
-
-    // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-    int documentNodeId = m_instrumentingAgents.persistentDOMAgent()->boundNodeId(&node->document());
-    if (!documentNodeId)
-        makeUnexpected("Document must have been requested"_s);
-
-    return m_instrumentingAgents.persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
 }
 
 Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestContent(const Protocol::Canvas::CanvasId& canvasId)
@@ -201,27 +184,6 @@ Protocol::ErrorStringOr<String> InspectorCanvasAgent::requestContent(const Proto
     if (!inspectorCanvas)
         return makeUnexpected(errorString);
     return inspectorCanvas->getContentAsDataURL();
-}
-
-Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> InspectorCanvasAgent::requestClientNodes(const Protocol::Canvas::CanvasId& canvasId)
-{
-    Protocol::ErrorString errorString;
-
-    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
-    if (!domAgent)
-        return makeUnexpected("DOM domain must be enabled"_s);
-
-    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
-    if (!inspectorCanvas)
-        return makeUnexpected(errorString);
-
-    auto clientNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
-    for (auto& clientNode : inspectorCanvas->clientNodes()) {
-        // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-        if (auto documentNodeId = domAgent->boundNodeId(&clientNode->document()))
-            clientNodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, clientNode));
-    }
-    return clientNodeIds;
 }
 
 Protocol::ErrorStringOr<Ref<Protocol::Runtime::RemoteObject>> InspectorCanvasAgent::resolveContext(const Protocol::Canvas::CanvasId& canvasId, const String& objectGroup)
@@ -363,41 +325,6 @@ Protocol::ErrorStringOr<void> InspectorCanvasAgent::setShaderProgramHighlighted(
 
 #endif // ENABLE(WEBGL)
 
-void InspectorCanvasAgent::frameNavigated(LocalFrame& frame)
-{
-    if (frame.isMainFrame()) {
-        reset();
-        return;
-    }
-
-    Vector<InspectorCanvas*> inspectorCanvases;
-    for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
-        if (auto* canvasElement = inspectorCanvas->canvasElement()) {
-            if (canvasElement->document().frame() == &frame)
-                inspectorCanvases.append(inspectorCanvas.get());
-        }
-    }
-
-    for (auto* inspectorCanvas : inspectorCanvases)
-        unbindCanvas(*inspectorCanvas);
-}
-
-void InspectorCanvasAgent::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
-{
-    auto* context = canvasBase.renderingContext();
-    if (!context) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    auto inspectorCanvas = findInspectorCanvas(*context);
-    ASSERT(inspectorCanvas);
-    if (!inspectorCanvas)
-        return;
-
-    m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
-}
-
 void InspectorCanvasAgent::didCreateCanvasRenderingContext(CanvasRenderingContext& context)
 {
     if (findInspectorCanvas(context)) {
@@ -414,6 +341,21 @@ void InspectorCanvasAgent::didCreateCanvasRenderingContext(CanvasRenderingContex
     }
 }
 
+void InspectorCanvasAgent::didChangeCanvasSize(CanvasRenderingContext& context)
+{
+    RefPtr<InspectorCanvas> inspectorCanvas;
+
+    if (!inspectorCanvas)
+        inspectorCanvas = findInspectorCanvas(context);
+
+    ASSERT(inspectorCanvas);
+    if (!inspectorCanvas)
+        return;
+
+    const auto& size = inspectorCanvas->canvasContext().canvasBase().size();
+    m_frontendDispatcher->canvasSizeChanged(inspectorCanvas->identifier(), size.width(), size.height());
+}
+
 void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context)
 {
     RefPtr<InspectorCanvas> inspectorCanvas;
@@ -425,8 +367,7 @@ void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context
     if (!inspectorCanvas)
         return;
 
-    if (auto* node = inspectorCanvas->canvasElement())
-        m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), node->memoryCost());
+    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().canvasBase().memoryCost());
 }
 
 void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const std::optional<FloatRect>&)
@@ -731,6 +672,8 @@ InspectorCanvas& InspectorCanvasAgent::bindCanvas(CanvasRenderingContext& contex
 
 void InspectorCanvasAgent::unbindCanvas(InspectorCanvas& inspectorCanvas)
 {
+    didFinishRecordingCanvasFrame(inspectorCanvas.canvasContext(), true);
+
 #if ENABLE(WEBGL)
     Vector<InspectorShaderProgram*> programsToRemove;
     for (auto& inspectorProgram : m_identifierToInspectorProgram.values()) {

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -47,7 +47,7 @@ class InjectedScriptManager;
 namespace WebCore {
 
 class CanvasRenderingContext;
-class LocalFrame;
+class ScriptExecutionContext;
 
 #if ENABLE(WEBGL)
 class InspectorShaderProgram;
@@ -55,24 +55,22 @@ class WebGLProgram;
 class WebGLRenderingContextBase;
 #endif // ENABLE(WEBGL)
 
-class InspectorCanvasAgent final : public InspectorAgentBase, public Inspector::CanvasBackendDispatcherHandler, public CanvasObserver {
+class InspectorCanvasAgent : public InspectorAgentBase, public Inspector::CanvasBackendDispatcherHandler, public CanvasObserver {
     WTF_MAKE_NONCOPYABLE(InspectorCanvasAgent);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    InspectorCanvasAgent(PageAgentContext&);
     ~InspectorCanvasAgent();
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*);
     void willDestroyFrontendAndBackend(Inspector::DisconnectReason);
     void discardAgent();
+    virtual bool enabled() const;
 
     // CanvasBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<void> enable();
     Inspector::Protocol::ErrorStringOr<void> disable();
-    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&);
     Inspector::Protocol::ErrorStringOr<String> requestContent(const Inspector::Protocol::Canvas::CanvasId&);
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObject>> resolveContext(const Inspector::Protocol::Canvas::CanvasId&, const String& objectGroup);
     Inspector::Protocol::ErrorStringOr<void> setRecordingAutoCaptureFrameCount(int);
     Inspector::Protocol::ErrorStringOr<void> startRecording(const Inspector::Protocol::Canvas::CanvasId&, std::optional<int>&& frameCount, std::optional<int>&& memoryLimit);
@@ -90,9 +88,8 @@ public:
     void canvasDestroyed(CanvasBase&) final;
 
     // InspectorInstrumentation
-    void frameNavigated(LocalFrame&);
-    void didChangeCSSCanvasClientNodes(CanvasBase&);
     void didCreateCanvasRenderingContext(CanvasRenderingContext&);
+    void didChangeCanvasSize(CanvasRenderingContext&);
     void didChangeCanvasMemory(CanvasRenderingContext&);
     void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
     void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
@@ -113,6 +110,24 @@ public:
 #undef PROCESS_ARGUMENT_DECLARATION
     void recordAction(CanvasRenderingContext&, String&&, InspectorCanvasCallTracer::ProcessedArguments&& = { });
 
+protected:
+    InspectorCanvasAgent(WebAgentContext&);
+
+    virtual void internalEnable();
+    virtual void internalDisable();
+
+    void reset();
+    void unbindCanvas(InspectorCanvas&);
+
+    RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
+    RefPtr<InspectorCanvas> findInspectorCanvas(CanvasRenderingContext&);
+
+    virtual bool matchesCurrentContext(ScriptExecutionContext*) const = 0;
+
+    std::unique_ptr<Inspector::CanvasFrontendDispatcher> m_frontendDispatcher;
+
+    MemoryCompactRobinHoodHashMap<String, RefPtr<InspectorCanvas>> m_identifierToInspectorCanvas;
+
 private:
     struct RecordingOptions {
         std::optional<long> frameCount;
@@ -125,12 +140,8 @@ private:
 #if ENABLE(WEBGL)
     void programDestroyedTimerFired();
 #endif // ENABLE(WEBGL)
-    void reset();
 
     InspectorCanvas& bindCanvas(CanvasRenderingContext&, bool captureBacktrace);
-    void unbindCanvas(InspectorCanvas&);
-    RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
-    RefPtr<InspectorCanvas> findInspectorCanvas(CanvasRenderingContext&);
 
 #if ENABLE(WEBGL)
     void unbindProgram(InspectorShaderProgram&);
@@ -138,13 +149,10 @@ private:
     RefPtr<InspectorShaderProgram> findInspectorProgram(WebGLProgram&);
 #endif // ENABLE(WEBGL)
 
-    std::unique_ptr<Inspector::CanvasFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::CanvasBackendDispatcher> m_backendDispatcher;
 
     Inspector::InjectedScriptManager& m_injectedScriptManager;
-    Page& m_inspectedPage;
 
-    MemoryCompactRobinHoodHashMap<String, RefPtr<InspectorCanvas>> m_identifierToInspectorCanvas;
     Vector<String> m_removedCanvasIdentifiers;
     Timer m_canvasDestroyedTimer;
 

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PageCanvasAgent.h"
+
+#include "CSSStyleImageValue.h"
+#include "CanvasBase.h"
+#include "CanvasGradient.h"
+#include "CanvasPattern.h"
+#include "CanvasRenderingContext.h"
+#include "Document.h"
+#include "Element.h"
+#include "FrameDestructionObserverInlines.h"
+#include "HTMLCanvasElement.h"
+#include "HTMLImageElement.h"
+#include "HTMLVideoElement.h"
+#include "ImageBitmap.h"
+#include "ImageData.h"
+#include "InspectorCanvas.h"
+#include "InspectorDOMAgent.h"
+#include "LocalFrame.h"
+#include "Page.h"
+
+#if ENABLE(OFFSCREEN_CANVAS)
+#include "OffscreenCanvas.h"
+#endif
+
+namespace WebCore {
+
+using namespace Inspector;
+
+PageCanvasAgent::PageCanvasAgent(PageAgentContext& context)
+    : InspectorCanvasAgent(context)
+    , m_inspectedPage(context.inspectedPage)
+{
+}
+
+PageCanvasAgent::~PageCanvasAgent() = default;
+
+bool PageCanvasAgent::enabled() const
+{
+    return m_instrumentingAgents.enabledPageCanvasAgent() == this && InspectorCanvasAgent::enabled();
+}
+
+void PageCanvasAgent::internalEnable()
+{
+    m_instrumentingAgents.setEnabledPageCanvasAgent(this);
+
+    InspectorCanvasAgent::internalEnable();
+}
+
+void PageCanvasAgent::internalDisable()
+{
+    m_instrumentingAgents.setEnabledPageCanvasAgent(nullptr);
+
+    InspectorCanvasAgent::internalDisable();
+}
+
+Protocol::ErrorStringOr<Protocol::DOM::NodeId> PageCanvasAgent::requestNode(const Protocol::Canvas::CanvasId& canvasId)
+{
+    Protocol::ErrorString errorString;
+
+    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
+    if (!inspectorCanvas)
+        return makeUnexpected(errorString);
+
+    auto* node = inspectorCanvas->canvasElement();
+    if (!node)
+        return makeUnexpected("Missing element of canvas for given canvasId"_s);
+
+    // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
+    int documentNodeId = m_instrumentingAgents.persistentDOMAgent()->boundNodeId(&node->document());
+    if (!documentNodeId)
+        return makeUnexpected("Document must have been requested"_s);
+
+    return m_instrumentingAgents.persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
+}
+
+Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Protocol::Canvas::CanvasId& canvasId)
+{
+    Protocol::ErrorString errorString;
+
+    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    if (!domAgent)
+        return makeUnexpected("DOM domain must be enabled"_s);
+
+    auto inspectorCanvas = assertInspectorCanvas(errorString, canvasId);
+    if (!inspectorCanvas)
+        return makeUnexpected(errorString);
+
+    auto clientNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
+    for (auto& clientNode : inspectorCanvas->clientNodes()) {
+        // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
+        if (auto documentNodeId = domAgent->boundNodeId(&clientNode->document()))
+            clientNodeIds->addItem(domAgent->pushNodeToFrontend(errorString, documentNodeId, clientNode));
+    }
+    return clientNodeIds;
+}
+
+void PageCanvasAgent::frameNavigated(LocalFrame& frame)
+{
+    if (frame.isMainFrame()) {
+        reset();
+        return;
+    }
+
+    Vector<InspectorCanvas*> inspectorCanvases;
+    for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
+        if (auto* canvasElement = inspectorCanvas->canvasElement()) {
+            if (canvasElement->document().frame() == &frame)
+                inspectorCanvases.append(inspectorCanvas.get());
+        }
+    }
+    for (auto* inspectorCanvas : inspectorCanvases)
+        unbindCanvas(*inspectorCanvas);
+}
+
+void PageCanvasAgent::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
+{
+    auto* context = canvasBase.renderingContext();
+    if (!context) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto inspectorCanvas = findInspectorCanvas(*context);
+    ASSERT(inspectorCanvas);
+    if (!inspectorCanvas)
+        return;
+
+    m_frontendDispatcher->clientNodesChanged(inspectorCanvas->identifier());
+}
+
+bool PageCanvasAgent::matchesCurrentContext(ScriptExecutionContext* scriptExecutionContext) const
+{
+    auto* document = dynamicDowncast<Document>(scriptExecutionContext);
+    if (!document)
+        return false;
+
+    // FIXME: <https://webkit.org/b/168475> Web Inspector: Correctly display iframe's WebSockets
+    return document->page() == &m_inspectedPage;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorCanvasAgent.h"
+
+namespace WebCore {
+
+class LocalFrame;
+class Page;
+
+class PageCanvasAgent final : public InspectorCanvasAgent {
+    WTF_MAKE_NONCOPYABLE(PageCanvasAgent);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    PageCanvasAgent(PageAgentContext&);
+    ~PageCanvasAgent();
+
+    // CanvasBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+
+    // InspectorInstrumentation
+    void frameNavigated(LocalFrame&);
+    void didChangeCSSCanvasClientNodes(CanvasBase&);
+
+private:
+    bool enabled() const override;
+
+    void internalEnable() override;
+    void internalDisable() override;
+
+    bool matchesCurrentContext(ScriptExecutionContext*) const override;
+
+    Page& m_inspectedPage;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WorkerCanvasAgent.h"
+
+#include "WorkerOrWorkletGlobalScope.h"
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WorkerCanvasAgent::WorkerCanvasAgent(WorkerAgentContext& context)
+    : InspectorCanvasAgent(context)
+    , m_globalScope(context.globalScope)
+{
+    ASSERT(context.globalScope.isContextThread());
+}
+
+WorkerCanvasAgent::~WorkerCanvasAgent() = default;
+
+Protocol::ErrorStringOr<Protocol::DOM::NodeId> WorkerCanvasAgent::requestNode(const Protocol::Canvas::CanvasId&)
+{
+    return makeUnexpected("Not supported"_s);
+}
+
+Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::DOM::NodeId>>> WorkerCanvasAgent::requestClientNodes(const Protocol::Canvas::CanvasId&)
+{
+    return makeUnexpected("Not supported"_s);
+}
+
+bool WorkerCanvasAgent::matchesCurrentContext(ScriptExecutionContext* scriptExecutionContext) const
+{
+    auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(scriptExecutionContext);
+    if (!globalScope)
+        return false;
+
+    return globalScope == &m_globalScope;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorCanvasAgent.h"
+
+namespace WebCore {
+
+class WorkerOrWorkletGlobalScope;
+
+class WorkerCanvasAgent final : public InspectorCanvasAgent {
+    WTF_MAKE_NONCOPYABLE(WorkerCanvasAgent);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    WorkerCanvasAgent(WorkerAgentContext&);
+    ~WorkerCanvasAgent();
+
+    // CanvasBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> requestNode(const Inspector::Protocol::Canvas::CanvasId&) override;
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> requestClientNodes(const Inspector::Protocol::Canvas::CanvasId&) override;
+
+private:
+    bool matchesCurrentContext(ScriptExecutionContext*) const override;
+
+    WorkerOrWorkletGlobalScope& m_globalScope;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -94,9 +94,11 @@ void WorkerConsoleClient::profileEnd(JSC::JSGlobalObject*, const String&) { }
 void WorkerConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String&) { }
 void WorkerConsoleClient::timeStamp(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }
 
+// FIXME: <https://webkit.org/b/243362> Web Inspector: support starting/stopping recordings from the console in a Worker
 void WorkerConsoleClient::record(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }
 void WorkerConsoleClient::recordEnd(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }
 
+// FIXME: <https://webkit.org/b/243361> Web Inspector: support console screenshots in a Worker
 void WorkerConsoleClient::screenshot(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -106,7 +106,6 @@ localizedStrings["0 Console warnings"] = "0 Console warnings";
 localizedStrings["1 match"] = "1 match";
 localizedStrings["1080p"] = "1080p";
 localizedStrings["2D"] = "2D";
-localizedStrings["2D (Offscreen)"] = "2D (Offscreen)";
 /* Label indicating that network activity is being simulated with 3G connectivity. */
 localizedStrings["3G"] = "3G";
 localizedStrings["720p"] = "720p";

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -25,16 +25,20 @@
 
 WI.Canvas = class Canvas extends WI.Object
 {
-    constructor(identifier, contextType, {domNode, cssCanvasName, contextAttributes, memoryCost, stackTrace} = {})
+    constructor(target, identifier, contextType, size, {domNode, cssCanvasName, contextAttributes, memoryCost, stackTrace} = {})
     {
         super();
 
+        console.assert(target instanceof WI.Target, target);
         console.assert(identifier);
         console.assert(contextType);
+        console.assert(!size || size instanceof WI.Size, size);
         console.assert(!stackTrace || stackTrace instanceof WI.StackTrace, stackTrace);
 
+        this._target = target;
         this._identifier = identifier;
         this._contextType = contextType;
+        this._size = size || null;
         this._domNode = domNode || null;
         this._cssCanvasName = cssCanvasName || "";
         this._contextAttributes = contextAttributes || {};
@@ -53,11 +57,24 @@ WI.Canvas = class Canvas extends WI.Object
         this._recordingState = WI.Canvas.RecordingState.Inactive;
         this._recordingFrames = [];
         this._recordingBufferUsed = 0;
+
+        // COMPATIBILITY (macOS X.0, iOS X.0): `Canvas.canvasSizeChanged` did not exist yet.
+        if (!InspectorBackend.hasEvent("Canvas.canvasSizeChanged")) {
+            console.assert(!size);
+
+            this.requestNode().then((node) => {
+                if (node) {
+                    node.addEventListener(WI.DOMNode.Event.AttributeModified, this._calculateSize, this);
+                    node.addEventListener(WI.DOMNode.Event.AttributeRemoved, this._calculateSize, this);
+                }
+            });
+            this._calculateSize();
+        }
     }
 
     // Static
 
-    static fromPayload(payload)
+    static fromPayload(target, payload)
     {
         let contextType = null;
         switch (payload.contextType) {
@@ -86,16 +103,20 @@ WI.Canvas = class Canvas extends WI.Object
             console.error("Invalid canvas context type", payload.contextType);
         }
 
+        // COMPATIBILITY (macOS X.0, iOS X.0): `width` and `height` did not exist yet.
+        let size = ("width" in payload && "height" in payload) ? new WI.Size(payload.width, payload.height) : null;
+
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `backtrace` was renamed to `stackTrace`.
         if (payload.backtrace)
             payload.stackTrace = {callFrames: payload.backtrace};
 
-        return new WI.Canvas(payload.canvasId, contextType, {
+        return new WI.Canvas(target, payload.canvasId, contextType, size, {
+            height: payload.height,
             domNode: payload.nodeId ? WI.domManager.nodeForId(payload.nodeId) : null,
             cssCanvasName: payload.cssCanvasName,
             contextAttributes: payload.contextAttributes,
             memoryCost: payload.memoryCost,
-            stackTrace: WI.StackTrace.fromPayload(WI.assumingMainTarget(), payload.stackTrace),
+            stackTrace: WI.StackTrace.fromPayload(target, payload.stackTrace),
         });
     }
 
@@ -153,8 +174,11 @@ WI.Canvas = class Canvas extends WI.Object
 
     // Public
 
+    get target() { return this._target; }
     get identifier() { return this._identifier; }
     get contextType() { return this._contextType; }
+    get size() { return this._size; }
+    get memoryCost() { return this._memoryCost; }
     get cssCanvasName() { return this._cssCanvasName; }
     get contextAttributes() { return this._contextAttributes; }
     get extensions() { return this._extensions; }
@@ -167,21 +191,6 @@ WI.Canvas = class Canvas extends WI.Object
     get recordingActive()
     {
         return this._recordingState !== WI.Canvas.RecordingState.Inactive;
-    }
-
-    get memoryCost()
-    {
-        return this._memoryCost;
-    }
-
-    set memoryCost(memoryCost)
-    {
-        if (memoryCost === this._memoryCost)
-            return;
-
-        this._memoryCost = memoryCost;
-
-        this.dispatchEventToListeners(WI.Canvas.Event.MemoryChanged);
     }
 
     get displayName()
@@ -217,8 +226,12 @@ WI.Canvas = class Canvas extends WI.Object
             this._requestNodePromise = new Promise((resolve, reject) => {
                 WI.domManager.ensureDocument();
 
-                let target = WI.assumingMainTarget();
-                target.CanvasAgent.requestNode(this._identifier, (error, nodeId) => {
+                if (!this._target.hasCommand("Canvas.requestNode")) {
+                    resolve(null);
+                    return;
+                }
+
+                this._target.CanvasAgent.requestNode(this._identifier, (error, nodeId) => {
                     if (error) {
                         resolve(null);
                         return;
@@ -242,8 +255,7 @@ WI.Canvas = class Canvas extends WI.Object
         if (!Canvas.supportsRequestContentForContextType(this._contextType))
             return Promise.resolve(null);
 
-        let target = WI.assumingMainTarget();
-        return target.CanvasAgent.requestContent(this._identifier).then((result) => result.content).catch((error) => console.error(error));
+        return this._target.CanvasAgent.requestContent(this._identifier).then((result) => result.content).catch((error) => console.error(error));
     }
 
     requestClientNodes(callback)
@@ -266,76 +278,22 @@ WI.Canvas = class Canvas extends WI.Object
             callback(this._clientNodes);
         };
 
-        let target = WI.assumingMainTarget();
-
-        // COMPATIBILITY (iOS 13): Canvas.requestCSSCanvasClientNodes was renamed to Canvas.requestClientNodes.
-        if (!target.hasCommand("Canvas.requestClientNodes")) {
-            target.CanvasAgent.requestCSSCanvasClientNodes(this._identifier, wrappedCallback);
+        if (this._target.hasCommand("Canvas.requestClientNodes")) {
+            this._target.CanvasAgent.requestClientNodes(this._identifier, wrappedCallback);
             return;
         }
 
-        target.CanvasAgent.requestClientNodes(this._identifier, wrappedCallback);
-    }
-
-    requestSize()
-    {
-        function calculateSize(domNode) {
-            function getAttributeValue(name) {
-                let value = Number(domNode.getAttribute(name));
-                if (!Number.isInteger(value) || value < 0)
-                    return NaN;
-                return value;
-            }
-
-            return {
-                width: getAttributeValue("width"),
-                height: getAttributeValue("height")
-            };
+        // COMPATIBILITY (iOS 13): Canvas.requestCSSCanvasClientNodes was renamed to Canvas.requestClientNodes.
+        if (this._target.hasCommand("Canvas.requestCSSCanvasClientNodes")) {
+            this._target.CanvasAgent.requestCSSCanvasClientNodes(this._identifier, wrappedCallback);
+            return;
         }
 
-        function getPropertyValue(remoteObject, name) {
-            return new Promise((resolve, reject) => {
-                remoteObject.getProperty(name, (error, result) => {
-                    if (error) {
-                        reject(error);
-                        return;
-                    }
-                    resolve(result);
-                });
-            });
-        }
-
-        return this.requestNode().then((domNode) => {
-            if (!domNode)
-                return null;
-
-            let size = calculateSize(domNode);
-            if (!isNaN(size.width) && !isNaN(size.height))
-                return size;
-
-            // Since the "width" and "height" properties of canvas elements are more than just
-            // attributes, we need to invoke the getter for each to get the actual value.
-            //  - https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-width
-            //  - https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-height
-            let remoteObject = null;
-            return WI.RemoteObject.resolveNode(domNode).then((object) => {
-                remoteObject = object;
-                return Promise.all([getPropertyValue(object, "width"), getPropertyValue(object, "height")]);
-            }).then((values) => {
-                let width = values[0].value;
-                let height = values[1].value;
-                values[0].release();
-                values[1].release();
-                remoteObject.release();
-                return {width, height};
-            });
-        });
+        wrappedCallback(null, []);
     }
 
     startRecording(singleFrame)
     {
-        let target = WI.assumingMainTarget();
-
         let handleStartRecording = (error) => {
             if (error) {
                 console.error(error);
@@ -345,7 +303,7 @@ WI.Canvas = class Canvas extends WI.Object
             this._recordingState = WI.Canvas.RecordingState.ActiveFrontend;
 
             // COMPATIBILITY (iOS 12.1): Canvas.recordingStarted did not exist yet
-            if (target.hasEvent("Canvas.recordingStarted"))
+            if (this._target.hasEvent("Canvas.recordingStarted"))
                 return;
 
             this._recordingFrames = [];
@@ -355,22 +313,21 @@ WI.Canvas = class Canvas extends WI.Object
         };
 
         // COMPATIBILITY (iOS 12.1): `frameCount` did not exist yet.
-        if (target.hasCommand("Canvas.startRecording", "singleFrame")) {
-            target.CanvasAgent.startRecording(this._identifier, singleFrame, handleStartRecording);
+        if (this._target.hasCommand("Canvas.startRecording", "singleFrame")) {
+            this._target.CanvasAgent.startRecording(this._identifier, singleFrame, handleStartRecording);
             return;
         }
 
         if (singleFrame) {
             const frameCount = 1;
-            target.CanvasAgent.startRecording(this._identifier, frameCount, handleStartRecording);
+            this._target.CanvasAgent.startRecording(this._identifier, frameCount, handleStartRecording);
         } else
-            target.CanvasAgent.startRecording(this._identifier, handleStartRecording);
+            this._target.CanvasAgent.startRecording(this._identifier, handleStartRecording);
     }
 
     stopRecording()
     {
-        let target = WI.assumingMainTarget();
-        target.CanvasAgent.stopRecording(this._identifier);
+        this._target.CanvasAgent.stopRecording(this._identifier);
     }
 
     saveIdentityToCookie(cookie)
@@ -380,6 +337,31 @@ WI.Canvas = class Canvas extends WI.Object
         else if (this._domNode)
             cookie[WI.Canvas.NodePathCookieKey] = this._domNode.path;
 
+    }
+
+    sizeChanged(size)
+    {
+        // Called from WI.CanvasManager.
+
+        // COMPATIBILITY (macOS X.0, iOS X.0): `width` and `height` did not exist yet.
+        if (this._size?.equals(size))
+            return;
+
+        this._size = size;
+
+        this.dispatchEventToListeners(WI.Canvas.Event.SizeChanged);
+    }
+
+    memoryChanged(memoryCost)
+    {
+        // Called from WI.CanvasManager.
+
+        if (memoryCost === this._memoryCost)
+            return;
+
+        this._memoryCost = memoryCost;
+
+        this.dispatchEventToListeners(WI.Canvas.Event.MemoryChanged);
     }
 
     enableExtension(extension)
@@ -465,6 +447,26 @@ WI.Canvas = class Canvas extends WI.Object
         this._nextShaderProgramDisplayNumber[programType] = (this._nextShaderProgramDisplayNumber[programType] || 0) + 1;
         return this._nextShaderProgramDisplayNumber[programType];
     }
+
+    // Private
+
+    async _calculateSize()
+    {
+        let remoteObject = await WI.RemoteObject.resolveCanvasContext(this);
+        if (!remoteObject)
+            return;
+
+        function inspectedPage_context_getCanvasSize() {
+            return {
+                width: this.canvas.width,
+                height: this.canvas.height,
+            };
+        }
+        let size = await remoteObject.callFunctionJSON(inspectedPage_context_getCanvasSize);
+        remoteObject.release();
+
+        this.sizeChanged(WI.Size.fromJSON(size));
+    }
 };
 
 WI.Canvas._nextContextUniqueDisplayNameNumber = 1;
@@ -496,6 +498,7 @@ WI.Canvas.RecordingState = {
 };
 
 WI.Canvas.Event = {
+    SizeChanged: "canvas-size-changed",
     MemoryChanged: "canvas-memory-changed",
     ExtensionEnabled: "canvas-extension-enabled",
     ClientNodesChanged: "canvas-client-nodes-changed",

--- a/Source/WebInspectorUI/UserInterface/Models/Geometry.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Geometry.js
@@ -77,6 +77,13 @@ WI.Size = class Size
         this.height = height || 0;
     }
 
+    // Static
+
+    static fromJSON(json)
+    {
+        return new WI.Size(json.width, json.height);
+    }
+
     // Public
 
     toString()

--- a/Source/WebInspectorUI/UserInterface/Models/Recording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Recording.js
@@ -157,7 +157,7 @@ WI.Recording = class Recording extends WI.Object
         case Recording.Type.Canvas2D:
             return WI.UIString("2D");
         case Recording.Type.OffscreenCanvas2D:
-            return WI.UIString("2D (Offscreen)");
+            return WI.UIString("Offscreen2D");
         case Recording.Type.CanvasBitmapRenderer:
             return WI.UIString("Bitmap Renderer", "Recording Type Canvas Bitmap Renderer", "A type of canvas recording in the Graphics Tab");
         case Recording.Type.CanvasWebGL:
@@ -333,6 +333,11 @@ WI.Recording = class Recording extends WI.Object
 
         recordingNameSet.add(name);
         this._displayName = name;
+    }
+
+    is2D()
+    {
+        return WI.Recording.is2D(this._type);
     }
 
     async swizzle(index, type)

--- a/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js
@@ -25,8 +25,10 @@
 
 WI.ShaderProgram = class ShaderProgram extends WI.Object
 {
-    constructor(identifier, programType, canvas, {sharesVertexFragmentShader} = {})
+    constructor(target, identifier, programType, canvas, {sharesVertexFragmentShader} = {})
     {
+        console.assert(target instanceof WI.Target, target);
+        console.assert(target === canvas.target, target, canvas.target);
         console.assert(identifier);
         console.assert(Object.values(ShaderProgram.ProgramType).includes(programType));
         console.assert(canvas instanceof WI.Canvas);
@@ -34,6 +36,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
 
         super();
 
+        this._target = target;
         this._identifier = identifier;
         this._programType = programType;
         this._canvas = canvas;
@@ -79,6 +82,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
 
     // Public
 
+    get target() { return this._target; }
     get identifier() { return this._identifier; }
     get programType() { return this._programType; }
     get canvas() { return this._canvas; }
@@ -127,8 +131,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
 
         this._disabled = disabled;
 
-        let target = WI.assumingMainTarget();
-        target.CanvasAgent.setShaderProgramDisabled(this._identifier, disabled);
+        this._target.CanvasAgent.setShaderProgramDisabled(this._identifier, disabled);
 
         this.dispatchEventToListeners(ShaderProgram.Event.DisabledChanged);
     }
@@ -138,10 +141,8 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         console.assert(Object.values(ShaderProgram.ShaderType).includes(shaderType));
         console.assert(ShaderProgram.programTypeSupportsShaderType(this._programType, shaderType));
 
-        let target = WI.assumingMainTarget();
-
         // COMPATIBILITY (iOS 13): `content` was renamed to `source`.
-        target.CanvasAgent.requestShaderSource(this._identifier, shaderType, (error, source) => {
+        this._target.CanvasAgent.requestShaderSource(this._identifier, shaderType, (error, source) => {
             if (error) {
                 WI.reportInternalError(error);
                 callback(null);
@@ -157,8 +158,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         console.assert(Object.values(ShaderProgram.ShaderType).includes(shaderType));
         console.assert(ShaderProgram.programTypeSupportsShaderType(this._programType, shaderType));
 
-        let target = WI.assumingMainTarget();
-        target.CanvasAgent.updateShader(this._identifier, shaderType, source);
+        this._target.CanvasAgent.updateShader(this._identifier, shaderType, source);
     }
 
     showHighlight()
@@ -166,8 +166,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         console.assert(this._programType === ShaderProgram.ProgramType.Render);
         console.assert(this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2);
 
-        let target = WI.assumingMainTarget();
-        target.CanvasAgent.setShaderProgramHighlighted(this._identifier, true);
+        this._target.CanvasAgent.setShaderProgramHighlighted(this._identifier, true);
     }
 
     hideHighlight()
@@ -175,8 +174,7 @@ WI.ShaderProgram = class ShaderProgram extends WI.Object
         console.assert(this._programType === ShaderProgram.ProgramType.Render);
         console.assert(this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2);
 
-        let target = WI.assumingMainTarget();
-        target.CanvasAgent.setShaderProgramHighlighted(this._identifier, false);
+        this._target.CanvasAgent.setShaderProgramHighlighted(this._identifier, false);
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js
@@ -29,42 +29,47 @@ WI.CanvasObserver = class CanvasObserver extends InspectorBackend.Dispatcher
 
     canvasAdded(canvas)
     {
-        WI.canvasManager.canvasAdded(canvas);
+        WI.canvasManager.canvasAdded(this._target, canvas);
     }
 
     canvasRemoved(canvasId)
     {
-        WI.canvasManager.canvasRemoved(canvasId);
+        WI.canvasManager.canvasRemoved(this._target, canvasId);
+    }
+
+    canvasSizeChanged(canvasId, width, height)
+    {
+        WI.canvasManager.canvasSizeChanged(this._target, canvasId, width, height);
     }
 
     canvasMemoryChanged(canvasId, memoryCost)
     {
-        WI.canvasManager.canvasMemoryChanged(canvasId, memoryCost);
+        WI.canvasManager.canvasMemoryChanged(this._target, canvasId, memoryCost);
     }
 
     clientNodesChanged(canvasId)
     {
-        WI.canvasManager.clientNodesChanged(canvasId);
+        WI.canvasManager.clientNodesChanged(this._target, canvasId);
     }
 
     recordingStarted(canvasId, initiator)
     {
-        WI.canvasManager.recordingStarted(canvasId, initiator);
+        WI.canvasManager.recordingStarted(this._target, canvasId, initiator);
     }
 
     recordingProgress(canvasId, frames, bufferUsed)
     {
-        WI.canvasManager.recordingProgress(canvasId, frames, bufferUsed);
+        WI.canvasManager.recordingProgress(this._target, canvasId, frames, bufferUsed);
     }
 
     recordingFinished(canvasId, recording)
     {
-        WI.canvasManager.recordingFinished(canvasId, recording);
+        WI.canvasManager.recordingFinished(this._target, canvasId, recording);
     }
 
     extensionEnabled(canvasId, extension)
     {
-        WI.canvasManager.extensionEnabled(canvasId, extension);
+        WI.canvasManager.extensionEnabled(this._target, canvasId, extension);
     }
 
     programCreated(shaderProgram)
@@ -76,17 +81,17 @@ WI.CanvasObserver = class CanvasObserver extends InspectorBackend.Dispatcher
                 programId: arguments[1],
             };
         }
-        WI.canvasManager.programCreated(shaderProgram);
+        WI.canvasManager.programCreated(this._target, shaderProgram);
     }
 
     programDeleted(programId)
     {
-        WI.canvasManager.programDeleted(programId);
+        WI.canvasManager.programDeleted(this._target, programId);
     }
 
     // COMPATIBILITY (iOS 13): Canvas.events.cssCanvasClientNodesChanged was renamed to Canvas.events.clientNodesChanged.
     cssCanvasClientNodesChanged(canvasId)
     {
-        WI.canvasManager.clientNodesChanged(canvasId);
+        WI.canvasManager.clientNodesChanged(this._target, canvasId);
     }
 };


### PR DESCRIPTION
#### b5959d78adc403bde81fdad57864ec9fcf73fa21
<pre>
Web Inspector: support OffscreenCanvas for Canvas related operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=180833">https://bugs.webkit.org/show_bug.cgi?id=180833</a>
&lt;rdar://problem/36059660&gt;

Reviewed by Patrick Angle.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/JavaScriptCore/inspector/protocol/Recording.json:
Expose the entire domain (minus a few commands/events) to the `&quot;worker&quot;` target.

* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::createLazyAgents):
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::createLazyAgents):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::InspectorCanvasAgent):
(WebCore::InspectorCanvasAgent::enable):
(WebCore::InspectorCanvasAgent::disable):
(WebCore::InspectorCanvasAgent::enabled const): Added.
(WebCore::InspectorCanvasAgent::internalEnable): Added.
(WebCore::InspectorCanvasAgent::internalDisable): Added.
(WebCore::InspectorCanvasAgent::didChangeCanvasSize): Added.
(WebCore::InspectorCanvasAgent::didChangeCanvasMemory):
(WebCore::InspectorCanvasAgent::unbindCanvas):
(WebCore::InspectorCanvasAgent::requestNode): Deleted.
(WebCore::InspectorCanvasAgent::requestClientNodes): Deleted.
(WebCore::InspectorCanvasAgent::frameNavigated): Deleted.
(WebCore::InspectorCanvasAgent::didChangeCSSCanvasClientNodes): Deleted.
* Source/WebCore/inspector/agents/page/PageCanvasAgent.h: Added.
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp: Added.
(WebCore::PageCanvasAgent::PageCanvasAgent):
(WebCore::PageCanvasAgent::enabled const):
(WebCore::PageCanvasAgent::internalEnable):
(WebCore::PageCanvasAgent::internalDisable):
(WebCore::PageCanvasAgent::requestNode):
(WebCore::PageCanvasAgent::requestClientNodes):
(WebCore::PageCanvasAgent::frameNavigated):
(WebCore::PageCanvasAgent::didChangeCSSCanvasClientNodes):
(WebCore::PageCanvasAgent::matchesCurrentContext const):
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.h: Added.
* Source/WebCore/inspector/agents/worker/WorkerCanvasAgent.cpp: Added.
(WebCore::WorkerCanvasAgent::WorkerCanvasAgent):
(WebCore::WorkerCanvasAgent::requestNode):
(WebCore::WorkerCanvasAgent::requestClientNodes):
(WebCore::WorkerCanvasAgent::matchesCurrentContext const):
Split `InspectorCanvasAgent` into `PageCanvasAgent` and `WorkerCanvasAgent`.

* Source/WebInspectorUI/UserInterface/Protocol/CanvasObserver.js:
(WI.CanvasObserver.prototype.canvasAdded):
(WI.CanvasObserver.prototype.canvasRemoved):
(WI.CanvasObserver.prototype.canvasSizeChanged):
(WI.CanvasObserver.prototype.canvasMemoryChanged):
(WI.CanvasObserver.prototype.clientNodesChanged):
(WI.CanvasObserver.prototype.recordingStarted):
(WI.CanvasObserver.prototype.recordingProgress):
(WI.CanvasObserver.prototype.recordingFinished):
(WI.CanvasObserver.prototype.extensionEnabled):
(WI.CanvasObserver.prototype.programCreated):
(WI.CanvasObserver.prototype.programDeleted):
(WI.CanvasObserver.prototype.cssCanvasClientNodesChanged):
Pass along the `WI.Target`.

* Source/WebInspectorUI/UserInterface/Controllers/CanvasManager.js:
(WI.CanvasManager):
(WI.CanvasManager.prototype.disable):
(WI.CanvasManager.prototype.canvasAdded):
(WI.CanvasManager.prototype.canvasRemoved):
(WI.CanvasManager.prototype.canvasSizeChanged): Added.
(WI.CanvasManager.prototype.canvasMemoryChanged):
(WI.CanvasManager.prototype.clientNodesChanged):
(WI.CanvasManager.prototype.recordingStarted):
(WI.CanvasManager.prototype.recordingProgress):
(WI.CanvasManager.prototype.recordingFinished):
(WI.CanvasManager.prototype.extensionEnabled):
(WI.CanvasManager.prototype.programCreated):
(WI.CanvasManager.prototype.programDeleted):
(WI.CanvasManager.prototype._canvasForIdentifier): Added.
(WI.CanvasManager.prototype._handleTargetRemoved): Added.
(WI.CanvasManager.prototype._mainResourceDidChange):
(WI.CanvasManager.prototype.get shaderPrograms):
`WI.Canvas`/`WI.ShaderProgram` now need to be keyed by a `WI.Target` -&gt; identifier combo since the same identifier could be used by two different `WI.Target` (e.g. main page and `Worker`).

* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas):
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.get target): Added.
(WI.Canvas.prototype.get size): Added.
(WI.Canvas.prototype.get memoryCost):
(WI.Canvas.prototype.requestNode):
(WI.Canvas.prototype.requestContent):
(WI.Canvas.prototype.requestClientNodes):
(WI.Canvas.prototype.startRecording):
(WI.Canvas.prototype.stopRecording):
(WI.Canvas.prototype.sizeChanged): Added.
(WI.Canvas.prototype.memoryChanged): Renamed from `set memoryCost`.
(WI.Canvas.prototype.async _calculateSize): Added.
(WI.Canvas.prototype.requestSize): Deleted.
* Source/WebInspectorUI/UserInterface/Models/ShaderProgram.js:
(WI.ShaderProgram):
(WI.ShaderProgram.prototype.get target): Added.
(WI.ShaderProgram.prototype.set disabled):
(WI.ShaderProgram.prototype.requestShaderSource):
(WI.ShaderProgram.prototype.updateShader):
(WI.ShaderProgram.prototype.showHighlight):
(WI.ShaderProgram.prototype.hideHighlight):
Use the `this._target` instead of `WI.assumingMainTarget()`.

* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::setSize): Deleted.
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::setSize): Added.
(WebCore::CanvasBase::setImageBuffer const):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeCanvasSize): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didCommitLoadImpl):
(WebCore::InspectorInstrumentation::didChangeCSSCanvasClientNodesImpl):
(WebCore::InspectorInstrumentation::didChangeCanvasSizeImpl): Added.
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView):
(WI.CanvasContentView.prototype.initialLayout):
(WI.CanvasContentView.prototype.attached):
(WI.CanvasContentView.prototype.detached):
(WI.CanvasContentView.prototype._populateCanvasElementButtonContextMenu):
(WI.CanvasContentView.prototype._updateSize): Added.
(WI.CanvasContentView.prototype._refreshPixelSize): Deleted.
Now that `Canvas.requestNode` won&apos;t always work, we need a different way of getting the owner to find it&apos;s size.
Additionally, since the owner might not be a `Element`, we can&apos;t leverage `WI.DOMNode.Event.AttributeModified` to listen for changes in the size.
Instead, add instrumentation for when the size changes in C++ and notify the frontend as such (as well as adding logic to grab the `context.canvas.{width,height}` from the `Canvas.resolveCanvasContext` instead since that will always work).

* Source/WebInspectorUI/UserInterface/Models/Geometry.js:
(WI.Size.fromJSON):
Drive-by: Add a helper to make some logic slightly easier.

* Source/WebInspectorUI/UserInterface/Models/Recording.js:
(WI.Recording.displayNameForRecordingType):
(WI.Recording.prototype.is2D):
Drive-by: Fix display name to be consistent with `WI.Canvas.displayNameForContextType`.
Drive-by: Add missing method.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/canvas/resources/create-context-utilities.js:
(destroyCanvases):
(InspectorTest.CreateContextUtilities.addSimpleTestCase):
* LayoutTests/inspector/canvas/resources/worker.js: Added.
(createContext):
(destroyContexts):
* LayoutTests/inspector/canvas/create-context-2d.html:
* LayoutTests/inspector/canvas/create-context-2d-expected.txt:
* LayoutTests/inspector/canvas/create-context-bitmaprenderer.html:
* LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt:
* LayoutTests/inspector/canvas/create-context-webgl.html:
* LayoutTests/inspector/canvas/create-context-webgl-expected.txt:
* LayoutTests/inspector/canvas/create-context-webgl2.html:
* LayoutTests/inspector/canvas/create-context-webgl2-expected.txt:

Canonical link: <a href="https://commits.webkit.org/267488@main">https://commits.webkit.org/267488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91dde642d4bcffb9677b61f833634afa2a365c64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17203 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19311 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15171 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14439 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19639 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15970 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18299 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15011 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/4280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4008 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19484 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19522 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15772 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4127 "Passed tests") | 
<!--EWS-Status-Bubble-End-->