### PR TITLE
Defining a custom element should not cause global object's structure transitions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS constructor
+PASS connectedCallback
+PASS attributeChangedCallback
+PASS disconnectedCallback
+PASS adoptedCallback
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CustomElementInterface holds constructors and callbacks strongly, preventing them from being GCed if there are no other references</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-lifecycle-callbacks">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/garbage-collect.js"></script>
+
+<body>
+<div id="customElementsRoot"></div>
+<iframe id="emptyIframe" srcdoc></iframe>
+<script>
+"use strict";
+
+const tagNames = [...new Array(100)].map((_, i) => `x-foo${i}`);
+const delay = (t, ms) => new Promise(resolve => { t.step_timeout(resolve, ms); });
+
+const connectedCallbackCalls = new Set;
+const disconnectedCallbackCalls = new Set;
+const attributeChangedCallbackCalls = new Set;
+const adoptedCallbackCalls = new Set;
+
+for (const tagName of tagNames) {
+    const constructor = class extends HTMLElement {
+        connectedCallback() { connectedCallbackCalls.add(tagName); }
+        disconnectedCallback() { disconnectedCallbackCalls.add(tagName); }
+        attributeChangedCallback() { attributeChangedCallbackCalls.add(tagName); }
+        adoptedCallback() { adoptedCallbackCalls.add(tagName); }
+    };
+
+    constructor.observedAttributes = ["foo"];
+
+    customElements.define(tagName, constructor);
+
+    delete constructor.prototype.connectedCallback;
+    delete constructor.prototype.disconnectedCallback;
+    delete constructor.prototype.attributeChangedCallback;
+    delete constructor.prototype.adoptedCallback;
+}
+
+promise_test(async t => {
+    await maybeGarbageCollectAsync();
+
+    assert_true(tagNames.every(tagName => typeof customElements.get(tagName) === "function"));
+}, "constructor");
+
+promise_test(async t => {
+    await maybeGarbageCollectAsync();
+    for (const tagName of tagNames) {
+        customElementsRoot.append(document.createElement(tagName));
+    }
+
+    await delay(t, 10);
+    assert_equals(connectedCallbackCalls.size, tagNames.length);
+}, "connectedCallback");
+
+promise_test(async t => {
+    await maybeGarbageCollectAsync();
+    for (const xFoo of customElementsRoot.children) {
+        xFoo.setAttribute("foo", "bar");
+    }
+
+    await delay(t, 10);
+    assert_equals(attributeChangedCallbackCalls.size, tagNames.length);
+}, "attributeChangedCallback");
+
+promise_test(async t => {
+    await maybeGarbageCollectAsync();
+    customElementsRoot.innerHTML = "";
+
+    await delay(t, 10);
+    assert_equals(disconnectedCallbackCalls.size, tagNames.length);
+}, "disconnectedCallback");
+
+promise_test(async t => {
+    await maybeGarbageCollectAsync();
+    for (const tagName of tagNames) {
+        emptyIframe.contentDocument.adoptNode(document.createElement(tagName));
+    }
+
+    await delay(t, 10);
+    assert_equals(adoptedCallbackCalls.size, tagNames.length);
+}, "adoptedCallback");
+</script>

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -361,4 +361,21 @@ void JSCustomElementInterface::didUpgradeLastElementInConstructionStack()
     m_constructionStack.last() = nullptr;
 }
 
+template<typename Visitor>
+void JSCustomElementInterface::visitJSFunctions(Visitor& visitor) const
+{
+    visitor.append(m_constructor);
+    visitor.append(m_connectedCallback);
+    visitor.append(m_disconnectedCallback);
+    visitor.append(m_adoptedCallback);
+    visitor.append(m_attributeChangedCallback);
+    visitor.append(m_formAssociatedCallback);
+    visitor.append(m_formResetCallback);
+    visitor.append(m_formDisabledCallback);
+    visitor.append(m_formStateRestoreCallback);
+}
+
+template void JSCustomElementInterface::visitJSFunctions(JSC::AbstractSlotVisitor&) const;
+template void JSCustomElementInterface::visitJSFunctions(JSC::SlotVisitor&) const;
+
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -104,6 +104,7 @@ public:
 
     virtual ~JSCustomElementInterface();
 
+    template<typename Visitor> void visitJSFunctions(Visitor&) const;
 private:
     JSCustomElementInterface(const QualifiedName&, JSC::JSObject* callback, JSDOMGlobalObject*);
 

--- a/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
@@ -168,13 +168,6 @@ JSValue JSCustomElementRegistry::define(JSGlobalObject& lexicalGlobalObject, Cal
             elementInterface->disableShadow();
     }
 
-    auto addToGlobalObjectWithPrivateName = [&] (JSObject* objectToAdd) {
-        if (objectToAdd) {
-            PrivateName uniquePrivateName;
-            globalObject()->putDirect(vm, uniquePrivateName, objectToAdd);
-        }
-    };
-
     if (registry.document() && registry.document()->settings().formAssociatedCustomElementsEnabled()) {
         auto formAssociatedValue = constructor->get(&lexicalGlobalObject, Identifier::fromString(vm, "formAssociated"_s));
         RETURN_IF_EXCEPTION(scope, { });
@@ -200,19 +193,8 @@ JSValue JSCustomElementRegistry::define(JSGlobalObject& lexicalGlobalObject, Cal
             RETURN_IF_EXCEPTION(scope, { });
             if (formStateRestoreCallback)
                 elementInterface->setFormStateRestoreCallback(formStateRestoreCallback);
-
-            addToGlobalObjectWithPrivateName(formAssociatedCallback);
-            addToGlobalObjectWithPrivateName(formResetCallback);
-            addToGlobalObjectWithPrivateName(formDisabledCallback);
-            addToGlobalObjectWithPrivateName(formStateRestoreCallback);
         }
     }
