### PR TITLE
[GTK4] Handle hold gesture events

### DIFF
--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -246,7 +246,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(const IntPoint& position)
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event)
 {
-    WebWheelEvent::Phase phase = gdk_event_is_scroll_stop_event(event) ?
+    WebWheelEvent::Phase phase = !event || gdk_event_is_scroll_stop_event(event) ?
         WebWheelEvent::Phase::PhaseEnded :
         WebWheelEvent::Phase::PhaseChanged;
     return createWebWheelEvent(event, phase, WebWheelEvent::Phase::PhaseNone);
@@ -298,7 +298,8 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const 
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const IntPoint& position, const IntPoint& globalPosition, const FloatSize& wheelTicks)
 {
-    WebWheelEvent::Phase phase = gdk_event_is_scroll_stop_event(event) ?
+    WebWheelEvent::Phase phase = gdk_event_get_event_type(const_cast<GdkEvent*>(event)) != GDK_SCROLL
+        || gdk_event_is_scroll_stop_event(event) ?
         WebWheelEvent::Phase::PhaseEnded :
         WebWheelEvent::Phase::PhaseChanged;
     return createWebWheelEvent(event, position, globalPosition, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone);
@@ -313,7 +314,8 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const 
     bool hasPreciseScrollingDeltas = false;
 
 #if GTK_CHECK_VERSION(4, 7, 0)
-    hasPreciseScrollingDeltas = gdk_scroll_event_get_unit(const_cast<GdkEvent*>(event)) != GDK_SCROLL_UNIT_WHEEL;
+    hasPreciseScrollingDeltas = gdk_event_get_event_type(const_cast<GdkEvent*>(event)) != GDK_SCROLL
+        || gdk_scroll_event_get_unit(const_cast<GdkEvent*>(event)) != GDK_SCROLL_UNIT_WHEEL;
 
     if (hasPreciseScrollingDeltas)
         delta = wheelTicks;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1320,7 +1320,7 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
 #endif
 
 #if USE(GTK4)
-static gboolean webkitWebViewBaseScroll(WebKitWebViewBase* webViewBase, double deltaX, double deltaY, GtkEventController* eventController)
+static gboolean handleScroll(WebKitWebViewBase* webViewBase, double deltaX, double deltaY, bool isEnd, GtkEventController* eventController)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
     if (priv->dialog)
@@ -1334,27 +1334,37 @@ static gboolean webkitWebViewBaseScroll(WebKitWebViewBase* webViewBase, double d
 
         int32_t eventTime = static_cast<int32_t>(gtk_event_controller_get_current_event_time(eventController));
 
-        GdkDevice* device = gdk_event_get_device(event);
-        GdkInputSource source = gdk_device_get_source(device);
-
-        bool isEnd = gdk_scroll_event_is_stop(event) ? true : false;
+        GdkDevice* device = gtk_event_controller_get_current_event_device(eventController);
+        // We only have hold events on touchpads, so assume one if we get no event.
+        GdkInputSource source = device ? gdk_device_get_source(device) : GDK_SOURCE_TOUCHPAD;
 
         PlatformGtkScrollData scrollData = { .delta = delta, .eventTime = eventTime, .source = source, .isEnd = isEnd };
         if (controller->handleScrollWheelEvent(&scrollData))
             return GDK_EVENT_STOP;
     }
 
-    if (shouldInvertDirectionForScrollEvent(priv->mouseIsOverScrollbar, gdk_event_get_modifier_state(event) & GDK_SHIFT_MASK))
+    if (!isEnd && shouldInvertDirectionForScrollEvent(priv->mouseIsOverScrollbar, gdk_event_get_modifier_state(event) & GDK_SHIFT_MASK))
         std::swap(deltaX, deltaY);
 
-    priv->pageProxy->handleWheelEvent(NativeWebWheelEvent(event, priv->lastMotionEvent ? IntPoint(priv->lastMotionEvent->position) : IntPoint(), FloatSize(-deltaX, -deltaY)));
+    if (event)
+        priv->pageProxy->handleWheelEvent(NativeWebWheelEvent(event, priv->lastMotionEvent ? IntPoint(priv->lastMotionEvent->position) : IntPoint(), FloatSize(-deltaX, -deltaY)));
 
     return GDK_EVENT_STOP;
 }
 
+static void webkitWebViewBaseScrollBegin(WebKitWebViewBase* webViewBase, GtkEventController* controller)
+{
+    handleScroll(webViewBase, 0, 0, false, controller);
+}
+
+static gboolean webkitWebViewBaseScroll(WebKitWebViewBase* webViewBase, double deltaX, double deltaY, GtkEventController* eventController)
+{
+    return handleScroll(webViewBase, deltaX, deltaY, false, eventController);
+}
+
 static void webkitWebViewBaseScrollEnd(WebKitWebViewBase* webViewBase, GtkEventController* controller)
 {
-    webkitWebViewBaseScroll(webViewBase, 0, 0, controller);
+    handleScroll(webViewBase, 0, 0, true, controller);
 }
 #endif
 
@@ -2090,6 +2100,7 @@ static void webkitWebViewBaseConstructed(GObject* object)
 
 #if USE(GTK4)
     auto* controller = gtk_event_controller_scroll_new(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES);
+    g_signal_connect_object(controller, "scroll-begin", G_CALLBACK(webkitWebViewBaseScrollBegin), viewWidget, G_CONNECT_SWAPPED);
     g_signal_connect_object(controller, "scroll", G_CALLBACK(webkitWebViewBaseScroll), viewWidget, G_CONNECT_SWAPPED);
     g_signal_connect_object(controller, "scroll-end", G_CALLBACK(webkitWebViewBaseScrollEnd), viewWidget, G_CONNECT_SWAPPED);
     gtk_widget_add_controller(viewWidget, controller);

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -195,10 +195,11 @@ bool ViewGestureController::SwipeProgressTracker::handleEvent(PlatformGtkScrollD
     }
 
     Seconds time = Seconds::fromMilliseconds(eventTime);
-    if (time != m_prevTime)
+    if (time > m_prevTime) {
         m_velocity = deltaX / (time - m_prevTime).milliseconds();
+        m_prevTime = time;
+    }
 
-    m_prevTime = time;
     m_progress += deltaX;
 
     bool swipingLeft = m_viewGestureController.isPhysicallySwipingLeft(m_direction);


### PR DESCRIPTION
#### e9ba79dac78dd3f149ea27d52e0b6cb684990e5a
<pre>
[GTK4] Handle hold gesture events
<a href="https://bugs.webkit.org/show_bug.cgi?id=237247">https://bugs.webkit.org/show_bug.cgi?id=237247</a>

Reviewed by Michael Catanzaro.

In GTK 4.7.x, scroll controllers don&apos;t necessarily work with scroll events,
but can also involve hold gesture events, as well as no event at all.

Handle scroll-begin signal, and add safeguards for null and hold events
everywhere.

* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(handleScroll):
(webkitWebViewBaseScrollBegin):
(webkitWebViewBaseScroll):
(webkitWebViewBaseScrollEnd):
(webkitWebViewBaseConstructed):
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
(WebKit::ViewGestureController::SwipeProgressTracker::handleEvent):

Canonical link: <a href="https://commits.webkit.org/253084@main">https://commits.webkit.org/253084@main</a>
</pre>
