### PR TITLE
[GStreamer][MediaStream] Video resizing fixes

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -870,8 +870,6 @@ webkit.org/b/230028 media/media-source/media-source-seek-twice.html [ Pass Timeo
 
 # rvfc related failures
 imported/w3c/web-platform-tests/video-rvfc [ Pass ]
-fast/mediastream/getUserMedia-rvfc.html [ Pass Failure ]
-webrtc/peerConnection-rvfc.html [ Failure ]
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.https.html [ Skip ]
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html [ Skip ]
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -87,13 +87,18 @@ uint64_t toGstUnsigned64Time(const MediaTime&);
 bool isThunderRanked();
 #endif
 
-inline GstClockTime toGstClockTime(const MediaTime &mediaTime)
+inline GstClockTime toGstClockTime(const MediaTime& mediaTime)
 {
     if (mediaTime.isInvalid())
         return GST_CLOCK_TIME_NONE;
     if (mediaTime < MediaTime::zeroTime())
         return 0;
     return static_cast<GstClockTime>(toGstUnsigned64Time(mediaTime));
+}
+
+inline GstClockTime toGstClockTime(const Seconds& seconds)
+{
+    return toGstClockTime(MediaTime::createWithDouble(seconds.seconds()));
 }
 
 inline MediaTime fromGstClockTime(GstClockTime time)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -30,6 +30,13 @@
 
 namespace WebCore {
 
+static inline void setBufferFields(GstBuffer* buffer, const MediaTime& presentationTime, double frameRate)
+{
+    GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_LIVE);
+    GST_BUFFER_DTS(buffer) = GST_BUFFER_PTS(buffer) = toGstClockTime(presentationTime);
+    GST_BUFFER_DURATION(buffer) = toGstClockTime(1_s / frameRate);
+}
+
 Ref<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, CanvasContentType canvasContentType, Rotation videoRotation, const MediaTime& presentationTime, const IntSize& destinationSize, double frameRate, bool videoMirrored, std::optional<VideoFrameTimeMetadata>&& metadata)
 {
     ensureGStreamerInitialized();
@@ -57,8 +64,6 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuf
         break;
     }
     const char* formatName = gst_video_format_to_string(format);
-    gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
-
     int frameRateNumerator, frameRateDenominator;
     gst_util_double_to_fraction(frameRate, &frameRateNumerator, &frameRateDenominator);
 
@@ -67,19 +72,10 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuf
 
     GRefPtr<GstSample> sample;
 
-    auto setBufferFields = [&](GstBuffer* buffer) {
-        GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_LIVE);
-
-        GST_BUFFER_DTS(buffer) = GST_BUFFER_PTS(buffer) = toGstClockTime(presentationTime);
-
-        auto duration = 1_s / frameRate;
-        GST_BUFFER_DURATION(buffer) = toGstClockTime(MediaTime::createWithDouble(duration.seconds()));
-    };
-
     // Optionally resize the video frame to fit destinationSize. This code path is used mostly by
     // the mock realtime video source when the gUM constraints specifically required exact width
     // and/or height values.
-    if (!destinationSize.isZero()) {
+    if (!destinationSize.isZero() && size != destinationSize) {
         GstVideoInfo inputInfo;
         gst_video_info_from_caps(&inputInfo, caps.get());
 
@@ -97,18 +93,17 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuf
             GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
             gst_video_converter_frame(converter.get(), inputFrame.get(), outputFrame.get());
         }
-        gst_buffer_add_video_meta(outputBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);
 
         if (metadata)
             webkitGstBufferSetVideoFrameTimeMetadata(outputBuffer.get(), *metadata);
 
-        setBufferFields(outputBuffer.get());
+        setBufferFields(outputBuffer.get(), presentationTime, frameRate);
         sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
     } else {
         if (metadata)
             buffer = webkitGstBufferSetVideoFrameTimeMetadata(buffer.get(), *metadata);
 
-        setBufferFields(buffer.get());
+        setBufferFields(buffer.get(), presentationTime, frameRate);
         sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     }
 
