### PR TITLE
[MSE] Make startVideoFrameMetadataGathering idempotent

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1444,7 +1444,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged()
 
 void MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering()
 {
-    ASSERT(!m_videoFrameMetadataGatheringObserver && m_synchronizer);
+    if (m_videoFrameMetadataGatheringObserver)
+        return;
+    ASSERT(m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
     acceleratedRenderingStateChanged();
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1391,7 +1391,9 @@ void MediaPlayerPrivateWebM::clearTracks()
 
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
-    ASSERT(!m_videoFrameMetadataGatheringObserver && m_synchronizer);
+    if (m_videoFrameMetadataGatheringObserver)
+        return;
+    ASSERT(m_synchronizer);
     m_isGatheringVideoFrameMetadata = true;
     acceleratedRenderingStateChanged();
 


### PR DESCRIPTION
#### 0828cefc9534aa69c4de088250bba50427e46706
<pre>
[MSE] Make startVideoFrameMetadataGathering idempotent
<a href="https://bugs.webkit.org/show_bug.cgi?id=243457">https://bugs.webkit.org/show_bug.cgi?id=243457</a>
&lt;rdar://97986538&gt;

Reviewed by Eric Carlson.

Currently, startVideoFrameMetadataGathering asserts that it has not been
called before after 253011@main, however, there are multiple scenarios where
the gatherer needs to be &quot;ensured&quot; and nothing more. Since the function
is only called to ensure that a metadata gatherer is running without the
expectation a new gatherer will be created, we can make the method idempotent
rather than expecting it will only be called once.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::startVideoFrameMetadataGathering):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):

Canonical link: <a href="https://commits.webkit.org/253051@main">https://commits.webkit.org/253051@main</a>
</pre>
