### PR TITLE
fast/dom/HTMLLinkElement/link-stylesheet-load-once.html very frequently fail

### DIFF
--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,7 +1,7 @@
-data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
+resources/link-stylesheet-load-once.css - willSendRequest <NSURLRequest URL resources/link-stylesheet-load-once.css, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
 link-stylesheet-load-once.html - didFinishLoading
-data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 200>
-data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
+resources/link-stylesheet-load-once.css - didReceiveResponse <NSURLResponse resources/link-stylesheet-load-once.css, http status code 0>
+resources/link-stylesheet-load-once.css - didFinishLoading
 This tests overriding rel content attribute with the same value.
 You should see 1 in a green box below:
 

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
@@ -6,6 +6,9 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
     testRunner.dumpResourceLoadCallbacks();
+    internals.clearMemoryCache();
+    if (testRunner.setSerializeHTTPLoads)
+        testRunner.setSerializeHTTPLoads();
 }
 
 let loadCount = 0;
@@ -29,7 +32,7 @@ function didLoad(element)
 }
 
 </script>
-<link rel="stylesheet" href="data:text/css,div { background: green; width: 100px; height: 100px }" onload="didLoad(this)">
+<link rel="stylesheet" href="resources/link-stylesheet-load-once.css" onload="didLoad(this)">
 </head>
 <body>
 <p>This tests overriding rel content attribute with the same value.<br>

--- a/LayoutTests/fast/dom/HTMLLinkElement/resources/link-stylesheet-load-once.css
+++ b/LayoutTests/fast/dom/HTMLLinkElement/resources/link-stylesheet-load-once.css
@@ -1,0 +1,5 @@
+div {
+    background: green;
+    width: 100px;
+    height: 100px;
+}

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3675,5 +3675,3 @@ webkit.org/b/242840 fast/text/international/system-language/han-text-style.html 
 webkit.org/b/242905 compositing/tiling/tiled-mask-inwindow.html [ Pass Failure ]
 
 webkit.org/b/243547 fast/mediastream/getUserMedia-to-canvas-1.html [ Pass Timeout ]
-
-webkit.org/b/243563 fast/dom/HTMLLinkElement/link-stylesheet-load-once.html [ Skip ] 

--- a/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,8 +1,0 @@
-data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - willSendRequest <NSURLRequest URL data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, main document URL (null), http method GET> redirectResponse (null)
-data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didReceiveResponse <NSURLResponse data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D, http status code 0>
-data:text/css,div%20%7B%20background:%20green;%20width:%20100px;%20height:%20100px%20%7D - didFinishLoading
-link-stylesheet-load-once.html - didFinishLoading
-This tests overriding rel content attribute with the same value.
-You should see 1 in a green box below:
-
-1

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2294,5 +2294,3 @@ webkit.org/b/242226 http/tests/media/modern-media-controls/time-control [ Pass C
 webkit.org/b/243515 svg/compositing/svg-poster-circle.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-with-border-padding.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 [ Monterey+ ] svg/compositing/outermost-svg-directly-composited-transformed-group-child.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/243563 fast/dom/HTMLLinkElement/link-stylesheet-load-once.html [ Pass Failure ] 

--- a/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,8 +1,0 @@
-data:text/css,div { background: green; width: 100px; height: 100px } - willSendRequest <NSURLRequest URL data:text/css,div { background: green; width: 100px; height: 100px }, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
-link-stylesheet-load-once.html - didFinishLoading
-data:text/css,div { background: green; width: 100px; height: 100px } - didReceiveResponse <NSURLResponse data:text/css,div { background: green; width: 100px; height: 100px }, http status code 0>
-data:text/css,div { background: green; width: 100px; height: 100px } - didFinishLoading
-This tests overriding rel content attribute with the same value.
-You should see 1 in a green box below:
-
-1


### PR DESCRIPTION
#### 7b24f7be0a0b3b3d0ab21575b14837effe8ee93c
<pre>
fast/dom/HTMLLinkElement/link-stylesheet-load-once.html very frequently fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=243563">https://bugs.webkit.org/show_bug.cgi?id=243563</a>

Reviewed by Chris Dumez.

Clear memory cache, serialize load, and use an external CSS file instead of data URL to stabilize the test.

* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt:
* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html:
* LayoutTests/fast/dom/HTMLLinkElement/resources/link-stylesheet-load-once.css: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt: Removed.
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/253147@main">https://commits.webkit.org/253147@main</a>
</pre>
