### PR TITLE
[macOS] Disable sandbox reports for certain violations

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -513,6 +513,7 @@
             "avd-version"
             "clock-gates"
             "clock-ids"
+            "coprovider-group"
             "decode-samples-per-second"
             "function-avd_reset"
             "function-mcc_dataset"
@@ -790,7 +791,8 @@
 (allow file-read-data (path "/private/var/db/nsurlstoraged/dafsaData.bin"))
 
 (deny file-read* (with no-report)
-    (home-literal "/Library/Preferences/com.apple.networkd.plist"))
+    (home-literal "/Library/Preferences/com.apple.networkd.plist")
+    (literal "/Library/Preferences/com.apple.networkd.plist"))
 
 #if PLATFORM(MAC)
 (allow mach-lookup

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -41,7 +41,7 @@
 #if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
 #include <WebKitAdditions/SystemContentSandbox-macos.defs>
 #endif
- 
+
 ;; Utility functions for home directory relative path filters
 (define (home-regex home-relative-regex)
   (regex (string-append "^" (regex-quote (param "HOME_DIR")) home-relative-regex)))

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -755,6 +755,9 @@
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76782530>
 )
 
+(deny sysctl-read (with no-report)
+    (sysctl-name "vm.task_no_footprint_for_debug"))
+
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")
     (iokit-property "AAPL,OpenCLdisabled")
@@ -1204,7 +1207,7 @@
         (syscall-unix-rarely-in-use-need-backtrace))
 )
 
-(deny syscall-unix (syscall-number
+(deny syscall-unix (with no-report) (syscall-number
     SYS_connect
     SYS_socket))
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -35,7 +35,7 @@
 #if ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
 #include <WebKitAdditions/SystemContentSandbox-macos.defs>
 #endif
- 
+
 ;;;
 ;;; The following rules were originally contained in 'system.sb'. We are duplicating them here so we can
 ;;; remove unneeded sandbox extensions.
@@ -1432,8 +1432,10 @@
 (allow mach-lookup
     (global-name "com.apple.PowerManagement.control")
     (global-name "com.apple.SystemConfiguration.configd")
-    (global-name "com.apple.assertiond.processassertionconnection")
-)
+    (global-name "com.apple.assertiond.processassertionconnection"))
+#else
+(deny mach-lookup (with no-report)
+    (global-name "com.apple.PowerManagement.control"))
 #endif
 
 #if HAVE(STATIC_FONT_REGISTRY)
@@ -1450,7 +1452,7 @@
 #endif
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
-(deny mach-lookup
+(deny mach-lookup (with no-report)
 #else
 (allow mach-lookup
 #endif
@@ -2391,6 +2393,7 @@
     (home-literal "/Library/Preferences/com.apple.CFNetwork.plist")
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
     (home-literal "/Library/Preferences/com.apple.networkd.plist")
+    (literal "/Library/Preferences/com.apple.networkd.plist")
 #endif
 )
 #endif


### PR DESCRIPTION
#### de03c7b052b32b641eacb16fbb3d4d3607cbc1b1
<pre>
[macOS] Disable sandbox reports for certain violations
<a href="https://bugs.webkit.org/show_bug.cgi?id=243725">https://bugs.webkit.org/show_bug.cgi?id=243725</a>
&lt;rdar://problem/98376964&gt;

Reviewed by Chris Dumez.

Disable sandbox reports for certain violations on macOS. This is a small improvement in performance and power usage.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/253285@main">https://commits.webkit.org/253285@main</a>
</pre>
