### PR TITLE
<html> element should not have 'manifest' IDL attribute

### DIFF
--- a/LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest-expected.txt
+++ b/LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest-expected.txt
@@ -1,0 +1,10 @@
+This tests that manifest IDL attribute does not exist on html element
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS "manifest" in document.documentElement is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest.html
+++ b/LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+description('This tests that manifest IDL attribute does not exist on html element');
+shouldBeFalse('"manifest" in document.documentElement');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/URL-attribute-reflection-expected.txt
+++ b/LayoutTests/fast/dom/URL-attribute-reflection-expected.txt
@@ -18,7 +18,6 @@ PASS testURLReflection('href', 'area') is 'URL'
 PASS testURLReflection('href', 'link') is 'URL'
 PASS testURLReflection('href', 'base') is 'URL'
 FAIL testURLReflection('icon', 'command') should be URL. Was none.
-PASS testURLReflection('manifest', 'html') is 'URL'
 PASS testURLReflection('poster', 'video') is 'URL'
 PASS testURLReflection('src', 'audio') is 'URL'
 PASS testURLReflection('src', 'embed') is 'URL'

--- a/LayoutTests/fast/dom/URL-attribute-reflection.html
+++ b/LayoutTests/fast/dom/URL-attribute-reflection.html
@@ -58,7 +58,6 @@ shouldBe("testURLReflection('href', 'area')", "'URL'");
 shouldBe("testURLReflection('href', 'link')", "'URL'");
 shouldBe("testURLReflection('href', 'base')", "'URL'");
 shouldBe("testURLReflection('icon', 'command')", "'URL'");
-shouldBe("testURLReflection('manifest', 'html')", "'URL'");
 shouldBe("testURLReflection('poster', 'video')", "'URL'");
 shouldBe("testURLReflection('src', 'audio')", "'URL'");
 shouldBe("testURLReflection('src', 'embed')", "'URL'");

--- a/Source/WebCore/html/HTMLHtmlElement.idl
+++ b/Source/WebCore/html/HTMLHtmlElement.idl
@@ -21,6 +21,5 @@
     Exposed=Window
 ] interface HTMLHtmlElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString version;
-    [Reflect, URL] attribute DOMString manifest;
 };
 


### PR DESCRIPTION
#### 332debf04f061ac75ba6130142c68b310d5f0090
<pre>
&lt;html&gt; element should not have &apos;manifest&apos; IDL attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=58129">https://bugs.webkit.org/show_bug.cgi?id=58129</a>

Reviewed by Chris Dumez.

Removed manifest IDL attribute from the html element.

Blink removed this attribute in 2014:
<a href="https://github.com/chromium/chromium/commit/46d5f250f5b3171c2acfb48d9c97c52d35fd3db7">https://github.com/chromium/chromium/commit/46d5f250f5b3171c2acfb48d9c97c52d35fd3db7</a>

* LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest-expected.txt: Added.
* LayoutTests/fast/dom/HTMLHtmlElement/html-element-manifest.html: Added.
* LayoutTests/fast/dom/URL-attribute-reflection-expected.txt:
* LayoutTests/fast/dom/URL-attribute-reflection.html:
* Source/WebCore/html/HTMLHtmlElement.idl:

Canonical link: <a href="https://commits.webkit.org/253053@main">https://commits.webkit.org/253053@main</a>
</pre>
