### PR TITLE
Deeply nested phrasing content is parsed incorrectly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/adoption_agency_check_the_end_tag_name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/adoption_agency_check_the_end_tag_name-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The algorithm should not reparent properly nested tags assert_equals: expected "<code some-attribute=\"\"><div><code><code><code><code></code></code></code></code></div></code>" but got "<code some-attribute=\"\"></code><div><code some-attribute=\"\"><code><code><code><code></code></code></code></code></code></div>"
+PASS The algorithm should not reparent properly nested tags
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1417,14 +1417,23 @@ void HTMLTreeBuilder::processAnyOtherEndTagForInBody(AtomHTMLToken&& token)
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html#parsing-main-inbody
 void HTMLTreeBuilder::callTheAdoptionAgency(AtomHTMLToken& token)
 {
-    // The adoption agency algorithm is N^2. We limit the number of iterations
-    // to stop from hanging the whole browser. This limit is specified in the
-    // adoption agency algorithm: 
-    // http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#parsing-main-inbody
+    // The adoption agency algorithm is N^2. We limit the number of iterations to stop from hanging the whole browser.
+    // This limit is specified in the adoption agency algorithm:
+    // https://html.spec.whatwg.org/multipage/parsing.html#adoption-agency-algorithm
     static const int outerIterationLimit = 8;
     static const int innerIterationLimit = 3;
 
-    // 1, 2, 3 and 16 are covered by the for() loop.
+    // 2. If the current node is an HTML element whose tag name is subject,
+    // and the current node is not in the list of active formatting elements,
+    // then pop the current node off the stack of open elements and return.
+    if (!m_tree.isEmpty() && m_tree.currentStackItem().isElement()
+        && m_tree.currentElement().hasLocalName(token.name())
+        && !m_tree.activeFormattingElements().contains(m_tree.currentElement())) {
+        m_tree.openElements().pop();
+        return;
+    }
+
+    // 4 is covered by the for() loop.
     for (int i = 0; i < outerIterationLimit; ++i) {
         // 4.
         RefPtr<Element> formattingElement = m_tree.activeFormattingElements().closestElementInScopeWithName(token.name());


### PR DESCRIPTION
#### 67d7bd2e0aa2ed0355e51c406ff56021e603590f
<pre>
Deeply nested phrasing content is parsed incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=162527">https://bugs.webkit.org/show_bug.cgi?id=162527</a>

Reviewed by Brent Fulgham.

Fixed the bug by implementing the missing early return in the adoption agency algorithm.

Based on <a href="https://crrev.com/69ad2d7d5eecfb79a8b5dc4d01b575926500ef08">https://crrev.com/69ad2d7d5eecfb79a8b5dc4d01b575926500ef08</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/adoption_agency_check_the_end_tag_name-expected.txt:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::callTheAdoptionAgency):

Canonical link: <a href="https://commits.webkit.org/252979@main">https://commits.webkit.org/252979@main</a>
</pre>
