### PR TITLE
Bypass CSP for webkit-pdfjs-viewer by default

### DIFF
--- a/Source/WebCore/platform/LegacySchemeRegistry.cpp
+++ b/Source/WebCore/platform/LegacySchemeRegistry.cpp
@@ -276,10 +276,22 @@ static URLSchemesMap& CORSEnabledSchemes()
     return schemes;
 }
 
+#if ENABLE(PDFJS)
+static Span<const ASCIILiteral> builtinCSPBypassingSchemes()
+{
+    static constexpr std::array schemes { "webkit-pdfjs-viewer"_s };
+    return schemes;
+}
+#endif
+
 static URLSchemesMap& ContentSecurityPolicyBypassingSchemes() WTF_REQUIRES_LOCK(schemeRegistryLock)
 {
     ASSERT(schemeRegistryLock.isHeld());
+#if ENABLE(PDFJS)
+    static auto schemes = makeNeverDestroyedSchemeSet(builtinCSPBypassingSchemes);
+#else
     static NeverDestroyed<URLSchemesMap> schemes;
+#endif
     return schemes;
 }
 


### PR DESCRIPTION
#### 374d0b0b4520a44242ee475819810f438e39507d
<pre>
Bypass CSP for webkit-pdfjs-viewer by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=243324">https://bugs.webkit.org/show_bug.cgi?id=243324</a>

Reviewed by NOBODY (OOPS!).

WebKit bundles PDF.js under the webkit-pdfjs-viewer scheme which could
get blocked if a website uses CSP.

* Source/WebCore/platform/LegacySchemeRegistry.cpp:
(WebCore::builtinCSPBypassingSchemes):
(WebCore::WTF_REQUIRES_LOCK):
</pre>