### PR TITLE
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::RangeResponseGenerator::removeTask

### DIFF
--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -96,7 +96,11 @@ static ResourceResponse synthesizedResponseForRange(const ResourceResponse& orig
 void RangeResponseGenerator::removeTask(WebCoreNSURLSessionDataTask *task)
 {
     ASSERT(isMainThread());
-    auto* data = m_map.get(task.originalRequest.URL.absoluteString);
+    auto url = task.originalRequest.URL;
+    // HashMap::get() crashes if a null String is passed.
+    if (!url)
+        return;
+    auto* data = m_map.get(url.absoluteString);
     if (!data)
         return;
     data->taskData.remove(task);
@@ -190,6 +194,8 @@ void RangeResponseGenerator::giveResponseToTasksWithFinishedRanges(Data& data)
 bool RangeResponseGenerator::willHandleRequest(WebCoreNSURLSessionDataTask *task, NSURLRequest *request)
 {
     ASSERT(isMainThread());
+    if (!request.URL)
+        return false;
     auto* data = m_map.get(request.URL.absoluteString);
     if (!data)
         return false;


### PR DESCRIPTION
#### fd72cc6f23e9c0bf6834183336d0e19b23127e3d
<pre>
CrashTracer: com.apple.WebKit.GPU at com.apple.WebCore: WebCore::RangeResponseGenerator::removeTask
<a href="https://bugs.webkit.org/show_bug.cgi?id=243593">https://bugs.webkit.org/show_bug.cgi?id=243593</a>
&lt;rdar://77013610&gt;

Reviewed by Chris Dumez.

Our HashMap implementation treats null Strings as a special value and
when such a string is passed onto `HashMap::get()` we end up dereferencing
a nullptr within the String implementation.

The fix is to null check the string we pass into `HashMap::get()`.

* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::removeTask):
(WebCore::RangeResponseGenerator::willHandleRequest):

Canonical link: <a href="https://commits.webkit.org/253164@main">https://commits.webkit.org/253164@main</a>
</pre>
