### PR TITLE
REGRESSION(253079@main): [ iOS ] fast/layers/add-layer-with-nested-stacking.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/fast/layers/add-layer-with-nested-stacking-expected.txt
+++ b/LayoutTests/platform/ios/fast/layers/add-layer-with-nested-stacking-expected.txt
@@ -7,5 +7,4 @@ layer at (8,8) size 784x100
   RenderBlock {DIV} at (0,0) size 784x100
 layer at (8,8) size 100x100
   RenderBlock (generated) at (0,0) size 100x100 [bgcolor=#008000]
-    RenderText at (0,-15) size 0x19
-      text run at (0,-15) width 0: ""
+    RenderText at (0,0) size 0x0


### PR DESCRIPTION
#### 027340c60cebe9a96bf1b4db1b65a12bba642fa1
<pre>
REGRESSION(253079@main): [ iOS ] fast/layers/add-layer-with-nested-stacking.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243560">https://bugs.webkit.org/show_bug.cgi?id=243560</a>
&lt;rdar://98150172&gt;

Unreviewed rebasline.

* LayoutTests/platform/ios/fast/layers/add-layer-with-nested-stacking-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253134@main">https://commits.webkit.org/253134@main</a>
</pre>
