### PR TITLE
Non-unified build fixes, earlyish August 2022 edition, bis

### DIFF
--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "Completion.h"
 
+#include "BuiltinNames.h"
 #include "BytecodeCacheError.h"
 #include "CatchScope.h"
 #include "CodeCache.h"

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -31,6 +31,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SimpleRange.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>


### PR DESCRIPTION
#### c63d141761a28f3b1ad73695c9e42ce9b96d4ac2
<pre>
Non-unified build fixes, earlyish August 2022 edition, bis
<a href="https://bugs.webkit.org/show_bug.cgi?id=243724">https://bugs.webkit.org/show_bug.cgi?id=243724</a>

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/runtime/Completion.cpp: Add missing
  BuiltinNames.h header inclusion.
* Source/WebKit/WebProcess/WebPage/FindController.h: Add missing
  wtf/ComplationHandler.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/253259@main">https://commits.webkit.org/253259@main</a>
</pre>
