### PR TITLE
[MSE][GStreamer] Improve logging for TrackQueue and others

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -141,13 +141,13 @@ void SourceBufferPrivateGStreamer::flush(const AtomString& trackId)
     // This is only for on-the-fly reenqueues after appends. When seeking, the seek will do its own flush.
 
     if (!m_playerPrivate.hasAllTracks()) {
-        // Source element has not emitted tracks yet, so we only need to clear the queue.
+        GST_DEBUG("Source element has not emitted tracks yet, so we only need to clear the queue. trackId = '%s'", trackId.string().utf8().data());
         MediaSourceTrackGStreamer* track = m_tracks.get(trackId);
         track->clearQueue();
         return;
     }
 
-    // Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well.
+    GST_DEBUG("Source element has emitted tracks, let it handle the flush, which may cause a pipeline flush as well. trackId = '%s'", trackId.string().utf8().data());
     webKitMediaSrcFlush(m_playerPrivate.webKitMediaSrc(), trackId);
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -545,6 +545,8 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
 {
     ASSERT(isMainThread());
     bool skipFlush = false;
+    GST_DEBUG_OBJECT(stream->source, "Flush requested for stream '%s'. isSeekingFlush = %s",
+        stream->track->trackId().string().utf8().data(), boolForPrinting(isSeekingFlush));
 
     {
         DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
@@ -635,6 +637,9 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         GST_DEBUG_OBJECT(stream->pad.get(), "Starting webKitMediaSrcLoop task and releasing the STREAM_LOCK.");
         gst_pad_start_task(stream->pad.get(), webKitMediaSrcLoop, stream->pad.get(), nullptr);
     }
+
+    GST_DEBUG_OBJECT(stream->source, "Flush request for stream '%s' (isSeekingFlush = %s) satisfied.",
+        stream->track->trackId().string().utf8().data(), boolForPrinting(isSeekingFlush));
 }
 
 void webKitMediaSrcFlush(WebKitMediaSrc* source, const AtomString& streamName)


### PR DESCRIPTION
#### 81357e3265d4833db915bf1b600c880e07f452d3
<pre>
[MSE][GStreamer] Improve logging for TrackQueue and others
<a href="https://bugs.webkit.org/show_bug.cgi?id=243660">https://bugs.webkit.org/show_bug.cgi?id=243660</a>

Reviewed by Xabier Rodriguez-Calvar.

Add more logging code to TrackQueue and to flushing code in
SourceBufferPrivateGStreamer and WebKitMediaSrc.

No changes in functionality.

* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::flush):
* Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.cpp:
(WebCore::TrackQueue::enqueueObject):
(WebCore::TrackQueue::pop):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcStreamFlush):

Canonical link: <a href="https://commits.webkit.org/253207@main">https://commits.webkit.org/253207@main</a>
</pre>
