### PR TITLE
[GStreamer][WebRTC] Capabilities probing support

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -945,8 +945,6 @@ webkit.org/b/235885 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.ht
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpParameters-maxFramerate.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-priority/RTCRtpParameters-encodings.html [ Failure ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc.html [ Failure ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc.html [ Failure ]
 webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
 webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
 webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
@@ -978,10 +976,9 @@ webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/video.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
 webkit.org/b/235885 webrtc/vp9-svc.html [ Failure ]
-webkit.org/b/235885 webrtc/vp9.html [ Failure ]
 
-# Hits an ASSERT because we don't have a WebRTC provider handling WebRTC-related media-capabilities.
-webkit.org/b/235885 [ Debug ] media/mediacapabilities/mock-encodingInfo.html [ Crash ]
+# Failing until additional WebRTC end-point patches have landed.
+webkit.org/b/235885 webrtc/vp9.html [ Skip ]
 
 # Expected to pass with GStreamer 1.22.
 webkit.org/b/235885 webrtc/no-port-zero-in-upd-candidates.html [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
@@ -10,16 +10,16 @@ PASS Test that decodingInfo rejects if the audio configuration contentType isn't
 PASS Test that decodingInfo returns a valid MediaCapabilitiesInfo objects
 PASS Test that decodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc video content type.
 PASS Test that decodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc audio content type.
-PASS Test that decodingInfo returns supported true for the codec audio/opus returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec audio/OPUS returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/ISAC returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/G722 returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f returned by RTCRtpReceiver.getCapabilities()
+PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/VP8 returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/VP9; profile-id=0 returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec video/VP9; profile-id=2 returned by RTCRtpReceiver.getCapabilities()
-PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f returned by RTCRtpReceiver.getCapabilities()
-PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f returned by RTCRtpReceiver.getCapabilities()
-PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
-PASS Test that decodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpReceiver.getCapabilities()
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
@@ -10,16 +10,16 @@ PASS Test that encodingInfo rejects if the audio configuration contentType isn't
 PASS Test that encodingInfo returns a valid MediaCapabilitiesInfo objects
 PASS Test that encodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc video content type.
 PASS Test that encodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc audio content type.
-PASS Test that encodingInfo returns supported true for the codec audio/opus returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec audio/OPUS returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/ISAC returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/G722 returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f returned by RTCRtpSender.getCapabilities()
+PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/VP8 returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/VP9; profile-id=0 returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec video/VP9; profile-id=2 returned by RTCRtpSender.getCapabilities()
-PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f returned by RTCRtpSender.getCapabilities()
-PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f returned by RTCRtpSender.getCapabilities()
-PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
-PASS Test that encodingInfo returns supported true for the codec video/H264; level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f returned by RTCRtpSender.getCapabilities()
 

--- a/LayoutTests/webrtc/vp9-profile2.html
+++ b/LayoutTests/webrtc/vp9-profile2.html
@@ -15,6 +15,7 @@
         <script>
 let vp9Profile2;
 test(() => {
+    internals.setWebRTCVP9Support(false, true);
     codecs = RTCRtpSender.getCapabilities("video").codecs;
     vp9Profiles = codecs.filter(codec => { return codec.mimeType === "video/VP9" && codec.sdpFmtpLine === "profile-id=2"; });
     assert_equals(vp9Profiles.length, 1);

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -32,7 +32,6 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSMediaCapabilitiesDecodingInfo.h"
 #include "JSMediaCapabilitiesEncodingInfo.h"
-#include "LibWebRTCProvider.h"
 #include "Logging.h"
 #include "MediaCapabilitiesDecodingInfo.h"
 #include "MediaCapabilitiesEncodingInfo.h"
@@ -42,6 +41,7 @@
 #include "MediaEngineConfigurationFactory.h"
 #include "Page.h"
 #include "Settings.h"
+#include "WebRTCProvider.h"
 #include <wtf/Logger.h>
 #include <wtf/SortedArrayMap.h>
 
@@ -183,14 +183,12 @@ static void gatherDecodingInfo(Document& document, MediaDecodingConfiguration&& 
     configuration.canExposeVP9 = document.settings().vp9DecoderEnabled();
 #endif
 
-#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC)
     if (configuration.type == MediaDecodingType::WebRTC) {
         if (auto* page = document.page())
             page->webRTCProvider().createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
         return;
     }
-#else
-    UNUSED_PARAM(document);
 #endif
     MediaEngineConfigurationFactory::createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
 }
@@ -203,7 +201,7 @@ static void gatherEncodingInfo(Document& document, MediaEncodingConfiguration&& 
         callback(WTFMove(result));
     };
 
-#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC)
     if (configuration.type == MediaEncodingType::WebRTC) {
         if (auto* page = document.page())
             page->webRTCProvider().createEncodingConfiguration(WTFMove(configuration), WTFMove(encodingCallback));

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -48,6 +48,7 @@
 #include "RTCSctpTransportBackend.h"
 #include "RTCSessionDescriptionInit.h"
 #include "RTCTrackEvent.h"
+#include "WebRTCProvider.h"
 #include <wtf/UUID.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenateNumbers.h>
@@ -58,7 +59,25 @@
 
 namespace WebCore {
 
-#if !USE(LIBWEBRTC) && !USE(GSTREAMER_WEBRTC)
+#if USE(LIBWEBRTC) || USE(GSTREAMER_WEBRTC)
+
+std::optional<RTCRtpCapabilities> PeerConnectionBackend::receiverCapabilities(ScriptExecutionContext& context, const String& kind)
+{
+    auto* page = downcast<Document>(context).page();
+    if (!page)
+        return { };
+    return page->webRTCProvider().receiverCapabilities(kind);
+}
+
+std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(ScriptExecutionContext& context, const String& kind)
+{
+    auto* page = downcast<Document>(context).page();
+    if (!page)
+        return { };
+    return page->webRTCProvider().senderCapabilities(kind);
+}
+
+#else
 
 static std::unique_ptr<PeerConnectionBackend> createNoPeerConnectionBackend(RTCPeerConnection&)
 {
@@ -78,7 +97,7 @@ std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(Scri
     ASSERT_NOT_REACHED();
     return { };
 }
-#endif
+#endif // USE(LIBWEBRTC) || USE(GSTREAMER_WEBRTC)
 
 PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
     : m_peerConnection(peerConnection)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -56,69 +56,6 @@ static std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectionBacke
 
 CreatePeerConnectionBackend PeerConnectionBackend::create = createGStreamerPeerConnectionBackend;
 
-static RTCRtpCapabilities gstreamerRtpCapatiblities(const String& kind)
-{
-    RTCRtpCapabilities capabilities;
-    capabilities.headerExtensions.append({ "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"_s });
-    if (kind == "audio"_s) {
-        capabilities.codecs.reserveCapacity(4);
-        capabilities.codecs.uncheckedAppend({ .mimeType = "audio/OPUS"_s,
-            .clockRate = 48000,
-            .channels = 2,
-            .sdpFmtpLine = emptyString() });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "audio/G722"_s,
-            .clockRate = 8000,
-            .channels = 1,
-            .sdpFmtpLine = emptyString() });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "audio/PCMA"_s,
-            .clockRate = 8000,
-            .channels = 1,
-            .sdpFmtpLine = emptyString() });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "audio/PCMU"_s,
-            .clockRate = 8000,
-            .channels = 1,
-            .sdpFmtpLine = emptyString() });
-    } else {
-        capabilities.headerExtensions.append({ "urn:3gpp:video-orientation"_s });
-        capabilities.codecs.reserveCapacity(6);
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP8"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = emptyString() });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP9"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = "profile-id=0"_s });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP9"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = "profile-id=1"_s });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/VP9"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = "profile-id=2"_s });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/H264"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"_s });
-        capabilities.codecs.uncheckedAppend({ .mimeType = "video/H264"_s,
-            .clockRate = 90000,
-            .channels = std::nullopt,
-            .sdpFmtpLine = "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f"_s });
-    }
-    return capabilities;
-}
-
-std::optional<RTCRtpCapabilities> PeerConnectionBackend::receiverCapabilities(ScriptExecutionContext&, const String& kind)
-{
-    return gstreamerRtpCapatiblities(kind);
-}
-
-std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(ScriptExecutionContext&, const String& kind)
-{
-    return gstreamerRtpCapatiblities(kind);
-}
-
 GStreamerPeerConnectionBackend::GStreamerPeerConnectionBackend(RTCPeerConnection& peerConnection)
     : PeerConnectionBackend(peerConnection)
     , m_endpoint(GStreamerMediaEndpoint::create(*this))

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -71,22 +71,6 @@ static std::unique_ptr<PeerConnectionBackend> createLibWebRTCPeerConnectionBacke
 
 CreatePeerConnectionBackend PeerConnectionBackend::create = createLibWebRTCPeerConnectionBackend;
 
