### PR TITLE
[JSC] Make JSMap and JSSet construction more simple and efficient

### DIFF
--- a/JSTests/stress/map-clear-get.js
+++ b/JSTests/stress/map-clear-get.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(map, key)
+{
+    return map.get(key);
+}
+noInline(test);
+
+var map = new Map();
+for (var i = 0; i < 1e4; ++i) {
+    map.clear();
+    shouldBe(test(map, {}), undefined);
+    shouldBe(test(map, {t:42}), undefined);
+}

--- a/JSTests/stress/set-clear-has.js
+++ b/JSTests/stress/set-clear-has.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(set, key)
+{
+    return set.has(key);
+}
+noInline(test);
+
+var set = new Set();
+for (var i = 0; i < 1e4; ++i) {
+    set.clear();
+    shouldBe(test(set, {}), false);
+    shouldBe(test(set, {t:42}), false);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5000,8 +5000,11 @@ void SpeculativeJIT::compile(Node* node)
         if (node->child2().useKind() != UntypedUse)
             speculate(node, node->child2());
 
-        m_jit.load32(MacroAssembler::Address(mapGPR, HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::offsetOfCapacity()), maskGPR);
+        CCallHelpers::JumpList notPresentInTable;
+
         m_jit.loadPtr(MacroAssembler::Address(mapGPR, HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::offsetOfBuffer()), bufferGPR);
+        notPresentInTable.append(m_jit.branchTestPtr(CCallHelpers::Zero, bufferGPR));
+        m_jit.load32(MacroAssembler::Address(mapGPR, HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::offsetOfCapacity()), maskGPR);
         m_jit.sub32(TrustedImm32(1), maskGPR);
         m_jit.move(hashGPR, indexGPR);
 
@@ -5013,8 +5016,9 @@ void SpeculativeJIT::compile(Node* node)
         m_jit.and32(maskGPR, indexGPR);
         m_jit.loadPtr(MacroAssembler::BaseIndex(bufferGPR, indexGPR, MacroAssembler::TimesEight), bucketGPR);
         m_jit.move(bucketGPR, resultGPR);
-        auto notPresentInTable = m_jit.branchPtr(MacroAssembler::Equal, 
-            bucketGPR, TrustedImmPtr(bitwise_cast<size_t>(HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::emptyValue())));
+
+        notPresentInTable.append(m_jit.branchPtr(MacroAssembler::Equal,
+            bucketGPR, TrustedImmPtr(bitwise_cast<size_t>(HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::emptyValue()))));
         loopAround.append(m_jit.branchPtr(MacroAssembler::Equal, 
             bucketGPR, TrustedImmPtr(bitwise_cast<size_t>(HashMapImpl<HashMapBucket<HashMapBucketDataKey>>::deletedValue()))));
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12340,6 +12340,7 @@ IGNORE_CLANG_WARNINGS_END
     void compileGetMapBucket()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LBasicBlock indexSetUp = m_out.newBlock();
         LBasicBlock loopStart = m_out.newBlock();
         LBasicBlock loopAround = m_out.newBlock();
         LBasicBlock slowPath = m_out.newBlock();
@@ -12347,8 +12348,6 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock notEmptyValue = m_out.newBlock();
         LBasicBlock notDeletedValue = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
-
-        LBasicBlock lastNext = m_out.insertNewBlocksBefore(loopStart);
 
         LValue map;
         if (m_node->child1().useKind() == MapObjectUse)
@@ -12365,8 +12364,11 @@ IGNORE_CLANG_WARNINGS_END
         LValue hash = lowInt32(m_node->child3());
 
         LValue buffer = m_out.loadPtr(map, m_heaps.HashMapImpl_buffer);
-        LValue mask = m_out.sub(m_out.load32(map, m_heaps.HashMapImpl_capacity), m_out.int32One);
 
+        m_out.branch(m_out.isNull(buffer), unsure(notPresentInTable), unsure(indexSetUp));
+
+        LBasicBlock lastNext = m_out.appendTo(indexSetUp, loopStart);
+        LValue mask = m_out.sub(m_out.load32(map, m_heaps.HashMapImpl_capacity), m_out.int32One);
         ValueFromBlock indexStart = m_out.anchor(hash);
         m_out.jump(loopStart);
 

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -51,9 +51,6 @@ AbstractModuleRecord::AbstractModuleRecord(VM& vm, Structure* structure, const I
 
 void AbstractModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& vm)
 {
-    DeferTerminationForAWhile deferScope(vm);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
-
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
@@ -62,8 +59,7 @@ void AbstractModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& vm)
     for (unsigned index = 0; index < values.size(); ++index)
         Base::internalField(index).set(vm, this, values[index]);
 
-    JSMap* map = JSMap::create(globalObject, vm, globalObject->mapStructure());
-    scope.releaseAssertNoException();
+    JSMap* map = JSMap::create(vm, globalObject->mapStructure());
     m_dependenciesMap.set(vm, this, map);
     putDirect(vm, Identifier::fromString(vm, "dependenciesMap"_s), m_dependenciesMap.get());
 }

