### PR TITLE
[Gardening]: New test: [ iOS15 wk2 Release ] compositing/reflections/mask-and-reflection.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2235,8 +2235,6 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html [ ImageOnlyFailure ]
 
-webkit.org/b/242515 [ arm64 ] compositing/reflections/mask-and-reflection.html [ ImageOnlyFailure ]
-
 webkit.org/b/242812 [ Release arm64 ] js/dom/Promise-reject-large-string.html [ Pass Failure ]
 
 webkit.org/b/241205 [ Release arm64 ] fast/forms/textfield-outline.html [ Pass Failure ]


### PR DESCRIPTION
#### 945992d29e9fcfdc0b8a592cd359fbd9a7b46ca7
<pre>
[Gardening]: New test: [ iOS15 wk2 Release ] compositing/reflections/mask-and-reflection.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=242489">https://bugs.webkit.org/show_bug.cgi?id=242489</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253016@main">https://commits.webkit.org/253016@main</a>
</pre>
