### PR TITLE
Scroll and flash text indicator for fragment when loading scroll to text fragment URL

### DIFF
--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-emoji.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-emoji.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-sentence.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start-sentence.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start.html
+++ b/LayoutTests/http/wpt/html/dom/scroll-to-text-fragment/scroll-to-text-fragment-start.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -1877,6 +1877,17 @@ ScrollAnimatorEnabled:
       default: false
     WebCore:
       default: false
+      
+ScrollToTextFragmentIndicatorEnabled:
+  type: bool
+  defaultValue:
+    WebKit:
+      default: true
+    WebKitLegacy:
+      default: true
+    WebCore:
+      default: true
+
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SelectTrailingWhitespaceEnabled:

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1085,7 +1085,7 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
     }
     
     if (auto* view = document().view())
-        view->cancelScheduledScrollToFocusedElement();
+        view->cancelScheduledScrolls();
 
     document().updateLayoutIgnorePendingStylesheets();
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1745,7 +1745,7 @@ void DOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping clamping
         return;
     }
 
-    view->cancelScheduledScrollToFocusedElement();
+    view->cancelScheduledScrolls();
     document()->updateLayoutIgnorePendingStylesheets();
 
     IntPoint layoutPos(view->mapFromCSSToLayoutUnits(scrollToOptions.left.value()), view->mapFromCSSToLayoutUnits(scrollToOptions.top.value()));

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -38,6 +38,7 @@
 #include "RenderLayerModelObject.h"
 #include "RenderPtr.h"
 #include "ScrollView.h"
+#include "SimpleRange.h"
 #include "StyleColor.h"
 #include "TiledBacking.h"
 #include <memory>
@@ -266,7 +267,7 @@ public:
     WEBCORE_EXPORT void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions& = ScrollPositionChangeOptions::createProgrammatic()) final;
     void restoreScrollbar();
     void scheduleScrollToFocusedElement(SelectionRevealMode);
-    void cancelScheduledScrollToFocusedElement();
+    void cancelScheduledScrolls();
     void scrollToFocusedElementImmediatelyIfNeeded();
     void updateLayerPositionsAfterScrolling() final;
     void updateCompositingLayersAfterScrolling() final;
@@ -746,6 +747,9 @@ private:
     bool useSlowRepaintsIfNotOverlapped() const;
     void updateCanBlitOnScrollRecursively();
     bool shouldLayoutAfterContentsResized() const;
+    
+    void cancelScheduledScrollToFocusedElement();
+    void cancelScheduledTextFragmentIndicatorTimer();
 
     ScrollingCoordinator* scrollingCoordinator() const;
     bool shouldUpdateCompositingLayersAfterScrolling() const;
@@ -785,6 +789,8 @@ private:
     void delegatesScrollingDidChange() final;
 
     void unobscuredContentSizeChanged() final;
+    
+    void textFragmentIndicatorTimerFired();
 
     // ScrollableArea interface
     void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
@@ -907,6 +913,8 @@ private:
 
     RefPtr<ContainerNode> m_maintainScrollPositionAnchor;
     RefPtr<Node> m_nodeToDraw;
+    std::optional<SimpleRange> m_pendingTextFragmentIndicatorRange;
+    String m_pendingTextFragmentIndicatorText;
 
     // Renderer to hold our custom scroll corner.
     RenderPtr<RenderScrollbarPart> m_scrollCorner;
@@ -916,6 +924,7 @@ private:
     Timer m_delayedScrollEventTimer;
     Timer m_delayedScrollToFocusedElementTimer;
     Timer m_speculativeTilingEnableTimer;
+    Timer m_delayedTextFragmentIndicatorTimer;
 
     MonotonicTime m_lastPaintTime;
 


### PR DESCRIPTION
#### c6891f9bece8cee95626f79d9199dad21ca65de9
<pre>
Scroll and flash text indicator for fragment when loading scroll to text fragment URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=243618">https://bugs.webkit.org/show_bug.cgi?id=243618</a>
rdar://83902653 (Separate scroll and flash for noting highlights on load)

Reviewed by Tim Horton.

Add code to properly scroll to the fragment that we have found as well as add
a delay for flashing the text indicator when we arrive at that location.
Previously, especially on Mac, if we created the text indicator immediately, it
would not show up unless we were on the first &apos;page&apos; of the website, and a scroll
did not need to happen. Otherwise, it was create at the offset of the range before
the scroll, resulting in an flash in a different location to the range. Even if it
was in the correct spot, it was very early, not leading to a very polished visual for
the user. Add a small delay, and the visual improves significantly.
Disable the indicator for ref-tests, as it can cause issues with testing.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::FrameView):
(WebCore::FrameView::reset):
(WebCore::FrameView::scrollToFragment):
(WebCore::FrameView::maintainScrollPositionAtAnchor):
(WebCore::FrameView::setScrollPosition):
(WebCore::FrameView::textFragmentIndicatorTimerFired):
(WebCore::FrameView::cancelScheduledTextFragmentIndicatorTimer):
(WebCore::FrameView::scrollToAnchor):
(WebCore::FrameView::setWasScrolledByUser):
* Source/WebCore/page/FrameView.h:

Canonical link: <a href="https://commits.webkit.org/253327@main">https://commits.webkit.org/253327@main</a>
</pre>
