### PR TITLE
readonly attribute should only apply on certain input types

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt
@@ -53,15 +53,15 @@ PASS [INPUT in TIME status] Must be barred from the constraint validation if it 
 PASS [INPUT in TIME status] The willValidate attribute must be false if it has a datalist ancestor
 PASS [INPUT in COLOR status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in COLOR status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in COLOR status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in COLOR status] Must be barred from the constraint validation if it is readonly
 PASS [INPUT in COLOR status] The willValidate attribute must be false if it has a datalist ancestor
 PASS [INPUT in FILE status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in FILE status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in FILE status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in FILE status] Must be barred from the constraint validation if it is readonly
 PASS [INPUT in FILE status] The willValidate attribute must be false if it has a datalist ancestor
 PASS [INPUT in SUBMIT status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in SUBMIT status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in SUBMIT status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in SUBMIT status] Must be barred from the constraint validation if it is readonly
 PASS [INPUT in SUBMIT status] The willValidate attribute must be false if it has a datalist ancestor
 PASS [BUTTON in SUBMIT status] Must be barred from the constraint validation
 PASS [BUTTON in SUBMIT status] The willValidate attribute must be true if an element is mutable

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate.html
@@ -41,8 +41,7 @@
     },
     //If an element is disabled, it is barred from constraint validation.
     //The willValidate attribute must be true if an element is mutable
-    //If the readonly attribute is specified on an INPUT element, the element is barred from constraint validation
-    //(with the assumption that the readonly attribute applies).
+    //If the readonly attribute is specified on an INPUT element, the element is barred from constraint validation.
     {
       tag: "input",
       types: ["text", "search", "tel", "url", "email", "password", "datetime-local", "date", "month", "week", "time"],
@@ -53,14 +52,14 @@
         {conditions: {disabled: false, readOnly: false}, expected: false, name: "[target] The willValidate attribute must be false if it has a datalist ancestor", ancestor: "datalist"},
       ]
     },
-    //In the following cases, the readonly attribute does not apply.
+    //In the following cases, the readonly attribute does not apply, however we should still bar the element from constraint validation.
     {
       tag: "input",
       types: ["color", "file", "submit"],
       testData: [
         {conditions: {disabled: true}, expected: false, name: "[target] Must be barred from the constraint validation if it is disabled"},
         {conditions: {disabled: false, readOnly: false}, expected: true, name: "[target] The willValidate attribute must be true if an element is mutable"},
-        {conditions: {readOnly: true}, expected: true, name: "[target] Must be not barred from the constraint validation even if it is readonly"},
+        {conditions: {readOnly: true}, expected: false, name: "[target] Must be barred from the constraint validation if it is readonly"},
         {conditions: {disabled: false, readOnly: false}, expected: false, name: "[target] The willValidate attribute must be false if it has a datalist ancestor", ancestor: "datalist"},
       ]
     },

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt
@@ -53,15 +53,15 @@ PASS [INPUT in TIME status] Must be barred from the constraint validation if it 
 FAIL [INPUT in TIME status] The willValidate attribute must be false if it has a datalist ancestor assert_false: The willValidate attribute should be false. expected false got true
 PASS [INPUT in COLOR status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in COLOR status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in COLOR status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in COLOR status] Must be barred from the constraint validation if it is readonly
 FAIL [INPUT in COLOR status] The willValidate attribute must be false if it has a datalist ancestor assert_false: The willValidate attribute should be false. expected false got true
 PASS [INPUT in FILE status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in FILE status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in FILE status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in FILE status] Must be barred from the constraint validation if it is readonly
 FAIL [INPUT in FILE status] The willValidate attribute must be false if it has a datalist ancestor assert_false: The willValidate attribute should be false. expected false got true
 PASS [INPUT in SUBMIT status] Must be barred from the constraint validation if it is disabled
 PASS [INPUT in SUBMIT status] The willValidate attribute must be true if an element is mutable
