### PR TITLE
[Alternate WebM Player] Process media data in buffered chunks

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -190,9 +190,11 @@ void MediaPlayerPrivateWebM::load(MediaStreamPrivate&)
 }
 #endif
 
-void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer&)
+void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+    // FIXME: Remove const_cast once https://bugs.webkit.org/show_bug.cgi?id=243370 is fixed.
+    append(const_cast<SharedBuffer&>(buffer));
 }
 
 void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
@@ -201,12 +203,9 @@ void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
     setNetworkState(MediaPlayer::NetworkState::NetworkError);
 }
 
-void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer& fragmentedBuffer)
+void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer&)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-
-    auto buffer = fragmentedBuffer.makeContiguous();
-    append(buffer);
 
     if (!m_hasVideo && !m_hasAudio) {
         ERROR_LOG(LOGIDENTIFIER, "could not load audio or video tracks");


### PR DESCRIPTION
#### 1d1d83d21c82a57c0324ac47c90a7c08a9221c85
<pre>
[Alternate WebM Player] Process media data in buffered chunks
<a href="https://bugs.webkit.org/show_bug.cgi?id=243368">https://bugs.webkit.org/show_bug.cgi?id=243368</a>
&lt;rdar://97828231&gt;

Reviewed by Eric Carlson.

Currently the WebM player has buffered network loading enabled, however,
the buffered chunks are not appened to the buffer parser as they come in
chunks but rather all the buffers are merged together and sent to the parser
when the whole media file finishes the network load.

The fix is to simply append as we receive the chunks rather than waiting
for the load to finish.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::loadFinished):

Canonical link: <a href="https://commits.webkit.org/252999@main">https://commits.webkit.org/252999@main</a>
</pre>
