### PR TITLE
Fix assertion when closing a window on macOS with UI-side compositing enabled

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -251,7 +251,7 @@ protected:
     std::optional<FramesPerSecond> nominalFramesPerSecond();
 
     WEBCORE_EXPORT virtual void applyLayerPositionsInternal() WTF_REQUIRES_LOCK(m_treeLock);
-    void removeAllNodes() WTF_REQUIRES_LOCK(m_treeLock);
+    WEBCORE_EXPORT void removeAllNodes() WTF_REQUIRES_LOCK(m_treeLock);
     
     virtual void hasNodeWithAnimatedScrollChanged(bool /* hasNodeWithAnimatedScroll */) { }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -54,6 +54,7 @@ RemoteScrollingCoordinatorProxy::RemoteScrollingCoordinatorProxy(WebPageProxy& w
 
 RemoteScrollingCoordinatorProxy::~RemoteScrollingCoordinatorProxy()
 {
+    m_scrollingTree->invalidate();
 }
 
 ScrollingNodeID RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -57,8 +57,12 @@ RemoteScrollingTree::RemoteScrollingTree(RemoteScrollingCoordinatorProxy& scroll
 {
 }
 
-RemoteScrollingTree::~RemoteScrollingTree()
+RemoteScrollingTree::~RemoteScrollingTree() = default;
+
+void RemoteScrollingTree::invalidate()
 {
+    Locker locker { m_treeLock };
+    removeAllNodes();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -46,6 +46,8 @@ public:
 
     bool isRemoteScrollingTree() const final { return true; }
 
+    void invalidate() final;
+
     void handleMouseEvent(const WebCore::PlatformMouseEvent&);
 
     const RemoteScrollingCoordinatorProxy& scrollingCoordinatorProxy() const { return m_scrollingCoordinatorProxy; }


### PR DESCRIPTION
#### 657e5c2cc8f40b6a578e93f75253d0dd793d9806
<pre>
Fix assertion when closing a window on macOS with UI-side compositing enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=243737">https://bugs.webkit.org/show_bug.cgi?id=243737</a>

Reviewed by Tim Horton.

Make sure we call `ScrollingEffectsController::stopAllTimers()` on scrolling tree
nodes in the UI process by implementing `RemoteScrollingTree::invalidate()` and
having it call `removeAllNodes()`, as we do in ThreadedScrollingTree.

* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::~RemoteScrollingCoordinatorProxy):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::invalidate):
(WebKit::RemoteScrollingTree::~RemoteScrollingTree): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:

Canonical link: <a href="https://commits.webkit.org/253269@main">https://commits.webkit.org/253269@main</a>
</pre>