-std::optional<RTCRtpCapabilities> PeerConnectionBackend::receiverCapabilities(ScriptExecutionContext& context, const String& kind)
-{
-    auto* page = downcast<Document>(context).page();
-    if (!page)
-        return { };
-    return page->webRTCProvider().receiverCapabilities(kind);
-}
-
-std::optional<RTCRtpCapabilities> PeerConnectionBackend::senderCapabilities(ScriptExecutionContext& context, const String& kind)
-{
-    auto* page = downcast<Document>(context).page();
-    if (!page)
-        return { };
-    return page->webRTCProvider().senderCapabilities(kind);
-}
-
 LibWebRTCPeerConnectionBackend::LibWebRTCPeerConnectionBackend(RTCPeerConnection& peerConnection, LibWebRTCProvider& provider)
     : PeerConnectionBackend(peerConnection)
     , m_endpoint(LibWebRTCMediaEndpoint::create(*this, provider))

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #if USE(GSTREAMER_WEBRTC)
+#include <gst/rtp/rtp.h>
 #define GST_USE_UNSTABLE_API
 #include <gst/webrtc/webrtc.h>
 #undef GST_USE_UNSTABLE_API
@@ -730,6 +731,25 @@ template<> void derefGPtr<GstPromise>(GstPromise* ptr)
 {
     if (ptr)
         gst_promise_unref(ptr);
+}
+
+template<> GRefPtr<GstRTPHeaderExtension> adoptGRef(GstRTPHeaderExtension* ptr)
+{
+    return GRefPtr<GstRTPHeaderExtension>(ptr, GRefPtrAdopt);
+}
+
+template<> GstRTPHeaderExtension* refGPtr<GstRTPHeaderExtension>(GstRTPHeaderExtension* ptr)
+{
+    if (ptr)
+        gst_object_ref(GST_OBJECT(ptr));
+
+    return ptr;
+}
+
+template<> void derefGPtr<GstRTPHeaderExtension>(GstRTPHeaderExtension* ptr)
+{
+    if (ptr)
+        gst_object_unref(ptr);
 }
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -42,6 +42,7 @@ typedef struct _GstWebRTCICETransport GstWebRTCICETransport;
 typedef struct _GstWebRTCRTPReceiver GstWebRTCRTPReceiver;
 typedef struct _GstWebRTCRTPSender GstWebRTCRTPSender;
 typedef struct _GstWebRTCRTPTransceiver GstWebRTCRTPTransceiver;
