### PR TITLE
[iOS] Allow clients to override `-supportsTextReplacement` to allow Find & Replace in UIFindInteraction

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -370,7 +370,7 @@ FOR_EACH_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
         return _findInteractionEnabled;
 
     if (action == @selector(findAndReplace:))
-        return _findInteractionEnabled && self._isEditable;
+        return _findInteractionEnabled && self.supportsTextReplacement;
 #endif
 
     return [super canPerformAction:action withSender:sender];
@@ -3001,7 +3001,15 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     return _contentView.get();
 }
 
-#endif
+- (BOOL)supportsTextReplacement
+{
+    if ([_customContentView respondsToSelector:@selector(supportsTextReplacement)])
+        return [(id<UITextSearching>)_customContentView.get() supportsTextReplacement];
+
+    return [_contentView supportsTextReplacementForWebView];
+}
+
+#endif // HAVE(UIFINDINTERACTION)
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -804,6 +804,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #endif
 
 #if HAVE(UIFINDINTERACTION)
+@property (nonatomic, readonly) BOOL supportsTextReplacementForWebView;
 - (NSInteger)offsetFromPosition:(UITextPosition *)from toPosition:(UITextPosition *)toPosition inDocument:(UITextSearchDocumentIdentifier)document;
 - (void)didBeginTextSearchOperation;
 - (void)didEndTextSearchOperation;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10554,6 +10554,11 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (BOOL)supportsTextReplacement
 {
+    return self.webView.supportsTextReplacement;
+}
+
+- (BOOL)supportsTextReplacementForWebView
+{
     return self.webView._editable;
 }
 


### PR DESCRIPTION
#### dd8f2a3b7e4cad0f99e911a8c57e83e1d96472aa
<pre>
[iOS] Allow clients to override `-supportsTextReplacement` to allow Find &amp; Replace in UIFindInteraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=243620">https://bugs.webkit.org/show_bug.cgi?id=243620</a>

Reviewed by Aditya Keerthi.

This patch plumbs the call to `-[WKContentView supportsTextReplacement]` through to `WKWebView`,
which (by default) simply calls back into the content view. Like many other (similar) methods on
`UIResponder` and `UITextInput`, this gives WKWebView clients an opportunity override
`-supportsTextReplacement` on `WKWebView` in order to influence whether or not `UIFindInteraction`
shows find-and-replace UI.

Test: WebKit.FindInteractionSupportsTextReplacement

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView canPerformAction:withSender:]):
(-[WKWebView supportsTextReplacement]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView supportsTextReplacement]):
(-[WKContentView supportsTextReplacementForWebView]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(-[FindInPageTestWKWebView initWithFrame:configuration:]):
(-[FindInPageTestWKWebView overrideSupportsTextReplacement:]):
(-[FindInPageTestWKWebView supportsTextReplacement]):

Add a test case to exercise whether or not text replacement is supported on the UIFindInteraction&apos;s
active find session in several scenarios:
- Non-editable web view.
- Editable web view.
- Editable web view that overrides `-supportsTextReplacement` and returns `NO`.
- Non-editable web view that overrides `-supportsTextReplacement` and returns `YES`.

Canonical link: <a href="https://commits.webkit.org/253208@main">https://commits.webkit.org/253208@main</a>
</pre>
