### PR TITLE
[JSC] Add NoIndexing miss optimization

### DIFF
--- a/JSTests/microbenchmarks/array-from-derived-object-func.js
+++ b/JSTests/microbenchmarks/array-from-derived-object-func.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+class Derived {
+    constructor()
+    {
+        this.length = 1024 * 1024 * 2;
+    }
+}
+
+let object = new Derived();
+for (let i = 0; i < 30; i++) {
+    let array = Array.from(object, () => 42);
+    shouldBe(array.length, 1024 * 1024 * 2);
+    shouldBe(1 in array, true);
+    shouldBe(array[0], 42);
+    shouldBe(array[1], 42);
+}

--- a/JSTests/microbenchmarks/array-from-object-func.js
+++ b/JSTests/microbenchmarks/array-from-object-func.js
@@ -1,0 +1,12 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (let i = 0; i < 30; i++) {
+    let array = Array.from({ length: 1024 * 1024 * 2 }, () => 42);
+    shouldBe(array.length, 1024 * 1024 * 2);
+    shouldBe(1 in array, true);
+    shouldBe(array[0], 42);
+    shouldBe(array[1], 42);
+}

--- a/JSTests/microbenchmarks/array-from-object.js
+++ b/JSTests/microbenchmarks/array-from-object.js
@@ -1,0 +1,12 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (let i = 0; i < 30; i++) {
+    let array = Array.from({ length: 1024 * 1024 * 2 });
+    shouldBe(array.length, 1024 * 1024 * 2);
+    shouldBe(1 in array, true);
+    shouldBe(array[0], undefined);
+    shouldBe(array[1], undefined);
+}

--- a/JSTests/stress/no-indexing-shape-invalidate.js
+++ b/JSTests/stress/no-indexing-shape-invalidate.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object, index) {
+    return object[index];
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e3; ++i)
+    shouldBe(test(object, i), undefined);
+Object.prototype[30] = 42;
+shouldBe(test(object, 30), 42);

--- a/JSTests/stress/no-indexing-shape-multiple.js
+++ b/JSTests/stress/no-indexing-shape-multiple.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object, index) {
+    return object[index];
+}
+noInline(test);
+
+let v1 = { length: 42 };
+let v2 = { length: 42, test: 42 };
+for (let i = 0; i < 1e6; ++i) {
+    shouldBe(test(v1, i), undefined);
+    shouldBe(test(v2, i), undefined);
+}

--- a/JSTests/stress/no-indexing-shape-negative.js
+++ b/JSTests/stress/no-indexing-shape-negative.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object, index) {
+    return object[index];
+}
+noInline(test);
+
+Object.prototype[-30] = 42;
+var object = {};
+for (var i = 0; i < 1e3; ++i)
+    shouldBe(test(object, i), undefined);
+shouldBe(test(object, -30), 42);

--- a/JSTests/stress/no-indexing-shape-other-array.js
+++ b/JSTests/stress/no-indexing-shape-other-array.js
@@ -1,0 +1,15 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object, index) {
+    return object[index];
+}
+noInline(test);
+
+var object = {};
+object.__proto__ = new Uint8Array(0);
+for (var i = 0; i < 1e3; ++i)
+    shouldBe(test(object, i), undefined);
+shouldBe(test(object, 30), undefined);

--- a/JSTests/stress/no-indexing-shape-prototype-invalidate.js
+++ b/JSTests/stress/no-indexing-shape-prototype-invalidate.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(object, index) {
+    return object[index];
+}
+noInline(test);
+
+var object = {};
+for (var i = 0; i < 1e3; ++i)
+    shouldBe(test(object, i), undefined);
+
+object.__proto__ = {
+    __proto__: Object.prototype,
+    [30]: 42
+};
+shouldBe(test(object, 30), 42);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -353,6 +353,13 @@ public:
         m_assembler.add<64>(dest, dest, dataTempRegister);
     }
 
