### PR TITLE
Disable PDF.js built-in findbar

### DIFF
--- a/Source/WebCore/Modules/pdfjs-extras/cocoa/style.css
+++ b/Source/WebCore/Modules/pdfjs-extras/cocoa/style.css
@@ -185,66 +185,8 @@ body {
     outline-offset: 2px;
 }
 
-/* Restyle the findbar */
+/* Remove the PDF.js findbar */
 
 #findbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: row-reverse;
-    background: var(--body-bg-color);
-    border-radius: 0;
-    box-shadow: none;
-
-    --main-color: rgba(249, 249, 250, 1);
-
-    --field-color: inherit;
-    --field-bg-color: rgba(0, 0, 0, 0.1);
-    --field-border-color: rgba(255,255,255,0.45);
-    --findbar-nextprevious-btn-bg-color: transparent;
-
-    --toggled-btn-color: rgba(255, 255, 255, 1);
-    --toggled-btn-bg-color: rgba(0, 0, 0, 0.3);
-    --button-hover-color: rgba(102, 102, 103, 1);
-    --toggled-hover-active-btn-color: rgba(0, 0, 0, 0.4);
-
-    --toolbar-icon-bg-color: rgba(255, 255, 255, 1);
-    --toolbar-icon-hover-bg-color: rgba(255, 255, 255, 1);
-}
-
-#findbar:not(.hidden) ~ #viewerContainer {
-    top: 32px;
-}
-
-#findbar::before,
-#findbar::after {
     display: none;
-}
-
-#findbarOptionsTwoContainer {
-    display: contents;
-}
-
-#findResultsCount,
-#findMsg {
-    background-color: transparent !important;
-    color: inherit !important;
-}
-
-#findbar .splitToolbarButton > .toolbarButton::before {
-    rotate: -90deg;
-    top: 4px;
-}
-
-#findInput:focus {
-    border-color: rgba(0, 103, 244, 0.48);
-    outline: 2px solid rgba(0, 103, 244, 0.48);
-}
-
-#findInput[data-status="notFound"] {
-    background: var(--field-bg-color);
-    color: var(--field-color);
 }

--- a/Source/WebCore/Modules/pdfjs-extras/content-script.js
+++ b/Source/WebCore/Modules/pdfjs-extras/content-script.js
@@ -23,6 +23,12 @@
  */
 
 const PDFJSContentScript = {
+    overrideSettings() {
+        // Disable the findbar provided by PDF.js
+        delete PDFViewerApplication.supportsIntegratedFind;
+        PDFViewerApplication.supportsIntegratedFind = true;
+    },
+
     setPageMode({ pages, continuous }) {
         PDFViewerApplication.pdfViewer.spreadMode = pages == "two" ? 1 : 0;
 
@@ -40,6 +46,8 @@ const PDFJSContentScript = {
     },
 
     init() {
+        this.overrideSettings();
+
         this.setPageMode({ pages: "single", continuous: true });
 
         window.addEventListener("message", (event) => {


### PR DESCRIPTION
#### cc7b06259688a71f2067e4fbabbbed0ec039781f
<pre>
Disable PDF.js built-in findbar
<a href="https://bugs.webkit.org/show_bug.cgi?id=237045">https://bugs.webkit.org/show_bug.cgi?id=237045</a>
&lt;rdar://89301856&gt;

Reviewed by Brent Fulgham.

* Source/WebCore/Modules/pdfjs-extras/cocoa/style.css:
(#findbar):
(#findbar:not(.hidden) ~ #viewerContainer): Deleted.
(#findbar::before,): Deleted.
(#findbarOptionsTwoContainer): Deleted.
(#findResultsCount,): Deleted.
(#findbar .splitToolbarButton &gt; .toolbarButton::before): Deleted.
(#findInput:focus): Deleted.
(#findInput[data-status=&quot;notFound&quot;]): Deleted.
* Source/WebCore/Modules/pdfjs-extras/content-script.js:
(const.PDFJSContentScript.overrideSettings):
(const.PDFJSContentScript.init):

Canonical link: <a href="https://commits.webkit.org/253226@main">https://commits.webkit.org/253226@main</a>
</pre>
