### PR TITLE
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: invocation function for block in WebCore::SourceBufferPrivateAVFObjC::enqueueSample

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1334,17 +1334,14 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
 
                 [m_displayLayer enqueueSampleBuffer:platformSample.sample.cmSampleBuffer];
                 [m_displayLayer prerollDecodeWithCompletionHandler:[this, logSiteIdentifier, weakThis = WeakPtr { *this }] (BOOL success) mutable {
-                    if (!weakThis)
-                        return;
-
-                    if (!success) {
-                        ERROR_LOG(logSiteIdentifier, "prerollDecodeWithCompletionHandler failed");
-                        return;
-                    }
-
-                    callOnMainThread([weakThis = WTFMove(weakThis)] () {
+                    callOnMainThread([this, logSiteIdentifier, weakThis = WTFMove(weakThis), success] () {
                         if (!weakThis)
                             return;
+                        
+                        if (!success) {
+                            ERROR_LOG(logSiteIdentifier, "prerollDecodeWithCompletionHandler failed");
+                            return;
+                        }
 
                         weakThis->bufferWasConsumed();
                     });


### PR DESCRIPTION
#### af4a9922d4cac4948126870d55fe638d4b228a1a
<pre>
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: invocation function for block in WebCore::SourceBufferPrivateAVFObjC::enqueueSample
<a href="https://bugs.webkit.org/show_bug.cgi?id=243414">https://bugs.webkit.org/show_bug.cgi?id=243414</a>
&lt;rdar://97912882&gt;

Reviewed by Eric Carlson.

If the AVSBDL prerollDecode isn&apos;t successful, it will call the completion
handler on a background thread with success = false. In such a case, we
ERROR_LOG inside the completion handler rather than on the main thread.
Since ERROR_LOG uses `this-&gt;logger()` behind the scenes and we are in a
background thread, there is a race between when `weakThis` is checked and
the call to the logger is made (at which point, `this` can be deleted).

The fix is to check weakThis and call the logger on the main thread where
we can ensure that there is no potential for a race to occur.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):

Canonical link: <a href="https://commits.webkit.org/253007@main">https://commits.webkit.org/253007@main</a>
</pre>
