### PR TITLE
Revert [253110@main] [webkitperl] Define package webkitdirs and export functions used in other modules

### DIFF
--- a/Tools/Scripts/do-webcore-rename
+++ b/Tools/Scripts/do-webcore-rename
@@ -31,7 +31,6 @@
 use strict;
 use warnings;
 
-use File::Basename;
 use File::Find;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -24,7 +24,6 @@
 use strict;
 use warnings;
 use English;
-use File::Basename;
 use File::Copy qw/ move /;
 use File::Temp qw/ tempdir tempfile /;
 use FindBin;

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -32,7 +32,6 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use File::Spec;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/run-regexp-tests
+++ b/Tools/Scripts/run-regexp-tests
@@ -30,7 +30,6 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/run-sunspider
+++ b/Tools/Scripts/run-sunspider
@@ -26,7 +26,6 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -29,7 +29,6 @@
 use strict;
 use warnings;
 use Cwd qw(realpath);
-use File::Basename;
 use File::Path qw(make_path);
 use File::Spec;
 use FindBin;

--- a/Tools/Scripts/sunspider-compare-results
+++ b/Tools/Scripts/sunspider-compare-results
@@ -26,7 +26,6 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use File::Spec;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/update-webkit-libs-jhbuild
+++ b/Tools/Scripts/update-webkit-libs-jhbuild
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 use warnings;
-use File::Basename;
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;

--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -30,7 +30,6 @@
 # A script to expose WebKit's build directory detection logic to non-perl scripts.
 
 use warnings;
-use File::Basename;
 use FindBin;
 use Getopt::Long;
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -29,8 +29,6 @@
 
 # Module to share code to get to WebKit directories.
 
-package webkitdirs;
-
 use strict;
 use version;
 use warnings;
@@ -69,117 +67,38 @@ BEGIN {
        &appDisplayNameFromBundle
        &appendToEnvironmentVariableList
        &archCommandLineArgumentsForRestrictedEnvironmentVariables
-       &architecture
-       &architecturesForProducts
-       &argumentsForConfiguration
-       &asanIsEnabled
        &availableXcodeSDKs
        &baseProductDir
-       &buildCMakeProjectOrExit
-       &buildVisualStudioProject
-       &buildXCodeProject
-       &buildXcodeScheme
-       &builtDylibPathForName
-       &canUseNinja
        &chdirWebKit
-       &checkForArgumentAndRemoveFromARGV
-       &checkForArgumentAndRemoveFromARGVGettingValue
-       &checkForArgumentAndRemoveFromArrayRef
-       &checkForArgumentAndRemoveFromArrayRefGettingValue
        &checkFrameworks
-       &checkRequiredSystemConfig
        &cmakeArgsFromFeatures
-       &configuration
-       &configuredXcodeWorkspace
-       &coverageIsEnabled
-       &currentPerlPath
        &currentSVNRevision
-       &debugMiniBrowser
        &debugSafari
-       &debugWebKitTestRunner
        &executableProductDir
-       &exitStatus
-       &extractNonMacOSHostConfiguration
-       &forceOptimizationLevel
-       &formatBuildTime
-       &generateBuildSystemFromCMakeProject
-       &inFlatpakSandbox
+       &extractNonHostConfiguration
        &iosVersion
-       &isARM64
-       &isAnyWindows
-       &isAppleCocoaWebKit
-       &isAppleMacWebKit
-       &isAppleWebKit
-       &isAppleWinWebKit
-       &isCMakeBuild
-       &isCygwin
-       &isEmbeddedWebKit
-       &isFTW
-       &isGenerateProjectOnly
-       &isGtk
-       &isInspectorFrontend
-       &isJSCOnly
-       &isPlayStation
-       &isWPE
-       &isWinCairo
-       &isWindows
-       &isX86_64
-       &jscPath
-       &jscProductDir
-       &launcherName
-       &launcherPath
-       &ltoMode
-       &markBaseProductDirectoryAsCreatedByXcodeBuildSystem
-       &maxCPULoad
-       &nativeArchitecture
        &nmPath
-       &numberOfCPUs
-       &osXVersion
-       &overrideConfiguredXcodeWorkspace
-       &parseAvailableXcodeSDKs
-       &passedArchitecture
        &passedConfiguration
-       &portName
        &prependToEnvironmentVariableList
        &printHelpAndExitForRunAndDebugWebKitAppIfNeeded
        &productDir
-       &prohibitUnknownPort
-       &relativeScriptsDir
-       &removeCMakeCache
-       &runGitUpdate
        &runIOSWebKitApp
-       &runInFlatpak
-       &runInFlatpakIfAvailable
        &runMacWebKitApp
-       &runWebKitTestRunner
        &safariPath
        &sdkDirectory
        &sdkPlatformDirectory
-       &setArchitecture
        &setConfiguration
-       &setConfigurationProductDir
-       &setPathForRunningWebKitApp
-       &setUpGuardMallocIfNeeded
-       &setupAppleWinEnv
        &setupMacWebKitEnvironment
        &setupUnixWebKitEnvironment
        &sharedCommandLineOptions
        &sharedCommandLineOptionsUsage
        &shouldUseFlatpak
+       &runInFlatpak
        &sourceDir
-       &splitVersionString
-       &tsanIsEnabled
-       &ubsanIsEnabled
        &willUseIOSDeviceSDK
        &willUseIOSSimulatorSDK
-       &winVersion
-       &wrapperPrefixIfNeeded
-       &xcodeSDK
-       &xcodeSDKPlatformName
        DO_NOT_USE_OPEN_COMMAND
-       Mac
        USE_OPEN_COMMAND
-       iOS
    );
    %EXPORT_TAGS = ( );
    @EXPORT_OK   = ();
@@ -1165,7 +1084,7 @@ sub XcodeOptions
     push @options, "ARCHS=$architecture" if $architecture;
     push @options, "SDKROOT=$xcodeSDK" if $xcodeSDK;
 
-    my @features = webkitperl::FeatureList::getFeatureOptionList();
+    my @features = getFeatureOptionList();
     foreach (@features) {
         if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
             push @options, "$_->{define}=";

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -29,7 +29,6 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -31,8 +31,6 @@
 # * A feature enabled here but not WebKitFeatures.cmake is EXPERIMENTAL.
 # * A feature enabled in WebKitFeatures.cmake but not here is a BUG.
 
-package webkitperl::FeatureList;
-
 use strict;
 use warnings;
 
@@ -575,7 +573,7 @@ my @features = (
 
 sub getFeatureOptionList()
 {
-    webkitdirs::prohibitUnknownPort();
+    prohibitUnknownPort();
     return @features;
 }
 


### PR DESCRIPTION
#### aff5e1addc0ed7ff4198f0407e692bbddc70d094
<pre>
Revert [253110@main] [webkitperl] Define package webkitdirs and export functions used in other modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=243454">https://bugs.webkit.org/show_bug.cgi?id=243454</a>

Unreviewed build fix. Broke Internal tooling.

* Tools/Scripts/do-webcore-rename:
* Tools/Scripts/package-root:
* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-regexp-tests:
* Tools/Scripts/run-sunspider:
* Tools/Scripts/set-webkit-configuration:
* Tools/Scripts/sunspider-compare-results:
* Tools/Scripts/update-webkit-libs-jhbuild:
* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitdirs.pm:
(XcodeOptions):
* Tools/Scripts/webkitperl/BuildSubproject.pm:
* Tools/Scripts/webkitperl/FeatureList.pm:
(getFeatureOptionList):

Canonical link: <a href="https://commits.webkit.org/253118@main">https://commits.webkit.org/253118@main</a>
</pre>
