### PR TITLE
fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt
@@ -4,9 +4,7 @@ This test verifies that panning up and down over an element that has an active '
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Observed first touchmove
 PASS Observed scroll event
-PASS observedTouchEnd became true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html
+++ b/LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html
@@ -38,20 +38,18 @@ html, body {
 jsTestIsAsync = true;
 scroller = document.getElementById("scroller");
 observedFirstTouchMove = false;
-observedTouchEnd = false;
-scroller.addEventListener("scroll", () => testPassed("Observed scroll event"), { once: true });
+observedScroll = false;
+scroller.addEventListener("scroll", () => observedScroll = true, { once: true });
 scroller.addEventListener("touchstart", () => observedFirstTouchMove = false, { passive: true });
-scroller.addEventListener("touchend", () => observedTouchEnd = true, { passive: true });
 scroller.addEventListener("touchmove", event => {
     if (observedFirstTouchMove)
         return;
 
     const startTime = Date.now();
     while (true) {
-        if (Date.now() - startTime > 100)
+        if (Date.now() - startTime > 50)
             break;
     }
-    testPassed("Observed first touchmove");
     observedFirstTouchMove = true;
 });
 
@@ -59,14 +57,9 @@ description("This test verifies that panning up and down over an element that ha
 
 if (window.testRunner) {
     (async function() {
-        await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
-            .begin(150, 150)
-            .move(150, 10, 0.5)
-            .move(150, 290, 1)
-            .move(150, 150, 0.5)
-            .end()
-            .takeResult());
-        await shouldBecomeEqual("observedTouchEnd", "true");
+        while (!observedScroll)
+            await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().begin(150, 290).move(150, 10, 0.5).end().takeResult());
+        testPassed("Observed scroll event");
         finishJSTest();
     })();
 }


### PR DESCRIPTION
#### 22b3fdb20cbe224bc44aa9eb0f3438e4edfb4ff1
<pre>
fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243413">https://bugs.webkit.org/show_bug.cgi?id=243413</a>
rdar://78840792

Reviewed by Megan Gardner.

Adjust this newly added test to be a bit more robust, by repeatedly swiping over the active
&quot;touchmove&quot; event listener region until scrolling happens.

* LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling-expected.txt:
* LayoutTests/fast/events/touch/ios/slow-touchmove-event-listener-does-not-prevent-scrolling.html:

Canonical link: <a href="https://commits.webkit.org/253019@main">https://commits.webkit.org/253019@main</a>
</pre>
