### PR TITLE
[Gardening]: [ iOS Debug ][ macOS Debug wk1 ] compositing/layer-creation/scale-rotation-animation-overlap.html is a flaky timeout

### DIFF
--- a/LayoutTests/platform/ios-15/TestExpectations
+++ b/LayoutTests/platform/ios-15/TestExpectations
@@ -8,3 +8,5 @@
 
 # rdar://97297483 ([ iOS16 ] fast/events/ios/rotation/zz-no-rotation.html is a constant timeout =)
 fast/events/ios/rotation/zz-no-rotation.html [ Pass ]
+
+webkit.org/b/243494 [ Debug ] compositing/layer-creation/scale-rotation-animation-overlap.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1897,3 +1897,5 @@ webkit.org/b/242692 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-s
 webkit.org/b/242692 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html [ Pass Failure ]
 webkit.org/b/242692 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html [ Pass Failure ]
 webkit.org/b/242692 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-color.html [ Pass Failure ]
+
+webkit.org/b/243494 [ Debug ] compositing/layer-creation/scale-rotation-animation-overlap.html [ Pass Timeout ]


### PR DESCRIPTION
#### 0e114ac53fe668967f53afe5b5575fe1a16b91cc
<pre>
[Gardening]: [ iOS Debug ][ macOS Debug wk1 ] compositing/layer-creation/scale-rotation-animation-overlap.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=243494">https://bugs.webkit.org/show_bug.cgi?id=243494</a>
&lt;rdar://98056010&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios-15/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253077@main">https://commits.webkit.org/253077@main</a>
</pre>
