### PR TITLE
Fix a parenting issue in the Adoption Agency Algorithm

### DIFF
--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -137,7 +137,7 @@ static inline void executeReparentTask(HTMLConstructionSiteTask& task)
     if (RefPtr parent = task.child->parentNode())
         parent->parserRemoveChild(*task.child);
 
-    if (task.child->parentNode())
+    if (task.child->parentNode() || task.child->contains(task.parent.get()))
         return;
 
     task.parent->parserAppendChild(*task.child);
@@ -150,7 +150,7 @@ static inline void executeInsertAlreadyParsedChildTask(HTMLConstructionSiteTask&
     if (RefPtr<ContainerNode> parent = task.child->parentNode())
         parent->parserRemoveChild(*task.child);
 
-    if (task.child->parentNode())
+    if (task.child->parentNode() || task.child->contains(task.parent.get()))
         return;
 
     if (task.nextChild && task.nextChild->parentNode() != task.parent)


### PR DESCRIPTION
#### 2e20c7f29e412b001cac0a9b39168324b123cf6d
<pre>
Fix a parenting issue in the Adoption Agency Algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=243599">https://bugs.webkit.org/show_bug.cgi?id=243599</a>

Reviewed by Chris Dumez.

Exit early when the child-to-be contains the new parent.

* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::executeReparentTask):
(WebCore::executeInsertAlreadyParsedChildTask):

Canonical link: <a href="https://commits.webkit.org/253155@main">https://commits.webkit.org/253155@main</a>
</pre>
