### PR TITLE
REGRESSION(250037@main): wpt /service-workers/service-worker/registration-updateviacache.https.html has become flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/update-max-aged-worker.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/update-max-aged-worker.py
@@ -13,7 +13,7 @@ def main(request, response):
     body = u'''
         const mainTime = {time:8f};
         const testName = {test};
-        importScripts('update-max-aged-worker-imported-script.py?test={test}');
+        importScripts('update-max-aged-worker-imported-script.py');
 
         addEventListener('message', event => {{
             event.source.postMessage({{

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3587,8 +3587,6 @@ webkit.org/b/240037 css3/background/background-repeat-space-content.html [ Pass 
 
 webkit.org/b/240069 fast/css/continuationCrash.html [ Pass Failure ]
 
-webkit.org/b/240074 imported/w3c/web-platform-tests/service-workers/service-worker/registration-updateviacache.https.html [ Pass Failure ]
-
 webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Pass Failure ]
 
 webkit.org/b/240081 webaudio/AudioBuffer/huge-buffer.html [ Pass Slow ]

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -169,6 +169,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     } else if (auto* activeServiceWorker = scriptExecutionContext.activeServiceWorker())
         options.serviceWorkerRegistrationIdentifier = activeServiceWorker->registrationIdentifier();
 #endif
+
     if (m_destination == FetchOptions::Destination::Sharedworker)
         m_userAgentForSharedWorker = scriptExecutionContext.userAgent(scriptRequest.url());
 

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -124,7 +124,6 @@ protected:
     WEBCORE_EXPORT void jobRejectedInServer(ServiceWorkerJobIdentifier, ExceptionData&&);
     WEBCORE_EXPORT void registrationJobResolvedInServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationData&&, ShouldNotifyWhenResolved);
     WEBCORE_EXPORT void startScriptFetchForServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationKey&&, FetchOptions::Cache);
-    WEBCORE_EXPORT void refreshImportedScripts(ServiceWorkerJobIdentifier, FetchOptions::Cache, Vector<URL>&&, ServiceWorkerJob::RefreshImportedScriptsCallback&&);
     WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, MessageWithMessagePorts&&, ServiceWorkerData&& source, String&& sourceOrigin);
     WEBCORE_EXPORT void updateRegistrationState(ServiceWorkerRegistrationIdentifier, ServiceWorkerRegistrationState, const std::optional<ServiceWorkerData>&);
     WEBCORE_EXPORT void updateWorkerState(ServiceWorkerIdentifier, ServiceWorkerState);

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -59,9 +59,6 @@ public:
     void resolvedWithUnregistrationResult(bool);
     void startScriptFetch(FetchOptions::Cache);
 
-    using RefreshImportedScriptsCallback = CompletionHandler<void(Vector<std::pair<URL, ScriptBuffer>>&&)>;
-    void refreshImportedScripts(const Vector<URL>&, FetchOptions::Cache, RefreshImportedScriptsCallback&&);
-
     using Identifier = ServiceWorkerJobIdentifier;
     Identifier identifier() const { return m_jobData.identifier().jobIdentifier; }
 
@@ -88,26 +85,8 @@ private:
 
     bool m_completed { false };
 
-    class ImportedScriptsLoader : public WorkerScriptLoaderClient {
-        WTF_MAKE_FAST_ALLOCATED;
-    public:
-        explicit ImportedScriptsLoader(RefreshImportedScriptsCallback&&);
-        ~ImportedScriptsLoader();
-        void load(ScriptExecutionContext&, const Vector<URL>&, FetchOptions::Cache);
-        void cancel();
-
-    private:
-        void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) final { }
-        void notifyFinished() final;
-
-        RefreshImportedScriptsCallback m_callback;
-        Vector<Ref<WorkerScriptLoader>> m_loaders;
-        size_t m_remainingLoads { 0 };
-    };
-
     ServiceWorkerOrClientIdentifier m_contextIdentifier;
     RefPtr<WorkerScriptLoader> m_scriptLoader;
-    std::unique_ptr<ImportedScriptsLoader> m_importedScriptsLoader;
 
 #if ASSERT_ENABLED
     Ref<Thread> m_creationThread { Thread::current() };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -608,12 +608,6 @@ void SWServer::refreshImportedScripts(const ServiceWorkerJobData& jobData, SWSer
     };
     bool shouldRefreshCache = registration.updateViaCache() == ServiceWorkerUpdateViaCache::None || (registration.getNewestWorker() && registration.isStale());
 
-    auto* connection = m_connections.get(jobData.connectionIdentifier());
-    if (connection) {
-        connection->refreshImportedScripts(jobData.identifier().jobIdentifier, shouldRefreshCache ? FetchOptions::Cache::NoCache : FetchOptions::Cache::Default, urls, WTFMove(callback));
-        return;
-    }
-
     ASSERT(jobData.connectionIdentifier() == Process::identifier());
     auto handler = RefreshImportedScriptsHandler::create(urls.size(), WTFMove(callback));
     for (auto& url : urls) {

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -118,7 +118,6 @@ public:
         virtual void resolveRegistrationJobInClient(ServiceWorkerJobIdentifier, const ServiceWorkerRegistrationData&, ShouldNotifyWhenResolved) = 0;
         virtual void resolveUnregistrationJobInClient(ServiceWorkerJobIdentifier, const ServiceWorkerRegistrationKey&, bool registrationResult) = 0;
         virtual void startScriptFetchInClient(ServiceWorkerJobIdentifier, const ServiceWorkerRegistrationKey&, FetchOptions::Cache) = 0;
-        virtual void refreshImportedScripts(ServiceWorkerJobIdentifier, FetchOptions::Cache, const Vector<URL>&, ServiceWorkerJob::RefreshImportedScriptsCallback&&) = 0;
 
         struct RegistrationReadyRequest {
             SecurityOriginData topOrigin;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -134,11 +134,6 @@ void WebSWServerConnection::startScriptFetchInClient(ServiceWorkerJobIdentifier 
     send(Messages::WebSWClientConnection::StartScriptFetchForServer(jobIdentifier, registrationKey, cachePolicy));
 }
 
-void WebSWServerConnection::refreshImportedScripts(ServiceWorkerJobIdentifier jobIdentifier, FetchOptions::Cache cachePolicy, const Vector<URL>& urls, ServiceWorkerJob::RefreshImportedScriptsCallback&& callback)
-{
-    sendWithAsyncReply(Messages::WebSWClientConnection::RefreshImportedScripts(jobIdentifier, cachePolicy, urls), WTFMove(callback));
-}
-
 void WebSWServerConnection::updateRegistrationStateInClient(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerRegistrationState state, const std::optional<ServiceWorkerData>& serviceWorkerData)
 {
     send(Messages::WebSWClientConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -96,7 +96,6 @@ private:
     void resolveRegistrationJobInClient(WebCore::ServiceWorkerJobIdentifier, const WebCore::ServiceWorkerRegistrationData&, WebCore::ShouldNotifyWhenResolved) final;
     void resolveUnregistrationJobInClient(WebCore::ServiceWorkerJobIdentifier, const WebCore::ServiceWorkerRegistrationKey&, bool unregistrationResult) final;
     void startScriptFetchInClient(WebCore::ServiceWorkerJobIdentifier, const WebCore::ServiceWorkerRegistrationKey&, WebCore::FetchOptions::Cache) final;
-    void refreshImportedScripts(WebCore::ServiceWorkerJobIdentifier, WebCore::FetchOptions::Cache, const Vector<URL>&, WebCore::ServiceWorkerJob::RefreshImportedScriptsCallback&&);
     void updateRegistrationStateInClient(WebCore::ServiceWorkerRegistrationIdentifier, WebCore::ServiceWorkerRegistrationState, const std::optional<WebCore::ServiceWorkerData>&) final;
     void updateWorkerStateInClient(WebCore::ServiceWorkerIdentifier, WebCore::ServiceWorkerState) final;
     void fireUpdateFoundEvent(WebCore::ServiceWorkerRegistrationIdentifier) final;

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -27,7 +27,6 @@ messages -> WebSWClientConnection {
     JobRejectedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ExceptionData exception)
     RegistrationJobResolvedInServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, struct WebCore::ServiceWorkerRegistrationData registration, enum:bool WebCore::ShouldNotifyWhenResolved shouldNotifyWhenResolved)
     StartScriptFetchForServer(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, WebCore::ServiceWorkerRegistrationKey registrationKey, WebCore::FetchOptions::Cache cachePolicy)
-    RefreshImportedScripts(WebCore::ServiceWorkerJobIdentifier jobDataIdentifier, WebCore::FetchOptions::Cache cachePolicy, Vector<URL> urls) -> (Vector<std::pair<URL, WebCore::ScriptBuffer>> results);
     UpdateRegistrationState(WebCore::ServiceWorkerRegistrationIdentifier identifier, enum:uint8_t WebCore::ServiceWorkerRegistrationState state, std::optional<WebCore::ServiceWorkerData> serviceWorkerIdentifier)
     UpdateWorkerState(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:uint8_t WebCore::ServiceWorkerState state)
     FireUpdateFoundEvent(WebCore::ServiceWorkerRegistrationIdentifier identifier)


### PR DESCRIPTION
#### 3f019cf4b5d2b381db5af9d2751583f7871ba8bf
<pre>
REGRESSION(250037@main): wpt /service-workers/service-worker/registration-updateviacache.https.html has become flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=243410">https://bugs.webkit.org/show_bug.cgi?id=243410</a>
&lt;rdar://97921749&gt;

Reviewed by Darin Adler.

This patch is a partial revert of 250037@main to address the flakiness while keeping the intended Web-facing
behavior change. In particular, I am reverting the logic to refresh the scripts imported by a service worker
from the client process that requested the update. We now refresh those scripts from the NetworkProcess
unconditionally, like we did before 250037@main.

As explained by Youenn when he landed his workaround in 251742@main, the issue is that after 250037@main, we
sometimes fetch those scripts from the network process, or service worker process or a regular WebProcess.
Depending on which client made the fetch, we could get different results because of memory caching.

You could end up with the following scenario for example:
1. First fetch of script A is made from WebProcess 1, which caches the script in its memory cache
2. Second fetch of script A occurs directly from the NetworkProcess, which would update the HTTP network
   cache only.
3. Third fetch of script A is made from WebProcess 1 which uses the version it has in its memory cache,
   even though it is not the latest one (WP1 is not aware of the update that occurred at step 2.)

For now, let&apos;s fetch everything from the network process again to avoid such caching issues and truly
address flakiness.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/update-max-aged-worker.py:
(main):
Revert workaround that Youenn added in 251742@main to try and address the flakiness, given that it doesn&apos;t
completely fix it and other browsers don&apos;t need it.

* LayoutTests/platform/ios/TestExpectations:
Unskip test now that it should no longer be flaky.

* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::RefreshImportedScriptsCallbackHandler::RefreshImportedScriptsCallbackHandler): Deleted.
(WebCore::RefreshImportedScriptsCallbackHandler::~RefreshImportedScriptsCallbackHandler): Deleted.
(WebCore::RefreshImportedScriptsCallbackHandler::call): Deleted.
(WebCore::SWClientConnection::refreshImportedScripts): Deleted.
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::ServiceWorkerJob::cancelPendingLoad):
(WebCore::ServiceWorkerJob::ImportedScriptsLoader::ImportedScriptsLoader): Deleted.
(WebCore::ServiceWorkerJob::ImportedScriptsLoader::~ImportedScriptsLoader): Deleted.
(WebCore::ServiceWorkerJob::ImportedScriptsLoader::load): Deleted.
(WebCore::ServiceWorkerJob::ImportedScriptsLoader::cancel): Deleted.
(WebCore::ServiceWorkerJob::ImportedScriptsLoader::notifyFinished): Deleted.
(WebCore::ServiceWorkerJob::refreshImportedScripts): Deleted.
* Source/WebCore/workers/service/ServiceWorkerJob.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::refreshImportedScripts):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::refreshImportedScripts): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in:
Partial revert of 250037@main.

Canonical link: <a href="https://commits.webkit.org/253140@main">https://commits.webkit.org/253140@main</a>
</pre>
