### PR TITLE
Make SQLite use libpas for malloc in NetworkProcess

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -562,12 +562,17 @@ void fastFree(void* object)
 #endif
 }
 
-size_t fastMallocSize(const void*)
+size_t fastMallocSize(const void* p)
 {
+#if BUSE(LIBPAS)
+    return bmalloc::api::mallocSize(p);
+#else
     // FIXME: This is incorrect; best fix is probably to remove this function.
     // Caller currently are all using this for assertion, not to actually check
     // the size of the allocation, so maybe we can come up with something for that.
+    UNUSED_PARAM(p);
     return 1;
+#endif
 }
 
 size_t fastMallocGoodSize(size_t size)

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -36,12 +36,19 @@
 #include <mutex>
 #include <sqlite3.h>
 #include <thread>
+#include <wtf/FastMalloc.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Lock.h>
 #include <wtf/Scope.h>
 #include <wtf/Threading.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringConcatenateNumbers.h>
+
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+// SQLITE_CONFIG_MALLOC requires malloc_size, which only libpas provides (not bmalloc).
+#define ENABLE_SQLITE_FAST_MALLOC BUSE(LIBPAS)
+#endif
 
 namespace WebCore {
 
@@ -75,6 +82,28 @@ static void initializeSQLiteIfNecessary()
 
 static Lock isDatabaseOpeningForbiddenLock;
 static bool isDatabaseOpeningForbidden WTF_GUARDED_BY_LOCK(isDatabaseOpeningForbiddenLock) { false };
+
+void SQLiteDatabase::useFastMalloc()
+{
+#if ENABLE(SQLITE_FAST_MALLOC)
+    int returnCode = sqlite3_config(SQLITE_CONFIG_LOOKASIDE, 0, 0);
+    RELEASE_LOG_ERROR_IF(returnCode != SQLITE_OK, SQLDatabase, "Unable to reduce lookaside buffer size: %d", returnCode);
+
+    static sqlite3_mem_methods fastMallocMethods = {
+        [](int n) { return fastMalloc(n); },
+        fastFree,
+        [](void *p, int n) { return fastRealloc(p, n); },
+        [](void *p) { return static_cast<int>(fastMallocSize(p)); },
+        [](int n) { return static_cast<int>(fastMallocGoodSize(n)); },
+        [](void*) { return SQLITE_OK; },
+        [](void*) { },
+        nullptr
+    };
+
+    returnCode = sqlite3_config(SQLITE_CONFIG_MALLOC, &fastMallocMethods);
+    RELEASE_LOG_ERROR_IF(returnCode != SQLITE_OK, SQLDatabase, "Unable to replace SQLite malloc: %d", returnCode);
+#endif
+}
 
 void SQLiteDatabase::setIsDatabaseOpeningForbidden(bool isForbidden)
 {

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -157,6 +157,8 @@ public:
     void disableThreadingChecks() { }
 #endif
 
+    WEBCORE_EXPORT static void useFastMalloc();
+
     WEBCORE_EXPORT static void setIsDatabaseOpeningForbidden(bool);
 
     WEBCORE_EXPORT void releaseMemory();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -80,6 +80,7 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/RuntimeApplicationChecks.h>
+#include <WebCore/SQLiteDatabase.h>
 #include <WebCore/SWServer.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
@@ -314,6 +315,7 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 #else
     WTF::setProcessPrivileges({ ProcessPrivilege::CanAccessRawCookies, ProcessPrivilege::CanAccessCredentials });
 #endif
+    WebCore::SQLiteDatabase::useFastMalloc();
     WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);
     platformInitializeNetworkProcess(parameters);
 

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -229,5 +229,12 @@ void disableScavenger()
 #endif
 }
 
+#if BUSE(LIBPAS)
+size_t mallocSize(const void* object)
+{
+    return bmalloc_get_allocation_size(const_cast<void*>(object));
+}
+#endif
+
 } } // namespace bmalloc::api
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -189,5 +189,9 @@ BEXPORT void enableMiniMode();
 // Used for debugging only.
 BEXPORT void disableScavenger();
 
+#if BUSE(LIBPAS)
+BEXPORT size_t mallocSize(const void*);
+#endif
+
 } // namespace api
 } // namespace bmalloc


### PR DESCRIPTION
#### 4a3c8a48a35408877f222cf3dab26901a9c7b887
<pre>
Make SQLite use libpas for malloc in NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=243642">https://bugs.webkit.org/show_bug.cgi?id=243642</a>
&lt;rdar://problem/98288137&gt;

Reviewed by Yusuke Suzuki.

This makes SQLite use libpas instead of system malloc in NetworkProcess. It seems to be a ~0.5% win
in Membuster. The wins come from:

1. libpas being more aggressive at returning memory to the OS via MADV_FREE.
2. libpas being fast enough that we can disable the lookaside allocator, which was dirtying 128KB of
   memory per connection. I tested this by running various IDB benchmarks which seemed neutral after
   this making this change.

This requires exporting libpas&apos;s implementation of malloc_size to WTF, since the current
implementation of that function in WTF doesn&apos;t do anything.

* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastMallocSize):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::useFastMalloc):
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::mallocSize):
* Source/bmalloc/bmalloc/bmalloc.h:

Canonical link: <a href="https://commits.webkit.org/253215@main">https://commits.webkit.org/253215@main</a>
</pre>
