### PR TITLE
Nullptr crash in FontCache::shouldAutoActivateFontIfNeeded

### DIFF
--- a/LayoutTests/fast/text/font-family-src-revert-crash-expected.txt
+++ b/LayoutTests/fast/text/font-family-src-revert-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash
+
+PASS

--- a/LayoutTests/fast/text/font-family-src-revert-crash.html
+++ b/LayoutTests/fast/text/font-family-src-revert-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+@font-face {
+    font-family: 'TestFont';
+    src: local(revert);
+}
+</style>
+</head>
+<body>
+<p style="font-family: TestFont">This test passes if WebKit does not crash</p>
+<div id="result"></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+onload = () => result.textContent = 'PASS';
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -1298,7 +1298,7 @@ bool FontCache::shouldAutoActivateFontIfNeeded(const AtomString& family)
         m_knownFamilies.remove(m_knownFamilies.random());
 
     // Only attempt to auto-activate fonts once for performance reasons.
-    return m_knownFamilies.add(family).isNewEntry;
+    return !family.isEmpty() && m_knownFamilies.add(family).isNewEntry;
 }
 
 static void autoActivateFont(const String& name, CGFloat size)


### PR DESCRIPTION
#### b7ebc2e0e5dd9a17a8300980bc466941eb0b4b8d
<pre>
Nullptr crash in FontCache::shouldAutoActivateFontIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=243500">https://bugs.webkit.org/show_bug.cgi?id=243500</a>

Reviewed by NOBODY (OOPS!).

Exit early if the string is empty to avoid the crash.

* LayoutTests/fast/text/font-family-src-revert-crash-expected.txt: Added.
* LayoutTests/fast/text/font-family-src-revert-crash.html: Added.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::shouldAutoActivateFontIfNeeded):
</pre>