### PR TITLE
[macOS] Reject getDisplayMedia prompt if system picker times out

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -66,6 +66,7 @@ private:
     Vector<RetainPtr<SCContentSharingSession>> m_pendingCaptureSessions;
     RetainPtr<WebDisplayMediaPromptHelper> m_promptHelper;
     CompletionHandler<void(std::optional<CaptureDevice>)> m_completionHandler;
+    std::unique_ptr<RunLoop::Timer<ScreenCaptureKitSharingSessionManager>> m_promptWatchdogTimer;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bbf09215e01bd134a9a834e27bcb9f677928029a
<pre>
[macOS] Reject getDisplayMedia prompt if system picker times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=243679">https://bugs.webkit.org/show_bug.cgi?id=243679</a>
&lt;rdar://98194903&gt;

Reviewed by Jer Noble.

Set a 60 second timeout when invoking the ScreenCaptureKit system picker, fail capture if
if it fires.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::pickerCanceledForSession): Clear the
timer. Drive-by: remove the session from the pending list.
(WebCore::ScreenCaptureKitSharingSessionManager::sessionDidEnd): Add logging.
(WebCore::ScreenCaptureKitSharingSessionManager::sessionDidChangeContent): Clear the
timer. Add logging.
(WebCore::ScreenCaptureKitSharingSessionManager::promptForGetDisplayMedia): Set timer,
cancel session if it fires.
(WebCore::ScreenCaptureKitSharingSessionManager::takeSharingSessionForFilter): Add logging.

Canonical link: <a href="https://commits.webkit.org/253260@main">https://commits.webkit.org/253260@main</a>
</pre>
