### PR TITLE
Rewrite swipe tests to use async/await

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3036,6 +3036,9 @@ accessibility/smart-invert-reference.html [ ImageOnlyFailure ]
 scrollingcoordinator/ios/fixed-frame-overflow-swipe.html [ ImageOnlyFailure ]
 imported/blink/compositing/video/video-controls-layer-creation-squashing.html [ ImageOnlyFailure ]
 
+# Test fails, but has flaky output.
+swipe/main-frame-pinning-requirement.html [ Pass Failure ]
+
 # These tests fail unexpectedly with accelerated drawing enabled.
 # Interestingly, these versions fail worse than the more recently updated WPT versions above.
 fast/canvas/set-colors.html [ Failure ]
@@ -3623,8 +3626,6 @@ fast/events/ios/pdf-modifer-key-down-crash.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html
 imported/w3c/web-platform-tests/html/user-activation/no-activation-thru-escape-key.html
-swipe/main-frame-pinning-requirement.html
-
 
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
 

--- a/LayoutTests/platform/ios/swipe/main-frame-pinning-requirement-expected.txt
+++ b/LayoutTests/platform/ios/swipe/main-frame-pinning-requirement-expected.txt
@@ -2,7 +2,5 @@ startSwipeGesture
 Failure. Should never begin a swipe, because we were in the middle of a scrolling gesture that started when the main frame was not pinned to the left.
 willEndSwipe
 didEndSwipe
-completeSwipeGesture
-startSwipeGesture
 didRemoveSwipeSnapshot
 

--- a/LayoutTests/swipe/basic-cached-back-swipe.html
+++ b/LayoutTests/swipe/basic-cached-back-swipe.html
@@ -43,7 +43,7 @@ function isFirstPage()
     return window.location.href.indexOf("second") == -1;
 }
 
-window.onload = function () {
+window.onload = async function () {
     if (!window.eventSender || !window.testRunner) {
         document.body.innerHTML = "This test must be run in WebKitTestRunner.";
         return;
@@ -68,7 +68,7 @@ window.onload = function () {
         return;
     }
 
-    startSwipeGesture();
+    await startSwipeGesture();
 };
 </script>
 </head>

--- a/LayoutTests/swipe/main-frame-pinning-requirement.html
+++ b/LayoutTests/swipe/main-frame-pinning-requirement.html
@@ -8,23 +8,23 @@ html {
 <script src="resources/swipe-test.js"></script>
 <script>
 
-function runTest()
+async function runTest()
 {
     // The first swipe should fail because we're scrolled to the middle of the document
     // and this is all a single gesture. We can only start swipes if we *begin*
     // pinned to the edge.
-    startSwipeGesture(function () {
-        completeSwipeGesture(function () {
-            testRunner.clearTestRunnerCallbacks();
-            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-            testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);    
+    await startSwipeGesture();
+    await completeSwipeGesture();
+    
+    testRunner.clearTestRunnerCallbacks();
+    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+    testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+    testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+    testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);    
 
-            // The second swipe should succeed because we are now scrolled to the left edge.
-            startSwipeGesture(function () { completeSwipeGesture(); });
-        });
-    });
+    // The second swipe should succeed because we are now scrolled to the left edge.
+    await startSwipeGesture();
+    await completeSwipeGesture();
 }
 
 function didBeginSwipeNotReachedCallback()
@@ -66,7 +66,7 @@ function isFirstPage()
     return window.location.href.indexOf("second") == -1;
 }
 
