### PR TITLE
Restrict sandbox rule for loading of injected bundles

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -882,7 +882,8 @@
 (deny file-read-xattr file-write-xattr (xattr-prefix "com.apple.security.private."))
 
 ;; Allow loading injected bundles.
-(allow file-map-executable)
+(with-filter (require-not (state-flag "WebContentProcessLaunched"))
+    (allow file-map-executable))
 
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
 ;; Allow ManagedPreference access


### PR DESCRIPTION
#### a05ced4f7e9595c86f0b0c14a3aec9fe4fbabfa9
<pre>
Restrict sandbox rule for loading of injected bundles
<a href="https://bugs.webkit.org/show_bug.cgi?id=243718">https://bugs.webkit.org/show_bug.cgi?id=243718</a>
&lt;rdar://problem/98364143&gt;

Reviewed by Chris Dumez.

Only allow loading injected bundles during WebContent process launch on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/253707@main">https://commits.webkit.org/253707@main</a>
</pre>
