### PR TITLE
Can't decode empty formdata with fetch

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Consume empty response.formData() as FormData promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Consume empty request.formData() as FormData promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Consume empty response.formData() as FormData
+PASS Consume empty request.formData() as FormData
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js
@@ -2,6 +2,7 @@ promise_test(async t => {
   const res = new Response(new FormData());
   const fd = await res.formData();
   assert_true(fd instanceof FormData);
+  for (const pair of fd.entries()) { assert_true(false); }
 }, 'Consume empty response.formData() as FormData');
 
 promise_test(async t => {
@@ -11,4 +12,5 @@ promise_test(async t => {
   });
   const fd = await req.formData();
   assert_true(fd instanceof FormData);
+  for (const pair of fd.entries()) { assert_true(false); }
 }, 'Consume empty request.formData() as FormData');

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Consume empty response.formData() as FormData promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Consume empty request.formData() as FormData promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Consume empty response.formData() as FormData
+PASS Consume empty request.formData() as FormData
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -194,8 +194,6 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         if (!currentBoundary)
             return nullptr;
         const uint8_t* nextBoundary = static_cast<const uint8_t*>(memmem(currentBoundary + boundaryLength, length - (currentBoundary + boundaryLength - data), boundary.data(), boundaryLength));
-        if (!nextBoundary)
-            return nullptr;
         while (nextBoundary) {
             parseMultipartPart(currentBoundary + boundaryLength, nextBoundary - currentBoundary - boundaryLength - strlen("\r\n"), form.get());
             currentBoundary = nextBoundary;


### PR DESCRIPTION
#### 0cd625839811c575a0e4cf7e99d00154be80ceab
<pre>
Can&apos;t decode empty formdata with fetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=225238">https://bugs.webkit.org/show_bug.cgi?id=225238</a>

Reviewed by Youenn Fablet.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):

Canonical link: <a href="https://commits.webkit.org/253047@main">https://commits.webkit.org/253047@main</a>
</pre>
