### PR TITLE
[Apple Pay] should be enabled in `WKWebView` by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -276,31 +276,26 @@ AppleMailPaginationQuirkEnabled:
     WebCore:
       default: false
 
-# FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ApplePayCapabilityDisclosureAllowed:
   type: bool
   condition: ENABLE(APPLE_PAY)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
       default: true
     WebCore:
-      default: true
+      default: false
 
-# FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ApplePayEnabled:
   type: bool
   condition: ENABLE(APPLE_PAY)
   defaultValue:
     WebKitLegacy:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
       default: false
     WebKit:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
-      default: false
+      default: true
     WebCore:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
       default: false
 
 AsynchronousSpellCheckingEnabled:


### PR DESCRIPTION
#### ed0fa49dcfa4f68b5f9e67b71b444cf288590503
<pre>
[Apple Pay] should be enabled in `WKWebView` by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=243423">https://bugs.webkit.org/show_bug.cgi?id=243423</a>
&lt;rdar://problem/97933441&gt;

Reviewed by NOBODY (OOPS!).

* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed0fa49dcfa4f68b5f9e67b71b444cf288590503

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/84641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/28594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/15767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/92601 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/147048 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/26952 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/24105 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/76757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/89017 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/90215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/21920 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/71982 "Built successfully") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/65210 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/76999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/77564 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/25002 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/11431 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/24910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/12349 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/26530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/35435 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/26469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->