### PR TITLE
estimatedBackgroundColorForRange for interaction regions can be very expensive

### DIFF
--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -281,7 +281,6 @@ private:
         { "constrain"_s, "Constrain to Regions"_s, true },
         { "clip"_s, "Clip to Regions"_s, true },
         { "wash"_s, "Draw Wash"_s, false },
-        { "contextualColor"_s, "Contextual Color"_s, true },
         { "contextualSize"_s, "Contextual Size"_s, true },
         { "cursor"_s, "Show Cursor"_s, true },
         { "hover"_s, "CSS Hover"_s, false },
@@ -500,11 +499,11 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
             return gradientData;
         };
 
-        auto makeGradient = [&] (bool hasLightBackground, Gradient::RadialData gradientData) {
+        auto makeGradient = [&] (Gradient::RadialData gradientData) {
             auto gradient = Gradient::create(WTFMove(gradientData), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
             if (region && valueForSetting("wash"_s) && valueForSetting("clip"_s)) {
                 gradient->addColorStop({ 0.1, Color(Color::white).colorWithAlpha(0.5) });
-                gradient->addColorStop({ 1, hasLightBackground ? Color(Color::black).colorWithAlpha(0.05) : Color(Color::white).colorWithAlpha(0.1) });
+                gradient->addColorStop({ 1, Color(Color::white).colorWithAlpha(0.1) });
             } else if (!valueForSetting("clip"_s) || !valueForSetting("constrain"_s)) {
                 gradient->addColorStop({ 0.1, Color(Color::white).colorWithAlpha(0.2) });
                 gradient->addColorStop({ 1, Color(Color::white).colorWithAlpha(0) });
@@ -546,18 +545,14 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
             }
         }
 
-        bool hasLightBackground = false;
-        if (!shouldUseBackdropGradient && valueForSetting("contextualColor"_s))
-            hasLightBackground = region->hasLightBackground;
-
         if (shouldClip) {
             for (const auto& path : clipPaths) {
                 float radius = valueForSetting("contextualSize"_s) ? 1.5 * path.boundingRect().size().minDimension() : defaultRadius;
-                context.setFillGradient(makeGradient(hasLightBackground, gradientData(radius)));
+                context.setFillGradient(makeGradient(gradientData(radius)));
                 context.fillPath(path);
             }
         } else {
-            context.setFillGradient(makeGradient(hasLightBackground, gradientData(defaultRadius)));
+            context.setFillGradient(makeGradient(gradientData(defaultRadius)));
             context.fillRect(dirtyRect);
         }
     }

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -105,10 +105,6 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         bounds.inflate(inlinePadding);
     }
 
-    bool hasLightBackground = true;
-    if (auto linkRange = makeRangeSelectingNode(*element))
-        hasLightBackground = estimatedBackgroundColorForRange(*linkRange, *element->document().frame()).luminance() > 0.5;
-
     float borderRadius = 0;
     if (const auto& renderBox = dynamicDowncast<RenderBox>(renderer))
         borderRadius = renderBox->borderRadii().minimumRadius();
@@ -119,7 +115,6 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     return { {
         element->identifier(),
         boundsRegion,
-        hasLightBackground,
         borderRadius
     } };
 }
@@ -127,7 +122,6 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 TextStream& operator<<(TextStream& ts, const InteractionRegion& interactionRegion)
 {
     ts.dumpProperty("region", interactionRegion.regionInLayerCoordinates);
-    ts.dumpProperty("hasLightBackground", interactionRegion.hasLightBackground);
     ts.dumpProperty("borderRadius", interactionRegion.borderRadius);
 
     return ts;

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -47,7 +47,6 @@ class RenderObject;
 struct InteractionRegion {
     ElementIdentifier elementIdentifier;
     Region regionInLayerCoordinates;
-    bool hasLightBackground { false };
     float borderRadius { 0 };
 
     WEBCORE_EXPORT ~InteractionRegion();
@@ -60,7 +59,6 @@ inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 {
     return a.elementIdentifier == b.elementIdentifier
         && a.regionInLayerCoordinates == b.regionInLayerCoordinates
-        && a.hasLightBackground == b.hasLightBackground
         && a.borderRadius == b.borderRadius;
 }
 
@@ -73,7 +71,6 @@ void InteractionRegion::encode(Encoder& encoder) const
 {
     encoder << elementIdentifier;
     encoder << regionInLayerCoordinates;
-    encoder << hasLightBackground;
     encoder << borderRadius;
 }
 
@@ -90,11 +87,6 @@ std::optional<InteractionRegion> InteractionRegion::decode(Decoder& decoder)
     if (!regionInLayerCoordinates)
         return std::nullopt;
     
-    std::optional<bool> hasLightBackground;
-    decoder >> hasLightBackground;
-    if (!hasLightBackground)
-        return std::nullopt;
-    
     std::optional<float> borderRadius;
     decoder >> borderRadius;
     if (!borderRadius)
@@ -103,7 +95,6 @@ std::optional<InteractionRegion> InteractionRegion::decode(Decoder& decoder)
     return { {
         WTFMove(*elementIdentifier),
         WTFMove(*regionInLayerCoordinates),
-        WTFMove(*hasLightBackground),
         WTFMove(*borderRadius)
     } };
 }


### PR DESCRIPTION
#### e665d218e7a3d462191c0e262f94cc86c73a50eb
<pre>
estimatedBackgroundColorForRange for interaction regions can be very expensive
<a href="https://bugs.webkit.org/show_bug.cgi?id=243705">https://bugs.webkit.org/show_bug.cgi?id=243705</a>
&lt;rdar://98338797&gt;

Reviewed by Simon Fraser and Wenson Hsieh.

* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::drawRect):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/InteractionRegion.h:
(WebCore::operator==):
(WebCore::InteractionRegion::encode const):
(WebCore::InteractionRegion::decode):
Remove estimatedBackgroundColorForRange calls from InteractionRegion, because
it can be very (very!) expensive, and is only used in the debug visualization.

Canonical link: <a href="https://commits.webkit.org/253249@main">https://commits.webkit.org/253249@main</a>
</pre>
