### PR TITLE
Show "Scroll" labels in the element tree for scrollable elements

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
@@ -1,0 +1,32 @@
+Tests for the CSS.nodeLayoutFlagsChanged event with the Scrollable enum.
+
+
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.Scrollable
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyScrollable
+PASS: Should be scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowHidden
+Changing to `overflow: scroll`...
+PASS: Should render nodes changed to `display: block`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowVisible
+Changing to `overflow: scroll`...
+PASS: Should have become scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.ContentShrunk
+Changing content length
+PASS: Should have become non-scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents
+PASS: iframe element should not be scrollable.
+PASS: iframe's #document node should not be scrollable
+PASS: Iframe <html> element should be scrollable.
+PASS: Iframe <body> element should not be scrollable.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.IFrameWithScrollableBody
+PASS: iframe element should not be scrollable.
+PASS: iframe's #document node should not be scrollable
+PASS: Iframe <html> element should not be scrollable.
+PASS: Iframe <body> element should be scrollable.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .scroller {
+        height: 200px;
+        width: 200px;
+        border: 1px solid black;
+    }
+
+    .scroller .contents {
+        height: 200%;
+        width: 100%;
+    }
+
+    #scroller {
+        overflow: scroll;
+    }
+    
+    #overflow-hidden {
+        overflow: hidden;
+    }
+
+    #overflow-visible {
+        overflow: visible;
+    }
+    
+    #content-shrinking {
+        overflow: scroll;
+    }
+
+    #content-shrinking.shrunk .contents {
+        height: 80%;
+    }
+</style>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let documentNode;
+
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.Scrollable");
+
+    function addTestCase({name, description, selector, setup, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            setup,
+            async test() {
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+                await domNodeHandler(domNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyScrollable",
+        description: "Test that an element with overflow:scroll and scrollable contents is scrollable",
+        selector: "#scroller",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should be scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowHidden",
+        description: "Test that nodes changed to `display: none` are not rendered.",
+        selector: "#overflow-hidden",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should not be initially scrollable.");
+
+            InspectorTest.log("Changing to `overflow: scroll`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "overflow: scroll"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render nodes changed to `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowVisible",
+        description: "Test that nodes that change from having visible overflow to `overflow:scroll` are scrollable",
+        selector: "#overflow-visible",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should not be initially scrollable.");
+
+            InspectorTest.log("Changing to `overflow: scroll`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "overflow: scroll"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should have become scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.ContentShrunk",
+        description: "Test that nodes whose content shrinks are no longer scrollable",
+        selector: "#content-shrinking",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should be initially scrollable.");
+
+            InspectorTest.log("Changing content length");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("class", "shrunk scroller"),
+            ]);
+            InspectorTest.expectTrue(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should have become non-scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents",
+        description: "Test scrollability of document nodes in an iframe",
+        selector: "#iframe",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe element should not be scrollable.");
+
+            let iframeDocumentNode = domNode.children[0];
+            InspectorTest.expectFalse(iframeDocumentNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe's #document node should not be scrollable");
+
+            let iframeHTMLNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("html"));
+            InspectorTest.expectTrue(iframeHTMLNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <html> element should be scrollable.");
+
+            let iframeBodyNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("body"));
+            InspectorTest.expectFalse(iframeBodyNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <body> element should not be scrollable.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.IFrameWithScrollableBody",
+        description: "Test scrollability of the body node in an iframe ",
+        selector: "#iframe-with-scrollable-body",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe element should not be scrollable.");
+
+            let iframeDocumentNode = domNode.children[0];
+            InspectorTest.expectFalse(iframeDocumentNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe's #document node should not be scrollable");
+
+            let iframeHTMLNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("html"));
+            InspectorTest.expectFalse(iframeHTMLNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <html> element should not be scrollable.");
+
+            let iframeBodyNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("body"));
+            InspectorTest.expectTrue(iframeBodyNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <body> element should be scrollable.");
+        },
+    });
+
+    WI.domManager.requestDocument().then((doc) => {
+        documentNode = doc;
+        suite.runTestCasesAndFinish();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.nodeLayoutFlagsChanged event with the Scrollable enum.</p>
+
+    <div class="scroller" id="scroller">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="overflow-hidden">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="overflow-visible">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="content-shrinking">
+        <div class="contents"></div>
+    </div>
+
+    <iframe id="iframe" srcdoc="
+    <html><style>body { height: 3000px; }</style><body>iframe document</body></html>
+    "></iframe>
+
+    <iframe id="iframe-with-scrollable-body" srcdoc="
+    <!DOCTYPE html><html><style>html { height: 100%; overflow: hidden; } body { height: 100%; overflow: scroll; } div { height: 1000px; }</style><body><div>contents</div></body></html>
+    "></iframe>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -273,6 +273,7 @@
             "type": "string",
             "enum": [
                 "rendered",
+                "scrollable",
                 "flex",
                 "grid"
             ],

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2672,6 +2672,11 @@ void Node::notifyInspectorOfRendererChange()
     InspectorInstrumentation::didChangeRendererForDOMNode(*this);
 }
 
+void Node::notifyInspectorOfRendererPropertyChange()
+{
+    InspectorInstrumentation::didChangeRendererPropertyForDOMNode(*this);
+}
+
 template<> ContainerNode* parent<Tree>(const Node& node)
 {
     return node.parentNode();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -529,6 +529,8 @@ public:
     void updateAncestorConnectedSubframeCountForRemoval() const;
     void updateAncestorConnectedSubframeCountForInsertion() const;
 
+    WEBCORE_EXPORT void notifyInspectorOfRendererPropertyChange();
+
 #if ENABLE(JIT)
     static ptrdiff_t nodeFlagsMemoryOffset() { return OBJECT_OFFSETOF(Node, m_nodeFlags); }
     static ptrdiff_t rareDataMemoryOffset() { return OBJECT_OFFSETOF(Node, m_rareDataWithBitfields); }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -185,6 +185,12 @@ void InspectorInstrumentation::didChangeRendererForDOMNodeImpl(InstrumentingAgen
         cssAgent->didChangeRendererForDOMNode(node);
 }
 
+void InspectorInstrumentation::didChangeRendererPropertyForDOMNodeImpl(InstrumentingAgents& instrumentingAgents, Node& node)
+{
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->didChangeRendererPropertyForDOMNode(node);
+}
+
 void InspectorInstrumentation::willModifyDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& oldValue, const AtomString& newValue)
 {
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -124,6 +124,7 @@ public:
     static void didRemoveDOMNode(Document&, Node&);
     static void willDestroyDOMNode(Node&);
     static void didChangeRendererForDOMNode(Node&);
+    static void didChangeRendererPropertyForDOMNode(Node&);
     static void willModifyDOMAttr(Document&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttr(Document&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttr(Document&, Element&, const AtomString& name);
@@ -346,6 +347,7 @@ private:
     static void didRemoveDOMNodeImpl(InstrumentingAgents&, Node&);
     static void willDestroyDOMNodeImpl(InstrumentingAgents&, Node&);
     static void didChangeRendererForDOMNodeImpl(InstrumentingAgents&, Node&);
+    static void didChangeRendererPropertyForDOMNodeImpl(InstrumentingAgents&, Node&);
     static void willModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name);
@@ -603,6 +605,13 @@ inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
     if (auto* agents = instrumentingAgents(node.document()))
         didChangeRendererForDOMNodeImpl(*agents, node);
+}
+
+inline void InspectorInstrumentation::didChangeRendererPropertyForDOMNode(Node& node)
+{
+    ASSERT(InspectorInstrumentationPublic::hasFrontends());
+    if (auto* agents = instrumentingAgents(node.document()))
+        didChangeRendererPropertyForDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -86,7 +86,7 @@ public:
 
     static CSSStyleRule* asCSSStyleRule(CSSRule&);
 
-    static RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> layoutFlagsForNode(Node&);
+    static RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> layoutFlagsForNode(const Node&);
 
     static std::optional<Inspector::Protocol::CSS::PseudoId> protocolValueForPseudoId(PseudoId);
 
@@ -123,6 +123,7 @@ public:
     void activeStyleSheetsUpdated(Document&);
     bool forcePseudoState(const Element&, CSSSelector::PseudoClassType);
     void didChangeRendererForDOMNode(Node&);
+    void didChangeRendererPropertyForDOMNode(Node&);
 
     // InspectorDOMAgent hooks
     void didRemoveDOMNode(Node&, Inspector::Protocol::DOM::NodeId);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -565,7 +565,7 @@ void FrameView::setContentsSize(const IntSize& size)
 
     ScrollView::setContentsSize(size);
     contentsResized();
-    
+
     Page* page = frame().page();
     if (!page)
         return;
@@ -2999,6 +2999,13 @@ void FrameView::addedOrRemovedScrollbar()
     }
 
     updateTiledBackingAdaptiveSizing();
+
+    if (UNLIKELY(InspectorInstrumentationPublic::hasFrontends())) {
+        auto* document = frame().document();
+        auto* documentElement = document ? document->documentElement() : nullptr;
+        if (documentElement)
+            documentElement->notifyInspectorOfRendererPropertyChange();
+    }
 }
 
 TiledBacking::Scrollability FrameView::computeScrollability() const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5455,16 +5455,22 @@ void RenderLayer::updateFiltersAfterStyleChange()
 
 void RenderLayer::updateLayerScrollableArea()
 {
-    if (!is<RenderBox>(renderer()) || !downcast<RenderBox>(renderer()).requiresLayerWithScrollableArea()) {
-        bool hadScrollableArea = scrollableArea();
-        clearLayerScrollableArea();
+    bool hasScrollableArea = scrollableArea();
+    bool needsScrollableArea = is<RenderBox>(renderer()) && downcast<RenderBox>(renderer()).requiresLayerWithScrollableArea();
 
-        if (hadScrollableArea && renderer().settings().asyncOverflowScrollingEnabled())
-            setNeedsCompositingConfigurationUpdate();
+    if (needsScrollableArea == hasScrollableArea)
         return;
+
+    if (needsScrollableArea)
+        ensureLayerScrollableArea();
+    else {
+        clearLayerScrollableArea();
+        if (renderer().settings().asyncOverflowScrollingEnabled())
+            setNeedsCompositingConfigurationUpdate();
     }
 
-    ensureLayerScrollableArea();
+    // Update the "scrollable" state of the node.
+    renderer().notifyInspectorOfPropertyChange();
 }
 
 void RenderLayer::updateFilterPaintingStrategy()

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -124,8 +124,10 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
     RenderElement::styleDidChange(diff, oldStyle);
     updateFromStyle();
 
+    bool gainedOrLostLayer = false;
     if (requiresLayer()) {
         if (!layer() && layerCreationAllowedForSubtree()) {
+            gainedOrLostLayer = true;
             if (s_wasFloating && isFloating())
                 setChildNeedsLayout();
             createLayer();
@@ -133,6 +135,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
                 layer()->setRepaintStatus(NeedsFullRepaint);
         }
     } else if (layer() && layer()->parent()) {
+        gainedOrLostLayer = true;
 #if ENABLE(CSS_COMPOSITING)
         if (oldStyle && oldStyle->hasBlendMode())
             layer()->willRemoveChildWithBlendMode();
@@ -152,6 +155,11 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
             setChildNeedsLayout();
         if (s_hadTransform)
             setNeedsLayoutAndPrefWidthsRecalc();
+    }
+
+    if (gainedOrLostLayer) {
+        // Update the "scrollable" state of the node.
+        notifyInspectorOfPropertyChange();
     }
 
     if (layer()) {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1287,6 +1287,9 @@ void RenderLayerScrollableArea::updateScrollInfoAfterLayout()
         m_layer.setNeedsPostLayoutCompositingUpdate();
 
     resnapAfterLayout();
+
+    // Update the "scrollable" state of the node.
+    m_layer.renderer().notifyInspectorOfPropertyChange();
 }
 
 bool RenderLayerScrollableArea::overflowControlsIntersectRect(const IntRect& localRect) const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -764,6 +764,8 @@ public:
 
     LayoutRect absoluteOutlineBounds() const { return outlineBoundsForRepaint(nullptr); }
 
+    void notifyInspectorOfPropertyChange();
+
     // FIXME: Renderers should not need to be notified about internal reparenting (webkit.org/b/224143).
     enum class IsInternalMove { No, Yes };
     virtual void insertedIntoTree(IsInternalMove = IsInternalMove::No);
@@ -1208,6 +1210,14 @@ inline void Node::setRenderer(RenderObject* renderer)
 
     if (UNLIKELY(InspectorInstrumentationPublic::hasFrontends()))
         notifyInspectorOfRendererChange();
+}
+
+inline void RenderObject::notifyInspectorOfPropertyChange()
+{
+    if (UNLIKELY(InspectorInstrumentationPublic::hasFrontends())) {
+        if (auto* node = this->node())
+            node->notifyInspectorOfRendererPropertyChange();
+    }
 }
 
 inline RenderObject* RenderObject::previousInFlowSibling() const

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1355,6 +1355,7 @@ WI.DOMNode.CustomElementState = {
 // Corresponds to `CSS.LayoutFlag`.
 WI.DOMNode.LayoutFlag = {
     Rendered: "rendered",
+    Scrollable: "scrollable",
 
     // These are mutually exclusive.
     Flex: "flex",


### PR DESCRIPTION
#### a5978d84ab162afdab227cb0ee09ebcd08dbbc78
<pre>
Show &quot;Scroll&quot; labels in the element tree for scrollable elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=243550">https://bugs.webkit.org/show_bug.cgi?id=243550</a>

Reviewed by NOBODY (OOPS!).

Show &quot;Scroll&quot; labels on the document, and on scrollable elements in the Elements tab. We indicate
document scrollability on the `&lt;html&gt;` node, even in quirks mode where `document.scrollingElement()`
is the `&lt;body&gt;`, unlike other browsers, because otherwise you can&apos;t distinguish a scrollable
document from a scrollable `&lt;body&gt;` on pages where the body is independently scrollable.

&quot;Scrollable&quot; is a renderer flag just like &quot;Rendered&quot;, and DOMTreeElement.js makes a new badge for it
just like &quot;flex&quot; and &quot;grid&quot; badges.

Invalidation of the &quot;scrollable&quot; state happens via
`RenderObject::notifyInspectorOfPropertyChange()`. Scrollable overflow depends on both style and
layout, but doing invalidation at this level is tricky, so instead do invalidation further
downstream, when a renderer gains or loses a RenderLayer, and when a RenderLayerScrollableArea
updates its scrolling state after layout. For the FrameView, we invalidate when its scrollbars
change.

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html: Added.
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::notifyInspectorOfRendererPropertyChange):
* Source/WebCore/dom/Node.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeRendererPropertyForDOMNodeImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeRendererPropertyForDOMNode):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
(WebCore::InspectorCSSAgent::didChangeRendererPropertyForDOMNode):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::setContentsSize):
(WebCore::FrameView::addedOrRemovedScrollbar):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollInfoAfterLayout):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::notifyInspectorOfPropertyChange):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement):
(WI.DOMTreeElement.prototype.onattach):
(WI.DOMTreeElement.prototype.updateTitle):
(WI.DOMTreeElement.prototype._updateLayoutBadges):
(WI.DOMTreeElement.prototype._handleLayoutFlagsChanged):
(WI.DOMTreeElement.prototype._updateLayoutBadge): Deleted.
</pre>