### PR TITLE
[WebIDL] Eagerly allocate element wrappers onto a butterfly storage of a static NodeList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ __cmake_systeminformation/
 
 # Local overrides configuration files
 LocalOverrides.xcconfig
+
+/BenchmarkTemp

--- a/JSTests/microbenchmarks/array-prototype-indexOf-contiguous-always-slow-put.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-contiguous-always-slow-put.js
@@ -1,0 +1,15 @@
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var {indexOf} = Array.prototype;
+    var searchElement = target[50];
+
+    for (var j = 0; j < 1e6; j++) {
+        if (indexOf.call(target, searchElement) !== 50)
+            throw new Error(`Bad assert: ${j}!`);
+    }
+})();

--- a/JSTests/microbenchmarks/array-prototype-indexOf-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-contiguous.js
@@ -1,0 +1,15 @@
+const length = 100;
+
+var target = new Array(100);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var {indexOf} = Array.prototype;
+    var searchElement = target[50];
+
+    for (var j = 0; j < 1e6; j++) {
+        if (indexOf.call(target, searchElement) !== 50)
+            throw new Error(`Bad assert: ${j}!`);
+    }
+})();

--- a/JSTests/microbenchmarks/array-prototype-slice-contiguous-always-slow-put.js
+++ b/JSTests/microbenchmarks/array-prototype-slice-contiguous-always-slow-put.js
@@ -1,0 +1,16 @@
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var {slice} = Array.prototype;
+    var lastSlice;
+
+    for (var j = 0; j < 1e7; j++)
+        lastSlice = slice.call(target);
+
+    if (lastSlice.pop().index !== 99)
+        throw new Error(`Bad assert!`);
+})();

--- a/JSTests/microbenchmarks/array-prototype-slice-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-slice-contiguous.js
@@ -1,0 +1,16 @@
+const length = 100;
+
+var target = new Array(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var {slice} = Array.prototype;
+    var lastSlice;
+
+    for (var j = 0; j < 1e7; j++)
+        lastSlice = slice.call(target);
+
+    if (lastSlice.pop().index !== 99)
+        throw new Error(`Bad assert!`);
+})();

--- a/JSTests/microbenchmarks/get-by-val-contiguous-always-slow-put.js
+++ b/JSTests/microbenchmarks/get-by-val-contiguous-always-slow-put.js
@@ -1,0 +1,17 @@
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var el;
+
+    for (var j = 0; j < 1e6; j++) {
+        for (var i = 0; i < length / 2; i++)
+            el = target[i];
+    }
+
+    if (el.index + 1 !== length / 2)
+        throw new Error(`Bad assert!`);
+})();

--- a/JSTests/microbenchmarks/get-by-val-contiguous.js
+++ b/JSTests/microbenchmarks/get-by-val-contiguous.js
@@ -1,0 +1,17 @@
+const length = 100;
+
+var target = new Array(100);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    var el;
+
+    for (var j = 0; j < 1e6; j++) {
+        for (var i = 0; i < length / 2; i++)
+            el = target[i];
+    }
+
+    if (el.index + 1 !== length / 2)
+        throw new Error(`Bad assert!`);
+})();

--- a/JSTests/stress/always-slow-put-contiguous-to-array-storage-1.js
+++ b/JSTests/stress/always-slow-put-contiguous-to-array-storage-1.js
@@ -1,0 +1,25 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function putByVal(target, index) { "use strict"; target[index] = {index}; }
+noInline(putByVal);
+
+const runs = 1e5;
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        if (i === runs - 1)
+            target[10000001] = 1;
+
+        for (var j = 0; j < length; j++)
+            putByVal(target, j);
+    }
+
+    assert(target.putByIndexCalls === length + (length * runs) + 1);
+    assert($vm.indexingMode(target) === "NonArrayWithSlowPutArrayStorage");
+    assert($vm.hasSparseModeArrayStorage(target));
+})();

--- a/JSTests/stress/always-slow-put-contiguous-to-array-storage-2.js
+++ b/JSTests/stress/always-slow-put-contiguous-to-array-storage-2.js
@@ -1,0 +1,25 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function putByVal(target, index) { "use strict"; target[index] = {index}; }
+noInline(putByVal);
+
+const runs = 1e5;
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        if (i === runs - 1)
+            Object.setPrototypeOf(target, { get 42() {}, set 42(_v) {} });
+
+        for (var j = 0; j < length; j++)
+            putByVal(target, j);
+    }
+
+    assert(target.putByIndexCalls === length + (length * runs));
+    assert($vm.indexingMode(target) === "NonArrayWithSlowPutArrayStorage");
+    assert($vm.hasSparseModeArrayStorage(target));
+})();

--- a/JSTests/stress/always-slow-put-contiguous-to-array-storage-3.js
+++ b/JSTests/stress/always-slow-put-contiguous-to-array-storage-3.js
@@ -1,0 +1,25 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function putByVal(target, index) { "use strict"; target[index] = {index}; }
+noInline(putByVal);
+
+const runs = 1e5;
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        if (i === runs - 1)
+            Object.defineProperty(target, 10000001, { get() {}, set() {} });
+
+        for (var j = 0; j < length; j++)
+            putByVal(target, j);
+    }
+
+    assert(target.putByIndexCalls === length + (length * runs));
+    assert($vm.indexingMode(target) === "NonArrayWithSlowPutArrayStorage");
+    assert($vm.hasSparseModeArrayStorage(target));
+})();

--- a/JSTests/stress/always-slow-put-contiguous-to-array-storage-4.js
+++ b/JSTests/stress/always-slow-put-contiguous-to-array-storage-4.js
@@ -1,0 +1,25 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function putByVal(target, index) { "use strict"; target[index] = {index}; }
+noInline(putByVal);
+
+const runs = 1e5;
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        if (i === runs - 1)
+            Object.defineProperty(Object.prototype, 10000001, { get() {}, set() {} });
+
+        for (var j = 0; j < length; j++)
+            putByVal(target, j);
+    }
+
+    assert(target.putByIndexCalls === length + (length * runs));
+    assert($vm.indexingMode(target) === "NonArrayWithSlowPutArrayStorage");
+    assert($vm.hasSparseModeArrayStorage(target));
+})();

--- a/JSTests/stress/array-reverse-contiguous-always-slow-put.js
+++ b/JSTests/stress/array-reverse-contiguous-always-slow-put.js
@@ -1,0 +1,9 @@
+const length = 100;
+
+var target = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    target[i] = {index: i};
+
+var reversed = Array.prototype.reverse.call(target);
+if (reversed.putByIndexCalls !== length * 2)
+    throw new Error(`Bad value: ${reversed.putByIndexCalls}!`);

--- a/JSTests/stress/delete-by-val-always-slow-put-contiguous-tricky.js
+++ b/JSTests/stress/delete-by-val-always-slow-put-contiguous-tricky.js
@@ -1,0 +1,21 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function deleteByVal(target, index) { "use strict"; delete target[index]; }
+noInline(deleteByVal);
+
+const runs = 1e6;
+const length = 100;
+
+var jsArrayContiguous = new Array(length);
+var alwaysSlowPutContiguous = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    jsArrayContiguous[i] = alwaysSlowPutContiguous[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        for (var j = 0; j < length; j++)
+            deleteByVal(i === runs - 100 ? alwaysSlowPutContiguous : jsArrayContiguous, j);
+    }
+
+    assert(alwaysSlowPutContiguous.deleteByIndexCalls === length);
+})();

--- a/JSTests/stress/for-in-always-slow-put-contiguous.js
+++ b/JSTests/stress/for-in-always-slow-put-contiguous.js
@@ -1,0 +1,15 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+const runs = 1e6;
+const length = 100;
+
+var alwaysSlowPutContiguous = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    alwaysSlowPutContiguous[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        for (var j in alwaysSlowPutContiguous)
+            assert(alwaysSlowPutContiguous[j].index === +j);
+    }
+})();

--- a/JSTests/stress/get-by-val-always-slow-put-contiguous-tricky.js
+++ b/JSTests/stress/get-by-val-always-slow-put-contiguous-tricky.js
@@ -1,0 +1,19 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function getByVal(target, index) { return target[index]; }
+noInline(getByVal);
+
+const runs = 1e6;
+const length = 100;
+
+var jsArrayContiguous = new Array(length);
+var alwaysSlowPutContiguous = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    jsArrayContiguous[i] = alwaysSlowPutContiguous[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        for (var j = 0; j < length; j++)
+            assert(getByVal(i === runs - 100 ? alwaysSlowPutContiguous : jsArrayContiguous, j).index === j);
+    }
+})();

--- a/JSTests/stress/put-by-val-always-slow-put-contiguous-tricky.js
+++ b/JSTests/stress/put-by-val-always-slow-put-contiguous-tricky.js
@@ -1,0 +1,21 @@
+function assert(x) { if (!x) throw new Error(`Bad assertion: ${x}!`); }
+
+function putByVal(target, index) { "use strict"; target[index] = {index}; }
+noInline(putByVal);
+
+const runs = 1e6;
+const length = 100;
+
+var jsArrayContiguous = new Array(length);
+var alwaysSlowPutContiguous = $vm.createAlwaysSlowPutContiguousObjectWithOverrides(length);
+for (var i = 0; i < length; i++)
+    jsArrayContiguous[i] = alwaysSlowPutContiguous[i] = {index: i};
+
+(function() {
+    for (var i = 0; i < runs; i++) {
+        for (var j = 0; j < length; j++)
+            putByVal(i === runs - 100 ? alwaysSlowPutContiguous : jsArrayContiguous, j);
+    }
+
+    assert(alwaysSlowPutContiguous.putByIndexCalls === 2 * length);
+})();

