### PR TITLE
HTML5 Media Element default controls do not work if JavaScript is disabled

### DIFF
--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -157,7 +157,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         }
         // FIXME: Is this check needed for other contexts?
         auto& script = window->wrapped().frame()->script();
-        if (!script.canExecuteScripts(AboutToExecuteScript) || script.isPaused())
+        if (!script.canExecuteScripts(m_isolatedWorld, AboutToExecuteScript) || script.isPaused())
             return;
     }
 

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -129,7 +129,7 @@ JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& exec
         return nullptr;
 
     auto& script = document.frame()->script();
-    if (!script.canExecuteScripts(AboutToCreateEventListener) || script.isPaused())
+    if (!script.canExecuteScripts(isolatedWorld(), AboutToCreateEventListener) || script.isPaused())
         return nullptr;
 
     ASSERT_WITH_MESSAGE(document.settings().scriptMarkupEnabled(), "Scripting element attributes should have been stripped during parsing");
@@ -192,7 +192,7 @@ RefPtr<JSLazyEventListener> JSLazyEventListener::create(CreationArguments&& argu
     TextPosition position;
     URL sourceURL;
     if (Frame* frame = arguments.document.frame()) {
-        if (!frame->script().canExecuteScripts(AboutToCreateEventListener))
+        if (!frame->script().canExecuteScripts(mainThreadNormalWorld(), AboutToCreateEventListener))
             return nullptr;
         position = frame->script().eventHandlerPosition();
         sourceURL = arguments.document.url();

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -135,7 +135,7 @@ void ScheduledAction::execute(Document& document)
         return;
 
     RefPtr<Frame> frame = window->wrapped().frame();
-    if (!frame || !frame->script().canExecuteScripts(AboutToExecuteScript))
+    if (!frame || !frame->script().canExecuteScripts(m_isolatedWorld, AboutToExecuteScript))
         return;
 
     if (m_function)

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -447,24 +447,28 @@ void ScriptController::updateDocument()
 
 Bindings::RootObject* ScriptController::cacheableBindingRootObject()
 {
-    if (!canExecuteScripts(NotAboutToExecuteScript))
+    auto& world = pluginWorld();
+
+    if (!canExecuteScripts(world, NotAboutToExecuteScript))
         return nullptr;
 
     if (!m_cacheableBindingRootObject) {
         JSLockHolder lock(commonVM());
-        m_cacheableBindingRootObject = Bindings::RootObject::create(nullptr, globalObject(pluginWorld()));
+        m_cacheableBindingRootObject = Bindings::RootObject::create(nullptr, globalObject(world));
     }
     return m_cacheableBindingRootObject.get();
 }
 
 Bindings::RootObject* ScriptController::bindingRootObject()
 {
-    if (!canExecuteScripts(NotAboutToExecuteScript))
+    auto& world = pluginWorld();
+
+    if (!canExecuteScripts(world, NotAboutToExecuteScript))
         return nullptr;
 
     if (!m_bindingRootObject) {
         JSLockHolder lock(commonVM());
-        m_bindingRootObject = Bindings::RootObject::create(nullptr, globalObject(pluginWorld()));
+        m_bindingRootObject = Bindings::RootObject::create(nullptr, globalObject(world));
     }
     return m_bindingRootObject.get();
 }
@@ -499,14 +503,16 @@ RefPtr<JSC::Bindings::Instance> ScriptController::createScriptInstanceForWidget(
 
 JSObject* ScriptController::jsObjectForPluginElement(HTMLPlugInElement* plugin)
 {
+    auto& world = pluginWorld();
+
     // Can't create JSObjects when JavaScript is disabled
-    if (!canExecuteScripts(NotAboutToExecuteScript))
+    if (!canExecuteScripts(world, NotAboutToExecuteScript))
         return nullptr;
 
     JSLockHolder lock(commonVM());
 
     // Create a JSObject bound to this element
-    auto* globalObj = globalObject(pluginWorld());
+    auto* globalObj = globalObject(world);
     // FIXME: is normal okay? - used for NP plugins?
     JSValue jsElementValue = toJS(globalObj, globalObj, plugin);
     if (!jsElementValue || !jsElementValue.isObject())
@@ -577,7 +583,7 @@ ValueOrException ScriptController::executeScriptInWorld(DOMWrapperWorld& world, 
 
     UserGestureIndicator gestureIndicator(parameters.forceUserGesture == ForceUserGesture::Yes ? std::optional<ProcessingUserGestureState>(ProcessingUserGesture) : std::nullopt, m_frame.document());
 
-    if (!canExecuteScripts(AboutToExecuteScript) || isPaused())
+    if (!canExecuteScripts(world, AboutToExecuteScript) || isPaused())
         return makeUnexpected(ExceptionDetails { "Cannot execute JavaScript in this document"_s });
 
     auto sourceURL = parameters.sourceURL;
@@ -752,10 +758,13 @@ void ScriptController::executeAsynchronousUserAgentScriptInWorld(DOMWrapperWorld
     call(&globalObject, thenFunction, callData, result.value(), arguments);
 }
 
-bool ScriptController::canExecuteScripts(ReasonForCallingCanExecuteScripts reason)
+bool ScriptController::canExecuteScripts(DOMWrapperWorld& world, ReasonForCallingCanExecuteScripts reason)
 {
     if (reason == AboutToExecuteScript)
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess());
+
+    if (world.type() == DOMWrapperWorld::Type::Internal)
+        return true;
 
     if (m_frame.document() && m_frame.document()->isSandboxed(SandboxScripts)) {
         // FIXME: This message should be moved off the console once a solution to https://bugs.webkit.org/show_bug.cgi?id=103274 exists.

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -128,7 +128,7 @@ public:
     void setWebAssemblyEnabled(bool, const String& errorMessage = String());
 
     static bool canAccessFromCurrentOrigin(Frame*, Document& accessingDocument);
-    WEBCORE_EXPORT bool canExecuteScripts(ReasonForCallingCanExecuteScripts);
+    WEBCORE_EXPORT bool canExecuteScripts(DOMWrapperWorld&, ReasonForCallingCanExecuteScripts);
 
     void setPaused(bool b) { m_paused = b; }
     bool isPaused() const { return m_paused; }

--- a/Source/WebCore/bindings/js/ScriptControllerMac.mm
+++ b/Source/WebCore/bindings/js/ScriptControllerMac.mm
@@ -75,7 +75,7 @@ RefPtr<JSC::Bindings::Instance> ScriptController::createScriptInstanceForWidget(
 
 WebScriptObject *ScriptController::windowScriptObject()
 {
-    if (!canExecuteScripts(NotAboutToExecuteScript))
+    if (!canExecuteScripts(pluginWorld(), NotAboutToExecuteScript))
         return nil;
 
     if (!m_windowScriptObject) {
@@ -90,7 +90,7 @@ WebScriptObject *ScriptController::windowScriptObject()
 JSContext *ScriptController::javaScriptContext()
 {
 #if JSC_OBJC_API_ENABLED
-    if (!canExecuteScripts(NotAboutToExecuteScript))
+    if (!canExecuteScripts(pluginWorld(), NotAboutToExecuteScript))
         return 0;
     JSContext *context = [JSContext contextWithJSGlobalContextRef:toGlobalRef(bindingRootObject()->globalObject())];
     return context;

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -228,7 +228,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition, Legac
 
     m_preparationTimeDocumentIdentifier = document.identifier();
 
-    if (!document.frame()->script().canExecuteScripts(AboutToExecuteScript))
+    if (!document.frame()->script().canExecuteScripts(mainThreadNormalWorld(), AboutToExecuteScript))
         return false;
 
     if (scriptType == ScriptType::Classic && !isScriptForEventSupported())

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -180,7 +180,7 @@ void HTMLCanvasElement::parseAttribute(const QualifiedName& name, const AtomStri
 RenderPtr<RenderElement> HTMLCanvasElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
     RefPtr<Frame> frame = document().frame();
-    if (frame && frame->script().canExecuteScripts(NotAboutToExecuteScript))
+    if (frame && frame->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
         return createRenderer<RenderHTMLCanvas>(*this, WTFMove(style));
     return HTMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -703,7 +703,7 @@ bool HTMLElement::rendererIsEverNeeded()
 {
     if (hasTagName(noscriptTag)) {
         RefPtr<Frame> frame = document().frame();
-        if (frame && frame->script().canExecuteScripts(NotAboutToExecuteScript))
+        if (frame && frame->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
             return false;
     } else if (hasTagName(noembedTag)) {
         RefPtr<Frame> frame = document().frame();

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -168,7 +168,7 @@ void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
 
 static bool isFrameLazyLoadable(const Document& document, const AtomString& loadingAttributeValue)
 {
-    if (!document.frame() || !document.frame()->script().canExecuteScripts(NotAboutToExecuteScript))
+    if (!document.frame() || !document.frame()->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
         return false;
 
     return equalLettersIgnoringASCIICase(loadingAttributeValue, "lazy"_s);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -903,7 +903,7 @@ bool HTMLImageElement::isDeferred() const
 
 bool HTMLImageElement::isLazyLoadable() const
 {
-    if (!document().frame() || !document().frame()->script().canExecuteScripts(NotAboutToExecuteScript))
+    if (!document().frame() || !document().frame()->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
         return false;
     return hasLazyLoadableAttributeValue(attributeWithoutSynchronization(HTMLNames::loadingAttr));
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3910,7 +3910,7 @@ bool HTMLMediaElement::controls() const
     RefPtr<Frame> frame = document().frame();
 
     // always show controls when scripting is disabled
-    if (frame && !frame->script().canExecuteScripts(NotAboutToExecuteScript))
+    if (frame && !frame->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
         return true;
 
     return hasAttributeWithoutSynchronization(controlsAttr);

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -49,7 +49,7 @@ HTMLParserOptions::HTMLParserOptions(Document& document)
     if (document.settings().htmlParserScriptingFlagPolicy() == HTMLParserScriptingFlagPolicy::Enabled)
         scriptingFlag = true;
     else
-        scriptingFlag = frame && frame->script().canExecuteScripts(NotAboutToExecuteScript);
+        scriptingFlag = frame && frame->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript);
 
     usePreHTML5ParserQuirks = document.settings().usePreHTML5ParserQuirks();
     maximumDOMTreeDepth = document.settings().maximumHTMLParserDOMTreeDepth();

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -111,7 +111,7 @@ bool HTMLParserScheduler::shouldYieldBeforeExecutingScript(const ScriptElement* 
     if (!document->body())
         return false;
 
-    if (!document->frame() || !document->frame()->script().canExecuteScripts(NotAboutToExecuteScript))
+    if (!document->frame() || !document->frame()->script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript))
         return false;
 
     if (!document->haveStylesheetsLoaded())

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -161,9 +161,6 @@ void PageDebugger::setJavaScriptPaused(const PageGroup& pageGroup, bool paused)
 
 void PageDebugger::setJavaScriptPaused(Frame& frame, bool paused)
 {
-    if (!frame.script().canExecuteScripts(NotAboutToExecuteScript))
-        return;
-
     frame.script().setPaused(paused);
 
     ASSERT(frame.document());

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1985,9 +1985,11 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
         if (document) {
             handlerObject = scriptListener.ensureJSFunction(*document);
             if (auto frame = document->frame()) {
+                auto& world = scriptListener.isolatedWorld();
+
                 // FIXME: Why do we need the canExecuteScripts check here?
-                if (frame->script().canExecuteScripts(NotAboutToExecuteScript))
-                    globalObject = frame->script().globalObject(scriptListener.isolatedWorld());
+                if (frame->script().canExecuteScripts(world, NotAboutToExecuteScript))
+                    globalObject = frame->script().globalObject(world);
             }
         }
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2323,7 +2323,7 @@ void FrameLoader::willRestoreFromCachedPage()
     closeURL();
     
     // Delete old status bar messages (if it _was_ activated on last URL).
-    if (m_frame.script().canExecuteScripts(NotAboutToExecuteScript)) {
+    if (m_frame.script().canExecuteScripts(mainThreadNormalWorld(), NotAboutToExecuteScript)) {
         DOMWindow* window = m_frame.document()->domWindow();
         window->setStatus(String());
         window->setDefaultStatus(String());
@@ -3999,18 +3999,17 @@ String FrameLoader::referrer() const
 
 void FrameLoader::dispatchDidClearWindowObjectsInAllWorlds()
 {
-    if (!m_frame.script().canExecuteScripts(NotAboutToExecuteScript))
-        return;
-
     Vector<Ref<DOMWrapperWorld>> worlds;
     ScriptController::getAllWorlds(worlds);
-    for (auto& world : worlds)
-        dispatchDidClearWindowObjectInWorld(world);
+    for (auto& world : worlds) {
+        if (m_frame.script().canExecuteScripts(world, NotAboutToExecuteScript))
+            dispatchDidClearWindowObjectInWorld(world);
+    }
 }
 
 void FrameLoader::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
 {
-    if (!m_frame.script().canExecuteScripts(NotAboutToExecuteScript) || !m_frame.windowProxy().existingJSWindowProxy(world))
+    if (!m_frame.script().canExecuteScripts(world, NotAboutToExecuteScript) || !m_frame.windowProxy().existingJSWindowProxy(world))
         return;
 
     m_client->dispatchDidClearWindowObjectInWorld(world);

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1006,7 +1006,7 @@ void WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& 
     Frame* coreFrame = core(m_webFrame);
     ASSERT(coreFrame);
 
-    if (!coreFrame->settings().isScriptEnabled())
+    if (!coreFrame->settings().isScriptEnabled() && world.type() != DOMWrapperWorld::Type::Internal)
         return;
 
     WebView* webView = m_webFrame->webView();


### PR DESCRIPTION
#### b19e822d6de4fc8c146ae45071186621da7c2910
<pre>
HTML5 Media Element default controls do not work if JavaScript is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=178040">https://bugs.webkit.org/show_bug.cgi?id=178040</a>
&lt;rdar://problem/32035810&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::cacheableBindingRootObject):
(WebCore::ScriptController::bindingRootObject):
(WebCore::ScriptController::jsObjectForPluginElement):
(WebCore::ScriptController::executeScriptInWorld):
(WebCore::ScriptController::canExecuteScripts):
Always execute scripts inside `WebCore::DOMWrapperWorld::Type::Internal` worlds, as they are (often)
necessary for basic builtin functionality (e.g. media controls).

* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::initializeJSFunction const):
(WebCore::JSLazyEventListener::create):
* Source/WebCore/bindings/js/ScheduledAction.cpp:
(WebCore::ScheduledAction::execute):
* Source/WebCore/bindings/js/ScriptControllerMac.mm:
(WebCore::ScriptController::windowScriptObject):
(WebCore::ScriptController::javaScriptContext):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createElementRenderer):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::rendererIsEverNeeded):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::isFrameLazyLoadable):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::isLazyLoadable const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::controls const):
* Source/WebCore/html/parser/HTMLParserOptions.cpp:
(WebCore::HTMLParserOptions::HTMLParserOptions):
* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
(WebCore::HTMLParserScheduler::shouldYieldBeforeExecutingScript):
* Source/WebCore/inspector/PageDebugger.cpp:
(WebCore::PageDebugger::setJavaScriptPaused):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForEventListener):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::reportExecutionContextCreation):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::dispatchDidClearWindowObjectsInAllWorlds):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
* Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
Pass along the `WebCore::DOMWrapperWorld` when checking whether script execution is possible. If it&apos;s
not possible to get a relevant `WebCore::DOMWrapperWorld`, assume the main world (e.g. for DOM stuff).
</pre>