### PR TITLE
Remove ancient immediate repaint hack in Element::setActive()

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7545,10 +7545,10 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
     };
 
     changeState(elementsToClearActive, CSSSelector::PseudoClassActive, false, [](auto& element) {
-        element.setActive(false, false, Style::InvalidationScope::SelfChildrenAndSiblings);
+        element.setActive(false, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
     changeState(elementsToSetActive, CSSSelector::PseudoClassActive, true, [](auto& element) {
-        element.setActive(true, false, Style::InvalidationScope::SelfChildrenAndSiblings);
+        element.setActive(true, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
     changeState(elementsToClearHover, CSSSelector::PseudoClassHover, false, [request](auto& element) {
         element.setHovered(false, Style::InvalidationScope::SelfChildrenAndSiblings, request);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -353,7 +353,7 @@ public:
     bool hasFocusVisible() const { return isUserActionElement() && isUserActionElementHasFocusVisible(); }
     bool hasFocusWithin() const { return isUserActionElement() && isUserActionElementHasFocusWithin(); };
 
-    virtual void setActive(bool = true, bool pause = false, Style::InvalidationScope = Style::InvalidationScope::All);
+    virtual void setActive(bool = true, Style::InvalidationScope = Style::InvalidationScope::All);
     virtual void setHovered(bool = true, Style::InvalidationScope = Style::InvalidationScope::All, HitTestRequest = {});
     virtual void setFocus(bool, FocusVisibility = FocusVisibility::Invisible);
     void setBeingDragged(bool);

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -97,7 +97,7 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
     if (mouseEventOptions != SendNoEvents)
         simulateMouseEvent(eventNames.mousedownEvent, element, underlyingEvent, creationOptions);
     if (mouseEventOptions != SendNoEvents || visualOptions == ShowPressedLook)
-        element.setActive(true, true);
+        element.setActive(true);
     if (mouseEventOptions != SendNoEvents)
         simulateMouseEvent(eventNames.mouseupEvent, element, underlyingEvent, creationOptions);
     element.setActive(false);

--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -70,7 +70,7 @@ auto BaseCheckableInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldC
     const String& key = event.keyIdentifier();
     if (key == "U+0020"_s) {
         ASSERT(element());
-        element()->setActive(true, true);
+        element()->setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case
         // and the caller will only dispatch a keypress if we don't call setDefaultHandled().
         return ShouldCallBaseEventHandler::No;

--- a/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
+++ b/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
@@ -43,7 +43,7 @@ auto BaseClickableWithKeyInputType::handleKeydownEvent(HTMLInputElement& element
 {
     const String& key = event.keyIdentifier();
     if (key == "U+0020"_s) {
-        element.setActive(true, true);
+        element.setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case
         // and the caller will only dispatch a keypress if we don't call setDefaultHandled().
         return ShouldCallBaseEventHandler::No;

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -213,7 +213,7 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
     HTMLElement::defaultEventHandler(event);
 }
 
-void HTMLAnchorElement::setActive(bool down, bool pause, Style::InvalidationScope invalidationScope)
+void HTMLAnchorElement::setActive(bool down, Style::InvalidationScope invalidationScope)
 {
     if (down && hasEditableStyle()) {
         switch (document().settings().editableLinkBehavior()) {
@@ -234,7 +234,7 @@ void HTMLAnchorElement::setActive(bool down, bool pause, Style::InvalidationScop
         }
     }
     
-    HTMLElement::setActive(down, pause, invalidationScope);
+    HTMLElement::setActive(down, invalidationScope);
 }
 
 void HTMLAnchorElement::parseAttribute(const QualifiedName& name, const AtomString& value)

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -90,7 +90,7 @@ private:
     bool isMouseFocusable() const override;
     bool isKeyboardFocusable(KeyboardEvent*) const override;
     void defaultEventHandler(Event&) final;
-    void setActive(bool active, bool pause, Style::InvalidationScope) final;
+    void setActive(bool active, Style::InvalidationScope) final;
     bool isURLAttribute(const Attribute&) const final;
     bool canStartSelection() const final;
     AtomString target() const override;

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -156,7 +156,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
     if (is<KeyboardEvent>(event)) {
         KeyboardEvent& keyboardEvent = downcast<KeyboardEvent>(event);
         if (keyboardEvent.type() == eventNames.keydownEvent && keyboardEvent.keyIdentifier() == "U+0020"_s) {
-            setActive(true, true);
+            setActive(true);
             // No setDefaultHandled() - IE dispatches a keypress in this case.
             return;
         }

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -86,17 +86,17 @@ HTMLFormElement* HTMLLabelElement::form() const
     return downcast<HTMLFormControlElement>(control.get())->form();
 }
 
-void HTMLLabelElement::setActive(bool down, bool pause, Style::InvalidationScope invalidationScope)
+void HTMLLabelElement::setActive(bool down, Style::InvalidationScope invalidationScope)
 {
     if (down == active())
         return;
 
     // Update our status first.
-    HTMLElement::setActive(down, pause, invalidationScope);
+    HTMLElement::setActive(down, invalidationScope);
 
     // Also update our corresponding control.
     if (auto element = control())
-        element->setActive(down, pause);
+        element->setActive(down);
 }
 
 void HTMLLabelElement::setHovered(bool over, Style::InvalidationScope invalidationScope, HitTestRequest request)

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -48,7 +48,7 @@ private:
     bool accessKeyAction(bool sendMouseEvents) final;
 
     // Overridden to update the hover/active state of the corresponding control.
-    void setActive(bool, bool pause, Style::InvalidationScope) final;
+    void setActive(bool, Style::InvalidationScope) final;
     void setHovered(bool, Style::InvalidationScope, HitTestRequest) final;
 
     // Overridden to either click() or focus() the corresponding control.

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -128,7 +128,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
         if (is<KeyboardEvent>(event)) {
             KeyboardEvent& keyboardEvent = downcast<KeyboardEvent>(event);
             if (keyboardEvent.type() == eventNames.keydownEvent && keyboardEvent.keyIdentifier() == "U+0020"_s) {
-                setActive(true, true);
+                setActive(true);
                 // No setDefaultHandled() - IE dispatches a keypress in this case.
                 return;
             }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -212,7 +212,6 @@ public:
     virtual std::optional<PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const = 0;
     virtual OptionSet<PointerCharacteristics> pointerCharacteristicsOfAllAvailablePointingDevices() const = 0;
 
-    virtual bool supportsImmediateInvalidation() { return false; }
     virtual void invalidateRootView(const IntRect&) = 0;
     virtual void invalidateContentsAndRootView(const IntRect&) = 0;
     virtual void invalidateContentsForSlowScroll(const IntRect&) = 0;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -95,7 +95,6 @@ private:
     bool runJavaScriptConfirm(WebCore::Frame&, const String&) override;
     bool runJavaScriptPrompt(WebCore::Frame&, const String& message, const String& defaultValue, String& result) override;
 
-    bool supportsImmediateInvalidation() final;
     void invalidateRootView(const WebCore::IntRect&) final;
     void invalidateContentsAndRootView(const WebCore::IntRect&) final;
     void invalidateContentsForSlowScroll(const WebCore::IntRect&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -545,11 +545,6 @@ void WebChromeClient::setStatusbarText(const String& status)
     }
 }
 
-bool WebChromeClient::supportsImmediateInvalidation()
-{
-    return true;
-}
-
 void WebChromeClient::invalidateRootView(const IntRect&)
 {
 }


### PR DESCRIPTION
#### febc2b35e81675c2ac913518602bb6acc388d91b
<pre>
Remove ancient immediate repaint hack in Element::setActive()
<a href="https://bugs.webkit.org/show_bug.cgi?id=174567">https://bugs.webkit.org/show_bug.cgi?id=174567</a>

Reviewed by Simon Fraser.

Based on work by Andreas Kling &lt;akling@apple.com&gt;.

Remove the &quot;pause&quot; flag from Element::setActive() that was used in ancient times
to have WebKit do a paint/sleep/paint maneuver. This clearly didn&apos;t fit with the
modern way of rendering and maintaining this esoteric Mac/WK1 quirk seems unnecessary.

* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setActive):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateClick):
* Source/WebCore/html/BaseCheckableInputType.cpp:
(WebCore::BaseCheckableInputType::handleKeydownEvent):
* Source/WebCore/html/BaseClickableWithKeyInputType.cpp:
(WebCore::BaseClickableWithKeyInputType::handleKeydownEvent):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::setActive):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::setActive):
* Source/WebCore/html/HTMLLabelElement.h:
* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::HTMLSummaryElement::defaultEventHandler):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::supportsImmediateInvalidation): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::supportsImmediateInvalidation): Deleted.

Canonical link: <a href="https://commits.webkit.org/253078@main">https://commits.webkit.org/253078@main</a>
</pre>
