### PR TITLE
Remove incorrect ASSERT in RemoteLayerTreeLayers

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -57,7 +57,6 @@
 
     if (replay) {
         _displayListDataForTesting = data;
-        ASSERT(displayList.ports.isEmpty());
         [self setNeedsDisplay];
         return;
     }


### PR DESCRIPTION
#### 79921d502bc7608608baa916f670bc84419b590f
<pre>
Remove incorrect ASSERT in RemoteLayerTreeLayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=243440">https://bugs.webkit.org/show_bug.cgi?id=243440</a>
&lt;rdar://problem/97953495&gt;

Reviewed by Tim Horton.

RemoteLayerTrees was calling an unknown method in an ASSERT within
CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER.

* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm:
(-[WKCompositingLayer _setWKContents:withDisplayList:replayForTesting:]):

Canonical link: <a href="https://commits.webkit.org/253049@main">https://commits.webkit.org/253049@main</a>
</pre>
