### PR TITLE
Remove syscall telemetry in GPUP and Network process

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -926,8 +926,8 @@
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
-            (allow mach-message-send (with telemetry)))))
-            
+            (allow mach-message-send))))
+
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
     (deny syscall-mach (with telemetry))
     (allow syscall-mach (machtrap-number

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -629,8 +629,8 @@
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
-            (allow mach-message-send (with telemetry)))))
-            
+            (allow mach-message-send))))
+
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
     (deny syscall-mach (with telemetry))
     (allow syscall-mach


### PR DESCRIPTION
#### 417aa9a2eba643fdda5cc2cc29cbb7b51a50a3f9
<pre>
Remove syscall telemetry in GPUP and Network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=243394">https://bugs.webkit.org/show_bug.cgi?id=243394</a>
&lt;rdar://problem/97900606&gt;

Reviewed by Chris Dumez.

Remove syscall telemetry in GPUP and Network process on macOS.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/252996@main">https://commits.webkit.org/252996@main</a>
</pre>
