### PR TITLE
[webkitperl] Define package webkitdirs and export functions used in other modules

### DIFF
--- a/Tools/Scripts/do-webcore-rename
+++ b/Tools/Scripts/do-webcore-rename
@@ -31,6 +31,7 @@
 use strict;
 use warnings;
 
+use File::Basename;
 use File::Find;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -24,6 +24,7 @@
 use strict;
 use warnings;
 use English;
+use File::Basename;
 use File::Copy qw/ move /;
 use File::Temp qw/ tempdir tempfile /;
 use FindBin;

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -32,6 +32,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use File::Spec;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/run-regexp-tests
+++ b/Tools/Scripts/run-regexp-tests
@@ -30,6 +30,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/run-sunspider
+++ b/Tools/Scripts/run-sunspider
@@ -26,6 +26,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -29,6 +29,7 @@
 use strict;
 use warnings;
 use Cwd qw(realpath);
+use File::Basename;
 use File::Path qw(make_path);
 use File::Spec;
 use FindBin;

--- a/Tools/Scripts/sunspider-compare-results
+++ b/Tools/Scripts/sunspider-compare-results
@@ -26,6 +26,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use File::Spec;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/update-webkit-libs-jhbuild
+++ b/Tools/Scripts/update-webkit-libs-jhbuild
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 use warnings;
+use File::Basename;
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;

--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -30,6 +30,7 @@
 # A script to expose WebKit's build directory detection logic to non-perl scripts.
 
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long;
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -29,6 +29,8 @@
 
 # Module to share code to get to WebKit directories.
 
+package webkitdirs;
+
 use strict;
 use version;
 use warnings;
@@ -67,38 +69,117 @@ BEGIN {
        &appDisplayNameFromBundle
        &appendToEnvironmentVariableList
        &archCommandLineArgumentsForRestrictedEnvironmentVariables
+       &architecture
+       &architecturesForProducts
+       &argumentsForConfiguration
+       &asanIsEnabled
        &availableXcodeSDKs
        &baseProductDir
+       &buildCMakeProjectOrExit
+       &buildVisualStudioProject
+       &buildXCodeProject
+       &buildXcodeScheme
+       &builtDylibPathForName
+       &canUseNinja
        &chdirWebKit
+       &checkForArgumentAndRemoveFromARGV
+       &checkForArgumentAndRemoveFromARGVGettingValue
+       &checkForArgumentAndRemoveFromArrayRef
+       &checkForArgumentAndRemoveFromArrayRefGettingValue
        &checkFrameworks
+       &checkRequiredSystemConfig
        &cmakeArgsFromFeatures
+       &configuration
+       &configuredXcodeWorkspace
+       &coverageIsEnabled
+       &currentPerlPath
        &currentSVNRevision
+       &debugMiniBrowser
        &debugSafari
+       &debugWebKitTestRunner
        &executableProductDir
-       &extractNonHostConfiguration
+       &exitStatus
+       &extractNonMacOSHostConfiguration
+       &forceOptimizationLevel
+       &formatBuildTime
+       &generateBuildSystemFromCMakeProject
+       &inFlatpakSandbox
        &iosVersion
+       &isARM64
+       &isAnyWindows
+       &isAppleCocoaWebKit
+       &isAppleMacWebKit
+       &isAppleWebKit
+       &isAppleWinWebKit
+       &isCMakeBuild
+       &isCygwin
+       &isEmbeddedWebKit
+       &isFTW
+       &isGenerateProjectOnly
+       &isGtk
+       &isInspectorFrontend
+       &isJSCOnly
+       &isPlayStation
+       &isWPE
+       &isWinCairo
+       &isWindows
+       &isX86_64
+       &jscPath
+       &jscProductDir
+       &launcherName
+       &launcherPath
+       &ltoMode
+       &markBaseProductDirectoryAsCreatedByXcodeBuildSystem
+       &maxCPULoad
+       &nativeArchitecture
        &nmPath
+       &numberOfCPUs
+       &osXVersion
+       &overrideConfiguredXcodeWorkspace
+       &parseAvailableXcodeSDKs
+       &passedArchitecture
        &passedConfiguration
+       &portName
        &prependToEnvironmentVariableList
        &printHelpAndExitForRunAndDebugWebKitAppIfNeeded
        &productDir
+       &prohibitUnknownPort
+       &relativeScriptsDir
+       &removeCMakeCache
+       &runGitUpdate
        &runIOSWebKitApp
+       &runInFlatpak
+       &runInFlatpakIfAvailable
        &runMacWebKitApp
+       &runWebKitTestRunner
        &safariPath
        &sdkDirectory
        &sdkPlatformDirectory
+       &setArchitecture
        &setConfiguration
+       &setConfigurationProductDir
+       &setPathForRunningWebKitApp
+       &setUpGuardMallocIfNeeded
+       &setupAppleWinEnv
        &setupMacWebKitEnvironment
        &setupUnixWebKitEnvironment
        &sharedCommandLineOptions
        &sharedCommandLineOptionsUsage
        &shouldUseFlatpak
-       &runInFlatpak
        &sourceDir
+       &splitVersionString
+       &tsanIsEnabled
+       &ubsanIsEnabled
        &willUseIOSDeviceSDK
        &willUseIOSSimulatorSDK
+       &winVersion
+       &wrapperPrefixIfNeeded
+       &xcodeSDK
+       &xcodeSDKPlatformName
        DO_NOT_USE_OPEN_COMMAND
+       Mac
        USE_OPEN_COMMAND
+       iOS
    );
    %EXPORT_TAGS = ( );
    @EXPORT_OK   = ();
