### PR TITLE
Add a runtime flag for imperative slot API

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -732,6 +732,18 @@ ImageBitmapEnabled:
     WebKit:
       default: true
 
+ImperativeSlotAPIEnabled:
+  type: bool
+  humanReadableName: "Imperative Slot API"
+  humanReadableDescription: "Imperative Shadow DOM Distribution API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
 InProcessCookieCacheEnabled:
   type: bool

--- a/Source/WebCore/features.json
+++ b/Source/WebCore/features.json
@@ -608,6 +608,16 @@
         "description": "An API to allow web content to observe system-wide user presence signals."
     },
     {
+        "name": "Imperative Slot API",
+        "status": {
+            "status": "In Development",
+            "enabled-by-default": false
+        },
+        "specification": "Web Components",
+        "url": "https://dom.spec.whatwg.org/#enumdef-slotassignmentmode",
+        "webkit-url": "https://webkit.org/b/218692"
+    },
+    {
         "name": "Indexed Database",
         "status": {
             "status": "Supported"


### PR DESCRIPTION
#### 998c7bfe023a2d19f103676774becb3b8b43b667
<pre>
Add a runtime flag for imperative slot API
<a href="https://bugs.webkit.org/show_bug.cgi?id=243634">https://bugs.webkit.org/show_bug.cgi?id=243634</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/features.json:

Canonical link: <a href="https://commits.webkit.org/253187@main">https://commits.webkit.org/253187@main</a>
</pre>