-FAIL [INPUT in SUBMIT status] Must be not barred from the constraint validation even if it is readonly assert_true: The willValidate attribute should be true. expected true got false
+PASS [INPUT in SUBMIT status] Must be barred from the constraint validation if it is readonly
 FAIL [INPUT in SUBMIT status] The willValidate attribute must be false if it has a datalist ancestor assert_false: The willValidate attribute should be false. expected false got true
 PASS [BUTTON in SUBMIT status] Must be barred from the constraint validation
 PASS [BUTTON in SUBMIT status] The willValidate attribute must be true if an element is mutable

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt
@@ -23,7 +23,7 @@ PASS input[type=url] showPicker() throws when disabled
 PASS input[type=week] showPicker() throws when disabled
 PASS input[type=button] showPicker() doesn't throw when readonly
 PASS input[type=checkbox] showPicker() doesn't throw when readonly
-PASS input[type=color] showPicker() doesn't throw when readonly
+FAIL input[type=color] showPicker() doesn't throw when readonly assert_throws_dom: function "() => { input.showPicker(); }" threw object "InvalidStateError: Input showPicker() cannot be used on immutable controls." that is not a DOMException NotAllowedError: property "code" is equal to 11, expected 0
 PASS input[type=date] showPicker() throws when readonly
 PASS input[type=datetime-local] showPicker() throws when readonly
 PASS input[type=email] showPicker() throws when readonly

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -243,7 +243,7 @@ bool BaseDateAndTimeInputType::shouldRespectListAttribute()
 bool BaseDateAndTimeInputType::valueMissing(const String& value) const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->isRequired() && value.isEmpty();
+    return element()->isMutable() && element()->isRequired() && value.isEmpty();
 }
 
 bool BaseDateAndTimeInputType::isKeyboardFocusable(KeyboardEvent*) const
