### PR TITLE
[ews] Update the icon and text style for skipped builds in EWS GitHub comments

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -22,6 +22,7 @@
 
 import json
 import logging
+import re
 import requests
 from requests.auth import HTTPBasicAuth
 
@@ -211,7 +212,12 @@ class GitHubEWS(GitHub):
         elif build.result == Buildbot.CANCELLED:
             status = GitHubEWS.ICON_BUILD_PASS
             name = u'~~{}~~'.format(name)
-        # FIXME: Handle other cases like SKIPPED, EXCEPTION, RETRY etc.
+        elif build.result == Buildbot.SKIPPED:
+            status = GitHubEWS.ICON_BUILD_PASS
+            if re.search(r'Pull request .* doesn\'t have relevant changes', build.state_string):
+                return u'| '
+            name = u'~~{}~~'.format(name)
+        # FIXME: Handle other cases like EXCEPTION, RETRY etc.
         else:
             status = GitHubEWS.ICON_BUILD_ERROR
 


### PR DESCRIPTION
#### 16f634e7bcf5d8d5c08d396876d4226761c3c088
<pre>
[ews] Update the icon and text style for skipped builds in EWS GitHub comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=243605">https://bugs.webkit.org/show_bug.cgi?id=243605</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.github_status_for_queue):

Canonical link: <a href="https://commits.webkit.org/253160@main">https://commits.webkit.org/253160@main</a>
</pre>
