### PR TITLE
[ews] Update the icon for ongoing builds used in ews GitHub comments

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -147,7 +147,7 @@ class GitHubEWS(GitHub):
     ICON_BUILD_PASS = u'\U00002705'
     ICON_BUILD_FAIL = u'\U0000274C'
     ICON_BUILD_WAITING = u'\U000023F3'
-    ICON_BUILD_ONGOING = u'\U000023F3'  # FIXME: Update this icon with a better one
+    ICON_BUILD_ONGOING = u'![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png)'
     ICON_BUILD_ERROR = u'\U0001F6D1'  # FIXME: Update this icon with a better one
     STATUS_BUBBLE_ROWS = [['style', 'ios', 'mac', 'wpe', 'win'],
                           ['webkitpy', 'ios-sim', 'mac-debug', 'gtk', 'wincairo'],


### PR DESCRIPTION
#### 0dfd3285168caaa121953021b7683efcd26e11b9
<pre>
[ews] Update the icon for ongoing builds used in ews GitHub comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=243496">https://bugs.webkit.org/show_bug.cgi?id=243496</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS):

Canonical link: <a href="https://commits.webkit.org/253082@main">https://commits.webkit.org/253082@main</a>
</pre>
