### PR TITLE
[PlayStation] Fix build after 253180@main

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -668,7 +668,7 @@ inline Vector<RefPtr<AXCoreObject>> AXObjectCache::objectsForIDs(const Vector<AX
 inline void AXObjectCache::passwordNotificationPostTimerFired() { }
 inline void AXObjectCache::performDeferredCacheUpdate() { }
 inline void AXObjectCache::postLiveRegionChangeNotification(AccessibilityObject*) { }
-inline void AXObjectCache::postNotification(AXCoreObject*, Document*, AXNotification, PostTarget) { }
+inline void AXObjectCache::postNotification(AccessibilityObject*, Document*, AXNotification, PostTarget) { }
 inline void AXObjectCache::postNotification(Node*, AXNotification, PostTarget) { }
 inline void AXObjectCache::postNotification(RenderObject*, AXNotification, PostTarget) { }
 inline void AXObjectCache::postPlatformNotification(AXCoreObject*, AXNotification) { }


### PR DESCRIPTION
#### 796cd23e491a4a46053f520bfe2427b41353edcb
<pre>
[PlayStation] Fix build after 253180@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243676">https://bugs.webkit.org/show_bug.cgi?id=243676</a>

Unreviewed build fix.

* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::postNotification):

Canonical link: <a href="https://commits.webkit.org/253222@main">https://commits.webkit.org/253222@main</a>
</pre>