@@ -288,7 +288,7 @@ void BaseDateAndTimeInputType::setValue(const String& value, bool valueChanged, 
 void BaseDateAndTimeInputType::handleDOMActivateEvent(Event&)
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly() || !element()->renderer() || !UserGestureIndicator::processingUserGesture())
+    if (!element()->isMutable() || !element()->renderer() || !UserGestureIndicator::processingUserGesture())
         return;
 
     if (m_dateTimeChooser)

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -95,9 +95,6 @@ bool ColorInputType::isKeyboardFocusable(KeyboardEvent*) const
 {
     ASSERT(element());
 #if PLATFORM(IOS_FAMILY)
-    if (element()->isReadOnly())
-        return false;
-
     return element()->isTextFormControlFocusable();
 #else
     return false;

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -113,8 +113,10 @@ public:
     void updateValidity();
     void setCustomValidity(const String&) override;
 
-    bool isReadOnly() const { return m_isReadOnly; }
-    bool isDisabledOrReadOnly() const { return isDisabledFormControl() || m_isReadOnly; }
+    virtual bool supportsReadOnly() const { return false; }
+    bool isReadOnly() const { return supportsReadOnly() && m_hasReadOnlyAttribute; }
+    bool isMutable() const { return !isDisabledFormControl() && !isReadOnly(); }
+    void updateReadOnlyState();
 
     WEBCORE_EXPORT String autocomplete() const;
     WEBCORE_EXPORT void setAutocomplete(const AtomString&);
@@ -197,7 +199,7 @@ private:
     bool m_isFocusingWithValidationMessage { false };
 
     unsigned m_disabled : 1;
-    unsigned m_isReadOnly : 1;
+    unsigned m_hasReadOnlyAttribute : 1;
     unsigned m_isRequired : 1;
     unsigned m_valueMatchesRenderer : 1;
     unsigned m_disabledByAncestorFieldset : 1;

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -428,6 +428,7 @@ private:
     void registerForSuspensionCallbackIfNeeded();
     void unregisterForSuspensionCallbackIfNeeded();
 
+    bool supportsReadOnly() const final;
     bool supportsMinLength() const { return isTextType(); }
     bool supportsMaxLength() const { return isTextType(); }
     bool tooShort(StringView, NeedsToCheckDirtyFlag) const;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -545,7 +545,7 @@ HTMLElement* HTMLTextAreaElement::placeholderElement() const
 
 bool HTMLTextAreaElement::matchesReadWritePseudoClass() const
 {
-    return !isDisabledOrReadOnly();
+    return isMutable();
 }
 
 void HTMLTextAreaElement::updatePlaceholderText()

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -86,6 +86,8 @@ private:
     void setNonDirtyValue(const String&, TextControlSetValueSelection);
     void setValueCommon(const String&, TextFieldEventBehavior, TextControlSetValueSelection);
 
+    bool supportsReadOnly() const final { return true; }
+
     bool supportsPlaceholder() const final { return true; }
     HTMLElement* placeholderElement() const final;
     void updatePlaceholderText() final;
@@ -128,7 +130,7 @@ private:
     bool shouldUseInputMethod() final;
     bool matchesReadWritePseudoClass() const final;
 
-    bool valueMissing(const String& value) const { return isRequiredFormControl() && !isDisabledOrReadOnly() && value.isEmpty(); }
+    bool valueMissing(const String& value) const { return isRequiredFormControl() && isMutable() && value.isEmpty(); }
     bool tooShort(StringView, NeedsToCheckDirtyFlag) const;
     bool tooLong(StringView, NeedsToCheckDirtyFlag) const;
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -573,7 +573,7 @@ void HTMLTextFormControlElement::readOnlyStateChanged()
 
 bool HTMLTextFormControlElement::isInnerTextElementEditable() const
 {
-    return !isDisabledOrReadOnly();
+    return isMutable();
 }
 
 void HTMLTextFormControlElement::updateInnerTextElementEditability()

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -138,7 +138,7 @@ HTMLElement* SearchInputType::cancelButtonElement() const
 auto SearchInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return TextFieldInputType::handleKeydownEvent(event);
 
     const String& key = event.keyIdentifier();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -125,7 +125,7 @@ bool TextFieldInputType::isEmptyValue() const
 bool TextFieldInputType::valueMissing(const String& value) const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->isRequired() && value.isEmpty();
+    return element()->isMutable() && element()->isRequired() && value.isEmpty();
 }
 
 void TextFieldInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
@@ -213,7 +213,7 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
 void TextFieldInputType::handleKeydownEventForSpinButton(KeyboardEvent& event)
 {
     ASSERT(element());
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return;
 #if ENABLE(DATALIST_ELEMENT)
     if (m_suggestionPicker)
@@ -766,7 +766,7 @@ void TextFieldInputType::focusAndSelectSpinButtonOwner()
 bool TextFieldInputType::shouldSpinButtonRespondToMouseEvents() const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly();
+    return element()->isMutable();
 }
 
 bool TextFieldInputType::shouldSpinButtonRespondToWheelEvents() const
@@ -781,7 +781,7 @@ bool TextFieldInputType::shouldDrawCapsLockIndicator() const
     if (element()->document().focusedElement() != element())
         return false;
 
-    if (element()->isDisabledOrReadOnly())
+    if (!element()->isMutable())
         return false;
 
     if (element()->hasAutoFillStrongPasswordButton())
