### PR TITLE
REGRESSION(253140@main): [ iOS MacOS Debug wk2 ] 5X Web-platform/service-workers (layout-tests) are constant crashes

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -607,8 +607,6 @@ void SWServer::refreshImportedScripts(const ServiceWorkerJobData& jobData, SWSer
             weakThis->refreshImportedScriptsFinished(jobDataIdentifier, registrationKey, scripts);
     };
     bool shouldRefreshCache = registration.updateViaCache() == ServiceWorkerUpdateViaCache::None || (registration.getNewestWorker() && registration.isStale());
-
-    ASSERT(jobData.connectionIdentifier() == Process::identifier());
     auto handler = RefreshImportedScriptsHandler::create(urls.size(), WTFMove(callback));
     for (auto& url : urls) {
         m_softUpdateCallback(ServiceWorkerJobData { jobData }, shouldRefreshCache, createScriptRequest(url, jobData, registration), [handler, url, size = urls.size()](auto&& result) {


### PR DESCRIPTION
#### dd3e427549812b4c40a35760ea06d9cbc76ba8a0
<pre>
REGRESSION(253140@main): [ iOS MacOS Debug wk2 ] 5X Web-platform/service-workers (layout-tests) are constant crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243589">https://bugs.webkit.org/show_bug.cgi?id=243589</a>
&lt;rdar://98195929&gt;

Unreviewed, drop outdated assertion after 253140@main since all the sw-imported
script refreshes now happen from the network process directly.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::refreshImportedScripts):

Canonical link: <a href="https://commits.webkit.org/253149@main">https://commits.webkit.org/253149@main</a>
</pre>
