### PR TITLE
Group WKWebView state which is per-process into a struct

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -362,17 +362,11 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     _usePlatformFindUI = YES;
 
 #if PLATFORM(IOS_FAMILY)
-    _avoidsUnsafeArea = YES;
     _obscuredInsetEdgesAffectedBySafeArea = UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
-    _viewportMetaTagWidth = WebCore::ViewportArguments::ValueAuto;
-    _initialScaleFactor = 1;
     _allowsViewportShrinkToFit = defaultAllowsViewportShrinkToFit;
     _allowsLinkPreview = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LinkPreviewEnabledByDefault);
     _findInteractionEnabled = NO;
     _needsToPresentLockdownModeMessage = YES;
-
-    _pendingFindLayerID = 0;
-    _committedFindLayerID = 0;
 
     auto fastClickingEnabled = []() {
         if (NSNumber *enabledValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitFastClickingDisabled"])
@@ -1586,7 +1580,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
             return;
 
 #if PLATFORM(IOS_FAMILY)
-        if (!withoutWaitingForAnimatedResize && strongSelf->_dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
+        if (!withoutWaitingForAnimatedResize && strongSelf->_perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
             strongSelf->_callbacksDeferredDuringResize.append([updateBlockCopy] {
                 updateBlockCopy();
             });
@@ -3691,7 +3685,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
     if (_page->minimumEffectiveDeviceWidth() == minimumEffectiveDeviceWidth)
         return;
 
-    if (_dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
+    if (_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
         _page->setViewportConfigurationViewLayoutSize(_page->viewLayoutSize(), _page->layoutSizeScaleFactor(), minimumEffectiveDeviceWidth);
     else
         _page->setMinimumEffectiveDeviceWidthWithoutViewportConfigurationUpdate(minimumEffectiveDeviceWidth);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -45,6 +45,7 @@
 #import "WKFullScreenWindowControllerIOS.h"
 #import <WebCore/FloatRect.h>
 #import <WebCore/LengthBox.h>
+#import <WebCore/ViewportArguments.h>
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -117,6 +118,65 @@ class ViewGestureController;
 @protocol _WKInputDelegate;
 @protocol _WKAppHighlightDelegate;
 
+#if PLATFORM(IOS_FAMILY)
+struct LiveResizeParameters {
+    CGFloat viewWidth;
+    CGPoint initialScrollPosition;
+};
+
+// This holds state that should be reset when the web process exits.
+struct PerWebProcessState {
+    CGFloat viewportMetaTagWidth { WebCore::ViewportArguments::ValueAuto };
+    CGFloat initialScaleFactor { 1 };
+    BOOL hasCommittedLoadForMainFrame { NO };
+    BOOL needsResetViewStateAfterCommitLoadForMainFrame { NO };
+
+    WebKit::DynamicViewportUpdateMode dynamicViewportUpdateMode { WebKit::DynamicViewportUpdateMode::NotResizing };
+
+    BOOL waitingForEndAnimatedResize { NO };
+    BOOL waitingForCommitAfterAnimatedResize { NO };
+
+    CGFloat animatedResizeOriginalContentWidth { 0 };
+
+    CGRect animatedResizeOldBounds { CGRectZero }; // FIXME: Use std::optional<>
+
+    std::optional<WebCore::FloatPoint> scrollOffsetToRestore;
+    std::optional<WebCore::FloatPoint> unobscuredCenterToRestore;
+
+    WebCore::Color scrollViewBackgroundColor;
+
+    BOOL invokingUIScrollViewDelegateCallback { NO };
+
+    BOOL didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback { NO };
+    BOOL didDeferUpdateVisibleContentRectsForAnyReason { NO };
+    BOOL didDeferUpdateVisibleContentRectsForUnstableScrollView { NO };
+
+    BOOL currentlyAdjustingScrollViewInsetsForKeyboard { NO };
+
+    BOOL hasScheduledVisibleRectUpdate { NO };
+    BOOL commitDidRestoreScrollPosition { NO };
+
+    BOOL avoidsUnsafeArea { YES };
+
+    std::optional<WebCore::FloatSize> lastSentViewLayoutSize;
+    std::optional<int32_t> lastSentDeviceOrientation;
+
+    std::optional<CGRect> frozenVisibleContentRect;
+    std::optional<CGRect> frozenUnobscuredContentRect;
+
+    WebKit::TransactionID firstPaintAfterCommitLoadTransactionID;
+    WebKit::TransactionID lastTransactionID;
+
+    std::optional<WebKit::TransactionID> firstTransactionIDAfterPageRestore;
+
+    WebCore::GraphicsLayer::PlatformLayerID pendingFindLayerID { 0 };
+    WebCore::GraphicsLayer::PlatformLayerID committedFindLayerID { 0 };
+
+    std::optional<LiveResizeParameters> liveResizeParameters;
+};
+
+#endif // PLATFORM(IOS_FAMILY)
+
 @interface WKWebView () WK_WEB_VIEW_PROTOCOLS {
 
 @package
@@ -167,21 +227,18 @@ class ViewGestureController;
     RetainPtr<UIFindInteraction> _findInteraction;
 #endif
 
-    WebCore::GraphicsLayer::PlatformLayerID _pendingFindLayerID;
-    WebCore::GraphicsLayer::PlatformLayerID _committedFindLayerID;
-
     RetainPtr<_WKRemoteObjectRegistry> _remoteObjectRegistry;
+    
+    PerWebProcessState _perProcessState;
 
     std::optional<CGSize> _viewLayoutSizeOverride;
-    std::optional<WebCore::FloatSize> _lastSentViewLayoutSize;
     std::optional<CGSize> _minimumUnobscuredSizeOverride;
     std::optional<CGSize> _maximumUnobscuredSizeOverride;
     CGRect _inputViewBoundsInWindow;
 
-    CGFloat _viewportMetaTagWidth;
+    // FIXME: More of these should move into _perProcessState.
     BOOL _viewportMetaTagWidthWasExplicit;
     BOOL _viewportMetaTagCameFromImageDocument;
-    CGFloat _initialScaleFactor;
     BOOL _fastClickingIsDisabled;
 
     BOOL _allowsLinkPreview;
@@ -192,46 +249,26 @@ class ViewGestureController;
 
     UIEdgeInsets _unobscuredSafeAreaInsets;
     BOOL _haveSetUnobscuredSafeAreaInsets;
-    BOOL _avoidsUnsafeArea;
     BOOL _needsToPresentLockdownModeMessage;
     UIRectEdge _obscuredInsetEdgesAffectedBySafeArea;
 
     UIInterfaceOrientation _interfaceOrientationOverride;
     BOOL _overridesInterfaceOrientation;
-    std::optional<int32_t> _lastSentDeviceOrientation;
 
     BOOL _allowsViewportShrinkToFit;
 
-    BOOL _hasCommittedLoadForMainFrame;
-    BOOL _needsResetViewStateAfterCommitLoadForMainFrame;
-    WebKit::TransactionID _firstPaintAfterCommitLoadTransactionID;
-    WebKit::TransactionID _lastTransactionID;
-    WebKit::DynamicViewportUpdateMode _dynamicViewportUpdateMode;
     WebKit::DynamicViewportSizeUpdateID _currentDynamicViewportSizeUpdateID;
     CATransform3D _resizeAnimationTransformAdjustments;
-    CGFloat _animatedResizeOriginalContentWidth;
-    CGRect _animatedResizeOldBounds;
     CGFloat _animatedResizeOldMinimumEffectiveDeviceWidth;
     int32_t _animatedResizeOldOrientation;
     UIEdgeInsets _animatedResizeOldObscuredInsets;
     RetainPtr<UIView> _resizeAnimationView;
     CGFloat _lastAdjustmentForScroller;
-    std::optional<CGRect> _frozenVisibleContentRect;
-    std::optional<CGRect> _frozenUnobscuredContentRect;
 
-    struct LiveResizeParameters {
-        CGFloat viewWidth;
-        CGPoint initialScrollPosition;
-    };
-    std::optional<LiveResizeParameters> _liveResizeParameters;
     RetainPtr<id> _endLiveResizeNotificationObserver;
 
-    BOOL _commitDidRestoreScrollPosition;
-    std::optional<WebCore::FloatPoint> _scrollOffsetToRestore;
     WebCore::FloatBoxExtent _obscuredInsetsWhenSaved;
 
-    std::optional<WebCore::FloatPoint> _unobscuredCenterToRestore;
-    std::optional<WebKit::TransactionID> _firstTransactionIDAfterPageRestore;
     double _scaleToRestore;
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
@@ -246,30 +283,21 @@ class ViewGestureController;
     RetainPtr<NSTimer> _enclosingScrollViewScrollTimer;
     BOOL _didScrollSinceLastTimerFire;
 
-    WebCore::Color _scrollViewBackgroundColor;
 
     // This value tracks the current adjustment added to the bottom inset due to the keyboard sliding out from the bottom
     // when computing obscured content insets. This is used when updating the visible content rects where we should not
     // include this adjustment.
     CGFloat _totalScrollViewBottomInsetAdjustmentForKeyboard;
-    BOOL _currentlyAdjustingScrollViewInsetsForKeyboard;
 
-    BOOL _invokingUIScrollViewDelegateCallback;
-    BOOL _didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback;
-    BOOL _didDeferUpdateVisibleContentRectsForAnyReason;
-    BOOL _didDeferUpdateVisibleContentRectsForUnstableScrollView;
     BOOL _alwaysSendNextVisibleContentRectUpdate;
     BOOL _contentViewShouldBecomeFirstResponderAfterNavigationGesture;
 
-    BOOL _waitingForEndAnimatedResize;
-    BOOL _waitingForCommitAfterAnimatedResize;
 
     Vector<WTF::Function<void ()>> _callbacksDeferredDuringResize;
     RetainPtr<NSMutableArray> _stableStatePresentationUpdateCallbacks;
 
     RetainPtr<WKPasswordView> _passwordView;
 
-    BOOL _hasScheduledVisibleRectUpdate;
     OptionSet<WebKit::ViewStabilityFlag> _viewStabilityWhenVisibleContentRectUpdateScheduled;
 
     std::optional<WebCore::WheelScrollGestureState> _currentScrollGestureState;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -483,7 +483,7 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
         [_customContentView web_setMinimumSize:self.bounds.size];
         [_customContentView web_setFixedOverlayView:_customContentFixedOverlayView.get()];
 
-        _scrollViewBackgroundColor = WebCore::Color();
+        _perProcessState.scrollViewBackgroundColor = WebCore::Color();
         [_scrollView setContentOffset:[self _initialContentOffsetForScrollView]];
         [_scrollView _setScrollEnabledInternal:YES];
 
@@ -537,14 +537,14 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
 
 - (void)_willInvokeUIScrollViewDelegateCallback
 {
-    _invokingUIScrollViewDelegateCallback = YES;
+    _perProcessState.invokingUIScrollViewDelegateCallback = YES;
 }
 
 - (void)_didInvokeUIScrollViewDelegateCallback
 {
-    _invokingUIScrollViewDelegateCallback = NO;
-    if (_didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback) {
-        _didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = NO;
+    _perProcessState.invokingUIScrollViewDelegateCallback = NO;
+    if (_perProcessState.didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback) {
+        _perProcessState.didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = NO;
         [self _scheduleVisibleContentRectUpdate];
     }
 }
@@ -607,15 +607,15 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 
 - (void)_resetCachedScrollViewBackgroundColor
 {
-    _scrollViewBackgroundColor = WebCore::Color();
+    _perProcessState.scrollViewBackgroundColor = WebCore::Color();
 }
 
 - (void)_updateScrollViewBackground
 {
     auto newScrollViewBackgroundColor = scrollViewBackgroundColor(self, AllowPageBackgroundColorOverride::Yes);
-    if (_scrollViewBackgroundColor != newScrollViewBackgroundColor) {
+    if (_perProcessState.scrollViewBackgroundColor != newScrollViewBackgroundColor) {
         [_scrollView _setBackgroundColorInternal:cocoaColor(newScrollViewBackgroundColor).get()];
-        _scrollViewBackgroundColor = newScrollViewBackgroundColor;
+        _perProcessState.scrollViewBackgroundColor = newScrollViewBackgroundColor;
     }
 
     [self _updateScrollViewIndicatorStyle];
@@ -756,6 +756,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     [self _hidePasswordView];
     [self _cancelAnimatedResize];
     [self _destroyResizeAnimationView];
+    [_contentView setHidden:NO];
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     [self _invalidateResizeAssertions];
@@ -764,44 +765,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     if (_gestureController)
         _gestureController->disconnectFromProcess();
 
-    _viewportMetaTagWidth = WebCore::ViewportArguments::ValueAuto;
-    _initialScaleFactor = 1;
-    _hasCommittedLoadForMainFrame = NO;
-    _needsResetViewStateAfterCommitLoadForMainFrame = NO;
-    _dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::NotResizing;
-    _waitingForEndAnimatedResize = NO;
-    _waitingForCommitAfterAnimatedResize = NO;
-    _animatedResizeOriginalContentWidth = 0;
-    _animatedResizeOldBounds = { };
-    [_contentView setHidden:NO];
-    _scrollOffsetToRestore = std::nullopt;
-    _unobscuredCenterToRestore = std::nullopt;
-    _scrollViewBackgroundColor = WebCore::Color();
-    _invokingUIScrollViewDelegateCallback = NO;
-    _didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = NO;
-    _didDeferUpdateVisibleContentRectsForAnyReason = NO;
-    _didDeferUpdateVisibleContentRectsForUnstableScrollView = NO;
-    _currentlyAdjustingScrollViewInsetsForKeyboard = NO;
-    _lastSentViewLayoutSize = std::nullopt;
-    _lastSentDeviceOrientation = std::nullopt;
-
-    _frozenVisibleContentRect = std::nullopt;
-    _frozenUnobscuredContentRect = std::nullopt;
-
-    _firstPaintAfterCommitLoadTransactionID = { };
-    _firstTransactionIDAfterPageRestore = std::nullopt;
-
-    _lastTransactionID = { };
-
-    _hasScheduledVisibleRectUpdate = NO;
-    _commitDidRestoreScrollPosition = NO;
-
-    _avoidsUnsafeArea = YES;
-
-    _pendingFindLayerID = 0;
-    _committedFindLayerID = 0;
-
-    _liveResizeParameters = std::nullopt;
+    _perProcessState = { };
 }
 
 - (void)_processWillSwap
@@ -825,7 +789,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 - (void)_didRelaunchProcess
 {
     WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _didRelaunchProcess] (pid=%d)", self, _page->processIdentifier());
-    _hasScheduledVisibleRectUpdate = NO;
+    _perProcessState.hasScheduledVisibleRectUpdate = NO;
     _viewStabilityWhenVisibleContentRectUpdateScheduled = { };
     if (_gestureController)
         _gestureController->connectToProcess();
@@ -833,10 +797,10 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 
 - (void)_didCommitLoadForMainFrame
 {
-    _firstPaintAfterCommitLoadTransactionID = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
+    _perProcessState.firstPaintAfterCommitLoadTransactionID = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
 
-    _hasCommittedLoadForMainFrame = YES;
-    _needsResetViewStateAfterCommitLoadForMainFrame = YES;
+    _perProcessState.hasCommittedLoadForMainFrame = YES;
+    _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame = YES;
 
     if (![self _scrollViewIsRubberBandingForRefreshControl])
         [_scrollView _stopScrollingAndZoomingAnimations];
@@ -904,16 +868,16 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     // If we've already passed endAnimatedResize, immediately complete
     // the resize when we have an up-to-date layer tree. Otherwise,
     // we will defer completion until endAnimatedResize.
-    _waitingForCommitAfterAnimatedResize = NO;
-    if (!_waitingForEndAnimatedResize)
+    _perProcessState.waitingForCommitAfterAnimatedResize = NO;
+    if (!_perProcessState.waitingForEndAnimatedResize)
         [self _didCompleteAnimatedResize];
 }
 
 - (void)_trackTransactionCommit:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction
 {
-    if (_didDeferUpdateVisibleContentRectsForUnstableScrollView) {
-        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _didCommitLayerTree:] - received a commit (%llu) while deferring visible content rect updates (_dynamicViewportUpdateMode %d, _needsResetViewStateAfterCommitLoadForMainFrame %d (wants commit %llu), sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, _currentlyAdjustingScrollViewInsetsForKeyboard %d)",
-        self, _page->identifier().toUInt64(), layerTreeTransaction.transactionID().toUInt64(), _dynamicViewportUpdateMode, _needsResetViewStateAfterCommitLoadForMainFrame, _firstPaintAfterCommitLoadTransactionID.toUInt64(), [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _currentlyAdjustingScrollViewInsetsForKeyboard);
+    if (_perProcessState.didDeferUpdateVisibleContentRectsForUnstableScrollView) {
+        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _didCommitLayerTree:] - received a commit (%llu) while deferring visible content rect updates (dynamicViewportUpdateMode %d, needsResetViewStateAfterCommitLoadForMainFrame %d (wants commit %llu), sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, currentlyAdjustingScrollViewInsetsForKeyboard %d)",
+        self, _page->identifier().toUInt64(), layerTreeTransaction.transactionID().toUInt64(), _perProcessState.dynamicViewportUpdateMode, _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame, _perProcessState.firstPaintAfterCommitLoadTransactionID.toUInt64(), [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard);
     }
 
     if (_timeOfFirstVisibleContentRectUpdateWithPendingCommit) {
@@ -965,31 +929,31 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
 - (BOOL)_restoreScrollAndZoomStateForTransaction:(const WebKit::RemoteLayerTreeTransaction&)layerTreeTransaction
 {
-    if (!_firstTransactionIDAfterPageRestore || layerTreeTransaction.transactionID() < _firstTransactionIDAfterPageRestore.value())
+    if (!_perProcessState.firstTransactionIDAfterPageRestore || layerTreeTransaction.transactionID() < _perProcessState.firstTransactionIDAfterPageRestore.value())
         return NO;
 
-    _firstTransactionIDAfterPageRestore = std::nullopt;
+    _perProcessState.firstTransactionIDAfterPageRestore = std::nullopt;
 
     BOOL needUpdateVisibleContentRects = NO;
 
-    if (_scrollOffsetToRestore && ![self _scrollViewIsRubberBandingForRefreshControl]) {
-        WebCore::FloatPoint scaledScrollOffset = _scrollOffsetToRestore.value();
-        _scrollOffsetToRestore = std::nullopt;
+    if (_perProcessState.scrollOffsetToRestore && ![self _scrollViewIsRubberBandingForRefreshControl]) {
+        WebCore::FloatPoint scaledScrollOffset = _perProcessState.scrollOffsetToRestore.value();
+        _perProcessState.scrollOffsetToRestore = std::nullopt;
 
         if (WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _scaleToRestore)) {
             scaledScrollOffset.scale(_scaleToRestore);
             WebCore::FloatPoint contentOffsetInScrollViewCoordinates = scaledScrollOffset - WebCore::FloatSize(_obscuredInsetsWhenSaved.left(), _obscuredInsetsWhenSaved.top());
 
             changeContentOffsetBoundedInValidRange(_scrollView.get(), contentOffsetInScrollViewCoordinates);
-            _commitDidRestoreScrollPosition = YES;
+            _perProcessState.commitDidRestoreScrollPosition = YES;
         }
 
         needUpdateVisibleContentRects = YES;
     }
 
-    if (_unobscuredCenterToRestore && ![self _scrollViewIsRubberBandingForRefreshControl]) {
-        WebCore::FloatPoint unobscuredCenterToRestore = _unobscuredCenterToRestore.value();
-        _unobscuredCenterToRestore = std::nullopt;
+    if (_perProcessState.unobscuredCenterToRestore && ![self _scrollViewIsRubberBandingForRefreshControl]) {
+        WebCore::FloatPoint unobscuredCenterToRestore = _perProcessState.unobscuredCenterToRestore.value();
+        _perProcessState.unobscuredCenterToRestore = std::nullopt;
 
         if (WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _scaleToRestore)) {
             CGRect unobscuredRect = UIEdgeInsetsInsetRect(self.bounds, _obscuredInsets);
@@ -1015,16 +979,16 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 {
     [self _trackTransactionCommit:layerTreeTransaction];
 
-    _lastTransactionID = layerTreeTransaction.transactionID();
+    _perProcessState.lastTransactionID = layerTreeTransaction.transactionID();
 
     if (![self usesStandardContentView])
         return;
 
-    LOG_WITH_STREAM(VisibleRects, stream << "-[WKWebView " << _page->identifier() << " _didCommitLayerTree:] transactionID " << layerTreeTransaction.transactionID() << " _dynamicViewportUpdateMode " << (int)_dynamicViewportUpdateMode);
+    LOG_WITH_STREAM(VisibleRects, stream << "-[WKWebView " << _page->identifier() << " _didCommitLayerTree:] transactionID " << layerTreeTransaction.transactionID() << " dynamicViewportUpdateMode " << (int)_perProcessState.dynamicViewportUpdateMode);
 
     bool needUpdateVisibleContentRects = _page->updateLayoutViewportParameters(layerTreeTransaction);
 
-    if (_dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
+    if (_perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
         [self _didCommitLayerTreeDuringAnimatedResize:layerTreeTransaction];
         return;
     }
@@ -1034,10 +998,10 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
     [self _updateScrollViewForTransaction:layerTreeTransaction];
 
-    _viewportMetaTagWidth = layerTreeTransaction.viewportMetaTagWidth();
+    _perProcessState.viewportMetaTagWidth = layerTreeTransaction.viewportMetaTagWidth();
     _viewportMetaTagWidthWasExplicit = layerTreeTransaction.viewportMetaTagWidthWasExplicit();
     _viewportMetaTagCameFromImageDocument = layerTreeTransaction.viewportMetaTagCameFromImageDocument();
-    _initialScaleFactor = layerTreeTransaction.initialScaleFactor();
+    _perProcessState.initialScaleFactor = layerTreeTransaction.initialScaleFactor();
 
     if (_page->inStableState() && layerTreeTransaction.isInStableState() && [_stableStatePresentationUpdateCallbacks count]) {
         for (dispatch_block_t action in _stableStatePresentationUpdateCallbacks.get())
@@ -1056,8 +1020,8 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     if (_gestureController)
         _gestureController->setRenderTreeSize(layerTreeTransaction.renderTreeSize());
 
-    if (_needsResetViewStateAfterCommitLoadForMainFrame && layerTreeTransaction.transactionID() >= _firstPaintAfterCommitLoadTransactionID) {
-        _needsResetViewStateAfterCommitLoadForMainFrame = NO;
+    if (_perProcessState.needsResetViewStateAfterCommitLoadForMainFrame && layerTreeTransaction.transactionID() >= _perProcessState.firstPaintAfterCommitLoadTransactionID) {
+        _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame = NO;
         if (![self _scrollViewIsRubberBandingForRefreshControl])
             [_scrollView setContentOffset:[self _initialContentOffsetForScrollView]];
 
@@ -1076,10 +1040,10 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = _page->scrollingPerformanceData())
         scrollPerfData->didCommitLayerTree([self visibleRectInViewCoordinates]);
 
-    if (_pendingFindLayerID) {
-        CALayer *layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(_pendingFindLayerID);
+    if (_perProcessState.pendingFindLayerID) {
+        CALayer *layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(_perProcessState.pendingFindLayerID);
         if (layer.superlayer) {
-            _committedFindLayerID = std::exchange(_pendingFindLayerID, 0);
+            _perProcessState.committedFindLayerID = std::exchange(_perProcessState.pendingFindLayerID, 0);
             _page->findClient().didAddLayerForFindOverlay(_page.get(), layer);
         }
     }
@@ -1140,7 +1104,7 @@ static void addOverlayEventRegions(WebCore::GraphicsLayer::PlatformLayerID layer
 
 - (void)_layerTreeCommitComplete
 {
-    _commitDidRestoreScrollPosition = NO;
+    _perProcessState.commitDidRestoreScrollPosition = NO;
 }
 
 - (void)_couldNotRestorePageState
@@ -1167,11 +1131,11 @@ static void addOverlayEventRegions(WebCore::GraphicsLayer::PlatformLayerID layer
     if (![self usesStandardContentView])
         return;
 
-    _firstTransactionIDAfterPageRestore = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
+    _perProcessState.firstTransactionIDAfterPageRestore = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
     if (scrollPosition)
-        _scrollOffsetToRestore = WebCore::ScrollableArea::scrollOffsetFromPosition(WebCore::FloatPoint(scrollPosition.value()), WebCore::toFloatSize(scrollOrigin));
+        _perProcessState.scrollOffsetToRestore = WebCore::ScrollableArea::scrollOffsetFromPosition(WebCore::FloatPoint(scrollPosition.value()), WebCore::toFloatSize(scrollOrigin));
     else
-        _scrollOffsetToRestore = std::nullopt;
+        _perProcessState.scrollOffsetToRestore = std::nullopt;
 
     _obscuredInsetsWhenSaved = obscuredInsets;
     _scaleToRestore = scale;
@@ -1191,8 +1155,8 @@ static void addOverlayEventRegions(WebCore::GraphicsLayer::PlatformLayerID layer
     if (![self usesStandardContentView])
         return;
 
-    _firstTransactionIDAfterPageRestore = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
-    _unobscuredCenterToRestore = center;
+    _perProcessState.firstTransactionIDAfterPageRestore = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).nextLayerTreeTransactionID();
+    _perProcessState.unobscuredCenterToRestore = center;
 
     _scaleToRestore = scale;
 }
@@ -1296,7 +1260,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_scrollToContentScrollPosition:(WebCore::FloatPoint)scrollPosition scrollOrigin:(WebCore::IntPoint)scrollOrigin animated:(BOOL)animated
 {
-    if (_commitDidRestoreScrollPosition || self._shouldDeferGeometryUpdates)
+    if (_perProcessState.commitDidRestoreScrollPosition || self._shouldDeferGeometryUpdates)
         return;
 
     // Don't allow content to do programmatic scrolls for non-scrollable pages when zoomed.
@@ -1420,8 +1384,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_zoomToInitialScaleWithOrigin:(WebCore::FloatPoint)origin animated:(BOOL)animated
 {
-    ASSERT(_initialScaleFactor > 0);
-    [self _zoomToPoint:origin atScale:_initialScaleFactor animated:animated];
+    ASSERT(_perProcessState.initialScaleFactor > 0);
+    [self _zoomToPoint:origin atScale:_perProcessState.initialScaleFactor animated:animated];
 }
 
 - (BOOL)_selectionRectIsFullyVisibleAndNonEmpty
@@ -1634,7 +1598,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (double)_initialScaleFactor
 {
-    return _initialScaleFactor;
+    return _perProcessState.initialScaleFactor;
 }
 
 - (double)_contentZoomScale
@@ -1755,13 +1719,13 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     // If the page set a viewport width that wasn't the device width, then it was
     // scaled and thus will probably need to zoom.
-    if (_viewportMetaTagWidth != WebCore::ViewportArguments::ValueDeviceWidth)
+    if (_perProcessState.viewportMetaTagWidth != WebCore::ViewportArguments::ValueDeviceWidth)
         return YES;
 
     // At this point, we have a page that asked for width = device-width. However,
     // if the content's width and height were large, we might have had to shrink it.
     // We'll enable double tap zoom whenever we're not at the actual initial scale.
-    return !WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _initialScaleFactor);
+    return !WebKit::scalesAreEssentiallyEqual(contentZoomScale(self), _perProcessState.initialScaleFactor);
 }
 
 #pragma mark UIScrollViewDelegate
@@ -2029,8 +1993,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (CGRect)_visibleContentRect
 {
-    if (_frozenVisibleContentRect)
-        return _frozenVisibleContentRect.value();
+    if (_perProcessState.frozenVisibleContentRect)
+        return _perProcessState.frozenVisibleContentRect.value();
 
     CGRect visibleRectInContentCoordinates = [self convertRect:self.bounds toView:_contentView.get()];
 
@@ -2088,21 +2052,21 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_dispatchSetViewLayoutSize:(WebCore::FloatSize)viewLayoutSize
 {
-    if (_lastSentViewLayoutSize && CGSizeEqualToSize(_lastSentViewLayoutSize.value(), viewLayoutSize))
+    if (_perProcessState.lastSentViewLayoutSize && CGSizeEqualToSize(_perProcessState.lastSentViewLayoutSize.value(), viewLayoutSize))
         return;
 
     LOG_WITH_STREAM(VisibleRects, stream << "-[WKWebView " << _page->identifier() << " _dispatchSetViewLayoutSize:] " << viewLayoutSize << " contentZoomScale " << contentZoomScale(self));
     _page->setViewportConfigurationViewLayoutSize(viewLayoutSize, _page->layoutSizeScaleFactor(), _page->minimumEffectiveDeviceWidth());
-    _lastSentViewLayoutSize = viewLayoutSize;
+    _perProcessState.lastSentViewLayoutSize = viewLayoutSize;
 }
 
 - (void)_dispatchSetDeviceOrientation:(int32_t)deviceOrientation
 {
-    if (_lastSentDeviceOrientation && _lastSentDeviceOrientation.value() == deviceOrientation)
+    if (_perProcessState.lastSentDeviceOrientation && _perProcessState.lastSentDeviceOrientation.value() == deviceOrientation)
         return;
 
     _page->setDeviceOrientation(deviceOrientation);
-    _lastSentDeviceOrientation = deviceOrientation;
+    _perProcessState.lastSentDeviceOrientation = deviceOrientation;
 }
 
 - (BOOL)_updateScrollViewContentInsetsIfNecessary
@@ -2116,7 +2080,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_beginAutomaticLiveResizeIfNeeded
 {
-    if (_liveResizeParameters)
+    if (_perProcessState.liveResizeParameters)
         return;
 
     if (!self.window)
@@ -2150,10 +2114,10 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_updateLiveResizeTransform
 {
-    CGFloat scale = self.bounds.size.width / _liveResizeParameters->viewWidth;
+    CGFloat scale = self.bounds.size.width / _perProcessState.liveResizeParameters->viewWidth;
     CGAffineTransform transform = CGAffineTransformMakeScale(scale, scale);
 
-    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(_liveResizeParameters->initialScrollPosition.x * scale, _liveResizeParameters->initialScrollPosition.y * scale)];
+    CGPoint newContentOffset = [self _contentOffsetAdjustedForObscuredInset:CGPointMake(_perProcessState.liveResizeParameters->initialScrollPosition.x * scale, _perProcessState.liveResizeParameters->initialScrollPosition.y * scale)];
     CGPoint currentContentOffset = [_scrollView contentOffset];
 
     transform.tx = currentContentOffset.x - newContentOffset.x;
@@ -2170,7 +2134,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (_page && _page->preferences().automaticLiveResizeEnabled())
         [self _beginAutomaticLiveResizeIfNeeded];
 
-    if (_liveResizeParameters)
+    if (_perProcessState.liveResizeParameters)
         [self _updateLiveResizeTransform];
     
     if (!self._shouldDeferGeometryUpdates) {
@@ -2340,7 +2304,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         } @catch (NSException *exception) {
             WKWEBVIEW_RELEASE_LOG("In CATransaction preCommitHandler, -[WKWebView %p _updateVisibleContentRects] threw an exception", webView);
         }
-        webView->_hasScheduledVisibleRectUpdate = NO;
+        webView->_perProcessState.hasScheduledVisibleRectUpdate = NO;
     } forPhase:kCATransactionPhasePreCommit];
 }
 
@@ -2348,16 +2312,16 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 {
     _viewStabilityWhenVisibleContentRectUpdateScheduled = [self _viewStabilityState:scrollView];
 
-    if (_hasScheduledVisibleRectUpdate) {
+    if (_perProcessState.hasScheduledVisibleRectUpdate) {
         auto timeNow = MonotonicTime::now();
         if ((timeNow - _timeOfRequestForVisibleContentRectUpdate) > delayBeforeNoVisibleContentsRectsLogging) {
-            WKWEBVIEW_RELEASE_LOG("-[WKWebView %p _scheduleVisibleContentRectUpdateAfterScrollInView]: _hasScheduledVisibleRectUpdate is true but haven't updated visible content rects for %.2fs (last update was %.2fs ago) - valid %d",
+            WKWEBVIEW_RELEASE_LOG("-[WKWebView %p _scheduleVisibleContentRectUpdateAfterScrollInView]: hasScheduledVisibleRectUpdate is true but haven't updated visible content rects for %.2fs (last update was %.2fs ago) - valid %d",
                 self, (timeNow - _timeOfRequestForVisibleContentRectUpdate).value(), (timeNow - _timeOfLastVisibleContentRectUpdate).value(), [self _isValid]);
         }
         return;
     }
 
-    _hasScheduledVisibleRectUpdate = YES;
+    _perProcessState.hasScheduledVisibleRectUpdate = YES;
     _timeOfRequestForVisibleContentRectUpdate = MonotonicTime::now();
 
     CATransactionPhase transactionPhase = [CATransaction currentPhase];
@@ -2440,7 +2404,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
 
 - (BOOL)_shouldDeferGeometryUpdates
 {
-    return _liveResizeParameters || _dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
+    return _perProcessState.liveResizeParameters || _perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
 }
 
 - (void)_updateVisibleContentRects
@@ -2450,7 +2414,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
     if (![self usesStandardContentView]) {
         [_passwordView setFrame:self.bounds];
         [_customContentView web_computedContentInsetDidChange];
-        _didDeferUpdateVisibleContentRectsForAnyReason = YES;
+        _perProcessState.didDeferUpdateVisibleContentRectsForAnyReason = YES;
         WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - usesStandardContentView is NO, bailing", self, _page->identifier().toUInt64());
         return;
     }
@@ -2459,36 +2423,36 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
     if (_timeOfFirstVisibleContentRectUpdateWithPendingCommit) {
         auto timeSinceFirstRequestWithPendingCommit = timeNow - *_timeOfFirstVisibleContentRectUpdateWithPendingCommit;
         if (timeSinceFirstRequestWithPendingCommit > delayBeforeNoCommitsLogging)
-            WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - have not received a commit %.2fs after visible content rect update; lastTransactionID %llu", self, _page->identifier().toUInt64(), timeSinceFirstRequestWithPendingCommit.value(), _lastTransactionID.toUInt64());
+            WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - have not received a commit %.2fs after visible content rect update; lastTransactionID %llu", self, _page->identifier().toUInt64(), timeSinceFirstRequestWithPendingCommit.value(), _perProcessState.lastTransactionID.toUInt64());
     }
 
-    if (_invokingUIScrollViewDelegateCallback) {
-        _didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = YES;
-        _didDeferUpdateVisibleContentRectsForAnyReason = YES;
+    if (_perProcessState.invokingUIScrollViewDelegateCallback) {
+        _perProcessState.didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = YES;
+        _perProcessState.didDeferUpdateVisibleContentRectsForAnyReason = YES;
         WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - _invokingUIScrollViewDelegateCallback is YES, bailing", self, _page->identifier().toUInt64());
         return;
     }
 
-    if (!CGRectIsEmpty(_animatedResizeOldBounds))
+    if (!CGRectIsEmpty(_perProcessState.animatedResizeOldBounds))
         [self _cancelAnimatedResize];
 
     if (self._shouldDeferGeometryUpdates
-        || (_needsResetViewStateAfterCommitLoadForMainFrame && ![_contentView sizeChangedSinceLastVisibleContentRectUpdate])
+        || (_perProcessState.needsResetViewStateAfterCommitLoadForMainFrame && ![_contentView sizeChangedSinceLastVisibleContentRectUpdate])
         || [_scrollView isZoomBouncing]
-        || _currentlyAdjustingScrollViewInsetsForKeyboard) {
-        _didDeferUpdateVisibleContentRectsForAnyReason = YES;
-        _didDeferUpdateVisibleContentRectsForUnstableScrollView = YES;
-        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - scroll view state is non-stable, bailing (_dynamicViewportUpdateMode %d, _needsResetViewStateAfterCommitLoadForMainFrame %d, sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, _currentlyAdjustingScrollViewInsetsForKeyboard %d)",
-            self, _page->identifier().toUInt64(), _dynamicViewportUpdateMode, _needsResetViewStateAfterCommitLoadForMainFrame, [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _currentlyAdjustingScrollViewInsetsForKeyboard);
+        || _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard) {
+        _perProcessState.didDeferUpdateVisibleContentRectsForAnyReason = YES;
+        _perProcessState.didDeferUpdateVisibleContentRectsForUnstableScrollView = YES;
+        WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - scroll view state is non-stable, bailing (dynamicViewportUpdateMode %d, needsResetViewStateAfterCommitLoadForMainFrame %d, sizeChangedSinceLastVisibleContentRectUpdate %d, [_scrollView isZoomBouncing] %d, currentlyAdjustingScrollViewInsetsForKeyboard %d)",
+            self, _page->identifier().toUInt64(), _perProcessState.dynamicViewportUpdateMode, _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame, [_contentView sizeChangedSinceLastVisibleContentRectUpdate], [_scrollView isZoomBouncing], _perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard);
         return;
     }
 
-    if (_didDeferUpdateVisibleContentRectsForAnyReason)
+    if (_perProcessState.didDeferUpdateVisibleContentRectsForAnyReason)
         WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _updateVisibleContentRects:] - performing first visible content rect update after deferring updates", self, _page->identifier().toUInt64());
 
-    _didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = NO;
-    _didDeferUpdateVisibleContentRectsForUnstableScrollView = NO;
-    _didDeferUpdateVisibleContentRectsForAnyReason = NO;
+    _perProcessState.didDeferUpdateVisibleContentRectsForUIScrollViewDelegateCallback = NO;
+    _perProcessState.didDeferUpdateVisibleContentRectsForUnstableScrollView = NO;
+    _perProcessState.didDeferUpdateVisibleContentRectsForAnyReason = NO;
 
     [self _updateScrollViewContentInsetsIfNecessary];
 
@@ -2500,7 +2464,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
 
     CGFloat scaleFactor = contentZoomScale(self);
     CGRect unobscuredRect = UIEdgeInsetsInsetRect(self.bounds, computedContentInsetUnadjustedForKeyboard);
-    CGRect unobscuredRectInContentCoordinates = _frozenUnobscuredContentRect ? _frozenUnobscuredContentRect.value() : [self convertRect:unobscuredRect toView:_contentView.get()];
+    CGRect unobscuredRectInContentCoordinates = _perProcessState.frozenUnobscuredContentRect ? _perProcessState.frozenUnobscuredContentRect.value() : [self convertRect:unobscuredRect toView:_contentView.get()];
     unobscuredRectInContentCoordinates = CGRectIntersection(unobscuredRectInContentCoordinates, [self _contentBoundsExtendedForRubberbandingWithScale:scaleFactor]);
 
     auto contentInsets = [self currentlyVisibleContentInsetsWithScale:scaleFactor obscuredInsets:computedContentInsetUnadjustedForKeyboard];
@@ -2596,9 +2560,9 @@ static int32_t activeOrientation(WKWebView *webView)
 
 - (void)_cancelAnimatedResize
 {
-    WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _cancelAnimatedResize] _dynamicViewportUpdateMode %d", self, _page->identifier().toUInt64(), _dynamicViewportUpdateMode);
+    WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _cancelAnimatedResize] dynamicViewportUpdateMode %d", self, _page->identifier().toUInt64(), _perProcessState.dynamicViewportUpdateMode);
 
-    if (_dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
+    if (_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
         return;
 
     if (!_customContentView) {
@@ -2608,14 +2572,14 @@ static int32_t activeOrientation(WKWebView *webView)
         _resizeAnimationTransformAdjustments = CATransform3DIdentity;
     }
 
-    _dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::NotResizing;
-    _animatedResizeOldBounds = { };
+    _perProcessState.dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::NotResizing;
+    _perProcessState.animatedResizeOldBounds = { };
     [self _scheduleVisibleContentRectUpdate];
 }
 
 - (void)_didCompleteAnimatedResize
 {
-    if (_dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
+    if (_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing)
         return;
 
     [_contentView setHidden:NO];
@@ -2661,8 +2625,8 @@ static int32_t activeOrientation(WKWebView *webView)
     _resizeAnimationView = nil;
     _resizeAnimationTransformAdjustments = CATransform3DIdentity;
 
-    _dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::NotResizing;
-    _animatedResizeOldBounds = { };
+    _perProcessState.dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::NotResizing;
+    _perProcessState.animatedResizeOldBounds = { };
 
     [self _didStopDeferringGeometryUpdates];
 }
@@ -2677,7 +2641,7 @@ static int32_t activeOrientation(WKWebView *webView)
     auto newMaximumUnobscuredSize = activeMaximumUnobscuredSize(self, newBounds);
     int32_t newOrientation = activeOrientation(self);
 
-    if (!_lastSentViewLayoutSize || newViewLayoutSize != _lastSentViewLayoutSize.value())
+    if (!_perProcessState.lastSentViewLayoutSize || newViewLayoutSize != _perProcessState.lastSentViewLayoutSize.value())
         [self _dispatchSetViewLayoutSize:newViewLayoutSize];
 
     if (_minimumUnobscuredSizeOverride)
@@ -2688,7 +2652,7 @@ static int32_t activeOrientation(WKWebView *webView)
     }
     [self _recalculateViewportSizesWithMinimumViewportInset:_minimumViewportInset maximumViewportInset:_maximumViewportInset throwOnInvalidInput:NO];
 
-    if (!_lastSentDeviceOrientation || newOrientation != _lastSentDeviceOrientation.value())
+    if (!_perProcessState.lastSentDeviceOrientation || newOrientation != _perProcessState.lastSentDeviceOrientation.value())
         [self _dispatchSetDeviceOrientation:newOrientation];
 
     while (!_callbacksDeferredDuringResize.isEmpty())
@@ -2740,7 +2704,7 @@ static int32_t activeOrientation(WKWebView *webView)
 
     if (adjustScrollView) {
         CGFloat bottomInsetBeforeAdjustment = [_scrollView contentInset].bottom;
-        SetForScope insetAdjustmentGuard(_currentlyAdjustingScrollViewInsetsForKeyboard, YES);
+        SetForScope insetAdjustmentGuard(_perProcessState.currentlyAdjustingScrollViewInsetsForKeyboard, YES);
         [_scrollView _adjustForAutomaticKeyboardInfo:keyboardInfo animated:YES lastAdjustment:&_lastAdjustmentForScroller];
         CGFloat bottomInsetAfterAdjustment = [_scrollView contentInset].bottom;
         // FIXME: This "total bottom content inset adjustment" mechanism hasn't worked since iOS 11, since -_adjustForAutomaticKeyboardInfo:animated:lastAdjustment:
@@ -2835,17 +2799,17 @@ static int32_t activeOrientation(WKWebView *webView)
     CGRect fullViewRect = self.bounds;
     CGRect unobscuredRect = UIEdgeInsetsInsetRect(fullViewRect, [self _computedObscuredInset]);
 
-    _frozenVisibleContentRect = [self convertRect:fullViewRect toView:_contentView.get()];
-    _frozenUnobscuredContentRect = [self convertRect:unobscuredRect toView:_contentView.get()];
+    _perProcessState.frozenVisibleContentRect = [self convertRect:fullViewRect toView:_contentView.get()];
+    _perProcessState.frozenUnobscuredContentRect = [self convertRect:unobscuredRect toView:_contentView.get()];
     _contentViewShouldBecomeFirstResponderAfterNavigationGesture = [_contentView isFirstResponder];
 
-    LOG_WITH_STREAM(VisibleRects, stream << "_navigationGestureDidBegin: freezing visibleContentRect " << WebCore::FloatRect(_frozenVisibleContentRect.value()) << " UnobscuredContentRect " << WebCore::FloatRect(_frozenUnobscuredContentRect.value()));
+    LOG_WITH_STREAM(VisibleRects, stream << "_navigationGestureDidBegin: freezing visibleContentRect " << WebCore::FloatRect(_perProcessState.frozenVisibleContentRect.value()) << " UnobscuredContentRect " << WebCore::FloatRect(_perProcessState.frozenUnobscuredContentRect.value()));
 }
 
 - (void)_navigationGestureDidEnd
 {
-    _frozenVisibleContentRect = std::nullopt;
-    _frozenUnobscuredContentRect = std::nullopt;
+    _perProcessState.frozenVisibleContentRect = std::nullopt;
+    _perProcessState.frozenUnobscuredContentRect = std::nullopt;
 
     if (_contentViewShouldBecomeFirstResponderAfterNavigationGesture) {
         if (self.window && ![_contentView isFirstResponder])
@@ -2889,10 +2853,10 @@ static int32_t activeOrientation(WKWebView *webView)
 
 - (void)_setAvoidsUnsafeArea:(BOOL)avoidsUnsafeArea
 {
-    if (_avoidsUnsafeArea == avoidsUnsafeArea)
+    if (_perProcessState.avoidsUnsafeArea == avoidsUnsafeArea)
         return;
 
-    _avoidsUnsafeArea = avoidsUnsafeArea;
+    _perProcessState.avoidsUnsafeArea = avoidsUnsafeArea;
 
     if ([self _updateScrollViewContentInsetsIfNecessary] && !self._shouldDeferGeometryUpdates && !_viewLayoutSizeOverride)
         [self _dispatchSetViewLayoutSize:[self activeViewLayoutSize:self.bounds]];
@@ -2968,19 +2932,19 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 
 - (void)_beginLiveResize
 {
-    if (_liveResizeParameters) {
+    if (_perProcessState.liveResizeParameters) {
         RELEASE_LOG_FAULT(Resize, "Error: _beginLiveResize called with an outstanding live resize.");
         return;
     }
 
-    if (_dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
+    if (_perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing) {
         RELEASE_LOG_FAULT(Resize, "Error: _beginLiveResize called during an animated resize.");
         return;
     }
 
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _beginLiveResize]", self, _page->identifier().toUInt64());
 
-    _liveResizeParameters = { { self.bounds.size.width, self.scrollView.contentOffset } };
+    _perProcessState.liveResizeParameters = { { self.bounds.size.width, self.scrollView.contentOffset } };
 
     [self _ensureResizeAnimationView];
 }
@@ -2989,16 +2953,16 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
 
-    if (!_liveResizeParameters)
+    if (!_perProcessState.liveResizeParameters)
         return;
 
     UIView *liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
     [liveResizeSnapshotView setFrame:self.bounds];
     [self addSubview:liveResizeSnapshotView];
 
-    _liveResizeParameters = std::nullopt;
+    _perProcessState.liveResizeParameters = std::nullopt;
 
-    ASSERT(_dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
+    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
     [self _destroyResizeAnimationView];
     [self _didStopDeferringGeometryUpdates];
 
@@ -3320,7 +3284,7 @@ static bool isLockdownModeWarningNeeded()
 {
     if (![self usesStandardContentView])
         return NO;
-    return _avoidsUnsafeArea;
+    return _perProcessState.avoidsUnsafeArea;
 }
 
 - (UIView *)_enclosingViewForExposedRectComputation
@@ -3533,12 +3497,12 @@ static bool isLockdownModeWarningNeeded()
 
 - (void)_beginAnimatedResizeWithUpdates:(void (^)(void))updateBlock
 {
-    bool hadPendingAnimatedResize = _dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
+    bool hadPendingAnimatedResize = _perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing;
     CGRect oldBounds = self.bounds;
     WebCore::FloatRect oldUnobscuredContentRect = _page->unobscuredContentRect();
 
-    auto isOldBoundsValid = !CGRectIsEmpty(oldBounds) || !CGRectIsEmpty(_animatedResizeOldBounds);
-    if (![self usesStandardContentView] || !_hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _liveResizeParameters) {
+    auto isOldBoundsValid = !CGRectIsEmpty(oldBounds) || !CGRectIsEmpty(_perProcessState.animatedResizeOldBounds);
+    if (![self usesStandardContentView] || !_perProcessState.hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _perProcessState.liveResizeParameters) {
         if ([_customContentView respondsToSelector:@selector(web_beginAnimatedResizeWithUpdates:)])
             [_customContentView web_beginAnimatedResizeWithUpdates:updateBlock];
         else
@@ -3548,17 +3512,17 @@ static bool isLockdownModeWarningNeeded()
 
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _beginAnimatedResizeWithUpdates:]", self, _page->identifier().toUInt64());
 
-    _dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::ResizingWithAnimation;
+    _perProcessState.dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::ResizingWithAnimation;
 
     CGFloat oldMinimumEffectiveDeviceWidth;
     int32_t oldOrientation;
     UIEdgeInsets oldObscuredInsets;
-    if (!CGRectIsEmpty(_animatedResizeOldBounds)) {
-        oldBounds = _animatedResizeOldBounds;
+    if (!CGRectIsEmpty(_perProcessState.animatedResizeOldBounds)) {
+        oldBounds = _perProcessState.animatedResizeOldBounds;
         oldMinimumEffectiveDeviceWidth = _animatedResizeOldMinimumEffectiveDeviceWidth;
         oldOrientation = _animatedResizeOldOrientation;
         oldObscuredInsets = _animatedResizeOldObscuredInsets;
-        _animatedResizeOldBounds = { };
+        _perProcessState.animatedResizeOldBounds = { };
     } else {
         oldMinimumEffectiveDeviceWidth = [self _minimumEffectiveDeviceWidth];
         oldOrientation = activeOrientation(self);
@@ -3584,12 +3548,12 @@ static bool isLockdownModeWarningNeeded()
         if (!CGRectIsEmpty(newBounds))
             [self _cancelAnimatedResize];
         else {
-            _animatedResizeOldBounds = oldBounds;
+            _perProcessState.animatedResizeOldBounds = oldBounds;
             _animatedResizeOldMinimumEffectiveDeviceWidth = oldMinimumEffectiveDeviceWidth;
             _animatedResizeOldOrientation = oldOrientation;
             _animatedResizeOldObscuredInsets = oldObscuredInsets;
-            _waitingForCommitAfterAnimatedResize = YES;
-            _waitingForEndAnimatedResize = YES;
+            _perProcessState.waitingForCommitAfterAnimatedResize = YES;
+            _perProcessState.waitingForEndAnimatedResize = YES;
         }
 
         [self _frameOrBoundsChanged];
@@ -3629,14 +3593,14 @@ static bool isLockdownModeWarningNeeded()
 
     // Compute the new scale to keep the current content width in the scrollview.
     CGFloat oldWebViewWidthInContentViewCoordinates = oldUnobscuredContentRect.width();
-    _animatedResizeOriginalContentWidth = [&] {
+    _perProcessState.animatedResizeOriginalContentWidth = [&] {
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
         if (self._isWindowResizingEnabled)
             return contentSizeInContentViewCoordinates.width;
 #endif
         return std::min(contentSizeInContentViewCoordinates.width, oldWebViewWidthInContentViewCoordinates);
     }();
-    CGFloat targetScale = newViewLayoutSize.width() / _animatedResizeOriginalContentWidth;
+    CGFloat targetScale = newViewLayoutSize.width() / _perProcessState.animatedResizeOriginalContentWidth;
     CGFloat resizeAnimationViewAnimationScale = targetScale / contentZoomScale(self);
     [_resizeAnimationView setTransform:CGAffineTransformMakeScale(resizeAnimationViewAnimationScale, resizeAnimationViewAnimationScale)];
 
@@ -3676,25 +3640,25 @@ static bool isLockdownModeWarningNeeded()
     UIEdgeInsets unobscuredSafeAreaInsets = [self _computedUnobscuredSafeAreaInset];
     WebCore::FloatBoxExtent unobscuredSafeAreaInsetsExtent(unobscuredSafeAreaInsets.top, unobscuredSafeAreaInsets.right, unobscuredSafeAreaInsets.bottom, unobscuredSafeAreaInsets.left);
 
-    _lastSentViewLayoutSize = newViewLayoutSize;
-    _lastSentDeviceOrientation = newOrientation;
+    _perProcessState.lastSentViewLayoutSize = newViewLayoutSize;
+    _perProcessState.lastSentDeviceOrientation = newOrientation;
 
     _page->dynamicViewportSizeUpdate(newViewLayoutSize, newMinimumUnobscuredSize, newMaximumUnobscuredSize, visibleRectInContentCoordinates, unobscuredRectInContentCoordinates, futureUnobscuredRectInSelfCoordinates, unobscuredSafeAreaInsetsExtent, targetScale, newOrientation, newMinimumEffectiveDeviceWidth, ++_currentDynamicViewportSizeUpdateID);
     if (WebKit::DrawingAreaProxy* drawingArea = _page->drawingArea())
         drawingArea->setSize(WebCore::IntSize(newBounds.size));
 
-    _waitingForCommitAfterAnimatedResize = YES;
-    _waitingForEndAnimatedResize = YES;
+    _perProcessState.waitingForCommitAfterAnimatedResize = YES;
+    _perProcessState.waitingForEndAnimatedResize = YES;
 }
 
 - (void)_endAnimatedResize
 {
-    WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endAnimatedResize] _dynamicViewportUpdateMode %d", self, _page->identifier().toUInt64(), _dynamicViewportUpdateMode);
+    WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endAnimatedResize] dynamicViewportUpdateMode %d", self, _page->identifier().toUInt64(), _perProcessState.dynamicViewportUpdateMode);
 
     // If we already have an up-to-date layer tree, immediately complete
     // the resize. Otherwise, we will defer completion until we do.
-    _waitingForEndAnimatedResize = NO;
-    if (!_waitingForCommitAfterAnimatedResize)
+    _perProcessState.waitingForEndAnimatedResize = NO;
+    if (!_perProcessState.waitingForCommitAfterAnimatedResize)
         [self _didCompleteAnimatedResize];
 }
 
@@ -3703,13 +3667,13 @@ static bool isLockdownModeWarningNeeded()
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _resizeWhileHidingContentWithUpdates:]", self, _page->identifier().toUInt64());
 
     [self _beginAnimatedResizeWithUpdates:updateBlock];
-    if (_dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::ResizingWithAnimation) {
+    if (_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::ResizingWithAnimation) {
         [_contentView setHidden:YES];
-        _dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::ResizingWithDocumentHidden;
+        _perProcessState.dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::ResizingWithDocumentHidden;
         
         // _resizeWhileHidingContentWithUpdates is used by itself; the client will
         // not call endAnimatedResize, so we can't wait for it.
-        _waitingForEndAnimatedResize = NO;
+        _perProcessState.waitingForEndAnimatedResize = NO;
     }
 }
 
@@ -4057,13 +4021,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_addLayerForFindOverlay
 {
-    if (!_page || _pendingFindLayerID || _committedFindLayerID)
+    if (!_page || _perProcessState.pendingFindLayerID || _perProcessState.committedFindLayerID)
         return;
 
     _page->addLayerForFindOverlay([weakSelf = WeakObjCPtr<WKWebView>(self)] (WebCore::GraphicsLayer::PlatformLayerID layerID) {
         auto strongSelf = weakSelf.get();
         if (strongSelf)
-            strongSelf->_pendingFindLayerID = layerID;
+            strongSelf->_perProcessState.pendingFindLayerID = layerID;
     });
 }
 
@@ -4072,11 +4036,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!_page)
         return;
 
-    if (!_pendingFindLayerID && !_committedFindLayerID)
+    if (!_perProcessState.pendingFindLayerID && !_perProcessState.committedFindLayerID)
         return;
 
-    _pendingFindLayerID = 0;
-    _committedFindLayerID = 0;
+    _perProcessState.pendingFindLayerID = 0;
+    _perProcessState.committedFindLayerID = 0;
 
     _page->removeLayerForFindOverlay([weakSelf = WeakObjCPtr<WKWebView>(self)] {
         auto strongSelf = weakSelf.get();
@@ -4090,10 +4054,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (CALayer *)_layerForFindOverlay
 {
-    if (!_page || !_committedFindLayerID)
+    if (!_page || !_perProcessState.committedFindLayerID)
         return nil;
 
-    return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(_committedFindLayerID);
+    return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(_perProcessState.committedFindLayerID);
 }
 
 #endif // HAVE(UIFINDINTERACTION)


### PR DESCRIPTION
#### ba12984f136d1a6f3560059f3df996fac9683e14
<pre>
Group WKWebView state which is per-process into a struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=243704">https://bugs.webkit.org/show_bug.cgi?id=243704</a>

Reviewed by Chris Dumez.

We often have bugs where we forget to reset state on WKWebView when the web process terminates (the
same is true on WebPageProxy, which I will fix separately).

To make it harder to create such bugs, group all the data that needs to be reset on web process
termination into a PerWebProcessState struct. `_processWillSwapOrDidExit` can then just reinitialize
this struct.

Currently PerWebProcessState is only used for iOS, but it&apos;s probable that future refactoring will
make it apply to all platforms.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView _internalDoAfterNextPresentationUpdate:withoutWaitingForPainting:withoutWaitingForAnimatedResize:]):
(-[WKWebView _setMinimumEffectiveDeviceWidth:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setHasCustomContentView:loadedMIMEType:]):
(-[WKWebView _willInvokeUIScrollViewDelegateCallback]):
(-[WKWebView _didInvokeUIScrollViewDelegateCallback]):
(-[WKWebView _resetCachedScrollViewBackgroundColor]):
(-[WKWebView _updateScrollViewBackground]):
(-[WKWebView _processWillSwapOrDidExit]):
(-[WKWebView _didRelaunchProcess]):
(-[WKWebView _didCommitLoadForMainFrame]):
(-[WKWebView _didCommitLayerTreeDuringAnimatedResize:]):
(-[WKWebView _trackTransactionCommit:]):
(-[WKWebView _restoreScrollAndZoomStateForTransaction:]):
(-[WKWebView _didCommitLayerTree:]):
(-[WKWebView _layerTreeCommitComplete]):
(-[WKWebView _restorePageScrollPosition:scrollOrigin:previousObscuredInset:scale:]):
(-[WKWebView _restorePageStateToUnobscuredCenter:scale:]):
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]):
(-[WKWebView _zoomToInitialScaleWithOrigin:animated:]):
(-[WKWebView _initialScaleFactor]):
(-[WKWebView _allowsDoubleTapGestures]):
(-[WKWebView _visibleContentRect]):
(-[WKWebView _dispatchSetViewLayoutSize:]):
(-[WKWebView _dispatchSetDeviceOrientation:]):
(-[WKWebView _beginAutomaticLiveResizeIfNeeded]):
(-[WKWebView _updateLiveResizeTransform]):
(-[WKWebView _frameOrBoundsChanged]):
(-[WKWebView _addUpdateVisibleContentRectPreCommitHandler]):
(-[WKWebView _scheduleVisibleContentRectUpdateAfterScrollInView:]):
(-[WKWebView _shouldDeferGeometryUpdates]):
(-[WKWebView _updateVisibleContentRects]):
(-[WKWebView _cancelAnimatedResize]):
(-[WKWebView _didCompleteAnimatedResize]):
(-[WKWebView _didStopDeferringGeometryUpdates]):
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):
(-[WKWebView _navigationGestureDidBegin]):
(-[WKWebView _navigationGestureDidEnd]):
(-[WKWebView _setAvoidsUnsafeArea:]):
(-[WKWebView _beginLiveResize]):
(-[WKWebView _endLiveResize]):
(-[WKWebView _safeAreaShouldAffectObscuredInsets]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
(-[WKWebView _endAnimatedResize]):
(-[WKWebView _resizeWhileHidingContentWithUpdates:]):
(-[WKWebView _addLayerForFindOverlay]):
(-[WKWebView _removeLayerForFindOverlay]):
(-[WKWebView _layerForFindOverlay]):

Canonical link: <a href="https://commits.webkit.org/253459@main">https://commits.webkit.org/253459@main</a>
</pre>
