### PR TITLE
Web Inspector: REGRESSION(?): Elements: Computed: property traces that wrap have an incorrectly aligned list item indicator

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css
@@ -96,7 +96,6 @@
 .computed-style-section .computed-property-item .property-trace-item::before {
     content: "\2022";
     display: inline-block;
-    position: absolute;
     margin-left: -0.8em;
 }
 


### PR DESCRIPTION
#### 3b90b5b1570fcafabe3b80c84132460684c860b2
<pre>
Web Inspector: REGRESSION(?): Elements: Computed: property traces that wrap have an incorrectly aligned list item indicator
<a href="https://bugs.webkit.org/show_bug.cgi?id=243508">https://bugs.webkit.org/show_bug.cgi?id=243508</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/ComputedStyleSection.css:
(.computed-style-section .computed-property-item .property-trace-item::before):

Canonical link: <a href="https://commits.webkit.org/253213@main">https://commits.webkit.org/253213@main</a>
</pre>
