### PR TITLE
Web Inspector: REGRESSION(?): Elements: Node: Attributes section is always empty

### DIFF
--- a/LayoutTests/inspector/view/basics-expected.txt
+++ b/LayoutTests/inspector/view/basics-expected.txt
@@ -70,12 +70,30 @@ PASS: Parent attached to root view should have 1 dirty descendant.
 PASS: Root view should not be dirty.
 PASS: Parent attached to root view should be dirty.
 PASS: Child attached to parent view should be dirty.
+- Simulating layout.
+PASS: Root view should have 0 dirty descendants.
+PASS: Parent attached to root view should have 0 dirty descendants.
+PASS: Root view should not be dirty.
+PASS: Parent attached to root view should not be dirty.
+PASS: Child attached to parent view should not be dirty.
+- Dirtying parent.
+PASS: Root view should have 1 dirty descendant.
+PASS: Parent attached to root view should have 0 dirty descendant.
+PASS: Root view should not be dirty.
+PASS: Parent attached to root view should be dirty.
+PASS: Child attached to parent view should not be dirty.
 - Removing parent view from root view.
 PASS: Root view should have 0 dirty descendants.
 PASS: Parent detached from root view should have 0 dirty descendants.
 PASS: Root view should not be dirty.
 PASS: Parent detached from root view should not be dirty.
 PASS: Child attached to detached parent view should not be dirty.
+- Dirtying child.
+PASS: Root view should have 0 dirty descendants.
+PASS: Parent attached to root view should have 1 dirty descendants.
+PASS: Root view should not be dirty.
+PASS: Parent detached from root view should not be dirty.
+PASS: Child attached to parent view should be dirty.
 - Adding parent view to root view.
 PASS: Root view should have 1 dirty descendant.
 PASS: Parent detached from root view should have 0 dirty descendants.

--- a/LayoutTests/inspector/view/basics.html
+++ b/LayoutTests/inspector/view/basics.html
@@ -204,6 +204,22 @@ function test()
             InspectorTest.expectTrue(parent._dirty, "Parent attached to root view should be dirty.");
             InspectorTest.expectTrue(child._dirty, "Child attached to parent view should be dirty.");
 
+            InspectorTest.log("- Simulating layout.");
+            WI.View._visitViewTreeForLayout();
+            InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+            InspectorTest.expectEqual(parent._dirtyDescendantsCount, 0, "Parent attached to root view should have 0 dirty descendants.");
+            InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
+            InspectorTest.expectFalse(parent._dirty, "Parent attached to root view should not be dirty.");
+            InspectorTest.expectFalse(child._dirty, "Child attached to parent view should not be dirty.");
+
+            InspectorTest.log("- Dirtying parent.");
+            parent.needsLayout();
+            InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 1, "Root view should have 1 dirty descendant.");
+            InspectorTest.expectEqual(parent._dirtyDescendantsCount, 0, "Parent attached to root view should have 0 dirty descendant.");
+            InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
+            InspectorTest.expectTrue(parent._dirty, "Parent attached to root view should be dirty.");
+            InspectorTest.expectFalse(child._dirty, "Child attached to parent view should not be dirty.");
+
             InspectorTest.log("- Removing parent view from root view.");
             rootView.removeSubview(parent);
             InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
@@ -211,6 +227,14 @@ function test()
             InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
             InspectorTest.expectFalse(parent._dirty, "Parent detached from root view should not be dirty.");
             InspectorTest.expectFalse(child._dirty, "Child attached to detached parent view should not be dirty.");
+
+            InspectorTest.log("- Dirtying child.");
+            child.needsLayout();
+            InspectorTest.expectEqual(rootView._dirtyDescendantsCount, 0, "Root view should have 0 dirty descendants.");
+            InspectorTest.expectEqual(parent._dirtyDescendantsCount, 1, "Parent attached to root view should have 1 dirty descendants.");
+            InspectorTest.expectFalse(rootView._dirty, "Root view should not be dirty.");
+            InspectorTest.expectFalse(parent._dirty, "Parent detached from root view should not be dirty.");
+            InspectorTest.expectTrue(child._dirty, "Child attached to parent view should be dirty.");
 
             InspectorTest.log("- Adding parent view to root view.");
             rootView.addSubview(parent);

--- a/Source/WebInspectorUI/UserInterface/Views/View.js
+++ b/Source/WebInspectorUI/UserInterface/Views/View.js
@@ -171,9 +171,6 @@ WI.View = class View extends WI.Object
     {
         this._setLayoutReason(layoutReason);
 
-        if (this._dirty)
-            return;
-
         WI.View._scheduleLayoutForView(this);
     }
 
@@ -354,10 +351,10 @@ WI.View = class View extends WI.Object
 
     static _scheduleLayoutForView(view)
     {
+        view._setDirty(true);
+
         if (!view._isAttachedToRoot)
             return;
-
-        view._setDirty(true);
 
         if (WI.View._scheduledLayoutUpdateIdentifier)
             return;


### PR DESCRIPTION
#### 10283406d898d5caab7f9370b6d74d354987145c
<pre>
Web Inspector: REGRESSION(?): Elements: Node: Attributes section is always empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=243504">https://bugs.webkit.org/show_bug.cgi?id=243504</a>
&lt;rdar://problem/98068602&gt;

Reviewed by Patrick Angle.

The `WI.DataGrid` in the Attributes section is never actually added as a subview, which (previously)
meant that `needsLayout()` didn&apos;t set `_dirty`. We should really be setting `_dirty` regardless of
whether the `WI.View` is attached to the root or not, as it can still be used (e.g. `updateLayout`).

* Source/WebInspectorUI/UserInterface/Views/View.js:
(WI.View.prototype.needsLayout):
(WI.View._scheduleLayoutForView):

* LayoutTests/inspector/view/basics.html:
* LayoutTests/inspector/view/basics-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253272@main">https://commits.webkit.org/253272@main</a>
</pre>
