### PR TITLE
[macOS] Suppress sandbox reports and telemetry

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -23,7 +23,7 @@
 
 (version 1)
 (deny default (with partial-symbolication))
-(deny nvram*)
+(deny nvram* (with no-report))
 (deny system-privilege)
 (allow system-audit file-read-metadata)
 
@@ -35,7 +35,7 @@
 #if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
 #include <WebKitAdditions/SystemContentSandbox-macos.defs>
 #endif
- 
+
 ;;;
 ;;; The following rules were originally contained in 'system.sb'. We are duplicating them here so we can
 ;;; remove unneeded sandbox extensions.
@@ -79,7 +79,7 @@
     (literal "/dev/dtracehelper"))
 
 ;;; Allow IPC to standard system agents.
-(allow ipc-posix-shm-read* (with telemetry)
+(allow ipc-posix-shm-read*
 #if !ENABLE(CFPREFS_DIRECT_MODE)
     (ipc-posix-name-prefix "apple.cfprefs.")
 #endif
@@ -92,39 +92,39 @@
         (preference-domain "com.apple.opengl")
         (preference-domain "com.nvidia.OpenGL"))
     ;; CVMS
-    (allow mach-lookup (with telemetry)
+    (allow mach-lookup
         (global-name "com.apple.cvmsServ"))
-    (allow file-read* (with telemetry)
+    (allow file-read*
         (prefix "/private/var/db/CVMS/cvmsCodeSignObj"))
     ;; OpenCL
     (allow iokit-open
         (iokit-connection "IOAccelerator")
         (iokit-registry-entry-class "IOSurfaceRootUserClient"))
-    (deny iokit-open (with telemetry)
+    (deny iokit-open
         (iokit-registry-entry-class "IOAccelerationUserClient"))
     ;; CoreVideo CVCGDisplayLink
-    (deny iokit-open (with telemetry)
+    (deny iokit-open
         (iokit-registry-entry-class "IOFramebufferSharedUserClient"))
 
     ;; These are needed for Encrypted Media on some hardware (MacMini8,1 for example)
-    (allow iokit-open (with telemetry)
+    (allow iokit-open
         (iokit-registry-entry-class "AppleIntelMEUserClient")
         (iokit-registry-entry-class "AppleSNBFBUserClient")
     )
 
     ;; QuartzCore
-    (deny iokit-open (with telemetry)
+    (deny iokit-open
         (iokit-registry-entry-class "AGPMClient")
         (iokit-registry-entry-class "AppleGraphicsControlClient")
         (iokit-registry-entry-class "AppleGraphicsPolicyClient"))
     ;; OpenGL
-    (deny iokit-open (with telemetry)
+    (deny iokit-open
         (iokit-registry-entry-class "AppleMGPUPowerControlClient"))
     ;; GPU bundles
-    (allow file-read* (with telemetry)
+    (allow file-read*
         (subpath "/Library/GPUBundles"))
     ;; DisplayServices
-    (allow iokit-set-properties (with telemetry)
+    (allow iokit-set-properties
         (require-all (iokit-connection "IODisplay")
         (require-any (iokit-property "brightness")
         (iokit-property "linear-brightness")
@@ -145,8 +145,8 @@
 (allow process-info-setcontrol (target self))
 (allow process-codesigning-status*)
 
-(deny sysctl* (with telemetry))
-(allow sysctl-read (with telemetry)
+(deny sysctl*)
+(allow sysctl-read
     (sysctl-name
         "hw.activecpu"
         "hw.cachelinesize"
@@ -176,6 +176,9 @@
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
+
+(deny sysctl-read (with no-report)
+    (sysctl-name "security.mac.amfi.qa_root_certs_allowed"))
 
 (deny iokit-get-properties)
 (allow iokit-get-properties
@@ -492,10 +495,38 @@
                             "display-rotation"
                             "display-scale"))))
 
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property
+            "artwork-display-gamut"
+            "product-id")))
+
+(with-filter (iokit-registry-entry-class "AppleMobileADBE0")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "APTDevice")))
+
+(with-filter (iokit-registry-entry-class "AppleARMIODevice")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property
+            "AAPL,phandle"
+            "ads-present"
+            "avd-version"
+            "clock-gates"
+            "clock-ids"
+            "decode-samples-per-second"
+            "function-avd_reset"
+            "function-mcc_dataset"
+            "h264-playback-level"
+            "interrupt-parent"
+            "interrupts"
+            "iommu-parent"
+            "power-gates"
+            "supports-apt")))
+
 (deny mach-lookup (xpc-service-name-prefix ""))
 (allow mach-lookup
     (xpc-service-name "com.apple.audio.SandboxHelper"))
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (xpc-service-name "com.apple.coremedia.videodecoder")
     (xpc-service-name "com.apple.coremedia.videoencoder"))
 
@@ -602,10 +633,10 @@
 
 ;; Sandbox extensions
 (define (apply-read-and-issue-extension op path-filter)
-    (op file-read* (with telemetry) path-filter)
+    (op file-read* path-filter)
     (op file-issue-extension (require-all (extension-class "com.apple.app-sandbox.read") path-filter)))
 (define (apply-write-and-issue-extension op path-filter)
-    (op file-write* (with telemetry) path-filter)
+    (op file-write* path-filter)
     (op file-issue-extension (require-all (extension-class "com.apple.app-sandbox.read-write") path-filter)))
 (define (read-only-and-issue-extensions path-filter)
     (apply-read-and-issue-extension allow path-filter))
@@ -617,7 +648,7 @@
 
 ;; Allow the OpenGL Profiler to attach.
 (with-filter (system-attribute apple-internal)
-    (allow mach-register (with telemetry) (global-name-regex #"^_oglprof_attach_<[0-9]+>$")))
+    (allow mach-register (global-name-regex #"^_oglprof_attach_<[0-9]+>$")))
 
 (if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
     (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_CACHE_DIR")))
@@ -634,7 +665,7 @@
     ;; Following is needed due to <rdar://problem/10427451> && <rdar://problem/10808817>
     (iokit-user-client-class "AudioAUUC"))
 
-(deny iokit-open (with telemetry)
+(deny iokit-open
     (iokit-user-client-class "AppleMultitouchDeviceUserClient")
     (iokit-user-client-class "IOHIDParamUserClient"))
 
@@ -654,9 +685,8 @@
     (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
 
 #if !ENABLE(CFPREFS_DIRECT_MODE)
-(allow mach-lookup (with telemetry)
-    (global-name "com.apple.cfprefsd.agent")
-)
+(allow mach-lookup
+    (global-name "com.apple.cfprefsd.agent"))
 #endif
 
 (allow mach-lookup
@@ -704,18 +734,23 @@
 (allow mach-lookup (xpc-service-name "com.apple.MTLCompilerService"))
 
 (deny mach-lookup (with no-log)
-    (global-name "com.apple.CoreServices.coreservicesd")
-    (global-name "com.apple.DiskArbitration.diskarbitrationd")
-    (global-name "com.apple.ViewBridgeAuxiliary")
-    (global-name "com.apple.windowserver.active"))
+    (global-name
+        "com.apple.CoreServices.coreservicesd"
+        "com.apple.DiskArbitration.diskarbitrationd"
+        "com.apple.ViewBridgeAuxiliary"
+        "com.apple.coreservices.launchservicesd"
+        "com.apple.windowserver.active"))
+        
+(deny mach-lookup (with no-report)
+    (global-name-prefix "com.apple.distributed_notifications"))
 
 ;; Needed to support encrypted media playback <rdar://problem/40038478>
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (global-name "com.apple.SecurityServer"))
 
 (allow file-read* (subpath "/private/var/db/mds/system")) ;; FIXME: This should be removed when <rdar://problem/9538414> is fixed.
 (with-filter (uid 0)
-    (allow file-write* (with telemetry)
+    (allow file-write*
         (subpath "/private/var/db/mds/system")) ;; FIXME: This should be removed when <rdar://problem/9538414> is fixed.
 )
 
@@ -727,17 +762,17 @@
 
 ;; CoreFoundation. We don't import com.apple.corefoundation.sb, because it allows unnecessary access to pasteboard.
 #if !HAVE(CSCHECKFIXDISABLE)
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (global-name "com.apple.CoreServices.coreservicesd"))
 #endif
 
-(allow system-fsctl (with telemetry) (fsctl-command (_IO "h" 47)))
+(allow system-fsctl (fsctl-command (_IO "h" 47)))
 
 ;; Graphics
 (system-graphics)
 
 ;; Networking
-(allow network-outbound (with telemetry)
+(allow network-outbound
 #if __MAC_OS_X_VERSION_MIN_REQUIRED <= 101500
        ;; Local mDNSResponder for DNS, arbitrary outbound TCP
        ;; Note: This is needed for some media playback features. <rdar://problem/38191574>
@@ -753,6 +788,9 @@
 
 ;; CFNetwork
 (allow file-read-data (path "/private/var/db/nsurlstoraged/dafsaData.bin"))
+
+(deny file-read* (with no-report)
+    (home-literal "/Library/Preferences/com.apple.networkd.plist"))
 
 #if PLATFORM(MAC)
 (allow mach-lookup
@@ -784,7 +822,7 @@
 ;; AirPlay
 (allow mach-lookup
     (global-name "com.apple.coremedia.routingcontext.xpc"))
-(allow mach-lookup (with telemetry)
+(allow mach-lookup
     (global-name "com.apple.coremedia.endpoint.xpc")
     (global-name "com.apple.coremedia.endpointstream.xpc")
     (global-name "com.apple.coremedia.endpointstreamaudioengine.xpc") ;; <rdar://76029596>
@@ -853,12 +891,15 @@
     )
 )
 
+(deny mach-lookup (with no-report)
+    (global-name "com.apple.cmio.registerassistantservice.system-extensions"))
+
 ;; Media capture, camera access
 (with-filter (extension "com.apple.webkit.camera")
     (shared-preferences-read "com.apple.cmio")
     (shared-preferences-read "com.apple.coremedia")
     (allow file-read* (subpath "/Library/CoreMediaIO/Plug-Ins/DAL"))
-    (allow mach-lookup (with telemetry)
+    (allow mach-lookup
         (global-name "com.apple.cmio.AppleCameraAssistant")
         (global-name "com.apple.cmio.registerassistantservice")
         (global-name "com.apple.cmio.registerassistantservice.system-extensions")
@@ -880,13 +921,16 @@
         )
 #endif
         )
-    (deny iokit-open (with telemetry)
+    (deny iokit-open
         ;; QuickTimeUSBVDCDigitizer
         (iokit-user-client-class "IOUSBDeviceUserClientV2")
         (iokit-user-client-class "IOUSBInterfaceUserClientV2"))
     (allow device-camera))
 
 #endif // PLATFORM(MAC)
+
+(deny mach-lookup (with no-report)
+    (global-name "com.apple.tccd.system"))
 
 #if HAVE(SC_CONTENT_SHARING_SESSION)
 (allow mach-lookup
@@ -902,20 +946,22 @@
 )
 #endif
 
+(deny mach-lookup (with no-report)
+    (global-name "com.apple.system.opendirectoryd.libinfo"))
+
 (allow mach-lookup
     (require-all
         (extension "com.apple.webkit.extension.mach")
         (global-name "com.apple.system.opendirectoryd.libinfo")))
 
-(allow mach-lookup (with telemetry)
-    (global-name "com.apple.relatived.tempest")
-)
+(allow mach-lookup
+    (global-name "com.apple.relatived.tempest"))
 
 (allow iokit-open
     (iokit-user-client-class "AppleAVDUserClient"))
 
 (when (equal? (param "CPU") "arm64")
-    (allow iokit-open (with telemetry)
+    (allow iokit-open
         (iokit-user-client-class "IOMobileFramebufferUserClient")
         ;; VideoToolbox VTImageRotationSession
         (iokit-user-client-class "IOSurfaceAcceleratorClient")
@@ -929,7 +975,7 @@
             (allow mach-message-send))))
 
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
-    (deny syscall-mach (with telemetry))
+    (deny syscall-mach)
     (allow syscall-mach (machtrap-number
         MSC__kernelrpc_mach_port_allocate_trap
         MSC__kernelrpc_mach_port_construct_trap
@@ -976,7 +1022,7 @@
 #endif // HAVE(SANDBOX_MESSAGE_FILTERING)
 
 (when (defined? 'syscall-unix)
-    (deny syscall-unix (with telemetry))
+    (deny syscall-unix)
     (allow syscall-unix (syscall-number
         SYS___channel_open
         SYS___disable_threadsignal

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -62,7 +62,9 @@
 (allow file-map-executable
     (home-subpath "/Library/Caches")
     (home-subpath "/Library/Containers")
+    (home-subpath "/Library/WebKit")
     (subpath (param "DARWIN_USER_TEMP_DIR"))
+    (subpath "/Library/Frameworks")
     (subpath "/Library/KerberosPlugins")
     (subpath "/System/Library/Frameworks")
     (subpath "/System/Library/KerberosPlugins")
@@ -470,7 +472,7 @@
     (prefix "/private/var/db/com.apple.networkextension."))
 
 (when (defined? 'syscall-unix)
-    (deny syscall-unix (with telemetry))
+    (deny syscall-unix)
     (allow syscall-unix (syscall-number
         SYS___channel_get_info
         SYS___channel_open
@@ -632,7 +634,7 @@
             (allow mach-message-send))))
 
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
-    (deny syscall-mach (with telemetry))
+    (deny syscall-mach)
     (allow syscall-mach
         (machtrap-number
             MSC__kernelrpc_mach_port_allocate_trap

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -129,7 +129,7 @@
 
 (define (IOAcceleratorMessageFilter)
     (apply-message-filter
-        (deny (with telemetry) (with message "IOAccelerator")
+        (deny (with message "IOAccelerator")
             iokit-async-external-method
             iokit-external-method
         )
@@ -209,7 +209,7 @@
             )
         )
 #endif
-        (deny (with telemetry)
+        (deny
             iokit-external-trap
         )
     )
@@ -217,7 +217,7 @@
 
 (define (IOSurfaceRootUserClientMessageFilter)
     (apply-message-filter
-        (deny (with telemetry) (with message "IOSurfaceRootUserClient")
+        (deny (with message "IOSurfaceRootUserClient")
             iokit-async-external-method
             iokit-external-method
         )
@@ -259,7 +259,7 @@
 #endif
         )
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 130000
-        (deny (with telemetry)
+        (deny
             iokit-external-trap)
 #else
         (allow
@@ -270,7 +270,7 @@
 
 (define (AppleAVDUserClientMessageFilter)
     (apply-message-filter
-        (deny (with telemetry) (with message "AppleAVDUserClient")
+        (deny (with message "AppleAVDUserClient")
             iokit-async-external-method
             iokit-external-method
             iokit-external-trap
@@ -280,7 +280,7 @@
 
 (define (IOSurfaceAcceleratorClientMessageFilter)
     (apply-message-filter
-        (deny (with telemetry) (with message "IOSurfaceAcceleratorClient")
+        (deny (with message "IOSurfaceAcceleratorClient")
             iokit-async-external-method
             iokit-external-trap
         )
@@ -296,11 +296,11 @@
 
 (define (IOMobileFramebufferUserClientMessageFilter)
     (apply-message-filter
-        (deny (with telemetry) (with message "IOMobileFramebufferUserClient")
+        (deny (with message "IOMobileFramebufferUserClient")
             iokit-async-external-method
             iokit-external-trap
         )
-        (allow (with telemetry-backtrace) iokit-external-method
+        (allow iokit-external-method
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
             (iokit-method-number
                 8
@@ -356,7 +356,7 @@
                 (iokit-registry-entry-class "IOAccelerationUserClient")
             )
             (apply-message-filter
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                     iokit-external-method
@@ -401,7 +401,7 @@
                 (iokit-registry-entry-class "AppleIntelMEUserClient")
             )
             (apply-message-filter
-                (deny (with telemetry) (with message "AppleIntelMEUserClient")
+                (deny (with message "AppleIntelMEUserClient")
                     iokit-external-method
                 )
                 (allow iokit-external-method
@@ -411,7 +411,7 @@
                     )
 #endif
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                 )
@@ -434,7 +434,7 @@
                 (iokit-registry-entry-class "AppleSNBFBUserClient")
             )
             (apply-message-filter
-                (deny (with telemetry) (with message "AppleSNBFBUserClient")
+                (deny (with message "AppleSNBFBUserClient")
                     iokit-external-method
                 )
                 (allow iokit-external-method
@@ -444,7 +444,7 @@
                     )
 #endif
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                 )
@@ -477,7 +477,7 @@
                 (iokit-registry-entry-class "AppleGraphicsControlClient")
             )
             (apply-message-filter
-                (deny (with telemetry) (with message "AppleGraphicsControlClient")
+                (deny (with message "AppleGraphicsControlClient")
                     iokit-async-external-method
                     iokit-external-method
                 )
@@ -491,7 +491,7 @@
                     )
 #endif
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-external-trap
                 )
             )
@@ -511,7 +511,7 @@
                 (iokit-registry-entry-class "AppleGraphicsPolicyClient")
             )
             (apply-message-filter
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                     iokit-external-method
@@ -534,7 +534,7 @@
                 (iokit-registry-entry-class "AppleMGPUPowerControlClient")
             )
             (apply-message-filter
-                (deny (with telemetry) (with message "AppleMGPUPowerControlClient")
+                (deny (with message "AppleMGPUPowerControlClient")
                     iokit-external-method
                 )
                 (allow iokit-external-method
@@ -546,7 +546,7 @@
                     )
 #endif
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                 )
@@ -919,13 +919,31 @@
 ;; <rdar://97677559>
 (deny iokit-get-properties
     (iokit-property "AppleDiagnosticDataSysCfg")
-    (iokit-property "AppleJPEGNumCores")
     (iokit-property "als-colorCfg")
     (iokit-property "ean-storage-present")
     (iokit-property "noMultiColorSupport")
-    (iokit-property "product-id")
     (iokit-property "syscfg-v2-data")
     (with no-report))
+
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property
+            "artwork-display-gamut"
+            "product-id")))
+
+(with-filter (iokit-registry-entry-class "AppleMobileADBE0")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "APTDevice")))
+
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "AppleARMIODevice")
+        (deny iokit-get-properties (with no-report)
+            (iokit-property "supports-apt"))))
+
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "AppleJPEGDriver")
+        (deny iokit-get-properties (with no-report)
+            (iokit-property "AppleJPEGNumCores"))))
 
 ;; <rdar://problem/60088861>
 (if (equal? (param "CPU") "arm64")
@@ -989,6 +1007,8 @@
 )
 #endif
 
+(deny mach-lookup (with no-report)
+    (global-name "com.apple.windowmanager.server"))
 
 ;; Utility functions for home directory relative path filters
 (define (home-regex home-relative-regex)
@@ -1145,6 +1165,9 @@
     (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_TEMP_DIR")))
 
 ;; IOKit user clients
+(deny iokit-open (with no-report)
+    (iokit-user-client-class "AppleJPEGDriverUserClient"))
+
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 (allow iokit-open
     (iokit-user-client-class "AppleMultitouchDeviceUserClient")
@@ -1168,7 +1191,7 @@
             (iokit-user-client-class "AppleUpstreamUserClient")
         )
         (apply-message-filter
-            (deny (with telemetry) (with message "AppleUpstreamUserClient")
+            (deny (with message "AppleUpstreamUserClient")
                 iokit-external-method
             )
             (allow iokit-external-method
@@ -1182,7 +1205,7 @@
                 )
 #endif
             )
-            (deny (with telemetry)
+            (deny
                 iokit-async-external-method
                 iokit-external-trap
             )
@@ -1205,7 +1228,7 @@
             (iokit-user-client-class "AudioAUUC")
         )
         (apply-message-filter
-            (deny (with telemetry) (with message "AudioAUUC")
+            (deny (with message "AudioAUUC")
                 iokit-external-method
             )
             (allow iokit-external-method
@@ -1219,7 +1242,7 @@
                 )
 #endif
             )
-            (deny (with telemetry)
+            (deny
                 iokit-async-external-method
                 iokit-external-trap
             )
@@ -1241,7 +1264,7 @@
             (iokit-user-client-class "IOAudioControlUserClient")
         )
         (apply-message-filter
-            (deny (with telemetry)
+            (deny
                 iokit-async-external-method
                 iokit-external-trap
                 iokit-external-method
@@ -1264,7 +1287,7 @@
             (iokit-user-client-class "IOAudioEngineUserClient")
         )
         (apply-message-filter
-            (deny (with telemetry)
+            (deny
                 iokit-async-external-method
                 iokit-external-trap
                 iokit-external-method
@@ -1361,9 +1384,6 @@
 
 ;; Audio
 (allow ipc-posix-shm-read* ipc-posix-shm-write-data
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
-    (with telemetry)
-#endif
     (ipc-posix-name-prefix "AudioIO"))
 
 #if !ENABLE(SET_WEBCONTENT_PROCESS_INFORMATION_IN_NETWORK_PROCESS)
@@ -1547,7 +1567,7 @@
     (allow mach-lookup
         (global-name "com.apple.system.notification_center")
         (apply-message-filter
-            (deny mach-message-send (with telemetry))
+            (deny mach-message-send)
             (deny mach-message-send (with no-report) (message-number 1023))
             (allow mach-message-send (message-number
                 1002
@@ -1685,10 +1705,10 @@
                 (iokit-user-client-class "IOUSBDeviceUserClientV2")
             )
             (apply-message-filter
-                (allow (with telemetry)
+                (allow
                     iokit-external-method
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                 )
@@ -1710,10 +1730,10 @@
                 (iokit-user-client-class "IOUSBInterfaceUserClientV2")
             )
             (apply-message-filter
-                (allow (with telemetry)
+                (allow
                     iokit-external-method
                 )
-                (deny (with telemetry)
+                (deny
                     iokit-async-external-method
                     iokit-external-trap
                 )
@@ -1786,12 +1806,12 @@
     (fsctl-command (_IO "h" 47))) ;; See <rdar://74387453>
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
-(deny file-ioctl (with telemetry))
+(deny file-ioctl)
 (allow file-ioctl (literal "/dev/dtracehelper"))
-(deny socket-ioctl (with telemetry))
+(deny socket-ioctl)
 
 (when (defined? 'system-fcntl)
-    (deny system-fcntl (with telemetry))
+    (deny system-fcntl)
     (allow system-fcntl
        (fcntl-command
             F_ADDFILESIGS_RETURN ;; ImageLoaderMachO::loadCodeSignature
@@ -1823,9 +1843,9 @@
         (allow system-fcntl (appcache-fcntl-commands)))
     (with-filter (state-flag "AppCacheDisabled")
         (deny system-fcntl
-            (with telemetry)
+            
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
-            (with telemetry-backtrace)
+            
 #endif
             (appcache-fcntl-commands)))
 #else
@@ -1839,11 +1859,11 @@
 
 (when (defined? 'process-codesigning*)
     ;; csops/csops_audittoken
-    (deny process-codesigning-text-offset-get (with telemetry))
-    (deny process-codesigning-cdhash-get (with telemetry))
-    (deny process-codesigning-blob-get (with telemetry))
-    (deny process-codesigning-teamid-get (with telemetry))
-    (allow process-codesigning-identity-get (with telemetry)) ;; codeSigningIdentifierForCurrentProcess
+    (deny process-codesigning-text-offset-get)
+    (deny process-codesigning-cdhash-get)
+    (deny process-codesigning-blob-get)
+    (deny process-codesigning-teamid-get)
+    (allow process-codesigning-identity-get) ;; codeSigningIdentifierForCurrentProcess
     (allow process-codesigning-entitlements-blob-get) ;; WK reading entitlments via SecTaskCopyValueForEntitlement and _getSelfParsedEntitlements (accessibility)
     (allow process-codesigning-status-get) ;; _xpc_get_entitlements
     (allow process-codesigning-status-set (target self))
@@ -1852,12 +1872,12 @@
 
 (when (defined? 'socket-option-get)
     ;; getsockopt
-    (deny socket-option-get (with telemetry))
+    (deny socket-option-get)
 )
 
 (when (defined? 'socket-option-set)
     ;; setsockopt
-    (deny socket-option-set (with telemetry))
+    (deny socket-option-set)
 )
 #endif
 
@@ -2077,7 +2097,7 @@
 (define (allow-mach-bootstrap-with-filter)
     (allow mach-bootstrap
         (apply-message-filter
-            (deny mach-message-send (with telemetry))
+            (deny mach-message-send)
             (allow mach-message-send
                 (mach-bootstrap-message-numbers)))))
 
@@ -2088,8 +2108,8 @@
         (if (require-ancestor-with-entitlement "com.apple.private.security.enable-state-flags")
             (allow mach-bootstrap
                 (apply-message-filter
-                    (deny mach-message-send (with telemetry-backtrace))
-                    (allow mach-message-send (with telemetry-backtrace)
+                    (deny mach-message-send)
+                    (allow mach-message-send 
                         (mach-bootstrap-message-numbers-post-launch))))
         ;; else
             (allow-mach-bootstrap-with-filter))
@@ -2105,7 +2125,7 @@
 #else
     (allow mach-bootstrap
         (apply-message-filter
-            (deny xpc-message-send (with telemetry))
+            (deny xpc-message-send)
             (allow xpc-message-send
                 (mach-bootstrap-message-numbers)))))
 #endif
@@ -2257,7 +2277,7 @@
 
 (when (equal? (param "CPU") "arm64")
     (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow iokit-open (with report)
+        (allow iokit-open
             (require-all
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-user-client-class
@@ -2269,7 +2289,7 @@
 #endif
         )
         ; else
-        (allow iokit-open (with report)
+        (allow iokit-open
             (require-all
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-user-client-class
@@ -2279,7 +2299,7 @@
         )
     )
     (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow iokit-open (with report)
+        (allow iokit-open
             (require-all
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-user-client-class
@@ -2291,7 +2311,7 @@
 #endif
         )
         ; else
-        (allow iokit-open (with report)
+        (allow iokit-open
             (require-all
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-user-client-class
@@ -2359,7 +2379,7 @@
 )
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 110000
-(deny darwin-notification-post (with telemetry))
+(deny darwin-notification-post)
 (allow darwin-notification-post
     (notification-name
         "com.apple.accessibility.AirPodsSpatialAudioLockToDeviceChanged"
@@ -2368,8 +2388,9 @@
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 110000
 (deny file-read* (with no-report)
-    (home-literal
-        "/Library/Preferences/com.apple.CFNetwork.plist"
-    )
+    (home-literal "/Library/Preferences/com.apple.CFNetwork.plist")
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+    (home-literal "/Library/Preferences/com.apple.networkd.plist")
+#endif
 )
 #endif


### PR DESCRIPTION
#### bb43456a2d03332548b492ecc9a74934801bbc91
<pre>
[macOS] Suppress sandbox reports and telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=243450">https://bugs.webkit.org/show_bug.cgi?id=243450</a>
&lt;rdar://97082153&gt;

Reviewed by Chris Dumez.

Improve performance and power usage by suppressing sandbox reports and telemetry on macOS.
No behavior change is introduced in this patch.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/253112@main">https://commits.webkit.org/253112@main</a>
</pre>
