### PR TITLE
Simplify JSGlobalObject::objectPrototypeIsSaneConcurrently()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -40,9 +40,10 @@ namespace JSC {
 
 ALWAYS_INLINE bool JSGlobalObject::objectPrototypeIsSaneConcurrently(Structure* objectPrototypeStructure)
 {
-    return !hasIndexedProperties(objectPrototypeStructure->indexingType())
-        && objectPrototypeStructure->hasMonoProto()
-        && objectPrototypeStructure->storedPrototype().isNull();
+    ASSERT(objectPrototypeStructure->typeInfo().isImmutablePrototypeExoticObject());
+    ASSERT(objectPrototypeStructure->storedPrototype().isNull());
+
+    return !hasIndexedProperties(objectPrototypeStructure->indexingType());
 }
 
 ALWAYS_INLINE bool JSGlobalObject::arrayPrototypeChainIsSaneConcurrently(Structure* arrayPrototypeStructure, Structure* objectPrototypeStructure)


### PR DESCRIPTION
#### 5509c16335d2881059642ad6492a281529d4c0a4
<pre>
Simplify JSGlobalObject::objectPrototypeIsSaneConcurrently()
<a href="https://bugs.webkit.org/show_bug.cgi?id=243543">https://bugs.webkit.org/show_bug.cgi?id=243543</a>

Reviewed by Yusuke Suzuki.

According to the spec [1], ObjectPrototype has immutable [[Prototype]] internal slot,
thus checking its value every time is redundant. Instead, we can asserted it&apos;s `null`.

[1]: <a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object</a>

* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::objectPrototypeIsSaneConcurrently):

Canonical link: <a href="https://commits.webkit.org/253124@main">https://commits.webkit.org/253124@main</a>
</pre>
