### PR TITLE
Iterate non-contiguous NSData regions instead of copying to contiguous buffer

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -265,7 +265,16 @@ void FragmentedSharedBuffer::forEachSegment(const Function<void(const Span<const
 {
     auto segments = m_segments;
     for (auto& segment : segments)
-        apply(Span { segment.segment->data(), segment.segment->size() });
+        segment.segment->iterate(apply);
+}
+
+void DataSegment::iterate(const Function<void(const Span<const uint8_t>&)>& apply) const
+{
+#if USE(FOUNDATION)
+    if (auto* data = std::get_if<RetainPtr<CFDataRef>>(&m_immutableData))
+        return iterate(data->get(), apply);
+#endif
+    apply({ data(), size() });
 }
 
 void FragmentedSharedBuffer::forEachSegmentAsSharedBuffer(const Function<void(Ref<SharedBuffer>&&)>& apply) const

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -102,6 +102,11 @@ public:
     WEBCORE_EXPORT bool containsMappedFileData() const;
 
 private:
+    void iterate(const Function<void(const Span<const uint8_t>&)>& apply) const;
+#if USE(FOUNDATION)
+    void iterate(CFDataRef, const Function<void(const Span<const uint8_t>&)>& apply) const;
+#endif
+
     explicit DataSegment(Vector<uint8_t>&& data)
         : m_immutableData(WTFMove(data)) { }
 #if USE(CF)

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -173,6 +173,13 @@ RetainPtr<NSData> DataSegment::createNSData() const
     return adoptNS([[WebCoreSharedBufferData alloc] initWithDataSegment:*this position:0 size:size()]);
 }
 
+void DataSegment::iterate(CFDataRef data, const Function<void(const Span<const uint8_t>&)>& apply) const
+{
+    [(__bridge NSData *)data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *) {
+        apply({ static_cast<const uint8_t*>(bytes), byteRange.length });
+    }];
+}
+
 RetainPtr<NSData> SharedBufferDataView::createNSData() const
 {
     return adoptNS([[WebCoreSharedBufferData alloc] initWithDataSegment:m_segment.get() position:m_positionWithinSegment size:size()]);

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -87,8 +87,9 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     FileSystem::makeAllDirectories(FileSystem::parentPath(scriptPath));
 
     auto iterateOverBufferAndWriteData = [&](const Function<bool(Span<const uint8_t>)>& writeData) {
-        for (auto& entry : *script.buffer())
-            writeData({ entry.segment->data(), entry.segment->size() });
+        script.buffer()->forEachSegment([&](Span<const uint8_t> span) {
+            writeData(span);
+        });
     };
 
     // Make sure we delete the file before writing as there may be code using a mmap'd version of this file.

--- a/Source/WebKit/Platform/SharedMemory.cpp
+++ b/Source/WebKit/Platform/SharedMemory.cpp
@@ -42,8 +42,10 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
         return nullptr;
 
     auto sharedMemoryPtr = static_cast<char*>(sharedMemory->data());
-    for (auto& segmentEntry : buffer)
-        memcpy(sharedMemoryPtr + segmentEntry.beginPosition, segmentEntry.segment->data(), segmentEntry.segment->size());
+    buffer.forEachSegment([sharedMemoryPtr] (Span<const uint8_t> segment) mutable {
+        memcpy(sharedMemoryPtr, segment.data(), segment.size());
+        sharedMemoryPtr += segment.size();
+    });
 
     return sharedMemory;
 }


### PR DESCRIPTION
#### f6b396ad7232f2f99822cfd5573cdc1798aa52d8
<pre>
Iterate non-contiguous NSData regions instead of copying to contiguous buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=243521">https://bugs.webkit.org/show_bug.cgi?id=243521</a>

Reviewed by Chris Dumez.

CFNetwork gives us NSData which we then copy to SharedMemory, but we do so by calling NSData.data which copies the data to a newly allocated buffer in about 1/4-1/3 of the cases of my local browsing.  Iterating using enumerateByteRangesUsingBlock instead removes this copy and allocation.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::forEachSegment const):
(WebCore::DataSegment::iterate const):
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/cocoa/SharedBufferCocoa.mm:
(WebCore::DataSegment::iterate const):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebKit/Platform/SharedMemory.cpp:
(WebKit::SharedMemory::copyBuffer):

Canonical link: <a href="https://commits.webkit.org/253363@main">https://commits.webkit.org/253363@main</a>
</pre>
