### PR TITLE
Release assert in ContainerNode::takeAllChildrenFrom via executeTakeAllChildrenAndReparentTask

### DIFF
--- a/LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation-expected.txt
+++ b/LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation-expected.txt
@@ -1,0 +1,16 @@
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|     <script>
+|       src="../../resources/dump-as-markup.js"
+|     "\n"
+|   <body>
+|     <p>
+|       "This test passes if WebKit does not crash."
+|     "\n"
+|     <a>
+|     <menu>
+|       <a>
+|         " "
+|       <a>
+|         "\n"

--- a/LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation.html
+++ b/LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script src="../../resources/dump-as-markup.js"></script>
+<p>This test passes if WebKit does not crash.</p>
+<a><menu> <span id="span"><iframe onload="document.implementation.createHTMLDocument().createElement('span').appendChild(span)"></iframe><a>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -332,9 +332,9 @@ void ContainerNode::takeAllChildrenFrom(ContainerNode* oldParent)
     NodeVector children;
     oldParent->removeAllChildrenWithScriptAssertion(ChildChange::Source::Parser, children);
 
-    // FIXME: assert that we don't dispatch events here since this container node is still disconnected.
     for (auto& child : children) {
-        RELEASE_ASSERT(!child->parentNode() && &child->treeScope() == &treeScope());
+        if (child->parentNode()) // Previous parserAppendChild may have mutated DOM.
+            continue;
         ASSERT(!ensurePreInsertionValidity(child, nullptr).hasException());
         child->setTreeScopeRecursively(treeScope());
         parserAppendChild(child);


### PR DESCRIPTION
#### 1f03945868bd3e74f1c4f06c4fd31040e29cf2a9
<pre>
Release assert in ContainerNode::takeAllChildrenFrom via executeTakeAllChildrenAndReparentTask
<a href="https://bugs.webkit.org/show_bug.cgi?id=243532">https://bugs.webkit.org/show_bug.cgi?id=243532</a>

Reviewed by Darin Adler.

Skip inserting a child that has been re-inserted back elsewhere in takeAllChildrenFrom
instead of hitting a release assertion. WebKit&apos;s new behavior matches that of Gecko and Blink.

* LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation-expected.txt: Added.
* LayoutTests/fast/parser/parser-take-all-children-from-iframe-load-mutation.html: Added.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::takeAllChildrenFrom):

Canonical link: <a href="https://commits.webkit.org/253119@main">https://commits.webkit.org/253119@main</a>
</pre>
