### PR TITLE
[Gardening]: [ GTK iOS15 wk2 ] compositing/overflow/rtl-scrollbar-layer-positioning.html is failing since added in r260445

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2288,3 +2288,5 @@ imported/w3c/web-platform-tests/speech-api/idlharness.window.html [ Failure ]
 
 # rdar://97297483 ([ iOS16 ] fast/events/ios/rotation/zz-no-rotation.html is a constant timeout =)
 fast/events/ios/rotation/zz-no-rotation.html [ Timeout ]
+
+webkit.org/b/210849 compositing/overflow/rtl-scrollbar-layer-positioning.html [ Pass Timeout ]


### PR DESCRIPTION
#### 017325709f184a4932520c398bdae5364cf058ec
<pre>
[Gardening]: [ GTK iOS15 wk2 ] compositing/overflow/rtl-scrollbar-layer-positioning.html is failing since added in r260445
<a href="https://bugs.webkit.org/show_bug.cgi?id=210849">https://bugs.webkit.org/show_bug.cgi?id=210849</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253050@main">https://commits.webkit.org/253050@main</a>
</pre>
