### PR TITLE
Cloning a `textarea` should not set the initial selection at the end of the text content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
@@ -3,47 +3,47 @@ PASS textarea: select()
 PASS textarea: select() a second time (must not fire select)
 PASS textarea: select() disconnected node
 PASS textarea: select() event queue
-FAIL textarea: select() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: select() twice in disconnected node (must fire select only once)
 PASS textarea: selectionStart
 PASS textarea: selectionStart a second time (must not fire select)
 PASS textarea: selectionStart disconnected node
 PASS textarea: selectionStart event queue
-FAIL textarea: selectionStart twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionStart twice in disconnected node (must fire select only once)
 PASS textarea: selectionEnd
 PASS textarea: selectionEnd a second time (must not fire select)
 PASS textarea: selectionEnd disconnected node
 PASS textarea: selectionEnd event queue
-FAIL textarea: selectionEnd twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionEnd twice in disconnected node (must fire select only once)
 PASS textarea: selectionDirection
 FAIL textarea: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
 PASS textarea: selectionDirection disconnected node
 PASS textarea: selectionDirection event queue
-FAIL textarea: selectionDirection twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionDirection twice in disconnected node (must fire select only once)
 PASS textarea: setSelectionRange()
 PASS textarea: setSelectionRange() a second time (must not fire select)
 PASS textarea: setSelectionRange() disconnected node
 PASS textarea: setSelectionRange() event queue
-FAIL textarea: setSelectionRange() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: setSelectionRange() twice in disconnected node (must fire select only once)
 PASS textarea: setRangeText()
 PASS textarea: setRangeText() a second time (must not fire select)
 PASS textarea: setRangeText() disconnected node
 PASS textarea: setRangeText() event queue
-FAIL textarea: setRangeText() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 15
+PASS textarea: setRangeText() twice in disconnected node (must fire select only once)
 PASS textarea: selectionStart out of range
 PASS textarea: selectionStart out of range a second time (must not fire select)
-FAIL textarea: selectionStart out of range disconnected node assert_true: event didn't fire expected true got false
-FAIL textarea: selectionStart out of range event queue assert_true: event didn't fire expected true got false
-FAIL textarea: selectionStart out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionStart out of range disconnected node
+PASS textarea: selectionStart out of range event queue
+PASS textarea: selectionStart out of range twice in disconnected node (must fire select only once)
 PASS textarea: selectionEnd out of range
 PASS textarea: selectionEnd out of range a second time (must not fire select)
-FAIL textarea: selectionEnd out of range disconnected node assert_true: event didn't fire expected true got false
-FAIL textarea: selectionEnd out of range event queue assert_true: event didn't fire expected true got false
-FAIL textarea: selectionEnd out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionEnd out of range disconnected node
+PASS textarea: selectionEnd out of range event queue
+PASS textarea: selectionEnd out of range twice in disconnected node (must fire select only once)
 PASS textarea: setSelectionRange out of range
 PASS textarea: setSelectionRange out of range a second time (must not fire select)
-FAIL textarea: setSelectionRange out of range disconnected node assert_true: event didn't fire expected true got false
-FAIL textarea: setSelectionRange out of range event queue assert_true: event didn't fire expected true got false
-FAIL textarea: setSelectionRange out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: setSelectionRange out of range disconnected node
+PASS textarea: setSelectionRange out of range event queue
+PASS textarea: setSelectionRange out of range twice in disconnected node (must fire select only once)
 PASS input type text: select()
 PASS input type text: select() a second time (must not fire select)
 PASS input type text: select() disconnected node

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
@@ -3,47 +3,47 @@ PASS textarea: select()
 PASS textarea: select() a second time (must not fire select)
 PASS textarea: select() disconnected node
 PASS textarea: select() event queue
-FAIL textarea: select() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: select() twice in disconnected node (must fire select only once)
 PASS textarea: selectionStart
 PASS textarea: selectionStart a second time (must not fire select)
 PASS textarea: selectionStart disconnected node
 PASS textarea: selectionStart event queue
