### PR TITLE
[GStreamer][MediaStream] Lift malloc restriction for stream collection posting

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -624,6 +624,7 @@ static void webkitMediaStreamSrcEnsureStreamCollectionPosted(WebKitMediaStreamSr
 
     self->priv->streamCollectionPosted.store(true);
     GST_DEBUG_OBJECT(self, "Posting stream collection");
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
     callOnMainThreadAndWait([element = GRefPtr<GstElement>(GST_ELEMENT_CAST(self))] {
         webkitMediaStreamSrcPostStreamCollection(WEBKIT_MEDIA_STREAM_SRC_CAST(element.get()));
     });


### PR DESCRIPTION
#### 81a9899c87f1c419d10e95f0fe563e37501919fa
<pre>
[GStreamer][MediaStream] Lift malloc restriction for stream collection posting
<a href="https://bugs.webkit.org/show_bug.cgi?id=243640">https://bugs.webkit.org/show_bug.cgi?id=243640</a>

Reviewed by Xabier Rodriguez-Calvar.

This is needed when the element is pushing audio buffers.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcEnsureStreamCollectionPosted):

Canonical link: <a href="https://commits.webkit.org/253200@main">https://commits.webkit.org/253200@main</a>
</pre>
