### PR TITLE
[GStreamer] Use makeGStreamerElement in more places

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2815,11 +2815,8 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     g_object_set(m_pipeline.get(), "audio-sink", m_audioSink.get(), "video-sink", createVideoSink(), nullptr);
 
     if (m_shouldPreservePitch) {
-        GstElement* scale = gst_element_factory_make("scaletempo", nullptr);
-
-        if (!scale)
-            GST_WARNING("Failed to create scaletempo");
-        else
+        GstElement* scale = makeGStreamerElement("scaletempo", nullptr);
+        if (scale)
             g_object_set(m_pipeline.get(), "audio-filter", scale, nullptr);
     }
 
@@ -3899,7 +3896,7 @@ GstElement* MediaPlayerPrivateGStreamer::createVideoSink()
 
     GstElement* videoSink = nullptr;
     if (!webkitGstCheckVersion(1, 18, 0)) {
-        m_fpsSink = gst_element_factory_make("fpsdisplaysink", "sink");
+        m_fpsSink = makeGStreamerElement("fpsdisplaysink", "sink");
         if (m_fpsSink) {
             g_object_set(m_fpsSink.get(), "silent", TRUE , nullptr);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -50,8 +50,8 @@ GStreamerAudioCapturer::GStreamerAudioCapturer()
 GstElement* GStreamerAudioCapturer::createConverter()
 {
     auto* bin = gst_bin_new(nullptr);
-    auto* audioconvert = gst_element_factory_make("audioconvert", nullptr);
-    auto* audioresample = gst_element_factory_make("audioresample", nullptr);
+    auto* audioconvert = makeGStreamerElement("audioconvert", nullptr);
+    auto* audioresample = makeGStreamerElement("audioresample", nullptr);
     gst_bin_add_many(GST_BIN_CAST(bin), audioconvert, audioresample, nullptr);
     gst_element_link(audioconvert, audioresample);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -68,9 +68,9 @@ GstElement* GStreamerVideoCapturer::createSource()
 GstElement* GStreamerVideoCapturer::createConverter()
 {
     auto* bin = gst_bin_new(nullptr);
-    auto* videoscale = gst_element_factory_make("videoscale", "videoscale");
-    auto* videoconvert = gst_element_factory_make("videoconvert", nullptr);
-    auto* videorate = gst_element_factory_make("videorate", "videorate");
+    auto* videoscale = makeGStreamerElement("videoscale", "videoscale");
+    auto* videoconvert = makeGStreamerElement("videoconvert", nullptr);
+    auto* videorate = makeGStreamerElement("videorate", "videorate");
 
     // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/issues/97#note_56575
     g_object_set(videorate, "drop-only", 1, "average-period", 1, nullptr);
@@ -85,7 +85,7 @@ GstElement* GStreamerVideoCapturer::createConverter()
         auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
         g_object_set(m_videoSrcMIMETypeFilter.get(), "caps", caps.get(), nullptr);
 
-        auto* decodebin = gst_element_factory_make("decodebin3", nullptr);
+        auto* decodebin = makeGStreamerElement("decodebin3", nullptr);
         gst_bin_add_many(GST_BIN_CAST(bin), m_videoSrcMIMETypeFilter.get(), decodebin, nullptr);
         gst_element_link(m_videoSrcMIMETypeFilter.get(), decodebin);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -22,6 +22,7 @@
 #if USE(GSTREAMER_WEBRTC)
 #include "RealtimeIncomingSourceGStreamer.h"
 
+#include "GStreamerCommon.h"
 #include <gst/app/gstappsink.h>
 #include <wtf/text/WTFString.h>
 
@@ -65,7 +66,7 @@ void RealtimeIncomingSourceGStreamer::registerClient()
 {
     GST_DEBUG("Registering new client");
     auto* queue = gst_element_factory_make("queue", nullptr);
-    auto* sink = gst_element_factory_make("appsink", nullptr);
+    auto* sink = makeGStreamerElement("appsink", nullptr);
     g_object_set(sink, "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
     g_signal_connect_swapped(sink, "new-sample", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* self, GstElement* sink) -> GstFlowReturn {
         auto sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -23,6 +23,7 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "GStreamerAudioCaptureSource.h"
+#include "GStreamerCommon.h"
 #include <wtf/text/StringToIntegerConversion.h>
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
@@ -43,8 +44,8 @@ RealtimeOutgoingAudioSourceGStreamer::RealtimeOutgoingAudioSourceGStreamer(Ref<M
     for (auto& [encodingName, clockRate] : encodings)
         gst_caps_append_structure(m_allowedCaps.get(), gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name", G_TYPE_STRING, encodingName, "clock-rate", G_TYPE_INT, clockRate, nullptr));
 
-    m_audioconvert = gst_element_factory_make("audioconvert", nullptr);
-    m_audioresample = gst_element_factory_make("audioresample", nullptr);
+    m_audioconvert = makeGStreamerElement("audioconvert", nullptr);
+    m_audioresample = makeGStreamerElement("audioresample", nullptr);
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_audioconvert.get(), m_audioresample.get(), nullptr);
     setSource(WTFMove(source));
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "GStreamerCommon.h"
 #include "GStreamerVideoCaptureSource.h"
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
@@ -34,9 +35,9 @@ RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer(Ref<M
 {
     registerWebKitGStreamerElements();
 
-    m_videoConvert = gst_element_factory_make("videoconvert", nullptr);
+    m_videoConvert = makeGStreamerElement("videoconvert", nullptr);
 
-    m_videoFlip = gst_element_factory_make("videoflip", nullptr);
+    m_videoFlip = makeGStreamerElement("videoflip", nullptr);
     gst_util_set_object_arg(G_OBJECT(m_videoFlip.get()), "method", "automatic");
 
     m_encoder = gst_element_factory_make("webrtcvideoencoder", nullptr);


### PR DESCRIPTION
#### 30ec4a7da2ed391580b109cbae2595e4b04652b3
<pre>
[GStreamer] Use makeGStreamerElement in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=243669">https://bugs.webkit.org/show_bug.cgi?id=243669</a>

Reviewed by Philippe Normand.

makeGStreamerElement() is supposed to be used when constructing
GStreamer elements other than those specific to WebKit or part of the
GStreamer core elements.

This patch fixes all calls to gst_element_factory_make() I found where
that was the case.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSink):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::createConverter):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::createConverter):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::RealtimeOutgoingAudioSourceGStreamer):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):

Canonical link: <a href="https://commits.webkit.org/253420@main">https://commits.webkit.org/253420@main</a>
</pre>
