### PR TITLE
[WASM-Function-References] Assertion failure when a function returns (ref <idx>) to JS

### DIFF
--- a/JSTests/wasm/function-references/bug243265.js
+++ b/JSTests/wasm/function-references/bug243265.js
@@ -1,0 +1,68 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+
+import * as assert from '../assert.js';
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+async function exportRefIndexResultFunc() {
+  /*
+   * (module
+   *   (type (func))
+   *   (type (func (result (ref 0))))
+   *   (global (ref 0) (ref.func 0))
+   *   (func)
+   *   (func (export "f") (type 1) (global.get 0))
+   * )
+   */
+  let instance = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x89\x80\x80\x80\x00\x02\x60\x00\x00\x60\x00\x01\x6b\x00\x03\x83\x80\x80\x80\x00\x02\x00\x01\x06\x87\x80\x80\x80\x00\x01\x6b\x00\x00\xd2\x00\x0b\x07\x85\x80\x80\x80\x00\x01\x01\x66\x00\x01\x0a\x91\x80\x80\x80\x00\x02\x82\x80\x80\x80\x00\x00\x0b\x84\x80\x80\x80\x00\x00\x23\x00\x0b"));
+  instance.exports.f();
+
+  /*
+   * (module
+   *   (type (func))
+   *   (type (func (result (ref 0))))
+   *   (func (import "m" "f") (type 1))
+   * )
+   */
+  new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x89\x80\x80\x80\x00\x02\x60\x00\x00\x60\x00\x01\x6b\x00\x02\x87\x80\x80\x80\x00\x01\x01\x6d\x01\x66\x00\x01"),
+                           { m: { f: instance.exports.f } });
+}
+
+async function refIndexArgToJS() {
+  /*
+   * (module
+   *   (type (func))
+   *   (type (func (param (ref null 0))))
+   *   (func (import "m" "f") (type 1))
+   *   (func (export "g") (type 0) (call 0 (ref.null 0)))
+   * )
+   */
+  {
+    let instance = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x89\x80\x80\x80\x00\x02\x60\x00\x00\x60\x01\x6c\x00\x00\x02\x87\x80\x80\x80\x00\x01\x01\x6d\x01\x66\x00\x01\x03\x82\x80\x80\x80\x00\x01\x00\x07\x85\x80\x80\x80\x00\x01\x01\x67\x00\x01\x0a\x8c\x80\x80\x80\x00\x01\x86\x80\x80\x80\x00\x00\xd0\x00\x10\x00\x0b"),
+                                            { m: { f: (g) => { assert.eq(g, null) } } });
+    instance.exports.g();
+  }
+
+  /*
+   * (module
+   *   (type (func (param funcref))) ;; encoded as (ref null func)
+   *   (func (import "m" "f") (type 0))
+   *   (func (export "g") (call 0 (ref.null 0)))
+   * )
+   */
+  {
+    let instance = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x88\x80\x80\x80\x00\x02\x60\x01\x70\x00\x60\x00\x00\x02\x87\x80\x80\x80\x00\x01\x01\x6d\x01\x66\x00\x00\x03\x82\x80\x80\x80\x00\x01\x01\x07\x85\x80\x80\x80\x00\x01\x01\x67\x00\x01\x0a\x8c\x80\x80\x80\x00\x01\x86\x80\x80\x80\x00\x00\xd0\x00\x10\x00\x0b"),
+                                            { m: { f: (g) => { assert.eq(g, null) } } });
+    instance.exports.g();
+  }
+}
+
+assert.asyncTest(exportRefIndexResultFunc());
+assert.asyncTest(refIndexArgToJS());

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -75,4 +75,82 @@ function testStructDeclaration() {
   );
 }
 
+function testStructJS() {
+  // JS API behavior not specified yet, import/export error for now.
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (struct))
+          (func (export "f") (result (ref null 0))
+            (ref.null 0))
+        )
+      `);
+      m.exports.f();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (struct))
+          (func (export "f") (param (ref null 0)))
+        )
+      `);
+      m.exports.f(null);
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (struct))
+          (import "m" "f" (func (param (ref null 0))))
+          (func (export "g") (call 0 (ref.null 0)))
+        )
+      `, { m: { f: (x) => { return; } } });
+      m.exports.g();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (struct))
+          (import "m" "f" (func (result (ref null 0))))
+          (func (export "g") (call 0) drop)
+        )
+      `, { m: { f: (x) => { return null; } } });
+      m.exports.g();
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+
+  // JS API behavior not specified yet, setting global errors for now.
+  assert.throws(
+    () => {
+      let m = instantiate(`
+        (module
+          (type (struct))
+          (global (export "g") (mut (ref null 0)) (ref.null 0))
+        )
+      `);
+      m.exports.g.value = 42;
+    },
+    WebAssembly.RuntimeError,
+    "Unsupported use of struct or array type"
+  )
+}
+
 testStructDeclaration();
