### PR TITLE
Make iOS scrolling API test assert if the wrong kind of simulated device is being used

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
@@ -36,7 +36,7 @@ namespace TestWebKitAPI {
 
 #if PLATFORM(IOS_FAMILY)
 
-TEST(WebKit, RestoreScrollPositionDuringResize)
+TEST(RestoreScrollPositionTests, RestoreScrollPositionDuringResize)
 {
     auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().pageCacheEnabled = NO;
@@ -45,9 +45,14 @@ TEST(WebKit, RestoreScrollPositionDuringResize)
     auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:webViewConfiguration.get()]);
+
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView stringByEvaluatingJavaScript:@"scrollTo(0, 1000)"];
     [webView waitForNextPresentationUpdate];
+
+    UIEdgeInsets contentInset = [[webView scrollView] adjustedContentInset];
+    // If this fires you're probably running using the wrong type of simulated device.
+    ASSERT_UNUSED(contentInset, !contentInset.top);
 
     CGPoint contentOffsetAfterScrolling = [webView scrollView].contentOffset;
     EXPECT_EQ(0, contentOffsetAfterScrolling.x);
@@ -56,9 +61,9 @@ TEST(WebKit, RestoreScrollPositionDuringResize)
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
 
-    contentOffsetAfterScrolling = [webView scrollView].contentOffset;
-    EXPECT_EQ(0, contentOffsetAfterScrolling.x);
-    EXPECT_EQ(0, contentOffsetAfterScrolling.y);
+    CGPoint contentOffsetInNewPage = [webView scrollView].contentOffset;
+    EXPECT_EQ(0, contentOffsetInNewPage.x);
+    EXPECT_EQ(0, contentOffsetInNewPage.y);
 
     [webView _beginAnimatedResizeWithUpdates:^{
         [webView setFrame:CGRectMake(0, 0, [webView frame].size.width + 100, 500)];
@@ -75,9 +80,9 @@ TEST(WebKit, RestoreScrollPositionDuringResize)
             TestWebKitAPI::Util::sleep(0.1);
     } while ([webView scrollView].contentOffset.y != 1000 && ++timeout <= 30);
 
-    contentOffsetAfterScrolling = [webView scrollView].contentOffset;
-    EXPECT_EQ(0, contentOffsetAfterScrolling.x);
-    EXPECT_EQ(1000, contentOffsetAfterScrolling.y);
+    CGPoint contentOffsetAfterBack = [webView scrollView].contentOffset;
+    EXPECT_EQ(0, contentOffsetAfterBack.x);
+    EXPECT_EQ(1000, contentOffsetAfterBack.y);
 }
 
 #endif


### PR DESCRIPTION
#### 55a8e6e36d1e4e2cd5b831d42c27c801bf8acb39
<pre>
Make iOS scrolling API test assert if the wrong kind of simulated device is being used
<a href="https://bugs.webkit.org/show_bug.cgi?id=243568">https://bugs.webkit.org/show_bug.cgi?id=243568</a>

Reviewed by Wenson Hsieh.

Improve this scrolling API test by making a RestoreScrollPositionTests test group for it,
having it assert if the UIScrollView has insets (suggesting you&apos;re using the wrong kind
of device), and naming the CGPoints appropriately.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/253139@main">https://commits.webkit.org/253139@main</a>
</pre>
