### PR TITLE
[GTK] fast/mediastream/media-element-current-time.html is failing since added in r256346

### DIFF
--- a/LayoutTests/fast/mediastream/media-element-current-time.html
+++ b/LayoutTests/fast/mediastream/media-element-current-time.html
@@ -2,6 +2,7 @@
 <video id="video" autoplay playsInline></video>
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
+<script src="../../media/utilities.js"></script>
 <script>
 
 promise_test(async() => {
@@ -15,16 +16,17 @@ promise_test(async() => {
     let currentTime = video.currentTime;
     assert_not_equals(currentTime, 0, "Playback has started, currentTime must not be zero");
 
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await waitForVideoFrame(video);
+    await waitForVideoFrame(video);
     assert_greater_than(video.currentTime, currentTime, "video is playing, time should advance");
 
     video.pause();
     currentTime = video.currentTime;
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await once(video, 'pause');
     assert_equals(video.currentTime, currentTime, "video is paused, currentTime must not advance");
 
-    await video.play();
-    await new Promise(resolve => setTimeout(resolve, 10));
+    video.play();
+    await once(video, 'playing');
     assert_greater_than(video.currentTime, currentTime, "Playback has started, currentTime should advance");
 
 }, "Check video.currentTime behavior");


### PR DESCRIPTION
#### 3e994a2e314219315bf6a8beb90f0e86399eeb94
<pre>
[GTK] fast/mediastream/media-element-current-time.html is failing since added in r256346
<a href="https://bugs.webkit.org/show_bug.cgi?id=208120">https://bugs.webkit.org/show_bug.cgi?id=208120</a>
&lt;rdar://problem/86967699&gt;

Reviewed by Eric Carlson.

* LayoutTests/fast/mediastream/media-element-current-time.html: Rely on events and rvFc to ensure
the test behavior is consistent.

Canonical link: <a href="https://commits.webkit.org/253220@main">https://commits.webkit.org/253220@main</a>
</pre>
