### PR TITLE
Media element never populates its UA shadow if it was initially created in a document without browsing context

### DIFF
--- a/LayoutTests/media/audio-controls-adoptNode-expected.txt
+++ b/LayoutTests/media/audio-controls-adoptNode-expected.txt
@@ -1,0 +1,6 @@
+Test that UA shadow from 'controls' attribute is still populated when using adoptNode.
+
+EXPECTED (mediaElement.getAttribute('controls') == '') OK
+EXPECTED (shadow?.childNodes.length > '0') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-controls-adoptNode.html
+++ b/LayoutTests/media/audio-controls-adoptNode.html
@@ -1,0 +1,16 @@
+<p>Test that UA shadow from 'controls' attribute is still populated when using adoptNode.<p>
+<script src=video-test.js></script>
+<script>
+var parser = new DOMParser;
+mediaElement = parser.parseFromString("<audio controls></audio>", "text/html").body.children[0];
+
+document.body.appendChild(document.adoptNode(mediaElement));
+
+testExpected("mediaElement.getAttribute('controls')", "");
+
+var shadow = window.internals?.shadowRoot(mediaElement);
+testExpected("shadow?.childNodes.length", 0, ">");
+
+endTest();
+
+</script>

--- a/LayoutTests/media/video-controls-adoptNode-expected.txt
+++ b/LayoutTests/media/video-controls-adoptNode-expected.txt
@@ -1,0 +1,6 @@
+Test that UA shadow from 'controls' attribute is still populated when using adoptNode.
+
+EXPECTED (mediaElement.getAttribute('controls') == '') OK
+EXPECTED (shadow?.childNodes.length > '0') OK
+END OF TEST
+

--- a/LayoutTests/media/video-controls-adoptNode.html
+++ b/LayoutTests/media/video-controls-adoptNode.html
@@ -1,0 +1,16 @@
+<p>Test that UA shadow from 'controls' attribute is still populated when using adoptNode.<p>
+<script src=video-test.js></script>
+<script>
+var parser = new DOMParser;
+mediaElement = parser.parseFromString("<video controls></video>", "text/html").body.children[0];
+
+document.body.appendChild(document.adoptNode(mediaElement));
+
+testExpected("mediaElement.getAttribute('controls')", "");
+
+var shadow = window.internals?.shadowRoot(mediaElement);
+testExpected("shadow?.childNodes.length", 0, ">");
+
+endTest();
+
+</script>

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -903,9 +903,7 @@ private:
     enum class SleepType { None, Display, System };
     SleepType shouldDisableSleep() const;
 
-    void didAddUserAgentShadowRoot(ShadowRoot&) override;
     DOMWrapperWorld& ensureIsolatedWorld();
-    bool ensureMediaControlsInjectedScript();
 
     PlatformMediaSession::MediaType mediaType() const override;
     PlatformMediaSession::MediaType presentationType() const override;
@@ -939,7 +937,7 @@ private:
     void initializeMediaSession();
 
     void updateCaptionContainer();
-    void ensureMediaControlsShadowRoot();
+    bool ensureMediaControls();
 
     using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
     bool setupAndCallJS(const JSSetupFunction&);
@@ -1131,7 +1129,6 @@ private:
     bool m_parsingInProgress : 1;
     bool m_elementIsHidden : 1;
     bool m_elementWasRemovedFromDOM : 1;
-    bool m_creatingControls : 1;
     bool m_receivedLayoutSizeChanged : 1;
     bool m_hasEverNotifiedAboutPlaying : 1;
 
@@ -1152,6 +1149,9 @@ private:
     bool m_shouldAudioPlaybackRequireUserGesture : 1;
     bool m_shouldVideoPlaybackRequireUserGesture : 1;
     bool m_volumeLocked : 1;
+
+    enum class ControlsState : uint8_t { None, Initializing, Ready };
+    ControlsState m_controlsState { ControlsState::None };
 
     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
 


### PR DESCRIPTION
#### f331cc98c1de65a0a2523c674859e01c1011fc8d
<pre>
Media element never populates its UA shadow if it was initially created in a document without browsing context
<a href="https://bugs.webkit.org/show_bug.cgi?id=222657">https://bugs.webkit.org/show_bug.cgi?id=222657</a>
&lt;rdar://problem/75266631&gt;

Reviewed by Eric Carlson.

Previously, `HTMLMediaElement` relied on `didAddUserAgentShadowRoot` to call the JS `createControls`
that actually populates the UA shadow root. This did not work with `adoptNode` because in that case
the UA shadow root already existed and was already attached to the `&lt;video&gt;`, so it was not called.

Rather than rely on this single path to set up everything, instead have a `ControlsState` enum that
`HTMLMediaElement` can internally reason about to decide whether or not it needs to inject the JS
that creates `createControls` and then call it. This also has the added benefit of having those two
steps now be in the same place, whereas before they were split across two unrelated functions.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::HTMLMediaElement):
(WebCore::HTMLMediaElement::updateCaptionContainer):
(WebCore::HTMLMediaElement::virtualHasPendingActivity const):
(WebCore::HTMLMediaElement::configureTextTrackDisplay):
(WebCore::HTMLMediaElement::updateTextTrackDisplay):
(WebCore::HTMLMediaElement::updateTextTrackRepresentationImageIfNeeded):
(WebCore::HTMLMediaElement::configureMediaControls):
(WebCore::HTMLMediaElement::ensureMediaControls): Added.
(WebCore::HTMLMediaElement::getCurrentMediaControlsStatus):
(WebCore::HTMLMediaElement::ensureMediaControlsShadowRoot): Deleted.
(WebCore::HTMLMediaElement::ensureMediaControlsInjectedScript): Deleted.
(WebCore::HTMLMediaElement::didAddUserAgentShadowRoot): Deleted.

* LayoutTests/media/audio-controls-adoptNode.html: Added.
* LayoutTests/media/audio-controls-adoptNode-expected.txt: Added.
* LayoutTests/media/video-controls-adoptNode.html: Added.
* LayoutTests/media/video-controls-adoptNode-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/253225@main">https://commits.webkit.org/253225@main</a>
</pre>
