### PR TITLE
[iOS] Programmatic focus triggered while evaluating user script should present the software keyboard

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -96,6 +96,7 @@ enum class SDKAlignedBehavior {
     WKContentViewDoesNotOverrideKeyCommands,
     WKWebsiteDataStoreInitReturningNil,
     UIBackForwardSkipsHistoryItemsWithoutUserGesture,
+    ProgrammaticFocusDuringUserScriptShowsInputViews,
 
     NumberOfBehaviors
 };


### PR DESCRIPTION
#### 2b0c968051a7552d2f54d39bf790e0970fce259d
<pre>
[iOS] Programmatic focus triggered while evaluating user script should present the software keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=243416">https://bugs.webkit.org/show_bug.cgi?id=243416</a>
rdar://97945400

Reviewed by Aditya Keerthi and Devin Rousso.

Allow `-evaluateJavaScript:completionHandler:` and `-callAsyncJavaScript:…completionHandler:` to
set the `m_userIsInteracting` flag on WebPage during the scope of user script evaluation. This
allows apps (linked on or after certain versions of iOS) to use `element.focus()` to properly focus
text fields and other form controls, and show the software keyboard in the process.

Test: KeyboardInputTests.InputSessionWhenEvaluatingJavaScript

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:

Add a new SDK-aligned behavior flag to guard this behavior behind a linked-on-or-after check.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):

When executing user script (i.e. from the WebKit client), set the `m_userIsInteracting` flag to true
as long as the app is linked on or after the SDK versions corresponding to
`SDKAlignedBehavior::ProgrammaticFocusDuringUserScriptShowsInputViews`.

* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Add an API test to verify that using `-_evaluateJavaScriptWithoutUserGesture:…:` to evaluate script
that focuses a text field does not cause an input session to start; however, using either
`-callAsyncJavaScript:…:` or `-evaluateJavaScript:…:` starts an input session.

Canonical link: <a href="https://commits.webkit.org/253034@main">https://commits.webkit.org/253034@main</a>
</pre>
