### PR TITLE
[git-webkit] Improve the error message when PR fails to create

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -146,7 +146,11 @@ class GitHub(Scm):
             )
             if response.status_code == 422:
                 sys.stderr.write('Validation failed when creating pull request\n')
-                sys.stderr.write('Does a pull request against this branch already exist?\n')
+                errors = response.json().get('errors')
+                if errors and len(errors) > 0:
+                    sys.stderr.write('List of errors:\n')
+                    for error in errors:
+                        sys.stderr.write('* {}\n'.format(error.get('message')))
                 return None
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))


### PR DESCRIPTION
#### 5ddd1c8eb7f236ae1d33ee5509b6d7b5bf0df6a7
<pre>
[git-webkit] Improve the error message when PR fails to create
<a href="https://bugs.webkit.org/show_bug.cgi?id=243617">https://bugs.webkit.org/show_bug.cgi?id=243617</a>
&lt;rdar://98218733&gt;

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
</pre>