### PR TITLE
[iOS] -requestAutocorrectionContextWithCompletionHandler: deadlocks when connecting to the GPU Process

### DIFF
--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -125,7 +125,7 @@ RefPtr<GPUProcessConnection> GPUProcessConnection::create(IPC::Connection& paren
     if (!connectionIdentifiers)
         return nullptr;
 
-    parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(connectionIdentifiers->client, getGPUProcessConnectionParameters()), 0);
+    parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(connectionIdentifiers->client, getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     auto instance = adoptRef(*new GPUProcessConnection(WTFMove(connectionIdentifiers->server)));
 #if ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### fb49b3310ad179a20a3fbc3b8088ecd9686ec85b
<pre>
[iOS] -requestAutocorrectionContextWithCompletionHandler: deadlocks when connecting to the GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=243695">https://bugs.webkit.org/show_bug.cgi?id=243695</a>
rdar://98336570

Reviewed by Tim Horton.

After the previous mitigation in 252568@main, iOS telemetry shows that we&apos;re still hitting frequent
hangs underneath this call stack. While 252568@main made it so that we&apos;ll avoid the sync IPC
altogether if the GPU process hasn&apos;t been initialized, it doesn&apos;t address the scenario in which the
GPU process has previously been initialized (and hasn&apos;t idle-exited), but the web process hasn&apos;t yet
established an IPC connection to the GPU process.

This happens because the IPC message to request a connection to the GPU process via the UI process
(using `WebProcessProxy::CreateGPUProcessConnection`) is just a normal asynchronous IPC message.
This means that if the UI process is blocked on a synchronous IPC message back to the web process at
the time of receiving `WebProcessProxy::CreateGPUProcessConnection`, we&apos;ll end up in deadlock since
the incoming IPC message will never be dispatched until we time out when waiting for the
autocorrection context response.

As a speculative fix, this patch adds the `DispatchMessageEvenWhenWaitingForSyncReply` IPC send
option to allow the incoming `CreateGPUProcessConnection` message to be dispatched, even when the
UI process is simultaneously waiting on a sync reply from the web process.

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::create):

Canonical link: <a href="https://commits.webkit.org/253254@main">https://commits.webkit.org/253254@main</a>
</pre>
