### PR TITLE
REGRESSION(248082@main): wpt /html/browsers/browsing-the-web/overlapping-navigations-and-traversals/tentative/forward-to-pruned-entry.html is flaky

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6979,6 +6979,11 @@ void WebPageProxy::backForwardGoToItem(const BackForwardItemIdentifier& itemID, 
     backForwardGoToItemShared(m_process.copyRef(), itemID, WTFMove(completionHandler));
 }
 
+void WebPageProxy::backForwardListContainsItem(const WebCore::BackForwardItemIdentifier& itemID, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(m_backForwardList->itemForID(itemID));
+}
+
 void WebPageProxy::backForwardGoToItemShared(Ref<WebProcessProxy>&& process, const BackForwardItemIdentifier& itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(m_process, !WebKit::isInspectorPage(*this), completionHandler(m_backForwardList->counts()));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2370,6 +2370,7 @@ private:
     // Back/Forward list management
     void backForwardAddItem(BackForwardListItemState&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
+    void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
     void backForwardItemAtIndex(int32_t index, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
     void backForwardListCounts(Messages::WebPageProxy::BackForwardListCountsDelayedReply&&);
     void backForwardClear();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -190,6 +190,7 @@ messages -> WebPageProxy {
     BackForwardAddItem(struct WebKit::BackForwardListItemState itemState)
     BackForwardGoToItem(struct WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardItemAtIndex(int32_t itemIndex) -> (std::optional<WebCore::BackForwardItemIdentifier> itemID) Synchronous
+    BackForwardListContainsItem(struct WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClear()
     WillGoToBackForwardListItem(struct WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache)

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -141,7 +141,11 @@ unsigned WebBackForwardListProxy::forwardListCount() const
 
 bool WebBackForwardListProxy::containsItem(const WebCore::HistoryItem& item) const
 {
-    return idToHistoryItemMap().contains(item.identifier());
+    // Items are removed asynchronously from idToHistoryItemMap() via IPC from the UIProcess so we need to ask
+    // the UIProcess to make sure this HistoryItem is still part of the back/forward list.
+    bool contains = false;
+    m_page->sendSync(Messages::WebPageProxy::BackForwardListContainsItem(item.identifier()), Messages::WebPageProxy::BackForwardListContainsItem::Reply(contains), m_page->identifier());
+    return contains;
 }
 
 const WebBackForwardListCounts& WebBackForwardListProxy::cacheListCountsIfNecessary() const


### PR DESCRIPTION
#### 86b715c057a4c7b896de365a19693369a866a13d
<pre>
REGRESSION(248082@main): wpt /html/browsers/browsing-the-web/overlapping-navigations-and-traversals/tentative/forward-to-pruned-entry.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=243518">https://bugs.webkit.org/show_bug.cgi?id=243518</a>
&lt;rdar://98082718&gt;

Reviewed by Geoffrey Garen.

The test calls `history.forward()` which determines that the next HistoryItem is #1
and schedules a navigation to #1. The test then does a synchronous fragment navigation,
which prunes the forward HistoryItem from the back/forward list. When the attempt to
navigate to HistoryItem #1 in the async task, it should no longer be part of the
back/forward and thus no navigation should happen.

The navigation to #1 was happening in WebKit however and this was causing the
test to be flaky (since the test checks on a timer to see if the navigation to #1
happened or not).

WebKit was trying to deal with this by checking BackForwardController::containsItem()
in ScheduledHistoryNavigation::fire() and aborting if the BackForwardController no
longer contains the HistoryItem. However, in the WebKit2 implementation, the Back /
Forward list lives in the UIProcess and WebBackForwardListProxy::containsItem() was
failing to ask the UIProcess. Instead, it was relying on the idToHistoryItemMap() map
on the WebProcess side. The issue with this is that the map only gets updated
asynchronously via IPC from the UIProcess. In the context of the test, we may not
have received this IPC from the UIProcess yet when the ScheduledHistoryNavigation
fires since the navigation that pruned the HistoryItem was a synchronous fragment
navigation.

To address the issue, I updated ebBackForwardListProxy::containsItem() to ask the
UIProcess instead of relying on idToHistoryItemMap(), for better reliability.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardListContainsItem):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::containsItem const):

Canonical link: <a href="https://commits.webkit.org/253121@main">https://commits.webkit.org/253121@main</a>
</pre>