-FAIL textarea: selectionStart twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionStart twice in disconnected node (must fire select only once)
 PASS textarea: selectionEnd
 PASS textarea: selectionEnd a second time (must not fire select)
 PASS textarea: selectionEnd disconnected node
 PASS textarea: selectionEnd event queue
-FAIL textarea: selectionEnd twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionEnd twice in disconnected node (must fire select only once)
 PASS textarea: selectionDirection
 FAIL textarea: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
 PASS textarea: selectionDirection disconnected node
 PASS textarea: selectionDirection event queue
-FAIL textarea: selectionDirection twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionDirection twice in disconnected node (must fire select only once)
 PASS textarea: setSelectionRange()
 PASS textarea: setSelectionRange() a second time (must not fire select)
 PASS textarea: setSelectionRange() disconnected node
 PASS textarea: setSelectionRange() event queue
-FAIL textarea: setSelectionRange() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: setSelectionRange() twice in disconnected node (must fire select only once)
 PASS textarea: setRangeText()
 PASS textarea: setRangeText() a second time (must not fire select)
 PASS textarea: setRangeText() disconnected node
 PASS textarea: setRangeText() event queue
-FAIL textarea: setRangeText() twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 15
+PASS textarea: setRangeText() twice in disconnected node (must fire select only once)
 PASS textarea: selectionStart out of range
 PASS textarea: selectionStart out of range a second time (must not fire select)
 PASS textarea: selectionStart out of range disconnected node
 PASS textarea: selectionStart out of range event queue
-FAIL textarea: selectionStart out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionStart out of range twice in disconnected node (must fire select only once)
 PASS textarea: selectionEnd out of range
 PASS textarea: selectionEnd out of range a second time (must not fire select)
 PASS textarea: selectionEnd out of range disconnected node
 PASS textarea: selectionEnd out of range event queue
-FAIL textarea: selectionEnd out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: selectionEnd out of range twice in disconnected node (must fire select only once)
 PASS textarea: setSelectionRange out of range
 PASS textarea: setSelectionRange out of range a second time (must not fire select)
 PASS textarea: setSelectionRange out of range disconnected node
 PASS textarea: setSelectionRange out of range event queue
-FAIL textarea: setSelectionRange out of range twice in disconnected node (must fire select only once) assert_equals: expected 0 but got 6
+PASS textarea: setSelectionRange out of range twice in disconnected node (must fire select only once)
 PASS input type text: select()
 PASS input type text: select() a second time (must not fire select)
 PASS input type text: select() disconnected node

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -583,7 +583,7 @@ void HTMLTextAreaElement::copyNonAttributePropertiesFromElement(const Element& s
 {
     auto& sourceElement = downcast<HTMLTextAreaElement>(source);
 
-    setValueCommon(sourceElement.value(), DispatchNoEvent, TextControlSetValueSelection::SetSelectionToEnd);
+    setValueCommon(sourceElement.value(), DispatchNoEvent, TextControlSetValueSelection::DoNotSet);
     m_isDirty = sourceElement.m_isDirty;
     HTMLTextFormControlElement::copyNonAttributePropertiesFromElement(source);
 


### PR DESCRIPTION
#### 32e61eadf821383b518f9cb06c8375111d0e89f4
<pre>
Cloning a `textarea` should not set the initial selection at the end of the text content
<a href="https://bugs.webkit.org/show_bug.cgi?id=243462">https://bugs.webkit.org/show_bug.cgi?id=243462</a>

Reviewed by Aditya Keerthi.

One of the subtests in `html/semantics/forms/textfieldselection/select-event.html` verifies that
after cloning a `textarea` element (but without attaching it to the document), the `selectionEnd` of
the `textarea` is at the start. However, after 248526@main, we started using the `SetSelectionToEnd`
flag when copying the value for cloned `textarea` elements.

As far as I can tell, this particular change wasn&apos;t necessary to pass any other web platform tests,
and additionally causes `select-event.html` to fail; as such, we should simply revert to using
`DoNotSet` here.

Changes covered by rebaselining the web platform test below (`select-event.html`).

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::copyNonAttributePropertiesFromElement):

Canonical link: <a href="https://commits.webkit.org/253070@main">https://commits.webkit.org/253070@main</a>
</pre>
