### PR TITLE
[GTK4] Update scrolling speed (again)

### DIFF
--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -42,6 +42,11 @@ namespace WebKit {
 
 using namespace WebCore;
 
+#if GTK_CHECK_VERSION(4, 7, 0)
+// Keep in sync with https://gitlab.gnome.org/GNOME/gtk/-/blob/493660a296af3b8a140714988ddece4199818a04/gtk/gtkscrolledwindow.c#L204
+static const double gtkScrollDeltaMultiplier = 2.5;
+#endif
+
 static inline bool isGdkKeyCodeFromKeyPad(unsigned keyval)
 {
     return keyval >= GDK_KEY_KP_Space && keyval <= GDK_KEY_KP_9;
@@ -318,7 +323,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const 
         || gdk_scroll_event_get_unit(const_cast<GdkEvent*>(event)) != GDK_SCROLL_UNIT_WHEEL;
 
     if (hasPreciseScrollingDeltas)
-        delta = wheelTicks;
+        delta = wheelTicks.scaled(gtkScrollDeltaMultiplier);
     else
         delta = wheelTicks.scaled(step);
 #else


### PR DESCRIPTION
#### 42bf19e8a470e05aa1028d6b94d8ea0eba620050
<pre>
[GTK4] Update scrolling speed (again)
<a href="https://bugs.webkit.org/show_bug.cgi?id=243683">https://bugs.webkit.org/show_bug.cgi?id=243683</a>

Reviewed by Michael Catanzaro.

Just recently we removed a multiplier from GTK scrolling deltas. However,
just recently GTK added another one:
- <a href="https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4929">https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4929</a>
- <a href="https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4933">https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4933</a>

So introduce a new one and set it to match the GTK value.

* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):

Canonical link: <a href="https://commits.webkit.org/253236@main">https://commits.webkit.org/253236@main</a>
</pre>
