### PR TITLE
[iOS] Tapping on Now Playing opens wrong app when using SFSafariViewController

### DIFF
--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -50,6 +50,7 @@
 #include "Quirks.h"
 #include "RenderMedia.h"
 #include "RenderView.h"
+#include "RuntimeApplicationChecks.h"
 #include "ScriptController.h"
 #include "Settings.h"
 #include "SourceBuffer.h"
@@ -1197,6 +1198,14 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
     double currentTime = m_element.currentTime();
     if (!std::isfinite(currentTime) || !supportsSeeking)
         currentTime = MediaPlayer::invalidTime();
+    auto sourceApplicationIdentifier = m_element.sourceApplicationIdentifier();
+#if PLATFORM(COCOA)
+    // FIXME: Eventually, this should be moved into HTMLMediaElement, so all clients
+    // will use the same bundle identifier (the presentingApplication, rather than the
+    // sourceApplication).
+    if (!presentingApplicationBundleIdentifier().isNull())
+        sourceApplicationIdentifier = presentingApplicationBundleIdentifier();
+#endif
 
 #if ENABLE(MEDIA_SESSION)
     auto* session = mediaSession();
@@ -1215,11 +1224,11 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
             ASSERT(sessionMetadata->artworkImage()->data(), "An image must always have associated data");
             artwork = NowPlayingInfoArtwork { sessionMetadata->artworkSrc(), sessionMetadata->artworkImage()->mimeType(), sessionMetadata->artworkImage()->data() };
         }
-        return NowPlayingInfo { sessionMetadata->title(), sessionMetadata->artist(), sessionMetadata->album(), m_element.sourceApplicationIdentifier(), duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, WTFMove(artwork) };
+        return NowPlayingInfo { sessionMetadata->title(), sessionMetadata->artist(), sessionMetadata->album(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, WTFMove(artwork) };
     }
 #endif
 
-    return NowPlayingInfo { m_element.mediaSessionTitle(), emptyString(), emptyString(), m_element.sourceApplicationIdentifier(), duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, { } };
+    return NowPlayingInfo { m_element.mediaSessionTitle(), emptyString(), emptyString(), sourceApplicationIdentifier, duration, currentTime, rate, supportsSeeking, m_element.mediaUniqueIdentifier(), isPlaying, allowsNowPlayingControlsVisibility, { } };
 }
 
 void MediaElementSession::updateMediaUsageIfChanged()

--- a/Source/WebCore/platform/RuntimeApplicationChecks.h
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.h
@@ -67,6 +67,9 @@ WEBCORE_EXPORT void setApplicationBundleIdentifierOverride(const String&);
 WEBCORE_EXPORT String applicationBundleIdentifier();
 WEBCORE_EXPORT void clearApplicationBundleIdentifierTestingOverride();
 
+WEBCORE_EXPORT void setPresentingApplicationBundleIdentifier(const String&);
+WEBCORE_EXPORT const String& presentingApplicationBundleIdentifier();
+
 namespace CocoaApplication {
 
 WEBCORE_EXPORT bool isIBooks();

--- a/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -91,6 +91,22 @@ void clearApplicationBundleIdentifierTestingOverride()
 #endif
 }
 
+static String& presentingApplicationBundleIdentifierStorage()
+{
+    static MainThreadNeverDestroyed<String> identifier;
+    return identifier;
+}
+
+void setPresentingApplicationBundleIdentifier(const String& identifier)
+{
+    presentingApplicationBundleIdentifierStorage() = identifier;
+}
+
+const String& presentingApplicationBundleIdentifier()
+{
+    return presentingApplicationBundleIdentifierStorage();
+}
+
 static bool applicationBundleIsEqualTo(const String& bundleIdentifierString)
 {
     return applicationBundleIdentifier() == bundleIdentifierString;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -93,6 +93,7 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << uiProcessBundleIdentifier;
     encoder << latencyQOS;
     encoder << throughputQOS;
+    encoder << presentingApplicationBundleIdentifier;
 #endif
     encoder << presentingApplicationPID;
 #if PLATFORM(COCOA)
@@ -319,6 +320,8 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
     if (!decoder.decode(parameters.latencyQOS))
         return false;
     if (!decoder.decode(parameters.throughputQOS))
+        return false;
+    if (!decoder.decode(parameters.presentingApplicationBundleIdentifier))
         return false;
 #endif
     if (!decoder.decode(parameters.presentingApplicationPID))

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -144,6 +144,7 @@ struct WebProcessCreationParameters {
     String uiProcessBundleIdentifier;
     int latencyQOS { 0 };
     int throughputQOS { 0 };
+    String presentingApplicationBundleIdentifier;
 #endif
 
     ProcessID presentingApplicationPID { 0 };

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -270,6 +270,8 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
     m_uiProcessBundleIdentifier = parameters.uiProcessBundleIdentifier;
 
+    WebCore::setPresentingApplicationBundleIdentifier(parameters.presentingApplicationBundleIdentifier);
+
 #if ENABLE(SANDBOX_EXTENSIONS)
     SandboxExtension::consumePermanently(parameters.uiProcessBundleResourcePathExtensionHandle);
 #if ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### 084e01d07525c8d55324a76d903c0ee5dd12b64b
<pre>
[iOS] Tapping on Now Playing opens wrong app when using SFSafariViewController
<a href="https://bugs.webkit.org/show_bug.cgi?id=243481">https://bugs.webkit.org/show_bug.cgi?id=243481</a>

Reviewed by Chris Dumez.

When creating a NowPlayingInfo struct, we use the sourceApplicationIdentifier,
which when running via SFSafariViewController, will be &quot;com.apple.SafariViewService&quot;.
But NowPlaying wants to know the presenting application, so that bundle identifier
must be plumbed down from the UIProcess to the WebContent process. The presenting
application PID is already sent, but is insufficient for the API we need to call.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::nowPlayingInfo const):
* Source/WebCore/platform/RuntimeApplicationChecks.h:
* Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm:
(WebCore::presentingApplicationBundleIdentifierStorage):
(WebCore::setPresentingApplicationBundleIdentifier):
(WebCore::presentingApplicationBundleIdentifier):
* Source/WebKit/Shared/WebProcessCreationParameters.cpp:
(WebKit::WebProcessCreationParameters::encode const):
(WebKit::WebProcessCreationParameters::decode):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/253115@main">https://commits.webkit.org/253115@main</a>
</pre>