--- a/Source/JavaScriptCore/runtime/HashMapImpl.h
+++ b/Source/JavaScriptCore/runtime/HashMapImpl.h
@@ -209,7 +209,7 @@ public:
         return bitwise_cast<BucketType**>(this);
     }
 
-    static HashMapBuffer* create(JSGlobalObject* globalObject, VM& vm, JSCell*, uint32_t capacity)
+    static HashMapBuffer* tryCreate(JSGlobalObject* globalObject, VM& vm, uint32_t capacity)
     {
         auto scope = DECLARE_THROW_SCOPE(vm);
         size_t allocationSize = HashMapBuffer::allocationSize(capacity);
@@ -239,7 +239,7 @@ ALWAYS_INLINE uint32_t wangsInt64Hash(uint64_t key);
 ALWAYS_INLINE uint32_t jsMapHash(JSBigInt*);
 ALWAYS_INLINE uint32_t jsMapHash(JSGlobalObject*, VM&, JSValue);
 ALWAYS_INLINE uint32_t shouldShrink(uint32_t capacity, uint32_t keyCount);
-ALWAYS_INLINE uint32_t shouldRehashAfterAdd(uint32_t capacity, uint32_t keyCount, uint32_t deleteCount);
+ALWAYS_INLINE uint32_t shouldRehash(uint32_t capacity, uint32_t keyCount, uint32_t deleteCount);
 ALWAYS_INLINE uint32_t nextCapacity(uint32_t capacity, uint32_t keyCount);
 
 template <typename HashMapBucketType>
@@ -256,20 +256,7 @@ public:
 
     HashMapImpl(VM& vm, Structure* structure)
         : Base(vm, structure)
-        , m_keyCount(0)
-        , m_deleteCount(0)
-        , m_capacity(4)
     {
-    }
-
-    HashMapImpl(VM& vm, Structure* structure, uint32_t sizeHint)
-        : Base(vm, structure)
-        , m_keyCount(0)
-        , m_deleteCount(0)
-    {
-        uint32_t capacity = (Checked<uint32_t>(sizeHint) * 2) + 1;
-        capacity = std::max<uint32_t>(WTF::roundUpToPowerOfTwo(capacity), 4U);
-        m_capacity = capacity;
     }
 
     ALWAYS_INLINE HashMapBucketType** buffer() const
@@ -277,7 +264,7 @@ public:
         return m_buffer->buffer();
     }
 
-    void finishCreation(JSGlobalObject*, VM&);
+    void finishCreation(VM&);
     void finishCreation(JSGlobalObject*, VM&, HashMapImpl* base);
 
     static HashMapBucketType* emptyValue()
@@ -320,7 +307,7 @@ public:
         return m_keyCount;
     }
 
-    ALWAYS_INLINE void clear(JSGlobalObject*);
+    ALWAYS_INLINE void clear(VM&);
 
     ALWAYS_INLINE size_t bufferSizeInBytes() const
     {
@@ -355,42 +342,39 @@ public:
     }
 
 private:
-    ALWAYS_INLINE uint32_t shouldRehashAfterAdd() const
-    {
-        return JSC::shouldRehashAfterAdd(m_capacity, m_keyCount, m_deleteCount);
-    }
-
     ALWAYS_INLINE uint32_t shouldShrink() const
     {
         return JSC::shouldShrink(m_capacity, m_keyCount);
     }
 
-    ALWAYS_INLINE void setUpHeadAndTail(JSGlobalObject*, VM&);
+    ALWAYS_INLINE void setUpHeadAndTail(VM&);
 
     ALWAYS_INLINE void addNormalizedNonExistingForCloning(JSGlobalObject*, JSValue key, JSValue = JSValue());
