### PR TITLE
[iOS] Safari sometimes crashes with an NSInternalInconsistencyException after long pressing on an image

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.h
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngine.h
@@ -30,6 +30,7 @@
 #include "WebsiteData.h"
 #include <WebCore/ClientOrigin.h>
 #include <pal/SessionID.h>
+#include <wtf/CallbackAggregator.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -38,10 +39,6 @@
 namespace IPC {
 class Connection;
 }
-
-namespace WTF {
-class CallbackAggregator;
-};
 
 namespace WebCore {
 struct RetrieveRecordsOptions;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -584,35 +584,10 @@ static ProcessAccessType computeWebProcessAccessTypeForDataRemoval(OptionSet<Web
     return ProcessAccessType::None;
 }
 
-class RemovalCallbackAggregator : public ThreadSafeRefCounted<RemovalCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
-public:
-    static Ref<RemovalCallbackAggregator> create(WebsiteDataStore& dataStore, CompletionHandler<void()>&& completionHandler)
-    {
-        return adoptRef(*new RemovalCallbackAggregator(dataStore, WTFMove(completionHandler)));
-    }
-
-    ~RemovalCallbackAggregator()
-    {
-        ASSERT(RunLoop::isMain());
-        RunLoop::main().dispatch(WTFMove(m_completionHandler));
-    }
-
-private:
-    RemovalCallbackAggregator(WebsiteDataStore& dataStore, CompletionHandler<void()>&& completionHandler)
-        : m_protectedDataStore(dataStore)
-        , m_completionHandler(WTFMove(completionHandler))
-    {
-        ASSERT(RunLoop::isMain());
-    }
-
-    Ref<WebsiteDataStore> m_protectedDataStore;
-    CompletionHandler<void()> m_completionHandler;
-};
-
 void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime modifiedSince, Function<void()>&& completionHandler)
 {
     RELEASE_LOG(Storage, "WebsiteDataStore::removeData started to delete data modified since %f for session %" PRIu64, modifiedSince.secondsSinceEpoch().value(), m_sessionID.toUInt64());
-    auto callbackAggregator = RemovalCallbackAggregator::create(*this, [sessionID = m_sessionID, completionHandler = WTFMove(completionHandler)] {
+    auto callbackAggregator = MainRunLoopCallbackAggregator::create([protectedThis = Ref { *this }, sessionID = m_sessionID, completionHandler = WTFMove(completionHandler)] {
         RELEASE_LOG(Storage, "WebsiteDataStore::removeData finished deleting modified data for session %" PRIu64, sessionID.toUInt64());
         completionHandler();
     });
@@ -697,7 +672,7 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, WallTime
 void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Vector<WebsiteDataRecord>& dataRecords, Function<void()>&& completionHandler)
 {
     RELEASE_LOG(Storage, "WebsiteDataStore::removeData started to delete data for session %" PRIu64, m_sessionID.toUInt64());
-    auto callbackAggregator = RemovalCallbackAggregator::create(*this, [sessionID = m_sessionID, completionHandler = WTFMove(completionHandler)] {
+    auto callbackAggregator = MainRunLoopCallbackAggregator::create([protectedThis = Ref { *this }, sessionID = m_sessionID, completionHandler = WTFMove(completionHandler)] {
         RELEASE_LOG(Storage, "WebsiteDataStore::removeData finished deleting data for session %" PRIu64, sessionID.toUInt64());
         completionHandler();
     });

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11003,7 +11003,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     data->hasSelectableText = hasTextResults;
 
     auto weakSelf = WeakObjCPtr<WKContentView>(self);
-    auto aggregator = CallbackAggregator::create([weakSelf, data]() mutable {
+    auto aggregator = MainRunLoopCallbackAggregator::create([weakSelf, data]() mutable {
         auto strongSelf = weakSelf.get();
         if (!strongSelf || !strongSelf->_waitingForDynamicImageAnalysisContextMenuActions)
             return;
@@ -11127,7 +11127,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
         // making redundant image analysis requests for the same image data.
 
         auto data = Box<WebKit::ImageAnalysisContextMenuActionData>::create();
-        auto aggregator = CallbackAggregator::create([weakSelf, location, data]() mutable {
+        auto aggregator = MainRunLoopCallbackAggregator::create([weakSelf, location, data]() mutable {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h
@@ -30,12 +30,9 @@
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/PartitionedSecurityOrigin.h>
 #include <WebCore/SecurityOrigin.h>
+#include <wtf/CallbackAggregator.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
-
-namespace WTF {
-class CallbackAggregator;
-}
 
 namespace WebCore {
 struct MessageWithMessagePorts;


### PR DESCRIPTION
#### 4d8b0ef1158ffb8caff351c0e4b11cf07f4b7298
<pre>
[iOS] Safari sometimes crashes with an NSInternalInconsistencyException after long pressing on an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=243464">https://bugs.webkit.org/show_bug.cgi?id=243464</a>
rdar://97436180

Reviewed by Chris Dumez.

After the changes in &lt;commits.webkit.org/250218@main&gt;, I started using `WTF::CallbackAggregator` to
allow the context menu to present (or continue presenting) after all three of:

- Visual Look Up analysis
- Object lifting (for &quot;Copy Subject&quot;)
- Machine-readable-code analysis

...have completed. To achieve this, I created a `Ref&lt;CallbackAggregator&gt;` that wraps the overall
`CompletionHandler`, and copied this `Ref` as a captured variable in each of the Objective-C blocks
that are passed into the three asynchronous analysis methods. When the ref-count of this aggregator
reaches 0, we then invoke the overall completion handler. However, there are corner cases in which
VisionKitCore might:

(1) ...never invoke the completion block we pass to it, and also
(2) ...destroy the completion block we give it on a background thread

In this scenario, the last reference to the `CallbackAggregator` may be removed on a background
thread, which means we&apos;ll end up trying to present (or update) the context menu interaction from the
background, thereby triggering this exception.

To fix this, we instead create and deploy an alternate version of `CallbackAggregator` that hops to
the main thread before calling the completion handler by subclassing `ThreadSafeRefCounted` with the
`DestructionThread::MainRunLoop` template parameter, in the case where the destructor is invoked on
the background.

* Source/WTF/wtf/CallbackAggregator.h:
(WTF::CallbackAggregatorOnThread::create):
(WTF::CallbackAggregatorOnThread::~CallbackAggregatorOnThread):
(WTF::CallbackAggregatorOnThread::CallbackAggregatorOnThread):
(WTF::CallbackAggregator::create): Deleted.
(WTF::CallbackAggregator::~CallbackAggregator): Deleted.
(WTF::CallbackAggregator::CallbackAggregator): Deleted.

Add support for `MainRunLoopCallbackAggregator`.

* Source/WebKit/NetworkProcess/cache/CacheStorageEngine.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::removeData):

Replace the existing `RemovalCallbackAggregator` with `MainRunLoopCallbackAggregator` here as well.

(WebKit::RemovalCallbackAggregator::create): Deleted.
(WebKit::RemovalCallbackAggregator::~RemovalCallbackAggregator): Deleted.
(WebKit::RemovalCallbackAggregator::RemovalCallbackAggregator): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:]):
(-[WKContentView imageAnalysisGestureDidTimeOut:]):

Deploy `MainRunLoopCallbackAggregator` in image analysis code, to ensure that the completion handler
is invoked on the main runloop.

* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h:

Canonical link: <a href="https://commits.webkit.org/253073@main">https://commits.webkit.org/253073@main</a>
</pre>
