### PR TITLE
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::WebCoreDecompressionSession::handleDecompressionOutput

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -258,7 +258,7 @@ void WebCoreDecompressionSession::decodeSample(CMSampleBufferRef sample, bool di
     }
 
     MonotonicTime startTime = MonotonicTime::now();
-    VTDecompressionSessionDecodeFrameWithOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, [this, displaying, startTime](OSStatus status, VTDecodeInfoFlags infoFlags, CVImageBufferRef imageBuffer, CMTime presentationTimeStamp, CMTime presentationDuration) {
+    VTDecompressionSessionDecodeFrameWithOutputHandler(m_decompressionSession.get(), sample, flags, nullptr, [protectedThis = Ref { *this }, this, displaying, startTime](OSStatus status, VTDecodeInfoFlags infoFlags, CVImageBufferRef imageBuffer, CMTime presentationTimeStamp, CMTime presentationDuration) {
         double deltaRatio = (MonotonicTime::now() - startTime).seconds() / PAL::CMTimeGetSeconds(presentationDuration);
 
         updateQosWithDecodeTimeStatistics(deltaRatio);


### PR DESCRIPTION
#### 4a0b62f3b33f6f1ce7ac40fdcbcac0c7b5dc7b80
<pre>
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::WebCoreDecompressionSession::handleDecompressionOutput
<a href="https://bugs.webkit.org/show_bug.cgi?id=243427">https://bugs.webkit.org/show_bug.cgi?id=243427</a>
&lt;rdar://85670643&gt;

Reviewed by Eric Carlson.

When setting the output handler for VTDecompressionSessionDecodeFrameWithOutputHandler
we fail to give the completion handler a strong reference to `this` which
can result in the caller being deleted while the completion handler is
running.

The fix is to pass a strong reference to `this` for the output handler.

* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSample):

Canonical link: <a href="https://commits.webkit.org/253014@main">https://commits.webkit.org/253014@main</a>
</pre>
