### PR TITLE
html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html is failing in WebKit

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -590,7 +590,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-elemen
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigate_history_go_forward.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc_change_hash.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-remove-children.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popups/popup-animated-hide-display.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verifies that one form used to target multiple frames in succession navigates all of them. Test timed out
+PASS Verifies that one form used to target multiple frames in succession navigates all of them.
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -322,8 +322,13 @@ void HTMLFormElement::submitIfPossible(Event* event, HTMLFormControlElement* sub
 
     m_isSubmittingOrPreparingForSubmission = false;
 
-    if (m_shouldSubmit)
-        submit(event, !submitter, trigger, submitter);
+    if (!m_shouldSubmit)
+        return;
+
+    if (auto plannedFormSubmission = std::exchange(m_plannedFormSubmission, nullptr))
+        plannedFormSubmission->cancel();
+
+    submit(event, !submitter, trigger, submitter);
 }
 
 void HTMLFormElement::submit()
@@ -440,9 +445,6 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
         formSubmission->setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
     if (relAttributes.noreferrer)
         formSubmission->setReferrerPolicy(ReferrerPolicy::NoReferrer);
-
-    if (m_plannedFormSubmission)
-        m_plannedFormSubmission->cancel();
 
     m_plannedFormSubmission = formSubmission;
 


### PR DESCRIPTION
#### 28180db1730cdc22b09a2315e17c55dbe37c4e7c
<pre>
html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243471">https://bugs.webkit.org/show_bug.cgi?id=243471</a>

Reviewed by Darin Adler.

Align with Gecko and Blink and allow a single form to submit to multiple frames concurrently
when using form.submit().

Previously, WebKit would always cancel the form&apos;s planned navigation when a new form submission
occurs. However, in other browsers, it seems to depend on the method used to submit the form.
In particular, form.submit() doesn&apos;t cancel the planned navigation while other methods (like
form.requestSubmit() do).

html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html covers the
case where we should not cancel the planned navigation.

imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets.html
covers a case where we&apos;re meant to cancel the planned navigation.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-multiple-targets-expected.txt:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitIfPossible):
(WebCore::HTMLFormElement::submit):

Canonical link: <a href="https://commits.webkit.org/253072@main">https://commits.webkit.org/253072@main</a>
</pre>
