### PR TITLE
[GStreamer] Build failure with USE(GSTREAMER_MPEGTS)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2065,8 +2065,8 @@ void MediaPlayerPrivateGStreamer::processMpegTsSection(GstMpegtsSection* section
         for (unsigned i = 0; i < pmt->streams->len; ++i) {
             const GstMpegtsPMTStream* stream = static_cast<const GstMpegtsPMTStream*>(g_ptr_array_index(pmt->streams, i));
             if (stream->stream_type == 0x05 || stream->stream_type >= 0x80) {
-                AtomString pid = String::number(stream->pid);
-                auto track = InbandMetadataTextTrackPrivateGStreamer::create(
+                AtomString pid = AtomString::number(stream->pid);
+                RefPtr<InbandMetadataTextTrackPrivateGStreamer> track = InbandMetadataTextTrackPrivateGStreamer::create(
                     InbandTextTrackPrivate::Kind::Metadata, InbandTextTrackPrivate::CueFormat::Data, pid);
 
                 // 4.7.10.12.2 Sourcing in-band text tracks
@@ -2086,14 +2086,14 @@ void MediaPlayerPrivateGStreamer::processMpegTsSection(GstMpegtsSection* section
                     for (unsigned k = 0; k < descriptor->length; ++k)
                         inbandMetadataTrackDispatchType.append(hex(descriptor->data[k], 2));
                 }
-                track->setInBandMetadataTrackDispatchType(inbandMetadataTrackDispatchType.toString());
+                track->setInBandMetadataTrackDispatchType(inbandMetadataTrackDispatchType.toAtomString());
 
                 m_metadataTracks.add(pid, track);
                 m_player->addTextTrack(*track);
             }
         }
     } else {
-        AtomString pid = String::number(section->pid);
+        AtomString pid = AtomString::number(section->pid);
         RefPtr<InbandMetadataTextTrackPrivateGStreamer> track = m_metadataTracks.get(pid);
         if (!track)
             return;


### PR DESCRIPTION
#### 8871637ce2eecc8617dcda7ba2dc53aadf8f2530
<pre>
[GStreamer] Build failure with USE(GSTREAMER_MPEGTS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=243667">https://bugs.webkit.org/show_bug.cgi?id=243667</a>

Reviewed by Alicia Boya Garcia and Philippe Normand.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::processMpegTsSection): Explicitly
use RefPtr&lt;T&gt; instead of auto to ensure that a RefPtr is created for the
instantiated InbandMetadataTextTrackPrivateGStreamer; also use
AtomString::number() to explicitly create strings instead of relying on
the implicit String to AtomString conversion which is no longer
available after 250289@main.

Canonical link: <a href="https://commits.webkit.org/253212@main">https://commits.webkit.org/253212@main</a>
</pre>
