### PR TITLE
CrashTracer: com.apple.WebKit.GPU at WebCore: WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastImage

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2685,8 +2685,9 @@ bool MediaPlayerPrivateAVFoundationObjC::videoOutputHasAvailableFrame()
     if (m_lastImage)
         return true;
 
+    createVideoOutput();
     if (!m_videoOutput)
-        createVideoOutput();
+        return false;
 
     return m_videoOutput->hasImageForTime(PAL::toMediaTime([m_avPlayerItem currentTime]));
 }


### PR DESCRIPTION
#### fe559a33ed551a72a122847ec66644f5e6e7cfd2
<pre>
CrashTracer: com.apple.WebKit.GPU at WebCore: WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=243551">https://bugs.webkit.org/show_bug.cgi?id=243551</a>
&lt;rdar://96360645&gt;

Reviewed by Eric Carlson.

Previously, if we didn&apos;t have a `m_videoOutput` in `videoOutputHasAvailableFrame`,
we would attempt to create it with `createVideoOutput` and continue dereferencing
`m_videoOutput`. However, `createVideoOutput` is not guaranteed to create
a `m_videoOutput` which results in a nullptr dereference when we attempt
to use `m_videoOutput` on the next line.

The fix is to always call `createVideoOutput` and null check `m_videoOutput`
right after.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::videoOutputHasAvailableFrame):

Canonical link: <a href="https://commits.webkit.org/253128@main">https://commits.webkit.org/253128@main</a>
</pre>
