### PR TITLE
Long press hint for Rich Links in Mail is solid black

### DIFF
--- a/LayoutTests/fast/text-indicator/text-indicator-nested-anchors-expected.txt
+++ b/LayoutTests/fast/text-indicator/text-indicator-nested-anchors-expected.txt
@@ -1,0 +1,10 @@
+PASS innerAnchorRect.x is outerAnchorRect.x
+PASS innerAnchorRect.y is outerAnchorRect.y
+PASS innerAnchorRect.width is outerAnchorRect.width
+PASS innerAnchorRect.height is outerAnchorRect.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello
+Apple's website
+

--- a/LayoutTests/fast/text-indicator/text-indicator-nested-anchors.html
+++ b/LayoutTests/fast/text-indicator/text-indicator-nested-anchors.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        function getBoundingRectForElementWithId(elementId) {
+            const range = document.createRange();
+            range.selectNodeContents(document.getElementById(elementId));
+
+            const indicator = internals.textIndicatorForRange(range, {
+                useBoundingRectAndPaintAllContentForComplexRanges : true,
+                useUserSelectAllCommonAncestor : true,
+            });
+            return indicator.textBoundingRectInRootViewCoordinates;
+        }
+
+        function runTest() {
+            if (!window.internals)
+                return;
+
+            innerAnchorRect = getBoundingRectForElementWithId("innerAnchor");
+            outerAnchorRect = getBoundingRectForElementWithId("outerAnchor");
+
+            shouldBe("innerAnchorRect.x", "outerAnchorRect.x");
+            shouldBe("innerAnchorRect.y", "outerAnchorRect.y");
+            shouldBe("innerAnchorRect.width", "outerAnchorRect.width");
+            shouldBe("innerAnchorRect.height", "outerAnchorRect.height");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+<div id="testCases">
+    <div>
+        <a id="outerAnchor" href="https://apple.com" style="user-select: all; -webkit-user-select: all">
+            <table>
+                <tbody>
+                <tr>
+                    <td><div>hello</div></td>
+                </tr>
+                <tr>
+                    <td>
+                        <a id="innerAnchor" href="https://apple.com">Apple's website</a>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </a>
+    </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -117,6 +117,10 @@ enum class TextIndicatorOption : uint16_t {
     // Compute a background color to use when rendering a platter around the content image, falling back to a default if the
     // content's background is too complex to be captured by a single color.
     ComputeEstimatedBackgroundColor = 1 << 11,
+
+    // By default, TextIndicator does not consider the user-select property.
+    // If this option is set, expand the range to include the highest `user-select: all` ancestor.
+    UseUserSelectAllCommonAncestor = 1 << 12,
 };
 
 struct TextIndicatorData {
@@ -183,7 +187,8 @@ template<> struct EnumTraits<WebCore::TextIndicatorOption> {
         WebCore::TextIndicatorOption::DoNotClipToVisibleRect,
         WebCore::TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
         WebCore::TextIndicatorOption::UseSelectionRectForSizing,
-        WebCore::TextIndicatorOption::ComputeEstimatedBackgroundColor
+        WebCore::TextIndicatorOption::ComputeEstimatedBackgroundColor,
+        WebCore::TextIndicatorOption::UseUserSelectAllCommonAncestor
     >;
 };
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1183,6 +1183,7 @@ public:
         bool useBoundingRectAndPaintAllContentForComplexRanges { false };
         bool computeEstimatedBackgroundColor { false };
         bool respectTextColor { false };
+        bool useUserSelectAllCommonAncestor { false };
 
         OptionSet<WebCore::TextIndicatorOption> coreOptions()
         {
@@ -1193,6 +1194,8 @@ public:
                 options.add(TextIndicatorOption::ComputeEstimatedBackgroundColor);
             if (respectTextColor)
                 options.add(TextIndicatorOption::RespectTextColor);
+            if (useUserSelectAllCommonAncestor)
+                options.add(TextIndicatorOption::UseUserSelectAllCommonAncestor);
             return options;
         }
     };

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -287,6 +287,7 @@ enum HEVCParameterCodec {
     boolean useBoundingRectAndPaintAllContentForComplexRanges = false;
     boolean computeEstimatedBackgroundColor = false;
     boolean respectTextColor = false;
+    boolean useUserSelectAllCommonAncestor = false;
 };
 
 [

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -849,7 +849,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
     auto selectionRange = corePage()->focusController().focusedOrMainFrame().selection().selection().firstRange();
 
     auto indicatorOptions = [&](const SimpleRange& range) {
-        OptionSet<TextIndicatorOption> options { TextIndicatorOption::UseBoundingRectAndPaintAllContentForComplexRanges };
+        OptionSet<TextIndicatorOption> options { TextIndicatorOption::UseBoundingRectAndPaintAllContentForComplexRanges, TextIndicatorOption::UseUserSelectAllCommonAncestor };
         if (ImageOverlay::isInsideOverlay(range))
             options.add({ TextIndicatorOption::PaintAllContent, TextIndicatorOption::PaintBackgrounds });
         return options;


### PR DESCRIPTION
#### a010904c451cd76eea5d885b648375c79135384f
<pre>
Long press hint for Rich Links in Mail is solid black
<a href="https://bugs.webkit.org/show_bug.cgi?id=243437">https://bugs.webkit.org/show_bug.cgi?id=243437</a>
rdar://97644287

Reviewed by Aditya Keerthi and Wenson Hsieh.

Currently, a TextIndicator only surrounds the Element that is selected.
Instead, it should consider the element and all of its ancestors up until an
ancestor has a `-webkit-user-select: all` as a single unit. This provides a
better user experience and gets around the root cause of why the indicator for
the actual text is a solid color, which is due to the behavior of
`-webkit-user-select: none` with TextIndicator.

* LayoutTests/fast/text-indicator/text-indicator-nested-anchors-expected.txt: Added.
* LayoutTests/fast/text-indicator/text-indicator-nested-anchors.html: Added.
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::TextIndicator::createWithNode):
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::textIndicatorForRange):
(WebCore::Internals::textIndicatorForNode):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

Canonical link: <a href="https://commits.webkit.org/253097@main">https://commits.webkit.org/253097@main</a>
</pre>
