### PR TITLE
Revert [253181@main] to re-land 250811@main: Undefined subroutine &Test262::Runner::isWindows"

### DIFF
--- a/Tools/Scripts/do-webcore-rename
+++ b/Tools/Scripts/do-webcore-rename
@@ -31,6 +31,7 @@
 use strict;
 use warnings;
 
+use File::Basename;
 use File::Find;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/make-new-script-test
+++ b/Tools/Scripts/make-new-script-test
@@ -31,6 +31,7 @@ use warnings;
 use FindBin;
 use lib $FindBin::Bin;
 
+use Cwd;
 use File::Basename;
 use Getopt::Long;
 use webkitdirs;

--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -24,6 +24,7 @@
 use strict;
 use warnings;
 use English;
+use File::Basename;
 use File::Copy qw/ move /;
 use File::Temp qw/ tempdir tempfile /;
 use FindBin;

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -32,13 +32,16 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use File::Spec;
+use File::Temp qw(tempdir);
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use JSON::PP;
 use lib $FindBin::Bin;
 use List::Util qw(min max);
 use POSIX;
+use VCSUtils;
 use webkitdirs;
 use Scalar::Util qw(looks_like_number);
 use Text::ParseWords;

--- a/Tools/Scripts/run-regexp-tests
+++ b/Tools/Scripts/run-regexp-tests
@@ -30,6 +30,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/run-sunspider
+++ b/Tools/Scripts/run-sunspider
@@ -26,6 +26,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -29,6 +29,7 @@
 use strict;
 use warnings;
 use Cwd qw(realpath);
+use File::Basename;
 use File::Path qw(make_path);
 use File::Spec;
 use FindBin;

--- a/Tools/Scripts/sunspider-compare-results
+++ b/Tools/Scripts/sunspider-compare-results
@@ -26,6 +26,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use File::Spec;
 use FindBin;
 use Getopt::Long qw(:config pass_through);

--- a/Tools/Scripts/test262/Runner.pm
+++ b/Tools/Scripts/test262/Runner.pm
@@ -45,6 +45,7 @@ use Config;
 use Time::HiRes qw(time);
 use IO::Handle;
 use IO::Select;
+use Pod::Usage;
 use webkitdirs;
 
 my $Bin;

--- a/Tools/Scripts/update-iexploder-cssproperties
+++ b/Tools/Scripts/update-iexploder-cssproperties
@@ -39,6 +39,7 @@ use lib $FindBin::Bin;
 use VCSUtils;
 use webkitdirs;
 
+use File::Basename;
 use File::Spec;
 
 sub generateEntityListFromFile($);

--- a/Tools/Scripts/update-webkit-libs-jhbuild
+++ b/Tools/Scripts/update-webkit-libs-jhbuild
@@ -19,6 +19,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 use warnings;
+use Cwd qw(realpath);
+use Digest::MD5 qw(md5_hex);
+use File::Basename;
 use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;

--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -30,6 +30,7 @@
 # A script to expose WebKit's build directory detection logic to non-perl scripts.
 
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long;
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -29,6 +29,8 @@
 
 # Module to share code to get to WebKit directories.
 
+package webkitdirs;
+
 use strict;
 use version;
 use warnings;