+typedef struct _GstRTPHeaderExtension GstRTPHeaderExtension;
 #endif
 
 namespace WTF {
@@ -189,6 +190,11 @@ template <> void derefGPtr<GstWebRTCICETransport>(GstWebRTCICETransport*);
 template <> GRefPtr<GstPromise> adoptGRef(GstPromise*);
 template <> GstPromise* refGPtr<GstPromise>(GstPromise*);
 template <> void derefGPtr<GstPromise>(GstPromise*);
+
+template<> GRefPtr<GstRTPHeaderExtension> adoptGRef(GstRTPHeaderExtension*);
+template<> GstRTPHeaderExtension* refGPtr<GstRTPHeaderExtension>(GstRTPHeaderExtension*);
+template<> void derefGPtr<GstRTPHeaderExtension>(GstRTPHeaderExtension*);
+
 #endif
 
 } // namespace WTF


### PR DESCRIPTION
#### ea06abc8501c66cf264414965269f23deab87741
<pre>
[GStreamer][WebRTC] Capabilities probing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=243723">https://bugs.webkit.org/show_bug.cgi?id=243723</a>

Reviewed by Xabier Rodriguez-Calvar.

The GStreamerRegistryScanner can now probe for RTP payloads, depayloaders and extensions, so that
the WebRTC MediaCapabilities now correspond to the ones available on the GStreamer runtime. The
PeerConnectionBackend RTP sender and receiver capabilies also make use of the probed capabilies. The
corresponding code is no longer specific to the LibWebRTC backend, since we use the new
WebRTCProvider base class.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt:
* LayoutTests/platform/glib/webrtc/vp9-expected.txt: Added.
* LayoutTests/webrtc/vp9-profile2.html:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::gatherDecodingInfo):
(WebCore::gatherEncodingInfo):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::receiverCapabilities):
(WebCore::PeerConnectionBackend::senderCapabilities):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::gstreamerRtpCapatiblities): Deleted.
(WebCore::PeerConnectionBackend::receiverCapabilities): Deleted.
(WebCore::PeerConnectionBackend::senderCapabilities): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::receiverCapabilities): Deleted.
(WebCore::PeerConnectionBackend::senderCapabilities): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp:
(WTF::adoptGRef):
(WTF::refGPtr&lt;GstRTPHeaderExtension&gt;):
(WTF::derefGPtr&lt;GstRTPHeaderExtension&gt;):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::ElementFactories::ElementFactories):
(WebCore::GStreamerRegistryScanner::ElementFactories::~ElementFactories):
(WebCore::GStreamerRegistryScanner::ElementFactories::elementFactoryTypeToString):
(WebCore::GStreamerRegistryScanner::ElementFactories::factory const):
(WebCore::GStreamerRegistryScanner::ElementFactories::hasElementForMediaType const):
(WebCore::GStreamerRegistryScanner::audioRtpCapabilities):
(WebCore::GStreamerRegistryScanner::videoRtpCapabilities):
(WebCore::probeRtpExtensions):
(WebCore::GStreamerRegistryScanner::fillAudioRtpCapabilities):
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp:
(WebCore::GStreamerWebRTCProvider::receiverCapabilities):
(WebCore::GStreamerWebRTCProvider::senderCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeAudioEncodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeVideoEncodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeAudioDecodingCapabilities):
(WebCore::GStreamerWebRTCProvider::initializeVideoDecodingCapabilities):

Canonical link: <a href="https://commits.webkit.org/253297@main">https://commits.webkit.org/253297@main</a>
</pre>
