### PR TITLE
html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html is failing in WebKit

### DIFF
--- a/LayoutTests/fast/loader/nested-document-handling-expected.txt
+++ b/LayoutTests/fast/loader/nested-document-handling-expected.txt
@@ -3,7 +3,7 @@ Check that we properly handle nested document loads during unload events. Passes
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Load succeeded.
+PASS Threw exception: HierarchyRequestError: The operation would yield an incorrect node tree.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/loader/nested-document-handling.html
+++ b/LayoutTests/fast/loader/nested-document-handling.html
@@ -9,11 +9,6 @@ description('Check that we properly handle nested document loads during unload e
 
 window.jsTestIsAsync = true;
 
-function finishTest() {
-    testPassed('Load succeeded.');
-    finishJSTest();
-}
-
 function runTest() {
     let topFrame = document.documentElement.appendChild(document.createElement("iframe"));
     topFrame.id = 'topFrame';
@@ -24,7 +19,15 @@ function runTest() {
     aFrame.contentWindow.onunload = () => {
         topFrame.src = "javascript:''";
 
-        let bFrame = topFrame.contentDocument.appendChild(document.createElement("iframe"));
+        let bFrame;
+
+        try {
+            bFrame = topFrame.contentDocument.appendChild(document.createElement("iframe"));
+        } catch (e) {
+            testPassed("Threw exception: " + e);
+            finishJSTest();
+            return;
+        }
         bFrame.id = 'bFrame';
 
         bFrame.contentWindow.onunload = () => {

--- a/LayoutTests/fast/repaint/repaint-during-scroll-with-zoom.html
+++ b/LayoutTests/fast/repaint/repaint-during-scroll-with-zoom.html
@@ -17,34 +17,35 @@
     </style>
 </head>
 <body>
-    <iframe src="javascript:void(0);"></iframe>
+    <iframe src="about:blank"></iframe>
     <script>
-        var frame = window.frames[0];
-        var doc = frame.document;
-        doc.body.style.backgroundColor = 'white';
-        doc.body.style.width = '2000px';
-        doc.body.style.height = '2000px';
-        doc.body.appendChild(doc.createTextNode('scroll me'));
-        frame.scrollBy(100, 100);
-    </script>
-    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
         function testScrollRepaint()
         {
-            if (window.testRunner) {
-                testRunner.waitUntilDone();
-                frame.onscroll = function() {
-                    if (window.testRunner)
-                        testRunner.notifyDone();
-                };
-            }
+            var frame = window.frames[0];
+            frame.onscroll = function() {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            };
             frame.scrollBy(-90, -90);
         }
+        onload = () => {
+            var frame = window.frames[0];
+            var doc = frame.document;
+            doc.body.style.backgroundColor = 'white';
+            doc.body.style.width = '2000px';
+            doc.body.style.height = '2000px';
+            doc.body.appendChild(doc.createTextNode('scroll me'));
+            frame.scrollBy(100, 100);
 
-        if (window.testRunner) {
-            testRunner.displayAndTrackRepaints();
-            testScrollRepaint();
-        } else {
-            setTimeout(testScrollRepaint, 100);
+            if (window.testRunner) {
+                testRunner.displayAndTrackRepaints();
+                testScrollRepaint();
+            } else {
+                setTimeout(testScrollRepaint, 100);
+            }
         }
     </script>
 </body>

--- a/LayoutTests/http/tests/navigation/lockedhistory-iframe-expected.txt
+++ b/LayoutTests/http/tests/navigation/lockedhistory-iframe-expected.txt
@@ -4,6 +4,4 @@ This test verifies that setting the iframe.src through javascript to # does not 
 
 ============== Back Forward List ==============
 curr->  http://127.0.0.1:8000/navigation/lockedhistory-iframe.html  **nav target**
-            http://127.0.0.1:8000/navigation/lockedhistory-iframe.html# (in frame "<!--frame1-->")
-                about:blank (in frame "<!--frame2-->")
 ===============================================

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-javascript-url-iframe-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-javascript-url-iframe-in-iframe-expected.txt
@@ -1,12 +1,6 @@
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 main frame - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame
-frame "<!--frame2-->" - didStartProvisionalLoadForFrame
-frame "<!--frame2-->" - didCommitLoadForFrame
-frame "<!--frame2-->" - didFinishDocumentLoadForFrame
-frame "<!--frame2-->" - didHandleOnloadEventsForFrame
-frame "<!--frame2-->" - didFinishLoadForFrame
-frame "<!--frame2-->" - willPerformClientRedirectToURL: javascript:document.write('%3Cimg%20src=%22http://127.0.0.1:8000/security/resources/compass.jpg%22%3E');
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/resources/compass.jpg because 'block-all-mixed-content' appears in the Content Security Policy.
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/javascript-url-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/javascript-url-allowed-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: The 'allow' directive has been replaced with 'default-src'. Please use that directive instead, as 'allow' has no effect.
 CONSOLE MESSAGE: The 'allow' directive has been replaced with 'default-src'. Please use that directive instead, as 'allow' has no effect.
-CONSOLE MESSAGE: The 'allow' directive has been replaced with 'default-src'. Please use that directive instead, as 'allow' has no effect.
 ALERT: PASS
 

--- a/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load2-expected.txt
+++ b/LayoutTests/http/tests/security/showModalDialog-sync-cross-origin-page-load2-expected.txt
@@ -1,3 +1,4 @@
+ALERT: <html><head></head><body></body></html>
 CONSOLE MESSAGE: showModalDialog() is deprecated and will be removed. Please use the <dialog> element instead.
 This test passes if it does not alert the fail.html's content when clicking the button.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Document-contentType/contentType/contenttype_javascripturi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Document-contentType/contentType/contenttype_javascripturi-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Javascript URI document.contentType === 'text/html' assert_equals: expected "text/html" but got ""
+PASS Javascript URI document.contentType === 'text/html'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Verifies that form submissions cancel javascript navigations to prevent duplicate load events. assert_equals: expected "/formaction.html" but got "blank"
+PASS Verifies that form submissions cancel javascript navigations to prevent duplicate load events.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/109-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/109-expected.txt
@@ -1,4 +1,4 @@
 Not tested
 
-FAIL  scheduler: javascript URL in iframe, src set via DOM assert_array_equals: expected property 2 to be "inline script #3" but got "iframe onload" (expected array ["inline script #1", "inline script #2", "inline script #3", "JS URL", "iframe onload"] got ["inline script #1", "inline script #2", "iframe onload", "inline script #3", "JS URL"])
+PASS  scheduler: javascript URL in iframe, src set via DOM
 

--- a/LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-javascript-url-iframe-in-iframe-expected.txt
+++ b/LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-javascript-url-iframe-in-iframe-expected.txt
@@ -1,12 +1,6 @@
 main frame - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 frame "<!--frame1-->" - didCommitLoadForFrame
-frame "<!--frame2-->" - didStartProvisionalLoadForFrame
-frame "<!--frame2-->" - didCommitLoadForFrame
-frame "<!--frame2-->" - didFinishDocumentLoadForFrame
-frame "<!--frame2-->" - didHandleOnloadEventsForFrame
-frame "<!--frame2-->" - didFinishLoadForFrame
-frame "<!--frame2-->" - willPerformClientRedirectToURL: javascript:document.write('<img src=%22http://127.0.0.1:8000/security/resources/compass.jpg%22>');
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/resources/compass.jpg because 'block-all-mixed-content' appears in the Content Security Policy.
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/LayoutTests/webarchive/loading/javascript-url-iframe-crash-expected.txt
+++ b/LayoutTests/webarchive/loading/javascript-url-iframe-crash-expected.txt
@@ -6,11 +6,6 @@ main frame - didFinishLoadForFrame
 main frame - didStartProvisionalLoadForFrame
 main frame - didCancelClientRedirectForFrame
 main frame - didCommitLoadForFrame
-frame "<!--frame1-->" - didStartProvisionalLoadForFrame
-frame "<!--frame1-->" - didCommitLoadForFrame
-frame "<!--frame1-->" - didFinishDocumentLoadForFrame
-frame "<!--frame1-->" - didHandleOnloadEventsForFrame
-frame "<!--frame1-->" - didFinishLoadForFrame
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didFinishDocumentLoadForFrame

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -773,7 +773,7 @@ bool ScriptController::canExecuteScripts(ReasonForCallingCanExecuteScripts reaso
     return m_frame.loader().client().allowScript(m_frame.settings().isScriptEnabled());
 }
 
-void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> requesterSecurityOrigin, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL)
+void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> requesterSecurityOrigin, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL, bool& didReplaceDocument)
 {
     ASSERT(url.protocolIsJavaScript());
 
@@ -828,8 +828,10 @@ void ScriptController::executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigi
 
         // DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL can cause the DocumentLoader to get deref'ed and possible destroyed,
         // so protect it with a RefPtr.
-        if (RefPtr<DocumentLoader> loader = m_frame.document()->loader())
+        if (RefPtr<DocumentLoader> loader = m_frame.document()->loader()) {
             loader->writer().replaceDocumentWithResultOfExecutingJavascriptURL(scriptResult, ownerDocument.get());
+            didReplaceDocument = true;
+        }
     }
 }
 

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -108,7 +108,12 @@ public:
     JSC::JSValue evaluateInWorldIgnoringException(const ScriptSourceCode&, DOMWrapperWorld&);
 
     // This asserts that URL argument is a JavaScript URL.
-    void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin> = nullptr, ShouldReplaceDocumentIfJavaScriptURL = ReplaceDocumentIfJavaScriptURL);
+    void executeJavaScriptURL(const URL&, RefPtr<SecurityOrigin>, ShouldReplaceDocumentIfJavaScriptURL, bool& didReplaceDocument);
+    void executeJavaScriptURL(const URL& url, RefPtr<SecurityOrigin> securityOrigin = nullptr, ShouldReplaceDocumentIfJavaScriptURL shouldReplaceDocumentIfJavaScriptURL = ReplaceDocumentIfJavaScriptURL)
+    {
+        bool didReplaceDocument = false;
+        executeJavaScriptURL(url, securityOrigin, shouldReplaceDocumentIfJavaScriptURL, didReplaceDocument);
+    }
 
     static void initializeMainThread();
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -996,10 +996,10 @@ void DocumentLoader::responseReceived(const ResourceResponse& response, Completi
     RefPtr<SubresourceLoader> mainResourceLoader = this->mainResourceLoader();
     if (mainResourceLoader)
         mainResourceLoader->markInAsyncResponsePolicyCheck();
-    auto requestIdentifier = PolicyCheckIdentifier::create();
+    auto requestIdentifier = PolicyCheckIdentifier::generate();
     frameLoader()->checkContentPolicy(m_response, requestIdentifier, [this, protectedThis = Ref { *this }, mainResourceLoader = WTFMove(mainResourceLoader),
         completionHandler = completionHandlerCaller.release(), requestIdentifier] (PolicyAction policy, PolicyCheckIdentifier responseIdentifier) mutable {
-        RELEASE_ASSERT(responseIdentifier.isValidFor(requestIdentifier));
+        RELEASE_ASSERT(responseIdentifier == requestIdentifier);
         continueAfterContentPolicy(policy);
         if (mainResourceLoader)
             mainResourceLoader->didReceiveResponsePolicy();

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -75,6 +75,9 @@ public:
     LockBackForwardList lockBackForwardList() const { return m_lockBackForwardList; }
     void setLockBackForwardList(LockBackForwardList value) { m_lockBackForwardList = value; }
 
+    bool isInitialFrameSrcLoad() const { return m_isInitialFrameSrcLoad; }
+    void setIsInitialFrameSrcLoad(bool isInitialFrameSrcLoad) { m_isInitialFrameSrcLoad = isInitialFrameSrcLoad; }
+
     const String& clientRedirectSourceForHistory() const { return m_clientRedirectSourceForHistory; }
     void setClientRedirectSourceForHistory(const String& clientRedirectSourceForHistory) { m_clientRedirectSourceForHistory = clientRedirectSourceForHistory; }
 
@@ -126,6 +129,7 @@ private:
     InitiatedByMainFrame m_initiatedByMainFrame { InitiatedByMainFrame::Unknown };
     SystemPreviewInfo m_systemPreviewInfo;
     bool m_isRequestFromClientOrUserInput { false };
+    bool m_isInitialFrameSrcLoad { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -332,6 +332,8 @@ private:
         MayNotAttemptCacheOnlyLoadForFormSubmissionItem
     };
 
+    void executeJavaScriptURL(const URL&, const NavigationAction&);
+
     bool allChildrenAreComplete() const; // immediate children, not all descendants
 
     void checkTimerFired();

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -72,47 +72,9 @@ enum class FrameLoadType : uint8_t {
 enum class IsMetaRefresh : bool { No, Yes };
 enum class WillContinueLoading : bool { No, Yes };
 
-class PolicyCheckIdentifier {
-public:
-    PolicyCheckIdentifier() = default;
-
-    static PolicyCheckIdentifier create();
-
-    bool isValidFor(PolicyCheckIdentifier);
-    bool operator==(const PolicyCheckIdentifier& other) const { return m_process == other.m_process && m_policyCheck == other.m_policyCheck; }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PolicyCheckIdentifier> decode(Decoder&);
-
-private:
-    PolicyCheckIdentifier(ProcessIdentifier process, uint64_t policyCheck)
-        : m_process(process)
-        , m_policyCheck(policyCheck)
-    { }
-
-    ProcessIdentifier m_process;
-    uint64_t m_policyCheck { 0 };
-};
-
-template<class Encoder>
-void PolicyCheckIdentifier::encode(Encoder& encoder) const
-{
-    encoder << m_process << m_policyCheck;
-}
-
-template<class Decoder>
-std::optional<PolicyCheckIdentifier> PolicyCheckIdentifier::decode(Decoder& decoder)
-{
-    auto process = ProcessIdentifier::decode(decoder);
-    if (!process)
-        return std::nullopt;
-
-    uint64_t policyCheck;
-    if (!decoder.decode(policyCheck))
-        return std::nullopt;
-
-    return PolicyCheckIdentifier { *process, policyCheck };
-}
+enum LocalPolicyCheckIdentifierType { };
+using LocalPolicyCheckIdentifier = ObjectIdentifier<LocalPolicyCheckIdentifierType>;
+using PolicyCheckIdentifier = ProcessQualified<LocalPolicyCheckIdentifier>;
 
 enum class ShouldContinuePolicyCheck : bool {
     Yes,

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -137,6 +137,9 @@ public:
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
     void setIsRequestFromClientOrUserInput(bool isRequestFromClientOrUserInput) { m_isRequestFromClientOrUserInput = isRequestFromClientOrUserInput; }
 
+    bool isInitialFrameSrcLoad() const { return m_isInitialFrameSrcLoad; }
+    void setIsInitialFrameSrcLoad(bool isInitialFrameSrcLoad) { m_isInitialFrameSrcLoad = isInitialFrameSrcLoad; }
+
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
     // originating document. See comment above the class for more details.
@@ -153,6 +156,7 @@ private:
     bool m_hasOpenedFrames { false };
     bool m_openedByDOMWithOpener { false };
     bool m_isRequestFromClientOrUserInput { false };
+    bool m_isInitialFrameSrcLoad { false };
     std::optional<BackForwardItemIdentifier> m_targetBackForwardItemIdentifier;
     std::optional<BackForwardItemIdentifier> m_sourceBackForwardItemIdentifier;
     LockHistory m_lockHistory { LockHistory::No };

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "FrameLoader.h"
+#include "FrameLoaderClient.h"
 #include "ResourceRequest.h"
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -61,7 +62,7 @@ enum class NavigationPolicyDecision : uint8_t {
 
 enum class PolicyDecisionMode { Synchronous, Asynchronous };
 
-class FrameLoader::PolicyChecker {
+class FrameLoader::PolicyChecker : public CanMakeWeakPtr<FrameLoader::PolicyChecker> {
     WTF_MAKE_NONCOPYABLE(PolicyChecker);
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -93,6 +94,8 @@ private:
     BlobURLHandle extendBlobURLLifetimeIfNecessary(const ResourceRequest&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous) const;
 
     Frame& m_frame;
+
+    HashMap<PolicyCheckIdentifier, FramePolicyFunction> m_javaScriptURLPolicyChecks;
 
     bool m_delegateIsDecidingNavigationPolicy;
     bool m_delegateIsHandlingUnimplementablePolicy;

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -576,7 +576,7 @@ bool ContentSecurityPolicy::allowObjectFromSource(const URL& url, RedirectRespon
 
 bool ContentSecurityPolicy::allowChildFrameFromSource(const URL& url, RedirectResponseReceived redirectResponseReceived) const
 {
-    if (LegacySchemeRegistry::schemeShouldBypassContentSecurityPolicy(url.protocol()))
+    if (LegacySchemeRegistry::schemeShouldBypassContentSecurityPolicy(url.protocol()) || url.protocolIsJavaScript())
         return true;
     String sourceURL;
     TextPosition sourcePosition(OrdinalNumber::beforeFirst(), OrdinalNumber());

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -293,6 +293,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::QuotaIncreaseRequestIdentifier',
         'WebCore::PluginLoadClientPolicy',
         'WebCore::PointerID',
+        'WebCore::PolicyCheckIdentifier',
         'WebCore::PushSubscriptionIdentifier',
         'WebCore::ProcessIdentifier',
         'WebCore::RealtimeMediaSourceIdentifier',


### PR DESCRIPTION
#### 7de67f9a0ccc4fc8ce195e32f61e7873ad81345e
<pre>
html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243736">https://bugs.webkit.org/show_bug.cgi?id=243736</a>

Reviewed by Geoffrey Garen and Darin Adler.

The test was failing because the load event would fire prematurely for an iframe whose src
attribute is a JavaScript URL, before this JS URL has been executed. The reason for this is
that FrameLoader::SubframeLoader::requestFrame() would have a very special handling of JS
URLS which would call loadOrRedirectSubframe() with &quot;about:blank&quot; and then schedule a
navigation to the JS URL. The issue was that loading &quot;about:blank&quot; would trigger the load
event, since the iframe probably completed its first load.

To address the issue, we now drop the special handling for JS URLs inside requestFrame()
and instead go through the regular FrameLoader loading logic, even if the URL is a JS
URL. In PolicyChecker, we bypass doing the policy check with the client when the URL
is a JS URL, to maintain the previous behavior but we call the completion handler
asynchronously so that the JS URL is executed asynchronously, as is expected.

* LayoutTests/fast/loader/nested-document-handling-expected.txt:
* LayoutTests/fast/loader/nested-document-handling.html:
* LayoutTests/fast/repaint/repaint-during-scroll-with-zoom.html:
Update a couple of tests due to our behavior change. I have verified that those tests
were not passing in Chrome or Firefox before my changes. Our behavior on those tests
is now aligned with other major browsers.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/109-expected.txt:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/ScriptController.h:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::responseReceived):
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::shouldExecuteAsynchronouslyIfJavaScript const):
(WebCore::FrameLoadRequest::setShouldExecuteAsynchronouslyIfJavaScript):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::shouldExecuteJavaScriptURLSynchronously):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::executeJavaScriptURL):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameLoaderTypes.h:
(WebCore::PolicyCheckIdentifier::operator== const): Deleted.
(WebCore::PolicyCheckIdentifier::PolicyCheckIdentifier): Deleted.
(WebCore::PolicyCheckIdentifier::encode const): Deleted.
(WebCore::PolicyCheckIdentifier::decode): Deleted.
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::shouldExecuteAsynchronouslyIfJavaScript const):
(WebCore::NavigationAction::setShouldExecuteAsynchronouslyIfJavaScript):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::FrameLoader::PolicyChecker::checkNavigationPolicy):
(WebCore::FrameLoader::PolicyChecker::checkNewWindowPolicy):
(WebCore::FrameLoader::PolicyChecker::stopCheck):
(WebCore::PolicyCheckIdentifier::create): Deleted.
(WebCore::PolicyCheckIdentifier::isValidFor): Deleted.
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::requestFrame):
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):

Canonical link: <a href="https://commits.webkit.org/253350@main">https://commits.webkit.org/253350@main</a>
</pre>
