### PR TITLE
Non-unified build fixes, earlyish August 2022 edition

### DIFF
--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
@@ -25,12 +25,12 @@
 #pragma once
 
 #include "BufferSource.h"
+#include "ExceptionOr.h"
 #include "Formats.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
 #include <zlib.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -25,11 +25,11 @@
 #pragma once
 
 #include "BufferSource.h"
+#include "ExceptionOr.h"
 #include "Formats.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
-#include <wtf/text/WTFString.h>
 #include <zlib.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -22,6 +22,8 @@
 
 #include "AddEventListenerOptions.h"
 #include "EventNames.h"
+#include "HTMLFrameOwnerElement.h"
+#include "MediaQuery.h"
 #include "MediaQueryListEvent.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/css/StyleMedia.cpp
+++ b/Source/WebCore/css/StyleMedia.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "StyleMedia.h"
 
+#include <JavaScriptCore/ConsoleMessage.h>
+
 namespace WebCore {
 
 StyleMedia::StyleMedia(DOMWindow& window)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -50,6 +50,7 @@
 #include "FrameSelection.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLFormElement.h"
+#include "HTMLFrameOwnerElement.h"
 #include "HitTestResult.h"
 #include "ImageOverlay.h"
 #include "InspectorController.h"

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -22,6 +22,7 @@
 
 #include "FloatQuad.h"
 #include "RenderBlock.h"
+#include "RenderLayer.h"
 #include "RenderSVGInlineInlines.h"
 #include "RenderSVGShape.h"
 #include "SVGElementTypeHelpers.h"

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -36,10 +36,10 @@ class CSSStyleRule;
 class CSSStyleSheet;
 class ExtensionStyleSheets;
 class MediaQueryEvaluator;
-enum class CascadeLevel : uint8_t;
 
 namespace Style {
 
+enum class CascadeLevel : uint8_t;
 class InspectorCSSOMWrappers;
 class Resolver;
 


### PR DESCRIPTION
#### 5309a1f2de7d6901a1836bef2e489ea88d5a22a9
<pre>
Non-unified build fixes, earlyish August 2022 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=243658">https://bugs.webkit.org/show_bug.cgi?id=243658</a>

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/compression/CompressionStreamEncoder.h: Add
  missing wtf/ExceptionOr.h header inclusion, remove the redundant
  wtf/text/WTFString.h one.
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
  Ditto.
* Source/WebCore/css/MediaQueryList.cpp: Add missing
  HTMLFrameOwnerElement.h and MediaQuery.h header inclusions.
* Source/WebCore/css/StyleMedia.cpp: Add missing
  JavaScriptCore/ConsoleMessage.h header inclusion.
* Source/WebCore/page/ContextMenuController.cpp: Add missing
  HTMLFrameOwnerElement.h header inclusion.
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp: Add missing
  RenderLayer.h header inclusion.
* Source/WebCore/style/StyleScopeRuleSets.h: Move forward declaration of
  WebCore::Style::CascadeLevel inside its corresponding namespace.

Canonical link: <a href="https://commits.webkit.org/253205@main">https://commits.webkit.org/253205@main</a>
</pre>
