### PR TITLE
Unreviewed. Update OptionsWPE.cmake and NEWS for the 2.37.1 release

### DIFF
--- a/Source/WebKit/wpe/NEWS
+++ b/Source/WebKit/wpe/NEWS
@@ -1,4 +1,29 @@
 =================
+WPE WebKit 2.37.1
+=================
+
+What's new in WPE WebKit 2.37.1?
+
+  - Add initial implementation of WebRTC using GstWebRTC if GStreamer 1.20 is available,
+    disabled by default via web view settings.
+  - Add new API to set WebView's Content-Security-Policy for web extensions support.
+  - Add new API to run async JavaScript functions.
+  - Expose typed arrays in JavaScriptCore GLib API.
+  - Add support for PDF documents using PDF.js.
+  - Show font name and font variant settings in the inspector.
+  - MediaSession is enabled by default, allowing remote media control using MPRIS.
+  - Modernized media controls UI.
+  - Add Support Google Dynamic Ad Insertion (DAI).
+  - Add support for capturing encoded video streams from a webcam.
+  - Make it possible to use the remote inspector from other browsers using WEBKIT_INSPECTOR_HTTP_SERVER env var.
+  - Add support for IPv6 in the remote inspector.
+  - Update form elements style to match libadwaita.
+  - Fix canvas animations and images with threaded rendering enabled.
+  - Switch to use gi-docgen for API documentation instead of gtk-doc.
+  - Remove the ATK a11y implementation that has been replaced by AT-SPI DBus interfaces.
+  - Fix several crashes and rendering issues.
+
+=================
 WPE WebKit 2.35.1
 =================
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 include(VersioningUtils)
 
-SET_PROJECT_VERSION(2 37 0)
+SET_PROJECT_VERSION(2 37 1)
 
 # This is required because we use the DEPFILE argument to add_custom_command().
 # Remove after upgrading cmake_minimum_required() to 3.20.


### PR DESCRIPTION
#### 2502047d493277918b6fb093a3891de9919152f3
<pre>
Unreviewed. Update OptionsWPE.cmake and NEWS for the 2.37.1 release

* Source/WebKit/wpe/NEWS: Add release notes for 2.37.1.
* Source/cmake/OptionsWPE.cmake: Bump version numbers.

Canonical link: <a href="https://commits.webkit.org/253009@main">https://commits.webkit.org/253009@main</a>
</pre>