+    void add8(TrustedImm32 imm, Address address)
+    {
+        load8(address, getCachedMemoryTempRegisterIDAndInvalidate());
+        add32(imm, memoryTempRegister, getCachedDataTempRegisterIDAndInvalidate());
+        store8(dataTempRegister, address);
+    }
+
     void and32(RegisterID src, RegisterID dest)
     {
         and32(dest, src, dest);

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -129,6 +129,7 @@ public:
         IndexedTypedArrayFloat32Load,
         IndexedTypedArrayFloat64Load,
         IndexedStringLoad,
+        IndexedNoIndexingMiss,
         IndexedInt32Store,
         IndexedDoubleStore,
         IndexedContiguousStore,
@@ -156,12 +157,6 @@ public:
     template<typename T>
     const T& as() const { return *static_cast<const T*>(this); }
 
-
-    template<typename AccessCaseType, typename... Arguments>
-    static std::unique_ptr<AccessCaseType> create(Arguments... arguments)
-    {
-        return std::unique_ptr<AccessCaseType>(new AccessCaseType(arguments...));
-    }
 
     static Ref<AccessCase> create(VM&, JSCell* owner, AccessType, CacheableIdentifier, PropertyOffset = invalidOffset,
         Structure* = nullptr, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(), RefPtr<PolyProtoAccessChain>&& = nullptr);

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -199,12 +199,7 @@ class ArrayProfile {
     friend class UnlinkedArrayProfile;
 
 public:
-    explicit ArrayProfile()
-        : m_mayInterceptIndexedAccesses(false)
-        , m_usesOriginalArrayStructures(true)
-        , m_didPerformFirstRunPruning(false)
-    {
-    }
+    explicit ArrayProfile() = default;
 
 #if USE(LARGE_TYPED_ARRAYS)
     static constexpr uint64_t s_smallTypedArrayMaxLength = std::numeric_limits<int32_t>::max();
@@ -255,9 +250,9 @@ private:
 #if USE(LARGE_TYPED_ARRAYS)
     bool m_mayBeLargeTypedArray { false };
 #endif
-    bool m_mayInterceptIndexedAccesses : 1;
-    bool m_usesOriginalArrayStructures : 1;
-    bool m_didPerformFirstRunPruning : 1;
+    bool m_mayInterceptIndexedAccesses : 1 { false };
+    bool m_usesOriginalArrayStructures : 1 { true };
+    bool m_didPerformFirstRunPruning : 1 { false };
     ArrayModes m_observedArrayModes { 0 };
 };
 static_assert(sizeof(ArrayProfile) == 12);

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -120,7 +120,22 @@ public:
             vm.writeBarrier(owner);
         return absenceOfSetEffectWithoutBarrier(object, uid, prototype);
     }
-    
+
+    static ObjectPropertyCondition absenceOfIndexedPropertiesWithoutBarrier(JSObject* object, JSObject* prototype)
+    {
+        ObjectPropertyCondition result;
+        result.m_object = object;
+        result.m_condition = PropertyCondition::absenceOfIndexedPropertiesWithoutBarrier(prototype);
+        return result;
+    }
+
+    static ObjectPropertyCondition absenceOfIndexedProperties(VM& vm, JSCell* owner, JSObject* object, JSObject* prototype)
+    {
+        if (owner)
+            vm.writeBarrier(owner);
+        return absenceOfIndexedPropertiesWithoutBarrier(object, prototype);
+    }
+
     static ObjectPropertyCondition equivalenceWithoutBarrier(
         JSObject* object, UniquedStringImpl* uid, JSValue value)
     {

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
@@ -170,6 +170,7 @@ ObjectPropertyConditionSet generateConditionsForPropertyMiss(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, UniquedStringImpl* uid);
 ObjectPropertyConditionSet generateConditionsForPropertySetterMiss(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, UniquedStringImpl* uid);
+ObjectPropertyConditionSet generateConditionsForIndexedMiss(VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure);
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHit(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, JSObject* prototype,
     UniquedStringImpl* uid);

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
@@ -724,7 +724,7 @@ AccessGenerationResult PolymorphicAccess::regenerate(const GCSafeConcurrentJSLoc
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
         if (codeBlock->useDataIC()) {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86) || CPU(X86_64) || CPU(ARM64)
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()));
 #else
             jit.load8(CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()), state.scratchGPR);
