### PR TITLE
Non-unified build fixes after 253216@main

### DIFF
--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -27,6 +27,7 @@
 
 #include "PermissionState.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebPermissionControllerProxy.h"
 
+#include "WebPageProxy.h"
 #include "WebPermissionControllerProxyMessages.h"
 #include "WebProcessProxy.h"
 #include <WebCore/ClientOrigin.h>

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -29,13 +29,14 @@
 #include "WebPageProxyIdentifier.h"
 
 namespace WebCore {
-class WebProcessProxy;
 enum class PermissionState : uint8_t;
 struct ClientOrigin;
 struct PermissionDescriptor;
 }
 
 namespace WebKit {
+
+class WebProcessProxy;
 
 class WebPermissionControllerProxy final : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;


### PR DESCRIPTION
#### 8f2328441dc45a7d44b31094e65ca006afae45b7
<pre>
Non-unified build fixes after 253216@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243692">https://bugs.webkit.org/show_bug.cgi?id=243692</a>

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/permissions/PermissionController.h: Add missing
  header.
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp: Add missing
  include.
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h: Fix
  WebProcessProxy forward declaration.

Canonical link: <a href="https://commits.webkit.org/253238@main">https://commits.webkit.org/253238@main</a>
</pre>
