### PR TITLE
Link to the test duration treemap from results.html

### DIFF
--- a/LayoutTests/fast/harness/results-expected.txt
+++ b/LayoutTests/fast/harness/results-expected.txt
@@ -43,5 +43,8 @@ canvas/philip/tests/2d.gradient.interpolate.solid.html	fail	history
 editing/spelling/spelling-marker-includes-hyphen.html	image	history
 editing/spelling/spelling-markers-in-overlapping-lines.html	image	history
 webarchive/loading/test-loading-archive-subresource-null-mimetype.html	crash	history
-httpd access log: access_log.txt
-httpd error log: error_log.txt
+Additional test data
+
+httpd access log
+httpd error log
+Test durations

--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -647,17 +647,8 @@ class TestResultsController
         if (this.testResults.usesExpectationsFile() && this.testResults.unexpectedPassTests.length)
             this.containerElement.appendChild(this.buildOneSection(this.testResults.unexpectedPassTests, 'passes-table'));
 
-        if (this.testResults.hasHttpTests) {
-            let httpdAccessLogLink = document.createElement('p');
-            httpdAccessLogLink.innerHTML = 'httpd access log: <a href="access_log.txt">access_log.txt</a>';
+        this.containerElement.appendChild(this.buildMiscLinksSection());
 
-            let httpdErrorLogLink = document.createElement('p');
-            httpdErrorLogLink.innerHTML = 'httpd error log: <a href="error_log.txt">error_log.txt</a>';
-            
-            this.containerElement.appendChild(httpdAccessLogLink);
-            this.containerElement.appendChild(httpdErrorLogLink);
-        }
-        
         this.updateTestlistCounts();
     }
 
@@ -719,6 +710,31 @@ class TestResultsController
         let sectionBuilderClass = TestResultsController.sectionBuilderClassForTableID(tableID);
         let sectionBuilder = new sectionBuilderClass(tests, tableID, this);
         return sectionBuilder.build();
+    }
+
+    buildMiscLinksSection()
+    {
+        let section = document.createElement('section');
+        let header = document.createElement('h1');
+        header.textContent = 'Additional test data';
+        section.appendChild(header);
+
+        if (this.testResults.hasHttpTests) {
+            let httpdAccessLogLink = document.createElement('p');
+            httpdAccessLogLink.innerHTML = '<a href="access_log.txt">httpd access log</a>';
+
+            let httpdErrorLogLink = document.createElement('p');
+            httpdErrorLogLink.innerHTML = '<a href="error_log.txt">httpd error log</a>';
+            
+            section.appendChild(httpdAccessLogLink);
+            section.appendChild(httpdErrorLogLink);
+        }
+
+        let perfTreeMapLink = document.createElement('p');
+        perfTreeMapLink.innerHTML = '<a href="test-duration-treemap.html">Test durations</a>';
+        section.appendChild(perfTreeMapLink);
+
+        return section;
     }
 
     updateTestlistCounts()

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -542,7 +542,11 @@ class Manager(object):
             self._save_json_files(summarized_results, initial_results)
 
             results_path = self._filesystem.join(self._results_directory, "results.html")
-            self._copy_results_html_file(results_path)
+            self._copy_results_html_file("results.html", results_path)
+
+            treemap_path = self._filesystem.join(self._results_directory, "test-duration-treemap.html")
+            self._copy_results_html_file("test-duration-treemap.html", treemap_path)
+
             if initial_results.keyboard_interrupted:
                 exit_code = INTERRUPTED_EXIT_STATUS
             else:
@@ -713,9 +717,9 @@ class Manager(object):
         self._filesystem.remove(times_json_path)
         self._filesystem.remove(incremental_results_path)
 
-    def _copy_results_html_file(self, destination_path):
+    def _copy_results_html_file(self, filename, destination_path):
         base_dir = self._port.path_from_webkit_base('LayoutTests', 'fast', 'harness')
-        results_file = self._filesystem.join(base_dir, 'results.html')
+        results_file = self._filesystem.join(base_dir, filename)
         # Note that the results.html template file won't exist when we're using a MockFileSystem during unit tests,
         # so make sure it exists before we try to copy it.
         if self._filesystem.exists(results_file):


### PR DESCRIPTION
#### 8a822bfdb17be0c02ac093a0dbe3ef2adb8d994c
<pre>
Link to the test duration treemap from results.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=243607">https://bugs.webkit.org/show_bug.cgi?id=243607</a>

Reviewed by Ryan Haddad.

We have a nice visualization of test durations in test-duration-treemap.html.
To encourage developers to fix slow tests, make it easy to access for all runs
by copying test-duration-treemap.html into the results directory, and linking
to it from results.html.

* LayoutTests/fast/harness/results-expected.txt:
* LayoutTests/fast/harness/results.html:
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._end_test_run):
(Manager._copy_results_html_file):

Canonical link: <a href="https://commits.webkit.org/253166@main">https://commits.webkit.org/253166@main</a>
</pre>
