### PR TITLE
Add `JSGenerateToNativeObject` attributes to `Text`

### DIFF
--- a/Source/WebCore/dom/Text.idl
+++ b/Source/WebCore/dom/Text.idl
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -19,6 +20,7 @@
 
 [
     CustomToJSObject,
+    JSGenerateToNativeObject,
     Exposed=Window
 ] interface Text : CharacterData {
     [CallWith=CurrentDocument] constructor(optional DOMString data = "");


### PR DESCRIPTION
#### 062294f6788fc6ce5688e47ffe1c23955cacbff1
<pre>
Add `JSGenerateToNativeObject` attributes to `Text`
<a href="https://bugs.webkit.org/show_bug.cgi?id=243655">https://bugs.webkit.org/show_bug.cgi?id=243655</a>

Reviewed by Ryosuke Niwa.

`HTMLSlotElement.assign()` takes `undefined assign((Element or Text)...nodes)`
as its signature.
This requires to call `convertVariadicArguments()` that calls
`JSToWrappedOverloader::toWrapped()` that requires
`WrapperType::toWrapped()`

To fullfill this requirement, we need generate `JSText::toWrapped()` to `Text`
by adding `JSGenerateToNativeObject`.

* Source/WebCore/dom/Text.idl:

Canonical link: <a href="https://commits.webkit.org/253202@main">https://commits.webkit.org/253202@main</a>
</pre>
