### PR TITLE
CSS.supports returns false for custom properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L3-expected.txt
@@ -15,5 +15,5 @@ PASS two argument form fails for unknown property (but known descriptor, univers
 PASS one argument form fails for invalid value
 PASS two argument form fails for invalid value
 PASS one argument form succeeds for custom property
-FAIL two argument form succeeds for custom property assert_equals: expected true but got false
+PASS two argument form succeeds for custom property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/conditional-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/conditional-rules-expected.txt
@@ -1,5 +1,5 @@
 
 PASS @supports should ignore registered syntax
 PASS CSS.supports(conditionText) should ignore registered syntax
-FAIL CSS.supports(property, value) should ignore registered syntax assert_true: expected true got false
+PASS CSS.supports(property, value) should ignore registered syntax
 

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -58,9 +58,16 @@ static String valueWithoutImportant(const String& value)
 
 bool DOMCSSNamespace::supports(Document& document, const String& property, const String& value)
 {
-    CSSPropertyID propertyID = cssPropertyID(property.stripWhiteSpace());
-
     CSSParserContext parserContext(document);
+
+    auto propertyNameWithoutWhitespace = property.stripWhiteSpace();
+    CSSPropertyID propertyID = cssPropertyID(propertyNameWithoutWhitespace);
+    if (propertyID == CSSPropertyInvalid && isCustomPropertyName(propertyNameWithoutWhitespace)) {
+        auto dummyStyle = MutableStyleProperties::create();
+        constexpr bool importance = false;
+        return CSSParser::parseCustomPropertyValue(dummyStyle, AtomString { propertyNameWithoutWhitespace }, value, importance, parserContext) != CSSParser::ParseResult::Error;
+    }
+
     if (!isCSSPropertyExposed(propertyID, &document.settings()))
         return false;
 


### PR DESCRIPTION
#### 69362356a5abb6fcd0c1a11de27b42ecf85e6b7b
<pre>
CSS.supports returns false for custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=154669">https://bugs.webkit.org/show_bug.cgi?id=154669</a>

Reviewed by Alexey Proskuryakov.

Fix the bug that the version of DOMCSSNamespace::supports which takes property ID and value separately
couldn&apos;t parse CSS custom properties.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/conditional-rules-expected.txt:
* Source/WebCore/css/DOMCSSNamespace.cpp:
(WebCore::DOMCSSNamespace::supports):

Canonical link: <a href="https://commits.webkit.org/252987@main">https://commits.webkit.org/252987@main</a>
</pre>
