### PR TITLE
REGRESSION(252930@main): [ iOS15 ] 3 Mathml (layout-tests) are constant text failures

### DIFF
--- a/LayoutTests/platform/ios-15/mathml/presentation/mo-stretch-expected.txt
+++ b/LayoutTests/platform/ios-15/mathml/presentation/mo-stretch-expected.txt
@@ -1,0 +1,310 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x259
+  RenderBlock {HTML} at (0,0) size 800x259
+    RenderBody {BODY} at (8,8) size 784x243
+      RenderMathMLMath {math} at (0,0) size 108x25
+        RenderMathMLRow {mrow} at (0,0) size 108x25
+          RenderMathMLOperator {mo} at (0,6) size 6x14
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "("
+          RenderMathMLOperator {mo} at (5,6) size 6x14
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: ")"
+          RenderMathMLOperator {mo} at (10,6) size 9x14
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "{"
+          RenderMathMLOperator {mo} at (18,6) size 8x14
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "}"
+          RenderMathMLOperator {mo} at (25,6) size 7x14
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "["
+          RenderMathMLOperator {mo} at (31,6) size 6x14
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "]"
+          RenderMathMLOperator {mo} at (36,5) size 9x15
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2308}"
+          RenderMathMLOperator {mo} at (44,5) size 8x15
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2309}"
+          RenderMathMLOperator {mo} at (51,5) size 9x15
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230A}"
+          RenderMathMLOperator {mo} at (59,5) size 8x15
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230B}"
+          RenderMathMLOperator {mo} at (66,3) size 9x19
+            RenderBlock (anonymous) at (0,0) size 8x20
+              RenderText {#text} at (0,-3) size 8x25
+                text run at (0,-3) width 8: "\x{222B}"
+          RenderMathMLOperator {mo} at (74,0) size 8x25
+            RenderBlock (anonymous) at (0,0) size 4x12
+              RenderText {#text} at (0,-6) size 4x25
+                text run at (0,-6) width 4: "|"
+          RenderMathMLOperator {mo} at (81,1) size 9x15
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2016}"
+          RenderMathMLOperator {mo} at (89,1) size 19x15
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2225}"
+      RenderText {#text} at (107,1) size 5x19
+        text run at (107,1) width 5: " "
+      RenderBR {BR} at (0,0) size 0x0
+      RenderMathMLMath {math} at (0,25) size 123x143
+        RenderMathMLRow {mrow} at (0,0) size 123x143
+          RenderMathMLOperator {mo} at (0,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "("
+          RenderMathMLOperator {mo} at (7,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: ")"
+          RenderMathMLOperator {mo} at (14,0) size 11x143
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "{"
+          RenderMathMLOperator {mo} at (24,0) size 11x143
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "}"
+          RenderMathMLOperator {mo} at (34,0) size 9x143
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "["
+          RenderMathMLOperator {mo} at (42,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "]"
+          RenderMathMLOperator {mo} at (49,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2308}"
+          RenderMathMLOperator {mo} at (56,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2309}"
+          RenderMathMLOperator {mo} at (63,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230A}"
+          RenderMathMLOperator {mo} at (70,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230B}"
+          RenderMathMLOperator {mo} at (77,0) size 13x143
+            RenderBlock (anonymous) at (0,0) size 8x20
+              RenderText {#text} at (0,-3) size 8x25
+                text run at (0,-3) width 8: "\x{222B}"
+          RenderMathMLOperator {mo} at (89,0) size 8x143
+            RenderBlock (anonymous) at (0,0) size 4x12
+              RenderText {#text} at (0,-6) size 4x25
+                text run at (0,-6) width 4: "|"
+          RenderMathMLOperator {mo} at (96,0) size 9x76
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2016}"
+          RenderMathMLOperator {mo} at (104,0) size 19x76
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2225}"
+          RenderMathMLSpace {mspace} at (122,0) size 0x76
+      RenderText {#text} at (122,85) size 5x19
+        text run at (122,85) width 5: " "
+      RenderMathMLMath {math} at (126,50) size 123x93
+        RenderMathMLRow {mrow} at (0,0) size 123x93
+          RenderMathMLOperator {mo} at (0,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "("
+          RenderMathMLOperator {mo} at (7,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: ")"
+          RenderMathMLOperator {mo} at (14,0) size 11x93
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "{"
+          RenderMathMLOperator {mo} at (24,0) size 11x93
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "}"
+          RenderMathMLOperator {mo} at (34,0) size 9x93
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "["
+          RenderMathMLOperator {mo} at (42,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "]"
+          RenderMathMLOperator {mo} at (49,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2308}"
+          RenderMathMLOperator {mo} at (56,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2309}"
+          RenderMathMLOperator {mo} at (63,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230A}"
+          RenderMathMLOperator {mo} at (70,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230B}"
+          RenderMathMLOperator {mo} at (77,0) size 13x93
+            RenderBlock (anonymous) at (0,0) size 8x20
+              RenderText {#text} at (0,-3) size 8x25
+                text run at (0,-3) width 8: "\x{222B}"
+          RenderMathMLOperator {mo} at (89,0) size 8x93
+            RenderBlock (anonymous) at (0,0) size 4x12
+              RenderText {#text} at (0,-6) size 4x25
+                text run at (0,-6) width 4: "|"
+          RenderMathMLOperator {mo} at (96,0) size 9x51
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2016}"
+          RenderMathMLOperator {mo} at (104,0) size 19x51
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2225}"
+          RenderMathMLSpace {mspace} at (122,0) size 0x51
+      RenderText {#text} at (248,85) size 5x19
+        text run at (248,85) width 5: " "
+      RenderMathMLMath {math} at (252,80) size 114x33
+        RenderMathMLRow {mrow} at (0,0) size 114x33
+          RenderMathMLOperator {mo} at (0,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "("
+          RenderMathMLOperator {mo} at (7,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: ")"
+          RenderMathMLOperator {mo} at (14,10) size 9x14
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "{"
+          RenderMathMLOperator {mo} at (22,10) size 8x14
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "}"
+          RenderMathMLOperator {mo} at (29,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "["
+          RenderMathMLOperator {mo} at (36,0) size 9x33
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "]"
+          RenderMathMLOperator {mo} at (44,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2308}"
+          RenderMathMLOperator {mo} at (51,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2309}"
+          RenderMathMLOperator {mo} at (58,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230A}"
+          RenderMathMLOperator {mo} at (65,0) size 8x33
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230B}"
+          RenderMathMLOperator {mo} at (72,7) size 10x19
+            RenderBlock (anonymous) at (0,0) size 8x20
+              RenderText {#text} at (0,-3) size 8x25
+                text run at (0,-3) width 8: "\x{222B}"
+          RenderMathMLOperator {mo} at (81,0) size 7x33
+            RenderBlock (anonymous) at (0,0) size 4x12
+              RenderText {#text} at (0,-6) size 4x25
+                text run at (0,-6) width 4: "|"
+          RenderMathMLOperator {mo} at (87,3) size 10x15
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2016}"
+          RenderMathMLOperator {mo} at (96,3) size 18x15
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2225}"
+          RenderMathMLSpace {mspace} at (113,0) size 0x21
+      RenderText {#text} at (365,85) size 5x19
+        text run at (365,85) width 5: " "
+      RenderBR {BR} at (0,0) size 0x0
+      RenderMathMLMath {math} at (0,168) size 137x75
+        RenderMathMLRoot {msqrt} at (0,0) size 137x75
+          RenderMathMLOperator {mo} at (14,1) size 9x74
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "("
+          RenderMathMLOperator {mo} at (22,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: ")"
+          RenderMathMLOperator {mo} at (29,1) size 11x74
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "{"
+          RenderMathMLOperator {mo} at (39,1) size 11x74
+            RenderBlock (anonymous) at (0,0) size 8x14
+              RenderText {#text} at (0,-6) size 8x25
+                text run at (0,-6) width 8: "}"
+          RenderMathMLOperator {mo} at (49,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "["
+          RenderMathMLOperator {mo} at (56,1) size 9x74
+            RenderBlock (anonymous) at (0,0) size 6x14
+              RenderText {#text} at (0,-6) size 6x25
+                text run at (0,-6) width 6: "]"
+          RenderMathMLOperator {mo} at (64,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2308}"
+          RenderMathMLOperator {mo} at (71,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{2309}"
+          RenderMathMLOperator {mo} at (78,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230A}"
+          RenderMathMLOperator {mo} at (85,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 8x16
+              RenderText {#text} at (0,-5) size 8x25
+                text run at (0,-5) width 8: "\x{230B}"
+          RenderMathMLOperator {mo} at (92,1) size 13x74
+            RenderBlock (anonymous) at (0,0) size 8x20
+              RenderText {#text} at (0,-3) size 8x25
+                text run at (0,-3) width 8: "\x{222B}"
+          RenderMathMLOperator {mo} at (104,1) size 8x74
+            RenderBlock (anonymous) at (0,0) size 4x12
+              RenderText {#text} at (0,-6) size 4x25
+                text run at (0,-6) width 4: "|"
+          RenderMathMLOperator {mo} at (111,1) size 9x42
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2016}"
+          RenderMathMLOperator {mo} at (119,1) size 18x42
+            RenderBlock (anonymous) at (0,0) size 9x16
+              RenderText {#text} at (0,-5) size 9x25
+                text run at (0,-5) width 9: "\x{2225}"
+          RenderMathMLSpace {mspace} at (137,1) size 0x42
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-15/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/ios-15/mathml/presentation/roots-expected.txt
@@ -1,0 +1,536 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x506
+  RenderBlock {html} at (0,0) size 800x506
+    RenderBody {body} at (8,16) size 784x474
+      RenderBlock {p} at (0,0) size 784x22
+        RenderText {#text} at (0,0) size 181x19
+          text run at (0,0) width 181: "square root (should be red): "
+        RenderMathMLMath {math} at (180,2) size 24x20
+          RenderMathMLRoot {msqrt} at (0,0) size 23x20 [color=#FF0000]
+            RenderMathMLToken {mn} at (14,1) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "2"
+      RenderBlock {p} at (0,38) size 784x22
+        RenderText {#text} at (0,0) size 113x19
+          text run at (0,0) width 113: "long square root: "
+        RenderMathMLMath {math} at (112,2) size 51x20
+          RenderMathMLRoot {msqrt} at (0,0) size 50x20
+            RenderMathMLRow {mrow} at (14,1) size 36x13
+              RenderMathMLToken {mi} at (0,4) size 9x8 [padding: 0 2 0 0]
+                RenderBlock (anonymous) at (0,0) size 8x8
+                  RenderText {#text} at (0,-9) size 8x25
+                    text run at (0,-9) width 8: "x"
+              RenderMathMLOperator {mo} at (8,2) size 19x10
+                RenderBlock (anonymous) at (3,0) size 12x10
+                  RenderText {#text} at (0,-8) size 11x25
+                    text run at (0,-8) width 11: "+"
+              RenderMathMLToken {mn} at (26,0) size 9x11
+                RenderBlock (anonymous) at (0,0) size 8x11
+                  RenderText {#text} at (0,-6) size 8x25
+                    text run at (0,-6) width 8: "1"
+      RenderBlock {p} at (0,76) size 784x23
+        RenderText {#text} at (0,3) size 227x19
+          text run at (0,3) width 227: "long square root with implied row: "
+        RenderMathMLMath {math} at (226,0) size 60x20
+          RenderMathMLRoot {msqrt} at (0,0) size 59x20
+            RenderMathMLScripts {msup} at (14,1) size 19x18
+              RenderMathMLToken {mi} at (0,9) size 9x8 [padding: 0 2 0 0]
+                RenderBlock (anonymous) at (0,0) size 8x8
+                  RenderText {#text} at (0,-9) size 8x25
+                    text run at (0,-9) width 8: "x"
+              RenderMathMLToken {mn} at (8,0) size 7x9
+                RenderBlock (anonymous) at (0,0) size 6x9
+                  RenderText {#text} at (0,-4) size 6x19
+                    text run at (0,-4) width 6: "2"
+            RenderMathMLOperator {mo} at (32,8) size 19x11
+              RenderBlock (anonymous) at (3,0) size 12x10
+                RenderText {#text} at (0,-8) size 11x25
+                  text run at (0,-8) width 11: "+"
+            RenderMathMLToken {mn} at (50,6) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "1"
+      RenderBlock {p} at (0,115) size 784x28
+        RenderText {#text} at (0,4) size 117x19
+          text run at (0,4) width 117: "root of a fraction: "
+        RenderMathMLMath {math} at (116,0) size 51x29
+          RenderMathMLRoot {msqrt} at (0,0) size 50x29
+            RenderMathMLFraction {mfrac} at (14,1) size 36x28
+              RenderMathMLRow {mrow} at (0,0) size 35x12
+                RenderMathMLToken {mi} at (0,4) size 9x8 [padding: 0 2 0 0]
+                  RenderBlock (anonymous) at (0,0) size 8x8
+                    RenderText {#text} at (0,-9) size 8x25
+                      text run at (0,-9) width 8: "x"
+                RenderMathMLOperator {mo} at (8,2) size 19x10
+                  RenderBlock (anonymous) at (3,0) size 12x10
+                    RenderText {#text} at (0,-8) size 11x25
+                      text run at (0,-8) width 11: "+"
+                RenderMathMLToken {mn} at (26,0) size 9x11
+                  RenderBlock (anonymous) at (0,0) size 8x11
+                    RenderText {#text} at (0,-6) size 8x25
+                      text run at (0,-6) width 8: "1"
+              RenderMathMLRow {mrow} at (0,14) size 35x13
+                RenderMathMLToken {mi} at (0,4) size 9x8 [padding: 0 2 0 0]
+                  RenderBlock (anonymous) at (0,0) size 8x8
+                    RenderText {#text} at (0,-9) size 8x25
+                      text run at (0,-9) width 8: "x"
+                RenderMathMLOperator {mo} at (8,2) size 19x10
+                  RenderBlock (anonymous) at (3,0) size 12x10
+                    RenderText {#text} at (0,-8) size 11x25
+                      text run at (0,-8) width 11: "+"
+                RenderMathMLToken {mn} at (26,0) size 9x11
+                  RenderBlock (anonymous) at (0,0) size 8x11
+                    RenderText {#text} at (0,-6) size 8x25
+                      text run at (0,-6) width 8: "2"
+      RenderBlock {p} at (0,159) size 784x22
+        RenderText {#text} at (0,0) size 177x19
+          text run at (0,0) width 177: "cube root (should be blue): "
+        RenderMathMLMath {math} at (176,1) size 24x21 [color=#0000FF]
+          RenderMathMLRoot {mroot} at (0,0) size 23x21
+            RenderMathMLToken {mn} at (14,2) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "2"
+            RenderMathMLToken {mn} at (4,0) size 5x9
+              RenderBlock (anonymous) at (0,0) size 5x8
+                RenderText {#text} at (0,-3) size 5x15
+                  text run at (0,-3) width 5: "3"
+      RenderBlock {p} at (0,197) size 784x22
+        RenderText {#text} at (0,0) size 77x19
+          text run at (0,0) width 77: "long index: "
+        RenderMathMLMath {math} at (76,1) size 54x21
+          RenderMathMLRoot {mroot} at (0,0) size 53x21
+            RenderMathMLToken {mn} at (44,2) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "2"
+            RenderMathMLRow {mrow} at (4,2) size 35x7
+              RenderMathMLToken {mi} at (0,1) size 5x5 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 5x5
+                  RenderText {#text} at (0,-5) size 5x15
+                    text run at (0,-5) width 5: "x"
+              RenderMathMLOperator {mo} at (4,0) size 12x6
+                RenderBlock (anonymous) at (2,0) size 7x6
+                  RenderText {#text} at (0,-5) size 7x15
+                    text run at (0,-5) width 7: "+"
+              RenderMathMLToken {mi} at (15,1) size 5x6 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 5x7
+                  RenderText {#text} at (0,-5) size 5x15
+                    text run at (0,-5) width 5: "y"
+              RenderMathMLOperator {mo} at (19,0) size 11x6
+                RenderBlock (anonymous) at (2,0) size 7x6
+                  RenderText {#text} at (0,-5) size 7x15
+                    text run at (0,-5) width 7: "+"
+              RenderMathMLToken {mi} at (29,1) size 6x5 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 4x5
+                  RenderText {#text} at (0,-5) size 4x15
+                    text run at (0,-5) width 4: "z"
+      RenderBlock {p} at (0,235) size 784x29
+        RenderText {#text} at (0,5) size 188x19
+          text run at (0,5) width 188: "long index w/ complex base: "
+        RenderMathMLMath {math} at (187,0) size 81x29
+          RenderMathMLRoot {mroot} at (0,0) size 80x29
+            RenderMathMLFraction {mfrac} at (44,2) size 36x27
+              RenderMathMLRow {mrow} at (0,0) size 35x12
+                RenderMathMLToken {mi} at (0,4) size 9x8 [padding: 0 2 0 0]
+                  RenderBlock (anonymous) at (0,0) size 8x8
+                    RenderText {#text} at (0,-9) size 8x25
+                      text run at (0,-9) width 8: "x"
+                RenderMathMLOperator {mo} at (8,2) size 19x10
+                  RenderBlock (anonymous) at (3,0) size 12x10
+                    RenderText {#text} at (0,-8) size 11x25
+                      text run at (0,-8) width 11: "+"
+                RenderMathMLToken {mn} at (26,0) size 9x11
+                  RenderBlock (anonymous) at (0,0) size 8x11
+                    RenderText {#text} at (0,-6) size 8x25
+                      text run at (0,-6) width 8: "1"
+              RenderMathMLRow {mrow} at (0,14) size 35x13
+                RenderMathMLToken {mi} at (0,4) size 9x8 [padding: 0 2 0 0]
+                  RenderBlock (anonymous) at (0,0) size 8x8
+                    RenderText {#text} at (0,-9) size 8x25
+                      text run at (0,-9) width 8: "x"
+                RenderMathMLOperator {mo} at (8,2) size 19x10
+                  RenderBlock (anonymous) at (3,0) size 12x10
+                    RenderText {#text} at (0,-8) size 11x25
+                      text run at (0,-8) width 11: "+"
+                RenderMathMLToken {mn} at (26,0) size 9x11
+                  RenderBlock (anonymous) at (0,0) size 8x11
+                    RenderText {#text} at (0,-6) size 8x25
+                      text run at (0,-6) width 8: "2"
+            RenderMathMLRow {mrow} at (4,5) size 35x8
+              RenderMathMLToken {mi} at (0,1) size 5x5 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 5x5
+                  RenderText {#text} at (0,-5) size 5x15
+                    text run at (0,-5) width 5: "x"
+              RenderMathMLOperator {mo} at (4,0) size 12x6
+                RenderBlock (anonymous) at (2,0) size 7x6
+                  RenderText {#text} at (0,-5) size 7x15
+                    text run at (0,-5) width 7: "+"
+              RenderMathMLToken {mi} at (15,1) size 5x6 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 5x7
+                  RenderText {#text} at (0,-5) size 5x15
+                    text run at (0,-5) width 5: "y"
+              RenderMathMLOperator {mo} at (19,0) size 11x6
+                RenderBlock (anonymous) at (2,0) size 7x6
+                  RenderText {#text} at (0,-5) size 7x15
+                    text run at (0,-5) width 7: "+"
+              RenderMathMLToken {mi} at (29,1) size 6x5 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 4x5
+                  RenderText {#text} at (0,-5) size 4x15
+                    text run at (0,-5) width 4: "z"
+      RenderBlock {p} at (0,280) size 784x28
+        RenderText {#text} at (0,6) size 77x19
+          text run at (0,6) width 77: "high index: "
+        RenderMathMLMath {math} at (76,0) size 24x29
+          RenderMathMLRoot {mroot} at (0,0) size 24x29
+            RenderMathMLToken {mn} at (15,10) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "2"
+            RenderMathMLFraction {mfrac} at (4,0) size 6x17
+              RenderMathMLFraction {mfrac} at (0,0) size 5x11
+                RenderMathMLToken {mi} at (0,0) size 5x5 [padding: 0 1 0 0]
+                  RenderBlock (anonymous) at (0,0) size 5x5
+                    RenderText {#text} at (0,-5) size 5x15
+                      text run at (0,-5) width 5: "x"
+                RenderMathMLToken {mi} at (0,5) size 5x6 [padding: 0 1 0 0]
+                  RenderBlock (anonymous) at (0,0) size 5x7
+                    RenderText {#text} at (0,-5) size 5x15
+                      text run at (0,-5) width 5: "y"
+              RenderMathMLToken {mi} at (0,12) size 5x5 [padding: 0 1 0 0]
+                RenderBlock (anonymous) at (0,0) size 4x5
+                  RenderText {#text} at (0,-5) size 4x15
+                    text run at (0,-5) width 4: "z"
+      RenderBlock {p} at (0,324) size 784x32
+        RenderText {#text} at (0,12) size 160x19
+          text run at (0,12) width 160: "Imbricated square roots: "
+        RenderMathMLMath {math} at (159,0) size 314x33
+          RenderMathMLRoot {msqrt} at (0,0) size 313x33
+            RenderMathMLToken {mn} at (14,15) size 9x12
+              RenderBlock (anonymous) at (0,0) size 8x11
+                RenderText {#text} at (0,-6) size 8x25
+                  text run at (0,-6) width 8: "1"
+            RenderMathMLOperator {mo} at (22,17) size 19x11
+              RenderBlock (anonymous) at (3,0) size 12x10
+                RenderText {#text} at (0,-8) size 11x25
+                  text run at (0,-8) width 11: "+"
+            RenderMathMLRoot {msqrt} at (40,1) size 273x32
+              RenderMathMLRow {mrow} at (14,1) size 258x30
+                RenderMathMLToken {mn} at (0,12) size 8x11
+                  RenderBlock (anonymous) at (0,0) size 8x11
+                    RenderText {#text} at (0,-6) size 8x25
+                      text run at (0,-6) width 8: "2"
+                RenderMathMLOperator {mo} at (8,14) size 19x10
+                  RenderBlock (anonymous) at (3,0) size 12x10
+                    RenderText {#text} at (0,-8) size 11x25
+                      text run at (0,-8) width 11: "+"
+                RenderMathMLRoot {msqrt} at (26,0) size 231x29
+                  RenderMathMLRow {mrow} at (14,1) size 217x28
+                    RenderMathMLToken {mn} at (0,10) size 8x12
+                      RenderBlock (anonymous) at (0,0) size 8x12
+                        RenderText {#text} at (0,-6) size 8x25
+                          text run at (0,-6) width 8: "3"
+                    RenderMathMLOperator {mo} at (8,12) size 19x10
+                      RenderBlock (anonymous) at (3,0) size 12x10
+                        RenderText {#text} at (0,-8) size 11x25
+                          text run at (0,-8) width 11: "+"
+                    RenderMathMLRoot {msqrt} at (26,0) size 190x27
+                      RenderMathMLRow {mrow} at (14,1) size 176x26
+                        RenderMathMLToken {mn} at (0,8) size 8x11
+                          RenderBlock (anonymous) at (0,0) size 8x11
+                            RenderText {#text} at (0,-6) size 8x25
+                              text run at (0,-6) width 8: "4"
+                        RenderMathMLOperator {mo} at (8,10) size 19x10
+                          RenderBlock (anonymous) at (3,0) size 12x10
+                            RenderText {#text} at (0,-8) size 11x25
+                              text run at (0,-8) width 11: "+"
+                        RenderMathMLRoot {msqrt} at (26,0) size 150x26
+                          RenderMathMLRow {mrow} at (14,1) size 136x25
+                            RenderMathMLToken {mn} at (0,5) size 8x13
+                              RenderBlock (anonymous) at (0,0) size 8x13
+                                RenderText {#text} at (0,-5) size 8x25
+                                  text run at (0,-5) width 8: "5"
+                            RenderMathMLOperator {mo} at (8,8) size 19x10
+                              RenderBlock (anonymous) at (3,0) size 12x10
+                                RenderText {#text} at (0,-8) size 11x25
+                                  text run at (0,-8) width 11: "+"
+                            RenderMathMLRoot {msqrt} at (26,0) size 109x24
+                              RenderMathMLRow {mrow} at (14,1) size 95x23
+                                RenderMathMLToken {mn} at (0,4) size 8x12
+                                  RenderBlock (anonymous) at (0,0) size 8x12
+                                    RenderText {#text} at (0,-6) size 8x25
+                                      text run at (0,-6) width 8: "6"
+                                RenderMathMLOperator {mo} at (8,6) size 19x10
+                                  RenderBlock (anonymous) at (3,0) size 12x10
+                                    RenderText {#text} at (0,-8) size 11x25
+                                      text run at (0,-8) width 11: "+"
+                                RenderMathMLRoot {msqrt} at (26,0) size 68x22
+                                  RenderMathMLRow {mrow} at (14,1) size 54x21
+                                    RenderMathMLToken {mn} at (0,2) size 8x12
+                                      RenderBlock (anonymous) at (0,0) size 8x12
+                                        RenderText {#text} at (0,-6) size 8x25
+                                          text run at (0,-6) width 8: "7"
+                                    RenderMathMLOperator {mo} at (8,4) size 19x10
+                                      RenderBlock (anonymous) at (3,0) size 12x10
+                                        RenderText {#text} at (0,-8) size 11x25
+                                          text run at (0,-8) width 11: "+"
+                                    RenderMathMLRoot {msqrt} at (26,0) size 27x20
+                                      RenderMathMLToken {mi} at (14,1) size 13x12 [padding: 0 2 0 0]
+                                        RenderBlock (anonymous) at (0,0) size 12x11
+                                          RenderText {#text} at (0,-6) size 12x25
+                                            text run at (0,-6) width 12: "A"
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {p} at (0,372) size 784x43
+        RenderText {#text} at (0,23) size 114x19
+          text run at (0,23) width 114: "Imbricated roots: "
+        RenderMathMLMath {math} at (113,0) size 329x42
+          RenderMathMLRoot {mroot} at (0,0) size 329x42
+            RenderMathMLRow {mrow} at (14,2) size 315x40
+              RenderMathMLToken {mn} at (0,24) size 8x11
+                RenderBlock (anonymous) at (0,0) size 8x11
+                  RenderText {#text} at (0,-6) size 8x25
+                    text run at (0,-6) width 8: "1"
+              RenderMathMLOperator {mo} at (8,26) size 19x10
+                RenderBlock (anonymous) at (3,0) size 12x10
+                  RenderText {#text} at (0,-8) size 11x25
+                    text run at (0,-8) width 11: "+"
+              RenderMathMLRoot {mroot} at (26,0) size 288x40
+                RenderMathMLRow {mrow} at (14,2) size 274x38
+                  RenderMathMLToken {mn} at (0,21) size 8x11
+                    RenderBlock (anonymous) at (0,0) size 8x11
+                      RenderText {#text} at (0,-6) size 8x25
+                        text run at (0,-6) width 8: "2"
+                  RenderMathMLOperator {mo} at (8,23) size 19x10
+                    RenderBlock (anonymous) at (3,0) size 12x10
+                      RenderText {#text} at (0,-8) size 11x25
+                        text run at (0,-8) width 11: "+"
+                  RenderMathMLRoot {mroot} at (26,0) size 247x37
+                    RenderMathMLRow {mrow} at (14,2) size 233x35
+                      RenderMathMLToken {mn} at (0,18) size 8x12
+                        RenderBlock (anonymous) at (0,0) size 8x12
+                          RenderText {#text} at (0,-6) size 8x25
+                            text run at (0,-6) width 8: "3"
+                      RenderMathMLOperator {mo} at (8,20) size 19x10
+                        RenderBlock (anonymous) at (3,0) size 12x10
+                          RenderText {#text} at (0,-8) size 11x25
+                            text run at (0,-8) width 11: "+"
+                      RenderMathMLRoot {mroot} at (26,0) size 206x35
+                        RenderMathMLRow {mrow} at (14,2) size 192x33
+                          RenderMathMLToken {mn} at (0,15) size 8x11
+                            RenderBlock (anonymous) at (0,0) size 8x11
+                              RenderText {#text} at (0,-6) size 8x25
+                                text run at (0,-6) width 8: "4"
+                          RenderMathMLOperator {mo} at (8,17) size 19x10
+                            RenderBlock (anonymous) at (3,0) size 12x10
+                              RenderText {#text} at (0,-8) size 11x25
+                                text run at (0,-8) width 11: "+"
+                          RenderMathMLRoot {mroot} at (26,0) size 165x32
+                            RenderMathMLRow {mrow} at (14,2) size 151x30
+                              RenderMathMLToken {mn} at (0,11) size 8x13
+                                RenderBlock (anonymous) at (0,0) size 8x13
+                                  RenderText {#text} at (0,-5) size 8x25
+                                    text run at (0,-5) width 8: "5"
+                              RenderMathMLOperator {mo} at (8,14) size 19x10
+                                RenderBlock (anonymous) at (3,0) size 12x10
+                                  RenderText {#text} at (0,-8) size 11x25
+                                    text run at (0,-8) width 11: "+"
+                              RenderMathMLRoot {mroot} at (26,0) size 124x30
+                                RenderMathMLRow {mrow} at (14,2) size 110x28
+                                  RenderMathMLToken {mn} at (0,9) size 8x12
+                                    RenderBlock (anonymous) at (0,0) size 8x12
+                                      RenderText {#text} at (0,-6) size 8x25
+                                        text run at (0,-6) width 8: "6"
+                                  RenderMathMLOperator {mo} at (8,11) size 19x10
+                                    RenderBlock (anonymous) at (3,0) size 12x10
+                                      RenderText {#text} at (0,-8) size 11x25
+                                        text run at (0,-8) width 11: "+"
+                                  RenderMathMLRoot {mroot} at (26,0) size 83x27
+                                    RenderMathMLRow {mrow} at (14,2) size 69x25
+                                      RenderMathMLToken {mn} at (0,6) size 8x12
+                                        RenderBlock (anonymous) at (0,0) size 8x12
+                                          RenderText {#text} at (0,-6) size 8x25
+                                            text run at (0,-6) width 8: "7"
+                                      RenderMathMLOperator {mo} at (8,8) size 19x10
+                                        RenderBlock (anonymous) at (3,0) size 12x10
+                                          RenderText {#text} at (0,-8) size 11x25
+                                            text run at (0,-8) width 11: "+"
+                                      RenderMathMLRoot {mroot} at (26,0) size 42x24
+                                        RenderMathMLToken {mi} at (29,5) size 13x12 [padding: 0 2 0 0]
+                                          RenderBlock (anonymous) at (0,0) size 12x11
+                                            RenderText {#text} at (0,-6) size 12x25
+                                              text run at (0,-6) width 12: "A"
+                                        RenderMathMLFraction {mfrac} at (4,0) size 20x13
+                                          RenderMathMLRow {mrow} at (0,0) size 20x7
+                                            RenderMathMLToken {mi} at (0,1) size 5x5 [padding: 0 1 0 0]
+                                              RenderBlock (anonymous) at (0,0) size 5x5
+                                                RenderText {#text} at (0,-5) size 5x15
+                                                  text run at (0,-5) width 5: "x"
+                                            RenderMathMLOperator {mo} at (4,0) size 12x6
+                                              RenderBlock (anonymous) at (2,0) size 7x6
+                                                RenderText {#text} at (0,-5) size 7x15
+                                                  text run at (0,-5) width 7: "+"
+                                            RenderMathMLToken {mi} at (15,1) size 5x6 [padding: 0 1 0 0]
+                                              RenderBlock (anonymous) at (0,0) size 5x7
+                                                RenderText {#text} at (0,-5) size 5x15
+                                                  text run at (0,-5) width 5: "y"
+                                          RenderMathMLToken {mi} at (7,7) size 6x6 [padding: 0 1 0 0]
+                                            RenderBlock (anonymous) at (0,0) size 4x5
+                                              RenderText {#text} at (0,-5) size 4x15
+                                                text run at (0,-5) width 4: "z"
+                                    RenderMathMLToken {mn} at (4,3) size 5x9
+                                      RenderBlock (anonymous) at (0,0) size 5x8
+                                        RenderText {#text} at (0,-3) size 5x15
+                                          text run at (0,-3) width 5: "9"
+                                RenderMathMLToken {mn} at (4,4) size 5x9
+                                  RenderBlock (anonymous) at (0,0) size 5x8
+                                    RenderText {#text} at (0,-3) size 5x15
+                                      text run at (0,-3) width 5: "8"
+                            RenderMathMLToken {mn} at (4,6) size 5x8
+                              RenderBlock (anonymous) at (0,0) size 5x7
+                                RenderText {#text} at (0,-4) size 5x15
+                                  text run at (0,-4) width 5: "7"
+                        RenderMathMLToken {mn} at (4,6) size 5x9
+                          RenderBlock (anonymous) at (0,0) size 5x8
+                            RenderText {#text} at (0,-3) size 5x15
+                              text run at (0,-3) width 5: "6"
+                    RenderMathMLToken {mn} at (4,7) size 5x9
+                      RenderBlock (anonymous) at (0,0) size 5x8
+                        RenderText {#text} at (0,-3) size 5x15
+                          text run at (0,-3) width 5: "5"
+                RenderMathMLToken {mn} at (4,9) size 5x8
+                  RenderBlock (anonymous) at (0,0) size 5x7
+                    RenderText {#text} at (0,-3) size 5x15
+                      text run at (0,-3) width 5: "4"
+            RenderMathMLToken {mn} at (4,9) size 5x9
+              RenderBlock (anonymous) at (0,0) size 5x8
+                RenderText {#text} at (0,-3) size 5x15
+                  text run at (0,-3) width 5: "3"
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {p} at (0,431) size 784x43
+        RenderText {#text} at (0,23) size 74x19
+          text run at (0,23) width 74: "RTL roots: "
+        RenderMathMLMath {math} at (73,0) size 329x42
+          RenderMathMLRoot {mroot} at (0,0) size 329x42
+            RenderMathMLRow {mrow} at (0,2) size 314x40
+              RenderMathMLToken {mn} at (305,24) size 9x11
+                RenderBlock (anonymous) at (0,0) size 8x11
+                  RenderText {#text} at (0,-6) size 8x25
+                    text run at (0,-6) width 8: "1"
+              RenderMathMLOperator {mo} at (287,26) size 19x10
+                RenderBlock (anonymous) at (3,0) size 12x10
+                  RenderText {#text} at (0,-8) size 11x25
+                    text run at (0,-8) width 11 RTL: "+"
+              RenderMathMLRoot {mroot} at (0,0) size 288x40
+                RenderMathMLRow {mrow} at (0,2) size 273x38
+                  RenderMathMLToken {mn} at (264,21) size 9x11
+                    RenderBlock (anonymous) at (0,0) size 8x11
+                      RenderText {#text} at (0,-6) size 8x25
+                        text run at (0,-6) width 8: "2"
+                  RenderMathMLOperator {mo} at (246,23) size 19x10
+                    RenderBlock (anonymous) at (3,0) size 12x10
+                      RenderText {#text} at (0,-8) size 11x25
+                        text run at (0,-8) width 11 RTL: "+"
+                  RenderMathMLRoot {mroot} at (0,0) size 247x37
+                    RenderMathMLRow {mrow} at (0,2) size 232x35
+                      RenderMathMLToken {mn} at (223,18) size 9x12
+                        RenderBlock (anonymous) at (0,0) size 8x12
+                          RenderText {#text} at (0,-6) size 8x25
+                            text run at (0,-6) width 8: "3"
+                      RenderMathMLOperator {mo} at (205,20) size 19x10
+                        RenderBlock (anonymous) at (3,0) size 12x10
+                          RenderText {#text} at (0,-8) size 11x25
+                            text run at (0,-8) width 11 RTL: "+"
+                      RenderMathMLRoot {mroot} at (0,0) size 206x35
+                        RenderMathMLRow {mrow} at (0,2) size 191x33
+                          RenderMathMLToken {mn} at (182,15) size 9x11
+                            RenderBlock (anonymous) at (0,0) size 8x11
+                              RenderText {#text} at (0,-6) size 8x25
+                                text run at (0,-6) width 8: "4"
+                          RenderMathMLOperator {mo} at (164,17) size 19x10
+                            RenderBlock (anonymous) at (3,0) size 12x10
+                              RenderText {#text} at (0,-8) size 11x25
+                                text run at (0,-8) width 11 RTL: "+"
+                          RenderMathMLRoot {mroot} at (0,0) size 165x32
+                            RenderMathMLRow {mrow} at (0,2) size 150x30
+                              RenderMathMLToken {mn} at (141,11) size 9x13
+                                RenderBlock (anonymous) at (0,0) size 8x13
+                                  RenderText {#text} at (0,-5) size 8x25
+                                    text run at (0,-5) width 8: "5"
+                              RenderMathMLOperator {mo} at (123,14) size 19x10
+                                RenderBlock (anonymous) at (3,0) size 12x10
+                                  RenderText {#text} at (0,-8) size 11x25
+                                    text run at (0,-8) width 11 RTL: "+"
+                              RenderMathMLRoot {mroot} at (0,0) size 124x30
+                                RenderMathMLRow {mrow} at (0,2) size 109x28
+                                  RenderMathMLToken {mn} at (100,9) size 9x12
+                                    RenderBlock (anonymous) at (0,0) size 8x12
+                                      RenderText {#text} at (0,-6) size 8x25
+                                        text run at (0,-6) width 8: "6"
+                                  RenderMathMLOperator {mo} at (82,11) size 19x10
+                                    RenderBlock (anonymous) at (3,0) size 12x10
+                                      RenderText {#text} at (0,-8) size 11x25
+                                        text run at (0,-8) width 11 RTL: "+"
+                                  RenderMathMLRoot {mroot} at (0,0) size 83x27
+                                    RenderMathMLRow {mrow} at (0,2) size 68x25
+                                      RenderMathMLToken {mn} at (59,6) size 9x12
+                                        RenderBlock (anonymous) at (0,0) size 8x12
+                                          RenderText {#text} at (0,-6) size 8x25
+                                            text run at (0,-6) width 8: "7"
+                                      RenderMathMLOperator {mo} at (41,8) size 19x10
+                                        RenderBlock (anonymous) at (3,0) size 12x10
+                                          RenderText {#text} at (0,-8) size 11x25
+                                            text run at (0,-8) width 11 RTL: "+"
+                                      RenderMathMLRoot {mroot} at (0,0) size 42x24
+                                        RenderMathMLToken {mi} at (0,5) size 12x12 [padding: 0 0 0 2]
+                                          RenderBlock (anonymous) at (0,0) size 12x11
+                                            RenderText {#text} at (0,-6) size 12x25
+                                              text run at (0,-6) width 12: "A"
+                                        RenderMathMLFraction {mfrac} at (17,0) size 20x13
+                                          RenderMathMLRow {mrow} at (0,0) size 20x7
+                                            RenderMathMLToken {mi} at (14,1) size 6x5 [padding: 0 0 0 1]
+                                              RenderBlock (anonymous) at (0,0) size 5x5
+                                                RenderText {#text} at (0,-5) size 5x15
+                                                  text run at (0,-5) width 5: "x"
+                                            RenderMathMLOperator {mo} at (4,0) size 11x6
+                                              RenderBlock (anonymous) at (2,0) size 7x6
+                                                RenderText {#text} at (0,-5) size 7x15
+                                                  text run at (0,-5) width 7 RTL: "+"
+                                            RenderMathMLToken {mi} at (0,1) size 5x6 [padding: 0 0 0 1]
+                                              RenderBlock (anonymous) at (0,0) size 5x7
+                                                RenderText {#text} at (0,-5) size 5x15
+                                                  text run at (0,-5) width 5: "y"
+                                          RenderMathMLToken {mi} at (7,7) size 6x6 [padding: 0 0 0 1]
+                                            RenderBlock (anonymous) at (0,0) size 4x5
+                                              RenderText {#text} at (0,-5) size 4x15
+                                                text run at (0,-5) width 4: "z"
+                                    RenderMathMLToken {mn} at (73,3) size 5x9
+                                      RenderBlock (anonymous) at (0,0) size 5x8
+                                        RenderText {#text} at (0,-3) size 5x15
+                                          text run at (0,-3) width 5: "9"
+                                RenderMathMLToken {mn} at (114,4) size 5x9
+                                  RenderBlock (anonymous) at (0,0) size 5x8
+                                    RenderText {#text} at (0,-3) size 5x15
+                                      text run at (0,-3) width 5: "8"
+                            RenderMathMLToken {mn} at (155,6) size 5x8
+                              RenderBlock (anonymous) at (0,0) size 5x7
+                                RenderText {#text} at (0,-4) size 5x15
+                                  text run at (0,-4) width 5: "7"
+                        RenderMathMLToken {mn} at (196,6) size 5x9
+                          RenderBlock (anonymous) at (0,0) size 5x8
+                            RenderText {#text} at (0,-3) size 5x15
+                              text run at (0,-3) width 5: "6"
+                    RenderMathMLToken {mn} at (237,7) size 5x9
+                      RenderBlock (anonymous) at (0,0) size 5x8
+                        RenderText {#text} at (0,-3) size 5x15
+                          text run at (0,-3) width 5: "5"
+                RenderMathMLToken {mn} at (278,9) size 5x8
+                  RenderBlock (anonymous) at (0,0) size 5x7
+                    RenderText {#text} at (0,-3) size 5x15
+                      text run at (0,-3) width 5: "4"
+            RenderMathMLToken {mn} at (319,9) size 5x9
+              RenderBlock (anonymous) at (0,0) size 5x8
+                RenderText {#text} at (0,-3) size 5x15
+                  text run at (0,-3) width 5: "3"
+        RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-15/mathml/radical-fallback-expected.txt
+++ b/LayoutTests/platform/ios-15/mathml/radical-fallback-expected.txt
@@ -1,0 +1,23 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x222
+  RenderBlock {HTML} at (0,0) size 800x222
+    RenderBody {BODY} at (8,16) size 784x190
+      RenderBlock {P} at (0,0) size 784x87
+        RenderText {#text} at (0,67) size 132x19
+          text run at (0,67) width 132: "Large LTR radicals: "
+        RenderMathMLMath {math} at (131,0) size 25x82
+          RenderMathMLRoot {msqrt} at (0,0) size 15x82
+            RenderMathMLSpace {mspace} at (14,1) size 0x81
+          RenderMathMLRoot {msqrt} at (14,0) size 10x82
+            RenderMathMLSpace {mspace} at (8,1) size 0x81
+        RenderText {#text} at (0,0) size 0x0
+      RenderBlock {P} at (0,103) size 784x87
+        RenderText {#text} at (0,67) size 132x19
+          text run at (0,67) width 132: "Large RTL radicals: "
+        RenderMathMLMath {math} at (131,0) size 25x82
+          RenderMathMLRoot {msqrt} at (8,0) size 16x82
+            RenderMathMLSpace {mspace} at (0,1) size 0x81
+          RenderMathMLRoot {msqrt} at (0,0) size 9x82
+            RenderMathMLSpace {mspace} at (0,1) size 0x81
+        RenderText {#text} at (0,0) size 0x0


### PR DESCRIPTION
#### 4b895d0d35f370283014f7e140bc0cad9bb8dc29
<pre>
REGRESSION(252930@main): [ iOS15 ] 3 Mathml (layout-tests) are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=243465">https://bugs.webkit.org/show_bug.cgi?id=243465</a>
&lt;rdar://98006456&gt;

Unreviewed Rebasline.

* LayoutTests/platform/ios-15/mathml/presentation/mo-stretch-expected.txt: Added.
* LayoutTests/platform/ios-15/mathml/presentation/roots-expected.txt: Added.
* LayoutTests/platform/ios-15/mathml/radical-fallback-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/253052@main">https://commits.webkit.org/253052@main</a>
</pre>
