### PR TITLE
Virtualize SlotAssignment in preparation for imperative slot API

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2820,7 +2820,7 @@ void Element::childrenChanged(const ChildChange& change)
         case ChildChange::Type::TextInserted:
         case ChildChange::Type::TextRemoved:
         case ChildChange::Type::TextChanged:
-            shadowRoot->didChangeDefaultSlot();
+            shadowRoot->didMutateTextNodesOfShadowHost();
             break;
         case ChildChange::Type::NonContentsChildInserted:
         case ChildChange::Type::NonContentsChildRemoved:

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -250,7 +250,7 @@ void ShadowRoot::addSlotElementByName(const AtomString& name, HTMLSlotElement& s
 {
     ASSERT(&slot.rootNode() == this);
     if (!m_slotAssignment)
-        m_slotAssignment = makeUnique<SlotAssignment>();
+        m_slotAssignment = makeUnique<NamedSlotAssignment>();
 
     return m_slotAssignment->addSlotElementByName(name, slot, *this);
 }

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -101,7 +101,7 @@ public:
     void willRemoveAssignedNode(const Node&);
 
     void didRemoveAllChildrenOfShadowHost();
-    void didChangeDefaultSlot();
+    void didMutateTextNodesOfShadowHost();
     void hostChildElementDidChange(const Element&);
     void hostChildElementDidChangeSlotAttribute(Element&, const AtomString& oldValue, const AtomString& newValue);
 

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -51,7 +51,7 @@ static const AtomString& summarySlotName()
     return summarySlot;
 }
 
-class DetailsSlotAssignment final : public SlotAssignment {
+class DetailsSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) override;
     const AtomString& slotNameForHostChild(const Node&) const override;
@@ -64,7 +64,7 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
         // since we don't know the answer when this function is called inside Element::removedFrom.
         didChangeSlot(summarySlotName(), shadowRoot);
     } else
-        didChangeSlot(SlotAssignment::defaultSlotName(), shadowRoot);
+        didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
 }
 
 const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child) const
@@ -78,7 +78,7 @@ const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child)
         if (&child == childrenOfType<HTMLSummaryElement>(details).first())
             return summarySlotName();
     }
-    return SlotAssignment::defaultSlotName();
+    return NamedSlotAssignment::defaultSlotName();
 }
 
 Ref<HTMLDetailsElement> HTMLDetailsElement::create(const QualifiedName& tagName, Document& document)

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -41,20 +41,20 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLSummaryElement);
 
 using namespace HTMLNames;
 
-class SummarySlotElement final : public SlotAssignment {
+class SummarySlotAssignment final : public NamedSlotAssignment {
 private:
-    void hostChildElementDidChange(const Element&, ShadowRoot& shadowRoot) override
+    void hostChildElementDidChange(const Element&, ShadowRoot& shadowRoot) final
     {
-        didChangeSlot(SlotAssignment::defaultSlotName(), shadowRoot);
+        didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
     }
 
-    const AtomString& slotNameForHostChild(const Node&) const override { return SlotAssignment::defaultSlotName(); }
+    const AtomString& slotNameForHostChild(const Node&) const final { return NamedSlotAssignment::defaultSlotName(); }
 };
 
 Ref<HTMLSummaryElement> HTMLSummaryElement::create(const QualifiedName& tagName, Document& document)
 {
     Ref<HTMLSummaryElement> summary = adoptRef(*new HTMLSummaryElement(tagName, document));
-    summary->addShadowRoot(ShadowRoot::create(document, makeUnique<SummarySlotElement>()));
+    summary->addShadowRoot(ShadowRoot::create(document, makeUnique<SummarySlotAssignment>()));
     return summary;
 }
 


### PR DESCRIPTION
#### 6db28e858de5d9b40275fe51b864e26bb303fca6
<pre>
Virtualize SlotAssignment in preparation for imperative slot API
<a href="https://bugs.webkit.org/show_bug.cgi?id=243649">https://bugs.webkit.org/show_bug.cgi?id=243649</a>

Reviewed by Antti Koivisto.

This patch introduces SlotAssignment abstract interface, which is implemented by NamedSlotAssignment
(or ImperativeSlotAssignment in the future). The interface has mostly pure virtual functions except
two that need to be inlined for NamedSlotAssignment to avoid a perf regression.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::childrenChanged):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::addSlotElementByName):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::slotNameFromAttributeValue):
(WebCore::slotNameFromSlotAttribute):
(WebCore::NamedSlotAssignment::findAssignedSlot): Renamed from SlotAssignment.
(WebCore::NamedSlotAssignment::hasAssignedNodes): Ditto.
(WebCore::NamedSlotAssignment::renameSlotElement): Ditto.
(WebCore::NamedSlotAssignment::addSlotElementByName): Ditto.
(WebCore::NamedSlotAssignment::removeSlotElementByName): Ditto.
(WebCore::NamedSlotAssignment::resolveSlotsAfterSlotMutation): Ditto.
(WebCore::NamedSlotAssignment::slotFallbackDidChange): Ditto.
(WebCore::NamedSlotAssignment::didChangeSlot): Ditto.
(WebCore::NamedSlotAssignment::didRemoveAllChildrenOfShadowHost): Added.
(WebCore::NamedSlotAssignment::didMutateTextNodesOfShadowHost): Added.
(WebCore::NamedSlotAssignment::hostChildElementDidChange): Renamed from SlotAssignment.
(WebCore::NamedSlotAssignment::hostChildElementDidChangeSlotAttribute): Ditto.
(WebCore::NamedSlotAssignment::assignedNodesForSlot): Ditto.
(WebCore::NamedSlotAssignment::willRemoveAssignedNode): Ditto.
(WebCore::NamedSlotAssignment::slotNameForHostChild const): Ditto.
(WebCore::NamedSlotAssignment::findFirstSlotElement): Ditto.
(WebCore::NamedSlotAssignment::assignSlots): Ditto.
(WebCore::NamedSlotAssignment::assignToSlot): Ditto.

* Source/WebCore/dom/SlotAssignment.h:
(WebCore::SlotAssignment): Added.
(WebCore::NamedSlotAssignment): Renamed from SlotAssignment.
(WebCore::NamedSlotAssignment::defaultSlotName): Ditto.
(WebCore::ShadowRoot::didRemoveAllChildrenOfShadowHost): Now call a virtual function.
(WebCore::ShadowRoot::didMutateTextNodesOfShadowHost): Ditto. Renamed from didChangeDefaultSlot.
(WebCore::ShadowRoot::hostChildElementDidChange): Added UNLIKELY.
(WebCore::ShadowRoot::hostChildElementDidChangeSlotAttribute): Now calls a single virtual function
instead of directly calling didChangeSlot and tearing the render tree.

* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::hostChildElementDidChange):
(WebCore::DetailsSlotAssignment::slotNameForHostChild const):

* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::HTMLSummaryElement::create):

Canonical link: <a href="https://commits.webkit.org/253266@main">https://commits.webkit.org/253266@main</a>
</pre>
