### PR TITLE
Crash in `-[UIKeyboardTaskQueue performTaskOnMainThread:waitUntilDone:]` when opening a new tab while focusing a text field

### DIFF
--- a/LayoutTests/fast/forms/ios/remove-view-after-focus-expected.txt
+++ b/LayoutTests/fast/forms/ios/remove-view-after-focus-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that unparenting the web view due to creating a new tab on a zero delay timer after focusing a text field doesn't trigger a crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/remove-view-after-focus.html
+++ b/LayoutTests/fast/forms/ios/remove-view-after-focus.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    font-size: 20px;
+}
+</style>
+</head>
+<body>
+    <div><input value="foobar"></input></div>
+</body>
+<script>
+jsTestIsAsync = true;
+input = document.querySelector("input");
+
+async function activateAndWaitForInputSessionWithNewPageHandler(element)
+{
+    const x = element.offsetLeft + element.offsetWidth / 2;
+    const y = element.offsetTop + element.offsetHeight / 2;
+    await new Promise(resolve => {
+        testRunner.runUIScript(`
+            (function() {
+                uiController.willCreateNewPageCallback = () => {
+                    uiController.removeViewFromWindow();
+                    uiController.addViewToWindow();
+                };
+                uiController.didShowKeyboardCallback = () => uiController.uiScriptComplete();
+                uiController.singleTapAtPoint(${x}, ${y}, function() { });
+            })()`, resolve);
+    });
+}
+
+input.addEventListener("focus", () => {
+    input.select();
+    setTimeout(() => {
+        newWindow = open("about:blank");
+        newWindow.close();
+    }, 5);
+});
+
+addEventListener("load", async () => {
+    description("This test verifies that unparenting the web view due to creating a new tab on a zero delay timer after focusing a text field doesn't trigger a crash.");
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await activateAndWaitForInputSessionWithNewPageHandler(input);
+    await UIHelper.resignFirstResponder();
+    testPassed("Did not crash");
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -452,7 +452,6 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _textInteractionDidChangeFocusedElement;
     BOOL _treatAsContentEditableUntilNextEditorStateUpdate;
     BOOL _isWaitingOnPositionInformation;
-    BOOL _isRequestingAutocorrectionContext;
     BOOL _autocorrectionContextNeedsUpdate;
 
     WebCore::PointerID _commitPotentialTapPointerId;


### PR DESCRIPTION
#### 36df83e80e966c2307bd64e93c6591b6bfc6378a
<pre>
Crash in `-[UIKeyboardTaskQueue performTaskOnMainThread:waitUntilDone:]` when opening a new tab while focusing a text field
<a href="https://bugs.webkit.org/show_bug.cgi?id=243590">https://bugs.webkit.org/show_bug.cgi?id=243590</a>
rdar://97846917

Reviewed by Megan Gardner.

After adjusting the mechanism to preemptively compute and send autocorrection context data to the
UI process in 252481@main, there are some scenarios in which the web content process would&apos;ve
previously deadlocked for one second, but now crashes (due to getting the UIKit keyboard task queue
into a bad state). 251885@main mitigated one such instance (wherein the IPC message to show a modal
prompt would be handled in the UI process in the middle of a sync-wait for autocorrection context).
However, crash telemetry reveals another (similar) scenario that isn&apos;t addressed by 251885@main:

Web Process                                         UI Process
-----------                                         ----------
(1) Send `ElementDidFocus`
(2) Send `HandleAutocorrectionContext`              (3) Receive `ElementDidFocus`
                                                    (4) UIKit calls `-requestAutocorrectionContext`,
(5) Send `CreateNewPage` (sync)                         and we begin sync-waiting in that method
                                                    (6) Receive `HandleAutocorrectionContext`, and
                                                        call the completion handler
                                                    (7) Receive `CreateNewPage`; Safari code removes
                                                        the web view from the window, causing us to
                                                        resign first responder. UIKit reloads input
                                                        views as a result, and attempts to add a
                                                        task to the keyboard task queue
                                                    (8) `UIKeyboardTaskQueue` throws an exception

At this point, note that we&apos;re still inside of the scope of the method call to
`-requestAutocorrectionContextWithCompletionHandler:` in the UI process, since this is all happening
underneath the syncwait. The exception occurs because UIKit keyboard code expects the task execution
context to be the same object in the narrow window of time after the completion block passed to
`-requestAutocorrectionContextWithCompletionHandler:` is invoked, but before we&apos;ve returned from
that method call.

To fix this, we refactor the syncwaiting in `-requestAutocorrectionContextWithCompletionHandler:`,
such that we don&apos;t invoke the autocorrection context completion handler until *after* we&apos;re done
with the syncwait (and have finished processing any incoming IPC messages in the process). This
keeps the task queue&apos;s execution context chain in a good state, even in the case where incoming IPC
may trigger additional keyboard tasks.

Test: fast/forms/ios/remove-view-after-focus.html

* LayoutTests/fast/forms/ios/remove-view-after-focus-expected.txt: Added.
* LayoutTests/fast/forms/ios/remove-view-after-focus.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):

Move logic for invoking the pending autocorrection completion handler out of
`-_handleAutocorrectionContext:`, and into `-requestAutocorrectionContextWithCompletionHandler:`
instead. In the case where the syncwait was successful, `_autocorrectionContextNeedsUpdate` will be
`NO`, and we simply call the incoming completion handler with the last autocorrection context we
received.

(-[WKContentView _handleAutocorrectionContext:]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _elementDidBlur]):

This refactoring also allows us to remove the mitigation added in 251885@main, which only deals with
a special case of this issue, where incoming sync IPC focuses or blurs an element.

Canonical link: <a href="https://commits.webkit.org/253161@main">https://commits.webkit.org/253161@main</a>
</pre>
