### PR TITLE
Navigator.share() rejects with wrong exception when called multiple times

### DIFF
--- a/LayoutTests/platform/ios-simulator-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt
+++ b/LayoutTests/platform/ios-simulator-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Only allow one share call at a time, which is controlled by the [[sharePromise]] internal slot.
+

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1781,8 +1781,6 @@ imported/w3c/web-platform-tests/web-share/share-url-noscheme-manual.https.html [
 imported/w3c/web-platform-tests/web-share/share-url-pathonly-manual.https.html [ Skip ]
 imported/w3c/web-platform-tests/web-share/share-url-relative-manual.https.html [ Skip ]
 
-imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https.html [ DumpJSConsoleLogInStdErr ]
-
 # rdar://problem/59595496
 quicklook/keynote-09.html [ Failure ]
 quicklook/keynote.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Only allow one share call at a time, which is controlled by the [[sharePromise]] internal slot.
+


### PR DESCRIPTION
#### 7654da12692d947efe23243092725dc6abc96436
<pre>
Navigator.share() rejects with wrong exception when called multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=243652">https://bugs.webkit.org/show_bug.cgi?id=243652</a>

Reviewed by Chris Dumez.

Unfortunately, `run-webkit-tests` doesn&apos;t cause `isControlledByAutomation()`
to return `true`, so we can&apos;t test this directly. Instead, it needs to be run
with directly with web driver (as is done on WPT).

* LayoutTests/platform/ios-simulator-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt: Renamed from LayoutTests/platform/ios-simulator-wk2/share-sharePromise-internal-slot.https-expected.txt.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https-expected.txt: Renamed from LayoutTests/platform/ios-wk2/share-sharePromise-internal-slot.https-expected.txt.
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::share):
(WebCore::Navigator::showShareData):

Canonical link: <a href="https://commits.webkit.org/253419@main">https://commits.webkit.org/253419@main</a>
</pre>
