### PR TITLE
[Complex text codepath] Use ICU to determine grapheme cluster boundaries

### DIFF
--- a/LayoutTests/fast/text/resources/Thai_test.svg
+++ b/LayoutTests/fast/text/resources/Thai_test.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+<font id="HelveticaLight" horiz-adv-x="1024">
+<font-face units-per-em="2048" ascent="1577" descent="-471" font-family="Helvetica"/>
+<glyph unicode="&#x0E2A;" horiz-adv-x="455" d="M137 1469H317V0H137z"/>
+<glyph unicode="&#x0e42;" horiz-adv-x="455" d="M137 1469H317V0H137z"/>
+</font>
+</defs>
+</svg>

--- a/LayoutTests/fast/text/thai-joiner-expected.txt
+++ b/LayoutTests/fast/text/thai-joiner-expected.txt
@@ -1,0 +1,5 @@
+PASS 50 is >= document.getElementById('target').offsetWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ส‍โ

--- a/LayoutTests/fast/text/thai-joiner.html
+++ b/LayoutTests/fast/text/thai-joiner.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+@font-face {
+    font-family: "WebFont";
+    src: url("resources/Thai_test.svg") format("svg");
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'WebFont';"><span id="target">&#x0e2a;&#x200d;&#x0e42;</span></div>
+<script>
+window.jsTestIsAsync = true;
+[...document.fonts.entries()][0].load().then(function() {
+    shouldBeGreaterThanOrEqual("50", "document.getElementById('target').offsetWidth");
+    finishJSTest();
+});
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -1,6 +1,6 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -51,6 +51,8 @@ static std::variant<TextBreakIteratorICU, TextBreakIteratorPlatform> mapModeToBa
     case TextBreakIterator::Mode::Caret:
         return TextBreakIteratorICU(string, TextBreakIteratorICU::Mode::Character, locale.string().utf8().data());
     case TextBreakIterator::Mode::Delete:
+        return TextBreakIteratorICU(string, TextBreakIteratorICU::Mode::Character, locale.string().utf8().data());
+    case TextBreakIterator::Mode::Character:
         return TextBreakIteratorICU(string, TextBreakIteratorICU::Mode::Character, locale.string().utf8().data());
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Lars Knoll <lars@trolltech.com>
- * Copyright (C) 2007-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -49,7 +49,8 @@ public:
     enum class Mode {
         Line,
         Caret,
-        Delete
+        Delete,
+        Character
     };
 
     TextBreakIterator() = delete;

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -40,6 +40,8 @@ static std::variant<TextBreakIteratorICU, TextBreakIteratorPlatform> mapModeToBa
         return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::ComposedCharacter);
     case TextBreakIterator::Mode::Delete:
         return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::BackwardDeletion);
+    case TextBreakIterator::Mode::Character:
+        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::ComposedCharacter);
     }
 }
 


### PR DESCRIPTION
#### 12bc2f0ab0d71a2a547031280df9eedf3c536a69
<pre>
[Complex text codepath] Use ICU to determine grapheme cluster boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=243530">https://bugs.webkit.org/show_bug.cgi?id=243530</a>
&lt;rdar://problem/98103970&gt;

Reviewed by Yusuke Suzuki.

Instead of naive hand-rolled code that just checks for 4 specific classes of characters,
we should use ICU to correctly find the boundaries of grapheme clusters.

Because the complex text codepath is already so rare and slow, this patch has no effect on
performance (as measured using the Design MotionMark subtest).

Test: fast/text/thai-joiner.html

* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::mapModeToBackingIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::mapModeToBackingIterator):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::advanceByCombiningCharacterSequence):
(WebCore::ComplexTextController::collectComplexTextRuns):

Canonical link: <a href="https://commits.webkit.org/253188@main">https://commits.webkit.org/253188@main</a>
</pre>
