### PR TITLE
[ iOS ] 2* imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip* tests are constant Image failures

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3603,6 +3603,10 @@ webkit.org/b/240167 [ Release ] fast/css-custom-paint/animate-repaint.html [ Pas
 
 webkit.org/b/240489 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html [ Slow ]
 
+# webkit.org/b/243556 [ iOS ] 2* imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip* tests are constant Image failures
+imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html [ ImageOnlyFailure ]
+
 #  Correction to guard in Platform file removing iOS - Skip tests
 webkit.org/b/240579 http/tests/workers/service/shownotification-allowed-document.html [ Skip ]
 webkit.org/b/240579 http/tests/workers/service/shownotification-allowed.html [ Skip ]


### PR DESCRIPTION
#### c51aae96790fe49126faf7c231eed711b5777b16
<pre>
[ iOS ] 2* imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip* tests are constant Image failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=243556">https://bugs.webkit.org/show_bug.cgi?id=243556</a>
&lt;rdar://98144818&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253129@main">https://commits.webkit.org/253129@main</a>
</pre>
