### PR TITLE
[Xcode] Some projects do not have a scheme committed, breaking single-project workspace builds

### DIFF
--- a/PerformanceTests/Makefile.shared
+++ b/PerformanceTests/Makefile.shared
@@ -1,2 +1,4 @@
 SCRIPTS_PATH ?= ../../Tools/Scripts
+# Opt out of workspace builds, as these projects are not part of any workspace.
+USE_WORKSPACE = NO
 include ../../Makefile.shared

--- a/Source/ThirdParty/gtest/xcode/Makefile
+++ b/Source/ThirdParty/gtest/xcode/Makefile
@@ -1,2 +1,3 @@
 SCRIPTS_PATH ?= ../../../../Tools/Scripts
+SCHEME = gtest
 include ../../../../Makefile.shared

--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D07F2BC0486CC7A007CD1D0"
+               BuildableName = "gtest.framework"
+               BlueprintName = "gtest-framework"
+               ReferencedContainer = "container:gtest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D07F2BC0486CC7A007CD1D0"
+            BuildableName = "gtest.framework"
+            BlueprintName = "gtest-framework"
+            ReferencedContainer = "container:gtest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FB39D0D01200F0E300088E69"
+               BuildableName = "libwebrtc.dylib"
+               BlueprintName = "libwebrtc"
+               ReferencedContainer = "container:libwebrtc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FB39D0D01200F0E300088E69"
+            BuildableName = "libwebrtc.dylib"
+            BlueprintName = "libwebrtc"
+            ReferencedContainer = "container:libwebrtc.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A54C2256148B23DF00373FA3"
+               BuildableName = "WebInspectorUI.framework"
+               BlueprintName = "WebInspectorUI"
+               ReferencedContainer = "container:WebInspectorUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A54C2256148B23DF00373FA3"
+            BuildableName = "WebInspectorUI.framework"
+            BlueprintName = "WebInspectorUI"
+            ReferencedContainer = "container:WebInspectorUI.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Tools/ContentExtensionTester/Makefile
+++ b/Tools/ContentExtensionTester/Makefile
@@ -1,2 +1,3 @@
 SCRIPTS_PATH = ../Scripts
+USE_WORKSPACE = NO
 include ../../Makefile.shared

--- a/Tools/ImageDiff/Makefile
+++ b/Tools/ImageDiff/Makefile
@@ -1,4 +1,6 @@
 SCRIPTS_PATH = ../Scripts
+# Opt out of workspace builds, as ImageDiff is not part of any workspace.
+USE_WORKSPACE = NO
 
 TO_LOWER = $(shell echo $(1) | tr [:upper:] [:lower:])
 


### PR DESCRIPTION
#### 30e11f2d01fde5badcdd05513cb19949a965a816
<pre>
[Xcode] Some projects do not have a scheme committed, breaking single-project workspace builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=243512">https://bugs.webkit.org/show_bug.cgi?id=243512</a>

Reviewed by Alexey Proskuryakov.

Ensure all projects which are in the workspace have a scheme visible.
For tertiary projects not part of the workspace, opt out of workspace
builds.

* PerformanceTests/Makefile.shared: Opt out of workspace builds for all
  projects in this directory tree.
* Source/ThirdParty/gtest/xcode/Makefile: Set the default scheme name
  to &quot;gtest&quot;.
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme: Added.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme: Added.
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme: Added.
* Tools/ContentExtensionTester/Makefile: Opt out of workspace builds.
* Tools/ImageDiff/Makefile: Opt out of workspace builds.

Canonical link: <a href="https://commits.webkit.org/253095@main">https://commits.webkit.org/253095@main</a>
</pre>
