### PR TITLE
REGRESSION(252611@main): [ macOS ] http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html is a constant crash

### DIFF
--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -186,7 +186,7 @@ void ResourceLoadNotifier::sendRemainingDelegateMessages(DocumentLoader* loader,
     // If the request is null, willSendRequest cancelled the load. We should
     // only dispatch didFailLoading in this case.
     if (request.isNull()) {
-        ASSERT(error.isCancellation());
+        ASSERT(error.isCancellation() || error.isAccessControl());
         dispatchDidFailLoading(loader, identifier, error);
         return;
     }


### PR DESCRIPTION
#### b19197388e2bf601cff8ea60183edcec55f6851f
<pre>
REGRESSION(252611@main): [ macOS ] http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=243545">https://bugs.webkit.org/show_bug.cgi?id=243545</a>
&lt;rdar://98127995&gt;

Reviewed by Darin Adler.

Since 252611@main, blocked loads are reported as AccessControl errors instead of Cancellation
errors. We thus need to update the assertion in ResourceLoadNotifier::sendRemainingDelegateMessages()
accordingly.

* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::sendRemainingDelegateMessages):

Canonical link: <a href="https://commits.webkit.org/253116@main">https://commits.webkit.org/253116@main</a>
</pre>
