### PR TITLE
Punycode a few more Canadian Aboriginal syllabics characters when mixed with Latin characters

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -95,9 +95,19 @@ template<> bool isLookalikeCharacterOfScriptType<USCRIPT_TAMIL>(UChar32 codePoin
 template<> bool isLookalikeCharacterOfScriptType<USCRIPT_CANADIAN_ABORIGINAL>(UChar32 codePoint)
 {
     switch (codePoint) {
+    case 0x146D: /* CANADIAN SYLLABICS KI */
+    case 0x146F: /* CANADIAN SYLLABICS KO */
+    case 0x1472: /* CANADIAN SYLLABICS KA */
+    case 0x14AA: /* CANADIAN SYLLABICS MA */
+    case 0x157C: /* CANADIAN SYLLABICS NUNAVUT H */
+    case 0x1587: /* CANADIAN SYLLABICS TLHI */
     case 0x15AF: /* CANADIAN SYLLABICS AIVILIK B */
     case 0x15B4: /* CANADIAN SYLLABICS BLACKFOOT WE */
-    case 0x157C: /* CANADIAN SYLLABICS NUNAVUT H */
+    case 0x15C5: /* CANADIAN SYLLABICS CARRIER GHO */
+    case 0x15DE: /* CANADIAN SYLLABICS CARRIER THE */
+    case 0x15E9: /* CANADIAN SYLLABICS CARRIER PO */
+    case 0x15F1: /* CANADIAN SYLLABICS CARRIER GE */
+    case 0x15F4: /* CANADIAN SYLLABICS CARRIER GA */
     case 0x166D: /* CANADIAN SYLLABICS CHI SIGN */
     case 0x166E: /* CANADIAN SYLLABICS FULL STOP */
         return true;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -136,6 +136,26 @@ TEST(WTF_URLExtras, URLExtras_Spoof)
         "xn--a-1fj"_s, // 'a' U+166D
         "xn--a-2fj"_s, // U+166E 'a'
         "xn--a-3fj"_s, // 'a' U+166E
+        "xn--a-rli"_s, // U+146D 'a'
+        "xn--a-sli"_s, // 'a' U+146D
+        "xn--a-vli"_s, // U+146F 'a'
+        "xn--a-wli"_s, // 'a' U+146F
+        "xn--a-1li"_s, // U+1472 'a'
+        "xn--a-2li"_s, // 'a' U+1472
+        "xn--a-8oi"_s, // U+14AA 'a'
+        "xn--a-9oi"_s, // 'a' U+14AA
+        "xn--a-v1i"_s, // U+1587 'a'
+        "xn--a-w1i"_s, // 'a' U+1587
+        "xn--a-f5i"_s, // U+15C5 'a'
+        "xn--a-g5i"_s, // 'a' U+15C5
+        "xn--a-u6i"_s, // U+15DE 'a'
+        "xn--a-v6i"_s, // 'a' U+15DE
+        "xn--a-h7i"_s, // U+15E9 'a'
+        "xn--a-i7i"_s, // 'a' U+15E9
+        "xn--a-x7i"_s, // U+15F1 'a'
+        "xn--a-y7i"_s, // 'a' U+15F1
+        "xn--a-37i"_s, // U+15F4 'a'
+        "xn--a-47i"_s, // 'a' U+15F4
     };
     for (auto& host : punycodedSpoofHosts) {
         auto url = makeString("http://", host, "/").utf8();
@@ -164,9 +184,19 @@ TEST(WTF_URLExtras, URLExtras_NotSpoofed)
     EXPECT_STREQ("https://\u0BE6\u0BE7\u0BE8\u0BE9count/", userVisibleString(literalURL("https://\u0BE6\u0BE7\u0BE8\u0BE9count/")));
 
     // Canadian aboriginal
+    EXPECT_STREQ("https://\u146D\u1401abc/", userVisibleString(literalURL("https://\u146D\u1401abc/")));
+    EXPECT_STREQ("https://\u146F\u1401abc/", userVisibleString(literalURL("https://\u146F\u1401abc/")));
+    EXPECT_STREQ("https://\u1472\u1401abc/", userVisibleString(literalURL("https://\u1472\u1401abc/")));
+    EXPECT_STREQ("https://\u14AA\u1401abc/", userVisibleString(literalURL("https://\u14AA\u1401abc/")));
+    EXPECT_STREQ("https://\u157C\u1401abc/", userVisibleString(literalURL("https://\u157C\u1401abc/")));
+    EXPECT_STREQ("https://\u1587\u1401abc/", userVisibleString(literalURL("https://\u1587\u1401abc/")));
     EXPECT_STREQ("https://\u15AF\u1401abc/", userVisibleString(literalURL("https://\u15AF\u1401abc/")));
     EXPECT_STREQ("https://\u15B4\u1401abc/", userVisibleString(literalURL("https://\u15B4\u1401abc/")));
-    EXPECT_STREQ("https://\u157C\u1401abc/", userVisibleString(literalURL("https://\u157C\u1401abc/")));
+    EXPECT_STREQ("https://\u15C5\u1401abc/", userVisibleString(literalURL("https://\u15C5\u1401abc/")));
+    EXPECT_STREQ("https://\u15DE\u1401abc/", userVisibleString(literalURL("https://\u15DE\u1401abc/")));
+    EXPECT_STREQ("https://\u15E9\u1401abc/", userVisibleString(literalURL("https://\u15E9\u1401abc/")));
+    EXPECT_STREQ("https://\u15F1\u1401abc/", userVisibleString(literalURL("https://\u15F1\u1401abc/")));
+    EXPECT_STREQ("https://\u15F4\u1401abc/", userVisibleString(literalURL("https://\u15F4\u1401abc/")));
     EXPECT_STREQ("https://\u166D\u1401abc/", userVisibleString(literalURL("https://\u166D\u1401abc/")));
     EXPECT_STREQ("https://\u166E\u1401abc/", userVisibleString(literalURL("https://\u166E\u1401abc/")));
 }


### PR DESCRIPTION
#### b64fbc1b4bf78392372c53d1fda02f21af13b8f5
<pre>
Punycode a few more Canadian Aboriginal syllabics characters when mixed with Latin characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=243693">https://bugs.webkit.org/show_bug.cgi?id=243693</a>
rdar://98135919

Reviewed by Tim Horton.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isLookalikeCharacterOfScriptType&lt;USCRIPT_CANADIAN_ABORIGINAL&gt;):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/253241@main">https://commits.webkit.org/253241@main</a>
</pre>
