### PR TITLE
[Gardening]: REGRESSION (252871@main?): [ iOS ] fast/mediastream/getUserMedia-to-canvas-1.html is a flaky timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3669,3 +3669,5 @@ webkit.org/b/242825 editing/selection/ios/hide-selection-in-tiny-contenteditable
 webkit.org/b/242840 fast/text/international/system-language/han-text-style.html [ ImageOnlyFailure ]
 
 webkit.org/b/242905 compositing/tiling/tiled-mask-inwindow.html [ Pass Failure ]
+
+webkit.org/b/243547 fast/mediastream/getUserMedia-to-canvas-1.html [ Pass Timeout ]


### PR DESCRIPTION
#### 5e071502ce890a1cd61ae7255f7533f89caa0df1
<pre>
[Gardening]: REGRESSION (252871@main?): [ iOS ] fast/mediastream/getUserMedia-to-canvas-1.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=243547">https://bugs.webkit.org/show_bug.cgi?id=243547</a>
&lt;rdar://98129675&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253117@main">https://commits.webkit.org/253117@main</a>
</pre>
