### PR TITLE
contain-size-select-001.html and contain-size-select-002.html are failing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4900,11 +4900,6 @@ webkit.org/b/41796 imported/w3c/web-platform-tests/css/css-contain/contain-size-
 imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-size-inline-block-003.html [ ImageOnlyFailure ]
 
-# 1. The height driven by the imaginary box (strut) does not match the minimum height value set in the RenderTheme (e.g. see RenderThemeMac::adjustMenuListButtonStyle).
-# 2. We ignore the background-color property value (supposed to be white on white to renderer "blank" content).
-imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html [ ImageOnlyFailure ]
-
 # Counter style tests that fail on some platforms because of subtle character positioning differences, presumably from subpixel rounding.
 # These failures are slightly different per-platform, but it seems unwise to move the expectations into platform-specific expectations files.
 imported/w3c/web-platform-tests/css/css-counter-styles/bengali/css3-counter-styles-117.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001-expected.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html
@@ -7,7 +7,7 @@
 <meta name=assert content="<select> elements with 'contain: size' should be treated as having no contents.">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
   contain: size;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002-expected.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html
@@ -8,7 +8,7 @@
 <meta name=assert content="Check that setting 'contain: size' on a <select> elements causes it to be sized as having no contents.">
 <style>
 select {
-  color: white;
+  color: transparent;
   background: white;
 }
 </style>

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1688,7 +1688,7 @@ void RenderThemeMac::adjustMenuListButtonStyle(RenderStyle& style, const Element
     style.resetPadding();
     style.setBorderRadius(IntSize(int(baseBorderRadius + fontScale - 1), int(baseBorderRadius + fontScale - 1))); // FIXME: Round up?
 
-    const int minHeight = 15;
+    const int minHeight = 18;
     style.setMinHeight(Length(minHeight, LengthType::Fixed));
 
     style.setLineHeight(RenderStyle::initialLineHeight());


### PR DESCRIPTION
#### 5a258b32387ea30df2e0e6630a6a16a729aaf4d2
<pre>
contain-size-select-001.html and contain-size-select-002.html are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243527">https://bugs.webkit.org/show_bug.cgi?id=243527</a>
&lt;rdar://98096620&gt;

Reviewed by Aditya Keerthi.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html:
color: white; is supposed to account for the fact that browsers may still render text in the available space, and white on white is supposed to be invisible.
Except WebKit renders a special appearance in the background (menulist-button), so it&apos;s better to use transparent.

* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustMenuListButtonStyle const):
18 matches the actual minimum height.

Canonical link: <a href="https://commits.webkit.org/253218@main">https://commits.webkit.org/253218@main</a>
</pre>
