### PR TITLE
Scroll anchoring: naive implementation of selectAnchorElement(), implement updateScrollPosition(), hookup to layout

### DIFF
--- a/LayoutTests/accessibility/visible-character-range-width-changes.html
+++ b/LayoutTests/accessibility/visible-character-range-width-changes.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>

--- a/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
+++ b/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true CSSScrollAnchoringEnabled=false ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/editing/execCommand/insert-line-break-no-scroll.html
+++ b/LayoutTests/editing/execCommand/insert-line-break-no-scroll.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <p>Matching other execCommand identifiers, execCommand("InsertLineBreak") should not scroll the page to make selection visible.</p>
 <p>This test only works in WebKit, as other engines do not implement this command.</p>
 <div contenteditable>a</div>

--- a/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset-2.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset-2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, contentInset.top=150 ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, CSSScrollAnchoringEnabled=false, contentInset.top=150 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
+++ b/LayoutTests/editing/selection/ios/autoscroll-with-top-content-inset.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, contentInset.top=100 ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true, CSSScrollAnchoringEnabled=false, contentInset.top=100 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/dom/Window/window-scroll-arguments.html
+++ b/LayoutTests/fast/dom/Window/window-scroll-arguments.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>

--- a/LayoutTests/fast/dom/horizontal-scrollbar-when-dir-change.html
+++ b/LayoutTests/fast/dom/horizontal-scrollbar-when-dir-change.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useThreadedScrolling=false ] -->
+<!-- webkit-test-runner [ useThreadedScrolling=false CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/dom/vertical-scrollbar-in-rtl-doesnt-fire-onscroll.html
+++ b/LayoutTests/fast/dom/vertical-scrollbar-in-rtl-doesnt-fire-onscroll.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html dir=rtl style="-webkit-writing-mode:vertical-lr">
     <head>

--- a/LayoutTests/fast/dom/vertical-scrollbar-when-dir-change.html
+++ b/LayoutTests/fast/dom/vertical-scrollbar-when-dir-change.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useThreadedScrolling=false ] -->
+<!-- webkit-test-runner [ useThreadedScrolling=false CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
+++ b/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
+++ b/LayoutTests/fast/scrolling/latching/latching-and-wheel-events.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
+++ b/LayoutTests/fast/scrolling/latching/overflow-in-iframe-latching.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/programmatic-document-rtl-scroll.html
+++ b/LayoutTests/fast/scrolling/programmatic-document-rtl-scroll.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html dir="rtl">
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
+++ b/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 
 <html>

--- a/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 
 <html dir="rtl">

--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position.html
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Abs-pos with zero-height static parent. assert_equals: expected 220 but got 120
+PASS Abs-pos with zero-height static parent.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Ancestor changes in document scroller. assert_equals: expected 200 but got 150
+FAIL Ancestor changes in document scroller. assert_equals: expected 150 but got 220
 FAIL Ancestor changes in scrollable <div>. assert_equals: expected 200 but got 150
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchoring combined with scroll bounds clamping in the document. assert_equals: expected 100 but got 1600
+PASS Anchoring combined with scroll bounds clamping in the document.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anonymous-block-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anonymous-block-box-expected.txt
@@ -3,5 +3,5 @@ inserted
 inline
 after
 
-FAIL Anchor selection descent into anonymous block boxes. assert_equals: expected 250 but got 150
+PASS Anchor selection descent into anonymous block boxes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/basic-expected.txt
@@ -1,5 +1,5 @@
 abc
 def
 
-FAIL Minimal scroll anchoring example. assert_equals: expected 250 but got 150
+PASS Minimal scroll anchoring example.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/descend-into-container-with-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/descend-into-container-with-overflow-expected.txt
@@ -1,4 +1,4 @@
 bottom
 
-FAIL Zero-height container with visible overflow. assert_equals: expected 300 but got 200
+PASS Zero-height container with visible overflow.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/image-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/image-001-expected.txt
@@ -2,5 +2,5 @@
 
 
 
-FAIL Anchor selection can select images assert_equals: expected 200 but got 150
+PASS Anchor selection can select images
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inline-block-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inline-block-002-expected.txt
@@ -1,5 +1,5 @@
 
 
 
-FAIL Anchor selection can select empty inline-blocks assert_equals: expected 200 but got 150
+PASS Anchor selection can select empty inline-blocks
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inline-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/inline-block-expected.txt
@@ -2,5 +2,5 @@ abc
 
 def
 
-FAIL Anchor selection descent into inline blocks. assert_equals: expected 200 but got 150
+PASS Anchor selection descent into inline blocks.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/negative-layout-overflow-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor selection accounts for negative positioning. assert_equals: expected 350 but got 250
+PASS Anchor selection accounts for negative positioning.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Position changes in document scroller. assert_equals: expected 225 but got 200
+FAIL Position changes in document scroller. assert_equals: expected 200 but got 175
 FAIL Position changes in scrollable <div>. assert_equals: expected 225 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-ib-split-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-ib-split-expected.txt
@@ -2,5 +2,5 @@ Some title
 Sticky header
 Some actual content.
 
-PASS Scroll offset adjustments are correctly suppressed when changing the position of an inline
+FAIL Scroll offset adjustments are correctly suppressed when changing the position of an inline assert_equals: Element should become and remain fixed expected "fixed" but got "static"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-in-nested-scroll-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-in-nested-scroll-box-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Position changes in document scroller. assert_equals: expected 225 but got 200
+FAIL Position changes in document scroller. assert_equals: expected 200 but got 175
 FAIL Position changes in scrollable <div>. assert_equals: expected 225 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/reading-scroll-forces-anchoring-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/reading-scroll-forces-anchoring-expected.txt
@@ -1,12 +1,5 @@
-CONSOLE MESSAGE: Error: assert_equals: expected 250 but got 150
 abc
 def
 
-Harness Error (FAIL), message = Error: assert_equals: expected 250 but got 150
-
-TIMEOUT Reading scroll position forces scroll anchoring adjustment. Test timed out
-
-Harness Error (FAIL), message = Error: assert_equals: expected 250 but got 150
-
-TIMEOUT Reading scroll position forces scroll anchoring adjustment. Test timed out
+PASS Reading scroll position forces scroll anchoring adjustment.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Horizontal LTR. assert_equals: expected 130 but got 150
+FAIL Horizontal LTR. assert_equals: expected 150 but got 120
 FAIL Horizontal RTL. assert_equals: expected 130 but got 150
 FAIL Vertical-LR LTR. assert_equals: expected 120 but got 150
 FAIL Vertical-LR RTL. assert_equals: expected 120 but got 150

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/subtree-exclusion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/subtree-exclusion-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Subtree exclusion with overflow-anchor. assert_equals: expected 200 but got 50
+FAIL Subtree exclusion with overflow-anchor. assert_equals: expected 200 but got 150
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-expected.txt
@@ -1,4 +1,4 @@
 abc
 
-FAIL Scroll anchoring suppressed when scroll offset is zero. assert_equals: expected 0 but got 10
+PASS Scroll anchoring suppressed when scroll offset is zero.
 

--- a/LayoutTests/jquery/offset.html
+++ b/LayoutTests/jquery/offset.html
@@ -1,2 +1,3 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <script src="resources/helper.js"></script>
 <iframe src="resources/test/index.html?offset"></iframe>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2291,6 +2291,8 @@ webkit.org/b/243515 svg/compositing/outermost-svg-directly-composited-transforme
 webkit.org/b/243515 svg/compositing/outermost-svg-directly-composited-shape-child.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243515 svg/compositing/outermost-svg-directly-composited-group-child.html [ Pass ImageOnlyFailure ]
 
+webkit.org/b/261849 imported/w3c/web-platform-tests/css/cssom-view/position-sticky-root-scroller-with-scroll-behavior.html [ Failure ]
+
 webkit.org/b/243589 [ Debug ] http/wpt/service-workers/update-with-importScripts.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/credentials.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/registration-updateviacache.https.html [ Pass Crash ]

--- a/LayoutTests/scrollingcoordinator/mac/latching/main-frame-back-swipe.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/main-frame-back-swipe.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2351,6 +2351,11 @@ void Document::updateLayout(OptionSet<LayoutOptions> layoutOptions)
     if (layoutOptions.contains(LayoutOptions::RunPostLayoutTasksSynchronously) && view())
         view()->flushAnyPendingPostLayoutTasks();
 
+    if (layoutOptions.contains(LayoutOptions::IgnorePendingStylesheets)) {
+        if (RefPtr frameView = view())
+            frameView->updateScrollAnchoringPositionForScrollableAreas();
+    }
+
     m_ignorePendingStylesheets = oldIgnore;
 }
 
