### PR TITLE
Ensure -webkit-overflow-scroll tests run in mobile mode

### DIFF
--- a/LayoutTests/fast/scrolling/ios/overflow-scroll-inherited.html
+++ b/LayoutTests/fast/scrolling/ios/overflow-scroll-inherited.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true contentMode=mobile ] -->
 <html>
 <script>
 if (window.testRunner)

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -114,8 +114,3 @@ webkit.org/b/292090 media/video-canvas-createPattern.html [ Failure ]
 # Failure only on iPad simulator
 webkit.org/b/178588 fast/css/button-height.html [ Failure ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-gamut-002.html [ ImageOnlyFailure ]
-
-webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor.html [ Pass Failure ]
-webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed.html [ Pass Failure ]
-webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor.html [ Pass Failure ]
-webkit.org/b/243710 scrollingcoordinator/scrolling-tree/coordinated-frame.html [ Pass Failure ]

--- a/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scroll-inherited-expected.txt
+++ b/LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scroll-inherited-expected.txt
@@ -1,5 +1,0 @@
-test1 -webkit-overflow-scrolling: auto
-test2 -webkit-overflow-scrolling: auto
-test3 -webkit-overflow-scrolling: auto
-test4 -webkit-overflow-scrolling: auto
-

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ contentMode=mobile ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ contentMode=mobile ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ contentMode=mobile ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ contentMode=mobile ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/resources/doc-with-sticky.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/resources/doc-with-sticky.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
     <style>


### PR DESCRIPTION
#### c7f9e1da3dd819c25ec141ee483f1f62e63927a2
<pre>
Ensure -webkit-overflow-scroll tests run in mobile mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=243710">https://bugs.webkit.org/show_bug.cgi?id=243710</a>

Reviewed by Tim Horton.

iOS/iPadOS&apos;s &quot;desktop mode&quot; sets a policy that forces the
LegacyOverflowScrollingTouchEnabled setting to false; as a result, to
meaningfully test -webkit-overflow-scrolling: touch; we need to be in
mobile mode.

* LayoutTests/fast/scrolling/ios/overflow-scroll-inherited.html:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/fast/scrolling/ios/overflow-scroll-inherited-expected.txt: Removed.
* LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-gain-scrolling-ancestor.html:
* LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-in-fixed.html:
* LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame-lose-scrolling-ancestor.html:
* LayoutTests/scrollingcoordinator/scrolling-tree/coordinated-frame.html:
* LayoutTests/scrollingcoordinator/scrolling-tree/resources/doc-with-sticky.html:

Canonical link: <a href="https://commits.webkit.org/253361@main">https://commits.webkit.org/253361@main</a>
</pre>
