### PR TITLE
iOS 15: History back sometimes scrolls to top of the page

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -54,6 +54,7 @@
 #import "WKWebViewPrivateForTestingIOS.h"
 #import "WebBackForwardList.h"
 #import "WebIOSEventFactory.h"
+#import "WebPage.h"
 #import "WebPageProxy.h"
 #import "_WKActivatedElementInfoInternal.h"
 #import <WebCore/ColorCocoa.h>
@@ -951,7 +952,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     bool scrollingEnabled = _page->scrollingCoordinatorProxy()->hasScrollableOrZoomedMainFrame() || hasDockedInputView || isZoomed || scrollingNeededToRevealUI;
     [_scrollView _setScrollEnabledInternal:scrollingEnabled];
 
-    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && !WTF::areEssentiallyEqual<float>([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
+    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && !WebKit::scalesAreEssentiallyEqual([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
         LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << layerTreeTransaction.pageScaleFactor());
         [_scrollView setZoomScale:layerTreeTransaction.pageScaleFactor()];
     }
@@ -970,7 +971,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         WebCore::FloatPoint scaledScrollOffset = _scrollOffsetToRestore.value();
         _scrollOffsetToRestore = std::nullopt;
 
-        if (WTF::areEssentiallyEqual<float>(contentZoomScale(self), _scaleToRestore)) {
+        if (WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _scaleToRestore)) {
             scaledScrollOffset.scale(_scaleToRestore);
             WebCore::FloatPoint contentOffsetInScrollViewCoordinates = scaledScrollOffset - WebCore::FloatSize(_obscuredInsetsWhenSaved.left(), _obscuredInsetsWhenSaved.top());
 
@@ -985,7 +986,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         WebCore::FloatPoint unobscuredCenterToRestore = _unobscuredCenterToRestore.value();
         _unobscuredCenterToRestore = std::nullopt;
 
-        if (WTF::areEssentiallyEqual<float>(contentZoomScale(self), _scaleToRestore)) {
+        if (WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _scaleToRestore)) {
             CGRect unobscuredRect = UIEdgeInsetsInsetRect(self.bounds, _obscuredInsets);
             WebCore::FloatSize unobscuredContentSizeAtNewScale = WebCore::FloatSize(unobscuredRect.size) / _scaleToRestore;
             WebCore::FloatPoint topLeftInDocumentCoordinates = unobscuredCenterToRestore - unobscuredContentSizeAtNewScale / 2;
@@ -1745,7 +1746,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     // At this point, we have a page that asked for width = device-width. However,
     // if the content's width and height were large, we might have had to shrink it.
     // We'll enable double tap zoom whenever we're not at the actual initial scale.
-    return !WTF::areEssentiallyEqual<float>(contentZoomScale(self), _initialScaleFactor);
+    return !WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _initialScaleFactor);
 }
 
 #pragma mark UIScrollViewDelegate

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2519,4 +2519,8 @@ inline void WebPage::prepareToRunModalJavaScriptDialog() { }
 inline bool WebPage::shouldAvoidComputingPostLayoutDataForEditorState() const { return false; }
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+bool scalesAreEssentiallyEqual(float, float);
+#endif
+
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit/simple-tall.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/simple-tall.html
@@ -1,6 +1,8 @@
-<meta name='viewport' content='width=device-width, initial-scale=1'>
 <!DOCTYPE html>
 <html>
+<head>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+</head>
 <body>
   Simple and tall HTML file.
   <div style="height: 3000px;"></div>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
@@ -85,6 +85,33 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionDuringResize)
     EXPECT_EQ(1000, contentOffsetAfterBack.y);
 }
 
+TEST(RestoreScrollPositionTests, RestoreScrollPositionAfterBack)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 664)]);
+
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView _setViewScale:1.15]; // Simulate MobileSafari setting view scale on every didCommitNavigation.
+    [webView waitForNextPresentationUpdate];
+
+    [[webView scrollView] setContentOffset:CGPointMake(0, 1000)];
+    [webView waitForNextPresentationUpdate];
+
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView _setViewScale:1.15];
+    [webView waitForNextPresentationUpdate];
+
+    CGPoint contentOffsetInNewPage = [webView scrollView].contentOffset;
+    EXPECT_EQ(0, contentOffsetInNewPage.x);
+    EXPECT_EQ(0, contentOffsetInNewPage.y);
+
+    [webView synchronouslyGoBack];
+    [webView _setViewScale:1.15];
+    [webView waitForNextPresentationUpdate];
+
+    CGPoint contentOffsetAfterBack = [webView scrollView].contentOffset;
+    EXPECT_EQ(0, contentOffsetAfterBack.x);
+    EXPECT_TRUE(WTF::areEssentiallyEqual<float>(contentOffsetAfterBack.y, 1000.0f, 1.0f)); // It can be 999.5 but that's OK.
+}
 #endif
 
 }


### PR DESCRIPTION
#### 95d1502e5e90cecf932d5847e973b5e163999a3b
<pre>
iOS 15: History back sometimes scrolls to top of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=231563">https://bugs.webkit.org/show_bug.cgi?id=231563</a>
&lt;rdar://problem/84405417&gt;

Reviewed by Devin Rousso.

Sometimes, going back in history would fail to restore the scroll position because
in -[WKWebView _restoreScrollAndZoomStateForTransaction:] the comparison of contentZoomScale() and _scaleToRestore
would fail. In the case I debugged, _scaleToRestore was 1.15 and contentZoomScale() was 1.15044, the latter deviating
via the round-trip through UIScrollView&apos;s zoomScale.

So make all the scale comparisons in both WKWebView and WebPageIOS a little more lenient, allowing a delta of 0.01.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _restoreScrollAndZoomStateForTransaction:]):
(-[WKWebView _allowsDoubleTapGestures]):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::scalesAreEssentiallyEqual):
(WebKit::WebPage::restorePageState):
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::scaleFromUIProcess const):
(WebKit::WebPage::updateVisibleContentRects):
(WebKit::areEssentiallyEqualAsFloat): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/simple-tall.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/253221@main">https://commits.webkit.org/253221@main</a>
</pre>
