### PR TITLE
[WPE][GTK] Create GStreamerWebRTCProvider

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -25,6 +25,12 @@
 
 #pragma once
 
+// FIXME: We should likely rename this header file to WebRTCProvider.h because depending on the
+// build configuration we create either a LibWebRTCProvider, or a GStreamerWebRTCProvider or
+// fallback to WebRTCProvider. This rename would open another can of worms though, leading to the
+// renaming of more LibWebRTC-prefixed files in WebKit.
+// https://bugs.webkit.org/show_bug.cgi?id=243774
+
 #if USE(LIBWEBRTC)
 
 #if PLATFORM(COCOA)
@@ -32,7 +38,9 @@
 #elif USE(GSTREAMER)
 #include <WebCore/LibWebRTCProviderGStreamer.h>
 #endif
-#else
+#elif USE(GSTREAMER_WEBRTC)
+#include <WebCore/GStreamerWebRTCProvider.h>
+#else // !USE(LIBWEBRTC) && !USE(GSTREAMER_WEBRTC)
 #include <WebCore/WebRTCProvider.h>
 #endif
 
@@ -81,6 +89,15 @@ inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)
 {
     return makeUniqueRef<LibWebRTCProvider>(page);
 }
+
+#elif USE(GSTREAMER_WEBRTC)
+using LibWebRTCProvider = WebCore::GStreamerWebRTCProvider;
+
+inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage&)
+{
+    return makeUniqueRef<LibWebRTCProvider>();
+}
+
 #else
 using LibWebRTCProvider = WebCore::WebRTCProvider;
 


### PR DESCRIPTION
#### 517e8e1a86e53b1b69b194353a42f683e92881d2
<pre>
[WPE][GTK] Create GStreamerWebRTCProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=243735">https://bugs.webkit.org/show_bug.cgi?id=243735</a>

Reviewed by Carlos Garcia Campos and Xabier Rodriguez-Calvar.

For the time being, create a GStreamerWebRTCProvider from the LibWebRTCProvider code unit. Ideally
this file should be renamed though.

* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
(WebKit::createLibWebRTCProvider):

Canonical link: <a href="https://commits.webkit.org/253287@main">https://commits.webkit.org/253287@main</a>
</pre>
