### PR TITLE
[Gardening]: REGRESSION(252871@main): [ iPadOS ] 2X TestWebKitAPI.WebKit2 (API tests) are constantly failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -560,8 +560,12 @@ TEST(WebKit, WebAudioAndGetUserMedia)
 #endif
 
 #if ENABLE(GPU_PROCESS)
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=239315
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=243412
+#if PLATFORM(IOS)
+TEST(WebKit2, DISABLED_CrashGPUProcessWhileCapturing)
+#else 
 TEST(WebKit2, CrashGPUProcessWhileCapturing)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
@@ -708,8 +712,12 @@ TEST(WebKit2, CrashGPUProcessAfterApplyingConstraints)
     EXPECT_EQ(webViewPID, [webView _webProcessIdentifier]);
 }
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=239309
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=243412
+#if PLATFORM(IOS)
+TEST(WebKit2, DISABLED_CrashGPUProcessWhileCapturingAndCalling)
+#else
 TEST(WebKit2, CrashGPUProcessWhileCapturingAndCalling)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];


### PR DESCRIPTION
#### 285b652fd7ea36a3b7c81ad272fae65606e5bfd4
<pre>
[Gardening]: REGRESSION(252871@main): [ iPadOS ] 2X TestWebKitAPI.WebKit2 (API tests) are constantly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243412">https://bugs.webkit.org/show_bug.cgi?id=243412</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm: Disabling these tests due to constantly failing while being investigated.

Canonical link: <a href="https://commits.webkit.org/253043@main">https://commits.webkit.org/253043@main</a>
</pre>
