### PR TITLE
Introduce postMessage mechanism for PDF.js viewer and use it for context menu items

### DIFF
--- a/Source/WebCore/Modules/pdfjs-extras/content-script.js
+++ b/Source/WebCore/Modules/pdfjs-extras/content-script.js
@@ -23,7 +23,49 @@
  */
 
 const PDFJSContentScript = {
+    setPageMode({ pages, continuous }) {
+        PDFViewerApplication.pdfViewer.spreadMode = pages == "two" ? 1 : 0;
+
+        if (continuous) {
+            PDFViewerApplication.pdfViewer.scrollMode = 0;
+            PDFViewerApplication.pdfViewer.currentScaleValue = "page-width";
+        } else {
+            PDFViewerApplication.pdfViewer.scrollMode = 3;
+            PDFViewerApplication.pdfViewer.currentScaleValue = "page-fit";
+        }
+    },
+
     open(data) {
         PDFViewerApplication.open(data);
+    },
+
+    init() {
+        this.setPageMode({ pages: "single", continuous: true });
+
+        window.addEventListener("message", (event) => {
+            const { message, data } = event.data;
+            switch (message) {
+                case "open-pdf":
+                    this.open(data);
+                    break;
+                case "context-menu-single-page":
+                    this.setPageMode({ pages: "single", continuous: false });
+                    break;
+                case "context-menu-single-page-continuous":
+                    this.setPageMode({ pages: "single", continuous: true });
+                    break;
+                case "context-menu-two-pages":
+                    this.setPageMode({ pages: "two", continuous: false });
+                    break;
+                case "context-menu-two-pages-continuous":
+                    this.setPageMode({ pages: "two", continuous: true });
+                    break;
+                default:
+                    console.error("Unrecognized message:", event);
+                    break;
+            }
+        });
     }
 };
+
+PDFJSContentScript.init();

--- a/Source/WebCore/html/PDFDocument.h
+++ b/Source/WebCore/html/PDFDocument.h
@@ -19,7 +19,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -45,7 +45,9 @@ public:
     void finishedParsing();
     void injectStyleAndContentScript();
 
+    void postMessageToIframe(const String& name, JSC::JSObject* data);
     void sendPDFArrayBuffer();
+
     bool isFinishedParsing() const { return m_isFinishedParsing; }
     void setContentScriptLoaded(bool loaded) { m_isContentScriptLoaded = loaded; }
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -74,6 +74,10 @@
 #include <wtf/WallTime.h>
 #include <wtf/unicode/CharacterNames.h>
 
+#if ENABLE(PDFJS)
+#include "PDFDocument.h"
+#endif
+
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
 #endif
@@ -549,6 +553,20 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         }
 #endif
         break;
+#if ENABLE(PDFJS)
+    case ContextMenuItemPDFSinglePage:
+        performPDFJSAction(*frame, "context-menu-single-page"_s);
+        break;
+    case ContextMenuItemPDFSinglePageContinuous:
+        performPDFJSAction(*frame, "context-menu-single-page-continuous"_s);
+        break;
+    case ContextMenuItemPDFTwoPages:
+        performPDFJSAction(*frame, "context-menu-two-pages"_s);
+        break;
+    case ContextMenuItemPDFTwoPagesContinuous:
+        performPDFJSAction(*frame, "context-menu-two-pages-continuous"_s);
+        break;
+#endif
     default:
         break;
     }
@@ -1562,6 +1580,17 @@ void ContextMenuController::showImageControlsMenu(Event& event)
     clearContextMenu();
     handleContextMenuEvent(event);
     m_client.showContextMenu();
+}
+
+#endif
+
+#if ENABLE(PDFJS)
+
+void ContextMenuController::performPDFJSAction(Frame& frame, const String& action)
+{
+    auto* pdfDocument = dynamicDowncast<PDFDocument>(frame.ownerElement()->document());
+    if (pdfDocument)
+        pdfDocument->postMessageToIframe(action, nullptr);
 }
 
 #endif

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -92,6 +92,10 @@ private:
     void createAndAppendUnicodeSubMenu(ContextMenuItem&);
 #endif
 
+#if ENABLE(PDFJS)
+    void performPDFJSAction(Frame&, const String& action);
+#endif
+
     Page& m_page;
     ContextMenuClient& m_client;
     std::unique_ptr<ContextMenu> m_contextMenu;


### PR DESCRIPTION
#### 5b3fe7dc3092485e4822fb5ae51cb9f80e7ea0de
<pre>
Introduce postMessage mechanism for PDF.js viewer and use it for context menu items
<a href="https://bugs.webkit.org/show_bug.cgi?id=236668">https://bugs.webkit.org/show_bug.cgi?id=236668</a>
&lt;rdar://88985691&gt;

Reviewed by Brent Fulgham.

This introduces a mechanism to postMessage to the PDF.js iframe, and uses it for:
- context menu items
- rendering the initial PDF

Parts of the code by Ryan Reno.

* Source/WebCore/Modules/pdfjs-extras/content-script.js:
(const.PDFJSContentScript.setPageMode):
(const.PDFJSContentScript.open):
(const.PDFJSContentScript.init):
* Source/WebCore/html/PDFDocument.cpp:
(WebCore::PDFDocument::postMessageToIframe):
(WebCore::PDFDocument::sendPDFArrayBuffer):
* Source/WebCore/html/PDFDocument.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::performPDFJSAction):
* Source/WebCore/page/ContextMenuController.h:

Canonical link: <a href="https://commits.webkit.org/253223@main">https://commits.webkit.org/253223@main</a>
</pre>
