### PR TITLE
fast/events/ios/pdf-modifer-key-down-crash.html leaves an unfinished UIScript running

### DIFF
--- a/LayoutTests/fast/events/ios/pdf-modifer-key-down-crash.html
+++ b/LayoutTests/fast/events/ios/pdf-modifer-key-down-crash.html
@@ -7,7 +7,14 @@ if (!window.testRunner)
 else {
     testRunner.dumpAsText();
     testRunner.queueLoad("../..//images/resources/green_rectangle.pdf");
-    testRunner.queueLoadingScript('setTimeout("history.back()", 0); testRunner.runUIScript(`uiController.keyDown("", ["leftCommand"])`, () => {});');
+    testRunner.queueLoadingScript(`
+        (async function() {
+            setTimeout("history.back()", 0);
+            await new Promise(resolve => {
+                testRunner.runUIScript("uiController.keyDown('', ['leftCommand'])", resolve);
+            });
+        })();
+    `);
 } 
 </script>
 </head>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3624,7 +3624,6 @@ webkit.org/b/240579 http/tests/push-api [ Skip ]
 webkit.org/b/240579 http/wpt/push-api [ Skip ]
 
 # These tests finish with unfired UI script callbacks, causing crashes. See webkit.org/b/236794
-fast/events/ios/pdf-modifer-key-down-crash.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html
 imported/w3c/web-platform-tests/html/user-activation/no-activation-thru-escape-key.html


### PR DESCRIPTION
#### c1d267625fe474c6a0f475cfe5ffa34f837f9b9a
<pre>
fast/events/ios/pdf-modifer-key-down-crash.html leaves an unfinished UIScript running
<a href="https://bugs.webkit.org/show_bug.cgi?id=243332">https://bugs.webkit.org/show_bug.cgi?id=243332</a>
&lt;rdar://98164628&gt;

Reviewed by Ryosuke Niwa.

Use async/await in the queued script so that it waits for the runUIScript() to complete.

Also unskip the test.

* LayoutTests/fast/events/ios/pdf-modifer-key-down-crash.html:

Canonical link: <a href="https://commits.webkit.org/253253@main">https://commits.webkit.org/253253@main</a>
</pre>
