### PR TITLE
[Gardening]: REGRESSION (252720@main): [ iOS ] Four scrollingcoordinator/scrolling-tree/coordinated-frame tests are a consistent failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3701,3 +3701,9 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-unsafe-none-to-same-origin.https.html [ Pass Failure ]
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/javascript-url.https.html [ Pass Failure ]
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-so.https.html [ Pass Failure ]
+
+webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor.html [ Pass Failure ]
+webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed.html [ Pass Failure ]
+webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor.html [ Pass Failure ]
+webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame.html [ Pass Failure ]
+


### PR DESCRIPTION
#### 650ee1c49d6bae92fb1c191943cba217d29930bc
<pre>
[Gardening]: REGRESSION (252720@main): [ iOS ] Four scrollingcoordinator/scrolling-tree/coordinated-frame tests are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243710">https://bugs.webkit.org/show_bug.cgi?id=243710</a>
&lt;rdar://98356321&gt;

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253248@main">https://commits.webkit.org/253248@main</a>
</pre>
