### PR TITLE
Put ShadowRootInit.slotAssignment behind a flag

### DIFF
--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -26,5 +26,5 @@
 dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
-    SlotAssignmentMode slotAssignment = "named";
+    [EnabledBySetting=ImperativeSlotAPIEnabled] SlotAssignmentMode slotAssignment = "named";
 };


### PR DESCRIPTION
#### 6587a3af61c6433c2189643d53bdee2f672f18ee
<pre>
Put ShadowRootInit.slotAssignment behind a flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=243654">https://bugs.webkit.org/show_bug.cgi?id=243654</a>

Reviewed by Ryosuke Niwa.

`ShadowRootInit.slotAssignment` should not work if ImperativeSlotAPIEnabled=false.

* Source/WebCore/dom/ShadowRootInit.idl:

Canonical link: <a href="https://commits.webkit.org/253199@main">https://commits.webkit.org/253199@main</a>
</pre>
