### PR TITLE
[XHTML] innerHTML and outerHTML setters use a wrong default namespace

### DIFF
--- a/LayoutTests/fast/parser/innerHTML-setter-default-namespace-expected.txt
+++ b/LayoutTests/fast/parser/innerHTML-setter-default-namespace-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setting innerHTML on a HTML element with a non-HTML namespace as the default namespace
+PASS Setting outerHTML on a HTML element with a non-HTML namespace as the default namespace
+

--- a/LayoutTests/fast/parser/innerHTML-setter-default-namespace.xhtml
+++ b/LayoutTests/fast/parser/innerHTML-setter-default-namespace.xhtml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:bar="bar">
+<head>
+<title>Test for Shadow DOM innerHTML setter in XML</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<span xmlns="someNamespace" xmlns:html="http://www.w3.org/1999/xhtml">
+    <html:span id="target"/>
+</span>
+<script>
+<![CDATA[
+
+test(() => {
+    const element = document.getElementById("target");
+    element.innerHTML = '<b /><html:b />';
+    assert_equals(element.firstChild.prefix, null);
+    assert_equals(element.firstChild.namespaceURI, "someNamespace");
+    assert_equals(element.lastChild.prefix, 'html');
+    assert_equals(element.lastChild.namespaceURI, "http://www.w3.org/1999/xhtml");
+}, "Setting innerHTML on a HTML element with a non-HTML namespace as the default namespace");
+
+test(() => {
+    const element = document.getElementById("target");
+    element.outerHTML = '<b /><html:b />';
+    assert_equals(element.firstChild.prefix, null);
+    assert_equals(element.firstChild.namespaceURI, "someNamespace");
+    assert_equals(element.lastChild.prefix, 'html');
+    assert_equals(element.lastChild.namespaceURI, "http://www.w3.org/1999/xhtml");
+}, "Setting outerHTML on a HTML element with a non-HTML namespace as the default namespace");
+
+]]>
+</script>
+</body>
+</html>

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -268,17 +268,11 @@ static XMLParsingNamespaces findXMLParsingNamespaces(Element* contextElement)
 
     XMLParsingNamespaces result;
 
-    bool stopLookingForDefaultNamespace = false;
+    result.defaultNamespace = contextElement->lookupNamespaceURI(nullAtom());
 
     for (auto& element : lineageOfType<Element>(*contextElement)) {
-        if (is<SVGForeignObjectElement>(element))
-            stopLookingForDefaultNamespace = true;
-        else if (!stopLookingForDefaultNamespace)
-            result.defaultNamespace = element.namespaceURI();
-
         if (!element.hasAttributes())
             continue;
-
         for (auto& attribute : element.attributesIterator()) {
             if (attribute.prefix() == xmlnsAtom())
                 result.prefixNamespaces.set(attribute.localName(), attribute.value());


### PR DESCRIPTION
#### 1ffe018f5d5cd17e88f1a34ee7a62d47290ed07d
<pre>
[XHTML] innerHTML and outerHTML setters use a wrong default namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=243441">https://bugs.webkit.org/show_bug.cgi?id=243441</a>

Reviewed by Chris Dumez.

Fixed the bug that the setters of innerHTML and outerHTML use a wrong default namespace URI.
The new behavior matches that of Firefox and Chrome.

* LayoutTests/fast/parser/innerHTML-setter-default-namespace-expected.txt: Added.
* LayoutTests/fast/parser/innerHTML-setter-default-namespace.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::findXMLParsingNamespaces):

Canonical link: <a href="https://commits.webkit.org/253039@main">https://commits.webkit.org/253039@main</a>
</pre>
