### PR TITLE
EME test playback issues

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1317,19 +1317,6 @@ SKAttributionEnabled:
     WebKit:
       default: false
 
-SampleBufferContentKeySessionSupportEnabled:
-  type: bool
-  humanReadableName: "ContentKeySession support for SampleBuffer Renderers"
-  humanReadableDescription: "ContentKeySession support for SampleBuffer Renderers Enabled"
-  condition: HAVE(AVCONTENTKEYSPECIFIER)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 # FIXME: This should have it's own ENABLE.
 ScreenCaptureEnabled:

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -791,6 +791,19 @@ RestrictedHTTPResponseAccess:
     WebKit:
       default: true
 
+SampleBufferContentKeySessionSupportEnabled:
+  type: bool
+  humanReadableName: "ContentKeySession support for SampleBuffer Renderers"
+  humanReadableDescription: "ContentKeySession support for SampleBuffer Renderers Enabled"
+  condition: HAVE(AVCONTENTKEYSPECIFIER)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ScrollingPerformanceTestingEnabled:
   type: bool
   humanReadableName: "Scroll Performance Testing Enabled"

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -818,6 +818,24 @@ const char* MediaKeySession::activeDOMObjectName() const
     return "MediaKeySession";
 }
 
+void MediaKeySession::stop()
+{
+    if (m_closed) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Already closed");
+        return;
+    }
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    m_instanceSession->closeSession(m_sessionId, [this, weakThis = WeakPtr { this }, logIdentifier = LOGIDENTIFIER] {
+        if (!weakThis)
+            return;
+
+        ALWAYS_LOG(logIdentifier, "::lambda, closed");
+        sessionClosed();
+    });
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaKeySession::logChannel() const
 {

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -113,6 +113,7 @@ private:
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;
     bool virtualHasPendingActivity() const final;
+    void stop() final;
 
     // DisplayChangedObserver
     void displayChanged(PlatformDisplayID);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
@@ -28,6 +28,8 @@
 messages -> RemoteCDMFactoryProxy NotRefCounted {
     CreateCDM(String keySystem) -> (WebKit::RemoteCDMIdentifier identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
     SupportsKeySystem(String keySystem) -> (bool result) Synchronous
+    RemoveInstance(WebKit::RemoteCDMInstanceIdentifier identifier)
+    RemoveSession(WebKit::RemoteCDMInstanceSessionIdentifier identifier)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 
 #include "RemoteCDMIdentifier.h"
+#include "RemoteCDMInstanceIdentifier.h"
 #include "RemoteCDMInstanceSessionIdentifier.h"
 #include "WebProcessSupplement.h"
 #include <WebCore/CDMFactory.h>
@@ -68,14 +69,16 @@ public:
 
     void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
 
-    void addSession(Ref<RemoteCDMInstanceSession>&&);
+    void addSession(RemoteCDMInstanceSession&);
     void removeSession(RemoteCDMInstanceSessionIdentifier);
+
+    void removeInstance(RemoteCDMInstanceIdentifier);
 
 private:
     std::unique_ptr<WebCore::CDMPrivate> createCDM(const String&, const WebCore::CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 
-    HashMap<RemoteCDMInstanceSessionIdentifier, Ref<RemoteCDMInstanceSession>> m_sessions;
+    HashMap<RemoteCDMInstanceSessionIdentifier, WeakPtr<RemoteCDMInstanceSession>> m_sessions;
     HashMap<RemoteCDMIdentifier, std::unique_ptr<RemoteCDM>> m_cdms;
     WebProcess& m_process;
 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
@@ -57,8 +57,11 @@ RemoteCDMInstance::RemoteCDMInstance(WeakPtr<RemoteCDMFactory>&& factory, Remote
 
 RemoteCDMInstance::~RemoteCDMInstance()
 {
-    if (m_factory)
-        m_factory->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
+    if (!m_factory)
+        return;
+
+    m_factory->removeInstance(m_identifier);
+    m_factory->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteCDMInstance::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCDMInstance::unrequestedInitializationDataReceived(const String& type, Ref<SharedBuffer>&& initData)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -48,6 +48,11 @@ RemoteCDMInstanceSession::RemoteCDMInstanceSession(WeakPtr<RemoteCDMFactory>&& f
 {
 }
 
+RemoteCDMInstanceSession::~RemoteCDMInstanceSession()
+{
+    m_factory->removeSession(m_identifier);
+}
+
 #if !RELEASE_LOG_DISABLED
 void RemoteCDMInstanceSession::setLogIdentifier(const void* logIdentifier)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -31,6 +31,7 @@
 #include "RemoteCDMFactory.h"
 #include "RemoteCDMInstanceSessionIdentifier.h"
 #include <WebCore/CDMInstanceSession.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class SharedBuffer;
@@ -38,10 +39,10 @@ class SharedBuffer;
 
 namespace WebKit {
 
-class RemoteCDMInstanceSession final : private IPC::MessageReceiver, public WebCore::CDMInstanceSession {
+class RemoteCDMInstanceSession final : public IPC::MessageReceiver, public WebCore::CDMInstanceSession {
 public:
     static Ref<RemoteCDMInstanceSession> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMInstanceSessionIdentifier&&);
-    virtual ~RemoteCDMInstanceSession() = default;
+    virtual ~RemoteCDMInstanceSession();
 
     RemoteCDMInstanceSessionIdentifier identifier() const { return m_identifier; }
 


### PR DESCRIPTION
#### 5090cdf39f9e6db80b71781c882be7ebed9696b6
<pre>
EME test playback issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=243419">https://bugs.webkit.org/show_bug.cgi?id=243419</a>

Reviewed by Eric Carlson.

WebKit:

When adding unit tests for EME playback, the stress-test bot revealed that the EME tests could only
run about 800 iterations before starting to fail. The cause of the failure appears to be that
CDMInstanceSessions created in the GPU process are never destroyed when their counterparts in the
WebContent process are.

Add an explicit deletion message called when the WebContent-side objects destructors
are called. This also requires RemoteCDMFactory to store WeakPtrs to those objects
rather than strong Refs.

WebCore:

Close the underlying session when the ActiveDOMObject stop() method is called.

WTF:

Drive-by fix: move the SampleBufferContentKeySessionSupportEnabled preference
from &quot;Experimental&quot; to &quot;Internal&quot; preferences so that it is not auto-enabled
during layout tests.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::stop):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::addSession):
(WebKit::RemoteCDMFactory::removeSession):
(WebKit::RemoteCDMFactory::removeInstance):
(WebKit::RemoteCDMFactory::didReceiveSessionMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp:
(WebKit::RemoteCDMInstance::~RemoteCDMInstance):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp:
(WebKit::RemoteCDMInstanceSession::~RemoteCDMInstanceSession):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:

Canonical link: <a href="https://commits.webkit.org/253021@main">https://commits.webkit.org/253021@main</a>
</pre>
