### PR TITLE
[Cocoa] Remove invalid logging when using mock audio capture device

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -382,10 +382,10 @@ OSStatus CoreAudioSharedUnit::configureSpeakerProc(int sampleRate)
 }
 
 #if !LOG_DISABLED
-void CoreAudioSharedUnit::checkTimestamps(const AudioTimeStamp& timeStamp, uint64_t sampleTime, double hostTime)
+void CoreAudioSharedUnit::checkTimestamps(const AudioTimeStamp& timeStamp, double hostTime)
 {
-    if (!timeStamp.mSampleTime || sampleTime == m_latestMicTimeStamp || !hostTime)
-        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit::checkTimestamps: unusual timestamps, sample time = %lld, previous sample time = %lld, hostTime %f", sampleTime, m_latestMicTimeStamp, hostTime);
+    if (!timeStamp.mSampleTime || timeStamp.mSampleTime == m_latestMicTimeStamp || !hostTime)
+        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit::checkTimestamps: unusual timestamps, sample time = %f, previous sample time = %f, hostTime %f", timeStamp.mSampleTime, m_latestMicTimeStamp, hostTime);
 }
 #endif
 
@@ -442,9 +442,9 @@ OSStatus CoreAudioSharedUnit::processMicrophoneSamples(AudioUnitRenderActionFlag
     double adjustedHostTime = m_DTSConversionRatio * timeStamp.mHostTime;
     uint64_t sampleTime = timeStamp.mSampleTime;
 #if !LOG_DISABLED
-    checkTimestamps(timeStamp, sampleTime, adjustedHostTime);
+    checkTimestamps(timeStamp, adjustedHostTime);
 #endif
-    m_latestMicTimeStamp = sampleTime;
+    m_latestMicTimeStamp = timeStamp.mSampleTime;
     m_microphoneSampleBuffer->setTimes(adjustedHostTime, sampleTime);
 
     if (volume() != 1.0)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -121,7 +121,7 @@ private:
 
     CAAudioStreamDescription m_microphoneProcFormat;
     RefPtr<AudioSampleBufferList> m_microphoneSampleBuffer;
-    uint64_t m_latestMicTimeStamp { 0 };
+    double m_latestMicTimeStamp { 0 };
 
     CAAudioStreamDescription m_speakerProcFormat;
 
@@ -134,7 +134,7 @@ private:
     mutable std::optional<RealtimeMediaSourceSettings> m_currentSettings;
 
 #if !LOG_DISABLED
-    void checkTimestamps(const AudioTimeStamp&, uint64_t, double);
+    void checkTimestamps(const AudioTimeStamp&, double);
 
     String m_ioUnitName;
 #endif


### PR DESCRIPTION
#### fb6eb12811c6399eca76a38de1c247fb0e6bb141
<pre>
[Cocoa] Remove invalid logging when using mock audio capture device
<a href="https://bugs.webkit.org/show_bug.cgi?id=243516">https://bugs.webkit.org/show_bug.cgi?id=243516</a>
rdar://98079854

In a debug build we log an error whenever an audio buffer is scheduled to render with the
same timestamp as the previous buffer, because this should never happen. An audio timestamp
is a floating point number, but we were casting to a 64-bit integer for the comparison.
This doesn&apos;t work for the mock audio capture devices where timestamps are the number of
seconds since the device started, so only one buffer every second appeared to be different.

Reviewed by Jean-Yves Avenard.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::checkTimestamps): Drop `sampleTime` parameter, use
`timeStamp.mSampleTime` instead.
(WebCore::CoreAudioSharedUnit::processMicrophoneSamples):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/253096@main">https://commits.webkit.org/253096@main</a>
</pre>