--- a/LayoutTests/fast/dom/NodeList/nodelist-static-having-a-bad-time-expected.txt
+++ b/LayoutTests/fast/dom/NodeList/nodelist-static-having-a-bad-time-expected.txt
@@ -1,0 +1,10 @@
+This tests that static NodeList is created with appropriate indexing type when global object is having a bad time.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS setterCalls is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/NodeList/nodelist-static-having-a-bad-time.html
+++ b/LayoutTests/fast/dom/NodeList/nodelist-static-having-a-bad-time.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML">
+<script src="../../../resources/js-test-pre.js"></script>
+
+<body>
+<span></span>
+<span></span>
+<span></span>
+<script>
+description('This tests that static NodeList is created with appropriate indexing type when global object is having a bad time.');
+
+var setterCalls = 0;
+
+Object.defineProperty(Object.prototype, 42, {
+    set() { setterCalls++; },
+});
+
+var nodeList = document.querySelectorAll("span");
+nodeList[42] = 1
+
+shouldBe("setterCalls", "1");
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-1-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-1.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(nodeList, "length", { get() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-2.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.setPrototypeOf(nodeList, { get length() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-3-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-3.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(NodeList.prototype, "length", { get() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(nodeList, "length", { get() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.setPrototypeOf(nodeList, { get length() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3-expected.txt
@@ -1,0 +1,3 @@
+
+PASS NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(NodeList.prototype, "length", { get() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/support/NodeList-static-length-tampered.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/support/NodeList-static-length-tampered.js
@@ -1,0 +1,46 @@
+"use strict";
+
+function makeStaticNodeList(length) {
+    const fooRoot = document.createElement("div");
+
+    for (var i = 0; i < length; i++) {
+        const el = document.createElement("span");
+        el.className = "foo";
+        fooRoot.append(el);
+    }
+
+    document.body.append(fooRoot);
+    return fooRoot.querySelectorAll(".foo");
+}
+
+const indexOfNodeList = new Function("nodeList", `
+    const __cacheBust = ${Math.random()};
+
+    const el = nodeList[50];
+
+    let index = -1;
+
+    for (var i = 0; i < 1e5 / 2; i++) {
+        for (var j = 0; j < nodeList.length; j++) {
+            if (nodeList[j] === el) {
+                index = j;
+                break;
+            }
+        }
+    }
+
+    return index;
+`);
+
+const arrayIndexOfNodeList = new Function("nodeList", `
+    const __cacheBust = ${Math.random()};
+
+    const el = nodeList[50];
+    const {indexOf} = Array.prototype;
+
+    for (var i = 0; i < 1e5; i++) {
+        var index = indexOf.call(nodeList, el);
+    }
+
+    return index;
+`);

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -618,6 +618,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     builtins/BuiltinNames.h
     builtins/BuiltinUtils.h
 
+    bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
     bytecode/ArithProfile.h
     bytecode/ArrayAllocationProfile.h
     bytecode/ArrayProfile.h
@@ -1132,6 +1133,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/NumericStrings.h
     runtime/ObjectConstructor.h
     runtime/ObjectInitializationScope.h
+    runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
     runtime/ObjectPrototype.h
     runtime/Operations.h
     runtime/Options.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1090,7 +1090,7 @@
 		536B319C1F735E7D0037FC33 /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 536B31971F735E5B0037FC33 /* UnifiedSource134.cpp */; };
 		536B319D1F735E7D0037FC33 /* UnifiedSource135.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 536B31991F735E5D0037FC33 /* UnifiedSource135.cpp */; };
 		5370806B1FE232DF00299E44 /* JSArrayBufferView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66BB17B6B5AB00A7AE3F /* JSArrayBufferView.h */; };
-		5370B4F61BF26205005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5370B4F41BF25EA2005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h */; };
+		5370B4F61BF26205005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5370B4F41BF25EA2005C40FC /* AdaptiveInferredPropertyValueWatchpointBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		537FEEC92742BDA300C9EFEE /* StructureID.h in Headers */ = {isa = PBXBuildFile; fileRef = 537FEEC82742BDA300C9EFEE /* StructureID.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		537FEED02742BDE100C9EFEE /* StructureAlignedMemoryAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 537FEECC2742BDE000C9EFEE /* StructureAlignedMemoryAllocator.h */; };
 		5381B9391E60E97D0090F794 /* WasmFaultSignalHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 5381B9381E60E97D0090F794 /* WasmFaultSignalHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2011,7 +2011,7 @@
 		E3BF3C532390D205008BC752 /* WebAssemblyGlobalConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BF3C512390D1FC008BC752 /* WebAssemblyGlobalConstructor.h */; };
 		E3BFA5D021E853A1009C0EBA /* DFGDesiredGlobalProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BFA5CD21E853A1009C0EBA /* DFGDesiredGlobalProperty.h */; };
 		E3BFD0BC1DAF808E0065DEA2 /* AccessCaseSnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BFD0BA1DAF807C0065DEA2 /* AccessCaseSnippetParams.h */; };
-		E3C295DD1ED2CBDA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C295DC1ED2CBAA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h */; };
+		E3C295DD1ED2CBDA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C295DC1ED2CBAA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C4131D289E08EA001150F8 /* SyntheticModuleRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C4131C289E08E5001150F8 /* SyntheticModuleRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C694B323026877006FBE42 /* WasmOSREntryData.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C694B123026873006FBE42 /* WasmOSREntryData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C73A9125BFA73B00EFE303 /* WasmStreamingPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C73A9025BFA73400EFE303 /* WasmStreamingPlan.h */; };

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -86,6 +86,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -307,6 +308,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -375,6 +377,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -441,6 +444,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -504,6 +508,7 @@ bool AccessCase::needsScratchFPR() const
     case InstanceOfGeneric:
     case IndexedInt32Load:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -607,6 +612,7 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -675,6 +681,7 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -766,6 +773,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case ArrayLength:
     case StringLength:
@@ -1340,6 +1348,7 @@ void AccessCase::generateWithGuard(
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad: {
         ASSERT(!viaProxy());
         // This code is written such that the result could alias with the base or the property.
@@ -1393,6 +1402,9 @@ void AccessCase::generateWithGuard(
                 break;
             case IndexedContiguousLoad:
                 expectedShape = ContiguousShape;
+                break;
+            case IndexedAlwaysSlowPutContiguousLoad:
+                expectedShape = AlwaysSlowPutContiguousShape;
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -2537,6 +2549,7 @@ void AccessCase::generateImpl(AccessGenerationState& state)
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
@@ -2662,6 +2675,7 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case IndexedInt32Load:
     case IndexedDoubleLoad:
     case IndexedContiguousLoad:
+    case IndexedAlwaysSlowPutContiguousLoad:
     case IndexedArrayStorageLoad:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -116,6 +116,7 @@ public:
         IndexedInt32Load,
         IndexedDoubleLoad,
         IndexedContiguousLoad,
+        IndexedAlwaysSlowPutContiguousLoad,
         IndexedArrayStorageLoad,
         IndexedScopedArgumentsLoad,
         IndexedDirectArgumentsLoad,

--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
@@ -36,6 +36,8 @@ AdaptiveInferredPropertyValueWatchpointBase::AdaptiveInferredPropertyValueWatchp
     RELEASE_ASSERT(key.kind() == PropertyCondition::Equivalence);
 }
 
+AdaptiveInferredPropertyValueWatchpointBase::~AdaptiveInferredPropertyValueWatchpointBase() = default;
+
 void AdaptiveInferredPropertyValueWatchpointBase::initialize(const ObjectPropertyCondition& key)
 {
     m_key = key;

--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
@@ -34,7 +34,7 @@ namespace JSC {
 
 // FIXME: This isn't actually a Watchpoint. We should probably have a name which better reflects that:
 // https://bugs.webkit.org/show_bug.cgi?id=202381
-class AdaptiveInferredPropertyValueWatchpointBase {
+class JS_EXPORT_PRIVATE AdaptiveInferredPropertyValueWatchpointBase {
     WTF_MAKE_NONCOPYABLE(AdaptiveInferredPropertyValueWatchpointBase);
     WTF_MAKE_FAST_ALLOCATED;
 
@@ -47,7 +47,7 @@ public:
     void initialize(const ObjectPropertyCondition&);
     void install(VM&);
 
-    virtual ~AdaptiveInferredPropertyValueWatchpointBase() = default;
+    virtual ~AdaptiveInferredPropertyValueWatchpointBase();
 
     class StructureWatchpoint final : public Watchpoint {
     public:

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
@@ -69,6 +69,8 @@ void dumpArrayModes(PrintStream& out, ArrayModes arrayModes)
         out.print(comma, "NonArrayWithDouble");
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithContiguous))
         out.print(comma, "NonArrayWithContiguous");
+    if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithAlwaysSlowPutContiguous))
+        out.print(comma, "NonArrayWithAlwaysSlowPutContiguous");
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithArrayStorage))
         out.print(comma, "NonArrayWithArrayStorage");
     if (arrayModes & asArrayModesIgnoringTypedArrays(NonArrayWithSlowPutArrayStorage))
@@ -142,7 +144,8 @@ void ArrayProfile::computeUpdatedPrediction(const ConcurrentJSLocker&, CodeBlock
         lastSeenStructure->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero();
     JSGlobalObject* globalObject = codeBlock->globalObject();
     if (!globalObject->isOriginalArrayStructure(lastSeenStructure)
-        && !globalObject->isOriginalTypedArrayStructure(lastSeenStructure))
+        && !globalObject->isOriginalTypedArrayStructure(lastSeenStructure)
+        && !(hasAlwaysSlowPutContiguous(lastSeenStructure->indexingMode()) && globalObject->isOriginalSlowPutContigiousStructure(lastSeenStructure)))
         m_usesOriginalArrayStructures = false;
 }
 

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -86,6 +86,7 @@ constexpr ArrayModes asArrayModesIgnoringTypedArrays(IndexingType indexingMode)
     | asArrayModesIgnoringTypedArrays(NonArrayWithInt32)                   \
     | asArrayModesIgnoringTypedArrays(NonArrayWithDouble)                  \
     | asArrayModesIgnoringTypedArrays(NonArrayWithContiguous)              \
+    | asArrayModesIgnoringTypedArrays(NonArrayWithAlwaysSlowPutContiguous) \
     | asArrayModesIgnoringTypedArrays(NonArrayWithArrayStorage)            \
     | asArrayModesIgnoringTypedArrays(NonArrayWithSlowPutArrayStorage)     \
     | ALL_TYPED_ARRAY_MODES)
@@ -162,6 +163,11 @@ inline bool shouldUseFastArrayStorage(ArrayModes arrayModes)
 inline bool shouldUseContiguous(ArrayModes arrayModes)
 {
     return arrayModesIncludeIgnoringTypedArrays(arrayModes, ContiguousShape);
+}
+
+inline bool shouldUseAlwaysSlowPutContiguous(ArrayModes arrayModes)
+{
+    return arrayModesIncludeIgnoringTypedArrays(arrayModes, AlwaysSlowPutContiguousShape);
 }
 
 inline bool shouldUseDouble(ArrayModes arrayModes)

--- a/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp
@@ -984,6 +984,9 @@ void printInternal(PrintStream& out, AccessCase::AccessType type)
     case AccessCase::IndexedContiguousLoad:
         out.print("IndexedContiguousLoad");
         return;
+    case AccessCase::IndexedAlwaysSlowPutContiguousLoad:
+        out.print("IndexedAlwaysSlowPutContiguousLoad");
+        return;
     case AccessCase::IndexedArrayStorageLoad:
         out.print("IndexedArrayStorageLoad");
         return;

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -664,6 +664,9 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
             case ContiguousShape:
                 accessType = AccessCase::IndexedContiguousLoad;
                 break;
+            case AlwaysSlowPutContiguousShape:
+                accessType = AccessCase::IndexedAlwaysSlowPutContiguousLoad;
+                break;
             case ArrayStorageShape:
                 accessType = AccessCase::IndexedArrayStorageLoad;
                 break;

--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -43,6 +43,8 @@ namespace JSC {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Watchpoint);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WatchpointSet);
 
+FireDetail::~FireDetail() = default;
+
 void StringFireDetail::dump(PrintStream& out) const
 {
     out.print(m_string);

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -42,16 +42,16 @@ struct ArrayBufferViewWatchpointAdaptor;
 
 class VM;
 
-class FireDetail {
+class JS_EXPORT_PRIVATE FireDetail {
     void* operator new(size_t) = delete;
     
 public:
     FireDetail() = default;
-    virtual ~FireDetail() = default;
+    virtual ~FireDetail();
     virtual void dump(PrintStream&) const = 0;
 };
 
-class StringFireDetail final : public FireDetail {
+class JS_EXPORT_PRIVATE StringFireDetail final : public FireDetail {
 public:
     StringFireDetail(const char* string)
         : m_string(string)
@@ -153,7 +153,7 @@ public:
     { }
 
 protected:
-    ~Watchpoint();
+    JS_EXPORT_PRIVATE ~Watchpoint();
 
 private:
     friend class WatchpointSet;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2316,6 +2316,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             case Array::Int32:
             case Array::Double:
             case Array::Contiguous:
+            case Array::AlwaysSlowPutContiguous:
             case Array::ArrayStorage:
             case Array::SlowPutArrayStorage:
                 if (foldGetByValOnConstantProperty(m_graph.child(node, 0), m_graph.child(node, 1))) {
@@ -2445,6 +2446,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setNonCellTypeForNode(node, SpecDoubleReal);
             break;
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
             if (node->arrayMode().isEffectfulOutOfBounds())
@@ -3700,6 +3702,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::Undecided:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
@@ -4299,6 +4302,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::ArrayStorage: {
             if (mode.isInBounds())
                 break;
@@ -4330,6 +4334,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             case Array::Int32:
             case Array::Double:
             case Array::Contiguous:
+            case Array::AlwaysSlowPutContiguous:
             case Array::ArrayStorage: {
                 if (arrayMode.isInBounds())
                     break;

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -29,6 +29,7 @@
 
 #include "ArrayProfile.h"
 #include "SpeculatedType.h"
+#include "StructureSet.h"
 
 namespace JSC {
 
@@ -61,6 +62,7 @@ enum Type : uint8_t {
     Int32,
     Double,
     Contiguous,
+    AlwaysSlowPutContiguous,
     ArrayStorage,
     SlowPutArrayStorage,
     
@@ -264,6 +266,7 @@ public:
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
             return true;
@@ -332,7 +335,12 @@ public:
     
     bool isSlowPut() const
     {
-        return type() == Array::SlowPutArrayStorage;
+        return type() == Array::SlowPutArrayStorage || type() == Array::AlwaysSlowPutContiguous;
+    }
+
+    bool isAnyKindOfContiguous() const
+    {
+        return type() == Array::Contiguous || type() == Array::AlwaysSlowPutContiguous;
     }
 
     bool canCSEStorage() const
@@ -359,6 +367,7 @@ public:
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
             return true;
@@ -373,6 +382,7 @@ public:
         case Array::String:
         case Array::DirectArguments:
         case Array::ScopedArguments:
+        case Array::AlwaysSlowPutContiguous:
             return ArrayMode(Array::Generic);
         default:
             return *this;
@@ -400,6 +410,7 @@ public:
         case Array::Unprofiled:
         case Array::ForceExit:
         case Array::Generic:
+        case Array::AlwaysSlowPutContiguous:
         // TypedArrays do not have a self length property as of ES6.
         case Array::Int8Array:
         case Array::Int16Array:
@@ -440,9 +451,9 @@ public:
         }
     }
     
-    // Returns 0 if this is not OriginalArray.
-    Structure* originalArrayStructure(Graph&, const CodeOrigin&) const;
-    Structure* originalArrayStructure(Graph&, Node*) const;
+    // Returns empty set if this is not original array.
+    StructureSet originalArrayStructureSet(Graph&, const CodeOrigin&) const;
+    StructureSet originalArrayStructureSet(Graph&, Node*) const;
     
     bool doesConversion() const
     {
@@ -470,6 +481,9 @@ public:
             break;
         case Array::Contiguous:
             result = arrayModesWithIndexingShapes(ContiguousShape);
+            break;
+        case Array::AlwaysSlowPutContiguous:
+            result = arrayModesWithIndexingShapes(AlwaysSlowPutContiguousShape);
             break;
         case Array::ArrayStorage:
             return arrayModesWithIndexingShapes(ArrayStorageShape);

--- a/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h
@@ -80,6 +80,7 @@ private:
             case Array::Int32:
             case Array::Double:
             case Array::Contiguous:
+            case Array::AlwaysSlowPutContiguous:
                 m_badPropertyJump.fill(jit, jit->m_jit.branch32(
                     MacroAssembler::AboveOrEqual, m_propertyGPR,
                     MacroAssembler::TrustedImm32(MIN_SPARSE_ARRAY_INDEX)));
@@ -100,6 +101,7 @@ private:
             jit->callOperation(operationEnsureDouble, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
             jit->callOperation(operationEnsureContiguous, m_tempGPR, SpeculativeJIT::TrustedImmPtr(&vm), m_baseGPR);
             break;
         case Array::ArrayStorage:

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2516,9 +2516,6 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
                 return false;
 
             ArrayMode arrayMode = getArrayMode(Array::Read);
-            if (!arrayMode.isJSArray())
-                return false;
-
             if (!arrayMode.isJSArrayWithOriginalStructure())
                 return false;
 
@@ -2605,21 +2602,32 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
                 return false;
 
             ArrayMode arrayMode = getArrayMode(Array::Read);
-            if (!arrayMode.isJSArray())
-                return false;
-
-            if (!arrayMode.isJSArrayWithOriginalStructure())
-                return false;
-
             // We do not want to convert arrays into one type just to perform indexOf.
             if (arrayMode.doesConversion())
                 return false;
+
+            auto addToGraphAndSetResult = [&] {
+                insertChecks();
+
+                Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+                addVarArgChild(array);
+                addVarArgChild(get(virtualRegisterForArgumentIncludingThis(1, registerOffset))); // Search element.
+                if (argumentCountIncludingThis >= 3)
+                    addVarArgChild(get(virtualRegisterForArgumentIncludingThis(2, registerOffset))); // Start index.
+                addVarArgChild(nullptr);
+
+                Node* node = addToGraph(Node::VarArg, ArrayIndexOf, OpInfo(arrayMode.asWord()), OpInfo());
+                setResult(node);
+            };
+
+            JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
 
             switch (arrayMode.type()) {
             case Array::Double:
             case Array::Int32:
             case Array::Contiguous: {
-                JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (!arrayMode.isJSArrayWithOriginalStructure())
+                    return false;
 
                 Structure* arrayPrototypeStructure = globalObject->arrayPrototype()->structure();
                 Structure* objectPrototypeStructure = globalObject->objectPrototype()->structure();
@@ -2633,17 +2641,27 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
                     m_graph.registerAndWatchStructureTransition(arrayPrototypeStructure);
                     m_graph.registerAndWatchStructureTransition(objectPrototypeStructure);
 
-                    insertChecks();
+                    addToGraphAndSetResult();
+                    return true;
+                }
 
-                    Node* array = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
-                    addVarArgChild(array);
-                    addVarArgChild(get(virtualRegisterForArgumentIncludingThis(1, registerOffset))); // Search element.
-                    if (argumentCountIncludingThis >= 3)
-                        addVarArgChild(get(virtualRegisterForArgumentIncludingThis(2, registerOffset))); // Start index.
-                    addVarArgChild(nullptr);
+                return false;
+            }
 
-                    Node* node = addToGraph(Node::VarArg, ArrayIndexOf, OpInfo(arrayMode.asWord()), OpInfo());
-                    setResult(node);
+            case Array::AlwaysSlowPutContiguous: {
+                if (arrayMode.arrayClass() != Array::OriginalNonArray)
+                    return false;
+
+                Structure* objectPrototypeStructure = globalObject->objectPrototype()->structure();
+
+                if (globalObject->alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet().isStillValid()
+                    && objectPrototypeStructure->transitionWatchpointSetIsStillValid()
+                    && globalObject->objectPrototypeIsSaneConcurrently(objectPrototypeStructure)) {
+
+                    m_graph.watchpoints().addLazily(globalObject->alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet());
+                    m_graph.registerAndWatchStructureTransition(objectPrototypeStructure);
+
+                    addToGraphAndSetResult();
                     return true;
                 }
 

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -396,7 +396,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             break;
         }
             
-        case Array::Contiguous: {
+        case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous: {
             if (mode.isInBounds()) {
                 read(Butterfly_publicLength);
                 read(IndexedContiguousProperties);
@@ -667,6 +668,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             read(IndexedInt32Properties);
             return;
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
             read(IndexedContiguousProperties);
             return;
         default:
@@ -1016,6 +1018,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             return;
             
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
             if (mode.isInBounds() || mode.isOutOfBoundsSaneChain()) {
                 read(Butterfly_publicLength);
                 read(IndexedContiguousProperties);
@@ -1186,6 +1189,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case Array::String:
         case Array::DirectArguments:
         case Array::ScopedArguments:
+        case Array::AlwaysSlowPutContiguous:
             DFG_CRASH(graph, node, "impossible array mode for put");
             return;
         }
@@ -1433,6 +1437,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
             read(Butterfly_publicLength);

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3681,25 +3681,25 @@ private:
         } else {
             // Note that we only need to be using a structure check if we opt for InBoundsSaneChain, since
             // that needs to protect against JSArray's __proto__ being changed.
-            Structure* structure = arrayMode.originalArrayStructure(m_graph, origin.semantic);
+            StructureSet structureSet = arrayMode.originalArrayStructureSet(m_graph, origin.semantic);
         
             Edge indexEdge = index ? Edge(index, Int32Use) : Edge();
             
             if (arrayMode.doesConversion()) {
-                if (structure) {
+                if (!structureSet.isEmpty()) {
                     m_insertionSet.insertNode(
                         m_indexInBlock, SpecNone, ArrayifyToStructure, origin,
-                        OpInfo(m_graph.registerStructure(structure)), OpInfo(arrayMode.asWord()), Edge(array, CellUse), indexEdge);
+                        OpInfo(m_graph.registerStructure(structureSet.onlyStructure())), OpInfo(arrayMode.asWord()), Edge(array, CellUse), indexEdge);
                 } else {
                     m_insertionSet.insertNode(
                         m_indexInBlock, SpecNone, Arrayify, origin,
                         OpInfo(arrayMode.asWord()), Edge(array, CellUse), indexEdge);
                 }
             } else {
-                if (structure) {
+                if (!structureSet.isEmpty()) {
                     m_insertionSet.insertNode(
                         m_indexInBlock, SpecNone, CheckStructure, origin,
-                        OpInfo(m_graph.addStructureSet(structure)), Edge(array, CellUse));
+                        OpInfo(m_graph.addStructureSet(structureSet)), Edge(array, CellUse));
                 } else {
                     m_insertionSet.insertNode(
                         m_indexInBlock, SpecNone, CheckArray, origin,
@@ -4121,11 +4121,37 @@ private:
                 attemptToForceStringArrayModeByToStringConversion<StringOrStringObjectUse>(arrayMode, node);
         }
             
-        if (!arrayMode.supportsSelfLength())
+        if (!arrayMode.supportsSelfLength()) {
+            if (arrayMode.type() == Array::AlwaysSlowPutContiguous)
+                return attemptToMakeGetArrayLengthForAlwaysSlowPutContiguous(node, arrayMode);
+
             return false;
+        }
         
         convertToGetArrayLength(node, arrayMode);
         return true;
+    }
+
+    bool attemptToMakeGetArrayLengthForAlwaysSlowPutContiguous(Node* node, ArrayMode arrayMode)
+    {
+        if (arrayMode.arrayClass() != Array::OriginalNonArray)
+            return false;
+
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+        Structure* objectPrototypeStructure = globalObject->objectPrototype()->structure();
+
+        if (globalObject->alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet().isStillValid()
+            && objectPrototypeStructure->transitionWatchpointSetIsStillValid()
+            && globalObject->objectPrototypeIsSaneConcurrently(objectPrototypeStructure)) {
+
+            m_graph.watchpoints().addLazily(globalObject->alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet());
+            m_graph.registerAndWatchStructureTransition(objectPrototypeStructure);
+
+            convertToGetArrayLength(node, arrayMode);
+            return true;
+        }
+
+        return false;
     }
 
     void convertToGetArrayLength(Node* node, ArrayMode arrayMode)
@@ -4357,7 +4383,8 @@ private:
                 fixEdge<Int32Use>(searchElement);
             return;
         }
-        case Array::Contiguous: {
+        case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous: {
             if (searchElement->shouldSpeculateString())
                 fixEdge<StringUse>(searchElement);
             else if (searchElement->shouldSpeculateSymbol())

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -1873,7 +1873,8 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         break;
     }
     case Array::Int32:
-    case Array::Contiguous: {
+    case Array::Contiguous:
+    case Array::AlwaysSlowPutContiguous: {
         if (node->arrayMode().isInBounds()) {
             SpeculateStrictInt32Operand property(this, m_graph.varArgChild(node, 1));
             StorageOperand storage(this, m_graph.varArgChild(node, 2));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -2514,7 +2514,8 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         break;
     }
     case Array::Int32:
-    case Array::Contiguous: {
+    case Array::Contiguous:
+    case Array::AlwaysSlowPutContiguous: {
         if (node->arrayMode().isInBounds()) {
             SpeculateStrictInt32Operand property(this, m_graph.varArgChild(node, 1));
             StorageOperand storage(this, m_graph.varArgChild(node, 2));
@@ -2534,7 +2535,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
 
             m_jit.load64(MacroAssembler::BaseIndex(storageReg, propertyReg, MacroAssembler::TimesEight), result);
             if (node->arrayMode().isInBoundsSaneChain()) {
-                ASSERT(node->arrayMode().type() == Array::Contiguous);
+                ASSERT(node->arrayMode().isAnyKindOfContiguous());
                 JITCompiler::Jump notHole = m_jit.branchIfNotEmpty(result);
                 m_jit.move(TrustedImm64(JSValue::encode(jsUndefined())), result);
                 notHole.link(&m_jit);

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -254,6 +254,7 @@ public:
         case DFG::Array::Double:
             return indexedDoubleProperties;
         case DFG::Array::Contiguous:
+        case DFG::Array::AlwaysSlowPutContiguous:
             return indexedContiguousProperties;
         case DFG::Array::ArrayStorage:
         case DFG::Array::SlowPutArrayStorage:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3858,6 +3858,7 @@ private:
             case Array::Int32:
             case Array::Double:
             case Array::Contiguous:
+            case Array::AlwaysSlowPutContiguous:
                 speculate(
                     Uncountable, noValue(), nullptr,
                     m_out.aboveOrEqual(property, m_out.constInt32(MIN_SPARSE_ARRAY_INDEX)));
@@ -3875,6 +3876,7 @@ private:
             vmCall(Void, operationEnsureDouble, m_vmValue, cell);
             break;
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
             vmCall(Void, operationEnsureContiguous, m_vmValue, cell);
             break;
         case Array::ArrayStorage:
@@ -5054,7 +5056,8 @@ IGNORE_CLANG_WARNINGS_END
         case Array::Undecided:
         case Array::Int32:
         case Array::Double:
-        case Array::Contiguous: {
+        case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous: {
             setInt32(m_out.load32NonNegative(lowStorage(m_node->child2()), m_heaps.Butterfly_publicLength));
             return;
         }
@@ -5200,7 +5203,8 @@ IGNORE_CLANG_WARNINGS_END
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         switch (m_node->arrayMode().type()) {
         case Array::Int32:
-        case Array::Contiguous: {
+        case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous: {
             LValue index = lowInt32(m_graph.varArgChild(m_node, 1));
             LValue storage = lowStorage(m_graph.varArgChild(m_node, 2));
             
@@ -5214,13 +5218,13 @@ IGNORE_CLANG_WARNINGS_END
                 LValue isHole = m_out.isZero64(result);
                 if (m_node->arrayMode().isInBoundsSaneChain()) {
                     DFG_ASSERT(
-                        m_graph, m_node, m_node->arrayMode().type() == Array::Contiguous, m_node->arrayMode().type());
+                        m_graph, m_node, m_node->arrayMode().isAnyKindOfContiguous(), m_node->arrayMode().type());
                     result = m_out.select(
                         isHole, m_out.constInt64(JSValue::encode(jsUndefined())), result);
                 } else
                     speculate(LoadFromHole, noValue(), nullptr, isHole);
                 // We have to keep base alive to keep content in storage alive.
-                if (m_node->arrayMode().type() == Array::Contiguous)
+                if (m_node->arrayMode().isAnyKindOfContiguous())
                     ensureStillAliveHere(base);
                 return result;
             }
@@ -5252,7 +5256,7 @@ IGNORE_CLANG_WARNINGS_END
             
             m_out.appendTo(continuation, lastNext);
             // We have to keep base alive to keep content in storage alive.
-            if (m_node->arrayMode().type() == Array::Contiguous)
+            if (m_node->arrayMode().isAnyKindOfContiguous())
                 ensureStillAliveHere(base);
             return m_out.phi(Int64, fastResult, slowResult);
         }
@@ -6132,6 +6136,7 @@ IGNORE_CLANG_WARNINGS_END
         case Array::ForceExit:
         case Array::Generic:
         case Array::ScopedArguments:
+        case Array::AlwaysSlowPutContiguous:
         case Array::SelectUsingArguments:
         case Array::SelectUsingPredictions:
         case Array::Undecided:
@@ -6723,15 +6728,15 @@ IGNORE_CLANG_WARNINGS_END
                 searchElement = lowJSValue(searchElementEdge, ManualOperandSpeculation);
                 break;
             case ObjectUse:
-                ASSERT(m_node->arrayMode().type() == Array::Contiguous);
+                ASSERT(m_node->arrayMode().isAnyKindOfContiguous());
                 searchElement = lowObject(searchElementEdge);
                 break;
             case SymbolUse:
-                ASSERT(m_node->arrayMode().type() == Array::Contiguous);
+                ASSERT(m_node->arrayMode().isAnyKindOfContiguous());
                 searchElement = lowSymbol(searchElementEdge);
                 break;
             case OtherUse:
-                ASSERT(m_node->arrayMode().type() == Array::Contiguous);
+                ASSERT(m_node->arrayMode().isAnyKindOfContiguous());
                 speculate(searchElementEdge);
                 searchElement = lowJSValue(searchElementEdge, ManualOperandSpeculation);
                 break;
@@ -6799,7 +6804,7 @@ IGNORE_CLANG_WARNINGS_END
         }
 
         case StringUse:
-            ASSERT(m_node->arrayMode().type() == Array::Contiguous);
+            ASSERT(m_node->arrayMode().isAnyKindOfContiguous());
             // We have to keep base alive since that keeps storage alive.
             ensureStillAliveHere(base);
             setInt32(m_out.castToInt32(vmCall(Int64, operationArrayIndexOfString, weakPointer(globalObject), storage, lowString(searchElementEdge), startIndex)));
@@ -6811,6 +6816,7 @@ IGNORE_CLANG_WARNINGS_END
                 setInt32(m_out.castToInt32(vmCall(Int64, operationArrayIndexOfValueDouble, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex)));
                 return;
             case Array::Contiguous:
+            case Array::AlwaysSlowPutContiguous:
                 // We have to keep base alive since that keeps content of storage alive.
                 ensureStillAliveHere(base);
                 FALLTHROUGH;
@@ -19762,6 +19768,7 @@ IGNORE_CLANG_WARNINGS_END
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::Undecided:
         case Array::ArrayStorage: {
             IndexingType indexingModeMask = IsArray | IndexingShapeMask;
@@ -19857,6 +19864,7 @@ IGNORE_CLANG_WARNINGS_END
         case Array::Int32:
         case Array::Double:
         case Array::Contiguous:
+        case Array::AlwaysSlowPutContiguous:
         case Array::Undecided:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -60,7 +60,7 @@ public:
     }
     bool isZapped() const { return !*bitwise_cast<const uint32_t*>(this); }
 
-    bool isLive();
+    JS_EXPORT_PRIVATE bool isLive();
 
     bool isPreciseAllocation() const;
     CellContainer cellContainer() const;

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -863,6 +863,13 @@ static JSValue performLLIntGetByID(BytecodeIndex bytecodeIndex, CodeBlock* codeB
 
             if (!(--metadata.hitCountForLLIntCaching))
                 setupGetByIdPrototypeCache(globalObject, vm, codeBlock, bytecodeIndex, metadata, baseCell, slot, ident);
+        } else if (hasAlwaysSlowPutContiguous(baseCell->indexingMode()) && ident == vm.propertyNames->length) {
+            {
+                ConcurrentJSLocker locker(codeBlock->m_lock);
+                metadata.setArrayLengthMode();
+                metadata.arrayLengthMode.arrayProfile.observeStructure(structure);
+            }
+            vm.writeBarrier(codeBlock);
         }
     } else if (Options::useLLIntICs() && isJSArray(baseValue) && ident == vm.propertyNames->length) {
         {

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -552,17 +552,17 @@ const TagOffset = constexpr TagOffset
 const PayloadOffset = constexpr PayloadOffset
 
 # Constant for reasoning about butterflies.
-const IsArray                  = constexpr IsArray
-const IndexingShapeMask        = constexpr IndexingShapeMask
-const IndexingTypeMask         = constexpr IndexingTypeMask
-const NoIndexingShape          = constexpr NoIndexingShape
-const Int32Shape               = constexpr Int32Shape
-const DoubleShape              = constexpr DoubleShape
-const ContiguousShape          = constexpr ContiguousShape
-const ArrayStorageShape        = constexpr ArrayStorageShape
-const SlowPutArrayStorageShape = constexpr SlowPutArrayStorageShape
-const CopyOnWrite              = constexpr CopyOnWrite
-const ArrayWithUndecided       = constexpr ArrayWithUndecided
+const IsArray                      = constexpr IsArray
+const IndexingShapeMask            = constexpr IndexingShapeMask
+const IndexingTypeMask             = constexpr IndexingTypeMask
+const NoIndexingShape              = constexpr NoIndexingShape
+const Int32Shape                   = constexpr Int32Shape
+const DoubleShape                  = constexpr DoubleShape
+const ContiguousShape              = constexpr ContiguousShape
+const AlwaysSlowPutContiguousShape = constexpr AlwaysSlowPutContiguousShape
+const ArrayStorageShape            = constexpr ArrayStorageShape
+const CopyOnWrite                  = constexpr CopyOnWrite
+const ArrayWithUndecided           = constexpr ArrayWithUndecided
 
 # Type constants.
 const StructureType = constexpr StructureType

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -1747,8 +1747,8 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     jmp .opGetByValNotEmpty
 
 .opGetByValNotDouble:
-    subi ArrayStorageShape, t2
-    bia t2, SlowPutArrayStorageShape - ArrayStorageShape, .opGetByValNotIndexedStorage
+    bieq t2, AlwaysSlowPutContiguousShape, .opGetByValIsContiguous
+    bilt t2, ArrayStorageShape, .opGetByValNotIndexedStorage
     biaeq t1, -sizeof IndexingHeader + IndexingHeader::u.lengths.vectorLength[t3], .opGetByValSlow
     loadi ArrayStorage::m_vector + TagOffset[t3, t1, 8], t2
     loadi ArrayStorage::m_vector + PayloadOffset[t3, t1, 8], t1

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -1886,8 +1886,8 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     jmp .opGetByValDone
     
 .opGetByValNotDouble:
-    subi ArrayStorageShape, t2
-    bia t2, SlowPutArrayStorageShape - ArrayStorageShape, .opGetByValNotIndexedStorage
+    bieq t2, AlwaysSlowPutContiguousShape, .opGetByValIsContiguous
+    bilt t2, ArrayStorageShape, .opGetByValNotIndexedStorage
     biaeq t1, -sizeof IndexingHeader + IndexingHeader::u.lengths.vectorLength[t3], .opGetByValSlow
     get(m_dst, t0)
     loadq ArrayStorage::m_vector[t3, t1, 8], t2

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1012,7 +1012,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncReverse, (JSGlobalObject* globalObject, C
     thisObject->ensureWritable(vm);
 
     switch (thisObject->indexingType()) {
-    case ALL_CONTIGUOUS_INDEXING_TYPES:
+    case ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES:
     case ALL_INT32_INDEXING_TYPES: {
         auto& butterfly = *thisObject->butterfly();
         if (length > butterfly.publicLength())
@@ -1322,7 +1322,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncUnShift, (JSGlobalObject* globalObject, C
 
 enum class IndexOfDirection { Forward, Backward };
 template<IndexOfDirection direction>
-ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray* array, uint64_t length64, JSValue searchElement, uint64_t index64)
+ALWAYS_INLINE JSValue tryFastIndexOf(JSGlobalObject* globalObject, VM& vm, JSObject* array, uint64_t length64, JSValue searchElement, uint64_t index64)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1444,12 +1444,10 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncIndexOf, (JSGlobalObject* globalObject, C
     RETURN_IF_EXCEPTION(scope, { });
     JSValue searchElement = callFrame->argument(0);
 
-    if (isJSArray(thisObject)) {
-        JSValue result = fastIndexOf<IndexOfDirection::Forward>(globalObject, vm, asArray(thisObject), length, searchElement, index);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (result)
-            return JSValue::encode(result);
-    }
+    JSValue result = tryFastIndexOf<IndexOfDirection::Forward>(globalObject, vm, thisObject, length, searchElement, index);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (result)
+        return JSValue::encode(result);
 
     for (; index < length; ++index) {
         JSValue e = getProperty(globalObject, thisObject, index);
@@ -1496,12 +1494,10 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncLastIndexOf, (JSGlobalObject* globalObjec
 
     JSValue searchElement = callFrame->argument(0);
 
-    if (isJSArray(thisObject)) {
-        JSValue result = fastIndexOf<IndexOfDirection::Backward>(globalObject, vm, asArray(thisObject), length, searchElement, index);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (result)
-            return JSValue::encode(result);
-    }
+    JSValue result = tryFastIndexOf<IndexOfDirection::Backward>(globalObject, vm, thisObject, length, searchElement, index);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (result)
+        return JSValue::encode(result);
 
     do {
         ASSERT(index < length);

--- a/Source/JavaScriptCore/runtime/IndexingType.cpp
+++ b/Source/JavaScriptCore/runtime/IndexingType.cpp
@@ -88,6 +88,9 @@ void dumpIndexingType(PrintStream& out, IndexingType indexingType)
     case NonArrayWithContiguous:
         basicName = "NonArrayWithContiguous";
         break;
+    case NonArrayWithAlwaysSlowPutContiguous:
+        basicName = "NonArrayWithAlwaysSlowPutContiguous";
+        break;
     case NonArrayWithArrayStorage:
         basicName = "NonArrayWithArrayStorage";
         break;

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -68,12 +68,13 @@ static const IndexingType UndecidedShape                  = 0x02; // Only useful
 static const IndexingType Int32Shape                      = 0x04;
 static const IndexingType DoubleShape                     = 0x06;
 static const IndexingType ContiguousShape                 = 0x08;
-static const IndexingType ArrayStorageShape               = 0x0A;
-static const IndexingType SlowPutArrayStorageShape        = 0x0C;
+static const IndexingType AlwaysSlowPutContiguousShape    = 0x0A;
+static const IndexingType ArrayStorageShape               = 0x0C;
+static const IndexingType SlowPutArrayStorageShape        = 0x0E;
 
 static const IndexingType IndexingShapeMask               = 0x0E;
 static const IndexingType IndexingShapeShift              = 1;
-static const IndexingType NumberOfIndexingShapes          = 7;
+static const IndexingType NumberOfIndexingShapes          = 8;
 static const IndexingType IndexingTypeMask                = IndexingShapeMask | IsArray;
 
 // Whether or not the butterfly is copy on write. If it is copy on write then the butterfly is actually a JSImmutableButterfly. This should only ever be set if there are no named properties.
@@ -95,22 +96,23 @@ static const IndexingType IndexingTypeLockIsHeld          = 0x40;
 static const IndexingType IndexingTypeLockHasParked       = 0x80;
 
 // List of acceptable array types.
-static const IndexingType NonArray                        = 0x0;
-static const IndexingType NonArrayWithInt32               = Int32Shape;
-static const IndexingType NonArrayWithDouble              = DoubleShape;
-static const IndexingType NonArrayWithContiguous          = ContiguousShape;
-static const IndexingType NonArrayWithArrayStorage        = ArrayStorageShape;
-static const IndexingType NonArrayWithSlowPutArrayStorage = SlowPutArrayStorageShape;
-static const IndexingType ArrayClass                      = IsArray; // I'd want to call this "Array" but this would lead to disastrous namespace pollution.
-static const IndexingType ArrayWithUndecided              = IsArray | UndecidedShape;
-static const IndexingType ArrayWithInt32                  = IsArray | Int32Shape;
-static const IndexingType ArrayWithDouble                 = IsArray | DoubleShape;
-static const IndexingType ArrayWithContiguous             = IsArray | ContiguousShape;
-static const IndexingType ArrayWithArrayStorage           = IsArray | ArrayStorageShape;
-static const IndexingType ArrayWithSlowPutArrayStorage    = IsArray | SlowPutArrayStorageShape;
-static const IndexingType CopyOnWriteArrayWithInt32       = IsArray | Int32Shape | CopyOnWrite;
-static const IndexingType CopyOnWriteArrayWithDouble      = IsArray | DoubleShape | CopyOnWrite;
-static const IndexingType CopyOnWriteArrayWithContiguous  = IsArray | ContiguousShape | CopyOnWrite;
+static const IndexingType NonArray                            = 0x0;
+static const IndexingType NonArrayWithInt32                   = Int32Shape;
+static const IndexingType NonArrayWithDouble                  = DoubleShape;
+static const IndexingType NonArrayWithContiguous              = ContiguousShape;
+static const IndexingType NonArrayWithAlwaysSlowPutContiguous = AlwaysSlowPutContiguousShape;
+static const IndexingType NonArrayWithArrayStorage            = ArrayStorageShape;
+static const IndexingType NonArrayWithSlowPutArrayStorage     = SlowPutArrayStorageShape;
+static const IndexingType ArrayClass                          = IsArray; // I'd want to call this "Array" but this would lead to disastrous namespace pollution.
+static const IndexingType ArrayWithUndecided                  = IsArray | UndecidedShape;
+static const IndexingType ArrayWithInt32                      = IsArray | Int32Shape;
+static const IndexingType ArrayWithDouble                     = IsArray | DoubleShape;
+static const IndexingType ArrayWithContiguous                 = IsArray | ContiguousShape;
+static const IndexingType ArrayWithArrayStorage               = IsArray | ArrayStorageShape;
+static const IndexingType ArrayWithSlowPutArrayStorage        = IsArray | SlowPutArrayStorageShape;
+static const IndexingType CopyOnWriteArrayWithInt32           = IsArray | Int32Shape | CopyOnWrite;
+static const IndexingType CopyOnWriteArrayWithDouble          = IsArray | DoubleShape | CopyOnWrite;
+static const IndexingType CopyOnWriteArrayWithContiguous      = IsArray | ContiguousShape | CopyOnWrite;
 
 #define ALL_BLANK_INDEXING_TYPES \
     NonArray:                    \
@@ -135,13 +137,21 @@ static const IndexingType CopyOnWriteArrayWithContiguous  = IsArray | Contiguous
     ALL_WRITABLE_DOUBLE_INDEXING_TYPES: \
     case CopyOnWriteArrayWithDouble
 
-#define ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES    \
+#define ALL_WRITABLE_FAST_PUT_CONTIGUOUS_INDEXING_TYPES \
     NonArrayWithContiguous:                       \
     case ArrayWithContiguous                      \
 
-#define ALL_CONTIGUOUS_INDEXING_TYPES        \
-    ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES:  \
+#define ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES       \
+    ALL_WRITABLE_FAST_PUT_CONTIGUOUS_INDEXING_TYPES: \
+    case NonArrayWithAlwaysSlowPutContiguous
+
+#define ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES        \
+    ALL_WRITABLE_FAST_PUT_CONTIGUOUS_INDEXING_TYPES:  \
     case CopyOnWriteArrayWithContiguous
+
+#define ALL_CONTIGUOUS_INDEXING_TYPES         \
+    ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES:   \
+    case NonArrayWithAlwaysSlowPutContiguous
 
 #define ARRAY_WITH_ARRAY_STORAGE_INDEXING_TYPES \
     ArrayWithArrayStorage:                      \
@@ -177,6 +187,16 @@ inline bool hasContiguous(IndexingType indexingType)
     return (indexingType & IndexingShapeMask) == ContiguousShape;
 }
 
+inline bool hasAlwaysSlowPutContiguous(IndexingType indexingType)
+{
+    return (indexingType & IndexingShapeMask) == AlwaysSlowPutContiguousShape;
+}
+
+inline bool hasAnyContiguous(IndexingType indexingType)
+{
+    return hasContiguous(indexingType) || hasAlwaysSlowPutContiguous(indexingType);
+}
+
 inline bool hasArrayStorage(IndexingType indexingType)
 {
     return (indexingType & IndexingShapeMask) == ArrayStorageShape;
@@ -190,6 +210,11 @@ inline bool hasAnyArrayStorage(IndexingType indexingType)
 inline bool hasSlowPutArrayStorage(IndexingType indexingType)
 {
     return (indexingType & IndexingShapeMask) == SlowPutArrayStorageShape;
+}
+
+inline bool hasAnySlowPutIndexingType(IndexingType indexingType)
+{
+    return hasAlwaysSlowPutContiguous(indexingType) || hasSlowPutArrayStorage(indexingType);
 }
 
 inline bool shouldUseSlowPut(IndexingType indexingType)

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -730,16 +730,16 @@ JSArray* JSArray::fastSlice(JSGlobalObject* globalObject, JSObject* source, uint
 {
     VM& vm = globalObject->vm();
 
-    Structure* sourceStructure = source->structure();
-    if (sourceStructure->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero())
+    if (!source->canDoFastIndexedAccess())
         return nullptr;
 
-    auto arrayType = source->indexingType() | IsArray;
+    auto sourceIndexingType = source->indexingType();
+    auto arrayType = sourceIndexingType == NonArrayWithAlwaysSlowPutContiguous ? ArrayWithContiguous : sourceIndexingType | IsArray;
     switch (arrayType) {
     case ArrayWithDouble:
     case ArrayWithInt32:
     case ArrayWithContiguous: {
-        if (count >= MIN_SPARSE_ARRAY_INDEX || sourceStructure->holesMustForwardToPrototype(source))
+        if (count >= MIN_SPARSE_ARRAY_INDEX)
             return nullptr;
 
         if (startIndex + count > source->butterfly()->vectorLength())

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -950,6 +950,7 @@ void JSGlobalObject::init(VM& vm)
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(Int32Shape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithInt32));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(DoubleShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithDouble));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(ContiguousShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithContiguous));
+    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(AlwaysSlowPutContiguousShape)].setMayBeNull(vm, this, nullptr);
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(ArrayStorageShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithArrayStorage));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(SlowPutArrayStorageShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithSlowPutArrayStorage));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithInt32));
@@ -2415,6 +2416,9 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_typedArrayProto.visit(visitor);
     thisObject->m_typedArraySuperConstructor.visit(visitor);
     thisObject->m_regExpGlobalData.visitAggregate(visitor);
+
+    for (Structure* structure : thisObject->m_originalAlwaysSlowPutContiguousStructureSet)
+        visitor.appendUnbarriered(structure);
 }
 
 DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, JSGlobalObject);
@@ -2816,6 +2820,12 @@ JSGlobalObject* JSGlobalObject::createWithCustomMethodTable(VM& vm, Structure* s
     JSGlobalObject* globalObject = new (NotNull, allocateCell<JSGlobalObject>(vm)) JSGlobalObject(vm, structure, methodTable);
     globalObject->finishCreation(vm);
     return globalObject;
+}
+
+void JSGlobalObject::recordOriginalAlwaysSlowPutContiguousStructure(Structure* structure)
+{
+    ASSERT(structure->globalObject() == this);
+    m_originalAlwaysSlowPutContiguousStructureSet.add(structure);
 }
 
 void JSGlobalObject::finishCreation(VM& vm)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -534,6 +534,9 @@ public:
     InlineWatchpointSet m_sharedArrayBufferSpeciesWatchpointSet { ClearWatchpoint };
     InlineWatchpointSet m_typedArrayConstructorSpeciesWatchpointSet { IsWatched };
     InlineWatchpointSet m_typedArrayPrototypeIteratorProtocolWatchpointSet { IsWatched };
+
+    // Current this is being set up in JSDOMWindowBase and watches only NodeList.prototype.length getter to be original.
+    InlineWatchpointSet m_alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet { ClearWatchpoint };
 #define DECLARE_TYPED_ARRAY_TYPE_SPECIES_WATCHPOINT_SET(name) \
     InlineWatchpointSet m_typedArray ## name ## SpeciesWatchpointSet { ClearWatchpoint }; \
     InlineWatchpointSet m_typedArray ## name ## IteratorProtocolWatchpointSet { ClearWatchpoint };
@@ -664,6 +667,7 @@ public:
     }
     InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() { return m_typedArrayConstructorSpeciesWatchpointSet; }
     InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet() { return m_alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet; }
 
     bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
     bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
@@ -884,6 +888,14 @@ public:
     {
         return originalArrayStructureForIndexingType(structure->indexingMode() | IsArray) == structure;
     }
+
+    bool isOriginalSlowPutContigiousStructure(Structure* structure)
+    {
+        ASSERT(hasAlwaysSlowPutContiguous(structure->indexingMode()));
+        return m_originalAlwaysSlowPutContiguousStructureSet.contains(structure);
+    }
+
+    const StructureSet& originalAlwaysSlowPutContiguousStructureSet() const { return m_originalAlwaysSlowPutContiguousStructureSet; }
         
     Structure* booleanObjectStructure() const { return m_booleanObjectStructure.get(this); }
     Structure* callbackConstructorStructure() const { return m_callbackConstructorStructure.get(this); }
@@ -1320,6 +1332,8 @@ protected:
 
     void setNeedsSiteSpecificQuirks(bool needQuirks) { m_needsSiteSpecificQuirks = needQuirks; }
 
+    JS_EXPORT_PRIVATE void recordOriginalAlwaysSlowPutContiguousStructure(Structure*);
+
 private:
     friend class LLIntOffsetsExtractor;
 
@@ -1343,6 +1357,8 @@ private:
 #ifdef JSC_GLIB_API_ENABLED
     std::unique_ptr<WrapperMap> m_wrapperMap;
 #endif
+
+    StructureSet m_originalAlwaysSlowPutContiguousStructureSet;
 };
 
 inline JSArray* constructEmptyArray(JSGlobalObject* globalObject, ArrayAllocationProfile* profile, unsigned initialLength = 0, JSValue newTarget = JSValue())

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -572,6 +572,8 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
     
     if (i > MAX_ARRAY_INDEX)
         return thisObject->methodTable()->getOwnPropertySlot(thisObject, globalObject, Identifier::from(vm, i), slot);
+
+    unsigned attributes = hasAnySlowPutIndexingType(thisObject->indexingType()) && thisObject->structure()->typeInfo().slowPutArrayStorageVectorPropertiesAreReadOnly() ? static_cast<unsigned>(PropertyAttribute::ReadOnly) : static_cast<unsigned>(PropertyAttribute::None);
     
     switch (thisObject->indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
@@ -586,7 +588,7 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
         
         JSValue value = butterfly->contiguous().at(thisObject, i).get();
         if (value) {
-            slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::None), value);
+            slot.setValue(thisObject, attributes, value);
             return true;
         }
         
@@ -600,7 +602,7 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
         
         double value = butterfly->contiguousDouble().at(thisObject, i);
         if (value == value) {
-            slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::None), JSValue(JSValue::EncodeAsDouble, value));
+            slot.setValue(thisObject, attributes, JSValue(JSValue::EncodeAsDouble, value));
             return true;
         }
         
@@ -615,7 +617,7 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
         if (i < storage->vectorLength()) {
             JSValue value = storage->m_vector[i].get();
             if (value) {
-                slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::None), value);
+                slot.setValue(thisObject, attributes, value);
                 return true;
             }
         } else if (SparseArrayValueMap* map = storage->m_sparseMap.get()) {
@@ -1458,7 +1460,7 @@ ArrayStorage* JSObject::convertDoubleToArrayStorage(VM& vm)
 ArrayStorage* JSObject::convertContiguousToArrayStorage(VM& vm, TransitionKind transition)
 {
     DeferGC deferGC(vm);
-    ASSERT(hasContiguous(indexingType()));
+    ASSERT(hasAnyContiguous(indexingType()));
 
     unsigned vectorLength = m_butterfly->vectorLength();
     ArrayStorage* newStorage = constructConvertedArrayStorageWithoutCopyingElements(vm, vectorLength);
@@ -1748,6 +1750,7 @@ ContiguousJSValues JSObject::tryMakeWritableContiguousSlow(VM& vm)
         return convertDoubleToContiguous(vm);
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES:
+    case NonArrayWithAlwaysSlowPutContiguous:
         return ContiguousJSValues();
         
     default:
@@ -1818,11 +1821,14 @@ ArrayStorage* JSObject::ensureArrayStorageExistsAndEnterDictionaryIndexingMode(V
     case ALL_DOUBLE_INDEXING_TYPES:
         return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, convertDoubleToArrayStorage(vm));
         
-    case ALL_CONTIGUOUS_INDEXING_TYPES:
+    case ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES:
         return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, convertContiguousToArrayStorage(vm));
         
     case ALL_ARRAY_STORAGE_INDEXING_TYPES:
         return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, m_butterfly->arrayStorage());
+
+    case NonArrayWithAlwaysSlowPutContiguous:
+        return enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, convertContiguousToArrayStorage(vm, TransitionKind::AllocateSlowPutArrayStorage));
         
     default:
         CRASH();
@@ -1855,8 +1861,12 @@ void JSObject::switchToSlowPutArrayStorage(VM& vm)
         convertDoubleToArrayStorage(vm, TransitionKind::AllocateSlowPutArrayStorage);
         break;
         
-    case ALL_CONTIGUOUS_INDEXING_TYPES:
+    case ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES:
         convertContiguousToArrayStorage(vm, TransitionKind::AllocateSlowPutArrayStorage);
+        break;
+
+    case NonArrayWithAlwaysSlowPutContiguous:
+        enterDictionaryIndexingMode(vm);
         break;
         
     case NonArrayWithArrayStorage:
@@ -2968,8 +2978,9 @@ bool JSObject::putByIndexBeyondVectorLengthWithoutAttributes(JSGlobalObject* glo
         || (i >= MIN_SPARSE_ARRAY_INDEX && !isDenseEnoughForVector(i, countElements<indexingShape>(butterfly)))
         || indexIsSufficientlyBeyondLengthForSparseMap(i, butterfly->vectorLength())) {
         ASSERT(i <= MAX_ARRAY_INDEX);
-        ensureArrayStorageSlow(vm);
-        SparseArrayValueMap* map = allocateSparseIndexMap(vm);
+        bool needsDictionaryIndexingMode = hasAlwaysSlowPutContiguous(indexingType());
+        ArrayStorage* storage = ensureArrayStorageSlow(vm);
+        SparseArrayValueMap* map = needsDictionaryIndexingMode ? enterDictionaryIndexingModeWhenArrayStorageAlreadyExists(vm, storage)->m_sparseMap.get() : allocateSparseIndexMap(vm);
         bool result = map->putEntry(globalObject, this, i, value, false);
         RETURN_IF_EXCEPTION(scope, false);
         ASSERT(i >= arrayStorage()->length());

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -436,7 +436,7 @@ public:
             }
             FALLTHROUGH;
         }
-        case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES: {
+        case ALL_WRITABLE_FAST_PUT_CONTIGUOUS_INDEXING_TYPES: {
             if (i >= butterfly->vectorLength())
                 return false;
             butterfly->contiguous().at(this, i).setWithoutWriteBarrier(v);
@@ -474,6 +474,8 @@ public:
                 return false;
             setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
             return true;
+        case NonArrayWithAlwaysSlowPutContiguous:
+            return false;
         default:
             RELEASE_ASSERT(isCopyOnWrite(indexingMode()));
             return false;
@@ -493,7 +495,7 @@ public:
             }
             FALLTHROUGH;
         }
-        case ALL_CONTIGUOUS_INDEXING_TYPES: {
+        case ALL_FAST_PUT_CONTIGUOUS_INDEXING_TYPES: {
             ASSERT(i < butterfly->vectorLength());
             butterfly->contiguous().at(this, i).setWithoutWriteBarrier(v);
             if (i >= butterfly->publicLength())
@@ -860,7 +862,7 @@ public:
     bool isFrozen(VM& vm) { return structure()->isFrozen(vm); }
 
     JS_EXPORT_PRIVATE bool anyObjectInChainMayInterceptIndexedAccesses() const;
-    bool needsSlowPutIndexing() const;
+    JS_EXPORT_PRIVATE bool needsSlowPutIndexing() const;
 
 private:
     TransitionKind suggestedArrayStorageTransition() const;
@@ -987,6 +989,7 @@ public:
 
     JS_EXPORT_PRIVATE JSValue getMethod(JSGlobalObject*, CallData&, const Identifier&, const String& errorMessage);
 
+    bool canDoFastIndexedAccess();
     bool canPerformFastPutInline(VM&, PropertyName);
     bool canPerformFastPutInlineExcludingProto();
 
@@ -1081,7 +1084,7 @@ protected:
     ArrayStorage* convertContiguousToArrayStorage(VM&);
 
         
-    ArrayStorage* ensureArrayStorageExistsAndEnterDictionaryIndexingMode(VM&);
+    JS_EXPORT_PRIVATE ArrayStorage* ensureArrayStorageExistsAndEnterDictionaryIndexingMode(VM&);
         
     bool defineOwnNonIndexProperty(JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool throwException);
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -487,6 +487,21 @@ inline bool JSObject::canGetIndexQuicklyForTypedArray(unsigned i) const
     }
 }
 
+inline bool JSObject::canDoFastIndexedAccess()
+{
+    if (LIKELY(isJSArray(this)))
+        return asArray(this)->canDoFastIndexedAccess();
+
+    Structure* structure = this->structure();
+    if (structure->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero())
+        return false;
+
+    if (structure->holesMustForwardToPrototype(this))
+        return false;
+
+    return true;
+}
+
 inline JSValue JSObject::getIndexQuicklyForTypedArray(unsigned i, ArrayProfile* arrayProfile) const
 {
 #if USE(LARGE_TYPED_ARRAYS)

--- a/Source/JavaScriptCore/runtime/JSTypeInfo.h
+++ b/Source/JavaScriptCore/runtime/JSTypeInfo.h
@@ -60,6 +60,7 @@ static constexpr unsigned StructureIsImmortal = 1 << 17;
 static constexpr unsigned OverridesPut = 1 << 18;
 static constexpr unsigned OverridesGetPrototype = 1 << 19;
 static constexpr unsigned GetOwnPropertySlotMayBeWrongAboutDontEnum = 1 << 20;
+static constexpr unsigned SlowPutArrayStorageVectorPropertiesAreReadOnly = 1 << 21;
 
 static constexpr unsigned numberOfInlineBits = 8;
 static constexpr unsigned OverridesGetPrototypeOutOfLine = OverridesGetPrototype >> numberOfInlineBits;
@@ -109,6 +110,7 @@ public:
     bool getOwnPropertySlotIsImpure() const { return isSetOnFlags2<GetOwnPropertySlotIsImpure>(); }
     bool getOwnPropertySlotIsImpureForPropertyAbsence() const { return isSetOnFlags2<GetOwnPropertySlotIsImpureForPropertyAbsence>(); }
     bool getOwnPropertySlotMayBeWrongAboutDontEnum() const { return isSetOnFlags2<GetOwnPropertySlotMayBeWrongAboutDontEnum>(); }
+    bool slowPutArrayStorageVectorPropertiesAreReadOnly() const { return isSetOnFlags2<SlowPutArrayStorageVectorPropertiesAreReadOnly>(); }
     bool newImpurePropertyFiresWatchpoints() const { return isSetOnFlags2<NewImpurePropertyFiresWatchpoints>(); }
     bool isImmutablePrototypeExoticObject() const { return isSetOnFlags2<IsImmutablePrototypeExoticObject>(); }
     bool interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero() const { return isSetOnFlags2<InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero>(); }

--- a/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectPropertyChangeAdaptiveWatchpoint.h
@@ -30,7 +30,7 @@
 namespace JSC {
 
 template<typename WatchpointSet>
-class ObjectPropertyChangeAdaptiveWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
+class JS_EXPORT_PRIVATE ObjectPropertyChangeAdaptiveWatchpoint final : public AdaptiveInferredPropertyValueWatchpointBase {
 public:
     using Base = AdaptiveInferredPropertyValueWatchpointBase;
     ObjectPropertyChangeAdaptiveWatchpoint(JSCell* owner, const ObjectPropertyCondition& condition, WatchpointSet& watchpointSet)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -750,7 +750,7 @@ public:
         return m_transitionWatchpointSet;
     }
     
-    WatchpointSet* ensurePropertyReplacementWatchpointSet(VM&, PropertyOffset);
+    JS_EXPORT_PRIVATE WatchpointSet* ensurePropertyReplacementWatchpointSet(VM&, PropertyOffset);
     void startWatchingPropertyForReplacements(VM& vm, PropertyOffset offset)
     {
         ensurePropertyReplacementWatchpointSet(vm, offset);

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -99,7 +99,7 @@ inline IndexingType newIndexingType(IndexingType oldType, TransitionKind transit
         ASSERT(!hasIndexedProperties(oldType) || hasUndecided(oldType) || hasInt32(oldType) || hasDouble(oldType) || hasContiguous(oldType));
         return (oldType & ~IndexingShapeAndWritabilityMask) | ArrayStorageShape;
     case TransitionKind::AllocateSlowPutArrayStorage:
-        ASSERT(!hasIndexedProperties(oldType) || hasUndecided(oldType) || hasInt32(oldType) || hasDouble(oldType) || hasContiguous(oldType));
+        ASSERT(!hasIndexedProperties(oldType) || hasUndecided(oldType) || hasInt32(oldType) || hasDouble(oldType) || hasAnyContiguous(oldType));
         return (oldType & ~IndexingShapeAndWritabilityMask) | SlowPutArrayStorageShape;
     case TransitionKind::SwitchToSlowPutArrayStorage:
         ASSERT(hasArrayStorage(oldType));

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -996,6 +996,126 @@ public:
     }
 };
 
+class AlwaysSlowPutContiguousObject : public JSDestructibleObject {
+public:
+    using Base = JSDestructibleObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    AlwaysSlowPutContiguousObject(VM& vm, Structure* structure, Butterfly* butterfly)
+        : Base(vm, structure, butterfly)
+    {
+        DollarVMAssertScope assertScope;
+    }
+
+    template<typename CellType, SubspaceAccess>
+    static CompleteSubspace* subspaceFor(VM& vm)
+    {
+        return &vm.cellSpace();
+    }
+
+    DECLARE_INFO;
+
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject)
+    {
+        DollarVMAssertScope assertScope;
+        return Structure::create(vm, globalObject, globalObject->objectPrototype(), TypeInfo(ObjectType, StructureFlags), info(), NonArrayWithAlwaysSlowPutContiguous);
+    }
+
+    static AlwaysSlowPutContiguousObject* create(VM& vm, Structure* structure, Butterfly* butterfly)
+    {
+        DollarVMAssertScope assertScope;
+        AlwaysSlowPutContiguousObject* result = new (NotNull, allocateCell<AlwaysSlowPutContiguousObject>(vm)) AlwaysSlowPutContiguousObject(vm, structure, butterfly);
+        result->finishCreation(vm);
+        return result;
+    }
+};
+
+class AlwaysSlowPutContiguousObjectWithOverrides : public JSDestructibleObject {
+public:
+    using Base = JSDestructibleObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesPut;
+
+    AlwaysSlowPutContiguousObjectWithOverrides(VM& vm, Structure* structure, Butterfly* butterfly)
+        : Base(vm, structure, butterfly)
+    {
+        DollarVMAssertScope assertScope;
+    }
+
+    template<typename CellType, SubspaceAccess>
+    static CompleteSubspace* subspaceFor(VM& vm)
+    {
+        return &vm.cellSpace();
+    }
+
+    DECLARE_INFO;
+
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject)
+    {
+        DollarVMAssertScope assertScope;
+        return Structure::create(vm, globalObject, globalObject->objectPrototype(), TypeInfo(ObjectType, StructureFlags), info(), NonArrayWithAlwaysSlowPutContiguous | MayHaveIndexedAccessors);
+    }
+
+    static AlwaysSlowPutContiguousObjectWithOverrides* create(VM& vm, Structure* structure, Butterfly* butterfly)
+    {
+        DollarVMAssertScope assertScope;
+        AlwaysSlowPutContiguousObjectWithOverrides* result = new (NotNull, allocateCell<AlwaysSlowPutContiguousObjectWithOverrides>(vm)) AlwaysSlowPutContiguousObjectWithOverrides(vm, structure, butterfly);
+        result->finishCreation(vm);
+        return result;
+    }
+
+    static bool put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
+    {
+        DollarVMAssertScope assertScope;
+        auto* thisObject = jsCast<AlwaysSlowPutContiguousObjectWithOverrides*>(cell);
+        if (std::optional<uint32_t> index = parseIndex(propertyName))
+            return thisObject->methodTable()->putByIndex(thisObject, globalObject, index.value(), value, slot.isStrictMode());
+
+        return Base::put(cell, globalObject, propertyName, value, slot);
+    }
+
+    static bool putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
+    {
+        DollarVMAssertScope assertScope;
+        VM& vm = globalObject->vm();
+        auto* thisObject = jsCast<AlwaysSlowPutContiguousObjectWithOverrides*>(cell);
+        thisObject->increment(vm, Identifier::fromString(vm, "putByIndexCalls"_s));
+        return Base::putByIndex(cell, globalObject, propertyName, value, shouldThrow);
+    }
+
+    static bool deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, DeletePropertySlot& slot)
+    {
+        DollarVMAssertScope assertScope;
+        auto* thisObject = jsCast<AlwaysSlowPutContiguousObjectWithOverrides*>(cell);
+        if (std::optional<uint32_t> index = parseIndex(propertyName))
+            return thisObject->methodTable()->deletePropertyByIndex(thisObject, globalObject, index.value());
+        return Base::deleteProperty(cell, globalObject, propertyName, slot);
+    }
+
+    static bool deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned propertyName)
+    {
+        DollarVMAssertScope assertScope;
+        VM& vm = globalObject->vm();
+        auto* thisObject = jsCast<AlwaysSlowPutContiguousObjectWithOverrides*>(cell);
+        thisObject->increment(vm, Identifier::fromString(vm, "deleteByIndexCalls"_s));
+        return Base::deletePropertyByIndex(cell, globalObject, propertyName);
+    }
+
+    void finishCreation(VM& vm)
+    {
+        DollarVMAssertScope assertScope;
+        Base::finishCreation(vm);
+        putDirect(vm, Identifier::fromString(vm, "putByIndexCalls"_s), jsNumber(0), static_cast<unsigned>(PropertyAttribute::DontEnum));
+        putDirect(vm, Identifier::fromString(vm, "deleteByIndexCalls"_s), jsNumber(0), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
+
+    void increment(VM& vm, const Identifier& identifier)
+    {
+        DollarVMAssertScope assertScope;
+        uint32_t calls = getDirect(vm, identifier).asUInt32();
+        putDirect(vm, identifier, jsNumber(calls + 1), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
+};
+
 class DOMJITNode : public JSNonFinalObject {
 public:
     DOMJITNode(VM& vm, Structure* structure)
@@ -1871,6 +1991,8 @@ const ClassInfo StaticCustomAccessor::s_info = { "StaticCustomAccessor"_s, &Base
 const ClassInfo StaticCustomValue::s_info = { "StaticCustomValue"_s, &Base::s_info, &staticCustomValueTable, nullptr, CREATE_METHOD_TABLE(StaticCustomValue) };
 const ClassInfo StaticDontDeleteDontEnum::s_info = { "StaticDontDeleteDontEnum"_s, &Base::s_info, &staticDontDeleteDontEnumTable, nullptr, CREATE_METHOD_TABLE(StaticDontDeleteDontEnum) };
 const ClassInfo ObjectDoingSideEffectPutWithoutCorrectSlotStatus::s_info = { "ObjectDoingSideEffectPutWithoutCorrectSlotStatus"_s, &Base::s_info, &staticCustomAccessorTable, nullptr, CREATE_METHOD_TABLE(ObjectDoingSideEffectPutWithoutCorrectSlotStatus) };
+const ClassInfo AlwaysSlowPutContiguousObject::s_info = { "AlwaysSlowPutContiguousObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(AlwaysSlowPutContiguousObject) };
+const ClassInfo AlwaysSlowPutContiguousObjectWithOverrides::s_info = { "AlwaysSlowPutContiguousObjectWithOverrides"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(AlwaysSlowPutContiguousObjectWithOverrides) };
 
 ElementHandleOwner* Element::handleOwner()
 {
@@ -2148,6 +2270,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticCustomAccessor);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticCustomValue);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticDontDeleteDontEnum);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateObjectDoingSideEffectPutWithoutCorrectSlotStatus);
+static JSC_DECLARE_HOST_FUNCTION(functionCreateAlwaysSlowPutContiguousObject);
+static JSC_DECLARE_HOST_FUNCTION(functionCreateAlwaysSlowPutContiguousObjectWithOverrides);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateEmptyFunctionWithName);
 static JSC_DECLARE_HOST_FUNCTION(functionSetImpureGetterDelegate);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateBuiltin);
@@ -2208,6 +2332,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionResetJITSizeStatistics);
 #endif
 
 static JSC_DECLARE_HOST_FUNCTION(functionEnsureArrayStorage);
+static JSC_DECLARE_HOST_FUNCTION(functionHasSparseModeArrayStorage);
 #if PLATFORM(COCOA)
 static JSC_DECLARE_HOST_FUNCTION(functionSetCrashLogMessage);;
 #endif
@@ -3175,6 +3300,43 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateObjectDoingSideEffectPutWithoutCorrectSlo
     return JSValue::encode(result);
 }
 
+template<typename T>
+static JSValue createAlwaysSlowPutContiguousObject(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    JSLockHolder lock(vm);
+
+    uint32_t length = callFrame->argument(0).asUInt32();
+
+    Structure* structure = T::createStructure(vm, globalObject);
+
+    IndexingHeader indexingHeader;
+    indexingHeader.setVectorLength(length);
+    indexingHeader.setPublicLength(length);
+    Butterfly* butterfly = Butterfly::tryCreate(vm, nullptr, 0, structure->outOfLineCapacity(), true, indexingHeader, length * sizeof(EncodedJSValue));
+    if (!butterfly)
+        return jsUndefined();
+
+    for (uint32_t i = length; i--;)
+        butterfly->contiguous().atUnsafe(i).clear();
+
+    T* result = T::create(vm, structure, butterfly);
+    result->putDirect(vm, vm.propertyNames->length, jsNumber(length), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    return result;
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionCreateAlwaysSlowPutContiguousObject, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(createAlwaysSlowPutContiguousObject<AlwaysSlowPutContiguousObject>(globalObject, callFrame));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionCreateAlwaysSlowPutContiguousObjectWithOverrides, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(createAlwaysSlowPutContiguousObject<AlwaysSlowPutContiguousObjectWithOverrides>(globalObject, callFrame));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionCreateEmptyFunctionWithName, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -3926,6 +4088,17 @@ JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObje
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionHasSparseModeArrayStorage, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+
+    if (JSObject* object = callFrame->argument(0).getObject()) {
+        if (hasAnyArrayStorage(object->indexingMode()))
+            return JSValue::encode(jsBoolean(object->butterfly()->arrayStorage()->inSparseMode()));
+    }
+
+    return JSValue::encode(jsBoolean(false));
+}
 
 #if PLATFORM(COCOA)
 JSC_DEFINE_HOST_FUNCTION(functionSetCrashLogMessage, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -4034,6 +4207,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "createStaticCustomValue"_s, functionCreateStaticCustomValue, 0);
     addFunction(vm, "createStaticDontDeleteDontEnum"_s, functionCreateStaticDontDeleteDontEnum, 0);
     addFunction(vm, "createObjectDoingSideEffectPutWithoutCorrectSlotStatus"_s, functionCreateObjectDoingSideEffectPutWithoutCorrectSlotStatus, 0);
+    addFunction(vm, "createAlwaysSlowPutContiguousObject"_s, functionCreateAlwaysSlowPutContiguousObject, 0);
+    addFunction(vm, "createAlwaysSlowPutContiguousObjectWithOverrides"_s, functionCreateAlwaysSlowPutContiguousObjectWithOverrides, 0);
     addFunction(vm, "createEmptyFunctionWithName"_s, functionCreateEmptyFunctionWithName, 1);
     addFunction(vm, "getPrivateProperty"_s, functionGetPrivateProperty, 2);
     addFunction(vm, "setImpureGetterDelegate"_s, functionSetImpureGetterDelegate, 2);
@@ -4117,6 +4292,7 @@ void JSDollarVM::finishCreation(VM& vm)
 #endif
 
     addFunction(vm, "ensureArrayStorage"_s, functionEnsureArrayStorage, 1);
+    addFunction(vm, "hasSparseModeArrayStorage"_s, functionHasSparseModeArrayStorage, 1);
 
 #if PLATFORM(COCOA)
     addFunction(vm, "setCrashLogMessage"_s, functionSetCrashLogMessage, 1);

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -42,6 +42,7 @@
 #include "JSFetchResponse.h"
 #include "JSMicrotaskCallback.h"
 #include "JSNode.h"
+#include "JSNodeList.h"
 #include "Logging.h"
 #include "Page.h"
 #include "RejectedPromiseTracker.h"
@@ -134,6 +135,37 @@ void JSDOMWindowBase::finishCreation(VM& vm, JSWindowProxy* proxy)
 
     if (m_wrapped && m_wrapped->frame() && m_wrapped->frame()->settings().showModalDialogEnabled())
         putDirectCustomAccessor(vm, builtinNames(vm).showModalDialogPublicName(), CustomGetterSetter::create(vm, showModalDialogGetter, nullptr), static_cast<unsigned>(PropertyAttribute::CustomValue));
+
+    installAlwaysSlowPutContiguousPrototypesAreSaneWatchpoint(vm);
+}
+
+void JSDOMWindowBase::installAlwaysSlowPutContiguousPrototypesAreSaneWatchpoint(VM& vm)
+{
+    DeferTerminationForAWhile deferScope(vm);
+
+    auto* staticNodeListStructure = getDOMStructure<JSStaticNodeList>(vm, *this);
+    ASSERT(!staticNodeListStructure->isDictionary());
+
+    auto* staticNodeListPrototype = staticNodeListStructure->storedPrototypeObject();
+    auto* staticNodeListPrototypeStructure = staticNodeListPrototype->structure();
+
+    if (staticNodeListPrototypeStructure->isDictionary())
+        staticNodeListPrototypeStructure = staticNodeListPrototypeStructure->flattenDictionaryStructure(vm, staticNodeListPrototype);
+
+    PropertyOffset lengthOffset = staticNodeListPrototype->getDirectOffset(vm, vm.propertyNames->length);
+    JSValue lengthAccessor = staticNodeListPrototype->getDirect(lengthOffset);
+    ASSERT(lengthAccessor.isCustomGetterSetter());
+
+    staticNodeListPrototypeStructure->startWatchingPropertyForReplacements(vm, lengthOffset);
+
+    m_alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet.startWatching();
+
+    ObjectPropertyCondition prototypeLengthCondition = ObjectPropertyCondition::equivalence(vm, staticNodeListPrototype, staticNodeListPrototype, vm.propertyNames->length.impl(), lengthAccessor);
+
+    m_staticNodeListPrototypeLengthWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, prototypeLengthCondition, m_alwaysSlowPutContiguousPrototypesAreSaneWatchpointSet);
+    m_staticNodeListPrototypeLengthWatchpoint->install(vm);
+
+    recordOriginalAlwaysSlowPutContiguousStructure(staticNodeListStructure);
 }
 
 void JSDOMWindowBase::destroy(JSCell* cell)

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -30,8 +30,10 @@
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/Lookup.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/ObjectPropertyChangeAdaptiveWatchpoint.h>
 #include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/StructureInlines.h>
+#include <JavaScriptCore/Watchpoint.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <cstddef>
 #include <wtf/Forward.h>
@@ -104,6 +106,10 @@ private:
 
     RefPtr<DOMWindow> m_wrapped;
     RefPtr<Event> m_currentEvent;
+
+    void installAlwaysSlowPutContiguousPrototypesAreSaneWatchpoint(JSC::VM&);
+
+    std::unique_ptr<JSC::ObjectPropertyChangeAdaptiveWatchpoint<JSC::InlineWatchpointSet>> m_staticNodeListPrototypeLengthWatchpoint;
 };
 
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, DOMWindow&);

--- a/Source/WebCore/bindings/js/JSNodeListCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeListCustom.cpp
@@ -37,6 +37,84 @@
 namespace WebCore {
 using namespace JSC;
 
+// FIXME: Instead of handpicking methods from JSNodeList / JSObject, extract JSNodeListBase and make
+// JSStaticNodeList / JSLiveNodeList extend it (which would require massive changes to CodeGeneratorJS.pm though).
+const ClassInfo JSStaticNodeList::s_info = {
+    "NodeList"_s,
+    &Base::s_info,
+    nullptr,
+    nullptr,
+    std::nullopt, {
+        &JSStaticNodeList::destroy,
+        &JSStaticNodeList::getCallData,
+        &JSStaticNodeList::getConstructData,
+        &JSStaticNodeList::put,
+        &JSStaticNodeList::putByIndex,
+        &JSStaticNodeList::deleteProperty,
+        &JSStaticNodeList::deletePropertyByIndex,
+        &Base::Base::getOwnPropertySlot,
+        &Base::Base::getOwnPropertySlotByIndex,
+        &JSStaticNodeList::toThis,
+        &Base::Base::getOwnPropertyNames,
+        &Base::Base::getOwnSpecialPropertyNames,
+        &JSStaticNodeList::customHasInstance,
+        &JSStaticNodeList::defineOwnProperty,
+        &JSStaticNodeList::preventExtensions,
+        &JSStaticNodeList::isExtensible,
+        &JSStaticNodeList::setPrototype,
+        &JSStaticNodeList::getPrototype,
+        &JSStaticNodeList::dumpToStream,
+        &JSStaticNodeList::analyzeHeap,
+        &JSStaticNodeList::estimatedSize,
+        &JSStaticNodeList::visitChildren,
+        &JSStaticNodeList::visitChildren,
+        &JSStaticNodeList::visitOutputConstraints,
+        &JSStaticNodeList::visitOutputConstraints,
+    },
+    sizeof(JSStaticNodeList),
+};
+
+JSObject* JSStaticNodeList::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
+{
+    return Base::prototype(vm, globalObject);
+}
+
+JSStaticNodeList::JSStaticNodeList(Structure* structure, JSDOMGlobalObject& globalObject, Ref<StaticNodeList>&& impl)
+    : Base(structure, globalObject, WTFMove(impl))
+{
+}
+
+void JSStaticNodeList::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+
+    auto& nodeList = wrapped();
+    unsigned length = nodeList.length();
+
+    IndexingHeader indexingHeader;
+    indexingHeader.setVectorLength(length);
+    indexingHeader.setPublicLength(length);
+    auto* butterfly = Butterfly::tryCreate(vm, nullptr, 0, structure()->outOfLineCapacity(), true, indexingHeader, sizeof(EncodedJSValue) * length);
+    if (UNLIKELY(!butterfly))
+        return;
+
+    auto* globalObject = this->globalObject();
+    auto contiguousValues = butterfly->contiguous();
+
+    for (unsigned i = 0; i < length; ++i)
+        contiguousValues.atUnsafe(i).clear();
+
+    setButterfly(vm, butterfly);
+
+    for (unsigned i = 0; i < length; ++i) {
+        auto jsNode = toJS(globalObject, globalObject, *nodeList.item(i));
+        contiguousValues.atUnsafe(i).set(vm, this, jsNode);
+    }
+
+    if (UNLIKELY(needsSlowPutIndexing()))
+        ensureArrayStorageExistsAndEnterDictionaryIndexingMode(vm);
+}
+
 bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, const char** reason)
 {
     JSNodeList* jsNodeList = jsCast<JSNodeList*>(handle.slot()->asCell());
@@ -68,6 +146,8 @@ bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handl
 
 JSC::JSValue createWrapper(JSDOMGlobalObject& globalObject, Ref<NodeList>&& nodeList)
 {
+    if (nodeList->isStaticNodeList())
+        return createWrapper<StaticNodeList>(&globalObject, WTFMove(nodeList));
     // FIXME: Adopt reportExtraMemoryVisited, and switch to reportExtraMemoryAllocated.
     // https://bugs.webkit.org/show_bug.cgi?id=142595
     globalObject.vm().heap.deprecatedReportExtraMemory(nodeList->memoryCost());

--- a/Source/WebCore/bindings/js/JSNodeListCustom.h
+++ b/Source/WebCore/bindings/js/JSNodeListCustom.h
@@ -26,8 +26,39 @@
 #pragma once
 
 #include "JSDOMBinding.h"
+#include "JSNodeList.h"
+#include "StaticNodeList.h"
 
 namespace WebCore {
+
+class JSStaticNodeList final : public JSNodeList {
+public:
+    using Base = JSNodeList;
+    static constexpr unsigned StructureFlags = Base::Base::StructureFlags | JSC::SlowPutArrayStorageVectorPropertiesAreReadOnly;
+    static JSStaticNodeList* create(JSC::Structure* structure, JSDOMGlobalObject* globalObject, Ref<StaticNodeList>&& impl)
+    {
+        JSStaticNodeList* ptr = new (NotNull, JSC::allocateCell<JSStaticNodeList>(globalObject->vm())) JSStaticNodeList(structure, *globalObject, WTFMove(impl));
+        ptr->finishCreation(globalObject->vm());
+        return ptr;
+    }
+
+    DECLARE_INFO;
+
+    static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArrayWithAlwaysSlowPutContiguous);
+    }
+protected:
+    JSStaticNodeList(JSC::Structure*, JSDOMGlobalObject&, Ref<StaticNodeList>&&);
+
+    void finishCreation(JSC::VM&);
+};
+
+template<> struct JSDOMWrapperConverterTraits<StaticNodeList> {
+    using WrapperClass = JSStaticNodeList;
+    using ToWrappedReturnType = StaticNodeList*;
+};
 
 WEBCORE_EXPORT JSC::JSValue createWrapper(JSDOMGlobalObject&, Ref<NodeList>&&);
 

--- a/Source/WebCore/dom/NodeList.h
+++ b/Source/WebCore/dom/NodeList.h
@@ -56,6 +56,7 @@ public:
     virtual bool isLiveNodeList() const { return false; }
     virtual bool isChildNodeList() const { return false; }
     virtual bool isEmptyNodeList() const { return false; }
+    virtual bool isStaticNodeList() const { return false; }
     virtual size_t memoryCost() const { return 0; }
 };
 

--- a/Source/WebCore/dom/StaticNodeList.cpp
+++ b/Source/WebCore/dom/StaticNodeList.cpp
@@ -36,6 +36,11 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(StaticNodeList);
 WTF_MAKE_ISO_ALLOCATED_IMPL(StaticElementList);
 
+bool StaticNodeList::isStaticNodeList() const
+{
+    return true;
+}
+
 unsigned StaticNodeList::length() const
 {
     return m_nodes.size();
@@ -46,6 +51,11 @@ Node* StaticNodeList::item(unsigned index) const
     if (index < m_nodes.size())
         return const_cast<Node*>(m_nodes[index].ptr());
     return nullptr;
+}
+
+bool StaticElementList::isStaticNodeList() const
+{
+    return true;
 }
 
 unsigned StaticElementList::length() const

--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -45,6 +45,8 @@ public:
     unsigned length() const override;
     Node* item(unsigned index) const override;
 
+    bool isStaticNodeList() const final;
+
 private:
     StaticNodeList(Vector<Ref<Node>>&& nodes)
         : m_nodes(WTFMove(nodes))
@@ -63,6 +65,8 @@ public:
 
     unsigned length() const override;
     Element* item(unsigned index) const override;
+
+    bool isStaticNodeList() const final;
 
 private:
     StaticElementList(Vector<Ref<Element>>&& elements)


### PR DESCRIPTION
#### e0c79898e6c5e72041f0228bc6378027b7fd8ff2
<pre>
[WebIDL] Eagerly allocate element wrappers onto a butterfly storage of a static NodeList
<a href="https://bugs.webkit.org/show_bug.cgi?id=234538">https://bugs.webkit.org/show_bug.cgi?id=234538</a>

Reviewed by Yusuke Suzuki and Saam Barati.

This change greatly speeds up iterating static NodeList iteration (including via
Array.prototype.indexOf), making it on par with JSArray. It preserves current
(weird) NodeList semantics, including cases of transitioning to slow put array storage
mode, and is future-proof against aligning internal methods of DOM collections with
other browsers (<a href="http://webkit.org/b/218849).">http://webkit.org/b/218849).</a>

There was no way to achieve that with existing indexing types: put_by_val compiled
for NonArrayWithContiguous emits only indexing type check, thus incorrectly mutating
a NodeList instead of calling put() override. NonArrayWithSlowPutArrayStorage could
be semantically correct alternative only if all its elements are onto a sparse map,
which won&apos;t be much faster.

Two viable approaches were either introducing a new Contiguous-like indexing type,
or doing something similar to IndexedDirectArgumentsLoad. This change does the former
to reuse existing logic for DFG::ArrayMode refining and ArrayIndexOf compilation.

Another tricky part is that NodeList&apos;s &quot;length&quot; is a configurable getter on prototype,
unlike own non-configurable JSArray&apos;s &quot;length&quot;, and we need to ensure that both the
NodeList structure is original (inherits from NodeList.prototype) and the &quot;length&quot;
getter wasn&apos;t deleted / overriden.

For the static NodeList to leverage fast compiled get_by_val, it needs to have original
getOwnPropertySlotByIndex() method, so SlowPutArrayStorageVectorPropertiesAreReadOnly
out-of-line type info flag is added to reliably preserve ReadOnly attributes of its
indices as per spec [1].

This change is a locally confirmed 2% progression on all three Speedometer2/VanillaJS subtests.

[1] <a href="https://webidl.spec.whatwg.org/#LegacyPlatformObjectGetOwnProperty">https://webidl.spec.whatwg.org/#LegacyPlatformObjectGetOwnProperty</a> (step 1.2.7)

* .gitignore:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::generateWithGuard):
(JSC::AccessCase::generateImpl):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp:
* Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h:
* Source/JavaScriptCore/bytecode/ArrayProfile.cpp:
(JSC::dumpArrayModes):
(JSC::ArrayProfile::computeUpdatedPrediction):
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
(JSC::shouldUseAlwaysSlowPutContiguous):
* Source/JavaScriptCore/bytecode/PolymorphicAccess.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(JSC::DFG::ArrayMode::fromObserved):
(JSC::DFG::ArrayMode::refine const):
(JSC::DFG::ArrayMode::alreadyChecked const):
(JSC::DFG::arrayTypeToString):
(JSC::DFG::toIndexingShape):
(JSC::DFG::permitsBoundsCheckLowering):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::usesButterfly const):
(JSC::DFG::ArrayMode::isSlowPut const):
(JSC::DFG::ArrayMode::isAnyKindOfContiguous const):
(JSC::DFG::ArrayMode::lengthNeedsStorage const):
(JSC::DFG::ArrayMode::modeForPut const):
(JSC::DFG::ArrayMode::supportsSelfLength const):
(JSC::DFG::ArrayMode::arrayModesThatPassFiltering const):
* Source/JavaScriptCore/dfg/DFGArrayifySlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::attemptToMakeGetArrayLength):
(JSC::DFG::FixupPhase::attemptToMakeGetArrayLengthForAlwaysSlowPutContiguous):
(JSC::DFG::FixupPhase::fixupArrayIndexOf):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::jumpSlowForUnwantedArrayMode):
(JSC::DFG::SpeculativeJIT::checkArray):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
(JSC::FTL::AbstractHeapRepository::forArrayType):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayify):
(JSC::FTL::DFG::LowerDFGToB3::compileGetArrayLength):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByVal):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOf):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::performLLIntGetByID):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::tryFastIndexOf):
(JSC::fastIndexOf): Deleted.
* Source/JavaScriptCore/runtime/IndexingType.cpp:
(JSC::dumpIndexingType):
* Source/JavaScriptCore/runtime/IndexingType.h:
(JSC::hasAlwaysSlowPutContiguous):
(JSC::hasAnyContiguous):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastSlice):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::initAlwaysSlowPutContiguousWatchpointSet):
(JSC::JSGlobalObject::recordOriginalAlwaysSlowPutContiguousStructure):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::alwaysSlowPutContiguousWatchpointSet):
(JSC::JSGlobalObject::isOriginalSlowPutContigiousStructure):
(JSC::JSGlobalObject::originalAlwaysSlowPutContiguousStructures const):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::alwaysSlowPutContiguousPrototypeChainIsSane):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::getOwnPropertySlotByIndex):
(JSC::JSObject::convertContiguousToArrayStorage):
(JSC::JSObject::ensureArrayStorageExistsAndEnterDictionaryIndexingMode):
(JSC::JSObject::switchToSlowPutArrayStorage):
(JSC::JSObject::putByIndexBeyondVectorLengthWithoutAttributes):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::trySetIndexQuickly):
(JSC::JSObject::setIndexQuickly):
(JSC::JSObject::tryMakeWritableContiguous):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::canDoFastIndexedAccess):
* Source/JavaScriptCore/runtime/JSTypeInfo.h:
(JSC::TypeInfo::arrayStorageVectorPropertiesAreReadOnly const):
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
(JSC::newIndexingType):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::createAlwaysSlowPutContiguousObject):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::every const):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::finishCreation):
(WebCore::JSDOMWindowBase::installAlwaysSlowPutContiguousWatchpoints):
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSNodeListCustom.cpp:
(WebCore::JSStaticNodeList::createPrototype):
(WebCore::JSStaticNodeList::JSStaticNodeList):
(WebCore::JSStaticNodeList::finishCreation):
(WebCore::createWrapper):
* Source/WebCore/bindings/js/JSNodeListCustom.h:
(WebCore::JSStaticNodeList::create):
(WebCore::JSStaticNodeList::createStructure):
* Source/WebCore/dom/NodeList.h:
(WebCore::NodeList::isStaticNodeList const):
* Source/WebCore/dom/StaticNodeList.h:

Canonical link: <a href="https://commits.webkit.org/253834@main">https://commits.webkit.org/253834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f2d782b44efa1eca7d26970aed178c2eb860b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/96233 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149786 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29653 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91214 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92818 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74007 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/79318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79177 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/79318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79065 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27378 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/13014 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72741 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14029 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25916 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29010 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/36885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75553 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1089 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33306 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16728 "Passed tests") | 
<!--EWS-Status-Bubble-End-->