### PR TITLE
[Xcode] build-jsc and "Everything up to JavaScriptCore" should build TestWTF

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2334,7 +2334,7 @@
       "nicks" : [
          "emw"
       ],
-      "status" : "committer"
+      "status" : "reviewer"
    },
    {
       "aliases" : [


### PR DESCRIPTION
#### 715eff59fde88b82392133721f8dca65f08f5091
<pre>
[Xcode] build-jsc and &quot;Everything up to JavaScriptCore&quot; should build TestWTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=243703">https://bugs.webkit.org/show_bug.cgi?id=243703</a>

Reviewed by NOBODY (OOPS!).

Fix up TestWebKitAPI so that the &quot;TestWTF&quot; binary can be built in
isolation, without including headers from WebKit. Add it to the Xcode
build workflows that build up to JSC.

The result is that `build-jsc` and the &quot;Everything up to JavaScriptCore&quot;
scheme perform a minimal build of JSC and its dependencies, plus
TestWTF, which should be ideal for common JSC engineering workflows.

* Source/ThirdParty/gtest/xcode/Config/StaticLibraryTarget.xcconfig:
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj: Fix up
  the &quot;gtest-static&quot; target to copy all the headers we use to
  /usr/local/include/gtest. Previously we relied on headers in gtest.framework
  as well. Since TestWTF only uses the static library, it&apos;s valid to
  skip building gtest.framework.

* Tools/TestWebKitAPI/Configurations/Base.xcconfig: Defined a
  &quot;BUILDING_&lt;target name&gt;&quot; macro, like CMake does.
* Tools/TestWebKitAPI/Configurations/TestWTF.xcconfig: Remove the
  BUILDING_TEST_WTF macro in lieu of the above.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Replace
  TestWTFLibrary&apos;s dependency on WebKit.framework with a dependency on
  JavaScriptCore.framework

* Tools/TestWebKitAPI/config.h: Instead of separate sets of includes for
  CMake and Xcode, use BUILDING_* macros to determine which target is
  being built, and include a minimal set of headers for that target.
  This enables Xcode&apos;s TestWTF / TestWTFLibrary targets to avoid
  unnecessary WebCore and WebKit header dependencies.

* Tools/TestWebKitAPI/ios/mainIOS.mm:
(main): Avoid WebKit header dependency when compiling TestWTF.
* Tools/TestWebKitAPI/mac/mainMac.mm:
(main): Avoid WebKit header dependency when compiling TestWTF.
</pre>
----------------------------------------------------------------------
#### 69f0a14beb1489bd553dd0a229cf0a2af653f7be
<pre>
Make Elliott Williams a reviewer

Unreviewed, pending announcement on webkit-dev.

* metadata/contributors.json:
</pre>