-window.onload = function () {
+window.onload = async function () {
     if (!window.eventSender || !window.testRunner) {
         document.getElementById("large").innerHTML = "This test must be run in WebKitTestRunner.";
         return;
@@ -94,7 +94,7 @@ window.onload = function () {
     // Second page loaded.
     window.scrollTo(100, 0);
 
-    runTest();
+    await runTest();
 };
 </script>
 </head>

--- a/LayoutTests/swipe/pushState-cached-back-swipe.html
+++ b/LayoutTests/swipe/pushState-cached-back-swipe.html
@@ -6,6 +6,8 @@ html {
 }
 </style>
 <script src="resources/swipe-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+
 <script>
 
 function didBeginSwipeCallback()
@@ -49,7 +51,7 @@ function updateContent()
     document.body.innerHTML = isFirstPage() ? "first" : "second";
 }
 
-window.onload = function () {
+window.onload = async function () {
     if (!window.eventSender || !window.testRunner) {
         document.body.innerHTML = "This test must be run in WebKitTestRunner.";
         return;
@@ -71,14 +73,13 @@ window.onload = function () {
         updateContent();
     });
 
-    setTimeout(function () { 
-        history.pushState(null, null, "/second");
-        updateContent();
+    await UIHelper.delayFor(0);
 
-        setTimeout(function () {
-            startSwipeGesture();
-        }, 0);
-    }, 0);
+    history.pushState(null, null, "/second");
+    updateContent();
+
+    await UIHelper.delayFor(0);
+    await startSwipeGesture();
 };
 </script>
 </head>

--- a/LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html
+++ b/LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html
@@ -6,10 +6,11 @@ html {
 }
 </style>
 <script src="resources/swipe-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
 <script>
-function runTest()
+async function runTest()
 {
-    playEventStream(`[{
+    await playEventStream(`[{
         "relativeTimeMS" : 0,
         "kCGEventScrollGestureFlagBits" : 1,
         "kCGEventGestureHIDType" : 6,
@@ -40,19 +41,22 @@ function runTest()
         "kCGScrollWheelEventIsContinuous" : 1,
         "kCGScrollWheelEventPointDeltaAxis2" : 1,
         "kCGSEventTypeField" : 22
-      }]`, goBack);
+      }]`);
+      
+      await goBack();
 }
 
-function goBack()
+async function goBack()
 {
     window.history.back();
 
-    setTimeout(continueTest, 0);
+    await UIHelper.delayFor(0);
+    await continueTest();
 }
 
-function continueTest()
+async function continueTest()
 {
-    playEventStream(`[
+    await playEventStream(`[
       {
         "relativeTimeMS" : 0,
         "windowLocation" : "{400, 300}",
@@ -60,14 +64,15 @@ function continueTest()
         "kCGScrollWheelEventIsContinuous" : 1,
         "kCGScrollWheelEventPointDeltaAxis2" : 20,
         "kCGSEventTypeField" : 22
-      }]`, function () {
-        completeTest();
-      });
+      }]`);
+    
+    await completeTest();
 }
 
-function completeTest()
+async function completeTest()
 {
-    completeSwipeGesture(testComplete);
+    await completeSwipeGesture();
+    testComplete();
 }
 
 function didBeginSwipeCallback()
@@ -85,7 +90,7 @@ function updateContent()
     document.body.innerHTML = isFirstPage() ? "first" : "second";
 }
 
-window.onload = function () {
+window.onload = async function () {
     if (!window.eventSender || !window.testRunner) {
         document.body.innerHTML = "This test must be run in WebKitTestRunner.";
         return;
@@ -104,14 +109,13 @@ window.onload = function () {
         updateContent();
     });
 
-    setTimeout(function () { 
-        history.pushState(null, null, "/second");
-        updateContent();
+    await UIHelper.delayFor(0);
 
-        setTimeout(function () {
-            runTest();
-        }, 0);
-    }, 0);
+    history.pushState(null, null, "/second");
+    updateContent();
+
+    await UIHelper.delayFor(0);
+    await runTest();
 };
 </script>
 </head>

--- a/LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html
+++ b/LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html
@@ -6,6 +6,8 @@ html {
 }
 </style>
 <script src="resources/swipe-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+
 <script>
 history.scrollRestoration = "manual";
 
@@ -32,7 +34,7 @@ function didRemoveSwipeSnapshotCallback()
     testComplete();
 }
 
-window.onload = function () {
+window.onload = async function () {
     if (!window.eventSender || !window.testRunner) {
         document.body.innerHTML = "This test must be run in WebKitTestRunner.";
         return;
@@ -47,11 +49,10 @@ window.onload = function () {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    setTimeout(function () {
-        history.pushState({page: "second"}, "second", "?second");
-        document.body.innerHTML = "second";
-        startSwipeGesture();
-    }, 0);
+    await UIHelper.delayFor(0);
+    history.pushState({page: "second"}, "second", "?second");
+    document.body.innerHTML = "second";
+    await startSwipeGesture();
 };
 </script>
 </head>

--- a/LayoutTests/swipe/resources/swipe-test.js
+++ b/LayoutTests/swipe/resources/swipe-test.js
@@ -39,41 +39,53 @@ function measuredDurationShouldBeLessThan(key, timeInMS, message)
         log("Failure. " + message + " (expected: " + timeInMS + ", actual: " + duration + ")");
 }
 
-function startSwipeGesture(callback)
+async function startSwipeGesture()
 {
     log("startSwipeGesture");
-    testRunner.runUIScript(`
-    (function() {
-        uiController.beginBackSwipe(function() {
-            uiController.uiScriptComplete();
-        });
-    })();`, callback || function () {});
+
+    return new Promise(resolve => {
+        testRunner.runUIScript(`
+            (function() {
+                uiController.beginBackSwipe(function() {
+                    uiController.uiScriptComplete();
+                });
+            })();
+        `, resolve);
+    });
 }
 
-function completeSwipeGesture(callback)
+async function completeSwipeGesture()
 {
     log("completeSwipeGesture");
-    testRunner.runUIScript(`
-    (function() {
-        uiController.completeBackSwipe(function() {
-            uiController.uiScriptComplete();
-        });
-    })();`, callback || function () {});
+
+    return new Promise(resolve => {
+        testRunner.runUIScript(`
+            (function() {
+                uiController.completeBackSwipe(function() {
+                    uiController.uiScriptComplete();
+                });
+            })();
+        `, resolve);
+    });
 }
 
-function playEventStream(stream, callback)
+async function playEventStream(stream)
 {
     log("playEventStream");
     if (testRunner.isIOSFamily) {
         // FIXME: This test should probably not log playEventStream
         // on iOS, where it doesn't actually do it.
-        setTimeout(callback, 0);
-        return;
+        const timeout = 0;
+        return new Promise(resolve => setTimeout(resolve, timeout));
     }
-    testRunner.runUIScript(`
-    (function() {
-        uiController.playBackEventStream(\`${stream}\`, function() {
-            uiController.uiScriptComplete();
-        });
-    })();`, callback || function () {});
+
+    return new Promise(resolve => {
+        testRunner.runUIScript(`
+            (function() {
+                uiController.playBackEventStream(\`${stream}\`, function() {
+                    uiController.uiScriptComplete();
+                });
+            })();
+        `, resolve);
+    });
 }


### PR DESCRIPTION
#### 2ba1d4125996b291760835e6a3cc733f69893f33
<pre>
Rewrite swipe tests to use async/await
<a href="https://bugs.webkit.org/show_bug.cgi?id=243429">https://bugs.webkit.org/show_bug.cgi?id=243429</a>

Reviewed by Tim Horton.

These tests need to await for testRunner.runUIScript() to complete, so rewrite them
to use async/await.

This changed the results of swipe/main-frame-pinning-requirement.html, but it was
failing on iOS already, so just land new results and mark it flaky since its output
is not consistent.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/swipe/main-frame-pinning-requirement-expected.txt:
* LayoutTests/swipe/basic-cached-back-swipe.html:
* LayoutTests/swipe/main-frame-pinning-requirement.html:
* LayoutTests/swipe/pushState-cached-back-swipe.html:
* LayoutTests/swipe/pushState-programmatic-back-while-swiping-crash.html:
* LayoutTests/swipe/pushstate-with-manual-scrollrestoration.html:
* LayoutTests/swipe/resources/swipe-test.js:
(async startSwipeGesture.return.new.Promise.):
(async startSwipeGesture.return.new.Promise):
(async startSwipeGesture):
(async completeSwipeGesture.return.new.Promise.):
(async completeSwipeGesture.return.new.Promise):
(async completeSwipeGesture):
(async playEventStream.return.new.Promise.):
(async playEventStream.return.new.Promise):
(async playEventStream):
(startSwipeGesture): Deleted.
(completeSwipeGesture): Deleted.
(playEventStream): Deleted.

Canonical link: <a href="https://commits.webkit.org/253171@main">https://commits.webkit.org/253171@main</a>
</pre>
