### PR TITLE
Check XFB indexed bindings during bufferData calls

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3867,6 +3867,7 @@ webgl/2.0.y/conformance2/context/constants-and-properties-2.html [ Pass ]
 webgl/2.0.y/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html [ Pass ]
 webgl/2.0.y/conformance2/vertex_arrays/vertex-array-object.html [ Pass ]
 webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html [ Pass ]
+webgl/2.0.y/conformance2/transform_feedback/simultaneous_binding.html [ Pass ]
 webgl/1.0.x/conformance/extensions/oes-vertex-array-object.html [ Pass ]
 
 # Explicitly turn on conformance test until all of webgl/2.0.y is enabled

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.h
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.h
@@ -60,6 +60,7 @@ public:
     // synthesize a GL error.
     void setBoundIndexedTransformFeedbackBuffer(const AbstractLocker&, GCGLuint index, WebGLBuffer*);
     bool getBoundIndexedTransformFeedbackBuffer(GCGLuint index, WebGLBuffer** outBuffer);
+    bool hasBoundIndexedTransformFeedbackBuffer(const WebGLBuffer* buffer) { return m_boundIndexedTransformFeedbackBuffers.contains(buffer); }
     
     bool validateProgramForResume(WebGLProgram*) const;
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -77,6 +77,7 @@ public:
     void setVertexAttribEnabled(int index, bool flag);
     const VertexAttribState& getVertexAttribState(int index) { return m_vertexAttribState[index]; }
     void setVertexAttribState(const AbstractLocker&, GCGLuint, GCGLsizei, GCGLint, GCGLenum, GCGLboolean, GCGLsizei, GCGLintptr, bool, WebGLBuffer*);
+    bool hasArrayBuffer(WebGLBuffer* buffer) { return m_vertexAttribState.containsIf([&](auto& item) { return item.bufferBinding == buffer; }); }
     void unbindBuffer(const AbstractLocker&, WebGLBuffer&);
 
     void setVertexAttribDivisor(GCGLuint index, GCGLuint divisor);


### PR DESCRIPTION
#### 4c366686ccd2bb9b9664f4e0a52c241b4ac9bcb8
<pre>
Check XFB indexed bindings during bufferData calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=223358">https://bugs.webkit.org/show_bug.cgi?id=223358</a>

Reviewed by Kimmo Kinnunen.

A buffer which is simultaneously bound to an indexed
TRANSFORM_FEEDBACK_BUFFER binding point in the currently bound
transform feedback object and any other binding point in the WebGL API,
except generic TRANSFORM_FEEDBACK_BUFFER binding point, cannot be used.

Fixes conformance2/transform_feedback/simultaneous_binding.html

Drive-by:
* Skip extra error generation in copyBufferSubData and getBufferSubData.
* Remove deleted buffer from indexed uniform bindings.

* LayoutTests/TestExpectations:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateBufferDataTarget):
(WebCore::WebGL2RenderingContext::copyBufferSubData):
(WebCore::WebGL2RenderingContext::getBufferSubData):
(WebCore::WebGL2RenderingContext::uncacheDeletedBuffer):
* Source/WebCore/html/canvas/WebGLTransformFeedback.h:
(WebCore::WebGLTransformFeedback::hasBoundIndexedTransformFeedbackBuffer):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
(WebCore::WebGLVertexArrayObjectBase::hasArrayBuffer):

Canonical link: <a href="https://commits.webkit.org/253210@main">https://commits.webkit.org/253210@main</a>
</pre>
