### PR TITLE
[JSC] Implement Symbols as WeakMap keys

### DIFF
--- a/JSTests/stress/finalization-registry-registered-symbol.js
+++ b/JSTests/stress/finalization-registry-registered-symbol.js
@@ -1,0 +1,29 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    let registry = new FinalizationRegistry(function() { });
+    registry.register(Symbol.for("Hey"));
+}, `TypeError: register requires an object or a non-registered symbol as the target`);
+
+shouldThrow(() => {
+    let registry = new FinalizationRegistry(function() { });
+    registry.register(Symbol(), null, Symbol.for("Hey"));
+}, `TypeError: register requires an object or a non-registered symbol as the unregistration token`);
+
+shouldThrow(() => {
+    let registry = new FinalizationRegistry(function() { });
+    registry.unregister(Symbol.for("Hey"));
+}, `TypeError: unregister requires an object or a non-registered symbol as the unregistration token`);

--- a/JSTests/stress/v8-cleanup-from-different-realm-symbol.js
+++ b/JSTests/stress/v8-cleanup-from-different-realm-symbol.js
@@ -1,0 +1,36 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+let Realm = { create: $.createRealm, eval: (r, s) => $.evalScript.call(r, s)  };
+
+let r = Realm.create();
+
+let cleanup = Realm.eval(r, "var stored_global; function cleanup() { stored_global = globalThis; } cleanup;");
+let realm_global_this = Realm.eval(r, "globalThis");
+
+let fg = new FinalizationRegistry(cleanup);
+
+// Create an symbol and a register it in the FinalizationRegistry. The symbol needs
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol = Symbol();
+        fg.register(symbol);
+    }
+})();
+
+gc();
+
+// Assert that the cleanup function was called in its Realm.
+let timeout_func = function() {
+  let stored_global = Realm.eval(r, "stored_global;");
+  assertNotEquals(stored_global, globalThis);
+  assertEquals(stored_global, realm_global_this);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-cleanup-proxy-from-different-realm-symbol.js
+++ b/JSTests/stress/v8-cleanup-proxy-from-different-realm-symbol.js
@@ -1,0 +1,36 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+let Realm = { create: $.createRealm, eval: (r, s) => $.evalScript.call(r, s)  };
+
+let r = Realm.create();
+
+let cleanup = Realm.eval(r, "var stored_global; let cleanup = new Proxy(function() { stored_global = globalThis;}, {}); cleanup");
+let realm_global_this = Realm.eval(r, "globalThis");
+
+let fg = new FinalizationRegistry(cleanup);
+
+// Create an object and register it in the FinalizationRegistry. The object needs
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol = Symbol();
+        fg.register(symbol, "holdings");
+    }
+})();
+
+gc();
+
+// Assert that the cleanup function was called in its Realm.
+let timeout_func = function() {
+  let stored_global = Realm.eval(r, "stored_global;");
+  assertNotEquals(stored_global, globalThis);
+  assertEquals(stored_global, realm_global_this);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-finalization-registry-basics-symbol.js
+++ b/JSTests/stress/v8-finalization-registry-basics-symbol.js
@@ -68,24 +68,24 @@ load("./resources/v8-mjsunit.js", "caller relative");
 
 (function TestRegisterTargetAndHoldingsSameValue() {
   let fg = new FinalizationRegistry(() => {});
-  let obj = {a: 1};
+  let sym = Symbol();
   // SameValue(target, holdings) not ok
-  assertThrows(() => fg.register(obj, obj), TypeError,
+  assertThrows(() => fg.register(sym, sym), TypeError,
                "FinalizationRegistry.prototype.register: target and holdings must not be same");
-  let holdings = {a: 1};
-  fg.register(obj, holdings);
+  let holdings = Symbol();
+  fg.register(sym, holdings);
 })();
 
 (function TestRegisterWithoutFinalizationRegistry() {
-  assertThrows(() => FinalizationRegistry.prototype.register.call({}, {}, "holdings"), TypeError);
+  assertThrows(() => FinalizationRegistry.prototype.register.call({}, Symbol(), "holdings"), TypeError);
   // Does not throw:
   let fg = new FinalizationRegistry(() => {});
-  FinalizationRegistry.prototype.register.call(fg, {}, "holdings");
+  FinalizationRegistry.prototype.register.call(fg, Symbol(), "holdings");
 })();
 
 (function TestUnregisterWithNonExistentKey() {
   let fg = new FinalizationRegistry(() => {});
-  let success = fg.unregister({"k": "whatever"});
+  let success = fg.unregister(Symbol());
   assertFalse(success);
 })();
 
@@ -106,7 +106,7 @@ load("./resources/v8-mjsunit.js", "caller relative");
 })();
 
 (function TestWeakRefConstructor() {
-  let wr = new WeakRef({});
+  let wr = new WeakRef(Symbol());
   assertEquals(wr.toString(), "[object WeakRef]");
   assertNotSame(wr.__proto__, Object.prototype);
 
@@ -130,18 +130,11 @@ load("./resources/v8-mjsunit.js", "caller relative");
   let caught = false;
   let message = "";
   try {
-    let f = WeakRef({});
+    let f = WeakRef(Symbol());
   } catch (e) {
     message = e.message;
     caught = true;
   } finally {
     assertTrue(caught);
   }
-})();
-
-(function TestWeakRefWithProxy() {
-  let handler = {};
-  let obj = {};
-  let proxy = new Proxy(obj, handler);
-  let wr = new WeakRef(proxy);
 })();

--- a/JSTests/stress/v8-finalizationregistry-and-weakref-symbol.js
+++ b/JSTests/stress/v8-finalizationregistry-and-weakref-symbol.js
@@ -1,0 +1,45 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_called = false;
+let cleanup = function(holdings) {
+  let holdings_list = [];
+  holdings_list.push(holdings);
+  assertEquals(1, holdings_list.length);
+  assertEquals("holdings", holdings_list[0]);
+  cleanup_called = true;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let weak_refs = [];
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let s = Symbol();
+        weak_refs.push(new WeakRef(s));
+        fg.register(s, "holdings");
+    }
+})();
+
+// Since the WeakRef was created during this turn, it is not cleared by GC. The
+// pointer inside the FinalizationRegistry is not cleared either, since the WeakRef
+// keeps the target object alive.
+gc();
+(function() {
+    weak_refs.forEach((weak_ref) => assertEquals("symbol", typeof(weak_ref.deref())));
+})();
+
+// Trigger gc in next task
+setTimeout(() => {
+    gc();
+
+    // Check that cleanup callback was called in a follow up task
+    setTimeout(() => {
+        assertTrue(cleanup_called);
+        assertTrue(weak_refs.some((weak_ref) => weak_ref.deref() === undefined));
+    }, 0);
+}, 0);

