### PR TITLE
[ews-app] Save github comment_id to database and retrieve it appropriately

### DIFF
--- a/Tools/CISupport/ews-app/ews/models/patch.py
+++ b/Tools/CISupport/ews-app/ews/models/patch.py
@@ -164,3 +164,17 @@ class Change(models.Model):
         change.save()
         _log.debug('Marked change {} as obsolete={}'.format(change_id, obsolete))
         return SUCCESS
+
+    def set_comment_id(self, comment_id):
+        if type(comment_id) != int or comment_id < 0:
+            _log.error('Invalid comment_id {}, while trying to set comment_id for change: {}'.format(comment_id, self.change_id))
+            return FAILURE
+
+        if self.comment_id == comment_id:
+            _log.warn('Change {} already has comment id {} set.'.format(self.change_id, comment_id))
+            return SUCCESS
+
+        self.comment_id = comment_id
+        self.save()
+        _log.info('Updated change {} with comment id {}'.format(self.change_id, comment_id))
+        return SUCCESS


### PR DESCRIPTION
#### 3d75958bc36b9a194255de1dd9fe41ced029d1f0
<pre>
[ews-app] Save github comment_id to database and retrieve it appropriately
<a href="https://bugs.webkit.org/show_bug.cgi?id=243406">https://bugs.webkit.org/show_bug.cgi?id=243406</a>

Reviewed by Alexey Proskuryakov.

* Tools/CISupport/ews-app/ews/common/github.py:
* Tools/CISupport/ews-app/ews/models/patch.py:

Canonical link: <a href="https://commits.webkit.org/253000@main">https://commits.webkit.org/253000@main</a>
</pre>
