### PR TITLE
Add ScrollAnchoringController to FrameView

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1231,6 +1231,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/csp/ContentSecurityPolicyResponseHeaders.h
 
     page/scrolling/AsyncScrollingCoordinator.h
+    page/scrolling/ScrollAnchoringController.h
     page/scrolling/ScrollSnapOffsetsInfo.h
     page/scrolling/ScrollingConstraints.h
     page/scrolling/ScrollingCoordinator.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1850,6 +1850,7 @@ page/csp/ContentSecurityPolicySource.cpp
 page/csp/ContentSecurityPolicySourceList.cpp
 page/csp/ContentSecurityPolicySourceListDirective.cpp
 page/scrolling/AsyncScrollingCoordinator.cpp
+page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollLatchingController.cpp
 page/scrolling/ScrollingConstraints.cpp

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -104,6 +104,7 @@
 #include "ScriptDisallowedScope.h"
 #include "ScriptRunner.h"
 #include "ScriptedAnimationController.h"
+#include "ScrollAnchoringController.h"
 #include "ScrollAnimator.h"
 #include "ScrollSnapOffsetsInfo.h"
 #include "ScrollbarTheme.h"
@@ -214,6 +215,9 @@ FrameView::FrameView(Frame& frame)
     ScrollableArea::setVerticalScrollElasticity(verticalElasticity);
     ScrollableArea::setHorizontalScrollElasticity(horizontalElasticity);
 #endif
+    if (frame.document() && frame.document()->settings().cssScrollAnchoringEnabled())
+        m_scrollAnchoringController = WTF::makeUnique<ScrollAnchoringController>(*this);
+
 }
 
 Ref<FrameView> FrameView::create(Frame& frame)
@@ -2651,6 +2655,8 @@ void FrameView::didChangeScrollOffset()
     if (auto* page = frame().page())
         page->pageOverlayController().didScrollFrame(frame());
     frame().loader().client().didChangeScrollOffset();
+    if (m_scrollAnchoringController)
+        m_scrollAnchoringController->invalidateAnchorElement();
 }
 
 void FrameView::scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset& oldOffset, const ScrollOffset& newOffset)

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -74,6 +74,7 @@ class RenderStyle;
 class RenderView;
 class RenderWidget;
 class ScrollingCoordinator;
+class ScrollAnchoringController;
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)
 namespace Display {
@@ -978,6 +979,7 @@ private:
     ViewportRendererType m_viewportRendererType { ViewportRendererType::None };
     ScrollPinningBehavior m_scrollPinningBehavior { DoNotPin };
     SelectionRevealMode m_selectionRevealModeForFocusedElement { SelectionRevealMode::DoNotReveal };
+    std::unique_ptr<ScrollAnchoringController> m_scrollAnchoringController;
 
     bool m_shouldUpdateWhileOffscreen { true };
     bool m_overflowStatusDirty { true };

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -1,0 +1,54 @@
+/*
+* Copyright (C) 2022 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "ScrollAnchoringController.h"
+
+namespace WebCore {
+
+void ScrollAnchoringController::invalidateAnchorElement()
+{
+    m_anchorElement = nullptr;
+    m_lastPositionForAnchorElement = FloatPoint();
+}
+
+void ScrollAnchoringController::selectAnchorElement()
+{
+    // TODO: implement
+    // perform Anchor Element Selection algorithm on dom elements within frame view's viewable region
+    // Firefox appears to only iterate through frame tree under the current frame (unclear if
+    // looking through frame tree is sufficient)
+    // unclear to me where to call this from 
+}
+
+void ScrollAnchoringController::updateScrollPosition()
+{
+    // TODO: implement
+    // calling m_frame.scrollTo with different between m_anchorElement current position
+    // and m_lastPositionForAnchorElement
+    // should be called after suppression window (maybe Page::doAfterUpdateRendering())
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -1,0 +1,52 @@
+/*
+* Copyright (C) 2022 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "FloatPoint.h"
+#include "FrameView.h"
+
+namespace WebCore {
+
+class Element;
+
+class ScrollAnchoringController final {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit ScrollAnchoringController(FrameView& frameView)
+        : m_frameView(frameView)
+    { }
+    void invalidateAnchorElement();
+    void updateScrollPosition();
+    void selectAnchorElement();
+    FrameView& frameView() { return m_frameView; }
+
+private:
+    FrameView& m_frameView;
+    WeakPtr<Element> m_anchorElement;
+    FloatPoint m_lastPositionForAnchorElement;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### cf7fb88c873764d0fb8745794e13cd6f04761f9b
<pre>
Add ScrollAnchoringController to FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=243482">https://bugs.webkit.org/show_bug.cgi?id=243482</a>

Reviewed by Chris Dumez and Simon Fraser.

Add skeleton class ScrollAnchoringController to FrameView.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::FrameView):
(WebCore::FrameView::didChangeScrollOffset):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp: Added.
(WebCore::ScrollAnchoringController::invalidateAnchorNode):
(WebCore::ScrollAnchoringController::selectAnchorNode):
(WebCore::ScrollAnchoringController::updateScrollPositon):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h: Added.

Canonical link: <a href="https://commits.webkit.org/253126@main">https://commits.webkit.org/253126@main</a>
</pre>