+testStructJS();

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -46,7 +46,8 @@ namespace Wasm {
     macro(DivisionByZero, "Division by zero"_s) \
     macro(IntegerOverflow, "Integer overflow"_s) \
     macro(StackOverflow, "Stack overflow"_s) \
-    macro(FuncrefNotWasm, "Funcref must be an exported wasm function"_s)
+    macro(FuncrefNotWasm, "Funcref must be an exported wasm function"_s) \
+    macro(InvalidGCTypeUse, "Unsupported use of struct or array type"_s)
 
 enum class ExceptionType : uint32_t {
 #define MAKE_ENUM(enumName, error) enumName,

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -66,13 +66,26 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
             break;
         }
         default: {
-            if (isFuncref(type) || isExternref(type) || isI31ref(type))
+            if (isRefType(type))
                 jit.moveValueRegs(src.jsr(), dst);
             else
                 jit.breakpoint();
         }
         }
     };
+
+    // GC support is experimental and currently will throw a runtime error when struct
+    // and array type indices are exported via a function signature to JS.
+    if (Options::useWebAssemblyGC() && (wasmFrameConvention.argumentsIncludeGCTypeIndex || wasmFrameConvention.resultsIncludeGCTypeIndex)) {
+        GPRReg wasmContextInstanceGPR = PinnedRegisterInfo::get().wasmContextInstancePointer;
+        if (Context::useFastTLS()) {
+            wasmContextInstanceGPR = GPRInfo::argumentGPR2;
+            jit.loadWasmContextInstance(wasmContextInstanceGPR);
+        }
+
+        emitThrowWasmToJSException(jit, wasmContextInstanceGPR, ExceptionType::InvalidGCTypeUse);
+        return;
+    }
 
     if (signature.returnsVoid())
         jit.moveTrustedValue(jsUndefined(), JSRInfo::returnValueJSR);


### PR DESCRIPTION
#### 0c946f31a45171fb24601ae6e31a95ac874858e4
<pre>
[WASM-Function-References] Assertion failure when a function returns (ref &lt;idx&gt;) to JS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243265">https://bugs.webkit.org/show_bug.cgi?id=243265</a>

Reviewed by Justin Michaud.

This patch fixes some JS interaction cases in typed function reference
support. In particular, if a `(ref $t)` type is used at a JS&lt;-&gt;Wasm
boundary, assertion failures were possible in some cases.

When typed funcrefs were turned on, it was also possible for existing
interactions to fail. For example, for `funcref` uses because it is
normalized to `(ref null func)`.

The patch fixes this by generally treating Ref/RefNull type kinds the
same way that Externref/Funcref type kinds are in WasmToJS.cpp.

This patch also adds checking for uses of struct type indices to raise
an error when they are used in JS interactions through Ref/RefNull
types. When the Wasm GC JS API is more well-defined, these error cases
can likely be removed.

* ../../../JSTests/wasm/function-references/bug243265.js: Added.
(module):
(async exportRefIndexResultFunc):
(async refIndexArgToJS):
* ../../../JSTests/wasm/gc/structs.js:
* ../../../Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
* ../../../Source/JavaScriptCore/wasm/WasmExceptionType.h:
* ../../../Source/JavaScriptCore/wasm/WasmGlobal.cpp:
(JSC::Wasm::Global::set):
* ../../../Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
* ../../../Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::handleBadGCTypeIndexUse):
(JSC::Wasm::wasmToJS):
(JSC::Wasm::emitThrowWasmToJSException):

Canonical link: <a href="https://commits.webkit.org/253734@main">https://commits.webkit.org/253734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/apple/WebKit/commit/f3c8dc53d04f494090164e7c57b7395c016319a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9222 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104455 "The change is no longer eligible for processing.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/49925 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27407 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/104455 "The change is no longer eligible for processing.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/49925 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102331 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14641 "Found 1 new test failure: fast/dom/StyleSheet/detached-style-pi.xhtml (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89676 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/104455 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14435 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7657 "Found 1 new test failure: fast/dom/StyleSheet/detached-style-pi.xhtml (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/49285 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84360 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7744 "Found 1 new test failure: fast/dom/StyleSheet/detached-style-pi.xhtml (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106812 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26438 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19281 "Found 2 new test failures: fast/dom/StyleSheet/detached-style-pi.xhtml imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/106812 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85878 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106812 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28732 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6420 "Found 2 new test failures: fast/dom/StyleSheet/detached-style-pi.xhtml pdf/pdf-plugin-printing.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20173 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->