### PR TITLE
[GStreamer][MediaStream] Apply timestamps to mock audio/video buffers

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -116,11 +116,14 @@ void MockRealtimeAudioSourceGStreamer::render(Seconds delta)
         totalFrameCount -= bipBopCount;
         frameCount = std::min(totalFrameCount, m_maximiumFrameCount);
 
+        MediaTime presentationTime((m_samplesRendered * G_USEC_PER_SEC) / sampleRate(), G_USEC_PER_SEC);
+        GST_BUFFER_PTS(buffer.get()) = toGstClockTime(presentationTime);
+        GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_LIVE);
+
         auto caps = adoptGRef(gst_audio_info_to_caps(&info));
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         GStreamerAudioData data(WTFMove(sample), info);
-        MediaTime mediaTime((m_samplesRendered * G_USEC_PER_SEC) / sampleRate(), G_USEC_PER_SEC);
-        audioSamplesAvailable(mediaTime, data, *m_streamFormat, bipBopCount);
+        audioSamplesAvailable(presentationTime, data, *m_streamFormat, bipBopCount);
     }
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -163,7 +163,7 @@ void MockRealtimeVideoSourceGStreamer::updateSampleBuffer()
 
     std::optional<VideoFrameTimeMetadata> metadata;
     metadata->captureTime = MonotonicTime::now().secondsSinceEpoch();
-    auto presentationTime = MediaTime::createWithDouble((elapsedTime() + 100_ms).seconds());
+    auto presentationTime = MediaTime::createWithDouble((elapsedTime()).seconds());
     auto videoFrame = VideoFrameGStreamer::createFromPixelBuffer(pixelBuffer.releaseNonNull(), VideoFrameGStreamer::CanvasContentType::Canvas2D, videoFrameRotation(), presentationTime, size(), frameRate(), false, WTFMove(metadata));
     dispatchVideoFrameToObservers(videoFrame.get(), { });
 }


### PR DESCRIPTION
#### 4f577536c5c008829f38ca9f270ade55a615c52a
<pre>
[GStreamer][MediaStream] Apply timestamps to mock audio/video buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=243399">https://bugs.webkit.org/show_bug.cgi?id=243399</a>

Reviewed by Xabier Rodriguez-Calvar.

In case the buffers are pushed to an encoder, valid timestamps are required.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::render):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::updateSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/253106@main">https://commits.webkit.org/253106@main</a>
</pre>
