### PR TITLE
Remove WKWebsitePoliciesSetCustomHeaderFields

### DIFF
--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -59,7 +59,6 @@ Ref<WebsitePolicies> WebsitePolicies::copy() const
     policies->setWebsiteDataStore(m_websiteDataStore.get());
     policies->setUserContentController(m_userContentController.get());
     policies->setIdempotentModeAutosizingOnlyHonorsPercentages(m_idempotentModeAutosizingOnlyHonorsPercentages);
-    policies->setLegacyCustomHeaderFields(Vector<WebCore::HTTPHeaderField> { m_legacyCustomHeaderFields });
     policies->setCustomHeaderFields(Vector<WebCore::CustomHeaderFields> { m_customHeaderFields });
     policies->setAllowSiteSpecificQuirksToOverrideContentMode(m_allowSiteSpecificQuirksToOverrideContentMode);
     policies->setApplicationNameForDesktopUserAgent(m_applicationNameForDesktopUserAgent);
@@ -85,12 +84,9 @@ void WebsitePolicies::setUserContentController(RefPtr<WebKit::WebUserContentCont
 
 WebKit::WebsitePoliciesData WebsitePolicies::data()
 {
-    bool hasLegacyCustomHeaderFields = legacyCustomHeaderFields().size();
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
-    customHeaderFields.reserveInitialCapacity(this->customHeaderFields().size() + hasLegacyCustomHeaderFields);
+    customHeaderFields.reserveInitialCapacity(this->customHeaderFields().size());
     customHeaderFields.appendVector(this->customHeaderFields());
-    if (hasLegacyCustomHeaderFields)
-        customHeaderFields.uncheckedAppend({ legacyCustomHeaderFields(), { }});
 
     return {
         contentBlockersEnabled(),

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -77,9 +77,6 @@ public:
     void setDeviceOrientationAndMotionAccessState(WebCore::DeviceOrientationOrMotionPermissionState state) { m_deviceOrientationAndMotionAccessState = state; }
 #endif
 
-    const Vector<WebCore::HTTPHeaderField>& legacyCustomHeaderFields() const { return m_legacyCustomHeaderFields; }
-    void setLegacyCustomHeaderFields(Vector<WebCore::HTTPHeaderField>&& fields) { m_legacyCustomHeaderFields = WTFMove(fields); }
-
     const Vector<WebCore::CustomHeaderFields>& customHeaderFields() const { return m_customHeaderFields; }
     void setCustomHeaderFields(Vector<WebCore::CustomHeaderFields>&& fields) { m_customHeaderFields = WTFMove(fields); }
 
@@ -153,7 +150,6 @@ private:
 #if ENABLE(DEVICE_ORIENTATION)
     WebCore::DeviceOrientationOrMotionPermissionState m_deviceOrientationAndMotionAccessState { WebCore::DeviceOrientationOrMotionPermissionState::Prompt };
 #endif
-    Vector<WebCore::HTTPHeaderField> m_legacyCustomHeaderFields;
     Vector<WebCore::CustomHeaderFields> m_customHeaderFields;
     WebKit::WebsitePopUpPolicy m_popUpPolicy { WebKit::WebsitePopUpPolicy::Default };
     RefPtr<WebKit::WebsiteDataStore> m_websiteDataStore;

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -56,27 +56,13 @@ bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef websitePoli
     return toImpl(websitePolicies)->contentBlockersEnabled();
 }
 
-WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef websitePolicies)
+WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef)
 {
-    HashMap<WTF::String, RefPtr<API::Object>> fields;
-    for (const auto& field : toImpl(websitePolicies)->legacyCustomHeaderFields())
-        fields.add(field.name(), API::String::create(field.value()));
-    return toAPI(API::Dictionary::create(WTFMove(fields)).ptr());
+    return nullptr;
 }
 
-WK_EXPORT void WKWebsitePoliciesSetCustomHeaderFields(WKWebsitePoliciesRef websitePolicies, WKDictionaryRef dictionary)
+WK_EXPORT void WKWebsitePoliciesSetCustomHeaderFields(WKWebsitePoliciesRef, WKDictionaryRef)
 {
-    auto keys = adoptWK(WKDictionaryCopyKeys(dictionary));
-    size_t length = WKArrayGetSize(keys.get());
-    Vector<WebCore::HTTPHeaderField> fields;
-    fields.reserveInitialCapacity(length);
-    for (size_t i = 0; i < length; ++i) {
-        WKStringRef name = static_cast<WKStringRef>(WKArrayGetItemAtIndex(keys.get(), i));
-        auto field = WebCore::HTTPHeaderField::create(toImpl(name)->string(), toImpl(static_cast<WKStringRef>(WKDictionaryGetItemForKey(dictionary, name)))->string());
-        if (field && startsWithLettersIgnoringASCIICase(field->name(), "x-"_s))
-            fields.uncheckedAppend(WTFMove(*field));
-    }
-    toImpl(websitePolicies)->setLegacyCustomHeaderFields(WTFMove(fields));
 }
 
 void WKWebsitePoliciesSetAllowedAutoplayQuirks(WKWebsitePoliciesRef websitePolicies, WKWebsiteAutoplayQuirk allowedQuirks)

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebKit/WKBase.h>
+#include <WebKit/WKDeprecated.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,8 +60,8 @@ WK_EXPORT WKWebsitePoliciesRef WKWebsitePoliciesCreate();
 WK_EXPORT bool WKWebsitePoliciesGetContentBlockersEnabled(WKWebsitePoliciesRef);
 WK_EXPORT void WKWebsitePoliciesSetContentBlockersEnabled(WKWebsitePoliciesRef, bool);
 
-WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef);
-WK_EXPORT void WKWebsitePoliciesSetCustomHeaderFields(WKWebsitePoliciesRef, WKDictionaryRef);
+WK_EXPORT WKDictionaryRef WKWebsitePoliciesCopyCustomHeaderFields(WKWebsitePoliciesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKWebsitePoliciesSetCustomHeaderFields(WKWebsitePoliciesRef, WKDictionaryRef) WK_C_API_DEPRECATED;
 
 WK_EXPORT WKWebsiteAutoplayQuirk WKWebsitePoliciesGetAllowedAutoplayQuirks(WKWebsitePoliciesRef);
 WK_EXPORT void WKWebsitePoliciesSetAllowedAutoplayQuirks(WKWebsitePoliciesRef, WKWebsiteAutoplayQuirk);


### PR DESCRIPTION
#### 21027fde1383bfb7471742e6a23d28ceaad4ca91
<pre>
Remove WKWebsitePoliciesSetCustomHeaderFields
<a href="https://bugs.webkit.org/show_bug.cgi?id=243698">https://bugs.webkit.org/show_bug.cgi?id=243698</a>

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::copy const):
(API::WebsitePolicies::data):
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesCopyCustomHeaderFields):
(WKWebsitePoliciesSetCustomHeaderFields):
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[CustomHeaderFieldsDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[CustomHeaderFieldsDelegate webView:startURLSchemeTask:]):
(expectLegacyHeaders): Deleted.

Canonical link: <a href="https://commits.webkit.org/253245@main">https://commits.webkit.org/253245@main</a>
</pre>