@@ -4634,6 +4639,9 @@ void Document::runScrollSteps()
         }
         if (scrollAnimationsInProgress)
             page()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
+
+        frameView->updateScrollAnchoringElement();
+        frameView->updateScrollAnchoringPositionForScrollableAreas();
     }
 
     // FIXME: The order of dispatching is not specified: https://github.com/WICG/visual-viewport/issues/66.

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -736,6 +736,14 @@ public:
     ScrollbarGutter scrollbarGutterStyle() const final;
     ScrollbarWidth scrollbarWidthStyle() const final;
 
+    void updateScrollAnchoringElement() final;
+    void updateScrollPositionForScrollAnchoringController() final;
+    void invalidateScrollAnchoringElement();
+
+    void dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
+    void queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
+    void updateScrollAnchoringPositionForScrollableAreas();
+
 private:
     explicit LocalFrameView(LocalFrame&);
 
@@ -1017,6 +1025,7 @@ private:
     ScrollPinningBehavior m_scrollPinningBehavior { ScrollPinningBehavior::DoNotPin };
     SelectionRevealMode m_selectionRevealModeForFocusedElement { SelectionRevealMode::DoNotReveal };
     std::unique_ptr<ScrollAnchoringController> m_scrollAnchoringController;
+    ScrollableAreaSet m_scrollableAreasWithScrollAnchoringControllersNeedingUpdate;
 
     bool m_shouldUpdateWhileOffscreen { true };
     bool m_overflowStatusDirty { true };

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -32,21 +32,26 @@ namespace WebCore {
 
 class Element;
 
-class ScrollAnchoringController final {
+class ScrollAnchoringController final : public CanMakeWeakPtr<ScrollAnchoringController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScrollAnchoringController(LocalFrameView& frameView)
         : m_frameView(frameView)
     { }
     void invalidateAnchorElement();
-    void updateScrollPosition();
+    void adjustScrollPositionForAnchoring();
     void selectAnchorElement();
+    void chooseAnchorElement();
+    void updateAnchorElement();
     LocalFrameView& frameView() { return m_frameView; }
 
 private:
     LocalFrameView& m_frameView;
-    CheckedPtr<Element> m_anchorElement;
-    FloatPoint m_lastPositionForAnchorElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_anchorElement;
+    ScrollOffset computeOffset(RenderBox& candidate);
+    ScrollOffset m_lastOffsetForAnchorElement;
+    bool m_midUpdatingScrollPositionForAnchorElement { false };
+    bool m_isQueuedForScrollPositionUpdate { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -410,6 +410,8 @@ public:
     FloatSize deltaForPropagation(const FloatSize&) const;
     WEBCORE_EXPORT virtual float adjustVerticalPageScrollStepForFixedContent(float step);
     virtual bool needsAnimatedScroll() const { return false; }
+    virtual void updateScrollAnchoringElement() { }
+    virtual void updateScrollPositionForScrollAnchoringController() { }
 
 protected:
     WEBCORE_EXPORT ScrollableArea();


### PR DESCRIPTION
#### 6639646de774d4333e28e4288a36c5627ac6388f
<pre>
Scroll anchoring: naive implementation of selectAnchorElement(), implement updateScrollPosition(), hookup to layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=243702">https://bugs.webkit.org/show_bug.cgi?id=243702</a>
&lt;rdar://98695739&gt;

Reviewed by Simon Fraser.

For selectAnchorElement(), select the deepest child element that is within the viewport bounds of the
frame view, or the first fully contined by the viewport bounds. For updateScrollPosition()
calculate the change in offset and set the scroll position of the frame view if necessary.
Finally, in FrameViewLayoutContext::performLayout(), hookup calls to selectAnchorElement()
and updateScrollPosition() in the appropriate area.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::willDoLayout):
(WebCore::FrameView::performPostLayoutTasks):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::invalidateAnchorElement):
(WebCore::ScrollAnchoringController::computeOffset):
(WebCore::ScrollAnchoringController::selectAnchorElement):
(WebCore::ScrollAnchoringController::updateScrollPosition):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/268267@main">https://commits.webkit.org/268267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25e7962b9d6843809d19f3198eeece0267b907c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21953 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17475 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17649 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4587 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21724 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->