### PR TITLE
Web Inspector: REGRESSION(252653@main): Elements: clicking a layout badge doesn't do anything

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -2012,13 +2012,25 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         if (!this.listItemElement || this._elementCloseTag)
             return;
 
+        let hadLayoutBadge = !!this._layoutBadgeElement;
+
         if (this._layoutBadgeElement) {
             this._layoutBadgeElement.remove();
             this._layoutBadgeElement = null;
         }
 
-        if (!this.representedObject.layoutContextType)
+        if (!this.representedObject.layoutContextType) {
+            if (hadLayoutBadge) {
+                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
+                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
+            }
             return;
+        }
+
+        if (!hadLayoutBadge) {
+            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
+            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
+        }
 
         this._layoutBadgeElement = this.title.appendChild(document.createElement("span"));
         this._layoutBadgeElement.className = "layout-badge";
@@ -2083,17 +2095,6 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     _handleLayoutFlagsChanged(event)
     {
         this.listItemElement?.classList.toggle("rendered", this.representedObject.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered));
-
-        if (this._elementCloseTag)
-            return;
-
-        if (this.representedObject.layoutContextType && !this._layoutBadgeElement) {
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
-        } else if (!this.representedObject.layoutContextType && this._layoutBadgeElement) {
-            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
-        }
 
         this._updateLayoutBadge();
     }


### PR DESCRIPTION
#### f8a09808de412899ef3aa2f23386118e3546b2ec
<pre>
Web Inspector: REGRESSION(252653@main): Elements: clicking a layout badge doesn&apos;t do anything
<a href="https://bugs.webkit.org/show_bug.cgi?id=243552">https://bugs.webkit.org/show_bug.cgi?id=243552</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._updateLayoutBadge):
(WI.DOMTreeElement.prototype._handleLayoutFlagsChanged):
The event listeners for the layout overlay being shown/hidden exist to update the layout type badge.
Instead of adding/removing those event listeners whenever the layout flags change, do it when the
layout badge is created/destroyed as that&apos;s really what needs it, not the rest of `WI.DOMTreeElement`.
This also simplifies the logic for when we add/remove those event listeners.

Canonical link: <a href="https://commits.webkit.org/253219@main">https://commits.webkit.org/253219@main</a>
</pre>
