### PR TITLE
We should not assume that WeakPtr Console is accessed by one thread in JSC

### DIFF
--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -200,7 +200,7 @@ void JSGlobalObjectInspectorController::reportAPIException(JSGlobalObject* globa
 
 WeakPtr<ConsoleClient> JSGlobalObjectInspectorController::consoleClient() const
 {
-    return m_consoleClient.get();
+    return WeakPtr<ConsoleClient>(m_consoleClient.get(), EnableWeakPtrThreadingAssertions::No);
 }
 
 bool JSGlobalObjectInspectorController::developerExtrasEnabled() const


### PR DESCRIPTION
#### 713fb342252e8a46c8109d6dd11288168c8ba135
<pre>
We should not assume that WeakPtr Console is accessed by one thread in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=243443">https://bugs.webkit.org/show_bug.cgi?id=243443</a>

Reviewed by Devin Rousso.

Because VM on JavaScriptCore.framework can be migrated to the different thread from the initiated thread,
WeakPtr&apos;s thread check does not work for objects read in JSC. We should disable it for consoleClient.

* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::consoleClient const):

Canonical link: <a href="https://commits.webkit.org/253024@main">https://commits.webkit.org/253024@main</a>
</pre>
