### PR TITLE
[GTK4] Scrolling with touchpad is broken on Wayland

### DIFF
--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -38,8 +38,12 @@ static const Seconds swipeMinAnimationDuration = 100_ms;
 static const Seconds swipeMaxAnimationDuration = 400_ms;
 static const double swipeAnimationBaseVelocity = 0.002;
 
+#if GTK_CHECK_VERSION(4, 7, 0)
+static const double gtkScrollDeltaMultiplier = 1;
+#else
 // GTK divides all scroll deltas by 10, compensate for that
 static const double gtkScrollDeltaMultiplier = 10;
+#endif
 static const double swipeTouchpadBaseWidth = 400;
 
 // This is derivative of the easing function at t=0


### PR DESCRIPTION
#### 9b9c04184c998ba6efdd8931324097bb5e2489bc
<pre>
[GTK4] Scrolling with touchpad is broken on Wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=238203">https://bugs.webkit.org/show_bug.cgi?id=238203</a>

GTK 4.7.x has new API to know whether scroll deltas are continuous or
discrete, and the former don&apos;t have a multiplier anymore. Adjust event
handling accordingly.

Reviewed by Michael Catanzaro.

* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp

Canonical link: <a href="https://commits.webkit.org/253069@main">https://commits.webkit.org/253069@main</a>
</pre>
