### PR TITLE
Unreviewed, annotate setIndexQuicklyForArrayStorageIndexingType with ALWAYS_INLINE

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -529,7 +529,7 @@ inline void JSObject::setIndexQuicklyForTypedArray(unsigned i, JSValue value)
     }
 }
 
-inline void JSObject::setIndexQuicklyForArrayStorageIndexingType(VM& vm, unsigned i, JSValue v)
+ALWAYS_INLINE void JSObject::setIndexQuicklyForArrayStorageIndexingType(VM& vm, unsigned i, JSValue v)
 {
     ArrayStorage* storage = this->butterfly()->arrayStorage();
     WriteBarrier<Unknown>& x = storage->m_vector[i];


### PR DESCRIPTION
#### 626210e6c29c022840c0dcd62cfb93ef3709b76b
<pre>
Unreviewed, annotate setIndexQuicklyForArrayStorageIndexingType with ALWAYS_INLINE
<a href="https://bugs.webkit.org/show_bug.cgi?id=243633">https://bugs.webkit.org/show_bug.cgi?id=243633</a>

It is possible that b4f3fcf1248382b2578b6f38c1b4368a9ae014da regressed JetStream2/WSL.
This patch puts ALWAYS_INLINE to attempt to recover it.

* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::setIndexQuicklyForArrayStorageIndexingType):

Canonical link: <a href="https://commits.webkit.org/253185@main">https://commits.webkit.org/253185@main</a>
</pre>
