### PR TITLE
Unreviewed, revert speculation change in 252675@main

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -381,8 +381,9 @@ public:
         Node* left = node->child1().node();
         Node* right = node->child2().node();
 
+        // FIXME: Using nodeCanSpeculateInt32ForDiv caused JetStream2 regression.
         return Node::shouldSpeculateInt32OrBooleanForArithmetic(left, right)
-            && nodeCanSpeculateInt32ForDiv(node->arithNodeFlags(), node->sourceFor(pass));
+            && node->canSpeculateInt32(node->sourceFor(pass));
     }
     
     bool binaryArithShouldSpeculateInt32(Node* node, PredictionPass pass)


### PR DESCRIPTION
#### 43e4f7c272626a294b7406af6532331cbef19768
<pre>
Unreviewed, revert speculation change in 252675@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243643">https://bugs.webkit.org/show_bug.cgi?id=243643</a>

Caused JetStream2 regression.

* Source/JavaScriptCore/dfg/DFGGraph.h:

Canonical link: <a href="https://commits.webkit.org/253197@main">https://commits.webkit.org/253197@main</a>
</pre>
