### PR TITLE
Fix unverified exception in JSONPPathEntryTypeCall

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -902,8 +902,9 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
             if (JSONPPath.size() == 1 && JSONPPath.last().m_type != JSONPPathEntryTypeLookup) {
                 RELEASE_ASSERT(baseObject == globalObject);
                 JSGlobalLexicalEnvironment* scope = globalObject->globalLexicalEnvironment();
-                if (scope->hasProperty(globalObject, ident)) {
-                    RETURN_IF_EXCEPTION(throwScope, JSValue());
+                bool hasProperty = scope->hasProperty(globalObject, ident);
+                RETURN_IF_EXCEPTION(throwScope, JSValue());
+                if (hasProperty) {
                     PropertySlot slot(scope, PropertySlot::InternalMethodType::Get);
                     JSGlobalLexicalEnvironment::getOwnPropertySlot(scope, globalObject, ident, slot);
                     if (slot.getValue(globalObject, ident) == jsTDZValue())


### PR DESCRIPTION
#### 6f10652c4e36c36dbb79c8f9aaed8b51bcdcb8ae
<pre>
Fix unverified exception in JSONPPathEntryTypeCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=243674">https://bugs.webkit.org/show_bug.cgi?id=243674</a>
rdar://98326554

Reviewed by Alexey Shvayka.

Since hasProperty might throw an exception, we need to handle the exception in both
branches before proceeding.

* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):

Canonical link: <a href="https://commits.webkit.org/253233@main">https://commits.webkit.org/253233@main</a>
</pre>
