### PR TITLE
srcdoc iframes fail to clear when srcdoc attribute removed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify that the frame reloads with empty body after we remove srcdoc. Test timed out
+PASS Verify that the frame reloads with empty body after we remove srcdoc.
 

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -110,11 +110,9 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
 void HTMLFrameElementBase::parseAttribute(const QualifiedName& name, const AtomString& value)
 {
     if (name == srcdocAttr) {
-        if (value.isNull()) {
-            const AtomString& srcValue = attributeWithoutSynchronization(srcAttr);
-            if (!srcValue.isNull())
-                setLocation(stripLeadingAndTrailingHTMLSpaces(srcValue));
-        } else
+        if (value.isNull())
+            setLocation(stripLeadingAndTrailingHTMLSpaces(attributeWithoutSynchronization(srcAttr)));
+        else
             setLocation("about:srcdoc"_s);
     } else if (name == srcAttr && !hasAttributeWithoutSynchronization(srcdocAttr))
         setLocation(stripLeadingAndTrailingHTMLSpaces(value));


### PR DESCRIPTION
#### e540252620c955e9fe64be5e467ede4699426f3d
<pre>
srcdoc iframes fail to clear when srcdoc attribute removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=243385">https://bugs.webkit.org/show_bug.cgi?id=243385</a>

Reviewed by Darin Adler.

The bug was caused by the superfluous null string check in HTMLFrameElementBase::parseAttribute in the case of srcdoc being a null string.
When both src and srcdoc are both, we should navigate to about:blank instead.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset-expected.txt:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/252991@main">https://commits.webkit.org/252991@main</a>
</pre>
