### PR TITLE
[JSC] TypedArray iteration does not need to get "length"

### DIFF
--- a/JSTests/stress/detached-typed-array-iteration.js
+++ b/JSTests/stress/detached-typed-array-iteration.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var array = new Uint8Array(42);
+var count = 0;
+
+shouldThrow(() => {
+    for (let v of array) {
+        ++count;
+        $.detachArrayBuffer(array.buffer);
+    }
+}, `TypeError: Underlying ArrayBuffer has been detached from the view`);
+
+shouldBe(count, 1);

--- a/JSTests/stress/typed-array-from-custom-length.js
+++ b/JSTests/stress/typed-array-from-custom-length.js
@@ -8,4 +8,4 @@ Reflect.defineProperty(array, 'length', {
     value: 42
 });
 var result = Uint8Array.from(array);
-shouldBe(result.length, 42);
+shouldBe(result.length, 128); // Ignore "length"

--- a/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js
@@ -50,7 +50,7 @@ function arrayIteratorNextHelper(array, kind)
 
     var index = @getArrayIteratorInternalField(this, @arrayIteratorFieldIndex);
     if (index !== -1) {
-        var length = array.length >>> 0;
+        var length = @isTypedArrayView(array) ? @typedArrayLength(array) : @toLength(array.length);
         if (index < length) {
             @putArrayIteratorInternalField(this, @arrayIteratorFieldIndex, index + 1);
             done = false;

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -371,9 +371,6 @@ bool JSArrayBufferView::isIteratorProtocolFastAndNonObservable()
     if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
         return false;
 
-    if (getDirectOffset(vm, vm.propertyNames->length) != invalidOffset)
-        return false;
-
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2617,10 +2617,9 @@ void JSGlobalObject::installTypedArrayIteratorProtocolWatchpoint(JSObject* base,
         return ObjectPropertyCondition::absence(vm, this, base, propertyName.uid(), m_typedArrayProto.get(this));
     };
 
-    ObjectPropertyCondition lengthCondition = absenceCondition(vm.propertyNames->length);
     ObjectPropertyCondition iteratorCondition = absenceCondition(vm.propertyNames->iteratorSymbol);
 
-    if (!lengthCondition.isWatchable(PropertyCondition::EnsureWatchability) || !iteratorCondition.isWatchable(PropertyCondition::EnsureWatchability)) {
+    if (!iteratorCondition.isWatchable(PropertyCondition::EnsureWatchability)) {
         typedArrayIteratorProtocolWatchpointSet(typedArrayType).invalidate(vm, StringFireDetail("Was not able to set up iterator protocol watchpoint."));
         return;
     }
@@ -2628,28 +2627,16 @@ void JSGlobalObject::installTypedArrayIteratorProtocolWatchpoint(JSObject* base,
     RELEASE_ASSERT(!typedArrayIteratorProtocolWatchpointSet(typedArrayType).isBeingWatched());
     typedArrayIteratorProtocolWatchpointSet(typedArrayType).touch(vm, "Set up iterator protocol watchpoint.");
 
-    typedArrayPrototypeLengthAbsenceWatchpoint(typedArrayType) = makeUnique<ObjectAdaptiveStructureWatchpoint>(this, lengthCondition, typedArrayIteratorProtocolWatchpointSet(typedArrayType));
-    typedArrayPrototypeLengthAbsenceWatchpoint(typedArrayType)->install(vm);
     typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(typedArrayType) = makeUnique<ObjectAdaptiveStructureWatchpoint>(this, iteratorCondition, typedArrayIteratorProtocolWatchpointSet(typedArrayType));
     typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(typedArrayType)->install(vm);
 }
 
-void JSGlobalObject::installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype* prototype, GetterSetter* lengthGetterSetter)
+void JSGlobalObject::installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype* prototype)
 {
     VM& vm = this->vm();
-    {
-        ObjectPropertyCondition condition = setupAdaptiveWatchpoint(this, prototype, vm.propertyNames->iteratorSymbol);
-        m_typedArrayPrototypeSymbolIteratorWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, condition, m_typedArrayPrototypeIteratorProtocolWatchpointSet);
-        m_typedArrayPrototypeSymbolIteratorWatchpoint->install(vm);
-    }
-    {
-        PropertySlot slot(prototype, PropertySlot::InternalMethodType::VMInquiry, &vm);
-        prototype->getOwnPropertySlot(prototype, this, vm.propertyNames->length.impl(), slot);
-        prototype->structure()->startWatchingPropertyForReplacements(vm, slot.cachedOffset());
-        ObjectPropertyCondition speciesCondition = ObjectPropertyCondition::equivalence(vm, nullptr, prototype, vm.propertyNames->length.impl(), lengthGetterSetter);
-        m_typedArrayPrototypeLengthWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, speciesCondition, m_typedArrayPrototypeIteratorProtocolWatchpointSet);
-        m_typedArrayPrototypeLengthWatchpoint->install(vm);
-    }
+    ObjectPropertyCondition condition = setupAdaptiveWatchpoint(this, prototype, vm.propertyNames->iteratorSymbol);
+    m_typedArrayPrototypeSymbolIteratorWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, condition, m_typedArrayPrototypeIteratorProtocolWatchpointSet);
+    m_typedArrayPrototypeSymbolIteratorWatchpoint->install(vm);
 }
 
 void JSGlobalObject::installNumberPrototypeWatchpoint(NumberPrototype* numberPrototype)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -556,10 +556,8 @@ public:
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_arrayBufferPrototypeConstructorWatchpoints[2];
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayConstructorSpeciesWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayPrototypeSymbolIteratorWatchpoint;
-    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArrayPrototypeLengthWatchpoint;
 #define DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT(name) \
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## ConstructorSpeciesAbsenceWatchpoint; \
-    std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## PrototypeLengthAbsenceWatchpoint; \
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_typedArray ## name ## PrototypeSymbolIteratorAbsenceWatchpoint; \
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_typedArray ## name ## PrototypeConstructorWatchpoint;
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
@@ -577,20 +575,6 @@ public:
         }
         RELEASE_ASSERT_NOT_REACHED();
         return m_typedArrayInt8ConstructorSpeciesAbsenceWatchpoint;