--- a/JSTests/stress/v8-finalizationregistry-keeps-holdings-alive-symbol.js
+++ b/JSTests/stress/v8-finalizationregistry-keeps-holdings-alive-symbol.js
@@ -1,0 +1,45 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_called = false;
+let holdings_list = [];
+let cleanup = function(holdings) {
+  assertFalse(cleanup_called);
+  holdings_list.push(holdings);
+  cleanup_called = true;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let s1 = Symbol();
+let holdings = {'a': 'this is the holdings object'};
+
+// Ignition holds references to objects in temporary registers. These will be
+// released when the function exits. So only access o inside a function to
+// prevent any references to objects in temporary registers when a gc is
+// triggered.
+(() => {fg.register(s1, holdings);})()
+
+gc();
+assertFalse(cleanup_called);
+
+// Drop the last references to s1.
+(() => {s1 = null;})()
+
+// Drop the last reference to the holdings. The FinalizationRegistry keeps it
+// alive, so the cleanup function will be called as normal.
+holdings = null;
+gc();
+assertFalse(cleanup_called);
+
+let timeout_func = function() {
+  assertTrue(cleanup_called);
+  assertEquals(holdings_list.length, 1);
+  assertEquals(holdings_list[0].a, "this is the holdings object");
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-finalizationregistry-scheduled-for-cleanup-multiple-times-symbol.js
+++ b/JSTests/stress/v8-finalizationregistry-scheduled-for-cleanup-multiple-times-symbol.js
@@ -1,0 +1,83 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+// Flags: --no-stress-flush-bytecode
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup0_call_count = 0;
+let cleanup0_0_holdings_count = 0;
+let cleanup0_1_holdings_count = 0;
+
+let cleanup1_call_count = 0;
+let cleanup1_0_holdings_count = 0;
+let cleanup1_1_holdings_count = 0;
+
+let cleanup0 = function(holdings) {
+  if (holdings[holdings.length - 1] == "0")
+    ++cleanup0_0_holdings_count;
+  else
+    ++cleanup0_1_holdings_count;
+  ++cleanup0_call_count;
+}
+
+let cleanup1 = function(holdings) {
+  if (holdings[holdings.length - 1] == "0")
+    ++cleanup1_0_holdings_count;
+  else
+    ++cleanup1_1_holdings_count;
+  ++cleanup1_call_count;
+}
+
+let fg0 = new FinalizationRegistry(cleanup0);
+let fg1 = new FinalizationRegistry(cleanup1);
+
+// Register 1 weak reference for each FinalizationRegistry and kill the symbols they point to.
+(function() {
+  for (let i = 0; i < 1000; ++i) {
+    // The symbols need to be inside a closure so that we can reliably kill them.
+    let symbols = [];
+    symbols[0] = Symbol();
+    symbols[1] = Symbol();
+
+    fg0.register(symbols[0], "holdings0-0");
+    fg1.register(symbols[1], "holdings1-0");
+
+    // Drop the references to the symbols.
+    symbols = [];
+  }
+})();
+
+// Will schedule both fg0 and fg1 for cleanup.
+gc();
+
+// Before the cleanup task has a chance to run, do the same thing again, so both
+// FinalizationRegistries are (again) scheduled for cleanup. This has to be a IIFE function
+// (so that we can reliably kill the symbols) so we cannot use the same function
+// as before.
+(function() {
+  for (let i = 0; i < 1000; ++i) {
+    let symbols = [];
+    symbols[0] = Symbol();
+    symbols[1] = Symbol();
+    fg0.register(symbols[0], "holdings0-1");
+    fg1.register(symbols[1], "holdings1-1");
+    symbols = [];
+  }
+})();
+
+gc();
+
+let timeout_func = function() {
+  assertNotEquals(0, cleanup0_call_count);
+  assertNotEquals(0, cleanup0_0_holdings_count);
+  assertNotEquals(0, cleanup0_1_holdings_count);
+  assertNotEquals(0, cleanup1_call_count);
+  assertNotEquals(0, cleanup1_0_holdings_count);
+  assertNotEquals(0, cleanup1_0_holdings_count);
+}
+
+// Give the cleanup task a chance to run.
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-multiple-dirty-finalization-registries-symbol.js
+++ b/JSTests/stress/v8-multiple-dirty-finalization-registries-symbol.js
@@ -1,0 +1,48 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count1 = 0;
+let cleanup_call_count2 = 0;
+let cleanup = function(holdings) {
+    if (holdings === "holdings1")
+        ++cleanup_call_count1;
+    else if (holdings === "holdings2")
+        ++cleanup_call_count2;
+    else
+        throw new Error();
+}
+
+let fg1 = new FinalizationRegistry(cleanup);
+let fg2 = new FinalizationRegistry(cleanup);
+
+// Create two objects and register them in FinalizationRegistries. The objects need
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol1 = Symbol();
+        fg1.register(symbol1, "holdings1");
+
+        let symbol2 = Symbol();
+        fg2.register(symbol2, "holdings2");
+    }
+    // symbol1 and symbol2 go out of scope.
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count1);
+assertEquals(0, cleanup_call_count2);
+
+// Assert that the cleanup function was called.
+let timeout_func = function() {
+    assertNotEquals(0, cleanup_call_count1);
+    assertNotEquals(0, cleanup_call_count2);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-reentrant-gc-from-cleanup-symbol.js
+++ b/JSTests/stress/v8-reentrant-gc-from-cleanup-symbol.js
@@ -1,0 +1,26 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let called = false;
+let reentrant_gc = function(holdings) {
+    gc();
+    called = true;
+}
+
+let fg = new FinalizationRegistry(reentrant_gc);
+
+(function() {
+    for (let i = 0; i < 10; ++i)
+        fg.register(Symbol(), 42);
+})();
+
+gc();
+
+setTimeout(function() {
+    assertTrue(called);
+}, 0);

--- a/JSTests/stress/v8-stress-finalizationregistry-dirty-enqueue-symbol.js
+++ b/JSTests/stress/v8-stress-finalizationregistry-dirty-enqueue-symbol.js
@@ -1,0 +1,36 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --stress-compaction --expose-gc
+
+// Test that the dirty FinalizationRegistries that are enqueued during GC have
+// their slots correctly recorded by the GC.
+
+// 1) Create many JSFinalizationRegistry objects so that they span several pages
+// (page size is 256kb).
+let registries = [];
+for (let i = 0; i < 1024 * 8; i++) {
+  registries.push(new FinalizationRegistry(() => {}));
+}
+
+// 2) Force two GCs to ensure that JSFinalizatonRegistry objects are tenured.
+gc();
+gc();
+
+// 3) In a function: create a dummy target and register it in all
+// JSFinalizatonRegistry objects.
+(function() {
+  let garbage = Symbol();
+  registries.forEach((fr) => {
+    fr.register(garbage, 42);
+  });
+  garbage = null;
+})();
+
+// 4) Outside the function where the target is unreachable: force GC to collect
+// the object.
+gc();
+
+// 5) Force another GC to test that the slot was correctly updated.
+gc();

--- a/JSTests/stress/v8-undefined-holdings-symbol.js
+++ b/JSTests/stress/v8-undefined-holdings-symbol.js
@@ -1,0 +1,36 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup = function(holdings) {
+    assertEquals(holdings, undefined);
+    ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+
+// Create an symbol and register it in the FinalizationRegistry. The symbol needs to be inside
+// a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol = Symbol();
+        fg.register(symbol);
+    }
+})();
+
+// This GC will reclaim the target symbol and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called.
+let timeout_func = function() {
+    assertNotEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-after-cleanup-symbol.js
+++ b/JSTests/stress/v8-unregister-after-cleanup-symbol.js
@@ -1,0 +1,45 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup = function(holdings) {
+  assertEquals("holdings", holdings);
+  ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let key = Symbol();
+// Create an symbol and register it in the FinalizationRegistry. The symbol needs
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol = Symbol();
+        fg.register(symbol, "holdings", key);
+    }
+})();
+
+// This GC will reclaim the target symbol and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called.
+let timeout_func = function() {
+    assertNotEquals(0, cleanup_call_count);
+    let old_cleanup_call_count = cleanup_call_count;
+
+    // Unregister an already cleaned-up weak reference.
+    let success = fg.unregister(key);
+    // Since we may not collect everything we don't know what success will be unlike v8.
+    // assertFalse(success);
+
+    // Assert that it didn't do anything.
+    setTimeout(() => { assertEquals(old_cleanup_call_count, cleanup_call_count); }, 0);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-before-cleanup-symbol.js
+++ b/JSTests/stress/v8-unregister-before-cleanup-symbol.js
@@ -1,0 +1,39 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup = function(holdings) {
+  ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let key = Symbol();
+// Create an symbol and register it in the FinalizationRegistry. The symbol needs
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+  let symbol = Symbol();
+  fg.register(symbol, "my holdings", key);
+
+  // Clear the WeakCell before the GC has a chance to discover it.
+  let success = fg.unregister(key);
+  assertTrue(success);
+
+  // symbol goes out of scope.
+})();
+
+// This GC will reclaim the target symbol.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function won't be called, since we called unregister.
+let timeout_func = function() {
+  assertEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-called-twice-symbol.js
+++ b/JSTests/stress/v8-unregister-called-twice-symbol.js
@@ -1,0 +1,44 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup = function(holdings) {
+  ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let key = Symbol();
+// Create an symbol and register it in the FinalizationRegistry. The symbol needs
+// to be inside a closure so that we can reliably kill them!
+
+(function() {
+  let symbol = Symbol();
+  fg.register(symbol, "holdings", key);
+
+  // Unregister before the GC has a chance to discover the symbol.
+  let success = fg.unregister(key);
+  assertTrue(success);
+
+  // Call unregister again (just to assert we handle this gracefully).
+  success = fg.unregister(key);
+  assertFalse(success);
+
+  // symbol goes out of scope.
+})();
+
+// This GC will reclaim the target symbol.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function won't be called, since the weak reference
+// was unregistered.
+let timeout_func = function() {
+  assertEquals(0, cleanup_call_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-inside-cleanup2-symbol.js
+++ b/JSTests/stress/v8-unregister-inside-cleanup2-symbol.js
@@ -1,0 +1,47 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let called = false;
+let cleanup = function(holdings) {
+  // See which target we're cleaning up and unregister the other one.
+  if (holdings == 1) {
+    let success = fg.unregister(key2);
+    assertTrue(success || called);
+  } else {
+    assertSame(holdings, 2);
+    let success = fg.unregister(key1);
+    assertTrue(success || called);
+  }
+  called = true;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let key1 = Symbol();
+let key2 = Symbol();
+// Create two symbols and register them in the FinalizationRegistry. The symbols
+// need to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol1 = Symbol();
+        fg.register(symbol1, 1, key1);
+        let symbol2 = Symbol();
+        fg.register(symbol2, 2, key2);
+    }
+})();
+
+// This GC will reclaim target symbols and schedule cleanup.
+gc();
+assertFalse(called);
+
+// Assert that the cleanup function was called and cleaned up one holdings (but not the other one).
+let timeout_func = function() {
+    assertTrue(called);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-inside-cleanup3-symbol.js
+++ b/JSTests/stress/v8-unregister-inside-cleanup3-symbol.js
@@ -1,0 +1,49 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup_holdings_count = 0;
+let cleanup = function(holdings) {
+  assertEquals(holdings, "holdings");
+
+  // There's mores symbol with the same key that we haven't
+  // cleaned up yet so we should be able to unregister the
+  // callback for that one.
+  let success = fg.unregister(key);
+
+  assertTrue(success);
+
+  ++cleanup_holdings_count;
+  ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+// Create an symbol and register it in the FinalizationRegistry. The symbol needs to be inside
+// a closure so that we can reliably kill them!
+let key = Symbol();
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol = Symbol();
+        let symbol2 = Symbol();
+        fg.register(symbol, "holdings", key);
+        fg.register(symbol2, "holdings", key);
+    }
+})();
+
+// This GC will discover dirty WeakCells and schedule cleanup.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function was called.
+let timeout_func = function() {
+  assertEquals(1, cleanup_call_count);
+  assertEquals(1, cleanup_holdings_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-unregister-many-symbol.js
+++ b/JSTests/stress/v8-unregister-many-symbol.js
@@ -1,0 +1,51 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+let cleanup_call_count = 0;
+let cleanup_holdings_count = 0;
+let cleanup = function(holdings) {
+  assertEquals("holdings2", holdings);
+  ++cleanup_holdings_count;
+  ++cleanup_call_count;
+}
+
+let fg = new FinalizationRegistry(cleanup);
+let key1 = Symbol();
+let key2 = Symbol();
+// Create three symbols and register them in the FinalizationRegistry. The symbols
+// need to be inside a closure so that we can reliably kill them!
+
+(function() {
+    for (let i = 0; i < 1000; ++i) {
+        let symbol1a = Symbol();
+        fg.register(symbol1a, "holdings1a", key1);
+
+        let symbol1b = Symbol();
+        fg.register(symbol1b, "holdings1b", key1);
+
+        let symbol2 = Symbol();
+        fg.register(symbol2, "holdings2", key2);
+
+        // Unregister before the GC has a chance to discover the symbols.
+        let success = fg.unregister(key1);
+        assertTrue(success);
+    }
+})();
+
+// This GC will reclaim the target symbols.
+gc();
+assertEquals(0, cleanup_call_count);
+
+// Assert that the cleanup function will be called only for the reference which
+// was not unregistered.
+let timeout_func = function() {
+  assertNotEquals(0, cleanup_call_count);
+  assertNotEquals(0, cleanup_holdings_count);
+}
+
+setTimeout(timeout_func, 0);

--- a/JSTests/stress/v8-weak-unregistertoken-symbol.js
+++ b/JSTests/stress/v8-weak-unregistertoken-symbol.js
@@ -1,0 +1,29 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs-with-cleanup-some --expose-gc --noincremental-marking
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+var FR = new FinalizationRegistry (function (holdings) { globalThis.FRRan = true; });
+{
+    for (let i = 0; i < 1000; ++i) {
+        let obj = Symbol();
+        // obj is its own unregister token and becomes unreachable after this
+        // block. If the unregister token is held strongly this test will not
+        // terminate.
+        FR.register(obj, 42, obj);
+    }
+}
+
+let tryAgainCount = 10;
+function tryAgain() {
+    gc();
+    if (globalThis.FRRan)
+        return;
+    if (!--tryAgainCount)
+        throw new Error();
+    setTimeout(tryAgain, 0);
+}
+tryAgain();

--- a/JSTests/stress/weak-map-constructor.js
+++ b/JSTests/stress/weak-map-constructor.js
@@ -139,6 +139,6 @@ var nonObjectKeys = [
 ];
 
 for (var item of nonObjectKeys) {
-    testTypeError(item, 'TypeError: Attempted to set a non-object key in a WeakMap');
+    testTypeError(item, 'TypeError: WeakMap keys must be objects or non-registered symbols');
     testCallTypeError(item);
 }

--- a/JSTests/stress/weak-map-registered-symbol.js
+++ b/JSTests/stress/weak-map-registered-symbol.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol.for("B");
+
+function test() {
+    var map = new WeakMap();
+    shouldBe(map.get(s1), undefined);
+    shouldBe(map.get(s2), undefined);
+
+    shouldBe(map.has(s1), false);
+    shouldBe(map.has(s2), false);
+
+    map.set(s1, 1);
+    shouldThrow(() => {
+        map.set(s2, 2);
+    }, `TypeError: WeakMap keys must be objects or non-registered symbols`);
+
+    shouldBe(map.get(s1), 1);
+    shouldBe(map.get(s2), undefined);
+
+    shouldBe(map.has(s1), true);
+    shouldBe(map.has(s2), false);
+
+    shouldBe(map.delete(s1), true);
+    shouldBe(map.has(s1), false);
+
+    shouldBe(map.delete(s2), false);
+    shouldBe(map.has(s2), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-map-symbol.js
+++ b/JSTests/stress/weak-map-symbol.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var s4 = Symbol("A");
+var s5 = Symbol("B");
+var s6 = Symbol("C");
+
+function test() {
+    var map = new WeakMap();
+    shouldBe(map.get(s1), undefined);
+    shouldBe(map.get(s2), undefined);
+    shouldBe(map.get(s3), undefined);
+    shouldBe(map.get(s4), undefined);
+    shouldBe(map.get(s5), undefined);
+    shouldBe(map.get(s6), undefined);
+
+    shouldBe(map.has(s1), false);
+    shouldBe(map.has(s2), false);
+    shouldBe(map.has(s3), false);
+    shouldBe(map.has(s4), false);
+    shouldBe(map.has(s5), false);
+    shouldBe(map.has(s6), false);
+
+    map.set(s1, 1);
+    map.set(s2, 2);
+    map.set(s3, 3);
+
+    shouldBe(map.get(s1), 1);
+    shouldBe(map.get(s2), 2);
+    shouldBe(map.get(s3), 3);
+    shouldBe(map.get(s4), undefined);
+    shouldBe(map.get(s5), undefined);
+    shouldBe(map.get(s6), undefined);
+
+    shouldBe(map.has(s1), true);
+    shouldBe(map.has(s2), true);
+    shouldBe(map.has(s3), true);
+    shouldBe(map.has(s4), false);
+    shouldBe(map.has(s5), false);
+    shouldBe(map.has(s6), false);
+
+    shouldBe(map.delete(s1), true);
+    shouldBe(map.has(s1), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-map-various-one-site.js
+++ b/JSTests/stress/weak-map-various-one-site.js
@@ -1,0 +1,120 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function getTest(map, key)
+{
+    return map.get(key);
+}
+noInline(getTest);
+
+function hasTest(map, key)
+{
+    return map.has(key);
+}
+noInline(hasTest);
+
+function setTest(map, key, value)
+{
+    return map.set(key, value);
+}
+noInline(setTest);
+
+function deleteTest(map, key)
+{
+    return map.delete(key);
+}
+noInline(deleteTest);
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var o1 = {};
+var o2 = {};
+var o3 = {};
+
+function test() {
+    var map = new WeakMap();
+    shouldBe(getTest(map, s1), undefined);
+    shouldBe(getTest(map, s2), undefined);
+    shouldBe(getTest(map, s3), undefined);
+    shouldBe(getTest(map, o1), undefined);
+    shouldBe(getTest(map, o2), undefined);
+    shouldBe(getTest(map, o3), undefined);
+
+    shouldBe(hasTest(map, s1), false);
+    shouldBe(hasTest(map, s2), false);
+    shouldBe(hasTest(map, s3), false);
+    shouldBe(hasTest(map, o1), false);
+    shouldBe(hasTest(map, o2), false);
+    shouldBe(hasTest(map, o3), false);
+
+    shouldBe(setTest(map, s1, 1), map);
+    shouldBe(setTest(map, s2, 2), map);
+    shouldBe(setTest(map, o1, 3), map);
+    shouldBe(setTest(map, o2, 4), map);
+
+    shouldBe(getTest(map, s1), 1);
+    shouldBe(getTest(map, s2), 2);
+    shouldBe(getTest(map, s3), undefined);
+    shouldBe(getTest(map, o1), 3);
+    shouldBe(getTest(map, o2), 4);
+    shouldBe(getTest(map, o3), undefined);
+
+    shouldBe(hasTest(map, s1), true);
+    shouldBe(hasTest(map, s2), true);
+    shouldBe(hasTest(map, s3), false);
+    shouldBe(hasTest(map, o1), true);
+    shouldBe(hasTest(map, o2), true);
+    shouldBe(hasTest(map, o3), false);
+
+    shouldBe(deleteTest(map, s1), true);
+    shouldBe(hasTest(map, s1), false);
+
+    shouldBe(deleteTest(map, s3), false);
+    shouldBe(hasTest(map, s3), false);
+
+    shouldBe(deleteTest(map, o1), true);
+    shouldBe(hasTest(map, o1), false);
+
+    shouldBe(deleteTest(map, o3), false);
+    shouldBe(hasTest(map, o3), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();
+
+{
+    var map = new WeakMap();
+    shouldBe(getTest(map, "hey"), undefined);
+    shouldBe(hasTest(map, "hey"), false);
+    shouldBe(deleteTest(map, "hey"), false);
+    shouldThrow(() => {
+        setTest(map, "hey", "Hello");
+    }, `TypeError: WeakMap keys must be objects or non-registered symbols`);
+
+    shouldBe(getTest(map, 42), undefined);
+    shouldBe(hasTest(map, 42), false);
+    shouldBe(deleteTest(map, 42), false);
+    shouldThrow(() => {
+        setTest(map, 42, "Hello");
+    }, `TypeError: WeakMap keys must be objects or non-registered symbols`);
+
+}

--- a/JSTests/stress/weak-map-various.js
+++ b/JSTests/stress/weak-map-various.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var o1 = {};
+var o2 = {};
+var o3 = {};
+
+function test() {
+    var map = new WeakMap();
+    shouldBe(map.get(s1), undefined);
+    shouldBe(map.get(s2), undefined);
+    shouldBe(map.get(s3), undefined);
+    shouldBe(map.get(o1), undefined);
+    shouldBe(map.get(o2), undefined);
+    shouldBe(map.get(o3), undefined);
+
+    shouldBe(map.has(s1), false);
+    shouldBe(map.has(s2), false);
+    shouldBe(map.has(s3), false);
+    shouldBe(map.has(o1), false);
+    shouldBe(map.has(o2), false);
+    shouldBe(map.has(o3), false);
+
+    shouldBe(map.set(s1, 1), map);
+    shouldBe(map.set(s2, 2), map);
+    shouldBe(map.set(o1, 3), map);
+    shouldBe(map.set(o2, 4), map);
+
+    shouldBe(map.get(s1), 1);
+    shouldBe(map.get(s2), 2);
+    shouldBe(map.get(s3), undefined);
+    shouldBe(map.get(o1), 3);
+    shouldBe(map.get(o2), 4);
+    shouldBe(map.get(o3), undefined);
+
+    shouldBe(map.has(s1), true);
+    shouldBe(map.has(s2), true);
+    shouldBe(map.has(s3), false);
+    shouldBe(map.has(o1), true);
+    shouldBe(map.has(o2), true);
+    shouldBe(map.has(o3), false);
+
+    shouldBe(map.delete(s1), true);
+    shouldBe(map.has(s1), false);
+
+    shouldBe(map.delete(s3), false);
+    shouldBe(map.has(s3), false);
+
+    shouldBe(map.delete(o1), true);
+    shouldBe(map.has(o1), false);
+
+    shouldBe(map.delete(o3), false);
+    shouldBe(map.has(o3), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-ref-registered-symbol.js
+++ b/JSTests/stress/weak-ref-registered-symbol.js
@@ -1,0 +1,18 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    new WeakRef(Symbol.for("Hey"));
+}, `TypeError: First argument to WeakRef should be an object or a non-registered symbol`);

--- a/JSTests/stress/weak-set-constructor.js
+++ b/JSTests/stress/weak-set-constructor.js
@@ -141,6 +141,6 @@ var nonObjectKeys = [
 ];
 
 for (var item of nonObjectKeys) {
-    testTypeError(item, 'TypeError: Attempted to add a non-object value to a WeakSet');
+    testTypeError(item, 'TypeError: WeakSet values must be objects or non-registered symbols');
     testCallTypeError(item);
 }

--- a/JSTests/stress/weak-set-registered-symbol.js
+++ b/JSTests/stress/weak-set-registered-symbol.js
@@ -1,0 +1,46 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol.for("B");
+
+function test() {
+    var set = new WeakSet();
+    shouldBe(set.has(s1), false);
+    shouldBe(set.has(s2), false);
+
+    set.add(s1);
+    shouldThrow(() => {
+        set.add(s2);
+    }, `TypeError: WeakSet values must be objects or non-registered symbols`);
+
+    shouldBe(set.has(s1), true);
+    shouldBe(set.has(s2), false);
+
+    shouldBe(set.delete(s1), true);
+    shouldBe(set.has(s1), false);
+
+    shouldBe(set.delete(s2), false);
+    shouldBe(set.has(s2), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-set-symbol.js
+++ b/JSTests/stress/weak-set-symbol.js
@@ -1,0 +1,39 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var s4 = Symbol("A");
+var s5 = Symbol("B");
+var s6 = Symbol("C");
+
+function test() {
+    var set = new WeakSet();
+    shouldBe(set.has(s1), false);
+    shouldBe(set.has(s2), false);
+    shouldBe(set.has(s3), false);
+    shouldBe(set.has(s4), false);
+    shouldBe(set.has(s5), false);
+    shouldBe(set.has(s6), false);
+
+    set.add(s1);
+    set.add(s2);
+    set.add(s3);
+
+    shouldBe(set.has(s1), true);
+    shouldBe(set.has(s2), true);
+    shouldBe(set.has(s3), true);
+    shouldBe(set.has(s4), false);
+    shouldBe(set.has(s5), false);
+    shouldBe(set.has(s6), false);
+
+    shouldBe(set.delete(s1), true);
+    shouldBe(set.has(s1), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-set-various-one-site.js
+++ b/JSTests/stress/weak-set-various-one-site.js
@@ -1,0 +1,91 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function hasTest(set, key)
+{
+    return set.has(key);
+}
+noInline(hasTest);
+
+function addTest(set, key)
+{
+    return set.add(key);
+}
+noInline(addTest);
+
+function deleteTest(set, key)
+{
+    return set.delete(key);
+}
+noInline(deleteTest);
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var o1 = {};
+var o2 = {};
+var o3 = {};
+
+function test() {
+    var set = new WeakSet();
+    shouldBe(hasTest(set, s1), false);
+    shouldBe(hasTest(set, s2), false);
+    shouldBe(hasTest(set, s3), false);
+    shouldBe(hasTest(set, o1), false);
+    shouldBe(hasTest(set, o2), false);
+    shouldBe(hasTest(set, o3), false);
+
+    shouldBe(addTest(set, s1), set);
+    shouldBe(addTest(set, s2), set);
+    shouldBe(addTest(set, o1), set);
+    shouldBe(addTest(set, o2), set);
+
+    shouldBe(hasTest(set, s1), true);
+    shouldBe(hasTest(set, s2), true);
+    shouldBe(hasTest(set, s3), false);
+    shouldBe(hasTest(set, o1), true);
+    shouldBe(hasTest(set, o2), true);
+    shouldBe(hasTest(set, o3), false);
+
+    shouldBe(deleteTest(set, s1), true);
+    shouldBe(hasTest(set, s1), false);
+
+    shouldBe(deleteTest(set, o1), true);
+    shouldBe(hasTest(set, o1), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();
+
+{
+    var set = new WeakSet();
+    shouldBe(hasTest(set, "hey"), false);
+    shouldBe(deleteTest(set, "hey"), false);
+    shouldThrow(() => {
+        addTest(set, "hey");
+    }, `TypeError: WeakSet values must be objects or non-registered symbols`);
+
+    shouldBe(hasTest(set, 42), false);
+    shouldBe(deleteTest(set, 42), false);
+    shouldThrow(() => {
+        addTest(set, 42);
+    }, `TypeError: WeakSet values must be objects or non-registered symbols`);
+}

--- a/JSTests/stress/weak-set-various.js
+++ b/JSTests/stress/weak-set-various.js
@@ -1,0 +1,44 @@
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var s1 = Symbol("A");
+var s2 = Symbol("B");
+var s3 = Symbol("C");
+var o1 = {};
+var o2 = {};
+var o3 = {};
+
+function test() {
+    var set = new WeakSet();
+    shouldBe(set.has(s1), false);
+    shouldBe(set.has(s2), false);
+    shouldBe(set.has(s3), false);
+    shouldBe(set.has(o1), false);
+    shouldBe(set.has(o2), false);
+    shouldBe(set.has(o3), false);
+
+    shouldBe(set.add(s1), set);
+    shouldBe(set.add(s2), set);
+    shouldBe(set.add(o1), set);
+    shouldBe(set.add(o2), set);
+
+    shouldBe(set.has(s1), true);
+    shouldBe(set.has(s2), true);
+    shouldBe(set.has(s3), false);
+    shouldBe(set.has(o1), true);
+    shouldBe(set.has(o2), true);
+    shouldBe(set.has(o3), false);
+
+    shouldBe(set.delete(s1), true);
+    shouldBe(set.has(s1), false);
+
+    shouldBe(set.delete(o1), true);
+    shouldBe(set.has(o1), false);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -372,3 +372,12 @@ skip:
     - test/built-ins/Temporal/Instant/prototype/until/instant-string.js
     - test/built-ins/Temporal/PlainTime/prototype/since/balance-negative-time-units.js
     - test/built-ins/Temporal/PlainTime/prototype/until/balance-negative-time-units.js
+
+    # Symbols as WeakMap keys proposal breaks existing tests https://github.com/tc39/proposal-symbols-as-weakmap-keys
+    - test/built-ins/WeakMap/prototype/set/key-not-object-throw.js
+    - test/built-ins/WeakSet/symbol-disallowed-as-weakset-key.js
+    - test/built-ins/WeakSet/prototype/add/value-not-object-throw.js
+    - test/built-ins/WeakRef/target-not-object-throws.js
+    - test/built-ins/FinalizationRegistry/prototype/unregister/unregisterToken-not-object-throws.js
+    - test/built-ins/FinalizationRegistry/prototype/register/target-not-object-throws.js
+    - test/built-ins/FinalizationRegistry/prototype/register/unregisterToken-not-object-or-undefined-throws.js

--- a/LayoutTests/js/dom/basic-weakmap-expected.txt
+++ b/LayoutTests/js/dom/basic-weakmap-expected.txt
@@ -7,13 +7,13 @@ PASS WeakMap instanceof WeakMap is false
 PASS WeakMap.prototype instanceof WeakMap is false
 PASS new WeakMap() instanceof WeakMap is true
 PASS WeakMap() threw exception TypeError: calling WeakMap constructor without new is invalid.
-PASS map.set(0, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set(0.5, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set('foo', 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set(true, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set(false, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set(null, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
-PASS map.set(undefined, 1) threw exception TypeError: Attempted to set a non-object key in a WeakMap.
+PASS map.set(0, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set(0.5, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set('foo', 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set(true, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set(false, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set(null, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
+PASS map.set(undefined, 1) threw exception TypeError: WeakMap keys must be objects or non-registered symbols.
 PASS map.get(0) is undefined.
 PASS map.get(0.5) is undefined.
 PASS map.get('foo') is undefined.

--- a/LayoutTests/js/dom/basic-weakset-expected.txt
+++ b/LayoutTests/js/dom/basic-weakset-expected.txt
@@ -7,14 +7,13 @@ PASS WeakSet instanceof WeakSet is false
 PASS WeakSet.prototype instanceof WeakSet is false
 PASS new WeakSet() instanceof WeakSet is true
 PASS WeakSet() threw exception TypeError: calling WeakSet constructor without new is invalid.
-PASS set.add(0) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(0.5) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add('foo') threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(true) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(false) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(null) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(undefined) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
-PASS set.add(Symbol.iterator) threw exception TypeError: Attempted to add a non-object value to a WeakSet.
+PASS set.add(0) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add(0.5) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add('foo') threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add(true) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add(false) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add(null) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
+PASS set.add(undefined) threw exception TypeError: WeakSet values must be objects or non-registered symbols.
 PASS set.has(0) is false
 PASS set.has(0.5) is false
 PASS set.has('foo') is false
@@ -22,7 +21,6 @@ PASS set.has(true) is false
 PASS set.has(false) is false
 PASS set.has(null) is false
 PASS set.has(undefined) is false
-PASS set.has(Symbol.iterator) is false
 PASS set.delete(0) is false
 PASS set.delete(0.5) is false
 PASS set.delete('foo') is false
@@ -30,7 +28,6 @@ PASS set.delete(true) is false
 PASS set.delete(false) is false
 PASS set.delete(null) is false
 PASS set.delete(undefined) is false
-PASS set.delete(Symbol.iterator) is false
 PASS set.add(new String('foo')) is set
 PASS set.add(new String('foo')) is set
 PASS set.has(new String('foo')) is false
@@ -40,6 +37,10 @@ PASS set.delete(new String('foo')) is false
 PASS set.delete(object) is true
 PASS set.has(object) is false
 PASS set.delete(object) is false
+PASS set.add(Symbol.iterator) is set
+PASS set.has(Symbol.iterator) is true
+PASS set.delete(Symbol.iterator) is true
+PASS set.has(Symbol.iterator) is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/js/dom/script-tests/basic-weakset.js
+++ b/LayoutTests/js/dom/script-tests/basic-weakset.js
@@ -14,7 +14,6 @@ shouldThrow("set.add(true)")
 shouldThrow("set.add(false)")
 shouldThrow("set.add(null)")
 shouldThrow("set.add(undefined)")
-shouldThrow("set.add(Symbol.iterator)")
 shouldBeFalse("set.has(0)")
 shouldBeFalse("set.has(0.5)")
 shouldBeFalse("set.has('foo')")
@@ -22,7 +21,6 @@ shouldBeFalse("set.has(true)")
 shouldBeFalse("set.has(false)")
 shouldBeFalse("set.has(null)")
 shouldBeFalse("set.has(undefined)")
-shouldBeFalse("set.has(Symbol.iterator)")
 shouldBeFalse("set.delete(0)")
 shouldBeFalse("set.delete(0.5)")
 shouldBeFalse("set.delete('foo')")
@@ -30,7 +28,6 @@ shouldBeFalse("set.delete(true)")
 shouldBeFalse("set.delete(false)")
 shouldBeFalse("set.delete(null)")
 shouldBeFalse("set.delete(undefined)")
-shouldBeFalse("set.delete(Symbol.iterator)")
 
 var object = new String('hello');
 shouldBe("set.add(new String('foo'))", "set");
@@ -42,3 +39,8 @@ shouldBeFalse("set.delete(new String('foo'))");
 shouldBeTrue("set.delete(object)");
 shouldBeFalse("set.has(object)");
 shouldBeFalse("set.delete(object)");
+
+shouldBe("set.add(Symbol.iterator)", "set")
+shouldBeTrue("set.has(Symbol.iterator)")
+shouldBeTrue("set.delete(Symbol.iterator)")
+shouldBeFalse("set.has(Symbol.iterator)")

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3377,9 +3377,9 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             insertChecks();
             Node* map = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             Node* key = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            addToGraph(Check, Edge(key, ObjectUse));
+            addToGraph(Check, Edge(key, CellUse));
             Node* hash = addToGraph(MapHash, key);
-            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakMapObjectUse), Edge(key, ObjectUse), Edge(hash, Int32Use));
+            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakMapObjectUse), Edge(key, CellUse), Edge(hash, Int32Use));
             Node* resultNode = addToGraph(ExtractValueFromWeakMapGet, OpInfo(), OpInfo(prediction), holder);
 
             setResult(resultNode);
@@ -3396,9 +3396,9 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             insertChecks();
             Node* map = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             Node* key = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            addToGraph(Check, Edge(key, ObjectUse));
+            addToGraph(Check, Edge(key, CellUse));
             Node* hash = addToGraph(MapHash, key);
-            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakMapObjectUse), Edge(key, ObjectUse), Edge(hash, Int32Use));
+            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakMapObjectUse), Edge(key, CellUse), Edge(hash, Int32Use));
             Node* invertedResult = addToGraph(IsEmpty, holder);
             Node* resultNode = addToGraph(LogicalNot, invertedResult);
 
@@ -3416,9 +3416,9 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             insertChecks();
             Node* map = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             Node* key = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            addToGraph(Check, Edge(key, ObjectUse));
+            addToGraph(Check, Edge(key, CellUse));
             Node* hash = addToGraph(MapHash, key);
-            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakSetObjectUse), Edge(key, ObjectUse), Edge(hash, Int32Use));
+            Node* holder = addToGraph(WeakMapGet, Edge(map, WeakSetObjectUse), Edge(key, CellUse), Edge(hash, Int32Use));
             Node* invertedResult = addToGraph(IsEmpty, holder);
             Node* resultNode = addToGraph(LogicalNot, invertedResult);
 
@@ -3436,9 +3436,9 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             insertChecks();
             Node* base = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             Node* key = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
-            addToGraph(Check, Edge(key, ObjectUse));
+            addToGraph(Check, Edge(key, CellUse));
             Node* hash = addToGraph(MapHash, key);
-            addToGraph(WeakSetAdd, Edge(base, WeakSetObjectUse), Edge(key, ObjectUse), Edge(hash, Int32Use));
+            addToGraph(WeakSetAdd, Edge(base, WeakSetObjectUse), Edge(key, CellUse), Edge(hash, Int32Use));
             setResult(base);
             return true;
         }
@@ -3455,11 +3455,11 @@ bool ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, Intrinsic
             Node* key = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
             Node* value = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
 
-            addToGraph(Check, Edge(key, ObjectUse));
+            addToGraph(Check, Edge(key, CellUse));
             Node* hash = addToGraph(MapHash, key);
 
             addVarArgChild(Edge(base, WeakMapObjectUse));
-            addVarArgChild(Edge(key, ObjectUse));
+            addVarArgChild(Edge(key, CellUse));
             addVarArgChild(Edge(value));
             addVarArgChild(Edge(hash, Int32Use));
             addToGraph(Node::VarArg, WeakMapSet, OpInfo(0), OpInfo(0));

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1975,6 +1975,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case WeakSetAdd: {
         Edge& mapEdge = node->child1();
         Edge& keyEdge = node->child2();
+        if (keyEdge.useKind() != ObjectUse) {
+            read(World);
+            write(SideState);
+        }
         write(JSWeakSetFields);
         def(HeapLocation(WeakMapGetLoc, JSWeakSetFields, mapEdge, keyEdge), LazyNode(keyEdge.node()));
         return;
@@ -1984,6 +1988,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         Edge& mapEdge = graph.varArgChild(node, 0);
         Edge& keyEdge = graph.varArgChild(node, 1);
         Edge& valueEdge = graph.varArgChild(node, 2);
+        if (keyEdge.useKind() != ObjectUse) {
+            read(World);
+            write(SideState);
+        }
         write(JSWeakMapFields);
         def(HeapLocation(WeakMapGetLoc, JSWeakMapFields, mapEdge, keyEdge), LazyNode(valueEdge.node()));
         return;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2600,7 +2600,10 @@ private:
                 fixEdge<WeakSetObjectUse>(node->child1());
             else
                 RELEASE_ASSERT_NOT_REACHED();
-            fixEdge<ObjectUse>(node->child2());
+            if (node->child2()->shouldSpeculateObject())
+                fixEdge<ObjectUse>(node->child2());
+            else if (node->child2()->shouldSpeculateSymbol())
+                fixEdge<SymbolUse>(node->child2());
             fixEdge<Int32Use>(node->child3());
             break;
         }
@@ -2619,14 +2622,16 @@ private:
 
         case WeakSetAdd: {
             fixEdge<WeakSetObjectUse>(node->child1());
-            fixEdge<ObjectUse>(node->child2());
+            if (node->child2()->shouldSpeculateObject())
+                fixEdge<ObjectUse>(node->child2());
             fixEdge<Int32Use>(node->child3());
             break;
         }
 
         case WeakMapSet: {
             fixEdge<WeakMapObjectUse>(m_graph.varArgChild(node, 0));
-            fixEdge<ObjectUse>(m_graph.varArgChild(node, 1));
+            if (m_graph.varArgChild(node, 1)->shouldSpeculateObject())
+                fixEdge<ObjectUse>(m_graph.varArgChild(node, 1));
             fixEdge<Int32Use>(m_graph.varArgChild(node, 3));
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -37,6 +37,8 @@ class DateInstance;
 class JSBigInt;
 class JSPropertyNameEnumerator;
 class JSRopeString;
+class JSWeakMap;
+class JSWeakSet;
 class OptimizingCallLinkInfo;
 struct UnlinkedStringJumpTable;
 
@@ -218,8 +220,8 @@ JSC_DECLARE_JIT_OPERATION(operationCreateRest, JSCell*, (JSGlobalObject*, Regist
 JSC_DECLARE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM*, Structure*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetAdd, JSCell*, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationMapSet, JSCell*, (JSGlobalObject*, JSCell*, EncodedJSValue, EncodedJSValue, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationWeakSetAdd, void, (VM*, JSCell*, JSCell*, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationWeakMapSet, void, (VM*, JSCell*, JSCell*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationWeakSetAdd, void, (JSGlobalObject*, JSCell*, JSCell*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationWeakMapSet, void, (JSGlobalObject*, JSCell*, JSCell*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationFModOnInts, double, (int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationTypeOfIsObject, size_t, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationTypeOfIsFunction, size_t, (JSGlobalObject*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -405,6 +405,15 @@ public:
                         break;
                     }
                     break;
+                case WeakMapGet:
+                    VALIDATE((node), node->child2().useKind() == CellUse || node->child2().useKind() == ObjectUse || node->child2().useKind() == SymbolUse);
+                    break;
+                case WeakSetAdd:
+                    VALIDATE((node), node->child2().useKind() == CellUse || node->child2().useKind() == ObjectUse);
+                    break;
+                case WeakMapSet:
+                    VALIDATE((node), m_graph.varArgChild(node, 1).useKind() == CellUse || m_graph.varArgChild(node, 1).useKind() == ObjectUse);
+                    break;
                 default:
                     break;
                 }

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -76,9 +76,9 @@ public:
 
     JSValue takeDeadHoldingsValue();
 
-    bool unregister(VM&, JSObject* token);
-    // token should be a JSObject or undefined.
-    void registerTarget(VM&, JSObject* target, JSValue holdings, JSValue token);
+    bool unregister(VM&, JSCell* token);
+    // token should be a JSObject, Symbol, or undefined.
+    void registerTarget(VM&, JSCell* target, JSValue holdings, JSValue token);
 
     JS_EXPORT_PRIVATE size_t liveCount(const Locker<JSCellLock>&);
     JS_EXPORT_PRIVATE size_t deadCount(const Locker<JSCellLock>&);
@@ -92,7 +92,7 @@ private:
     JS_EXPORT_PRIVATE void finishCreation(VM&, JSGlobalObject*, JSObject* callback);
 
     struct Registration {
-        JSObject* target;
+        JSCell* target;
         WriteBarrier<Unknown> holdings;
     };
 
@@ -101,8 +101,8 @@ private:
     using DeadRegistrations = Vector<WriteBarrier<Unknown>>;
 
     // Note that we don't bother putting a write barrier on the key or target because they are weakly referenced.
-    HashMap<JSObject*, LiveRegistrations> m_liveRegistrations;
-    HashMap<JSObject*, DeadRegistrations> m_deadRegistrations;
+    HashMap<JSCell*, LiveRegistrations> m_liveRegistrations;
+    HashMap<JSCell*, DeadRegistrations> m_deadRegistrations;
     // We use a separate list for no unregister values instead of a special key in the tables above because the HashMap has a tendency to reallocate under us when iterating...
     LiveRegistrations m_noUnregistrationLive;
     DeadRegistrations m_noUnregistrationDead;

--- a/Source/JavaScriptCore/runtime/JSWeakMap.h
+++ b/Source/JavaScriptCore/runtime/JSWeakMap.h
@@ -48,7 +48,7 @@ public:
         return instance;
     }
 
-    ALWAYS_INLINE void set(VM&, JSObject* key, JSValue);
+    ALWAYS_INLINE void set(VM&, JSCell* key, JSValue);
 
 private:
     JSWeakMap(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/JSWeakMapInlines.h
+++ b/Source/JavaScriptCore/runtime/JSWeakMapInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-ALWAYS_INLINE void JSWeakMap::set(VM& vm, JSObject* key, JSValue value)
+ALWAYS_INLINE void JSWeakMap::set(VM& vm, JSCell* key, JSValue value)
 {
     add(vm, key, value);
 }

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
@@ -32,7 +32,7 @@ namespace JSC {
 
 const ClassInfo JSWeakObjectRef::s_info = { "WeakRef"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWeakObjectRef) };
 
-void JSWeakObjectRef::finishCreation(VM& vm, JSObject* value)
+void JSWeakObjectRef::finishCreation(VM& vm, JSCell* value)
 {
     m_lastAccessVersion = vm.currentWeakRefVersion();
     m_value.set(vm, this, value);

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
@@ -40,14 +40,14 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
     }
 
-    static JSWeakObjectRef* create(VM& vm, Structure* structure, JSObject* target)
+    static JSWeakObjectRef* create(VM& vm, Structure* structure, JSCell* target)
     {
         JSWeakObjectRef* instance = new (NotNull, allocateCell<JSWeakObjectRef>(vm)) JSWeakObjectRef(vm, structure);
         instance->finishCreation(vm, target);
         return instance;
     }
 
-    JSObject* deref(VM& vm)
+    JSCell* deref(VM& vm)
     {
         if (m_value && vm.currentWeakRefVersion() != m_lastAccessVersion) {
             m_lastAccessVersion = vm.currentWeakRefVersion();
@@ -73,10 +73,10 @@ private:
     {
     }
 
-    JS_EXPORT_PRIVATE void finishCreation(VM&, JSObject* value);
+    JS_EXPORT_PRIVATE void finishCreation(VM&, JSCell* value);
 
     uintptr_t m_lastAccessVersion;
-    WriteBarrier<JSObject> m_value;
+    WriteBarrier<JSCell> m_value;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFr
             if (key.isObject())
                 weakMap->set(vm, asObject(key), value);
             else
-                throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakMapNonObjectKeyError);
+                throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakMapInvalidKeyError);
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
@@ -100,7 +100,7 @@ void WeakMapImpl<WeakMapBucket>::takeSnapshotInternal(unsigned limit, Appender a
 {
     DisallowGC disallowGC;
     unsigned fetched = 0;
-    forEach([&] (JSObject* key, JSValue value) {
+    forEach([&](JSCell* key, JSValue value) {
         appender(key, value);
         ++fetched;
         if (limit && fetched >= limit)
@@ -113,7 +113,7 @@ void WeakMapImpl<WeakMapBucket>::takeSnapshotInternal(unsigned limit, Appender a
 template <>
 void WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::takeSnapshot(MarkedArgumentBuffer& buffer, unsigned limit)
 {
-    takeSnapshotInternal(limit, [&] (JSObject* key, JSValue) {
+    takeSnapshotInternal(limit, [&](JSCell* key, JSValue) {
         buffer.append(key);
     });
 }
@@ -121,7 +121,7 @@ void WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::takeSnapshot(MarkedArgume
 template <>
 void WeakMapImpl<WeakMapBucket<WeakMapBucketDataKeyValue>>::takeSnapshot(MarkedArgumentBuffer& buffer, unsigned limit)
 {
-    takeSnapshotInternal(limit, [&] (JSObject* key, JSValue value) {
+    takeSnapshotInternal(limit, [&](JSCell* key, JSValue value) {
         buffer.append(key);
         buffer.append(value);
     });

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.h
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-extern const ASCIILiteral WeakMapNonObjectKeyError;
+extern const ASCIILiteral WeakMapInvalidKeyError;
 
 JSC_DECLARE_HOST_FUNCTION(protoFuncWeakMapSet);
 

--- a/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
@@ -28,6 +28,7 @@
 
 #include "JSCInlines.h"
 #include "JSWeakObjectRef.h"
+#include "WeakMapImplInlines.h"
 #include "WeakObjectRefPrototype.h"
 
 namespace JSC {
@@ -60,14 +61,15 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakRef, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!callFrame->argument(0).isObject())
-        return throwVMTypeError(globalObject, scope, "First argument to WeakRef should be an object"_s);
+    JSValue target = callFrame->argument(0);
+    if (UNLIKELY(!canBeHeldWeakly(target)))
+        return throwVMTypeError(globalObject, scope, "First argument to WeakRef should be an object or a non-registered symbol"_s);
 
     JSObject* newTarget = asObject(callFrame->newTarget());
     Structure* weakObjectRefStructure = JSC_GET_DERIVED_STRUCTURE(vm, weakObjectRefStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSWeakObjectRef::create(vm, weakObjectRefStructure, callFrame->uncheckedArgument(0).getObject())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSWeakObjectRef::create(vm, weakObjectRefStructure, target.asCell())));
 }
 
 }

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -86,7 +86,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFr
             if (nextValue.isObject())
                 weakSet->add(vm, asObject(nextValue));
             else
-                throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakSetNonObjectValueError);
+                throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakSetInvalidValueError);
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/WeakSetPrototype.h
+++ b/Source/JavaScriptCore/runtime/WeakSetPrototype.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-extern const ASCIILiteral WeakSetNonObjectValueError;
+extern const ASCIILiteral WeakSetInvalidValueError;
 
 JSC_DECLARE_HOST_FUNCTION(protoFuncWeakSetAdd);
 


### PR DESCRIPTION
#### 290c0b91225ac430d66b4fff9a4f6606b063ba5d
<pre>
[JSC] Implement Symbols as WeakMap keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=243483">https://bugs.webkit.org/show_bug.cgi?id=243483</a>

Reviewed by Ross Kirsling and Saam Barati.

This patch implements stage-3 proposal &quot;Symbols as WeakMap keys&quot;[1].
Previously, WeakMap, WeakSet, FinalizationRegistry, and WeakRef are only accepting objects as keys.
But this proposal extends it to accept non-registered Symbols too.

The runtime implementation is just changed from using JSObject* to JSCell*. And we check whether the
given value is appropriate by using canBeHeldWeakly function (specified in the spec) instead of `isObject()`.

A bit complicated part is DFG / FTL handling for WeakMap / WeakSet functions. We extend it to accept SymbolUse
and CellUse. And we emit appropriate code for that, and modifying clobberizing rules and doesGC rules too for
these new UseKind.

[1]: <a href="https://github.com/tc39/proposal-symbols-as-weakmap-keys">https://github.com/tc39/proposal-symbols-as-weakmap-keys</a>

* JSTests/stress/finalization-registry-registered-symbol.js: Added.
(shouldThrow):
* JSTests/stress/v8-cleanup-from-different-realm-symbol.js: Added.
(let.timeout_func):
* JSTests/stress/v8-cleanup-proxy-from-different-realm-symbol.js: Added.
(let.timeout_func):
* JSTests/stress/v8-finalization-registry-basics-symbol.js: Copied from JSTests/stress/v8-finalization-registry-basics.js.
(TestConstructFinalizationRegistry):
(TestFinalizationRegistryConstructorCallAsFunction):
(TestConstructFinalizationRegistryCleanupNotCallable):
(TestConstructFinalizationRegistryWithNonCallableProxyAsCleanup):
(TestRegisterTargetAndHoldingsSameValue):
(TestRegisterWithoutFinalizationRegistry):
(TestUnregisterWithNonExistentKey):
(TestUnregisterWithNonFinalizationRegistry):
(TestWeakRefConstructorWithNonObject):
* JSTests/stress/v8-finalization-registry-basics.js:
(TestWeakRefConstructorWithNonObject):
* JSTests/stress/v8-finalizationregistry-and-weakref-symbol.js: Added.
(let.cleanup):
(setTimeout):
* JSTests/stress/v8-finalizationregistry-keeps-holdings-alive-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-finalizationregistry-scheduled-for-cleanup-multiple-times-symbol.js: Added.
(let.cleanup0):
(let.cleanup1):
(let.timeout_func):
* JSTests/stress/v8-multiple-dirty-finalization-registries-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-reentrant-gc-from-cleanup-symbol.js: Added.
(let.reentrant_gc):
(setTimeout):
* JSTests/stress/v8-stress-finalizationregistry-dirty-enqueue-symbol.js: Added.
(i.registries.push.new.FinalizationRegistry):
(registries.forEach):
* JSTests/stress/v8-undefined-holdings-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-after-cleanup-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-before-cleanup-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-called-twice-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-inside-cleanup2-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-inside-cleanup3-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-unregister-many-symbol.js: Added.
(let.cleanup):
(let.timeout_func):
* JSTests/stress/v8-weak-unregistertoken-symbol.js: Added.
(FR.new.FinalizationRegistry):
(tryAgain):
* JSTests/stress/weak-map-constructor.js:
* JSTests/stress/weak-map-registered-symbol.js: Added.
(shouldBe):
(shouldThrow):
* JSTests/stress/weak-map-symbol.js: Added.
(shouldBe):
(test):
* JSTests/stress/weak-map-various-one-site.js: Added.
(shouldThrow):
(getTest):
(hasTest):
(setTest):
(deleteTest):
(i.test.set shouldBe):
(i.test):
* JSTests/stress/weak-map-various.js: Added.
(shouldBe):
* JSTests/stress/weak-ref-registered-symbol.js: Added.
(shouldThrow):
* JSTests/stress/weak-set-constructor.js:
* JSTests/stress/weak-set-registered-symbol.js: Added.
(shouldBe):
(shouldThrow):
(test.set add):
* JSTests/stress/weak-set-symbol.js: Added.
(shouldBe):
* JSTests/stress/weak-set-various-one-site.js: Added.
(shouldThrow):
(set shouldThrow):
* JSTests/stress/weak-set-various.js: Added.
(shouldBe):
* JSTests/test262/config.yaml:
* LayoutTests/js/dom/basic-weakmap-expected.txt:
* LayoutTests/js/dom/basic-weakset-expected.txt:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/FinalizationRegistryPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::registerTarget):
(JSC::JSFinalizationRegistry::unregister):
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSWeakMap.h:
* Source/JavaScriptCore/runtime/JSWeakMapInlines.h:
(JSC::JSWeakMap::set):
* Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp:
(JSC::JSWeakObjectRef::finishCreation):
* Source/JavaScriptCore/runtime/JSWeakObjectRef.h:
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapImpl.cpp:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::takeSnapshotInternal):
(JSC::WeakMapImpl&lt;WeakMapBucket&lt;WeakMapBucketDataKey&gt;&gt;::takeSnapshot):
(JSC::WeakMapImpl&lt;WeakMapBucket&lt;WeakMapBucketDataKeyValue&gt;&gt;::takeSnapshot):
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
(JSC::WeakMapBucket::setKey):
(JSC::WeakMapBucket::key const):
(JSC::WeakMapBucket::deletedKey):
(JSC::WeakMapImpl::get):
(JSC::WeakMapImpl::findBucket):
(JSC::WeakMapImpl::has):
(JSC::WeakMapImpl::remove):
(JSC::WeakMapImpl::canUseBucket):
(JSC::WeakMapImpl::addInternal):
(JSC::WeakMapImpl::findBucketAlreadyHashed):
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::jsWeakMapHash):
(JSC::canBeHeldWeakly):
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::add):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::WeakMapPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapPrototype.h:
* Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetPrototype.cpp:
(JSC::WeakSetPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetPrototype.h:

Canonical link: <a href="https://commits.webkit.org/253135@main">https://commits.webkit.org/253135@main</a>
</pre>
