### PR TITLE
Fix leaks in WebKitTestRunner

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
@@ -105,7 +105,7 @@ void WKDownloadSetClient(WKDownloadRef download, WKDownloadClientBase* client)
                 completionHandler(WebKit::AllowOverwrite::No, { });
                 return;
             }
-            API::String* destination = toImpl(m_client.decideDestinationWithResponse(toAPI(download), toAPI(response), toAPI(suggestedFilename.impl()), m_client.base.clientInfo));
+            auto destination = adoptRef(toImpl(m_client.decideDestinationWithResponse(toAPI(download), toAPI(response), toAPI(suggestedFilename.impl()), m_client.base.clientInfo)));
             if (!destination) {
                 completionHandler(WebKit::AllowOverwrite::No, { });
                 return;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -253,14 +253,14 @@ static void runOpenPanel(WKPageRef page, WKFrameRef frame, WKOpenPanelParameters
     }
 #endif
 
-    WKArrayRef allowedMimeTypes = WKOpenPanelParametersCopyAllowedMIMETypes(parameters);
+    auto allowedMIMETypes = adoptWK(WKOpenPanelParametersCopyAllowedMIMETypes(parameters));
 
     if (WKOpenPanelParametersGetAllowsMultipleFiles(parameters)) {
-        WKOpenPanelResultListenerChooseFiles(resultListenerRef, fileURLs, allowedMimeTypes);
+        WKOpenPanelResultListenerChooseFiles(resultListenerRef, fileURLs, allowedMIMETypes.get());
         return;
     }
 
-    WKOpenPanelResultListenerChooseFiles(resultListenerRef, adoptWK(WKArrayCreate(&firstItem, 1)).get(), allowedMimeTypes);
+    WKOpenPanelResultListenerChooseFiles(resultListenerRef, adoptWK(WKArrayCreate(&firstItem, 1)).get(), allowedMIMETypes.get());
 }
 
 void TestController::runModal(WKPageRef page, const void* clientInfo)

--- a/Tools/WebKitTestRunner/mac/main.mm
+++ b/Tools/WebKitTestRunner/mac/main.mm
@@ -53,11 +53,14 @@ static void setDefaultsToConsistentValuesForTesting()
 
 static void disableAppNapInUIProcess()
 {
-    NSActivityOptions options = (NSActivityUserInitiatedAllowingIdleSystemSleep | NSActivityLatencyCritical) & ~(NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled);
-    static NeverDestroyed<RetainPtr<id>> assertion = [[NSProcessInfo processInfo] beginActivityWithOptions:options reason:@"WebKitTestRunner should not be subject to process suppression"];
+    static NeverDestroyed<RetainPtr<id>> assertion;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSActivityOptions options = (NSActivityUserInitiatedAllowingIdleSystemSleep | NSActivityLatencyCritical) & ~(NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled);
+        assertion.get() = [[NSProcessInfo processInfo] beginActivityWithOptions:options reason:@"WebKitTestRunner should not be subject to process suppression"];
+    });
     ASSERT_UNUSED(assertion, assertion.get());
 }
-
 
 int main(int argc, const char* argv[])
 {


### PR DESCRIPTION
#### 2c5c5725a6c0231437df23060a1954f5b2f87e8c
<pre>
Fix leaks in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=243711">https://bugs.webkit.org/show_bug.cgi?id=243711</a>
&lt;rdar://98357151&gt;

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp:
(WKDownloadSetClient):
- Fix leak of API::String since
  TestController::decideDestinationWithSuggestedFilename()
  returns a +1 retained WKStringRef.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::runOpenPanel):
- Fix leak of WKArrayRef since
  WKOpenPanelParametersCopyAllowedMIMETypes() returns a +1
  retained WKArrayRef.
* Tools/WebKitTestRunner/mac/main.mm:
(disableAppNapInUIProcess):
- Use idomatic NeverDestroyed&lt;&gt; declaration to make `leaks`
  stop reporting a false positive leak.

Canonical link: <a href="https://commits.webkit.org/253271@main">https://commits.webkit.org/253271@main</a>
</pre>
