### PR TITLE
[iOS][WP] Update sandbox message filter

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -557,30 +557,11 @@
 (allow mach-lookup
     (global-name "com.apple.system.notification_center")
     (apply-message-filter
-        (deny mach-message-send (with telemetry))
+        (deny mach-message-send)
         (deny mach-message-send (with no-report) (message-number 1023))
         (allow mach-message-send (message-number
-            1002
-            1009
-            1010
-            1011
-            1012
-            1016
-            1017
-            1018
-            1019
-            1021
-            1022
-            1025
-            1026
-            1028
-            1029
-            1030
-            1031
-            1032
-        ))
-    )
-)
+            1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))))
+
 (allow ipc-posix-shm-read*
        (ipc-posix-name "apple.shm.notification_center"))
 


### PR DESCRIPTION
#### 9c9fd5cc994223715e108248083355f9b0980c0f
<pre>
[iOS][WP] Update sandbox message filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=243533">https://bugs.webkit.org/show_bug.cgi?id=243533</a>
&lt;rdar://97993708&gt;

Reviewed by Chris Dumez.

Remove unneeeded messages from sandbox message filter in the WebContent process on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/253111@main">https://commits.webkit.org/253111@main</a>
</pre>
