### PR TITLE
Use the same simulated iPhone model for layout tests an API tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -30,6 +30,7 @@ from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.results.upload import Upload
 from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManager
+from webkitpy.xcode.device_type import DeviceType
 
 _log = logging.getLogger(__name__)
 
@@ -150,7 +151,11 @@ class Manager(object):
                 self._stream.writeln('')
 
     def _initialize_devices(self):
-        if 'simulator' in self._port.port_name:
+        if any(port in self._port.port_name for port in ['iphone-simulator', 'ios-simulator']):
+            SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType(hardware_family='iPhone', hardware_type='12'), allow_incomplete_match=False), self.host, simulator_ui=True)
+        elif 'ipad-simulator' in self._port.port_name:
+            SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType(hardware_family='iPad', hardware_type='(5th generation)'), allow_incomplete_match=False), self.host, simulator_ui=True)
+        elif 'simulator' in self._port.port_name:
             SimulatedDeviceManager.initialize_devices(DeviceRequest(self._port.DEVICE_TYPE, allow_incomplete_match=True), self.host, simulator_ui=False)
         elif 'device' in self._port.port_name:
             raise RuntimeError('Running api tests on {} is not supported'.format(self._port.port_name))


### PR DESCRIPTION
#### 123c6f6b61555beda2a7c90cbec50ca77e8b8ede
<pre>
Use the same simulated iPhone model for layout tests an API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=239885">https://bugs.webkit.org/show_bug.cgi?id=239885</a>
&lt;rdar://92505373&gt;

Reviewed by NOBODY (OOPS!).

Something is different about the way layout test and API test managers
request iOS simulators, which causes API tests to use the first available
model as opposed to the default device types specified for the iOS
Simulator port.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager._initialize_devices): As what might be a temporary workaround until
someone with more webkitpy knowledge can take a look, explicitly request
the device types that match our defaults for iPhone and iPad simulators.
</pre>