### PR TITLE
[git-webkit] Improve the error message when PR fails to create

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -391,3 +391,16 @@ What version of 'WebKit' should the bug be associated with?:
             self.assertEqual(github.Tracker(self.URL, redact={'project:WebKit': True}).issue(1).redacted, True)
             self.assertEqual(github.Tracker(self.URL, redact={'component:Text': True}).issue(1).redacted, True)
             self.assertEqual(github.Tracker(self.URL, redact={'version:Other': True}).issue(1).redacted, True)
+
+    def test_parse_error(self):
+        error_json = {'message': 'Validation Failed', 'errors': [{'resource': 'Issue', 'code': 'custom', 'field': 'body', 'message': 'body is too long (maximum is 65536 characters)'}], 'documentation_url': 'https://docs.github.com/rest/reference/pulls#create-a-pull-request'}
+        with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
+            parsed_error = '''Error Message: Validation Failed
+---\tERROR\t---
+Type: body is too long (maximum is 65536 characters)
+Resource: Issue
+Field: body
+---\t---\t---
+Documentation URL: https://docs.github.com/rest/reference/pulls#create-a-pull-request
+'''
+            self.assertEqual(github.Tracker(self.URL).parse_error(error_json), parsed_error)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -145,14 +145,11 @@ class GitHub(Scm):
                 ),
             )
             if response.status_code == 422:
-                sys.stderr.write('Validation failed when creating pull request\n')
-                sys.stderr.write('Does a pull request against this branch already exist?\n')
+                sys.stderr.write(self.tracker.parse_error(response.json()))
                 return None
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                message = response.json().get('message')
-                if message:
-                    sys.stderr.write('Message: {}\n'.format(message))
+                sys.stderr.write(self.tracker.parse_error(response.json()))
                 sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
                 return None
             result = self.PullRequest(response.json())
@@ -193,13 +190,12 @@ class GitHub(Scm):
                 json=updates,
             )
             if response.status_code == 422:
+                sys.stderr.write(self.tracker.parse_error(response.json()))
                 pull_request._opened = False
                 return pull_request
             if response.status_code // 100 != 2:
                 sys.stderr.write("Request to '{}' returned status code '{}'\n".format(url, response.status_code))
-                message = response.json().get('message')
-                if message:
-                    sys.stderr.write('Message: {}\n'.format(message))
+                sys.stderr.write(self.tracker.parse_error(response.json()))
                 sys.stderr.write(Tracker.REFRESH_TOKEN_PROMPT)
                 return None
             data = response.json()


### PR DESCRIPTION
#### b33f467f30964d66fc614575a5865746447cc38b
<pre>
[git-webkit] Improve the error message when PR fails to create
<a href="https://bugs.webkit.org/show_bug.cgi?id=243617">https://bugs.webkit.org/show_bug.cgi?id=243617</a>
&lt;rdar://98218733&gt;

Reviewed by Jonathan Bedard.

Currently when a 422 status code is received from GitHub, we assume only
one type of error condition and notify the user of such. Instead we can
parse the error message and format it nicely for the user.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:

Canonical link: <a href="https://commits.webkit.org/253428@main">https://commits.webkit.org/253428@main</a>
</pre>
