### PR TITLE
v2: CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::SourceBufferPrivateAVFObjC::layerDidReceiveError

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -40,6 +40,7 @@
 #include "TrackBuffer.h"
 #include "VideoTrackPrivate.h"
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
 #include <wtf/StringPrintStream.h>
 
@@ -551,6 +552,12 @@ void SourceBufferPrivate::updateTrackIds(Vector<std::pair<AtomString, AtomString
             continue;
         m_trackBufferMap.add(newId, makeUniqueRefFromNonNullUniquePtr(WTFMove(trackBuffer)));
     }
+}
+
+void SourceBufferPrivate::setClient(SourceBufferPrivateClient* client)
+{
+    ASSERT(isMainThread());
+    m_client = client;
 }
 
 void SourceBufferPrivate::setAllTrackBuffersNeedRandomAccess()

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -46,6 +46,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
@@ -101,7 +102,7 @@ public:
     WEBCORE_EXPORT virtual void seekToTime(const MediaTime&);
     WEBCORE_EXPORT virtual void updateTrackIds(Vector<std::pair<AtomString, AtomString>>&& trackIdPairs);
 
-    void setClient(SourceBufferPrivateClient* client) { m_client = client; }
+    WEBCORE_EXPORT void setClient(SourceBufferPrivateClient*);
     void setIsAttached(bool flag) { m_isAttached = flag; }
 
     const TimeRanges* buffered() const { return m_buffered.get(); }
@@ -153,7 +154,7 @@ protected:
     WEBCORE_EXPORT void setBufferedRanges(const PlatformTimeRanges&);
     void provideMediaData(const AtomString& trackID);
 
-    SourceBufferPrivateClient* m_client { nullptr };
+    WeakPtr<SourceBufferPrivateClient> m_client;
 
 private:
     void updateHighestPresentationTimestamp();

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -30,6 +30,7 @@
 #include "MediaDescription.h"
 #include <wtf/MediaTime.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ class MediaDescription;
 class PlatformTimeRanges;
 class VideoTrackPrivate;
 
-class SourceBufferPrivateClient {
+class SourceBufferPrivateClient : public CanMakeWeakPtr<SourceBufferPrivateClient> {
 public:
     virtual ~SourceBufferPrivateClient() = default;
 


### PR DESCRIPTION
#### f21c25fbef9b0febbada182d994d28cdfe0d3362
<pre>
v2: CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::SourceBufferPrivateAVFObjC::layerDidReceiveError
<a href="https://bugs.webkit.org/show_bug.cgi?id=243463">https://bugs.webkit.org/show_bug.cgi?id=243463</a>
&lt;rdar://96642283&gt;

Reviewed by Jer Noble.

By making the SourceBufferPrivateClient be held onto as a WeakPtr rather
than a raw pointer, we can check whether or not the object is alive before
calling it inside layerDidReceiveError.

Tested by forcibly deconstructing the client before calling layerDidReceiveError.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::setClient):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::setClient): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:

Canonical link: <a href="https://commits.webkit.org/253062@main">https://commits.webkit.org/253062@main</a>
</pre>
