### PR TITLE
[WPE][GTK] Incremental build fixes for PDF.js

### DIFF
--- a/Source/WebCore/Modules/pdfjs-extras/PdfJSExtras.cmake
+++ b/Source/WebCore/Modules/pdfjs-extras/PdfJSExtras.cmake
@@ -1,0 +1,9 @@
+set(PdfJSExtraFiles
+    ${WEBCORE_DIR}/Modules/pdfjs-extras/content-script.js
+)
+
+if (PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
+    list(APPEND PdfJSExtraFiles
+        ${WEBCORE_DIR}/Modules/pdfjs-extras/adwaita/style.css
+    )
+endif ()

--- a/Source/WebKit/PdfJSGResources.cmake
+++ b/Source/WebKit/PdfJSGResources.cmake
@@ -1,8 +1,5 @@
 include(../ThirdParty/pdfjs/PdfJSFiles.cmake)
-
-set(PdfJSExtraFiles
-    ${WEBCORE_DIR}/Modules/pdfjs-extras/content-script.js
-)
+include(../WebCore/Modules/pdfjs-extras/PdfJSExtras.cmake)
 
 macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
     add_custom_command(
@@ -30,6 +27,7 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
         DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
+        DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
         COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         VERBATIM
     )

--- a/Tools/glib/generate-pdfjs-resource-manifest.py
+++ b/Tools/glib/generate-pdfjs-resource-manifest.py
@@ -25,6 +25,7 @@ COMPRESSIBLE_EXTENSIONS = {'.html', '.js', '.css', '.svg', '.properties'}
 BASE_DIRS = {'pdfjs/', 'pdfjs-extras/'}
 
 IGNORE = {'LICENSE',
+          'PdfJSExtras.cmake',
           'PdfJSFiles.cmake',
           'README.webkit',
           'web/cmaps/LICENSE',


### PR DESCRIPTION
#### d0e360af8478a78b00e0d1e845c890ef99510b3a
<pre>
[WPE][GTK] Incremental build fixes for PDF.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=243430">https://bugs.webkit.org/show_bug.cgi?id=243430</a>

Reviewed by Adrian Perez de Castro.

PdfJSExtraFiles includes only the cross-platform files. If
platform-specific files are modified, they won&apos;t be rebuilt.

Also, the command that compiles the PdfJSGResourceBundleExtras resource
should depend on the depfile it generates, so the resource gets rebuilt
if any of the files change. The main PdfJSGResourceBundle already does
this, as do all our other GResources. It&apos;s confusing for a command to
depend on a file that it generates itself, but that&apos;s OK. Better than no
dependency tracking.

* Source/WebCore/Modules/pdfjs-extras/PdfJSExtras.cmake: Added.
* Source/WebKit/PdfJSGResources.cmake:
* Tools/glib/generate-pdfjs-resource-manifest.py:

Canonical link: <a href="https://commits.webkit.org/253195@main">https://commits.webkit.org/253195@main</a>
</pre>
