### PR TITLE
Unreviewed, fix the macOS build after 253244@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm
@@ -277,7 +277,7 @@ static unsigned gDidProcessRequestCount = 0;
 
 - (void)_webView:(WKWebView *)webView didFindMatches:(NSUInteger)matches forString:(NSString *)string withMatchIndex:(NSInteger)matchIndex
 {
-    _numCallsToDidFindMatches++;
+    _numberOfCallsToDidFindMatches++;
 }
 
 @end


### PR DESCRIPTION
#### 48127cd67cc98eb7287cb453ddddc945c994d47d
<pre>
Unreviewed, fix the macOS build after 253244@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243071">https://bugs.webkit.org/show_bug.cgi?id=243071</a>

Fix a misnamed ivar in `FindDelegate`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPageAPI.mm:
(-[FindDelegate _webView:didFindMatches:forString:withMatchIndex:]):

Canonical link: <a href="https://commits.webkit.org/253251@main">https://commits.webkit.org/253251@main</a>
</pre>
