### PR TITLE
[WPE][GTK] Missing Soup module documentation links

### DIFF
--- a/Source/WebKit/gtk/urlmap.js.in
+++ b/Source/WebKit/gtk/urlmap.js.in
@@ -10,6 +10,7 @@ baseURLs = [
   ["Gdk", "https://docs.gtk.org/gdk@GTK_API_VERSION@/"],
   ["Gtk", "https://docs.gtk.org/gtk@GTK_API_VERSION@/"],
   ["JavaScriptCore", "../javascriptcoregtk" + baseURLApiLevelSuffix],
+  ["Soup", "https://libsoup.org/libsoup-3.0/"],
   ["WebKit2", "../webkit2gtk" + baseURLApiLevelSuffix],
-  ["WebKit2WebExtension", "../webkit2gtk-web-extension" + baseURLApiLevelSuffix],
+  ["WebKit2WebExtension", "../webkit2gtk-web-extension" + baseURLApiLevelSuffix]
 ]

--- a/Source/WebKit/wpe/urlmap.js
+++ b/Source/WebKit/wpe/urlmap.js
@@ -7,7 +7,8 @@ baseURLs = [
   ["GLib", "https://docs.gtk.org/glib/"],
   ["GObject", "https://docs.gtk.org/gobject/"],
   ["Gio", "https://docs.gtk.org/gio/"],
+  ["Soup", "https://libsoup.org/libsoup-3.0/"],
   ["WPEJavaScriptCore", "../wpe-javascriptcore" + baseURLApiLevelSuffix],
   ["WPEWebExtension", "../wpe-web-extension" + baseURLApiLevelSuffix],
-  ["WPEWebKit", "../wpe-webkit" + baseURLApiLevelSuffix],
+  ["WPEWebKit", "../wpe-webkit" + baseURLApiLevelSuffix]
 ]


### PR DESCRIPTION
#### 6dfebc18131711b36782ae8aa527d246b8919764
<pre>
[WPE][GTK] Missing Soup module documentation links
<a href="https://bugs.webkit.org/show_bug.cgi?id=242900">https://bugs.webkit.org/show_bug.cgi?id=242900</a>

Reviewed by Michael Catanzaro.

* Source/WebKit/gtk/urlmap.js.in: Point &quot;Soup&quot;(libsoup-3.0) to <a href="https://libsoup.org/libsoup-3.0/">https://libsoup.org/libsoup-3.0/</a>
* Source/WebKit/wpe/urlmap.js: Ditto

Canonical link: <a href="https://commits.webkit.org/252982@main">https://commits.webkit.org/252982@main</a>
</pre>