-
-    addToGlobalObjectWithPrivateName(constructor);
-    addToGlobalObjectWithPrivateName(connectedCallback);
-    addToGlobalObjectWithPrivateName(disconnectedCallback);
-    addToGlobalObjectWithPrivateName(adoptedCallback);
-    addToGlobalObjectWithPrivateName(attributeChangedCallback);
 
     if (auto promise = registry.addElementDefinition(WTFMove(elementInterface)))
         promise->resolveWithJSValue(constructor);
@@ -266,5 +248,13 @@ JSValue JSCustomElementRegistry::whenDefined(JSGlobalObject& lexicalGlobalObject
 
     return promise;
 }
+
+template<typename Visitor>
+void JSCustomElementRegistry::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().visitJSCustomElementInterfaces(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCustomElementRegistry);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -76,8 +76,11 @@ RefPtr<DeferredPromise> CustomElementRegistry::addElementDefinition(Ref<JSCustom
 {
     AtomString localName = elementInterface->name().localName();
     ASSERT(!m_nameMap.contains(localName));
-    m_constructorMap.add(elementInterface->constructor(), elementInterface.ptr());
     m_nameMap.add(localName, elementInterface.copyRef());
+    {
+        Locker locker { m_constructorMapLock };
+        m_constructorMap.add(elementInterface->constructor(), elementInterface.ptr());
+    }
 
     if (elementInterface->isShadowDisabled())
         m_disabledShadowSet.add(localName);
@@ -107,11 +110,13 @@ JSCustomElementInterface* CustomElementRegistry::findInterface(const AtomString&
 
 JSCustomElementInterface* CustomElementRegistry::findInterface(const JSC::JSObject* constructor) const
 {
+    Locker locker { m_constructorMapLock };
     return m_constructorMap.get(constructor);
 }
 
 bool CustomElementRegistry::containsConstructor(const JSC::JSObject* constructor) const
 {
+    Locker locker { m_constructorMapLock };
     return m_constructorMap.contains(constructor);
 }
 
@@ -142,5 +147,16 @@ void CustomElementRegistry::upgrade(Node& root)
 
     upgradeElementsInShadowIncludingDescendants(downcast<ContainerNode>(root));
 }
+
+template<typename Visitor>
+void CustomElementRegistry::visitJSCustomElementInterfaces(Visitor& visitor) const
+{
+    Locker locker { m_constructorMapLock };
+    for (const auto& iterator : m_constructorMap)
+        iterator.value->visitJSFunctions(visitor);
+}
+
+template void CustomElementRegistry::visitJSCustomElementInterfaces(JSC::AbstractSlotVisitor&) const;
+template void CustomElementRegistry::visitJSCustomElementInterfaces(JSC::SlotVisitor&) const;
 
 }

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -27,6 +27,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "QualifiedName.h"
+#include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/text/AtomString.h>
@@ -73,16 +74,18 @@ public:
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }
     bool isShadowDisabled(const AtomString& name) const { return m_disabledShadowSet.contains(name); }
 
+    template<typename Visitor> void visitJSCustomElementInterfaces(Visitor&) const;
 private:
     CustomElementRegistry(DOMWindow&, ScriptExecutionContext*);
 
     DOMWindow& m_window;
     HashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
-    HashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap;
+    HashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>> m_promiseMap;
     MemoryCompactRobinHoodHashSet<AtomString> m_disabledShadowSet;
 
     bool m_elementDefinitionIsRunning { false };
+    mutable Lock m_constructorMapLock;
 
     friend class ElementDefinitionIsRunningSetForScope;
 };

--- a/Source/WebCore/dom/CustomElementRegistry.idl
+++ b/Source/WebCore/dom/CustomElementRegistry.idl
@@ -25,6 +25,7 @@
 
 [
     GenerateIsReachable=ImplScriptExecutionContext,
+    JSCustomMarkFunction,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface CustomElementRegistry {


### PR DESCRIPTION
#### 1b11bc2ebce8a49909b9396ce92bc947ec4d250c
<pre>
Defining a custom element should not cause global object&apos;s structure transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=233025">https://bugs.webkit.org/show_bug.cgi?id=233025</a>

Reviewed by Ryosuke Niwa.

This patch utilizes visitAdditionalChildren() to mark custom element&apos;s constructor / callbacks,
which saves up to 5 structure transitions per custom element definition.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/resources/garbage-collect.js: Added.
(async maybeGarbageCollectAsync):
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::visitJSFunctions):
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::JSCustomElementRegistry::define):
(WebCore::JSCustomElementRegistry::visitAdditionalChildren):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::visitJSCustomElementInterfaces):
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/CustomElementRegistry.idl:

Canonical link: <a href="https://commits.webkit.org/253330@main">https://commits.webkit.org/253330@main</a>
</pre>
