### PR TITLE
Allow iOS network process to connect to com.apple.appstored.xpc XPC service

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -220,6 +220,7 @@
            (global-name "com.apple.nehelper"))
 
     (allow mach-lookup
+           (global-name "com.apple.appstored.xpc")
            (global-name "com.apple.appstored.xpc.request"))
 
     ;; <rdar://89031731>


### PR DESCRIPTION
#### e485c13082887ab8c6c36da2d73339396e0ffd49
<pre>
Allow iOS network process to connect to com.apple.appstored.xpc XPC service
<a href="https://bugs.webkit.org/show_bug.cgi?id=243439">https://bugs.webkit.org/show_bug.cgi?id=243439</a>
&lt;rdar://97339327&gt;

Reviewed by Brady Eidson.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:

Canonical link: <a href="https://commits.webkit.org/253046@main">https://commits.webkit.org/253046@main</a>
</pre>
