### PR TITLE
Utilize setIndexQuicklyForArrayStorageIndexingType() in JSObject::setIndexQuickly()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -517,18 +517,9 @@ public:
                 butterfly->setPublicLength(i + 1);
             break;
         }
-        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            ArrayStorage* storage = butterfly->arrayStorage();
-            WriteBarrier<Unknown>& x = storage->m_vector[i];
-            JSValue old = x.get();
-            x.set(vm, this, v);
-            if (!old) {
-                ++storage->m_numValuesInVector;
-                if (i >= storage->length())
-                    storage->setLength(i + 1);
-            }
+        case ALL_ARRAY_STORAGE_INDEXING_TYPES:
+            setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
             break;
-        }
         case ALL_BLANK_INDEXING_TYPES:
             setIndexQuicklyForTypedArray(i, v);
             break;


### PR DESCRIPTION
#### b4f3fcf1248382b2578b6f38c1b4368a9ae014da
<pre>
Utilize setIndexQuicklyForArrayStorageIndexingType() in JSObject::setIndexQuickly()
<a href="https://bugs.webkit.org/show_bug.cgi?id=243544">https://bugs.webkit.org/show_bug.cgi?id=243544</a>

Reviewed by Yusuke Suzuki.

The helper is identical and inlineable.

* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::setIndexQuickly):

Canonical link: <a href="https://commits.webkit.org/253125@main">https://commits.webkit.org/253125@main</a>
</pre>