-    }
-
-    std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeLengthAbsenceWatchpoint(TypedArrayType type)
-    {
-        switch (type) {
-        case NotTypedArray:
-            RELEASE_ASSERT_NOT_REACHED();
-            return m_typedArrayInt8PrototypeLengthAbsenceWatchpoint;
-#define TYPED_ARRAY_TYPE_CASE(name) case Type ## name: return m_typedArray ## name ## PrototypeLengthAbsenceWatchpoint;
-            FOR_EACH_TYPED_ARRAY_TYPE(TYPED_ARRAY_TYPE_CASE)
-#undef TYPED_ARRAY_TYPE_CASE
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-        return m_typedArrayInt8PrototypeLengthAbsenceWatchpoint;
     }
 
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType type)
@@ -1307,7 +1291,7 @@ public:
     void tryInstallTypedArraySpeciesWatchpoint(TypedArrayType);
     void installTypedArrayIteratorProtocolWatchpoint(JSObject* prototype, TypedArrayType);
     void installTypedArrayConstructorSpeciesWatchpoint(JSTypedArrayViewConstructor*);
-    void installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype*, GetterSetter*);
+    void installTypedArrayPrototypeIteratorProtocolWatchpoint(JSTypedArrayViewPrototype*);
 
 protected:
     enum class HasSpeciesProperty : bool { Yes, No };

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -565,7 +565,7 @@ void JSTypedArrayViewPrototype::finishCreation(VM& vm, JSGlobalObject* globalObj
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().valuesPublicName(), valuesFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, valuesFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    globalObject->installTypedArrayPrototypeIteratorProtocolWatchpoint(this, lengthGetterSetter);
+    globalObject->installTypedArrayPrototypeIteratorProtocolWatchpoint(this);
 }
 
 JSTypedArrayViewPrototype* JSTypedArrayViewPrototype::create(


### PR DESCRIPTION
#### af1cc8c8b4cce68e686412df06a6646b76b96be3
<pre>
[JSC] TypedArray iteration does not need to get &quot;length&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243581">https://bugs.webkit.org/show_bug.cgi?id=243581</a>

Reviewed by Alexey Shvayka.

ArrayIterator#next spec says that if the array is TypedArray, we do not need to look up &quot;length&quot;,
and we can directly get TypedArray&apos;s internal length. This means that &quot;length&quot; property of instance,
Uint8Array.prototype, and TypedArray.prototype are unrelated to iterator protocol. This makes iterator
protocol guarantee simplified.

This patch applies this change: we no longer ensure &quot;length&quot; validity. We also adjust ArrayIterator#next&apos;s
slow path implementation to the spec.

[1]: <a href="https://tc39.es/ecma262/#sec-createarrayiterator">https://tc39.es/ecma262/#sec-createarrayiterator</a>

* JSTests/stress/typed-array-from-custom-length.js:
* Source/JavaScriptCore/builtins/ArrayIteratorPrototype.js:
(linkTimeConstant.arrayIteratorNextHelper):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::installTypedArrayIteratorProtocolWatchpoint):
(JSC::JSGlobalObject::installTypedArrayPrototypeIteratorProtocolWatchpoint):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::typedArrayPrototypeLengthAbsenceWatchpoint): Deleted.
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSTypedArrayViewPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/253153@main">https://commits.webkit.org/253153@main</a>
</pre>
