### PR TITLE
[macOS] The color CSS property value is ignored on <select> elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -741,7 +741,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-popup-el
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-popup-element/popup-open-display.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-popup-element/popup-open-overflow-display.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-popup-element/popup-stacking-context.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/select-sizing-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-x.xhtml [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-webgl.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width.html [ ImageOnlyFailure ]
@@ -4866,10 +4865,6 @@ imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.ht
 # 2. We ignore the background-color property value (supposed to be white on white to renderer "blank" content).
 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html [ ImageOnlyFailure ]
-
-# CSS property color is not working in select elements.
-webkit.org/b/238667 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-001.html [ ImageOnlyFailure ]
-webkit.org/b/238667 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-002.html [ ImageOnlyFailure ]
 
 # Counter style tests that fail on some platforms because of subtle character positioning differences, presumably from subpixel rounding.
 # These failures are slightly different per-platform, but it seems unwise to move the expectations into platform-specific expectations files.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -234,7 +234,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-textarea-element/placeh
 imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-b-element/b-usage.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/text-level-semantics/the-ruby-element/ruby-usage.html [ Pass ]
 
-imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/select-sizing-001.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-vertical.html [ Pass ]
 
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-dynamic-002.html [ Pass ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -877,6 +877,9 @@ webkit.org/b/219614 inspector/model/font-calculate-properties.html [ Failure ]
 webkit.org/b/223252 imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-003.html [ Failure ]
 webkit.org/b/223252 imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-004.html [ Failure ]
 
+webkit.org/b/243466 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-001.html [ ImageOnlyFailure ]
+webkit.org/b/243466 imported/w3c/web-platform-tests/css/css-contain/contain-size-select-elem-002.html [ ImageOnlyFailure ]
+
 webkit.org/b/229732 imported/w3c/web-platform-tests/css/css-fonts/font-display/font-display-failure-fallback.html [ Failure ]
 webkit.org/b/229732 fast/text/font-promises-gc.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3544,7 +3544,6 @@ webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/sizing
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/sizing-orthog-vrl-in-htb-008.xht [ Pass ]
 imported/w3c/web-platform-tests/css/mediaqueries/viewport-script-dynamic.html [ Pass ]
 imported/w3c/web-platform-tests/html/rendering/bindings/the-select-element-0/option-label.html [ Pass ]
-imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/select-sizing-001.html [ Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-modify-scrolling-attr-to-yes.html [ Pass ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-gamut-002.html [ Pass ]
 

--- a/LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 529x18
         text run at (0,0) width 529: "This tests that we don't honor line-height for controls that have restricted font size."
       RenderBR {BR} at (528,0) size 1x18
-      RenderMenuList {SELECT} at (2,20) size 302x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,20) size 302x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 302x18
           RenderText at (8,2) size 271x13
             text run at (8,2) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac-bigsur/fast/forms/select/optgroup-rendering-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/fast/forms/select/optgroup-rendering-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x323
         RenderText {#text} at (74,264) size 4x18
           text run at (74,264) width 4: " "
         RenderBR {BR} at (78,264) size 0x18
-        RenderMenuList {SELECT} at (2,287) size 74x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,287) size 74x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 74x18
             RenderText at (8,2) size 31x13
               text run at (8,2) width 31: "Three"

--- a/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -66,7 +66,7 @@ layer at (0,0) size 785x685
         RenderBlock {P} at (0,0) size 769x45
           RenderText {#text} at (0,2) size 267x18
             text run at (0,2) width 267: "How does your browser fare on this test? "
-          RenderMenuList {SELECT} at (268,3) size 243x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (268,3) size 243x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 242x18
               RenderText at (8,2) size 139x13
                 text run at (8,2) width 139: "The test renders correctly."

--- a/LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt
@@ -20,7 +20,7 @@ layer at (0,0) size 800x600
         RenderImage {IMG} at (0,0) size 76x103
         RenderText {#text} at (76,89) size 4x18
           text run at (76,89) width 4: " "
-        RenderMenuList {SELECT} at (82,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (82,90) size 51x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 51x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
         RenderImage {IMG} at (0,0) size 76x103
         RenderText {#text} at (76,89) size 4x18
           text run at (76,89) width 4: " "
-        RenderMenuList {SELECT} at (82,90) size 51x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (82,90) size 51x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 51x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt
@@ -11,14 +11,14 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,52) size 784x22
         RenderText {#text} at (0,1) size 22x18
           text run at (0,1) width 22: "foo"
-        RenderMenuList {SELECT} at (23,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (23,2) size 39x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
       RenderBlock {DIV} at (0,74) size 784x22
         RenderText {#text} at (0,1) size 22x18
           text run at (0,1) width 22: "foo"
-        RenderMenuList {SELECT} at (23,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (23,2) size 39x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt
+++ b/LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt
@@ -9,14 +9,14 @@ layer at (0,0) size 800x600
           text run at (419,0) width 321: "There should be spaces added before and after the"
           text run at (0,18) width 106: "inserted content."
       RenderBlock {DIV} at (0,52) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 38x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 38x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"
       RenderBlock {DIV} at (0,74) size 784x22
         RenderText {#text} at (0,1) size 12x18
           text run at (0,1) width 12: "x "
-        RenderMenuList {SELECT} at (14,2) size 38x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (14,2) size 38x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 38x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 784x96 [border: (5px solid #FF0000)]
-        RenderMenuList {SELECT} at (39,39) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (39,39) size 53x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 53x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"

--- a/LayoutTests/platform/mac/editing/selection/replaced-boundaries-3-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/replaced-boundaries-3-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 23x18
           text run at (0,0) width 23: "abc"
         RenderBR {BR} at (22,0) size 1x18
-        RenderMenuList {SELECT} at (2,20) size 224x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,20) size 224x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 224x18
             RenderText at (8,2) size 193x13
               text run at (8,2) width 193: "this select box shouldn't be selected"

--- a/LayoutTests/platform/mac/editing/selection/select-box-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-box-expected.txt
@@ -64,7 +64,7 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 784x22
           RenderText {#text} at (0,1) size 73x18
             text run at (0,1) width 73: "select box: "
-          RenderMenuList {SELECT} at (74,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (74,2) size 39x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 38x18
               RenderText at (8,2) size 6x13
                 text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
           text run at (332,0) width 432: "The caret should be at the end of the paragraph below, just after the"
           text run at (0,18) width 69: "select box."
       RenderBlock {DIV} at (0,52) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 37x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 37x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 37x18
             RenderText at (8,2) size 6x13
               text run at (8,2) width 6: "1"

--- a/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -33,7 +33,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -52,7 +52,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -71,7 +71,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -89,7 +89,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -110,7 +110,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -134,7 +134,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -158,7 +158,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -184,7 +184,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -199,7 +199,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -214,7 +214,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -231,7 +231,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -245,7 +245,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -261,7 +261,7 @@ layer at (0,0) size 785x2386
         RenderText {#text} at (10,10) size 60x18
           text run at (10,10) width 60: "Line One"
         RenderBR {BR} at (69,10) size 1x18
-        RenderMenuList {SELECT} at (10,30) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (10,30) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -277,7 +277,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"
@@ -294,7 +294,7 @@ layer at (0,0) size 785x2386
           RenderText {#text} at (0,0) size 60x18
             text run at (0,0) width 60: "Line One"
           RenderBR {BR} at (59,0) size 1x18
-          RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 100x18
               RenderText at (8,2) size 22x13
                 text run at (8,2) width 22: "One"

--- a/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt
@@ -37,21 +37,21 @@ layer at (0,0) size 785x1721
             RenderBlock (floating) {SPAN} at (0,68) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 127x15
                 text run at (0,2) width 127: "Your degree program*"
-            RenderMenuList {SELECT} at (325,68) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,68) size 180x18 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 87x13
                   text run at (8,2) width 87: "Program options"
             RenderBlock (floating) {SPAN} at (0,88) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 110x15
                 text run at (0,2) width 110: "Your year of study*"
-            RenderMenuList {SELECT} at (325,88) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,88) size 180x18 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 122x13
                   text run at (8,2) width 122: "Years you've been here"
             RenderBlock (floating) {SPAN} at (0,108) size 325x20 [color=#333333]
               RenderText {#text} at (0,2) size 153x15
                 text run at (0,2) width 153: "Shakespeare classes taken"
-            RenderMenuList {SELECT} at (325,108) size 180x18 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,108) size 180x18 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 74x13
                   text run at (8,2) width 74: "Number taken"
@@ -64,7 +64,7 @@ layer at (0,0) size 785x1721
             RenderBlock (floating) {SPAN} at (0,210) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 323x15
                 text run at (0,2) width 323: "What percentage of your research time is spent online?"
-            RenderMenuList {SELECT} at (325,210) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,210) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 106x13
                   text run at (8,2) width 106: "Percentages of time"
@@ -72,7 +72,7 @@ layer at (0,0) size 785x1721
               RenderText {#text} at (0,2) size 300x35
                 text run at (0,2) width 300: "What is holding you back from doing more research"
                 text run at (0,22) width 41: "online?"
-            RenderMenuList {SELECT} at (325,230) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,230) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 45x13
                   text run at (8,2) width 45: "Reasons"
@@ -112,14 +112,14 @@ layer at (0,0) size 785x1721
             RenderBlock (floating) {SPAN} at (0,427) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 275x15
                 text run at (0,2) width 275: "Which area of the ISE did you find most useful?"
-            RenderMenuList {SELECT} at (325,427) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,427) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 100x13
                   text run at (8,2) width 100: "Sections of the ISE"
             RenderBlock (floating) {SPAN} at (0,447) size 325x21 [color=#333333]
               RenderText {#text} at (0,2) size 251x15
                 text run at (0,2) width 251: "How did you find the navigation of the ISE?"
-            RenderMenuList {SELECT} at (325,447) size 180x19 [color=#000000D8] [bgcolor=#FFFFFF]
+            RenderMenuList {SELECT} at (325,447) size 180x19 [bgcolor=#FFFFFF]
               RenderBlock (anonymous) at (0,0) size 180x18
                 RenderText at (8,2) size 91x13
                   text run at (8,2) width 91: "Level of difficulty"

--- a/LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x400
         RenderText {#text} at (0,0) size 664x18
           text run at (0,0) width 664: "The text in the button, popup menu and list box should have the same case as in the accompanying text."
       RenderBlock {DIV} at (0,18) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 72x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 72x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 72x18
             RenderText at (8,2) size 36x13
               text run at (8,2) width 36: "HELLO"
@@ -21,7 +21,7 @@ layer at (0,0) size 800x400
             text run at (146,40) width 116: "HELLO WORLD"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,79) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 68x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 68x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 68x18
             RenderText at (8,2) size 34x13
               text run at (8,2) width 34: "HeLLo"
@@ -35,7 +35,7 @@ layer at (0,0) size 800x400
             text run at (138,40) width 101: "HeLLo WoRLd"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,140) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 60x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 60x18
             RenderText at (8,2) size 26x13
               text run at (8,2) width 26: "hello"
@@ -49,7 +49,7 @@ layer at (0,0) size 800x400
             text run at (122,40) width 74: "hello world"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,201) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 60x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 60x18
             RenderText at (8,2) size 15x13
               text run at (8,2) width 15: "SS"
@@ -63,7 +63,7 @@ layer at (0,0) size 800x400
             text run at (122,40) width 58: "SS SSSS"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,262) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 45x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 45x18
             RenderText at (8,2) size 7x13
               text run at (8,2) width 7: "\x{DF}"
@@ -77,7 +77,7 @@ layer at (0,0) size 800x400
             text run at (92,40) width 28: "\x{DF} \x{DF}\x{DF}"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,323) size 784x61
-        RenderMenuList {SELECT} at (2,41) size 45x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,41) size 45x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 45x18
             RenderText at (8,2) size 7x13
               text run at (8,2) width 7: "\x{DF}"

--- a/LayoutTests/platform/mac/fast/forms/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/003-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,0) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,0) size 58x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 58x18
           RenderText at (8,2) size 27x13
             text run at (8,2) width 27: "Hello"

--- a/LayoutTests/platform/mac/fast/forms/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/004-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 58x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 58x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 58x18
           RenderText at (8,2) size 27x13
             text run at (8,2) width 27: "Hello"
       RenderText {#text} at (62,1) size 4x18
         text run at (62,1) width 4: " "
-      RenderMenuList {SELECT} at (68,2) size 79x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (68,2) size 79x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 79x18
           RenderText at (8,2) size 48x13
             text run at (8,2) width 48: "Goodbye"

--- a/LayoutTests/platform/mac/fast/forms/basic-selects-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/basic-selects-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x486
       RenderBlock {DIV} at (0,0) size 784x470 [border: (1px solid #FF0000)]
         RenderText {#text} at (1,2) size 169x18
           text run at (1,2) width 169: "Whitespace in option text:"
-        RenderMenuList {SELECT} at (171,3) size 56x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (171,3) size 56x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 55x18
             RenderText at (8,2) size 24x13
               text run at (8,2) width 24: "f o o"
         RenderText {#text} at (228,2) size 8x18
           text run at (228,2) width 8: "a"
-        RenderMenuList {SELECT} at (237,3) size 56x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (237,3) size 56x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 55x18
             RenderText at (8,2) size 24x13
               text run at (8,2) width 24: "f o o"
@@ -22,7 +22,7 @@ layer at (0,0) size 800x486
         RenderBR {BR} at (1,22) size 0x18
         RenderText {#text} at (1,40) size 140x18
           text run at (1,40) width 140: "Simple select control:"
-        RenderMenuList {SELECT} at (142,41) size 50x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (142,41) size 50x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 49x18
             RenderText at (8,2) size 17x13
               text run at (8,2) width 17: "foo"
@@ -38,7 +38,7 @@ layer at (0,0) size 800x486
         RenderBR {BR} at (1,60) size 0x18
         RenderText {#text} at (1,78) size 198x18
           text run at (1,78) width 198: "Line-height should be ignored:"
-        RenderMenuList {SELECT} at (200,79) size 49x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (200,79) size 49x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 48x18
             RenderText at (8,2) size 17x13
               text run at (8,2) width 17: "foo"
@@ -54,7 +54,7 @@ layer at (0,0) size 800x486
         RenderBR {BR} at (1,98) size 0x18
         RenderText {#text} at (1,116) size 441x18
           text run at (1,116) width 441: "Padding should be respected, the arrow button shouldn't change size:"
-        RenderMenuList {SELECT} at (444,117) size 48x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (444,117) size 48x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 48x18
             RenderText at (8,2) size 17x13
               text run at (8,2) width 17: "foo"
@@ -102,7 +102,7 @@ layer at (0,0) size 800x486
         RenderBR {BR} at (1,232) size 0x18
         RenderText {#text} at (1,248) size 491x18
           text run at (1,248) width 491: "Height larger than font-size, button should grow, text baseline should center:"
-        RenderMenuList {SELECT} at (493,249) size 49x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (493,249) size 49x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 48x18
             RenderText at (8,2) size 17x13
               text run at (8,2) width 17: "foo"
@@ -118,13 +118,13 @@ layer at (0,0) size 800x486
         RenderBR {BR} at (1,266) size 0x18
         RenderText {#text} at (1,282) size 515x18
           text run at (1,282) width 515: "Heigh smaller than font-size, whole select shrinks and is baselined with the text:"
-        RenderMenuList {SELECT} at (517,283) size 50x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (517,283) size 50x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 49x18
             RenderText at (8,2) size 17x13
               text run at (8,2) width 17: "foo"
         RenderText {#text} at (568,282) size 8x18
           text run at (568,282) width 8: "a"
-        RenderMenuList {SELECT} at (577,283) size 50x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (577,283) size 50x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 49x18
             RenderText at (8,2) size 18x13
               text run at (8,2) width 18: "bar"
@@ -135,7 +135,7 @@ layer at (0,0) size 800x486
         RenderText {#text} at (1,316) size 169x18
           text run at (1,316) width 169: "select control with size=0:"
         RenderBR {BR} at (169,316) size 1x18
-        RenderMenuList {SELECT} at (3,335) size 195x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (3,335) size 195x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 195x18
             RenderText at (8,2) size 70x13
               text run at (8,2) width 70: "Future Series"
@@ -143,7 +143,7 @@ layer at (0,0) size 800x486
         RenderText {#text} at (1,354) size 169x18
           text run at (1,354) width 169: "select control with size=1:"
         RenderBR {BR} at (169,354) size 1x18
-        RenderMenuList {SELECT} at (3,373) size 195x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (3,373) size 195x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 195x18
             RenderText at (8,2) size 70x13
               text run at (8,2) width 70: "Future Series"

--- a/LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 408: "There should not be scroll bars below the popup and the button."
 layer at (8,94) size 100x50
   RenderBlock {DIV} at (0,86) size 100x50
-    RenderMenuList {SELECT} at (0,2) size 80x18 [color=#000000D8] [bgcolor=#FFFFFF]
+    RenderMenuList {SELECT} at (0,2) size 80x18 [bgcolor=#FFFFFF]
       RenderBlock (anonymous) at (0,0) size 80x18
         RenderText at (8,2) size 143x13
           text run at (8,2) width 143: "Lorem ipsum dolor sit amet"

--- a/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 529x18
         text run at (0,0) width 529: "This tests that we don't honor line-height for controls that have restricted font size."
       RenderBR {BR} at (528,0) size 1x18
-      RenderMenuList {SELECT} at (2,20) size 302x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,20) size 302x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 302x18
           RenderText at (8,2) size 271x13
             text run at (8,2) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac/fast/forms/disabled-select-change-index-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/disabled-select-change-index-expected.txt
@@ -13,12 +13,12 @@ layer at (0,0) size 800x600
           RenderText at (8,2) size 29x13
             text run at (8,2) width 29: "PASS"
       RenderBR {BR} at (64,23) size 0x18
-      RenderMenuList {SELECT} at (2,46) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,46) size 60x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 60x18
           RenderText at (8,2) size 29x13
             text run at (8,2) width 29: "PASS"
       RenderBR {BR} at (64,45) size 0x18
-      RenderMenuList {SELECT} at (2,68) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,68) size 60x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 60x18
           RenderText at (8,2) size 29x13
             text run at (8,2) width 29: "PASS"

--- a/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt
@@ -25,7 +25,7 @@ layer at (0,0) size 785x636
             RenderTableCell {TD} at (60,2) size 67x24 [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 64x22 [border: (2px solid #0000FF)]
                 RenderInline {FONT} at (0,0) size 60x28
-                  RenderMenuList {SELECT} at (2,2) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                  RenderMenuList {SELECT} at (2,2) size 60x18 [bgcolor=#FFFFFF]
                     RenderBlock (anonymous) at (0,0) size 60x18
                       RenderText at (8,2) size 29x13
                         text run at (8,2) width 29: "menu"
@@ -48,7 +48,7 @@ layer at (0,0) size 785x636
                       text run at (0,0) width 35: "button"
             RenderTableCell {TD} at (60,2) size 67x24 [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 64x22 [border: (2px solid #0000FF)]
-                RenderMenuList {SELECT} at (2,2) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (2,2) size 60x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 60x18
                     RenderText at (8,2) size 29x13
                       text run at (8,2) width 29: "menu"
@@ -71,7 +71,7 @@ layer at (0,0) size 785x636
             RenderTableCell {TD} at (60,2) size 67x24 [r=0 c=1 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 64x22 [border: (2px solid #0000FF)]
                 RenderInline {FONT} at (0,0) size 60x13
-                  RenderMenuList {SELECT} at (2,2) size 60x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                  RenderMenuList {SELECT} at (2,2) size 60x18 [bgcolor=#FFFFFF]
                     RenderBlock (anonymous) at (0,0) size 60x18
                       RenderText at (8,2) size 29x13
                         text run at (8,2) width 29: "menu"
@@ -114,7 +114,7 @@ layer at (0,0) size 785x636
                 text run at (0,0) width 35: "button"
           RenderText {#text} at (96,0) size 7x28
             text run at (96,0) width 7: " "
-          RenderMenuList {SELECT} at (104,9) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (104,9) size 61x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 60x18
               RenderText at (8,2) size 29x13
                 text run at (8,2) width 29: "menu"
@@ -134,7 +134,7 @@ layer at (0,0) size 785x636
               text run at (0,0) width 35: "button"
         RenderText {#text} at (82,1) size 5x18
           text run at (82,1) width 5: " "
-        RenderMenuList {SELECT} at (88,2) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (88,2) size 61x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 60x18
             RenderText at (8,2) size 29x13
               text run at (8,2) width 29: "menu"
@@ -155,7 +155,7 @@ layer at (0,0) size 785x636
                 text run at (0,0) width 35: "button"
           RenderText {#text} at (71,5) size 4x13
             text run at (71,5) width 4: " "
-          RenderMenuList {SELECT} at (76,2) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (76,2) size 61x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 60x18
               RenderText at (8,2) size 29x13
                 text run at (8,2) width 29: "menu"
@@ -186,37 +186,37 @@ layer at (0,0) size 785x636
       RenderBlock {DIV} at (0,546) size 769x30
         RenderInline {FONT} at (0,0) size 174x28
           RenderText {#text} at (0,0) size 0x0
-          RenderMenuList {SELECT} at (2,9) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (2,9) size 36x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 36x18
               RenderText at (8,2) size 0x13
                 text run at (8,2) width 0: " "
           RenderText {#text} at (40,0) size 6x28
             text run at (40,0) width 6: " "
-          RenderMenuList {SELECT} at (48,9) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (48,9) size 36x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 36x18
               RenderText at (8,2) size 3x13
                 text run at (8,2) width 3: "|"
           RenderText {#text} at (86,0) size 6x28
             text run at (86,0) width 6: " "
-          RenderMenuList {SELECT} at (94,9) size 78x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (94,9) size 78x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 78x18
               RenderText at (8,2) size 47x13
                 text run at (8,2) width 47: "xxxxxxxx"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,575) size 769x23
-        RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 36x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "
         RenderText {#text} at (40,1) size 4x18
           text run at (40,1) width 4: " "
-        RenderMenuList {SELECT} at (46,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (46,2) size 36x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 3x13
               text run at (8,2) width 3: "|"
         RenderText {#text} at (84,1) size 4x18
           text run at (84,1) width 4: " "
-        RenderMenuList {SELECT} at (90,2) size 78x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (90,2) size 78x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 78x18
             RenderText at (8,2) size 47x13
               text run at (8,2) width 47: "xxxxxxxx"
@@ -224,19 +224,19 @@ layer at (0,0) size 785x636
       RenderBlock {DIV} at (0,597) size 769x23
         RenderInline {FONT} at (0,0) size 167x13
           RenderText {#text} at (0,0) size 0x0
-          RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (2,2) size 36x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 36x18
               RenderText at (8,2) size 0x13
                 text run at (8,2) width 0: " "
           RenderText {#text} at (40,5) size 3x13
             text run at (40,5) width 3: " "
-          RenderMenuList {SELECT} at (44,2) size 37x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (44,2) size 37x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 36x18
               RenderText at (8,2) size 3x13
                 text run at (8,2) width 3: "|"
           RenderText {#text} at (82,5) size 3x13
             text run at (82,5) width 3: " "
-          RenderMenuList {SELECT} at (87,2) size 78x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (87,2) size 78x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 78x18
               RenderText at (8,2) size 47x13
                 text run at (8,2) width 47: "xxxxxxxx"

--- a/LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt
@@ -5,7 +5,7 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderText {#text} at (0,1) size 75x18
         text run at (0,1) width 75: "Test result: "
-      RenderMenuList {SELECT} at (76,2) size 61x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (76,2) size 61x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 60x18
           RenderText at (8,2) size 29x13
             text run at (8,2) width 29: "PASS"

--- a/LayoutTests/platform/mac/fast/forms/menulist-narrow-width-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-narrow-width-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 510x18
         text run at (0,0) width 510: "This tests that select elements with a narrow width (1px) are rendered correctly."
       RenderBR {BR} at (509,0) size 1x18
-      RenderMenuList {SELECT} at (0,20) size 1x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,20) size 1x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 31x18
           RenderText at (8,2) size 21x13
             text run at (8,2) width 21: "test"

--- a/LayoutTests/platform/mac/fast/forms/menulist-no-overflow-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-no-overflow-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (0,0) size 246x15 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,0) size 246x15 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 246x16
           RenderText at (10,2) size 214x11
             text run at (10,2) width 214: "No overflow should be allowed on popup menus!"

--- a/LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt
@@ -3,13 +3,13 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 69x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 69x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 69x18
           RenderText at (8,2) size 38x13
             text run at (8,2) width 38: "Default"
       RenderText {#text} at (73,1) size 4x18
         text run at (73,1) width 4: " "
-      RenderMenuList {SELECT} at (79,2) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (79,2) size 52x18 [color=#FF0000] [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 52x18
           RenderText at (8,2) size 21x13
             text run at (8,2) width 21: "Red"

--- a/LayoutTests/platform/mac/fast/forms/menulist-width-change-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/menulist-width-change-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,18) size 375x18
           text run at (0,18) width 375: "that the select automatically recalculates the correct width."
         RenderBR {BR} at (374,18) size 1x18
-        RenderMenuList {SELECT} at (2,38) size 134x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,38) size 134x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 134x18
             RenderText at (8,2) size 29x13
               text run at (8,2) width 29: "Short"

--- a/LayoutTests/platform/mac/fast/forms/option-script-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/option-script-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         text run at (0,18) width 107: "TEST FAILED: "
         text run at (106,18) width 316: "If the popup menu says \"document.write('Text')\"."
       RenderBR {BR} at (421,18) size 1x18
-      RenderMenuList {SELECT} at (2,38) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,38) size 53x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 53x18
           RenderText at (8,2) size 22x13
             text run at (8,2) width 22: "Text"

--- a/LayoutTests/platform/mac/fast/forms/option-strip-whitespace-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/option-strip-whitespace-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,140) size 0x18
         RenderText {#text} at (0,159) size 306x18
           text run at (0,159) width 306: "Five Spaces (with leading/trailing whitespace): "
-        RenderMenuList {SELECT} at (307,160) size 95x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (307,160) size 95x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 94x18
             RenderText at (8,2) size 63x13
               text run at (8,2) width 63: "Five Spaces"
@@ -27,7 +27,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,180) size 0x18
         RenderText {#text} at (0,199) size 291x18
           text run at (0,199) width 291: "Five Tabs (with leading/trailing whitespace): "
-        RenderMenuList {SELECT} at (292,200) size 82x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (292,200) size 82x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 81x18
             RenderText at (8,2) size 50x13
               text run at (8,2) width 50: "Five Tabs"
@@ -35,7 +35,7 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,220) size 0x18
         RenderText {#text} at (0,239) size 129x18
           text run at (0,239) width 129: "Mixed Whitespace: "
-        RenderMenuList {SELECT} at (130,240) size 82x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (130,240) size 82x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 81x18
             RenderText at (8,2) size 50x13
               text run at (8,2) width 50: "Five Tabs"

--- a/LayoutTests/platform/mac/fast/forms/option-text-clip-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/option-text-clip-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 713x18
         text run at (0,0) width 713: "This tests that the option text is clipped properly, and doesn't spill over into the arrow part of the popup control."
       RenderBR {BR} at (712,0) size 1x18
-      RenderMenuList {SELECT} at (0,20) size 150x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (0,20) size 150x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 150x18
           RenderText at (8,2) size 130x13
             text run at (8,2) width 130: "12345 6789 ABCD EFGH"

--- a/LayoutTests/platform/mac/fast/forms/select-align-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-align-expected.txt
@@ -7,34 +7,34 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 590x18
           text run at (0,0) width 590: "The following select elements should all be rendered on the left, with their text left justified."
       RenderBlock (anonymous) at (0,34) size 784x110
-        RenderMenuList {SELECT} at (0,2) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,2) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."
         RenderBR {BR} at (300,1) size 0x18
-        RenderMenuList {SELECT} at (0,24) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,24) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."
         RenderBR {BR} at (300,23) size 0x18
-        RenderMenuList {SELECT} at (0,46) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,46) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."
         RenderBR {BR} at (300,45) size 0x18
-        RenderMenuList {SELECT} at (0,68) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,68) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."
         RenderBR {BR} at (300,67) size 0x18
-        RenderMenuList {SELECT} at (0,90) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,90) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,144) size 784x22
-        RenderMenuList {SELECT} at (0,2) size 300x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,2) size 300x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 300x18
             RenderText at (8,2) size 158x13
               text run at (8,2) width 158: "This is should be left justified."

--- a/LayoutTests/platform/mac/fast/forms/select-baseline-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-baseline-expected.txt
@@ -6,13 +6,13 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 474x18
         text run at (0,0) width 474: "This tests that empty select controls and buttons have the correct baseline."
       RenderBR {BR} at (473,0) size 1x18
-      RenderMenuList {SELECT} at (2,22) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,22) size 36x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 36x18
           RenderText at (8,2) size 0x13
             text run at (8,2) width 0: " "
       RenderText {#text} at (40,21) size 31x18
         text run at (40,21) width 31: " test "
-      RenderMenuList {SELECT} at (72,22) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (72,22) size 53x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 52x18
           RenderText at (8,2) size 21x13
             text run at (8,2) width 21: "test"

--- a/LayoutTests/platform/mac/fast/forms/select-change-listbox-to-popup-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-change-listbox-to-popup-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 450x18
         text run at (0,0) width 450: "This tests that you can dynamically change a list box to a popup menu"
       RenderBR {BR} at (449,0) size 1x18
-      RenderMenuList {SELECT} at (2,20) size 217x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,20) size 217x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 217x18
           RenderText at (8,2) size 186x13
             text run at (8,2) width 186: "This should turn into a popup menu"

--- a/LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x90
         RenderTableSection {TBODY} at (1,1) size 64x30
           RenderTableRow {TR} at (0,2) size 64x26
             RenderTableCell {TD} at (2,2) size 60x26 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (4,4) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+              RenderMenuList {SELECT} at (4,4) size 52x18 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 52x18
                   RenderText at (8,2) size 21x13
                     text run at (8,2) width 21: "test"

--- a/LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
               text run at (8,2) width 127: "This text should be gray"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,72) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 163x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 163x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 163x18
             RenderText at (8,2) size 132x13
               text run at (8,2) width 132: "This text should be black"

--- a/LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 70x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 70x18
           RenderText at (8,2) size 39x13
             text run at (8,2) width 39: "banana"

--- a/LayoutTests/platform/mac/fast/forms/select-initial-position-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-initial-position-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,237) size 98x18
         text run at (0,237) width 98: "initial selected:"
       RenderBR {BR} at (97,237) size 1x18
-      RenderMenuList {SELECT} at (2,257) size 153x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,257) size 153x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 153x18
           RenderText at (8,2) size 122x13
             text run at (8,2) width 122: "this should be selected"
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,277) size 165x18
         text run at (0,277) width 165: "dynamic selected change:"
       RenderBR {BR} at (164,277) size 1x18
-      RenderMenuList {SELECT} at (2,297) size 153x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,297) size 153x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 153x18
           RenderText at (8,2) size 122x13
             text run at (8,2) width 122: "this should be selected"
@@ -41,7 +41,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,317) size 217x18
         text run at (0,317) width 217: "dynamic insert of selected option:"
       RenderBR {BR} at (216,317) size 1x18
-      RenderMenuList {SELECT} at (2,337) size 153x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,337) size 153x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 153x18
           RenderText at (8,2) size 122x13
             text run at (8,2) width 122: "this should be selected"

--- a/LayoutTests/platform/mac/fast/forms/select-selected-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-selected-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 258x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 258x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 258x18
           RenderText at (8,2) size 164x13
             text run at (8,2) width 164: "should see this option selected"

--- a/LayoutTests/platform/mac/fast/forms/select-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-style-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (540,40) size 1x18
       RenderInline {SPAN} at (0,0) size 70x28 [bgcolor=#FF0000]
         RenderText {#text} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (7,60) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (7,60) size 52x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 52x18
             RenderText at (8,2) size 21x13
               text run at (8,2) width 21: "test"
@@ -51,7 +51,7 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,160) size 508x18
         text run at (0,160) width 508: "This tests that background is white if only background-image:none is specified."
       RenderBR {BR} at (507,160) size 1x18
-      RenderMenuList {SELECT} at (2,180) size 52x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,180) size 52x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 52x18
           RenderText at (8,2) size 21x13
             text run at (8,2) width 21: "test"

--- a/LayoutTests/platform/mac/fast/forms/select-visual-hebrew-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-visual-hebrew-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,1) size 398x18
           text run at (0,1) width 398: "Text on the pop-up and in the list should look like this: \x{5E8}\x{5D5}\x{5EA}\x{5E4}\x{5DB}"
       RenderBlock (anonymous) at (0,87) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 62x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 62x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 62x18
             RenderText at (8,2) size 31x13
               text run at (8,2) width 31 RTL: "\x{5DB}\x{5E4}\x{5EA}\x{5D5}\x{5E8}"

--- a/LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt
@@ -18,21 +18,21 @@ layer at (0,0) size 800x600
           text run at (329,18) width 5: "."
       RenderBlock {DIV} at (0,52) size 784x44
         RenderBlock {DIV} at (0,0) size 784x22
-          RenderMenuList {SELECT} at (0,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8 RTL: "\x{5D0}"
                 text run at (15,2) width 8: "A"
           RenderText {#text} at (70,1) size 4x18
             text run at (70,1) width 4: " "
-          RenderMenuList {SELECT} at (74,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (74,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8: "A"
                 text run at (15,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (144,1) size 4x18
             text run at (144,1) width 4: " "
-          RenderMenuList {SELECT} at (148,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (148,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 5: "("
@@ -40,28 +40,28 @@ layer at (0,0) size 800x600
                 text run at (19,2) width 8: "A"
           RenderText {#text} at (218,1) size 4x18
             text run at (218,1) width 4: " "
-          RenderMenuList {SELECT} at (222,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (222,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 12: "(A"
                 text run at (19,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (0,0) size 0x0
         RenderBlock {DIV} at (0,22) size 784x22
-          RenderMenuList {SELECT} at (492,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (492,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8 RTL: "\x{5D0}"
                 text run at (15,2) width 8: "A"
           RenderText {#text} at (562,1) size 4x18
             text run at (562,1) width 4: " "
-          RenderMenuList {SELECT} at (566,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (566,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 15x13
                 text run at (8,2) width 8: "A"
                 text run at (15,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (636,1) size 4x18
             text run at (636,1) width 4: " "
-          RenderMenuList {SELECT} at (640,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (640,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 5: "("
@@ -69,7 +69,7 @@ layer at (0,0) size 800x600
                 text run at (19,2) width 8: "A"
           RenderText {#text} at (710,1) size 4x18
             text run at (710,1) width 4: " "
-          RenderMenuList {SELECT} at (714,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (714,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (8,2) size 19x13
                 text run at (8,2) width 12: "(A"
@@ -77,28 +77,28 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,96) size 784x44
         RenderBlock {DIV} at (0,0) size 784x22
-          RenderMenuList {SELECT} at (222,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (222,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8: "A"
                 text run at (54,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (218,1) size 4x18
             text run at (218,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (148,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (148,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8 RTL: "\x{5D0}"
                 text run at (54,2) width 8: "A"
           RenderText {#text} at (144,1) size 4x18
             text run at (144,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (74,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (74,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8: "A"
                 text run at (50,2) width 12 RTL: "(\x{5D0}"
           RenderText {#text} at (70,1) size 4x18
             text run at (70,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (0,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (0,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8 RTL: "\x{5D0}"
@@ -106,28 +106,28 @@ layer at (0,0) size 800x600
                 text run at (57,2) width 5 RTL: "("
           RenderText {#text} at (0,0) size 0x0
         RenderBlock {DIV} at (0,22) size 784x22
-          RenderMenuList {SELECT} at (714,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (714,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8: "A"
                 text run at (54,2) width 8 RTL: "\x{5D0}"
           RenderText {#text} at (710,1) size 4x18
             text run at (710,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (640,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (640,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (47,2) size 15x13
                 text run at (47,2) width 8 RTL: "\x{5D0}"
                 text run at (54,2) width 8: "A"
           RenderText {#text} at (636,1) size 4x18
             text run at (636,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (566,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (566,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8: "A"
                 text run at (50,2) width 12 RTL: "(\x{5D0}"
           RenderText {#text} at (562,1) size 4x18
             text run at (562,1) width 4 RTL: " "
-          RenderMenuList {SELECT} at (492,2) size 70x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (492,2) size 70x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 70x18
               RenderText at (43,2) size 19x13
                 text run at (43,2) width 8 RTL: "\x{5D0}"

--- a/LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x323
         RenderText {#text} at (73,264) size 4x18
           text run at (73,264) width 4: " "
         RenderBR {BR} at (77,264) size 0x18
-        RenderMenuList {SELECT} at (2,287) size 74x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,287) size 74x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 74x18
             RenderText at (8,2) size 31x13
               text run at (8,2) width 31: "Three"

--- a/LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x38
   RenderBlock {HTML} at (0,0) size 800x38
     RenderBody {BODY} at (8,8) size 784x22
-      RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 36x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 36x18
           RenderText at (8,2) size 0x13
             text run at (8,2) width 0: " "

--- a/LayoutTests/platform/mac/fast/forms/stuff-on-my-optgroup-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/stuff-on-my-optgroup-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 66x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 66x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 66x18
           RenderText at (8,2) size 22x13
             text run at (8,2) width 22: "One"
       RenderBR {BR} at (70,1) size 0x18
-      RenderMenuList {SELECT} at (2,24) size 66x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,24) size 66x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 66x18
           RenderText at (8,2) size 22x13
             text run at (8,2) width 22: "One"

--- a/LayoutTests/platform/mac/fast/invalid/014-expected.txt
+++ b/LayoutTests/platform/mac/fast/invalid/014-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x600
           text run at (288,0) width 324: "H2 should allow a form inside it, but p should not."
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {FORM} at (0,18) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 39x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 39x18
             RenderText at (8,2) size 8x13
               text run at (8,2) width 8: "A"
@@ -18,7 +18,7 @@ layer at (0,0) size 800x600
 layer at (470,46) size 47x50
   RenderBlock (positioned) {H2} at (470,45) size 47x51 [border: (2px solid #008000)]
     RenderBlock {FORM} at (2,2) size 43x22
-      RenderMenuList {SELECT} at (2,2) size 39x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 39x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 39x18
           RenderText at (8,2) size 8x13
             text run at (8,2) width 8: "A"

--- a/LayoutTests/platform/mac/fast/parser/document-write-option-expected.txt
+++ b/LayoutTests/platform/mac/fast/parser/document-write-option-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderMenuList {SELECT} at (2,2) size 316x18 [color=#000000D8] [bgcolor=#FFFFFF]
+      RenderMenuList {SELECT} at (2,2) size 316x18 [bgcolor=#FFFFFF]
         RenderBlock (anonymous) at (0,0) size 316x18
           RenderText at (8,2) size 285x13
             text run at (8,2) width 285: "This is a very long string so it makes the select bigger."

--- a/LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt
@@ -28,11 +28,11 @@ layer at (0,0) size 800x600
             RenderText {#text} at (0,0) size 35x13
               text run at (0,0) width 35: "button"
         RenderText {#text} at (0,0) size 0x0
-        RenderMenuList {SELECT} at (3,191) size 63x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (3,191) size 63x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 63x18
             RenderText at (8,2) size 32x13
               text run at (8,2) width 32: "select"
-        RenderMenuList {SELECT} at (3,213) size 63x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (3,213) size 63x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 63x18
             RenderText at (8,2) size 32x13
               text run at (8,2) width 32: "select"

--- a/LayoutTests/platform/mac/fast/replaced/replaced-breaking-mixture-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/replaced-breaking-mixture-expected.txt
@@ -10,7 +10,7 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,43) size 10x40
         RenderText {#text} at (0,0) size 25x18
           text run at (0,0) width 25: "Foo"
-        RenderMenuList {SELECT} at (2,20) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,20) size 53x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 53x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"
@@ -23,7 +23,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,25) size 25x18
           text run at (0,25) width 25: "Foo"
       RenderBlock {DIV} at (0,167) size 10x40
-        RenderMenuList {SELECT} at (2,2) size 53x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 53x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 53x18
             RenderText at (8,2) size 22x13
               text run at (8,2) width 22: "One"

--- a/LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt
@@ -4,15 +4,15 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DIV} at (0,0) size 5x66
-        RenderMenuList {SELECT} at (2,2) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 36x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "
-        RenderMenuList {SELECT} at (2,24) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,24) size 36x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "
-        RenderMenuList {SELECT} at (2,46) size 36x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,46) size 36x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 36x18
             RenderText at (8,2) size 0x13
               text run at (8,2) width 0: " "

--- a/LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt
+++ b/LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt
@@ -10,17 +10,17 @@ layer at (0,0) size 800x600
         RenderTableSection {TBODY} at (0,0) size 784x26
           RenderTableRow {TR} at (0,1) size 784x24
             RenderTableCell {TD} at (1,1) size 2x24 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+              RenderMenuList {SELECT} at (1,3) size 0x18 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 20x13
                     text run at (8,2) width 20: "one"
             RenderTableCell {TD} at (4,1) size 2x24 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+              RenderMenuList {SELECT} at (1,3) size 0x18 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 19x13
                     text run at (8,2) width 19: "two"
             RenderTableCell {TD} at (7,1) size 2x24 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,3) size 0x18 [color=#000000D8] [bgcolor=#FFFFFF]
+              RenderMenuList {SELECT} at (1,3) size 0x18 [bgcolor=#FFFFFF]
                 RenderBlock (anonymous) at (0,0) size 31x18
                   RenderText at (8,2) size 28x13
                     text run at (8,2) width 28: "three"

--- a/LayoutTests/platform/mac/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/bidi-menulist-expected.txt
@@ -14,7 +14,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 286x18
           text run at (0,0) width 286: "1) direction: rtl; -webkit-rtl-ordering: logical"
         RenderBR {BR} at (285,0) size 1x18
-        RenderMenuList {SELECT} at (0,20) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,20) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (31,2) size 61x13
               text run at (31,2) width 42 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
@@ -29,7 +29,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,18) size 118x18
           text run at (0,18) width 118: "2) text-align: right"
         RenderBR {BR} at (117,18) size 1x18
-        RenderMenuList {SELECT} at (0,38) size 200x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,38) size 200x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 200x18
             RenderText at (8,2) size 61x13
               text run at (8,2) width 20: "abc"
@@ -44,7 +44,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,18) size 72x18
           text run at (0,18) width 72: "3) No style"
         RenderBR {BR} at (71,18) size 1x18
-        RenderMenuList {SELECT} at (0,38) size 100x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,38) size 100x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 100x18
             RenderText at (8,2) size 61x13
               text run at (8,2) width 20: "abc"

--- a/LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x544
           text run at (0,0) width 497: "Verify that the alignment and writing direction of each selected item matches "
           text run at (496,0) width 213: "the one below the pop-up button."
       RenderBlock {DIV} at (0,34) size 784x242
-        RenderMenuList {SELECT} at (0,0) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,0) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (8,2) size 160x16
               text run at (8,2) width 31: "First "
@@ -23,7 +23,7 @@ layer at (0,0) size 800x544
             text run at (89,10) width 17: "03"
             text run at (105,10) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (141,10) width 32: " fifth"
-        RenderMenuList {SELECT} at (0,61) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,61) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (8,2) size 160x16
               text run at (8,2) width 25: "fifth"
@@ -38,14 +38,14 @@ layer at (0,0) size 800x544
             text run at (87,10) width 18: "03"
             text run at (104,10) width 41 RTL: " \x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (144,10) width 29: "First"
-        RenderMenuList {SELECT} at (0,122) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,122) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (8,2) size 160x16
               text run at (8,2) width 160: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
         RenderBlock {DIV} at (0,145) size 470x36
           RenderText {#text} at (10,10) size 163x16
             text run at (10,10) width 163: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
-        RenderMenuList {SELECT} at (0,183) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,183) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (8,2) size 160x16
               text run at (8,2) width 160 RTL: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
@@ -53,7 +53,7 @@ layer at (0,0) size 800x544
           RenderText {#text} at (10,10) size 163x16
             text run at (10,10) width 163 RTL: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
       RenderBlock {DIV} at (0,278) size 784x242
-        RenderMenuList {SELECT} at (0,0) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,0) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (332,2) size 160x16
               text run at (332,2) width 31: "First "
@@ -68,7 +68,7 @@ layer at (0,0) size 800x544
             text run at (376,10) width 18: "03"
             text run at (393,10) width 37 RTL: "\x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (429,10) width 31: " fifth"
-        RenderMenuList {SELECT} at (0,61) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,61) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (332,2) size 160x16
               text run at (332,2) width 25: "fifth"
@@ -83,14 +83,14 @@ layer at (0,0) size 800x544
             text run at (375,10) width 17: "03"
             text run at (391,10) width 42 RTL: " \x{5E9}\x{5E0}\x{5D9}\x{5D4} ("
             text run at (432,10) width 28: "First"
-        RenderMenuList {SELECT} at (0,122) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,122) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (332,2) size 160x16
               text run at (332,2) width 160: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
         RenderBlock {DIV} at (0,145) size 470x36
           RenderText {#text} at (297,10) size 163x16
             text run at (297,10) width 163: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"
-        RenderMenuList {SELECT} at (0,183) size 500x21 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (0,183) size 500x21 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 500x21
             RenderText at (332,2) size 160x16
               text run at (332,2) width 160 RTL: "First \x{5E9}\x{5E0}\x{5D9}\x{5D4} (03) \x{5E8}\x{5D1}\x{5D9}\x{5E2}\x{5D9}\x{5EA} fifth"

--- a/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt
@@ -56,7 +56,7 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (16,229) size 130x37
                   text run at (16,229) width 130: " option #2"
                 RenderBR {BR} at (145,229) size 1x37
-                RenderMenuList {SELECT} at (2,268) size 252x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (2,268) size 252x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 252x18
                     RenderText at (8,2) size 61x13
                       text run at (8,2) width 61: "Initial Value"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt
@@ -19,7 +19,7 @@ layer at (0,0) size 800x600
                       text run at (48,5) width 128: "Search the Web with"
                 RenderText {#text} at (175,2) size 5x20
                   text run at (175,3) width 5: " "
-                RenderMenuList {SELECT} at (181,4) size 82x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (181,4) size 82x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 81x18
                     RenderText at (8,2) size 50x13
                       text run at (8,2) width 50: "Netscape"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt
@@ -28,7 +28,7 @@ layer at (0,0) size 800x600
                   RenderText {#text} at (1,1) size 104x18
                     text run at (1,1) width 104: "Run Test Case:"
               RenderTableCell {TD} at (109,29) size 468x24 [r=1 c=1 rs=1 cs=1]
-                RenderMenuList {SELECT} at (3,3) size 259x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (3,3) size 259x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 259x18
                     RenderText at (8,2) size 72x13
                       text run at (8,2) width 72: "a_abortinstall"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -66,7 +66,7 @@ layer at (0,0) size 785x685
         RenderBlock {P} at (0,0) size 769x45
           RenderText {#text} at (0,2) size 267x18
             text run at (0,2) width 267: "How does your browser fare on this test? "
-          RenderMenuList {SELECT} at (268,3) size 242x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (268,3) size 242x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 241x18
               RenderText at (8,2) size 139x13
                 text run at (8,2) width 139: "The test renders correctly."

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -184,7 +184,7 @@ layer at (0,0) size 785x2589
         RenderBlock {P} at (0,0) size 769x45
           RenderText {#text} at (0,1) size 267x18
             text run at (0,1) width 267: "How does your browser fare on this test? "
-          RenderMenuList {SELECT} at (268,2) size 464x18 [color=#000000D8] [bgcolor=#FFFFFF]
+          RenderMenuList {SELECT} at (268,2) size 464x18 [bgcolor=#FFFFFF]
             RenderBlock (anonymous) at (0,0) size 463x18
               RenderText at (8,2) size 432x13
                 text run at (8,2) width 432: "The tests all render identically, and this browser may or may not grok CSS2 tables."

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           RenderTableRow {TR} at (0,2) size 398x42
             RenderTableCell {TD} at (2,2) size 394x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {FORM} at (2,2) size 390x22
-                RenderMenuList {SELECT} at (2,2) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (2,2) size 54x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 54x18
                     RenderText at (8,2) size 23x13
                       text run at (8,2) width 23: "Test"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
                     RenderText at (0,0) size 46x13
                       text run at (0,0) width 46: "Move to:"
               RenderTableCell {TD} at (668,2) size 114x24 [r=0 c=5 rs=1 cs=1]
-                RenderMenuList {SELECT} at (3,3) size 108x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (3,3) size 108x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 108x18
                     RenderText at (8,2) size 77x13
                       text run at (8,2) width 77: "Choose folder "

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug4382-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug4382-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         RenderTextControl {INPUT} at (52,2) size 134x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderText {#text} at (187,2) size 5x18
           text run at (187,2) width 5: " "
-        RenderMenuList {SELECT} at (193,3) size 77x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (193,3) size 77x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 76x18
             RenderText at (8,2) size 32x13
               text run at (8,2) width 32: "Excite"
@@ -27,7 +27,7 @@ layer at (0,0) size 800x600
           text run at (0,18) width 266: "The select should not contain blank items"
         RenderBR {BR} at (265,18) size 1x18
       RenderBlock {FORM} at (0,93) size 784x22
-        RenderMenuList {SELECT} at (2,2) size 221x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,2) size 221x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 221x18
             RenderText at (8,2) size 55x13
               text run at (8,2) width 55: "Quick Link"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug96334-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug96334-expected.txt
@@ -30,7 +30,7 @@ layer at (0,0) size 800x585
                         RenderTableSection {TBODY} at (2,2) size 195x30
                           RenderTableRow {TR} at (0,2) size 195x26
                             RenderTableCell {TD} at (2,2) size 191x26 [border: (1px solid #C0C0C0)] [r=0 c=0 rs=1 cs=1]
-                              RenderMenuList {SELECT} at (4,4) size 183x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                              RenderMenuList {SELECT} at (4,4) size 183x18 [bgcolor=#FFFFFF]
                                 RenderBlock (anonymous) at (0,0) size 183x18
                                   RenderText at (8,2) size 152x13
                                     text run at (8,2) width 152: "USE THIS JAVASCRIPT HERE"

--- a/LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x600
           RenderTableRow {TR} at (0,2) size 398x42
             RenderTableCell {TD} at (2,2) size 394x42 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
               RenderBlock {FORM} at (2,2) size 390x22
-                RenderMenuList {SELECT} at (2,2) size 54x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (2,2) size 54x18 [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 54x18
                     RenderText at (8,2) size 23x13
                       text run at (8,2) width 23: "Test"

--- a/LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {FORM} at (0,0) size 784x23
-        RenderMenuList {SELECT} at (2,3) size 93x18 [color=#000000D8] [bgcolor=#FFFFFF]
+        RenderMenuList {SELECT} at (2,3) size 93x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 93x18
             RenderText at (8,2) size 61x13
               text run at (8,2) width 61: "append cell"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -138,7 +138,7 @@ layer at (8,8) size 769x1435
               RenderBlock {P} at (1,17) size 451x63
                 RenderText {#text} at (0,0) size 263x18
                   text run at (0,0) width 263: "How does your browser fare on this test?"
-                RenderMenuList {SELECT} at (2,20) size 447x18 [color=#000000D8] [bgcolor=#FFFFFF]
+                RenderMenuList {SELECT} at (2,20) size 447x18 [color=#000000] [bgcolor=#FFFFFF]
                   RenderBlock (anonymous) at (0,0) size 447x18
                     RenderText at (8,2) size 212x13
                       text run at (8,2) width 212: "Document renders exactly as described."

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1625,14 +1625,6 @@ void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) c
     // White-space is locked to pre
     style.setWhiteSpace(WhiteSpace::Pre);
 
-    // Set the foreground color to black or gray when we have the aqua look.
-    Color c = Color::darkGray;
-    if (e) {
-        OptionSet<StyleColorOptions> options = e->document().styleColorOptions(&style);
-        c = !e->isDisabledFormControl() ? systemColor(CSSValueButtontext, options) : systemColor(CSSValueGraytext, options);
-    }
-    style.setColor(c);
-
     // Set the button's vertical size.
     setSizeFromFont(style, menuListButtonSizes());
 


### PR DESCRIPTION
#### d31184adaa0bc64aa4aa523dafd5e0437094d20e
<pre>
[macOS] The color CSS property value is ignored on &lt;select&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=238667">https://bugs.webkit.org/show_bug.cgi?id=238667</a>
rdar://91167635

Reviewed by Tim Nguyen.

Currently, `appearance: auto` on &lt;select&gt; elements forces a text color,
preventing authors from customizing it. This behavior is different from Chrome
and Firefox, and is a web compatibility issue.

To fix, remove the logic that forces a text color when using &lt;select&gt; elements
with a native appearance. The disabled text color behavior is preserved by an
existing rule in the UA style sheet.

This change also has the effect of using CanvasText rather than ButtonText as
the default text color, which matches pop-up buttons in AppKit and other
text content in WebKit.

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-bigsur/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac-bigsur/fast/forms/select/optgroup-rendering-expected.txt:
* LayoutTests/platform/mac-bigsur/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4641033-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4944770-1-expected.txt:
* LayoutTests/platform/mac/editing/pasteboard/4944770-2-expected.txt:
* LayoutTests/platform/mac/editing/selection/caret-before-select-expected.txt:
* LayoutTests/platform/mac/editing/selection/replaced-boundaries-3-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-box-expected.txt:
* LayoutTests/platform/mac/editing/selection/select-element-paragraph-boundary-expected.txt:
* LayoutTests/platform/mac/fast/block/float/float-avoidance-expected.txt:
* LayoutTests/platform/mac/fast/block/margin-collapse/103-expected.txt:
* LayoutTests/platform/mac/fast/css/text-transform-select-expected.txt:
* LayoutTests/platform/mac/fast/forms/003-expected.txt:
* LayoutTests/platform/mac/fast/forms/004-expected.txt:
* LayoutTests/platform/mac/fast/forms/basic-selects-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-clip-overflow-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/disabled-select-change-index-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-element-geometry-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-deselect-update-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-narrow-width-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-no-overflow-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-style-color-expected.txt:
* LayoutTests/platform/mac/fast/forms/menulist-width-change-expected.txt:
* LayoutTests/platform/mac/fast/forms/option-script-expected.txt:
* LayoutTests/platform/mac/fast/forms/option-strip-whitespace-expected.txt:
* LayoutTests/platform/mac/fast/forms/option-text-clip-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-align-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-baseline-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-change-listbox-to-popup-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-dirty-parent-pref-widths-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-disabled-appearance-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-element-focus-ring-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-initial-position-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-selected-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-style-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-visual-hebrew-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-writing-direction-natural-expected.txt:
* LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt:
* LayoutTests/platform/mac/fast/forms/selectlist-minsize-expected.txt:
* LayoutTests/platform/mac/fast/forms/stuff-on-my-optgroup-expected.txt:
* LayoutTests/platform/mac/fast/invalid/014-expected.txt:
* LayoutTests/platform/mac/fast/parser/document-write-option-expected.txt:
* LayoutTests/platform/mac/fast/replaced/replaced-breaking-expected.txt:
* LayoutTests/platform/mac/fast/replaced/replaced-breaking-mixture-expected.txt:
* LayoutTests/platform/mac/fast/replaced/three-selects-break-expected.txt:
* LayoutTests/platform/mac/fast/replaced/width100percent-menulist-expected.txt:
* LayoutTests/platform/mac/fast/text/international/bidi-menulist-expected.txt:
* LayoutTests/platform/mac/fast/text/international/pop-up-button-text-alignment-and-direction-expected.txt:
* LayoutTests/platform/mac/http/tests/navigation/javascriptlink-frames-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug1188-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug18359-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug29326-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug4382-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug96334-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/core/margins-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/dom/tableDom-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustMenuListStyle const):

Canonical link: <a href="https://commits.webkit.org/253074@main">https://commits.webkit.org/253074@main</a>
</pre>