+    ALWAYS_INLINE HashMapBucketType* addNormalizedNonExistingForCloningInternal(JSGlobalObject*, JSValue key, JSValue, uint32_t hash);
 
     template<typename CanUseBucket>
     ALWAYS_INLINE void addNormalizedInternal(JSGlobalObject*, JSValue key, JSValue, const CanUseBucket&);
 
     template<typename CanUseBucket>
-    ALWAYS_INLINE HashMapBucketType* addNormalizedInternal(VM&, JSValue key, JSValue, uint32_t hash, const CanUseBucket&);
+    ALWAYS_INLINE HashMapBucketType* addNormalizedInternal(JSGlobalObject*, JSValue key, JSValue, uint32_t hash, const CanUseBucket&);
 
     ALWAYS_INLINE HashMapBucketType** findBucketAlreadyHashedAndNormalized(JSGlobalObject*, JSValue key, uint32_t hash);
 
-    void rehash(JSGlobalObject*);
+    enum class RehashMode { BeforeAddition, AfterRemoval };
+    void rehash(JSGlobalObject*, RehashMode);
 
     ALWAYS_INLINE void checkConsistency() const;
 
-    void makeAndSetNewBuffer(JSGlobalObject*, VM&);
+    void makeAndSetNewBuffer(JSGlobalObject*, uint32_t newCapacity, VM&);
 
-    ALWAYS_INLINE void assertBufferIsEmpty() const;
+    ALWAYS_INLINE static void assertBufferIsEmpty(HashMapBucketType**, uint32_t capacity);
 
     WriteBarrier<HashMapBucketType> m_head;
     WriteBarrier<HashMapBucketType> m_tail;
     AuxiliaryBarrier<HashMapBufferType*> m_buffer;
-    uint32_t m_keyCount;
-    uint32_t m_deleteCount;
-    uint32_t m_capacity;
+    uint32_t m_keyCount { 0 };
+    uint32_t m_deleteCount { 0 };
+    uint32_t m_capacity { 0 };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMap.h
+++ b/Source/JavaScriptCore/runtime/JSMap.h
@@ -47,10 +47,10 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(JSMapType, StructureFlags), info());
     }
 
-    static JSMap* create(JSGlobalObject* globalObject, VM& vm, Structure* structure)
+    static JSMap* create(VM& vm, Structure* structure)
     {
         JSMap* instance = new (NotNull, allocateCell<JSMap>(vm)) JSMap(vm, structure);
-        instance->finishCreation(globalObject, vm);
+        instance->finishCreation(vm);
         return instance;
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -99,13 +99,9 @@ JSModuleLoader::JSModuleLoader(VM& vm, Structure* structure)
 
 void JSModuleLoader::finishCreation(JSGlobalObject* globalObject, VM& vm)
 {
-    DeferTerminationForAWhile deferScope(vm);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
-
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    JSMap* map = JSMap::create(globalObject, vm, globalObject->mapStructure());
-    scope.releaseAssertNoException();
+    JSMap* map = JSMap::create(vm, globalObject->mapStructure());
     putDirect(vm, Identifier::fromString(vm, "registry"_s), map);
 }
 

--- a/Source/JavaScriptCore/runtime/JSSet.h
+++ b/Source/JavaScriptCore/runtime/JSSet.h
@@ -47,15 +47,10 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(JSSetType, StructureFlags), info());
     }
 
-    static JSSet* create(JSGlobalObject* globalObject, VM& vm, Structure* structure)
+    static JSSet* create(VM& vm, Structure* structure)
     {
-        return create(globalObject, vm, structure, 0);
-    }
-
-    static JSSet* create(JSGlobalObject* globalObject, VM& vm, Structure* structure, uint32_t size)
-    {
-        JSSet* instance = new (NotNull, allocateCell<JSSet>(vm)) JSSet(vm, structure, size);
-        instance->finishCreation(globalObject, vm);
+        JSSet* instance = new (NotNull, allocateCell<JSSet>(vm)) JSSet(vm, structure);
+        instance->finishCreation(vm);
         return instance;
     }
 
@@ -66,11 +61,6 @@ public:
 private:
     JSSet(VM& vm, Structure* structure)
         : Base(vm, structure)
