### PR TITLE
warning: inline function ‘static void JSC::JSCell::visitOutputConstraints(JSC::JSCell*, JSC::SlotVisitor&)’ used but never defined

### DIFF
--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp
@@ -30,6 +30,7 @@
 
 #include "HeapCellInlines.h"
 #include "HeapInlines.h"
+#include "JSCellInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "SlotVisitorInlines.h"
 


### PR DESCRIPTION
#### b5b85e08222fc1fe547008c2cbadcadedd09cb44
<pre>
warning: inline function ‘static void JSC::JSCell::visitOutputConstraints(JSC::JSCell*, JSC::SlotVisitor&amp;)’ used but never defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=243404">https://bugs.webkit.org/show_bug.cgi?id=243404</a>

Reviewed by Justin Michaud.

* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.cpp:

Canonical link: <a href="https://commits.webkit.org/253001@main">https://commits.webkit.org/253001@main</a>
</pre>
