### PR TITLE
run-webkit-tests --leaks is broken again

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -477,10 +477,6 @@ def _set_up_derived_options(port, options):
     if port.port_name == "win":
         options.ignore_render_tree_dump_results = True
 
-    if options.leaks:
-        options.additional_env_var.append("JSC_usePoisoning=0")
-        options.additional_env_var.append("__XPC_JSC_usePoisoning=0")
-
 def run(port, options, args, logging_stream):
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -298,7 +298,7 @@ class Driver(object):
         child_processes = defaultdict(list)
 
         for line in output.splitlines():
-            m = re.match(b'^([^:]+): ([0-9]+)$', line)
+            m = re.match(r'^([^:]+): ([0-9]+)$', line)
             if m:
                 process_name = string_utils.decode(m.group(1), target_type=str)
                 process_id = string_utils.decode(m.group(2), target_type=str)


### PR DESCRIPTION
#### 5940cd0f7f9a1ae170b99da0479b5a4edc82ef57
<pre>
run-webkit-tests --leaks is broken again
<a href="https://bugs.webkit.org/show_bug.cgi?id=243708">https://bugs.webkit.org/show_bug.cgi?id=243708</a>
&lt;rdar://98356055&gt;

Reviewed by Ryan Haddad.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(_set_up_derived_options):
- Remove JSC_usePoisoning environment variables since support
  was removed in 209443@main (ff3b1882901f).
* Tools/Scripts/webkitpy/port/driver.py:
(Driver._parse_child_processes_output):
- Change regex from b&apos;&apos; to r&apos;&apos; to fix the bug.

Canonical link: <a href="https://commits.webkit.org/253268@main">https://commits.webkit.org/253268@main</a>
</pre>
