### PR TITLE
Clean up ComplexTextController::collectComplexTextRuns()

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -39,6 +39,10 @@ typedef const struct __CTLine * CTLineRef;
 
 typedef struct hb_buffer_t hb_buffer_t;
 
+namespace WTF {
+class CachedTextBreakIterator;
+}
+
 namespace WebCore {
 
 class FontCascade;
@@ -153,6 +157,8 @@ private:
     float runWidthSoFarFraction(unsigned glyphStartOffset, unsigned glyphEndOffset, unsigned oldCharacterInCurrentGlyph, GlyphIterationStyle) const;
 
     FloatPoint glyphOrigin(unsigned index) const { return index < m_glyphOrigins.size() ? m_glyphOrigins[index] : FloatPoint(); }
+
+    bool advanceByCombiningCharacterSequence(const WTF::CachedTextBreakIterator& graphemeClusterIterator, unsigned& location, UChar32& baseCharacter, unsigned& markCount);
 
     Vector<FloatSize, 256> m_adjustedBaseAdvances;
     Vector<FloatPoint, 256> m_glyphOrigins;


### PR DESCRIPTION
#### 96049953bf648ed38b387e104268d5ba7d237e2f
<pre>
Clean up ComplexTextController::collectComplexTextRuns()
<a href="https://bugs.webkit.org/show_bug.cgi?id=243636">https://bugs.webkit.org/show_bug.cgi?id=243636</a>

Reviewed by Yusuke Suzuki.

Now that we&apos;ve switched to ICU in 12bc2f0ab0d7, we can do some additional cleanup refactoring.
This is mostly a renaming patch, but also moves advanceByCombiningCharacterSequence() into
ComplexTextController so we don&apos;t have to pass quite so many arguments to it.

+==========+=============================+
| Old name | New name                    |
+==========+=============================+
| cp       | baseOfString                |
| location | currentIndex                |
| index    | previousIndex               |
| curr     | baseOfString + currentIndex |
| end      | baseOfString + m_end        |
+==========+=============================+

* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::advanceByCombiningCharacterSequence):
(WebCore::ComplexTextController::collectComplexTextRuns):
(WebCore::advanceByCombiningCharacterSequence): Deleted.
* Source/WebCore/platform/graphics/ComplexTextController.h:

Canonical link: <a href="https://commits.webkit.org/253278@main">https://commits.webkit.org/253278@main</a>
</pre>
