### PR TITLE
[libpas] Adjust libpas PAS_API visibility

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h
@@ -58,7 +58,7 @@ __PAS_BEGIN_EXTERN_C;
 #if defined(PAS_LIBMALLOC) && PAS_LIBMALLOC
 #define __PAS_API __attribute__((visibility("hidden")))
 #else
-#define __PAS_API
+#define __PAS_API __attribute__((visibility("default")))
 #endif
 
 #if defined(PAS_BMALLOC) && PAS_BMALLOC

--- a/Tools/WebKitTestRunner/CMakeLists.txt
+++ b/Tools/WebKitTestRunner/CMakeLists.txt
@@ -100,9 +100,6 @@ set(WebKitTestRunnerInjectedBundle_LIBRARIES
     WebKit::WebCoreTestSupport
     WebKit::WebKit
 )
-if (NOT USE_SYSTEM_MALLOC)
-    list(APPEND WebKitTestRunnerInjectedBundle_LIBRARIES bmalloc)
-endif ()
 
 set(WebKitTestRunnerInjectedBundle_IDL_FILES
     "${WebKitTestRunner_DIR}/InjectedBundle/Bindings/AccessibilityController.idl"


### PR DESCRIPTION
#### 6f313a256c8b70f611145386b8777436f22cd8a3
<pre>
[libpas] Adjust libpas PAS_API visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=243376">https://bugs.webkit.org/show_bug.cgi?id=243376</a>

Reviewed by Ross Kirsling.

Align visibility to BExport.h. Since libpas IsoHeap implementation is built
in the including side, we need to expose PAS_API functions.

* Source/bmalloc/libpas/src/libpas/pas_utils_prefix.h:
* Tools/WebKitTestRunner/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/252977@main">https://commits.webkit.org/252977@main</a>
</pre>
