### PR TITLE
Rename TextBreakIteratorCF::Mode values to be more honest about what they are

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -30,18 +30,18 @@ class TextBreakIteratorCF {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Mode {
-        Caret,
-        Delete
+        ComposedCharacter,
+        BackwardDeletion
     };
 
     TextBreakIteratorCF(StringView string, Mode mode)
         : m_string(string.createCFStringWithoutCopying())
     {
         switch (mode) {
-        case Mode::Caret:
+        case Mode::ComposedCharacter:
             m_type = kCFStringComposedCharacterCluster;
             break;
-        case Mode::Delete:
+        case Mode::BackwardDeletion:
             m_type = kCFStringBackwardDeletionCluster;
             break;
         }

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -37,9 +37,9 @@ static std::variant<TextBreakIteratorICU, TextBreakIteratorPlatform> mapModeToBa
     case TextBreakIterator::Mode::Line:
         return TextBreakIteratorICU(string, TextBreakIteratorICU::Mode::Line, locale.string().utf8().data());
     case TextBreakIterator::Mode::Caret:
-        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::Caret);
+        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::ComposedCharacter);
     case TextBreakIterator::Mode::Delete:
-        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::Delete);
+        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::BackwardDeletion);
     }
 }
 


### PR DESCRIPTION
#### 3923ca64434f099e823a6e00b13a53700271e86b
<pre>
Rename TextBreakIteratorCF::Mode values to be more honest about what they are
<a href="https://bugs.webkit.org/show_bug.cgi?id=243604">https://bugs.webkit.org/show_bug.cgi?id=243604</a>

Reviewed by Yusuke Suzuki.

TextBreakIteratorCF::Mode::Caret maps to kCFStringComposedCharacterCluster, and
TextBreakIteratorCF::Mode::Delete maps to kCFStringBackwardDeletionCluster. For this
CF-specific enum, the names should be more faithful about what they are, rather than
how WebKit uses them.

The map of &quot;WebKit&apos;s use case&quot; to &quot;which CF iterator to use&quot; is described in
mapModeToBackingIterator(). This is the right place for it; it shouldn&apos;t be sunk lower
into TextBreakIteratorCF like how it was.

* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
(WTF::TextBreakIteratorCF::TextBreakIteratorCF):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::mapModeToBackingIterator):

Canonical link: <a href="https://commits.webkit.org/253163@main">https://commits.webkit.org/253163@main</a>
</pre>
