### PR TITLE
[iPad] fast/dom/HTMLLinkElement/link-stylesheet-load-once.html is flaky

### DIFF
--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt
@@ -1,5 +1,4 @@
 resources/link-stylesheet-load-once.css - willSendRequest <NSURLRequest URL resources/link-stylesheet-load-once.css, main document URL link-stylesheet-load-once.html, http method GET> redirectResponse (null)
-link-stylesheet-load-once.html - didFinishLoading
 resources/link-stylesheet-load-once.css - didReceiveResponse <NSURLResponse resources/link-stylesheet-load-once.css, http status code 0>
 resources/link-stylesheet-load-once.css - didFinishLoading
 This tests overriding rel content attribute with the same value.

--- a/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
+++ b/LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html
@@ -2,13 +2,10 @@
 <html>
 <head>
 <script>
+
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
-    testRunner.dumpResourceLoadCallbacks();
-    internals.clearMemoryCache();
-    if (testRunner.setSerializeHTTPLoads)
-        testRunner.setSerializeHTTPLoads();
 }
 
 let loadCount = 0;
@@ -31,8 +28,19 @@ function didLoad(element)
     result.innerHTML = loadCount;
 }
 
+window.onload = () => {
+    setTimeout(() => {
+        if (window.testRunner) {
+            internals.clearMemoryCache();
+            testRunner.dumpResourceLoadCallbacks();
+            if (testRunner.setSerializeHTTPLoads)
+                testRunner.setSerializeHTTPLoads();
+        }
+        document.head.innerHTML = `<link rel="stylesheet" href="resources/link-stylesheet-load-once.css" onload="didLoad(this)">`;
+    }, 0);
+}
+
 </script>
-<link rel="stylesheet" href="resources/link-stylesheet-load-once.css" onload="didLoad(this)">
 </head>
 <body>
 <p>This tests overriding rel content attribute with the same value.<br>


### PR DESCRIPTION
#### eb5e242a31102f00d2daf6a0f6aa7bbd55af171e
<pre>
[iPad] fast/dom/HTMLLinkElement/link-stylesheet-load-once.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=243626">https://bugs.webkit.org/show_bug.cgi?id=243626</a>

Reviewed by Darin Adler.

This is a speculative attempt to fix the flakiness of link-stylesheet-load-once.html.

Luckily, the only difference between a successful run and a failed run is
when didFinishLoading for link-stylesheet-load-once.html is called relative to
when willSendRequest for link-stylesheet-load-once.css is called.

We can eliminate this difference by always waiting for load event then 0s timer.
(load event in JS may fire before didFinishLoading delegate callback in API)

* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once-expected.txt:
* LayoutTests/fast/dom/HTMLLinkElement/link-stylesheet-load-once.html:

Canonical link: <a href="https://commits.webkit.org/253183@main">https://commits.webkit.org/253183@main</a>
</pre>
