### PR TITLE
[Cocoa] Avoid unnecessary debug ASSERT when starting capture

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -400,13 +400,8 @@ void MediaPlayerPrivateMediaStreamAVFObjC::ensureLayers()
 
     auto size = snappedIntRect(m_player->playerContentBoxRect()).size();
     m_sampleBufferDisplayLayer->initialize(hideRootLayer(), size, [weakThis = WeakPtr { *this }, size](auto didSucceed) {
-        if (weakThis) {
-#if !RELEASE_LOG_DISABLED
-            if (weakThis->m_sampleBufferDisplayLayer)
-                weakThis->m_sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(reinterpret_cast<uintptr_t>(weakThis->logIdentifier()))));
-#endif
+        if (weakThis)
             weakThis->layersAreInitialized(size, didSucceed);
-        }
     });
 }
 
@@ -421,6 +416,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
 
     scheduleRenderingModeChanged();
 
+    m_sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(reinterpret_cast<uintptr_t>(logIdentifier()))));
     m_sampleBufferDisplayLayer->updateBoundsAndPosition(m_sampleBufferDisplayLayer->rootLayer().bounds, m_videoRotation);
     m_sampleBufferDisplayLayer->updateDisplayMode(m_displayMode < PausedImage, hideRootLayer());
     m_shouldUpdateDisplayLayer = true;


### PR DESCRIPTION
#### df7f18952ccf0421dbdc7ee63587f59dbc7bd8ef
<pre>
[Cocoa] Avoid unnecessary debug ASSERT when starting capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=243495">https://bugs.webkit.org/show_bug.cgi?id=243495</a>
rdar://98057679

Reviewed by Jer Noble.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::ensureLayers): Set layer log identifier in layersAreInitialized.
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized): Don&apos;t set layer
log identifier if initialization failed or it will assert.

Canonical link: <a href="https://commits.webkit.org/253090@main">https://commits.webkit.org/253090@main</a>
</pre>