@@ -132,6 +127,45 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
     : VideoFrame(presentationTime, false, videoRotation)
     , m_sample(sample)
 {
+}
+
+Ref<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
+{
+    auto* caps = gst_sample_get_caps(m_sample.get());
+
+    const auto* structure = gst_caps_get_structure(caps, 0);
+    int frameRateNumerator, frameRateDenominator;
+    if (!gst_structure_get_fraction(structure, "framerate", &frameRateNumerator, &frameRateDenominator)) {
+        frameRateNumerator = 1;
+        frameRateDenominator = 1;
+    }
+
+    GstVideoInfo inputInfo;
+    gst_video_info_from_caps(&inputInfo, caps);
+    auto format = GST_VIDEO_INFO_FORMAT(&inputInfo);
+    auto width = destinationSize.width();
+    auto height = destinationSize.height();
+    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, gst_video_format_to_string(format), "width", G_TYPE_INT, width,
+        "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
+    GstVideoInfo outputInfo;
+    gst_video_info_from_caps(&outputInfo, outputCaps.get());
+
+    auto* buffer = gst_sample_get_buffer(m_sample.get());
+    auto outputBuffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outputInfo), nullptr));
+    {
+        GUniquePtr<GstVideoConverter> converter(gst_video_converter_new(&inputInfo, &outputInfo, nullptr));
+        GstMappedFrame inputFrame(buffer, inputInfo, GST_MAP_READ);
+        GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
+        gst_video_converter_frame(converter.get(), inputFrame.get(), outputFrame.get());
+    }
+
+    double frameRate;
+    gst_util_fraction_to_double(frameRateNumerator, frameRateDenominator, &frameRate);
+
+    auto presentationTime = this->presentationTime();
+    setBufferFields(outputBuffer.get(), presentationTime, frameRate);
+    auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
+    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), presentationTime, rotation()));
 }
 
 RefPtr<JSC::Uint8ClampedArray> VideoFrameGStreamer::computeRGBAImageData() const
@@ -159,7 +193,6 @@ RefPtr<JSC::Uint8ClampedArray> VideoFrameGStreamer::computeRGBAImageData() const
     unsigned byteLength = GST_VIDEO_INFO_SIZE(&inputInfo);
     auto bufferStorage = JSC::ArrayBuffer::create(width * height, 4);
     auto outputBuffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_NO_SHARE, bufferStorage->data(), byteLength, 0, byteLength, nullptr, [](gpointer) { }));
-    gst_buffer_add_video_meta(outputBuffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_RGBA, width, height);
     GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
 
     GUniquePtr<GstVideoConverter> converter(gst_video_converter_new(&inputInfo, &outputInfo, nullptr));

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -30,6 +30,7 @@ typedef struct _GstSample GstSample;
 namespace WebCore {
 
 class PixelBuffer;
+class IntSize;
 
 class VideoFrameGStreamer final : public VideoFrame {
 public:
@@ -50,6 +51,9 @@ public:
     }
 
     static Ref<VideoFrameGStreamer> createFromPixelBuffer(Ref<PixelBuffer>&&, CanvasContentType canvasContentType, Rotation videoRotation, const MediaTime& presentationTime = MediaTime::invalidTime(), const IntSize& destinationSize = { }, double frameRate = 1, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& metadata = std::nullopt);
+
+
+    Ref<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GstSample* sample() const { return m_sample.get(); }
     RefPtr<JSC::Uint8ClampedArray> computeRGBAImageData() const;

--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
@@ -74,9 +74,7 @@ private:
     // RealtimeMediaSource::VideoFrameObserver
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
 
-#if PLATFORM(COCOA)
     RefPtr<VideoFrame> adaptVideoFrame(VideoFrame&);
-#endif
 
 #if !RELEASE_LOG_DISABLED
     void setLogger(const Logger&, const void*) final;


### PR DESCRIPTION
#### 8a44e02b866aad92a8c613ead7ed7d40daf45a1f
<pre>
[GStreamer][MediaStream] Video resizing fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243638">https://bugs.webkit.org/show_bug.cgi?id=243638</a>

Reviewed by Xabier Rodriguez-Calvar.

Resizing a media track from JS triggers a call to RealtimeMediaSource::setSize() but that doesn&apos;t
affect the mock video source per-se because it is wrapped in a RealtimeVideoSource. On Apple
platforms the RealtimeVideoSource actually resizes the video frame, but keeps the captureSize
un-modified. So the RealtimeVideoSource::adaptVideoFrame() method is also now implemented for
GStreamer ports.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::setBufferFields):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::resizeTo):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp:
(WebCore::RealtimeVideoSource::adaptVideoFrame):
(WebCore::RealtimeVideoSource::videoFrameAvailable):
* Source/WebCore/platform/mediastream/RealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/253289@main">https://commits.webkit.org/253289@main</a>
</pre>
