### PR TITLE
[WebRTC] Refactor generic code of LibWebRTCProvider into new WebRTCProvider

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1761,6 +1761,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/RealtimeVideoSource.h
     platform/mediastream/VideoPreset.h
     platform/mediastream/WebAudioSourceProvider.h
+    platform/mediastream/WebRTCProvider.h
+
+    platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
 
     platform/mediastream/libwebrtc/LibWebRTCEnumTraits.h
     platform/mediastream/libwebrtc/LibWebRTCMacros.h

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -186,7 +186,7 @@ static void gatherDecodingInfo(Document& document, MediaDecodingConfiguration&& 
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
     if (configuration.type == MediaDecodingType::WebRTC) {
         if (auto* page = document.page())
-            page->libWebRTCProvider().createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
+            page->webRTCProvider().createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
         return;
     }
 #else
@@ -206,7 +206,7 @@ static void gatherEncodingInfo(Document& document, MediaEncodingConfiguration&& 
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
     if (configuration.type == MediaEncodingType::WebRTC) {
         if (auto* page = document.page())
-            page->libWebRTCProvider().createEncodingConfiguration(WTFMove(configuration), WTFMove(encodingCallback));
+            page->webRTCProvider().createEncodingConfiguration(WTFMove(configuration), WTFMove(encodingCallback));
         return;
     }
 #else

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -90,7 +90,7 @@ PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
 #if USE(LIBWEBRTC)
     auto* document = peerConnection.document();
     if (auto* page = document ? document->page() : nullptr)
-        m_shouldFilterICECandidates = page->libWebRTCProvider().isSupportingMDNS();
+        m_shouldFilterICECandidates = page->webRTCProvider().isSupportingMDNS();
 #endif
 }
 
@@ -446,7 +446,8 @@ void PeerConnectionBackend::generateCertificate(Document& document, const Certif
         return;
     }
 
-    LibWebRTCCertificateGenerator::generateCertificate(document.securityOrigin(), page->libWebRTCProvider(), info, [promise = WTFMove(promise)](auto&& result) mutable {
+    auto& webRTCProvider = static_cast<LibWebRTCProvider&>(page->webRTCProvider());
+    LibWebRTCCertificateGenerator::generateCertificate(document.securityOrigin(), webRTCProvider, info, [promise = WTFMove(promise)](auto&& result) mutable {
         promise.settle(WTFMove(result));
     });
 #elif USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -36,6 +36,7 @@
 #include "IDLTypes.h"
 #include "LibWebRTCProvider.h"
 #include "RTCIceGatheringState.h"
+#include "RTCRtpCapabilities.h"
 #include "RTCRtpSendParameters.h"
 #include "RTCSessionDescription.h"
 #include "RTCSignalingState.h"

--- a/Source/WebCore/Modules/mediastream/RTCController.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCController.cpp
@@ -28,9 +28,9 @@
 #if ENABLE(WEB_RTC)
 
 #include "Document.h"
-#include "LibWebRTCProvider.h"
 #include "RTCNetworkManager.h"
 #include "RTCPeerConnection.h"
+#include "WebRTCProvider.h"
 
 namespace WebCore {
 
@@ -85,7 +85,7 @@ void RTCController::add(RTCPeerConnection& connection)
 
 void RTCController::disableICECandidateFilteringForAllOrigins()
 {
-    if (!LibWebRTCProvider::webRTCAvailable())
+    if (!WebRTCProvider::webRTCAvailable())
         return;
 
     m_shouldFilterICECandidates = false;
@@ -100,7 +100,7 @@ void RTCController::disableICECandidateFilteringForAllOrigins()
 
 void RTCController::disableICECandidateFilteringForDocument(Document& document)
 {
-    if (!LibWebRTCProvider::webRTCAvailable())
+    if (!WebRTCProvider::webRTCAvailable())
         return;
 
     if (auto* networkManager = document.rtcNetworkManager())
@@ -120,7 +120,7 @@ void RTCController::disableICECandidateFilteringForDocument(Document& document)
 
 void RTCController::enableICECandidateFiltering()
 {
-    if (!LibWebRTCProvider::webRTCAvailable())
+    if (!WebRTCProvider::webRTCAvailable())
         return;
 
     m_filteringDisabledOrigins.clear();

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -98,7 +98,7 @@ ExceptionOr<Ref<RTCPeerConnection>> RTCPeerConnection::create(Document& document
             peerConnection->registerToController(page->rtcController());
 #if USE(LIBWEBRTC) && (!LOG_DISABLED || !RELEASE_LOG_DISABLED)
             if (!page->sessionID().isEphemeral())
-                page->libWebRTCProvider().setLoggingLevel(LogWebRTC.level);
+                page->webRTCProvider().setLoggingLevel(LogWebRTC.level);
 #endif
         }
     }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -63,9 +63,10 @@ static std::unique_ptr<PeerConnectionBackend> createLibWebRTCPeerConnectionBacke
     if (!page)
         return nullptr;
 
-    page->libWebRTCProvider().setEnableWebRTCEncryption(page->settings().webRTCEncryptionEnabled());
+    auto& webRTCProvider = static_cast<LibWebRTCProvider&>(page->webRTCProvider());
+    webRTCProvider.setEnableWebRTCEncryption(page->settings().webRTCEncryptionEnabled());
 
-    return makeUnique<LibWebRTCPeerConnectionBackend>(peerConnection, page->libWebRTCProvider());
+    return makeUnique<LibWebRTCPeerConnectionBackend>(peerConnection, webRTCProvider);
 }
 
 CreatePeerConnectionBackend PeerConnectionBackend::create = createLibWebRTCPeerConnectionBackend;
@@ -75,7 +76,7 @@ std::optional<RTCRtpCapabilities> PeerConnectionBackend::receiverCapabilities(Sc
     auto* page = downcast<Document>(context).page();
     if (!page)
         return { };
-    return page->libWebRTCProvider().receiverCapabilities(kind);
+    return page->webRTCProvider().receiverCapabilities(kind);
 }
 
 std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(ScriptExecutionContext& context, const String& kind)
@@ -83,7 +84,7 @@ std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(Scri
     auto* page = downcast<Document>(context).page();
     if (!page)
         return { };
-    return page->libWebRTCProvider().senderCapabilities(kind);
+    return page->webRTCProvider().senderCapabilities(kind);
 }
 
 LibWebRTCPeerConnectionBackend::LibWebRTCPeerConnectionBackend(RTCPeerConnection& peerConnection, LibWebRTCProvider& provider)
@@ -198,7 +199,8 @@ bool LibWebRTCPeerConnectionBackend::setConfiguration(MediaEndpointConfiguration
     if (!page)
         return false;
 
-    return m_endpoint->setConfiguration(page->libWebRTCProvider(), configurationFromMediaEndpointConfiguration(WTFMove(configuration)));
+    auto& webRTCProvider = reinterpret_cast<LibWebRTCProvider&>(page->webRTCProvider());
+    return m_endpoint->setConfiguration(webRTCProvider, configurationFromMediaEndpointConfiguration(WTFMove(configuration)));
 }
 
 void LibWebRTCPeerConnectionBackend::gatherDecoderImplementationName(Function<void(String&&)>&& callback)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -113,8 +113,10 @@ Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& doc
     case cricket::MEDIA_TYPE_AUDIO: {
         rtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack = static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get());
         auto source = RealtimeIncomingAudioSource::create(WTFMove(audioTrack), fromStdString(rtcTrack->id()));
-        if (document.page())
-            source->setAudioModule(document.page()->libWebRTCProvider().audioModule());
+        if (document.page()) {
+            auto& webRTCProvider = reinterpret_cast<LibWebRTCProvider&>(document.page()->webRTCProvider());
+            source->setAudioModule(webRTCProvider.audioModule());
+        }
         return source;
     }
     case cricket::MEDIA_TYPE_VIDEO: {

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -37,9 +37,9 @@
 #include "CacheStorageConnection.h"
 #include "Document.h"
 #include "Frame.h"
-#include "LibWebRTCProvider.h"
 #include "Page.h"
 #include "Settings.h"
+#include "WebRTCProvider.h"
 #include "WorkletParameters.h"
 #include "WorkletPendingTasks.h"
 
@@ -94,7 +94,7 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> AudioWorkletMessagingProxy::create
     ASSERT(isMainThread());
     if (!m_document->page())
         return nullptr;
-    return m_document->page()->libWebRTCProvider().createRTCDataChannelRemoteHandlerConnection();
+    return m_document->page()->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
 void AudioWorkletMessagingProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2237,6 +2237,7 @@ platform/mediastream/RealtimeOutgoingAudioSource.cpp
 platform/mediastream/RealtimeOutgoingVideoSource.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/RealtimeVideoSource.cpp
+platform/mediastream/WebRTCProvider.cpp
 platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
 platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
 platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -144,7 +144,6 @@
 #include "LayoutDisallowedScope.h"
 #include "LazyLoadImageObserver.h"
 #include "LegacySchemeRegistry.h"
-#include "LibWebRTCProvider.h"
 #include "LoaderStrategy.h"
 #include "Logging.h"
 #include "MediaCanStartListener.h"
@@ -260,6 +259,7 @@
 #include "VisualViewport.h"
 #include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
+#include "WebRTCProvider.h"
 #include "WheelEvent.h"
 #include "WindowEventLoop.h"
 #include "WindowFeatures.h"
@@ -3610,7 +3610,7 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> Document::createRTCDataChannelRemo
     auto* page = this->page();
     if (!page)
         return nullptr;
-    return page->libWebRTCProvider().createRTCDataChannelRemoteHandlerConnection();
+    return page->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
 #if ENABLE(WEB_RTC)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -61,7 +61,6 @@
 #include "IDBConnectionToServer.h"
 #include "InspectorClient.h"
 #include "LibWebRTCAudioModule.h"
-#include "LibWebRTCProvider.h"
 #include "MediaRecorderPrivate.h"
 #include "MediaRecorderProvider.h"
 #include "ModalContainerTypes.h"
@@ -81,6 +80,7 @@
 #include "ThreadableWebSocketChannel.h"
 #include "UserContentProvider.h"
 #include "VisitedLinkStore.h"
+#include "WebRTCProvider.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <pal/SessionID.h>
 #include <wtf/NeverDestroyed.h>
@@ -1194,7 +1194,7 @@ PageConfiguration pageConfigurationWithEmptyClients(PAL::SessionID sessionID)
         sessionID,
         makeUniqueRef<EmptyEditorClient>(),
         SocketProvider::create(),
-        LibWebRTCProvider::create(),
+        WebRTCProvider::create(),
         CacheStorageProvider::create(),
         adoptRef(*new EmptyUserContentProvider),
         adoptRef(*new EmptyBackForwardClient),

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -90,7 +90,6 @@
 #include "InspectorInstrumentation.h"
 #include "LayoutDisallowedScope.h"
 #include "LegacySchemeRegistry.h"
-#include "LibWebRTCProvider.h"
 #include "LoaderStrategy.h"
 #include "LogInitialization.h"
 #include "Logging.h"
@@ -163,6 +162,7 @@
 #include "VisitedLinkStore.h"
 #include "VoidCallback.h"
 #include "WebCoreJSClientData.h"
+#include "WebRTCProvider.h"
 #include "WheelEventDeltaFilter.h"
 #include "WheelEventTestMonitor.h"
 #include "Widget.h"
@@ -291,7 +291,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #endif
     , m_speechRecognitionProvider((WTFMove(pageConfiguration.speechRecognitionProvider)))
     , m_mediaRecorderProvider((WTFMove(pageConfiguration.mediaRecorderProvider)))
-    , m_libWebRTCProvider(WTFMove(pageConfiguration.libWebRTCProvider))
+    , m_webRTCProvider(WTFMove(pageConfiguration.webRTCProvider))
     , m_domTimerAlignmentInterval(DOMTimer::defaultAlignmentInterval())
     , m_domTimerAlignmentIntervalIncreaseTimer(*this, &Page::domTimerAlignmentIntervalIncreaseTimerFired)
     , m_activityState(pageInitialActivityState())
@@ -592,8 +592,8 @@ Ref<DOMRectList> Page::passiveTouchEventListenerRectsForTesting()
 void Page::settingsDidChange()
 {
 #if USE(LIBWEBRTC)
-    m_libWebRTCProvider->setH265Support(settings().webRTCH265CodecEnabled());
-    m_libWebRTCProvider->setVP9Support(settings().webRTCVP9Profile0CodecEnabled(), settings().webRTCVP9Profile2CodecEnabled());
+    m_webRTCProvider->setH265Support(settings().webRTCH265CodecEnabled());
+    m_webRTCProvider->setVP9Support(settings().webRTCVP9Profile0CodecEnabled(), settings().webRTCVP9Profile2CodecEnabled());
 #endif
 }
 
@@ -3554,12 +3554,12 @@ void Page::applicationWillResignActive()
 
 void Page::applicationDidEnterBackground()
 {
-    m_libWebRTCProvider->setActive(false);
+    m_webRTCProvider->setActive(false);
 }
 
 void Page::applicationWillEnterForeground()
 {
-    m_libWebRTCProvider->setActive(true);
+    m_webRTCProvider->setActive(true);
 }
 
 void Page::applicationDidBecomeActive()
@@ -3693,7 +3693,7 @@ void Page::configureLoggingChannel(const String& channelName, WTFLogChannelState
 
 #if USE(LIBWEBRTC)
         if (channel == &LogWebRTC && m_mainFrame->document() && !sessionID().isEphemeral())
-            libWebRTCProvider().setLoggingLevel(LogWebRTC.level);
+            webRTCProvider().setLoggingLevel(LogWebRTC.level);
 #endif
     }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -131,7 +131,7 @@ class ImageOverlayController;
 class InspectorClient;
 class InspectorController;
 class IntSize;
-class LibWebRTCProvider;
+class WebRTCProvider;
 class LowPowerModeNotifier;
 class MediaCanStartListener;
 class MediaPlaybackTarget;
@@ -350,7 +350,7 @@ public:
 #if ENABLE(POINTER_LOCK)
     PointerLockController& pointerLockController() const { return *m_pointerLockController; }
 #endif
-    LibWebRTCProvider& libWebRTCProvider() { return m_libWebRTCProvider.get(); }
+    WebRTCProvider& webRTCProvider() { return m_webRTCProvider.get(); }
     RTCController& rtcController() { return m_rtcController; }
     WEBCORE_EXPORT void disableICECandidateFiltering();
     WEBCORE_EXPORT void enableICECandidateFiltering();
@@ -1073,7 +1073,7 @@ private:
     UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;
 
     UniqueRef<MediaRecorderProvider> m_mediaRecorderProvider;
-    UniqueRef<LibWebRTCProvider> m_libWebRTCProvider;
+    UniqueRef<WebRTCProvider> m_webRTCProvider;
     RTCController m_rtcController;
 
     PlatformDisplayID m_displayID { 0 };

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -62,11 +62,11 @@
 
 namespace WebCore {
 
-PageConfiguration::PageConfiguration(PAL::SessionID sessionID, UniqueRef<EditorClient>&& editorClient, Ref<SocketProvider>&& socketProvider, UniqueRef<LibWebRTCProvider>&& libWebRTCProvider, Ref<CacheStorageProvider>&& cacheStorageProvider, Ref<UserContentProvider>&& userContentProvider, Ref<BackForwardClient>&& backForwardClient, Ref<CookieJar>&& cookieJar, UniqueRef<ProgressTrackerClient>&& progressTrackerClient, UniqueRef<FrameLoaderClient>&& loaderClientForMainFrame, UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider, UniqueRef<MediaRecorderProvider>&& mediaRecorderProvider, Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry, UniqueRef<StorageProvider>&& storageProvider, UniqueRef<ModelPlayerProvider>&& modelPlayerProvider)
+PageConfiguration::PageConfiguration(PAL::SessionID sessionID, UniqueRef<EditorClient>&& editorClient, Ref<SocketProvider>&& socketProvider, UniqueRef<WebRTCProvider>&& webRTCProvider, Ref<CacheStorageProvider>&& cacheStorageProvider, Ref<UserContentProvider>&& userContentProvider, Ref<BackForwardClient>&& backForwardClient, Ref<CookieJar>&& cookieJar, UniqueRef<ProgressTrackerClient>&& progressTrackerClient, UniqueRef<FrameLoaderClient>&& loaderClientForMainFrame, UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider, UniqueRef<MediaRecorderProvider>&& mediaRecorderProvider, Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry, UniqueRef<StorageProvider>&& storageProvider, UniqueRef<ModelPlayerProvider>&& modelPlayerProvider)
     : sessionID(sessionID)
     , editorClient(WTFMove(editorClient))
     , socketProvider(WTFMove(socketProvider))
-    , libWebRTCProvider(WTFMove(libWebRTCProvider))
+    , webRTCProvider(WTFMove(webRTCProvider))
     , progressTrackerClient(WTFMove(progressTrackerClient))
     , backForwardClient(WTFMove(backForwardClient))
     , cookieJar(WTFMove(cookieJar))

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -62,7 +62,6 @@ class DragClient;
 class EditorClient;
 class FrameLoaderClient;
 class InspectorClient;
-class LibWebRTCProvider;
 class MediaRecorderProvider;
 class ModelPlayerProvider;
 class PaymentCoordinatorClient;
@@ -79,11 +78,12 @@ class UserContentURLPattern;
 class ValidationMessageClient;
 class VisitedLinkStore;
 class WebGLStateTracker;
+class WebRTCProvider;
 
 class PageConfiguration {
     WTF_MAKE_NONCOPYABLE(PageConfiguration); WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT PageConfiguration(PAL::SessionID, UniqueRef<EditorClient>&&, Ref<SocketProvider>&&, UniqueRef<LibWebRTCProvider>&&, Ref<CacheStorageProvider>&&, Ref<UserContentProvider>&&, Ref<BackForwardClient>&&, Ref<CookieJar>&&, UniqueRef<ProgressTrackerClient>&&, UniqueRef<FrameLoaderClient>&&, UniqueRef<SpeechRecognitionProvider>&&, UniqueRef<MediaRecorderProvider>&&, Ref<BroadcastChannelRegistry>&&, UniqueRef<StorageProvider>&&, UniqueRef<ModelPlayerProvider>&&);
+    WEBCORE_EXPORT PageConfiguration(PAL::SessionID, UniqueRef<EditorClient>&&, Ref<SocketProvider>&&, UniqueRef<WebRTCProvider>&&, Ref<CacheStorageProvider>&&, Ref<UserContentProvider>&&, Ref<BackForwardClient>&&, Ref<CookieJar>&&, UniqueRef<ProgressTrackerClient>&&, UniqueRef<FrameLoaderClient>&&, UniqueRef<SpeechRecognitionProvider>&&, UniqueRef<MediaRecorderProvider>&&, Ref<BroadcastChannelRegistry>&&, UniqueRef<StorageProvider>&&, UniqueRef<ModelPlayerProvider>&&);
     WEBCORE_EXPORT ~PageConfiguration();
     PageConfiguration(PageConfiguration&&);
 
@@ -109,7 +109,7 @@ public:
     std::optional<ApplicationManifest> applicationManifest;
 #endif
 
-    UniqueRef<LibWebRTCProvider> libWebRTCProvider;
+    UniqueRef<WebRTCProvider> webRTCProvider;
 
     UniqueRef<ProgressTrackerClient> progressTrackerClient;
     Ref<BackForwardClient> backForwardClient;

--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -88,6 +88,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
         platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
         platform/mediastream/gstreamer/GStreamerVideoEncoder.cpp
+        platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
         platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
         platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
         platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebRTCProvider.h"
+
+#include "ContentType.h"
+#include "MediaCapabilitiesDecodingInfo.h"
+#include "MediaCapabilitiesEncodingInfo.h"
+#include "MediaDecodingConfiguration.h"
+#include "MediaEncodingConfiguration.h"
+
+#include <wtf/Function.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+#if !USE(LIBWEBRTC) && !USE(GSTREAMER_WEBRTC)
+UniqueRef<WebRTCProvider> WebRTCProvider::create()
+{
+    return makeUniqueRef<WebRTCProvider>();
+}
+
+bool WebRTCProvider::webRTCAvailable()
+{
+    return false;
+}
+
+void WebRTCProvider::setActive(bool)
+{
+}
+
+void WebRTCProvider::setH264HardwareEncoderAllowed(bool)
+{
+}
+
+#endif
+
+RefPtr<RTCDataChannelRemoteHandlerConnection> WebRTCProvider::createRTCDataChannelRemoteHandlerConnection()
+{
+    return nullptr;
+}
+
+void WebRTCProvider::setH265Support(bool value)
+{
+    m_supportsH265 = value;
+#if ENABLE(WEB_RTC)
+    m_videoDecodingCapabilities = { };
+    m_videoEncodingCapabilities = { };
+#endif
+}
+
+void WebRTCProvider::setVP9Support(bool supportsVP9Profile0, bool supportsVP9Profile2)
+{
+    m_supportsVP9Profile0 = supportsVP9Profile0;
+    m_supportsVP9Profile2 = supportsVP9Profile2;
+
+#if ENABLE(WEB_RTC)
+    m_videoDecodingCapabilities = { };
+    m_videoEncodingCapabilities = { };
+#endif
+}
+
+bool WebRTCProvider::isSupportingH265() const
+{
+    return m_supportsH265;
+}
+
+bool WebRTCProvider::isSupportingVP9Profile0() const
+{
+    return m_supportsVP9Profile0;
+}
+
+bool WebRTCProvider::isSupportingVP9Profile2() const
+{
+    return m_supportsVP9Profile2;
+}
+
+bool WebRTCProvider::isSupportingMDNS() const
+{
+    return m_supportsMDNS;
+}
+
+void WebRTCProvider::setLoggingLevel(WTFLogLevel)
+{
+
+}
+
+void WebRTCProvider::clearFactory()
+{
+
+}
+
+#if ENABLE(WEB_RTC)
+
+std::optional<RTCRtpCapabilities> WebRTCProvider::receiverCapabilities(const String&)
+{
+    return { };
+}
+
+std::optional<RTCRtpCapabilities> WebRTCProvider::senderCapabilities(const String&)
+{
+    return { };
+}
+
+std::optional<RTCRtpCodecCapability> WebRTCProvider::codecCapability(const ContentType& contentType, const std::optional<RTCRtpCapabilities>& capabilities)
+{
+    if (!capabilities)
+        return { };
+
+    auto containerType = contentType.containerType();
+    for (auto& codec : capabilities->codecs) {
+        if (equalIgnoringASCIICase(containerType, codec.mimeType))
+            return codec;
+    }
+    return { };
+}
+
+std::optional<RTCRtpCapabilities>& WebRTCProvider::audioDecodingCapabilities()
+{
+    if (!m_audioDecodingCapabilities)
+        initializeAudioDecodingCapabilities();
+    return m_audioDecodingCapabilities;
+}
+
+std::optional<RTCRtpCapabilities>& WebRTCProvider::videoDecodingCapabilities()
+{
+    if (!m_videoDecodingCapabilities)
+        initializeVideoDecodingCapabilities();
+    return m_videoDecodingCapabilities;
+}
+
+std::optional<RTCRtpCapabilities>& WebRTCProvider::audioEncodingCapabilities()
+{
+    if (!m_audioEncodingCapabilities)
+        initializeAudioEncodingCapabilities();
+    return m_audioEncodingCapabilities;
+}
+
+std::optional<RTCRtpCapabilities>& WebRTCProvider::videoEncodingCapabilities()
+{
+    if (!m_videoEncodingCapabilities)
+        initializeVideoEncodingCapabilities();
+    return m_videoEncodingCapabilities;
+}
+
+#endif // ENABLE(WEB_RTC)
+
+std::optional<MediaCapabilitiesInfo> WebRTCProvider::computeVPParameters(const VideoConfiguration&)
+{
+    return { };
+}
+
+bool WebRTCProvider::isVPSoftwareDecoderSmooth(const VideoConfiguration&)
+{
+    return true;
+}
+
+bool WebRTCProvider::isVPXEncoderSmooth(const VideoConfiguration&)
+{
+    return false;
+}
+
+bool WebRTCProvider::isH264EncoderSmooth(const VideoConfiguration&)
+{
+    return true;
+}
+
+void WebRTCProvider::createDecodingConfiguration(MediaDecodingConfiguration&& configuration, DecodingConfigurationCallback&& callback)
+{
+    ASSERT(configuration.type == MediaDecodingType::WebRTC);
+
+    // FIXME: Validate additional parameters, in particular mime type parameters.
+    MediaCapabilitiesDecodingInfo info { WTFMove(configuration) };
+
+#if ENABLE(WEB_RTC)
+    if (info.supportedConfiguration.video) {
+        ContentType contentType { info.supportedConfiguration.video->contentType };
+        auto codec = codecCapability(contentType, videoDecodingCapabilities());
+        if (!codec) {
+            callback({ });
+            return;
+        }
+        if (auto infoOverride = videoDecodingCapabilitiesOverride(*info.supportedConfiguration.video)) {
+            if (!infoOverride->supported) {
+                callback({ });
+                return;
+            }
+            info.smooth = infoOverride->smooth;
+            info.powerEfficient = infoOverride->powerEfficient;
+        }
+    }
+    if (info.supportedConfiguration.audio) {
+        ContentType contentType { info.supportedConfiguration.audio->contentType };
+        auto codec = codecCapability(contentType, audioDecodingCapabilities());
+        if (!codec) {
+            callback({ });
+            return;
+        }
+    }
+#endif
+    info.supported = true;
+    callback(WTFMove(info));
+}
+
+void WebRTCProvider::createEncodingConfiguration(MediaEncodingConfiguration&& configuration, EncodingConfigurationCallback&& callback)
+{
+    ASSERT(configuration.type == MediaEncodingType::WebRTC);
+
+    // FIXME: Validate additional parameters, in particular mime type parameters.
+    MediaCapabilitiesEncodingInfo info { WTFMove(configuration) };
+
+#if ENABLE(WEB_RTC)
+    if (info.supportedConfiguration.video) {
+        ContentType contentType { info.supportedConfiguration.video->contentType };
+        auto codec = codecCapability(contentType, videoEncodingCapabilities());
+        if (!codec) {
+            callback({ });
+            return;
+        }
+        if (auto infoOverride = videoEncodingCapabilitiesOverride(*info.supportedConfiguration.video)) {
+            if (!infoOverride->supported) {
+                callback({ });
+                return;
+            }
+            info.smooth = infoOverride->smooth;
+            info.powerEfficient = infoOverride->powerEfficient;
+        }
+    }
+    if (info.supportedConfiguration.audio) {
+        ContentType contentType { info.supportedConfiguration.audio->contentType };
+        auto codec = codecCapability(contentType, audioEncodingCapabilities());
+        if (!codec) {
+            callback({ });
+            return;
+        }
+    }
+#endif
+    info.supported = true;
+    callback(WTFMove(info));
+}
+
+void WebRTCProvider::initializeAudioDecodingCapabilities()
+{
+
+}
+
+void WebRTCProvider::initializeVideoDecodingCapabilities()
+{
+
+}
+
+void WebRTCProvider::initializeAudioEncodingCapabilities()
+{
+
+}
+
+void WebRTCProvider::initializeVideoEncodingCapabilities()
+{
+
+}
+
+std::optional<MediaCapabilitiesDecodingInfo> WebRTCProvider::videoDecodingCapabilitiesOverride(const VideoConfiguration&)
+{
+    return { };
+}
+
+std::optional<MediaCapabilitiesEncodingInfo> WebRTCProvider::videoEncodingCapabilitiesOverride(const VideoConfiguration&)
+{
+    return { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MDNSRegisterError.h"
+#include "RTCDataChannelRemoteHandlerConnection.h"
+#include "RTCRtpCapabilities.h"
+#include "ScriptExecutionContextIdentifier.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Expected.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class ContentType;
+struct MediaCapabilitiesInfo;
+struct VideoConfiguration;
+struct MediaCapabilitiesDecodingInfo;
+struct MediaCapabilitiesEncodingInfo;
+struct MediaDecodingConfiguration;
+struct MediaEncodingConfiguration;
+
+class WEBCORE_EXPORT WebRTCProvider {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static UniqueRef<WebRTCProvider> create();
+    WebRTCProvider() = default;
+    virtual ~WebRTCProvider() = default;
+
+    static bool webRTCAvailable();
+    static void setH264HardwareEncoderAllowed(bool);
+
+    virtual void setActive(bool);
+
+    virtual RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection();
+
+    using DecodingConfigurationCallback = Function<void(MediaCapabilitiesDecodingInfo&&)>;
+    using EncodingConfigurationCallback = Function<void(MediaCapabilitiesEncodingInfo&&)>;
+    void createDecodingConfiguration(MediaDecodingConfiguration&&, DecodingConfigurationCallback&&);
+    void createEncodingConfiguration(MediaEncodingConfiguration&&, EncodingConfigurationCallback&&);
+
+    void setH265Support(bool);
+    void setVP9Support(bool supportsVP9Profile0, bool supportsVP9Profile2);
+    bool isSupportingH265() const;
+    bool isSupportingVP9Profile0() const;
+    bool isSupportingVP9Profile2() const;
+
+    bool isSupportingMDNS() const;
+
+#if ENABLE(WEB_RTC)
+    virtual std::optional<RTCRtpCapabilities> receiverCapabilities(const String&);
+    virtual std::optional<RTCRtpCapabilities> senderCapabilities(const String&);
+#endif
+
+    virtual void setLoggingLevel(WTFLogLevel);
+    virtual void clearFactory();
+
+protected:
+#if ENABLE(WEB_RTC)
+    std::optional<RTCRtpCapabilities>& audioDecodingCapabilities();
+    std::optional<RTCRtpCapabilities>& videoDecodingCapabilities();
+    std::optional<RTCRtpCapabilities>& audioEncodingCapabilities();
+    std::optional<RTCRtpCapabilities>& videoEncodingCapabilities();
+
+    std::optional<RTCRtpCodecCapability> codecCapability(const ContentType&, const std::optional<RTCRtpCapabilities>&);
+
+    std::optional<RTCRtpCapabilities> m_audioDecodingCapabilities;
+    std::optional<RTCRtpCapabilities> m_videoDecodingCapabilities;
+    std::optional<RTCRtpCapabilities> m_audioEncodingCapabilities;
+    std::optional<RTCRtpCapabilities> m_videoEncodingCapabilities;
+#endif
+
+    virtual std::optional<MediaCapabilitiesInfo> computeVPParameters(const VideoConfiguration&);
+    virtual bool isVPSoftwareDecoderSmooth(const VideoConfiguration&);
+    virtual bool isVPXEncoderSmooth(const VideoConfiguration&);
+    virtual bool isH264EncoderSmooth(const VideoConfiguration&);
+
+    bool m_supportsH265 { false };
+    bool m_supportsVP9Profile0 { false };
+    bool m_supportsVP9Profile2 { false };
+    bool m_supportsMDNS { false };
+
+private:
+    virtual void initializeAudioDecodingCapabilities();
+    virtual void initializeVideoDecodingCapabilities();
+    virtual void initializeAudioEncodingCapabilities();
+    virtual void initializeVideoEncodingCapabilities();
+
+    virtual std::optional<MediaCapabilitiesDecodingInfo> videoDecodingCapabilitiesOverride(const VideoConfiguration&);
+    virtual std::optional<MediaCapabilitiesEncodingInfo> videoEncodingCapabilitiesOverride(const VideoConfiguration&);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Author: Philippe Normand <philn@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#if USE(GSTREAMER_WEBRTC)
+#include "GStreamerWebRTCProvider.h"
+
+#include "MediaCapabilitiesDecodingInfo.h"
+#include "MediaCapabilitiesEncodingInfo.h"
+#include "MediaDecodingConfiguration.h"
+#include "MediaEncodingConfiguration.h"
+#include "NotImplemented.h"
+
+namespace WebCore {
+
+void WebRTCProvider::setH264HardwareEncoderAllowed(bool)
+{
+    // TODO: Hook this into GStreamerRegistryScanner.
+    notImplemented();
+}
+
+UniqueRef<WebRTCProvider> WebRTCProvider::create()
+{
+    return makeUniqueRef<GStreamerWebRTCProvider>();
+}
+
+bool WebRTCProvider::webRTCAvailable()
+{
+    return true;
+}
+
+void WebRTCProvider::setActive(bool)
+{
+    notImplemented();
+}
+
+std::optional<RTCRtpCapabilities> GStreamerWebRTCProvider::receiverCapabilities(const String& kind)
+{
+    UNUSED_PARAM(kind);
+    return { };
+}
+
+std::optional<RTCRtpCapabilities> GStreamerWebRTCProvider::senderCapabilities(const String& kind)
+{
+    UNUSED_PARAM(kind);
+    return { };
+}
+
+void GStreamerWebRTCProvider::initializeAudioEncodingCapabilities()
+{
+}
+
+void GStreamerWebRTCProvider::initializeVideoEncodingCapabilities()
+{
+}
+
+void GStreamerWebRTCProvider::initializeAudioDecodingCapabilities()
+{
+}
+
+void GStreamerWebRTCProvider::initializeVideoDecodingCapabilities()
+{
+}
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Author: Philippe Normand <philn@igalia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebRTCProvider.h"
+
+#if USE(GSTREAMER_WEBRTC)
+
+namespace WebCore {
+
+class WEBCORE_EXPORT GStreamerWebRTCProvider : public WebRTCProvider {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    std::optional<RTCRtpCapabilities> receiverCapabilities(const String& kind) final;
+    std::optional<RTCRtpCapabilities> senderCapabilities(const String& kind) final;
+
+private:
+    void initializeAudioDecodingCapabilities() final;
+    void initializeVideoDecodingCapabilities() final;
+    void initializeAudioEncodingCapabilities() final;
+    void initializeVideoEncodingCapabilities() final;
+};
+
+} // namespace Webcore
+
+#endif

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
@@ -43,12 +43,12 @@ WTF_WEAK_LINK_FORCE_IMPORT(webrtc::setApplicationStatus);
 
 namespace WebCore {
 
-UniqueRef<LibWebRTCProvider> LibWebRTCProvider::create()
+UniqueRef<WebRTCProvider> WebRTCProvider::create()
 {
     return makeUniqueRef<LibWebRTCProviderCocoa>();
 }
 
-void LibWebRTCProvider::setH264HardwareEncoderAllowed(bool allowed)
+void WebRTCProvider::setH264HardwareEncoderAllowed(bool allowed)
 {
     if (webRTCAvailable())
         webrtc::setH264HardwareEncoderAllowed(allowed);
@@ -80,13 +80,23 @@ std::unique_ptr<webrtc::VideoEncoderFactory> LibWebRTCProviderCocoa::createEncod
     return webrtc::createWebKitEncoderFactory(isSupportingH265() ? webrtc::WebKitH265::On : webrtc::WebKitH265::Off, vp9Support, DeprecatedGlobalSettings::webRTCH264LowLatencyEncoderEnabled() ? webrtc::WebKitH264LowLatency::On : webrtc::WebKitH264LowLatency::Off);
 }
 
+std::optional<MediaCapabilitiesInfo> LibWebRTCProviderCocoa::computeVPParameters(const VideoConfiguration& configuration)
+{
+    return WebCore::computeVPParameters(configuration);
+}
+
+bool LibWebRTCProviderCocoa::isVPSoftwareDecoderSmooth(const VideoConfiguration& configuration)
+{
+    return WebCore::isVPSoftwareDecoderSmooth(configuration);
+}
+
 void LibWebRTCProviderCocoa::setActive(bool value)
 {
     if (webRTCAvailable())
         webrtc::setApplicationStatus(value);
 }
 
-bool LibWebRTCProvider::webRTCAvailable()
+bool WebRTCProvider::webRTCAvailable()
 {
 #if PLATFORM(IOS)
     return true;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.h
@@ -44,8 +44,11 @@ public:
     std::unique_ptr<webrtc::VideoDecoderFactory> createDecoderFactory() override;
     std::unique_ptr<webrtc::VideoEncoderFactory> createEncoderFactory() override;
 
-private:
     void setActive(bool) final;
+
+private:
+    std::optional<MediaCapabilitiesInfo> computeVPParameters(const VideoConfiguration&) final;
+    bool isVPSoftwareDecoderSmooth(const VideoConfiguration&) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.cpp
@@ -28,16 +28,14 @@
 
 #if USE(LIBWEBRTC) && USE(GSTREAMER)
 
-#include <wtf/UniqueRef.h>
-
 namespace WebCore {
 
-UniqueRef<LibWebRTCProvider> LibWebRTCProvider::create()
+UniqueRef<WebRTCProvider> WebRTCProvider::create()
 {
     return makeUniqueRef<LibWebRTCProviderGStreamer>();
 }
 
-bool LibWebRTCProvider::webRTCAvailable()
+bool WebRTCProvider::webRTCAvailable()
 {
     return true;
 }

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -37,13 +37,13 @@
 #include "ErrorEvent.h"
 #include "EventNames.h"
 #include "FetchRequestCredentials.h"
-#include "LibWebRTCProvider.h"
 #include "LoaderStrategy.h"
 #include "MessageEvent.h"
 #include "Page.h"
 #include "PlatformStrategies.h"
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
+#include "WebRTCProvider.h"
 #include "Worker.h"
 #include "WorkerInitializationData.h"
 #include "WorkerInspectorProxy.h"
@@ -246,7 +246,7 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDat
     auto& document = downcast<Document>(*m_scriptExecutionContext);
     if (!document.page())
         return nullptr;
-    return document.page()->libWebRTCProvider().createRTCDataChannelRemoteHandlerConnection();
+    return document.page()->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
 void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -35,7 +35,6 @@
 #include "FetchLoader.h"
 #include "Frame.h"
 #include "FrameLoader.h"
-#include "LibWebRTCProvider.h"
 #include "LoaderStrategy.h"
 #include "Logging.h"
 #include "MessageWithMessagePorts.h"
@@ -45,6 +44,7 @@
 #include "ServiceWorkerClientData.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "Settings.h"
+#include "WebRTCProvider.h"
 #include "WorkerGlobalScope.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/MainThread.h>
@@ -152,7 +152,7 @@ RefPtr<CacheStorageConnection> ServiceWorkerThreadProxy::createCacheStorageConne
 RefPtr<RTCDataChannelRemoteHandlerConnection> ServiceWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());
-    return m_page->libWebRTCProvider().createRTCDataChannelRemoteHandlerConnection();
+    return m_page->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
 std::unique_ptr<FetchLoader> ServiceWorkerThreadProxy::createBlobLoader(FetchLoaderClient& client, const URL& blobURL)

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -32,7 +32,6 @@
 #include "EventNames.h"
 #include "Frame.h"
 #include "FrameLoader.h"
-#include "LibWebRTCProvider.h"
 #include "LoaderStrategy.h"
 #include "MessageEvent.h"
 #include "MessagePort.h"
@@ -43,6 +42,7 @@
 #include "SharedWorkerContextManager.h"
 #include "SharedWorkerGlobalScope.h"
 #include "SharedWorkerThread.h"
+#include "WebRTCProvider.h"
 #include "WorkerFetchResult.h"
 #include "WorkerInitializationData.h"
 #include "WorkerThread.h"
@@ -157,7 +157,7 @@ RefPtr<CacheStorageConnection> SharedWorkerThreadProxy::createCacheStorageConnec
 RefPtr<RTCDataChannelRemoteHandlerConnection> SharedWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());
-    return m_page->libWebRTCProvider().createRTCDataChannelRemoteHandlerConnection();
+    return m_page->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
 void SharedWorkerThreadProxy::postTaskToLoader(ScriptExecutionContext::Task&& task)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -86,7 +86,7 @@ NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier c
 {
     m_connection->open();
 
-    if (LibWebRTCProvider::webRTCAvailable())
+    if (WebRTCProvider::webRTCAvailable())
         WebProcess::singleton().libWebRTCNetwork().setConnection(m_connection.copyRef());
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -25,12 +25,15 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC) && PLATFORM(COCOA)
+#if USE(LIBWEBRTC)
+
+#if PLATFORM(COCOA)
 #include <WebCore/LibWebRTCProviderCocoa.h>
-#elif USE(LIBWEBRTC) && USE(GSTREAMER)
+#elif USE(GSTREAMER)
 #include <WebCore/LibWebRTCProviderGStreamer.h>
+#endif
 #else
-#include <WebCore/LibWebRTCProvider.h>
+#include <WebCore/WebRTCProvider.h>
 #endif
 
 namespace WebKit {
@@ -79,7 +82,7 @@ inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)
     return makeUniqueRef<LibWebRTCProvider>(page);
 }
 #else
-using LibWebRTCProvider = WebCore::LibWebRTCProvider;
+using LibWebRTCProvider = WebCore::WebRTCProvider;
 
 inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage&)
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
@@ -28,9 +28,10 @@
 #if ENABLE(WEB_RTC)
 
 #include "MDNSRegisterIdentifier.h"
-#include <WebCore/LibWebRTCProvider.h>
+#include <WebCore/MDNSRegisterError.h>
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h
@@ -26,12 +26,24 @@
 #pragma once
 
 #include "RTCDataChannelRemoteManager.h"
+
+#if USE(LIBWEBRTC)
 #include <WebCore/LibWebRTCProvider.h>
+#elif USE(GSTREAMER_WEBRTC)
+#include <WebCore/GStreamerWebRTCProvider.h>
+#endif
 
 namespace WebKit {
 
 #if ENABLE(WEB_RTC)
-class RemoteWorkerLibWebRTCProvider final : public WebCore::LibWebRTCProvider {
+
+#if USE(LIBWEBRTC)
+using LibWebRTCProviderBase = WebCore::LibWebRTCProvider;
+#else
+using LibWebRTCProviderBase = WebCore::GStreamerWebRTCProvider;
+#endif
+
+class RemoteWorkerLibWebRTCProvider final : public LibWebRTCProviderBase {
 public:
     RemoteWorkerLibWebRTCProvider() = default;
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -153,7 +153,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();
         pageConfiguration.userContentProvider = m_userContentController;
 #if ENABLE(WEB_RTC)
-        pageConfiguration.libWebRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
+        pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
 
         auto effectiveUserAgent =  WTFMove(userAgent);

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -101,7 +101,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();
     pageConfiguration.userContentProvider = m_userContentController;
 #if ENABLE(WEB_RTC)
-    pageConfiguration.libWebRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
+    pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
 
     pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, WebCore::FrameIdentifier::generate(), m_userAgent);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -869,8 +869,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     if (!parameters.iceCandidateFilteringEnabled)
         m_page->disableICECandidateFiltering();
 #if USE(LIBWEBRTC)
-    if (parameters.enumeratingAllNetworkInterfacesEnabled)
-        m_page->libWebRTCProvider().enableEnumeratingAllNetworkInterfaces();
+    if (parameters.enumeratingAllNetworkInterfacesEnabled) {
+        auto& rtcProvider = static_cast<LibWebRTCProvider&>(m_page->webRTCProvider());
+        rtcProvider.enableEnumeratingAllNetworkInterfaces();
+    }
 #endif
 #endif
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -182,7 +182,6 @@
 #import <WebCore/JSNotification.h>
 #import <WebCore/LegacyNSPasteboardTypes.h>
 #import <WebCore/LegacySchemeRegistry.h>
-#import <WebCore/LibWebRTCProvider.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/LogInitialization.h>
 #import <WebCore/MIMETypeRegistry.h>
@@ -229,6 +228,7 @@
 #import <WebCore/WebCoreJITOperations.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebCoreView.h>
+#import <WebCore/WebRTCProvider.h>
 #import <WebCore/WebViewVisualIdentificationOverlay.h>
 #import <WebCore/Widget.h>
 #import <WebKitLegacy/DOM.h>
@@ -1528,7 +1528,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
         WebCore::SocketProvider::create(),
-        WebCore::LibWebRTCProvider::create(),
+        WebCore::WebRTCProvider::create(),
         WebCore::CacheStorageProvider::create(),
         _private->group->userContentController(),
         BackForwardList::create(self),
@@ -1808,7 +1808,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         [[self preferences] privateBrowsingEnabled] ? PAL::SessionID::legacyPrivateSessionID() : PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(self),
         WebCore::SocketProvider::create(),
-        WebCore::LibWebRTCProvider::create(),
+        WebCore::WebRTCProvider::create(),
         WebCore::CacheStorageProvider::create(),
         _private->group->userContentController(),
         BackForwardList::create(self),

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -129,7 +129,6 @@
 #include <WebCore/JSElement.h>
 #include <WebCore/KeyboardEvent.h>
 #include <WebCore/LegacySchemeRegistry.h>
-#include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LogInitialization.h>
 #include <WebCore/Logging.h>
 #include <WebCore/MIMETypeRegistry.h>
@@ -171,6 +170,7 @@
 #include <WebCore/UserStyleSheet.h>
 #include <WebCore/WebCoreJITOperations.h>
 #include <WebCore/WebCoreTextRenderer.h>
+#include <WebCore/WebRTCProvider.h>
 #include <WebCore/WindowMessageBroadcaster.h>
 #include <WebCore/WindowsTouch.h>
 #include <comdef.h>
@@ -2899,7 +2899,7 @@ HRESULT WebView::initWithFrame(RECT frame, _In_ BSTR frameName, _In_ BSTR groupN
         PAL::SessionID::defaultSessionID(),
         makeUniqueRef<WebEditorClient>(this),
         SocketProvider::create(),
-        makeUniqueRef<LibWebRTCProvider>(),
+        makeUniqueRef<WebRTCProvider>(),
         CacheStorageProvider::create(),
         m_webViewGroup->userContentController(),
         BackForwardList::create(),


### PR DESCRIPTION
#### cd335044c81d195337935e921f49bd6c59311c92
<pre>
[WebRTC] Refactor generic code of LibWebRTCProvider into new WebRTCProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=243387">https://bugs.webkit.org/show_bug.cgi?id=243387</a>

Reviewed by Carlos Garcia Campos.

This patch refactors the WebRTC backend agnostic code into a new WebRTCProvider base class. The
LibWebRTCProvider inherits from it. A GStreamerWebRTCProvider is also introduced, mostly empty for
now, future patches will enhance it.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::gatherDecodingInfo):
(WebCore::gatherEncodingInfo):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::PeerConnectionBackend):
(WebCore::PeerConnectionBackend::generateCertificate):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::RTCController::disableICECandidateFilteringForAllOrigins):
(WebCore::RTCController::disableICECandidateFilteringForDocument):
(WebCore::RTCController::enableICECandidateFiltering):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::create):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::createLibWebRTCPeerConnectionBackend):
(WebCore::PeerConnectionBackend::receiverCapabilities):
(WebCore::PeerConnectionBackend::senderCapabilities):
(WebCore::LibWebRTCPeerConnectionBackend::setConfiguration):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::createSource):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::AudioWorkletMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
* Source/WebCore/Sources.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createRTCDataChannelRemoteHandlerConnection):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
(WebCore::Page::settingsDidChange):
(WebCore::Page::applicationDidEnterBackground):
(WebCore::Page::applicationWillEnterForeground):
(WebCore::Page::configureLoggingChannel):
* Source/WebCore/page/Page.h:
(WebCore::Page::webRTCProvider):
(WebCore::Page::libWebRTCProvider): Deleted.
* Source/WebCore/page/PageConfiguration.cpp:
(WebCore::PageConfiguration::PageConfiguration):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/platform/GStreamer.cmake:
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp: Added.
(WebCore::WebRTCProvider::webRTCAvailable):
(WebCore::WebRTCProvider::setActive):
(WebCore::WebRTCProvider::setH265Support):
(WebCore::WebRTCProvider::setVP9Support):
(WebCore::WebRTCProvider::setVP9VTBSupport):
(WebCore::WebRTCProvider::codecCapability):
(WebCore::WebRTCProvider::disableEnumeratingAllNetworkInterfaces):
(WebCore::WebRTCProvider::enableEnumeratingAllNetworkInterfaces):
(WebCore::WebRTCProvider::audioDecodingCapabilities):
(WebCore::WebRTCProvider::videoDecodingCapabilities):
(WebCore::WebRTCProvider::audioEncodingCapabilities):
(WebCore::WebRTCProvider::videoEncodingCapabilities):
(WebCore::WebRTCProvider::computeVPParameters):
(WebCore::WebRTCProvider::createDecodingConfiguration):
(WebCore::WebRTCProvider::createEncodingConfiguration):
(WebCore::WebRTCProvider::videoDecodingCapabilitiesOverride):
(WebCore::WebRTCProvider::videoEncodingCapabilitiesOverride):
* Source/WebCore/platform/mediastream/WebRTCProvider.h: Copied from Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h.
(WebCore::WebRTCProvider::createRTCDataChannelRemoteHandlerConnection):
(WebCore::WebRTCProvider::isSupportingH265 const):
(WebCore::WebRTCProvider::isSupportingVP9Profile0 const):
(WebCore::WebRTCProvider::isSupportingVP9Profile2 const):
(WebCore::WebRTCProvider::isSupportingVP9VTB const):
(WebCore::WebRTCProvider::disableNonLocalhostConnections):
(WebCore::WebRTCProvider::isSupportingMDNS const):
(WebCore::WebRTCProvider::setLoggingLevel):
(WebCore::WebRTCProvider::setEnableWebRTCEncryption):
(WebCore::WebRTCProvider::setUseDTLS10):
(WebCore::WebRTCProvider::clearFactory):
(WebCore::WebRTCProvider::isEnumeratingAllNetworkInterfacesEnabled const):
(WebCore::WebRTCProvider::isVPSoftwareDecoderSmooth):
(WebCore::WebRTCProvider::isVPXEncoderSmooth):
(WebCore::WebRTCProvider::isH264EncoderSmooth):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp: Added.
(WebCore::WebRTCProvider::setH264HardwareEncoderAllowed):
(WebCore::WebRTCProvider::create):
(WebCore::WebRTCProvider::webRTCAvailable):
(WebCore::WebRTCProvider::setActive):
(WebCore::GStreamerWebRTCProvider::receiverCapabilities):
(WebCore::GStreamerWebRTCProvider::senderCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeAudioEncodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeVideoEncodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeAudioDecodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeVideoDecodingCapabilities):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h: Added.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::LibWebRTCProvider::LibWebRTCProvider):
(WebCore::WebRTCProvider::setH264HardwareEncoderAllowed):
(WebCore::WebRTCProvider::setActive):
(WebCore::computeLogLevel):
(WebCore::LibWebRTCProvider::createSocketFactory):
(WebCore::LibWebRTCProvider::startedNetworkThread):
(WebCore::LibWebRTCProvider::setPeerConnectionFactory):
(WebCore::LibWebRTCProvider::initializeAudioDecodingCapabilities):
(WebCore::LibWebRTCProvider::initializeVideoDecodingCapabilities):
(WebCore::LibWebRTCProvider::initializeAudioEncodingCapabilities):
(WebCore::LibWebRTCProvider::initializeVideoEncodingCapabilities):
(WebCore::LibWebRTCProvider::videoDecodingCapabilitiesOverride):
(WebCore::LibWebRTCProvider::videoEncodingCapabilitiesOverride):
(WebCore::LibWebRTCProvider::create): Deleted.
(WebCore::LibWebRTCProvider::webRTCAvailable): Deleted.
(WebCore::LibWebRTCProvider::setH264HardwareEncoderAllowed): Deleted.
(WebCore::LibWebRTCProvider::setActive): Deleted.
(WebCore::LibWebRTCProvider::disableEnumeratingAllNetworkInterfaces): Deleted.
(WebCore::LibWebRTCProvider::enableEnumeratingAllNetworkInterfaces): Deleted.
(WebCore::LibWebRTCProvider::setH265Support): Deleted.
(WebCore::LibWebRTCProvider::setVP9Support): Deleted.
(WebCore::LibWebRTCProvider::setVP9VTBSupport): Deleted.
(WebCore::LibWebRTCProvider::audioDecodingCapabilities): Deleted.
(WebCore::LibWebRTCProvider::videoDecodingCapabilities): Deleted.
(WebCore::LibWebRTCProvider::audioEncodingCapabilities): Deleted.
(WebCore::LibWebRTCProvider::videoEncodingCapabilities): Deleted.
(WebCore::LibWebRTCProvider::codecCapability): Deleted.
(WebCore::computeVPParameters): Deleted.
(WebCore::isVPSoftwareDecoderSmooth): Deleted.
(WebCore::LibWebRTCProvider::createDecodingConfiguration): Deleted.
(WebCore::LibWebRTCProvider::createEncodingConfiguration): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
(WebCore::LibWebRTCProvider::audioModule):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp:
(WebCore::WebRTCProvider::create):
(WebCore::WebRTCProvider::setH264HardwareEncoderAllowed):
(WebCore::WebRTCProviderCocoa::computeVPParameters):
(WebCore::WebRTCProviderCocoa::isVPSoftwareDecoderSmooth):
(WebCore::WebRTCProviderCocoa::setActive):
(WebCore::WebRTCProvider::webRTCAvailable):
(WebCore::WebRTCProvider::registerWebKitVP9Decoder):
(WebCore::WebRTCProvider::registerWebKitVP8Decoder):
(WebCore::LibWebRTCProvider::create): Deleted.
(WebCore::LibWebRTCProvider::setH264HardwareEncoderAllowed): Deleted.
(WebCore::LibWebRTCProviderCocoa::setActive): Deleted.
(WebCore::LibWebRTCProvider::webRTCAvailable): Deleted.
(WebCore::LibWebRTCProvider::registerWebKitVP9Decoder): Deleted.
(WebCore::LibWebRTCProvider::registerWebKitVP8Decoder): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.cpp:
(WebCore::WebRTCProvider::create):
(WebCore::WebRTCProvider::webRTCAvailable):
(WebCore::LibWebRTCProvider::create): Deleted.
(WebCore::LibWebRTCProvider::webRTCAvailable): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::emulateRTCPeerConnectionPlatformEvent):
(WebCore::Internals::useMockRTCPeerConnectionFactory):
(WebCore::Internals::setEnumeratingAllNetworkInterfacesEnabled):
(WebCore::Internals::clearPeerConnectionFactory):
(WebCore::Internals::setWebRTCH265Support):
(WebCore::Internals::setWebRTCVP9Support):
(WebCore::Internals::setWebRTCVP9VTBSupport):
(WebCore::Internals::isSupportingVP9VTB const):
(WebCore::Internals::setEnableWebRTCEncryption):
(WebCore::Internals::setUseDTLS10):
(WebCore::Internals::setH264HardwareEncoderAllowed):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h:
* Source/WebKit/WebProcess/Storage/RemoteWorkerLibWebRTCProvider.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):

Canonical link: <a href="https://commits.webkit.org/253257@main">https://commits.webkit.org/253257@main</a>
</pre>
