### PR TITLE
Implement forced-colors media query.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Should be known: '(forced-colors)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(forced-colors: none)' assert_true: Can parse with JS expected true got false
-FAIL Should be known: '(forced-colors: active)' assert_true: Can parse with JS expected true got false
+PASS Should be known: '(forced-colors)'
+PASS Should be known: '(forced-colors: none)'
+PASS Should be known: '(forced-colors: active)'
 FAIL Should be parseable: '(forced-colors: 0)' assert_true: Can parse with JS expected true got false
 PASS Should be unknown: '(forced-colors: 0)'
 FAIL Should be parseable: '(forced-colors: no-preference)' assert_true: Can parse with JS expected true got false
@@ -14,5 +14,5 @@ FAIL Should be parseable: '(forced-colors: none active)' assert_true: Can parse 
 PASS Should be unknown: '(forced-colors: none active)'
 FAIL Should be parseable: '(forced-colors: active/none)' assert_true: Can parse with JS expected true got false
 PASS Should be unknown: '(forced-colors: active/none)'
-FAIL Check that none evaluates to false in the boolean context assert_equals: expected true but got false
+PASS Check that none evaluates to false in the boolean context
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1172,6 +1172,10 @@ hover
 progressive
 interlace
 
+// (forced-colors:) media feature.
+// none
+active
+
 // blend modes
 // normal
 multiply

--- a/Source/WebCore/css/MediaFeatureNames.h
+++ b/Source/WebCore/css/MediaFeatureNames.h
@@ -48,6 +48,7 @@
     macro(devicePixelRatio, "-webkit-device-pixel-ratio") \
     macro(deviceWidth, "device-width") \
     macro(dynamicRange, "dynamic-range") \
+    macro(forcedColors, "forced-colors") \
     macro(grid, "grid") \
     macro(height, "height") \
     macro(hover, "hover") \

--- a/Source/WebCore/css/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/MediaQueryEvaluator.cpp
@@ -489,6 +489,16 @@ static bool scanEvaluate(CSSValue* value, const CSSToLengthConversionData&, Fram
     return primitiveValue->valueID() == CSSValueProgressive;
 }
 
+static bool forcedColorsEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame&, MediaFeaturePrefix)
+{
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (!primitiveValue)
+        return false;
+
+    // On Cocoa platforms, there is no concept of "forced colors".
+    return primitiveValue->valueID() == CSSValueNone;
+}
+
 static bool gridEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame&, MediaFeaturePrefix op)
 {
     return zeroEvaluate(value, op);

--- a/Source/WebCore/css/MediaQueryExpression.cpp
+++ b/Source/WebCore/css/MediaQueryExpression.cpp
@@ -69,6 +69,8 @@ static inline bool isValidValueForIdentMediaFeature(const AtomString& feature, c
         return valueID == CSSValueHigh || valueID == CSSValueStandard;
     if (feature == MediaFeatureNames::scan)
         return valueID == CSSValueProgressive || valueID == CSSValueInterlace;
+    if (feature == MediaFeatureNames::forcedColors)
+        return valueID == CSSValueNone || valueID == CSSValueActive;
 
     return false;
 }
@@ -95,7 +97,8 @@ static inline bool featureWithValidIdent(const AtomString& mediaFeature, const C
         || mediaFeature == MediaFeatureNames::prefersReducedMotion
         || (mediaFeature == MediaFeatureNames::prefersDarkInterface && (context.useSystemAppearance || isUASheetBehavior(context.mode)))
         || mediaFeature == MediaFeatureNames::dynamicRange
-        || mediaFeature == MediaFeatureNames::scan;
+        || mediaFeature == MediaFeatureNames::scan
+        || mediaFeature == MediaFeatureNames::forcedColors;
 }
 
 static inline bool featureWithValidDensity(const String& mediaFeature, const CSSPrimitiveValue& value)
@@ -214,6 +217,7 @@ static inline bool isFeatureValidWithoutValue(const AtomString& mediaFeature, co
         || mediaFeature == MediaFeatureNames::displayMode
 #endif
         || mediaFeature == MediaFeatureNames::scan
+        || mediaFeature == MediaFeatureNames::forcedColors
         || mediaFeature == MediaFeatureNames::videoPlayableInline;
 }
 


### PR DESCRIPTION
#### 46513cc172ce079baedb34e890803058b9158b35
<pre>
Implement forced-colors media query.
<a href="https://bugs.webkit.org/show_bug.cgi?id=225281">https://bugs.webkit.org/show_bug.cgi?id=225281</a>
rdar://77715265

Reviewed by Tim Nguyen and Aditya Keerthi.

MQ always matchs &quot;none&quot;, as there is no concept of &quot;forced colors&quot; in
Cocoa.
<a href="https://www.w3.org/TR/mediaqueries-5/#forced-colors">https://www.w3.org/TR/mediaqueries-5/#forced-colors</a>

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/forced-colors-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/MediaFeatureNames.h:
* Source/WebCore/css/MediaQueryEvaluator.cpp:
(WebCore::forcedColorsEvaluate):
* Source/WebCore/css/MediaQueryExpression.cpp:
(WebCore::isValidValueForIdentMediaFeature):
(WebCore::featureWithValidIdent):
(WebCore::isFeatureValidWithoutValue):

Canonical link: <a href="https://commits.webkit.org/253290@main">https://commits.webkit.org/253290@main</a>
</pre>