@@ -809,7 +809,7 @@ void TextFieldInputType::capsLockStateMayHaveChanged()
 bool TextFieldInputType::shouldDrawAutoFillButton() const
 {
     ASSERT(element());
-    return !element()->isDisabledOrReadOnly() && element()->autoFillButtonType() != AutoFillButtonType::None;
+    return element()->isMutable() && element()->autoFillButtonType() != AutoFillButtonType::None;
 }
 
 void TextFieldInputType::autoFillButtonElementWasClicked()

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -471,7 +471,7 @@ void SliderThumbElement::handleTouchEvent(TouchEvent& touchEvent)
 {
     auto input = hostInput();
     ASSERT(input);
-    if (input->isReadOnly() || input->isDisabledFormControl()) {
+    if (!input->isMutable()) {
         clearExclusiveTouchIdentifier();
         stopDragging();
         touchEvent.setDefaultHandled();

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -319,7 +319,7 @@ std::optional<Style::ElementStyle> SearchFieldCancelButtonElement::resolveCustom
 void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
 {
     RefPtr<HTMLInputElement> input(downcast<HTMLInputElement>(shadowHost()));
-    if (!input || input->isDisabledOrReadOnly()) {
+    if (!input || !input->isMutable()) {
         if (!event.defaultHandled())
             HTMLDivElement::defaultEventHandler(event);
         return;
@@ -345,7 +345,7 @@ void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
 bool SearchFieldCancelButtonElement::willRespondToMouseClickEventsWithEditability(Editability editability) const
 {
     const RefPtr<HTMLInputElement> input = downcast<HTMLInputElement>(shadowHost());
-    if (input && !input->isDisabledOrReadOnly())
+    if (input && input->isMutable())
         return true;
 
     return HTMLDivElement::willRespondToMouseClickEventsWithEditability(editability);


### PR DESCRIPTION
#### af43ca312063d6ce476c3eb23c3755919916001d
<pre>
readonly attribute should only apply on certain input types
<a href="https://bugs.webkit.org/show_bug.cgi?id=240343">https://bugs.webkit.org/show_bug.cgi?id=240343</a>
&lt;rdar://93173726&gt;

Reviewed by Chris Dumez.

We should only apply the readonly attribute on certain input types: <a href="https://html.spec.whatwg.org/multipage/input.html#do-not-apply">https://html.spec.whatwg.org/multipage/input.html#do-not-apply</a>
Except in the constraint validation case (willValidate) for compat reasons, since it affects the :in-range/:out-of-range pseudo-classes, the relevant test has been updated to reflect that.
This also was the resolution of <a href="https://github.com/whatwg/html/issues/8133">https://github.com/whatwg/html/issues/8133</a> in the HTML spec triage meeting.

Also introduce isMutable() which corresponds to the spec concept of mutable form control.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/constraints/form-validation-willValidate-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt: Added.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::valueMissing const):
(WebCore::BaseDateAndTimeInputType::handleDOMActivateEvent):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::isKeyboardFocusable const):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::HTMLFormControlElement):
(WebCore::HTMLFormControlElement::parseAttribute):
(WebCore::HTMLFormControlElement::computeWillValidate const):
* Source/WebCore/html/HTMLFormControlElement.h:
(WebCore::HTMLFormControlElement::supportsReadOnly const):
(WebCore::HTMLFormControlElement::isReadOnly const):
(WebCore::HTMLFormControlElement::isMutable const):
(WebCore::HTMLFormControlElement::isDisabledOrReadOnly const): Deleted.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::supportsReadOnly const):
(WebCore::HTMLInputElement::showPicker):
(WebCore::HTMLInputElement::matchesReadWritePseudoClass const):
(WebCore::HTMLInputElement::createInnerTextStyle):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::matchesReadWritePseudoClass const):
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::isInnerTextElementEditable const):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::handleKeydownEvent):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::valueMissing const):
(WebCore::TextFieldInputType::handleKeydownEventForSpinButton):
(WebCore::TextFieldInputType::shouldSpinButtonRespondToMouseEvents const):
(WebCore::TextFieldInputType::shouldDrawCapsLockIndicator const):
(WebCore::TextFieldInputType::shouldDrawAutoFillButton const):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::handleTouchEvent):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldCancelButtonElement::defaultEventHandler):
(WebCore::SearchFieldCancelButtonElement::willRespondToMouseClickEventsWithEditability const):

Canonical link: <a href="https://commits.webkit.org/253321@main">https://commits.webkit.org/253321@main</a>
</pre>
