### PR TITLE
Non-unified build fixes, earlyish August 2022 edition

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -33,6 +33,7 @@
 #include "InlineTextBoxStyle.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutInitialContainingBlock.h"
+#include "LayoutListMarkerBox.h"
 #include "TextUtil.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/Range.h>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
 
+#include "InlineFormattingContext.h"
 #include "InlineLineBuilder.h"
 #include "LayoutUnits.h"
 
@@ -37,6 +38,7 @@ struct AncestorStack;
 class ContainerBox;
 struct DisplayBoxTree;
 struct IsFirstLastIndex;
+class InlineFormattingGeometry;
 class InlineFormattingState;
 class LineBox;
 class ListMarkerBox;

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -29,7 +29,6 @@
 namespace WebCore {
 
 class CachedSVGDocument;
-class SVGGElement;
 
 class SVGUseElement final : public SVGGraphicsElement, public SVGURIReference, private CachedSVGDocumentClient {
     WTF_MAKE_ISO_ALLOCATED(SVGUseElement);

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -25,9 +25,10 @@
 
 #include "config.h"
 
+#include "APIArray.h"
+#include "WKAPICast.h"
 #include "WKPreferencesRef.h"
 #include "WKPreferencesRefPrivate.h"
-#include "WKAPICast.h"
 #include "WebPreferences.h"
 #include <WebCore/Settings.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/NotificationClient.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/HashSet.h>
 
 namespace WebCore {
 class ScriptExecutionContext;


### PR DESCRIPTION
#### aa0a0259a6638d8bae3342ef6f49db4f06e7f7f4
<pre>
Non-unified build fixes, earlyish August 2022 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=243658">https://bugs.webkit.org/show_bug.cgi?id=243658</a>

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/compression/CompressionStreamEncoder.h: Add
  missing wtf/ExceptionOr.h header inclusion, remove the redundant
  wtf/text/WTFString.h one.
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
  Ditto.
* Source/WebCore/css/MediaQueryList.cpp: Add missing
  HTMLFrameOwnerElement.h and MediaQuery.h header inclusions.
* Source/WebCore/css/StyleMedia.cpp: Add missing
  JavaScriptCore/ConsoleMessage.h header inclusion.
* Source/WebCore/page/ContextMenuController.cpp: Add missing
  HTMLFrameOwnerElement.h header inclusion.
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp: Add missing
  RenderLayer.h header inclusion.
* Source/WebCore/style/StyleScopeRuleSets.h: Move forward declaration of
  WebCore::Style::CascadeLevel inside its corresponding namespace.
</pre>