-    {
-    }
-
-    JSSet(VM& vm, Structure* structure, uint32_t sizeHint)
-        : Base(vm, structure, sizeHint)
     {
     }
 };

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -68,7 +68,7 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
 
     JSValue iterable = callFrame->argument(0);
     if (iterable.isUndefinedOrNull())
-        RELEASE_AND_RETURN(scope, JSValue::encode(JSMap::create(globalObject, vm, mapStructure)));
+        return JSValue::encode(JSMap::create(vm, mapStructure));
 
     bool canPerformFastSet = JSMap::isSetFastAndNonObservable(mapStructure);
     if (auto* iterableMap = jsDynamicCast<JSMap*>(iterable)) {
@@ -76,8 +76,7 @@ JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame*
             RELEASE_AND_RETURN(scope, JSValue::encode(iterableMap->clone(globalObject, vm, mapStructure)));
     }
 
-    JSMap* map = JSMap::create(globalObject, vm, mapStructure);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    JSMap* map = JSMap::create(vm, mapStructure);
 
     JSValue adderFunction;
     CallData adderFunctionCallData;

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncClear, (JSGlobalObject* globalObject, CallF
     JSMap* map = getMap(globalObject, callFrame->thisValue());
     if (!map)
         return JSValue::encode(jsUndefined());
-    map->clear(globalObject);
+    map->clear(globalObject->vm());
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -67,8 +67,8 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue iterable = callFrame->argument(0);
-    if (iterable.isUndefinedOrNull()) 
-        RELEASE_AND_RETURN(scope, JSValue::encode(JSSet::create(globalObject, vm, setStructure)));
+    if (iterable.isUndefinedOrNull())
+        return JSValue::encode(JSSet::create(vm, setStructure));
 
     bool canPerformFastAdd = JSSet::isAddFastAndNonObservable(setStructure);
     if (auto* iterableSet = jsDynamicCast<JSSet*>(iterable)) {
@@ -76,8 +76,7 @@ JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame*
             RELEASE_AND_RETURN(scope, JSValue::encode(iterableSet->clone(globalObject, vm, setStructure)));
     }
 
-    JSSet* set = JSSet::create(globalObject, vm, setStructure);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    JSSet* set = JSSet::create(vm, setStructure);
 
     JSValue adderFunction;
     CallData adderFunctionCallData;

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncClear, (JSGlobalObject* globalObject, CallF
     JSSet* set = getSet(globalObject, callFrame->thisValue());
     if (!set)
         return JSValue::encode(jsUndefined());
-    set->clear(globalObject);
+    set->clear(globalObject->vm());
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -125,7 +125,7 @@ void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
 template<typename WeakMapBucket>
 ALWAYS_INLINE uint32_t WeakMapImpl<WeakMapBucket>::shouldRehashAfterAdd() const
 {
-    return JSC::shouldRehashAfterAdd(m_capacity, m_keyCount, m_deleteCount);
+    return JSC::shouldRehash(m_capacity, m_keyCount, m_deleteCount);
 }
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/JSDOMMapLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMMapLike.cpp
@@ -41,12 +41,7 @@ std::pair<bool, std::reference_wrapper<JSC::JSObject>> getBackingMap(JSC::JSGlob
     if (backingMap)
         return { false, *JSC::asObject(backingMap) };
 
-    JSC::DeferTerminationForAWhile deferScope(vm);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
-
-    backingMap = JSC::JSMap::create(&lexicalGlobalObject, vm, lexicalGlobalObject.mapStructure());
-    scope.releaseAssertNoException();
-
+    backingMap = JSC::JSMap::create(vm, lexicalGlobalObject.mapStructure());
     mapLike.putDirect(vm, builtinNames(vm).backingMapPrivateName(), backingMap, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
     return { true, *JSC::asObject(backingMap) };
 }

--- a/Source/WebCore/bindings/js/JSDOMSetLike.cpp
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.cpp
@@ -45,12 +45,7 @@ std::pair<bool, std::reference_wrapper<JSC::JSObject>> getBackingSet(JSC::JSGlob
     auto backingSet = setLike.getDirect(vm, builtinNames(vm).backingSetPrivateName());
     if (!backingSet) {
         auto& vm = lexicalGlobalObject.vm();
-        JSC::DeferTermination deferScope(vm);
-        auto scope = DECLARE_CATCH_SCOPE(vm);
-
-        backingSet = JSC::JSSet::create(&lexicalGlobalObject, vm, lexicalGlobalObject.setStructure());
-        scope.releaseAssertNoException();
-
+        backingSet = JSC::JSSet::create(vm, lexicalGlobalObject.setStructure());
         setLike.putDirect(vm, builtinNames(vm).backingSetPrivateName(), backingSet, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
         return { true, *JSC::asObject(backingSet) };
     }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4012,9 +4012,7 @@ DeserializationResult CloneDeserializer::deserialize()
         mapObjectStartState: {
             if (outputObjectStack.size() > maximumFilterRecursion)
                 return std::make_pair(JSValue(), SerializationReturnCode::StackOverflowError);
-            JSMap* map = JSMap::create(m_lexicalGlobalObject, m_lexicalGlobalObject->vm(), m_globalObject->mapStructure());
-            if (UNLIKELY(scope.exception()))
-                goto error;
+            JSMap* map = JSMap::create(m_lexicalGlobalObject->vm(), m_globalObject->mapStructure());
             m_gcBuffer.appendWithCrashOnOverflow(map);
             outputObjectStack.append(map);
             mapStack.append(map);
@@ -4043,9 +4041,7 @@ DeserializationResult CloneDeserializer::deserialize()
         setObjectStartState: {
             if (outputObjectStack.size() > maximumFilterRecursion)
                 return std::make_pair(JSValue(), SerializationReturnCode::StackOverflowError);
-            JSSet* set = JSSet::create(m_lexicalGlobalObject, m_lexicalGlobalObject->vm(), m_globalObject->setStructure());
-            if (UNLIKELY(scope.exception()))
-                goto error;
+            JSSet* set = JSSet::create(m_lexicalGlobalObject->vm(), m_globalObject->setStructure());
             m_gcBuffer.appendWithCrashOnOverflow(set);
             outputObjectStack.append(set);
             setStack.append(set);


### PR DESCRIPTION
#### 1ed1e4a336e15a59b94a21b0300658e2f7dc9fef
<pre>
[JSC] Make JSMap and JSSet construction more simple and efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=243557">https://bugs.webkit.org/show_bug.cgi?id=243557</a>
rdar://98068082

Reviewed by Mark Lam and Saam Barati.

This patch makes the initial buffer of JSMap / JSSet nullptr so that we can make allocation of them
simpler and efficient for non-using case. It cleans up many code in module loader etc. And it paves
the way to allocating them from DFG and FTL efficiently. It also cleans up SerializedScriptValue
implementation.

* JSTests/stress/map-clear-get.js: Added.
(shouldBe):
(test):
* JSTests/stress/set-clear-has.js: Added.
(shouldBe):
(set clear):
(set shouldBe):
(set new):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::finishCreation):
* Source/JavaScriptCore/runtime/HashMapImpl.h:
(JSC::HashMapBuffer::tryCreate):
(JSC::HashMapImpl::HashMapImpl):
(JSC::HashMapBuffer::create): Deleted.
(JSC::HashMapImpl::shouldRehashAfterAdd const): Deleted.
* Source/JavaScriptCore/runtime/HashMapImplInlines.h:
(JSC::shouldShrink):
(JSC::shouldRehash):
(JSC::nextCapacity):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::finishCreation):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::add):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::addNormalized):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::remove):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::clear):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::setUpHeadAndTail):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::addNormalizedNonExistingForCloning):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::addNormalizedNonExistingForCloningInternal):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::addNormalizedInternal):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::findBucketAlreadyHashedAndNormalized):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::rehash):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::makeAndSetNewBuffer):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::assertBufferIsEmpty):
(JSC::shouldRehashAfterAdd): Deleted.
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::assertBufferIsEmpty const): Deleted.
* Source/JavaScriptCore/runtime/JSMap.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::finishCreation):
* Source/JavaScriptCore/runtime/JSSet.h:
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::shouldRehashAfterAdd const):
* Source/WebCore/bindings/js/JSDOMMapLike.cpp:
(WebCore::getBackingMap):
* Source/WebCore/bindings/js/JSDOMSetLike.cpp:
(WebCore::getBackingSet):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::deserialize):

Canonical link: <a href="https://commits.webkit.org/253133@main">https://commits.webkit.org/253133@main</a>
</pre>
