### PR TITLE
Update browerbench.org's link to Speedometer2.1

### DIFF
--- a/Websites/browserbench.org/index.html
+++ b/Websites/browserbench.org/index.html
@@ -52,7 +52,7 @@
 <p>MotionMark is a benchmark designed to put browser graphics systems to the test.</p>
 </a>
 
-<a class="benchmark" href="Speedometer2.0" tabindex="0">
+<a class="benchmark" href="Speedometer2.1" tabindex="0">
 <img id="speedometer-logo"
     srcset="resources/Speedometer-Logo.png 1x, resources/Speedometer-Logo@2x.png 2x" alt="Speedometer">
 <p>Speedometer is a browser benchmark that measures the responsiveness of web applications.</p>


### PR DESCRIPTION
#### dcbfd8929b1dcdf5c9393c0906f5fd198344c67c
<pre>
Update browerbench.org&apos;s link to Speedometer2.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=243421">https://bugs.webkit.org/show_bug.cgi?id=243421</a>

Reviewed by Saam Barati.

* Websites/browserbench.org/index.html:

Canonical link: <a href="https://commits.webkit.org/253006@main">https://commits.webkit.org/253006@main</a>
</pre>
