### PR TITLE
[ iOS ] fast/canvas/image-object-in-canvas.html is a flaky timeout on iOS

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3607,6 +3607,8 @@ webkit.org/b/240489 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html [ ImageOnlyFailure ]
 
+webkit.org/b/243558 fast/canvas/image-object-in-canvas.html [ Slow ]
+
 #  Correction to guard in Platform file removing iOS - Skip tests
 webkit.org/b/240579 http/tests/workers/service/shownotification-allowed-document.html [ Skip ]
 webkit.org/b/240579 http/tests/workers/service/shownotification-allowed.html [ Skip ]


### PR DESCRIPTION
#### d9341f4583e66ab032866abc2f581d24770eebb2
<pre>
[ iOS ] fast/canvas/image-object-in-canvas.html is a flaky timeout on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243558">https://bugs.webkit.org/show_bug.cgi?id=243558</a>
&lt;rdar://98147510&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253131@main">https://commits.webkit.org/253131@main</a>
</pre>
