### PR TITLE
Unreviewed, not using `asObject` for WeakMap / WeakSet keys

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3460,7 +3460,7 @@ JSC_DEFINE_JIT_OPERATION(operationWeakSetAdd, void, (JSGlobalObject* globalObjec
         return;
     }
 
-    jsCast<JSWeakSet*>(set)->add(vm, asObject(key), JSValue(), hash);
+    jsCast<JSWeakSet*>(set)->add(vm, key, JSValue(), hash);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationWeakMapSet, void, (JSGlobalObject* globalObject, JSCell* map, JSCell* key, EncodedJSValue value, int32_t hash))
@@ -3475,7 +3475,7 @@ JSC_DEFINE_JIT_OPERATION(operationWeakMapSet, void, (JSGlobalObject* globalObjec
         return;
     }
 
-    jsCast<JSWeakMap*>(map)->add(vm, asObject(key), JSValue::decode(value), hash);
+    jsCast<JSWeakMap*>(map)->add(vm, key, JSValue::decode(value), hash);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetPrototypeOfObject, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* thisObject))


### PR DESCRIPTION
#### 6502f573d10cedd87a9c6e246d617e94ba1bb749
<pre>
Unreviewed, not using `asObject` for WeakMap / WeakSet keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=243598">https://bugs.webkit.org/show_bug.cgi?id=243598</a>

WeakSet and WeakMap accept cells now. So, we should drop `asObject`, it is not necessary.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/253158@main">https://commits.webkit.org/253158@main</a>
</pre>