@@ -732,7 +732,7 @@ AccessGenerationResult PolymorphicAccess::regenerate(const GCSafeConcurrentJSLoc
             jit.store8(state.scratchGPR, CCallHelpers::Address(stubInfo.m_stubInfoGPR, StructureStubInfo::offsetOfCountdown()));
 #endif
         } else {
-#if CPU(X86) || CPU(X86_64)
+#if CPU(X86) || CPU(X86_64) || CPU(ARM64)
             jit.move(CCallHelpers::TrustedImmPtr(&stubInfo.countdown), state.scratchGPR);
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(state.scratchGPR));
 #else
@@ -1022,6 +1022,9 @@ void printInternal(PrintStream& out, AccessCase::AccessType type)
         return;
     case AccessCase::IndexedStringLoad:
         out.print("IndexedStringLoad");
+        return;
+    case AccessCase::IndexedNoIndexingMiss:
+        out.print("IndexedNoIndexingMiss");
         return;
     case AccessCase::IndexedInt32Store:
         out.print("IndexedInt32Store");


### PR DESCRIPTION
#### 801dcc1c9e7aabec321390689bc45e35752f371b
<pre>
[JSC] Add NoIndexing miss optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=240290">https://bugs.webkit.org/show_bug.cgi?id=240290</a>
rdar://problem/93456330

Reviewed by Saam Barati.

`Array.from({ length: 42 })` idiom becomes common. And this is currently inefficient since we
perform missed indexed access of the object 42 times. But if we do not have indexed properties
for this object and it is plain normal object, then we can have optimization folding it to undefined
as we are skipping prototype-chain access for OOB array access.

This patch introduces IndexedNoIndexingMiss IC. It guards via structures, and they are ensured that
they do not have indexing types. To represent it in PropertyCondition, this patch addds AbsenceOfIndexedProperties
PropertyCondition. When we found NoIndexing, we attempt to create IC by collecting structures.

In the future, we would like to further optimize it in DFG and FTL by using this condition. But for now,
we just use IC. We also add simple optimization via AI-proven structures.

PropertyCondition AbsenceOfIndexedProperties is useful, and in the future patches, we should use it to ensure
that iterator protocol is met more efficiently.

Attached benchmark gets 7x performance improvement.

                                   ToT                     Patched

array-from-object           697.6093+-0.9029     ^     89.7427+-0.7996        ^ definitely 7.7734x faster
array-from-object-func      698.9900+-0.5077     ^    103.7614+-1.7910        ^ definitely 6.7365x faster

* JSTests/microbenchmarks/array-from-derived-object-func.js: Added.
(shouldBe):
(Derived):
* JSTests/microbenchmarks/array-from-object-func.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-from-object.js: Added.
(shouldBe):
* JSTests/stress/no-indexing-shape-invalidate.js: Added.
(shouldBe):
(test):
* JSTests/stress/no-indexing-shape-multiple.js: Added.
(shouldBe):
(test):
* JSTests/stress/no-indexing-shape-negative.js: Added.
(shouldBe):
(test):
* JSTests/stress/no-indexing-shape-other-array.js: Added.
(shouldBe):
(test):
* JSTests/stress/no-indexing-shape-prototype-invalidate.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add8):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::generateWithGuard):
(JSC::AccessCase::generateImpl):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::AccessCase::create): Deleted.
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
(JSC::ArrayProfile::ArrayProfile): Deleted.
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
(JSC::ObjectPropertyCondition::absenceOfIndexedPropertiesWithoutBarrier):
(JSC::ObjectPropertyCondition::absenceOfIndexedProperties):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::generateConditionsForIndexedMiss):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h:
* Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp:
(JSC::PolymorphicAccess::regenerate):
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::dumpInContext const):
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):
(JSC::PropertyCondition::validityRequiresImpurePropertyWatchpoint const):
(JSC::PropertyCondition::isStillValid const):
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/PropertyCondition.h:
(JSC::PropertyCondition::absenceOfIndexedPropertiesWithoutBarrier):
(JSC::PropertyCondition::absenceOfIndexedProperties):
(JSC::PropertyCondition::hasPrototype const):
(JSC::PropertyCondition::hash const):
(JSC::PropertyCondition::operator== const):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):

Canonical link: <a href="https://commits.webkit.org/253120@main">https://commits.webkit.org/253120@main</a>
</pre>
