### PR TITLE
CrashTracer: com.apple.WebKit.GPU at WebKit: WebKit::RemoteLegacyCDMSessionProxy::generateKeyRequest

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -74,6 +74,8 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     const void* logIdentifier() const final { return m_logIdentifier; }
+    const char* logClassName() const { return "RemoteLegacyCDMSessionProxy"; }
+    WTFLogChannel& logChannel() const;
 #endif
 
     // Messages


### PR DESCRIPTION
#### dc4fdf81f20ec660ea5456b5b6b47d2357316f53
<pre>
CrashTracer: com.apple.WebKit.GPU at WebKit: WebKit::RemoteLegacyCDMSessionProxy::generateKeyRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=243554">https://bugs.webkit.org/show_bug.cgi?id=243554</a>
&lt;rdar://79306462&gt;

Reviewed by Jer Noble.

Throughout RemoteLegacyCDMSessionProxy, we assume that `cdm.createSession(*this)`
will not give us a null `m_session`, however, there exists implementations
of `createSession` that do return a nullptr. Since we never null check,
this results in a nullptr dereference in `RemoteLegacyCDMSessionProxy::generateKeyRequest`
and potentially everywhere `m_session` is dereferenced.

The fix is to null check everytime we want to use `m_session`.

* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::RemoteLegacyCDMSessionProxy):
(WebKit::RemoteLegacyCDMSessionProxy::generateKeyRequest):
(WebKit::RemoteLegacyCDMSessionProxy::releaseKeys):
(WebKit::RemoteLegacyCDMSessionProxy::update):
(WebKit::RemoteLegacyCDMSessionProxy::getCachedKeyForKeyId):
(WebKit::RemoteLegacyCDMSessionProxy::logChannel const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
(WebKit::RemoteLegacyCDMSessionProxy::logClassName const):

Canonical link: <a href="https://commits.webkit.org/253152@main">https://commits.webkit.org/253152@main</a>
</pre>
