### PR TITLE
[Gardening]: [ iOS15 macOS wk2 ] fast/dom/HTMLLinkElement/link-stylesheet-load-once.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3677,3 +3677,5 @@ webkit.org/b/242840 fast/text/international/system-language/han-text-style.html 
 webkit.org/b/242905 compositing/tiling/tiled-mask-inwindow.html [ Pass Failure ]
 
 webkit.org/b/243547 fast/mediastream/getUserMedia-to-canvas-1.html [ Pass Timeout ]
+
+webkit.org/b/243563 fast/dom/HTMLLinkElement/link-stylesheet-load-once.html [ Skip ] 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2294,3 +2294,5 @@ webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass C
 webkit.org/b/243515 svg/compositing/svg-poster-circle.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-with-border-padding.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-directly-composited-transformed-group-child.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/243563 fast/dom/HTMLLinkElement/link-stylesheet-load-once.html [ Pass Failure ] 


### PR DESCRIPTION
#### 474ef37d3d464a955bc15129835cd4dfc554082c
<pre>
[Gardening]: [ iOS15 macOS wk2 ] fast/dom/HTMLLinkElement/link-stylesheet-load-once.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243563">https://bugs.webkit.org/show_bug.cgi?id=243563</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253136@main">https://commits.webkit.org/253136@main</a>
</pre>
