### PR TITLE
[Media] Fix RemoteMediaPlayerProxy::stopVideoFrameMetadataGathering typo

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1444,7 +1444,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged()
 
 void MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering()
 {
-    ASSERT(!m_videoFrameMetadataGatheringObserver || m_synchronizer);
+    ASSERT(!m_videoFrameMetadataGatheringObserver && m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
     acceleratedRenderingStateChanged();
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1391,7 +1391,7 @@ void MediaPlayerPrivateWebM::clearTracks()
 
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
-    ASSERT(!m_videoFrameMetadataGatheringObserver || m_synchronizer);
+    ASSERT(!m_videoFrameMetadataGatheringObserver && m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
     acceleratedRenderingStateChanged();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1155,7 +1155,7 @@ void RemoteMediaPlayerProxy::startVideoFrameMetadataGathering()
 void RemoteMediaPlayerProxy::stopVideoFrameMetadataGathering()
 {
     if (m_player)
-        m_player->startVideoFrameMetadataGathering();
+        m_player->stopVideoFrameMetadataGathering();
 }
 
 void RemoteMediaPlayerProxy::playerContentBoxRectChanged(const WebCore::LayoutRect& contentRect)


### PR DESCRIPTION
#### 7a5f68dbe338a1e637ec892668335e8885d63ae3
<pre>
[Media] Fix RemoteMediaPlayerProxy::stopVideoFrameMetadataGathering typo
<a href="https://bugs.webkit.org/show_bug.cgi?id=243420">https://bugs.webkit.org/show_bug.cgi?id=243420</a>
&lt;rdar://97932373&gt;

Reviewed by Eric Carlson and Jer Noble.

There is a typo in RemoteMediaPlayerProxy::stopVideoFrameMetadataGathering
that calls m_player-&gt;startVideoFrameMetadataGathering rather than
m_player-&gt;stopVideoFrameMetadataGathering, potentially causing premature
metadata gathering.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::stopVideoFrameMetadataGathering):

Fixed up the assertions to catch startVideoFrameMetadataGathering from
being called twice.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):

Canonical link: <a href="https://commits.webkit.org/253011@main">https://commits.webkit.org/253011@main</a>
</pre>
