### PR TITLE
[ Mac wk1 ] Many recently imported mixed-content WPT tests are failing on Mac wk1

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1919,3 +1919,6 @@ webkit.org/b/243494 [ Debug ] compositing/layer-creation/scale-rotation-animatio
 
 # Skip Compression Stream Tests on WK1
 imported/w3c/web-platform-tests/compression [ Skip ]
+
+# webkit.org/b/243733 [ Mac wk1 ] Many recently imported mixed-content WPT tests are failing on Mac wk1
+imported/w3c/web-platform-tests/mixed-content [ Skip ]


### PR DESCRIPTION
#### 74f89ca466d72dc05e8f5ead74d6a948293b26ca
<pre>
[ Mac wk1 ] Many recently imported mixed-content WPT tests are failing on Mac wk1
<a href="https://bugs.webkit.org/show_bug.cgi?id=243733">https://bugs.webkit.org/show_bug.cgi?id=243733</a>
&lt;rdar://problem/98389628&gt;

Reviewed by NOBODY (OOPS!).

* LayoutTests/platform/mac-wk1/TestExpectations:

These tests were failing because WebKitLegacy does not support Shared Workers or Beacon,
but these tests required their support. I&apos;ve skipped the relevant test cases, and
re-allowed the passing tests.
</pre>