### PR TITLE
[Alternate WebM Player] Fix video seek buttons

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -280,6 +280,7 @@ void MediaPlayerPrivateWebM::seek(const MediaTime& time)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "time = ", time);
 
+    [m_synchronizer setRate:0 time:PAL::toCMTime(time)];
     for (auto& trackBufferPair : m_trackBufferMap) {
         TrackBuffer& trackBuffer = trackBufferPair.value;
         auto trackId = trackBufferPair.key;
@@ -287,7 +288,7 @@ void MediaPlayerPrivateWebM::seek(const MediaTime& time)
         trackBuffer.setNeedsReenqueueing(true);
         reenqueueMediaForTime(trackBuffer, trackId, time);
     }
-    [m_synchronizer setRate:effectiveRate() time:PAL::toCMTime(time)];
+    [m_synchronizer setRate:m_rate];
     m_player->timeChanged();
 }
 


### PR DESCRIPTION
#### 08124a28f248c08a7aac458932c616f0bdf34465
<pre>
[Alternate WebM Player] Fix video seek buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=243297">https://bugs.webkit.org/show_bug.cgi?id=243297</a>
&lt;rdar://97727161&gt;

Reviewed by Jer Noble.

When seeking with the +/-15 second buttons, the player attempts to seek
while simutaneously playing the currently enqueued frames (a non-zero rate),
this introduces a bug not found in scrub seeking (which sets the effective
playback rate to 0 while seeking).

In order to fix this, we set our rate to 0 while we seek to a position and
then after re-enqueing the correct frames, we continue at the player&apos;s previous
playback rate.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::seek):

Canonical link: <a href="https://commits.webkit.org/253089@main">https://commits.webkit.org/253089@main</a>
</pre>
