### PR TITLE
REGRESSION (iOS 16): Unable to search in PDFs in Safari

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -365,6 +365,14 @@ FOR_EACH_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 #undef FORWARD_CANPERFORMACTION_TO_WKCONTENTVIEW
 
+#if HAVE(UIFINDINTERACTION)
+    if (action == @selector(find:) || action == @selector(findNext:) || action == @selector(findPrevious:))
+        return _findInteractionEnabled;
+
+    if (action == @selector(findAndReplace:))
+        return _findInteractionEnabled && self._isEditable;
+#endif
+
     return [super canPerformAction:action withSender:sender];
 }
 
@@ -384,6 +392,30 @@ FOR_EACH_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
     return [super targetForAction:action withSender:sender];
 }
+
+#if HAVE(UIFINDINTERACTION)
+
+- (void)find:(id)sender
+{
+    [_findInteraction presentFindNavigatorShowingReplace:NO];
+}
+
+- (void)findNext:(id)sender
+{
+    [_findInteraction findNext];
+}
+
+- (void)findPrevious:(id)sender
+{
+    [_findInteraction findPrevious];
+}
+
+- (void)findAndReplace:(id)sender
+{
+    [_findInteraction presentFindNavigatorShowingReplace:YES];
+}
+
+#endif
 
 - (void)willFinishIgnoringCalloutBarFadeAfterPerformingAction
 {
@@ -3943,7 +3975,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)performTextSearchWithQueryString:(NSString *)string usingOptions:(UITextSearchOptions *)options resultAggregator:(id<UITextSearchAggregator>)aggregator
 {
-    [_contentView performTextSearchWithQueryString:string usingOptions:options resultAggregator:aggregator];
+    [[self _searchableObject] performTextSearchWithQueryString:string usingOptions:options resultAggregator:aggregator];
 }
 
 - (void)replaceFoundTextInRange:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document withText:(NSString *)replacementText

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -164,10 +164,6 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
 
 #if HAVE(UIFINDINTERACTION)
 #define FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M) \
-    M(find) \
-    M(findNext) \
-    M(findPrevious) \
-    M(findAndReplace) \
     M(useSelectionForFind) \
     M(_findSelected)
 #else

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4120,12 +4120,6 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 #if HAVE(UIFINDINTERACTION)
-    if (action == @selector(find:) || action == @selector(findNext:) || action == @selector(findPrevious:))
-        return self.webView._findInteractionEnabled;
-
-    if (action == @selector(findAndReplace:))
-        return self.webView._findInteractionEnabled && self.supportsTextReplacement;
-
     if (action == @selector(useSelectionForFind:) || action == @selector(_findSelected:)) {
         if (!self.webView._findInteractionEnabled)
             return NO;
@@ -10479,26 +10473,6 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 #if HAVE(UIFINDINTERACTION)
 
-- (void)findForWebView:(id)sender
-{
-    [self.webView._findInteraction presentFindNavigatorShowingReplace:NO];
-}
-
-- (void)findNextForWebView:(id)sender
-{
-    [self.webView._findInteraction findNext];
-}
-
-- (void)findPreviousForWebView:(id)sender
-{
-    [self.webView._findInteraction findPrevious];
-}
-
-- (void)findAndReplaceForWebView:(id)sender
-{
-    [self.webView._findInteraction presentFindNavigatorShowingReplace:YES];
-}
-
 - (void)useSelectionForFindForWebView:(id)sender
 {
     if (!_page->hasSelectedRange())
@@ -10514,7 +10488,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 - (void)_findSelectedForWebView:(id)sender
 {
     [self useSelectionForFindForWebView:sender];
-    [self findForWebView:sender];
+    [self.webView find:sender];
 }
 
 - (void)performTextSearchWithQueryString:(NSString *)string usingOptions:(UITextSearchOptions *)options resultAggregator:(id<UITextSearchAggregator>)aggregator

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
@@ -147,6 +147,31 @@ TEST(WebKit, WKPDFViewLosesApplicationForegroundNotification)
     TestWebKitAPI::Util::run(&finished);
 }
 
+#if HAVE(UIFINDINTERACTION)
+
+TEST(WebKit, WKPDFViewFindActions)
+{
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+
+    EXPECT_FALSE([webView canPerformAction:@selector(find:) withSender:nil]);
+    EXPECT_FALSE([webView canPerformAction:@selector(findNext:) withSender:nil]);
+    EXPECT_FALSE([webView canPerformAction:@selector(findPrevious:) withSender:nil]);
+    EXPECT_FALSE([webView canPerformAction:@selector(findAndReplace:) withSender:nil]);
+
+    [webView setFindInteractionEnabled:YES];
+
+    EXPECT_TRUE([webView canPerformAction:@selector(find:) withSender:nil]);
+    EXPECT_TRUE([webView canPerformAction:@selector(findNext:) withSender:nil]);
+    EXPECT_TRUE([webView canPerformAction:@selector(findPrevious:) withSender:nil]);
+    EXPECT_FALSE([webView canPerformAction:@selector(findAndReplace:) withSender:nil]);
+}
+
+#endif
+
 #endif
 
 #if ENABLE(UI_PROCESS_PDF_HUD)


### PR DESCRIPTION
#### 19bc5f6241e523672c8b4fcda0fc7ed53ac8d5fb
<pre>
REGRESSION (iOS 16): Unable to search in PDFs in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=243522">https://bugs.webkit.org/show_bug.cgi?id=243522</a>
rdar://98018313

Reviewed by Wenson Hsieh.

Safari adopted UIFindInteraction to support find-in-page in iOS 16. UIKit also
provides new UIResponderStandardEditActions in iOS 16 to support find actions.
Currently, WebKit only responds to these actions if there is a WKContentView,
as WKWebView forwards `canPerformAction:withSender:` to the content view.
However, if a PDF is loaded, there is no content view, and the find actions have
no effect. Previously, Safari overrode the actions to grab the find interaction
and present the find navigator. That logic was removed to take full advantage of
the new find API, but revealed a flaw in our find-in-PDF support.

To fix, move the find actions (with the exception of &quot;find using selection&quot;, which
is unsupported due to a lack of functionality in PDFHostViewController) from
WKContentView into WKWebView. This approach ensures that the find navigator is
presented even if the content is in a WKPDFView.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView canPerformAction:withSender:]):
(-[WKWebView find:]):
(-[WKWebView findNext:]):
(-[WKWebView findPrevious:]):
(-[WKWebView findAndReplace:]):
(-[WKWebView performTextSearchWithQueryString:usingOptions:resultAggregator:]):

Use the current searchable object here, so that the WKPDFView is used for
searching when a PDF is loaded.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _findSelectedForWebView:]):
(-[WKContentView findForWebView:]): Deleted.
(-[WKContentView findNextForWebView:]): Deleted.
(-[WKContentView findPreviousForWebView:]): Deleted.
(-[WKContentView findAndReplaceForWebView:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(swizzledPerformTextSearchWithQueryString):
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/253114@main">https://commits.webkit.org/253114@main</a>
</pre>
