### PR TITLE
Cache CFString lengths in TextBreakIteratorCF

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -35,8 +35,9 @@ public:
     };
 
     TextBreakIteratorCF(StringView string, Mode mode)
-        : m_string(string.createCFStringWithoutCopying())
     {
+        setText(string);
+
         switch (mode) {
         case Mode::ComposedCharacter:
             m_type = kCFStringComposedCharacterCluster;
@@ -56,22 +57,22 @@ public:
     void setText(StringView string)
     {
         m_string = string.createCFStringWithoutCopying();
+        m_stringLength = static_cast<unsigned long>(CFStringGetLength(m_string.get()));
     }
 
     std::optional<unsigned> preceding(unsigned location) const
     {
         if (!location)
             return { };
-        auto length = static_cast<unsigned long>(CFStringGetLength(m_string.get()));
-        if (location > length)
-            return length;
+        if (location > m_stringLength)
+            return m_stringLength;
         auto range = CFStringGetRangeOfCharacterClusterAtIndex(m_string.get(), location - 1, m_type);
         return range.location;
     }
 
     std::optional<unsigned> following(unsigned location) const
     {
-        if (location >= static_cast<unsigned long>(CFStringGetLength(m_string.get())))
+        if (location >= m_stringLength)
             return { };
         auto range = CFStringGetRangeOfCharacterClusterAtIndex(m_string.get(), location, m_type);
         return range.location + range.length;
@@ -79,7 +80,7 @@ public:
 
     bool isBoundary(unsigned location) const
     {
-        if (location == static_cast<unsigned long>(CFStringGetLength(m_string.get())))
+        if (location == m_stringLength)
             return true;
         auto range = CFStringGetRangeOfCharacterClusterAtIndex(m_string.get(), location, m_type);
         return static_cast<unsigned long>(range.location) == location;
@@ -88,6 +89,7 @@ public:
 private:
     RetainPtr<CFStringRef> m_string;
     CFStringCharacterClusterType m_type;
+    unsigned long m_stringLength { 0 };
 };
 
 }


### PR DESCRIPTION
#### b6c245783c36fef878f48154e1a91a81886a6482
<pre>
Cache CFString lengths in TextBreakIteratorCF
<a href="https://bugs.webkit.org/show_bug.cgi?id=243603">https://bugs.webkit.org/show_bug.cgi?id=243603</a>

Reviewed by Yusuke Suzuki.

Caching the result should be faster than repeatedly calling CFStringGetLength().

* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
(WTF::TextBreakIteratorCF::setText):
(WTF::TextBreakIteratorCF::preceding const):
(WTF::TextBreakIteratorCF::following const):
(WTF::TextBreakIteratorCF::isBoundary const):

Canonical link: <a href="https://commits.webkit.org/253172@main">https://commits.webkit.org/253172@main</a>
</pre>