@@ -64,42 +66,142 @@ BEGIN {
        &XcodeOptionString
        &XcodeOptionStringNoConfig
        &XcodeOptions
+       &XcodeSDKPath
        &XcodeStaticAnalyzerOption
        &appDisplayNameFromBundle
        &appendToEnvironmentVariableList
        &archCommandLineArgumentsForRestrictedEnvironmentVariables
+       &architecture
+       &architecturesForProducts
+       &argumentsForConfiguration
+       &asanIsEnabled
        &availableXcodeSDKs
        &baseProductDir
+       &buildCMakeProjectOrExit
+       &buildVisualStudioProject
+       &buildXCodeProject
+       &buildXcodeScheme
+       &builtDylibPathForName
+       &canUseNinja
        &chdirWebKit
+       &checkForArgumentAndRemoveFromARGV
+       &checkForArgumentAndRemoveFromARGVGettingValue
+       &checkForArgumentAndRemoveFromArrayRef
+       &checkForArgumentAndRemoveFromArrayRefGettingValue
        &checkFrameworks
+       &checkRequiredSystemConfig
        &cmakeArgsFromFeatures
+       &configuration
+       &configuredXcodeWorkspace
+       &coverageIsEnabled
+       &currentPerlPath
        &currentSVNRevision
+       &debugMiniBrowser
        &debugSafari
+       &debugWebKitTestRunner
+       &determineCurrentSVNRevision
+       &determineIsWin64
+       &determineXcodeSDK
        &executableProductDir
-       &extractNonHostConfiguration
+       &exitStatus
+       &extractNonMacOSHostConfiguration
+       &forceOptimizationLevel
+       &formatBuildTime
+       &generateBuildSystemFromCMakeProject
+       &getJhbuildPath
+       &getJhbuildModulesetName
+       &inFlatpakSandbox
        &iosVersion
+       &isARM64
+       &isAnyWindows
+       &isAppleCocoaWebKit
+       &isAppleMacWebKit
+       &isAppleWebKit
+       &isAppleWinWebKit
+       &isCMakeBuild
+       &isCygwin
+       &isDebianBased
+       &isFedoraBased
+       &isEmbeddedWebKit
+       &isFTW
+       &isGenerateProjectOnly
+       &isGtk
+       &isIOSWebKit
+       &isInspectorFrontend
+       &isJSCOnly
+       &isLinux
+       &isPlayStation
+       &isWPE
+       &isWinCairo
+       &isWin64
+       &isWindows
+       &isX86_64
+       &jscPath
+       &jscProductDir
+       &launcherName
+       &launcherPath
+       &ltoMode
+       &markBaseProductDirectoryAsCreatedByXcodeBuildSystem
+       &maxCPULoad
+       &nativeArchitecture
        &nmPath
+       &numberOfCPUs
+       &osXVersion
+       &overrideConfiguredXcodeWorkspace
+       &parseAvailableXcodeSDKs
+       &passedArchitecture
        &passedConfiguration
+       &plistPathFromBundle
+       &portName
        &prependToEnvironmentVariableList
        &printHelpAndExitForRunAndDebugWebKitAppIfNeeded
        &productDir
+       &prohibitUnknownPort
+       &relativeScriptsDir
+       &removeCMakeCache
+       &runGitUpdate
        &runIOSWebKitApp
+       &runInFlatpak
+       &runInFlatpakIfAvailable
        &runMacWebKitApp
+       &runMiniBrowser
+       &runSafari
+       &runSvnUpdateAndResolveChangeLogs
+       &runWebKitTestRunner
        &safariPath
        &sdkDirectory
        &sdkPlatformDirectory
+       &setArchitecture
+       &setBaseProductDir
        &setConfiguration
+       &setConfigurationProductDir
+       &setPathForRunningWebKitApp
+       &setUpGuardMallocIfNeeded
+       &setXcodeSDK
+       &setupAppleWinEnv
        &setupMacWebKitEnvironment
        &setupUnixWebKitEnvironment
        &sharedCommandLineOptions
        &sharedCommandLineOptionsUsage
        &shouldUseFlatpak
-       &runInFlatpak
        &sourceDir
+       &splitVersionString
+       &tsanIsEnabled
+       &ubsanIsEnabled
+       &willUseAppleTVDeviceSDK
+       &willUseAppleTVSimulatorSDK
        &willUseIOSDeviceSDK
        &willUseIOSSimulatorSDK
+       &willUseWatchDeviceSDK
+       &willUseWatchSimulatorSDK
+       &winVersion
+       &wrapperPrefixIfNeeded
+       &xcodeSDK
+       &xcodeSDKPlatformName
        DO_NOT_USE_OPEN_COMMAND
+       Mac
        USE_OPEN_COMMAND
+       iOS
    );
    %EXPORT_TAGS = ( );
    @EXPORT_OK   = ();
@@ -1105,7 +1207,7 @@ sub XcodeOptions
     push @options, "ARCHS=$architecture" if $architecture;
     push @options, "SDKROOT=$xcodeSDK" if $xcodeSDK;
 
-    my @features = getFeatureOptionList();
+    my @features = webkitperl::FeatureList::getFeatureOptionList();
     foreach (@features) {
         if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
             push @options, "$_->{define}=";

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -29,6 +29,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use FindBin;
 use Getopt::Long qw(:config pass_through);
 use lib $FindBin::Bin;

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -31,12 +31,14 @@
 # * A feature enabled here but not WebKitFeatures.cmake is EXPERIMENTAL.
 # * A feature enabled in WebKitFeatures.cmake but not here is a BUG.
 
+package webkitperl::FeatureList;
+
 use strict;
 use warnings;
 
 use FindBin;
 use lib $FindBin::Bin;
-use webkitdirs;
+use autouse 'webkitdirs' => qw(prohibitUnknownPort);
 
 BEGIN {
    use Exporter   ();
@@ -573,7 +575,7 @@ my @features = (
 
 sub getFeatureOptionList()
 {
-    prohibitUnknownPort();
+    webkitdirs::prohibitUnknownPort();
     return @features;
 }
 


### PR DESCRIPTION
#### 2e6cf95b1034656c4ede516fbe9274e4cf7a9375
<pre>
Revert [253181@main] to re-land 250811@main: Undefined subroutine &amp;Test262::Runner::isWindows&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243454">https://bugs.webkit.org/show_bug.cgi?id=243454</a>

Unreviewed build fix.

* Tools/Scripts/do-webcore-rename:
* Tools/Scripts/make-new-script-test:
* Tools/Scripts/package-root:
* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-regexp-tests:
* Tools/Scripts/run-sunspider:
* Tools/Scripts/set-webkit-configuration:
* Tools/Scripts/sunspider-compare-results:
* Tools/Scripts/test262/Runner.pm:
* Tools/Scripts/update-iexploder-cssproperties:
* Tools/Scripts/update-webkit-libs-jhbuild:
* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitdirs.pm:
(XcodeOptions):
* Tools/Scripts/webkitperl/BuildSubproject.pm:
* Tools/Scripts/webkitperl/FeatureList.pm:
(getFeatureOptionList):

Canonical link: <a href="https://commits.webkit.org/253243@main">https://commits.webkit.org/253243@main</a>
</pre>
