### PR TITLE
Unreviewed. [WPE] Fix make dist

### DIFF
--- a/Tools/wpe/manifest.txt.in
+++ b/Tools/wpe/manifest.txt.in
@@ -90,7 +90,6 @@ file Tools/glib/generate-inspector-gresource-manifest.py
 file Tools/glib/generate-modern-media-controls-gresource-manifest.py
 file Tools/glib/generate-pdfjs-resource-manifest.py
 
-directory Tools/gtkdoc
 directory Tools/MiniBrowser
 directory Tools/TestWebKitAPI
 


### PR DESCRIPTION
#### 80ae1a6bd6bcc08cd2af0918961c91d320d6e0fc
<pre>
Unreviewed. [WPE] Fix make dist

* Tools/wpe/manifest.txt.in: Remove reference to gtkdoc
  directory which no longer exists.

Canonical link: <a href="https://commits.webkit.org/253005@main">https://commits.webkit.org/253005@main</a>
</pre>
