### PR TITLE
Web Inspector: REGRESSION(?): Elements: Computed: expanding a property trace causes layout shift

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css
@@ -42,6 +42,7 @@
 }
 
 .computed-style-section .computed-property-item.expanded {
+    margin-top: -0.5px;
     padding-bottom: 2px;
     background-color: var(--background-color-intermediate);
     border-top: 0.5px solid var(--text-color-quaternary);


### PR DESCRIPTION
#### 94bf53eaaa1513df81a142c4e1dbd1d7c7a6e6c5
<pre>
Web Inspector: REGRESSION(?): Elements: Computed: expanding a property trace causes layout shift
<a href="https://bugs.webkit.org/show_bug.cgi?id=243507">https://bugs.webkit.org/show_bug.cgi?id=243507</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css:
(.computed-style-section .computed-property-item.expanded):
Adjust the `margin-top` to match the `border-top`. We don&apos;t care about the `border-bottom` because
a whole bunch more content gets added, so everything below will already be shifted down.

Canonical link: <a href="https://commits.webkit.org/253217@main">https://commits.webkit.org/253217@main</a>
</pre>
