### PR TITLE
[ews] Update the icon and text style for cancelled builds in EWS GitHub comments

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -208,7 +208,10 @@ class GitHubEWS(GitHub):
             status = GitHubEWS.ICON_BUILD_PASS
         elif build.result == Buildbot.FAILURE:
             status = GitHubEWS.ICON_BUILD_FAIL
-        # FIXME: Handle other cases like SKIPPED, CANCELLED, EXCEPTION, RETRY etc.
+        elif build.result == Buildbot.CANCELLED:
+            status = GitHubEWS.ICON_BUILD_PASS
+            name = u'~~{}~~'.format(name)
+        # FIXME: Handle other cases like SKIPPED, EXCEPTION, RETRY etc.
         else:
             status = GitHubEWS.ICON_BUILD_ERROR
 


### PR DESCRIPTION
#### ad20c78ad514d672085f4f43ca12002de068a028
<pre>
[ews] Update the icon and text style for cancelled builds in EWS GitHub comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=243592">https://bugs.webkit.org/show_bug.cgi?id=243592</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.github_status_for_queue):

Canonical link: <a href="https://commits.webkit.org/253151@main">https://commits.webkit.org/253151@main</a>
</pre>
