### PR TITLE
Adopt Upgrade-Insecure-Request in SharedWorker handling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-classic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-classic.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-classic to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-module.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-module.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-module to same-https origin and downgrade redirection from https context.
 

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -74,14 +74,16 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, String&&
     if (!url.isValid())
         return Exception { SyntaxError, "Invalid script URL"_s };
 
+    auto* contentSecurityPolicy = document.contentSecurityPolicy();
+    if (contentSecurityPolicy)
+        contentSecurityPolicy->upgradeInsecureRequestIfNeeded(url, ContentSecurityPolicy::InsecureRequestType::Load);
+
     // Per the specification, any same-origin URL (including blob: URLs) can be used. data: URLs can also be used, but they create a worker with an opaque origin.
     if (!document.securityOrigin().canRequest(url) && !url.protocolIsData())
         return Exception { SecurityError, "URL of the shared worker is cross-origin"_s };
 
-    if (auto* contentSecurityPolicy = document.contentSecurityPolicy()) {
-        if (!contentSecurityPolicy->allowWorkerFromSource(url))
-            return Exception { SecurityError };
-    }
+    if (contentSecurityPolicy && !contentSecurityPolicy->allowWorkerFromSource(url))
+        return Exception { SecurityError };
 
     WorkerOptions options;
     if (maybeOptions) {


### PR DESCRIPTION
#### 885184bd06a46aaa9fc6ad7d699f7bc357321650
<pre>
Adopt Upgrade-Insecure-Request in SharedWorker handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=243615">https://bugs.webkit.org/show_bug.cgi?id=243615</a>
&lt;rdar://problem/98216606&gt;

Reviewed by Chris Dumez.

The implementation of SharedWorker did not honor Upgrade-Insecure-Request, causing about 8 test cases (16 sub-tests) to fail.

* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-module.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-classic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-module.https-expected.txt:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):

Canonical link: <a href="https://commits.webkit.org/253167@main">https://commits.webkit.org/253167@main</a>
</pre>
