### PR TITLE
[iOS] Tests with incomplete UIScripts cause flaky crashes under WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree()

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3623,11 +3623,6 @@ webkit.org/b/240579 http/tests/workers/service/getnotifications.html [ Skip ]
 webkit.org/b/240579 http/tests/push-api [ Skip ]
 webkit.org/b/240579 http/wpt/push-api [ Skip ]
 
-# These tests finish with unfired UI script callbacks, causing crashes. See webkit.org/b/236794
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-047.html
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048.html
-imported/w3c/web-platform-tests/html/user-activation/no-activation-thru-escape-key.html
-
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]
 
 webkit.org/b/231266 fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html [ Pass Failure ]

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1715,6 +1715,10 @@ void TestInvocation::done()
     m_gotFinalMessage = true;
     invalidateWaitToDumpWatchdogTimer();
     invalidateWaitForPostDumpWatchdogTimer();
+
+    if (m_pendingUIScriptInvocationData)
+        outputText("FAIL - test completed with incomplete UI scripts\n"_s);
+
     RunLoop::main().dispatch([] {
         TestController::singleton().notifyDone();
     });


### PR DESCRIPTION
#### 47aeeca5223d79b2bae3f8cfb7d60f1ced54d524
<pre>
[iOS] Tests with incomplete UIScripts cause flaky crashes under WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree()
<a href="https://bugs.webkit.org/show_bug.cgi?id=236794">https://bugs.webkit.org/show_bug.cgi?id=236794</a>
&lt;rdar://89100788&gt;

Reviewed by NOBODY (OOPS!).

If a test calls notifyDone() before all the scripts triggered via `testRunner.runUIScript()` have completed,
then the UI process can be left in a bad state for the next test (for example, the keyboard may still be visible),
and we can hit an assertion in `TestInvocation::runUISideScriptImmediately()` on the next test.

Make a test fail if this happens, so that the error is attributed to the correct test.

Remove some expectations for tests that used to hit this but have been fixed.

* LayoutTests/platform/ios/TestExpectations:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::done):
</pre>