@@ -1084,7 +1165,7 @@ sub XcodeOptions
     push @options, "ARCHS=$architecture" if $architecture;
     push @options, "SDKROOT=$xcodeSDK" if $xcodeSDK;
 
-    my @features = getFeatureOptionList();
+    my @features = webkitperl::FeatureList::getFeatureOptionList();
     foreach (@features) {
         if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
             push @options, "$_->{define}=";

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -29,6 +29,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -31,6 +31,8 @@
 # * A feature enabled here but not WebKitFeatures.cmake is EXPERIMENTAL.
 # * A feature enabled in WebKitFeatures.cmake but not here is a BUG.
 
+package webkitperl::FeatureList;
+
 use strict;
 use warnings;
 
@@ -573,7 +575,7 @@ my @features = (
 
 sub getFeatureOptionList()
 {
-    prohibitUnknownPort();
+    webkitdirs::prohibitUnknownPort();
     return @features;
 }
 

--- a/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/parser_unittests.pl
+++ b/Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/parser_unittests.pl
@@ -33,6 +33,7 @@ use Getopt::Long;
 use Test::More;
 use lib File::Spec->catdir($FindBin::Bin, "..");
 use LoadAsModule qw(PrepareChangeLog prepare-ChangeLog);
+use VCSUtils;
 
 sub captureOutput($);
 sub convertAbsolutePathToRelativeUnixPath($$);
@@ -133,8 +134,8 @@ sub captureOutput($)
 sub convertAbsolutePathToRelativeUnixPath($$)
 {
     my ($string, $path) = @_;
-    my $sourceDir = LoadAsModule::unixPath(LoadAsModule::sourceDir());
-    my $relativeUnixPath = LoadAsModule::unixPath($path);
+    my $sourceDir = unixPath(LoadAsModule::sourceDir());
+    my $relativeUnixPath = unixPath($path);
     $sourceDir .= "/" unless $sourceDir =~ m-/$-;
     my $quotedSourceDir = quotemeta($sourceDir);
     $relativeUnixPath  =~ s/$quotedSourceDir//;


### PR DESCRIPTION
#### ecde243930f2bd6202905b67322b95a38e6b9119
<pre>
[webkitperl] Define package webkitdirs and export functions used in other modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=243454">https://bugs.webkit.org/show_bug.cgi?id=243454</a>

Reviewed by Ross Kirsling.

Module &apos;webkitdirs.pm&apos; needs a package name definition, otherwise the export function mechanism
doesn&apos;t work.

What was happening until now was that all functions defined in &apos;webkitdirs.pm&apos; were exported into
the &apos;main&apos; namespace. A module living in the &apos;main&apos; namespace (that is, a module without a package
name), could use all functions defined in &apos;webkitdirs.pm&apos;. But a module with a package name would
need to append the namespace &apos;main&apos; to call a function defined in &apos;webkitdirs.pm&apos;.

Once the package name for &apos;webkitdirs&apos; was defined it was also necessary to export a few more
functions that were used in other modules.

* Tools/Scripts/webkitdirs.pm: Define module name and export functions used from other modules.
* Tools/Scripts/webkitperl/FeatureList.pm: Define module name.
* Tools/Scripts/webkitperl/prepare-ChangeLog_unittest/parser_unittests.pl:
(convertAbsolutePathToRelativeUnixPath): Function &apos;unixPath&apos; is not defined in LoadAsModule package
but VCSUtils.
* Tools/Scripts/do-webcore-rename: Use &apos;File::Basename&apos;.
* Tools/Scripts/package-root:
* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-regexp-tests:
* Tools/Scripts/run-sunspider:
* Tools/Scripts/set-webkit-configuration:
* Tools/Scripts/sunspider-compare-results:
* Tools/Scripts/update-webkit-libs-jhbuild:
* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitperl/BuildSubproject.pm:

Canonical link: <a href="https://commits.webkit.org/253110@main">https://commits.webkit.org/253110@main</a>
</pre>
