### PR TITLE
Add complete set of PDF.js context menu items

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1703,6 +1703,14 @@
 "Certain experiences and features may not function as expected. You can turn off Lockdown Mode for this app in Settings." = "Certain experiences and features may not function as expected. You can turn off Lockdown Mode for this app in Settings.";
 
 /* PDFJS strings */
+"Automatically Resize" = "Automatically Resize";
+
+"Zoom In" = "Zoom In";
+
+"Zoom Out" = "Zoom Out";
+
+"Actual Size" = "Actual Size";
+
 "Single Page" = "Single Page";
 
 "Single Page Continuous" = "Single Page Continuous";
@@ -1711,3 +1719,6 @@
 
 "Two Pages Continuous" = "Two Pages Continuous";
 
+"Next Page" = "Next Page";
+
+"Previous Page" = "Previous Page";

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -144,9 +144,8 @@ Ref<DocumentParser> PDFDocument::createParser()
 void PDFDocument::createDocumentStructure()
 {
     // Description of parameters:
-    // - `#pagemode=none` prevents the sidebar from showing on load.
     // - Empty `?file=` parameter prevents default pdf from loading.
-    auto viewerURL = "webkit-pdfjs-viewer://pdfjs/web/viewer.html?file=#pagemode=none"_s;
+    auto viewerURL = "webkit-pdfjs-viewer://pdfjs/web/viewer.html?file="_s;
     auto rootElement = HTMLHtmlElement::create(*this);
     appendChild(rootElement);
     rootElement->insertedByParser();

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -488,6 +488,26 @@ String contextMenuItemTagInspectElement()
 }
 
 #if ENABLE(PDFJS)
+String contextMenuItemPDFAutoSize()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Automatically Resize", "_Automatically Resize", "Automatically Resize context menu item");
+}
+
+String contextMenuItemPDFZoomIn()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Zoom In", "_Zoom In", "Zoom In Continuous context menu item");
+}
+
+String contextMenuItemPDFZoomOut()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Zoom Out", "_Zoom Out", "Zoom Out context menu item");
+}
+
+String contextMenuItemPDFActualSize()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Actual Size", "_Actual Size", "Actual Size context menu item");
+}
+
 String contextMenuItemPDFSinglePage()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Single Page", "_Single Page", "Single Page context menu item");
@@ -506,6 +526,16 @@ String contextMenuItemPDFTwoPages()
 String contextMenuItemPDFTwoPagesContinuous()
 {
     return WEB_UI_STRING_WITH_MNEMONIC("Two Pages Continuous", "_Two Pages Continuous", "Two Pages Continuous context menu item");
+}
+
+String contextMenuItemPDFNextPage()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Next Page", "_Next Page", "Next Page context menu item");
+}
+
+String contextMenuItemPDFPreviousPage()
+{
+    return WEB_UI_STRING_WITH_MNEMONIC("Previous Page", "_Previous Page", "Previous Page context menu item");
 }
 #endif
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -162,10 +162,16 @@ namespace WebCore {
 #endif // ENABLE(CONTEXT_MENUS)
 
 #if ENABLE(PDFJS)
-WEBCORE_EXPORT String contextMenuItemPDFSinglePage();
-WEBCORE_EXPORT String contextMenuItemPDFSinglePageContinuous();
-WEBCORE_EXPORT String contextMenuItemPDFTwoPages();
-WEBCORE_EXPORT String contextMenuItemPDFTwoPagesContinuous();
+    String contextMenuItemPDFAutoSize();
+    String contextMenuItemPDFZoomIn();
+    String contextMenuItemPDFZoomOut();
+    String contextMenuItemPDFActualSize();
+    String contextMenuItemPDFSinglePage();
+    String contextMenuItemPDFSinglePageContinuous();
+    String contextMenuItemPDFTwoPages();
+    String contextMenuItemPDFTwoPagesContinuous();
+    String contextMenuItemPDFNextPage();
+    String contextMenuItemPDFPreviousPage();
 #endif
 
 #if !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### f45efb47d0b878c56267ea737cdd1d1bdb6a41e7
<pre>
Add complete set of PDF.js context menu items
<a href="https://bugs.webkit.org/show_bug.cgi?id=243709">https://bugs.webkit.org/show_bug.cgi?id=243709</a>
rdar://98356019

Reviewed by Aditya Keerthi.

- Add zoom-related items and next/previous page items
- Fix default zoom
- Hide Back/Forward/Inspect Element items
- Add leading separator when there is a preceding context menu item like Share/Services/etc.

* Source/WebCore/Modules/pdfjs-extras/content-script.js:
(const.PDFJSContentScript.overrideSettings):
(const.PDFJSContentScript.setPageMode):
(const.PDFJSContentScript.autoResize):
(const.PDFJSContentScript.init):
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/PDFDocument.cpp:
(WebCore::PDFDocument::createDocumentStructure):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::addInspectElementItem):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemPDFAutoSize):
(WebCore::contextMenuItemPDFZoomIn):
(WebCore::contextMenuItemPDFZoomOut):
(WebCore::contextMenuItemPDFActualSize):
(WebCore::contextMenuItemPDFNextPage):
(WebCore::contextMenuItemPDFPreviousPage):
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/253250@main">https://commits.webkit.org/253250@main</a>
</pre>
