### PR TITLE
REGRESSION(css-values-4 viewport units): Safari window resizing is glitchy on apple.com

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5723,7 +5723,7 @@ void FrameView::clearSizeOverrideForCSSDefaultViewportUnits()
 
     m_defaultViewportSizeOverride = std::nullopt;
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 void FrameView::setSizeForCSSDefaultViewportUnits(FloatSize size)
@@ -5749,7 +5749,7 @@ void FrameView::setOverrideSizeForCSSDefaultViewportUnits(OverrideViewportSize s
     m_defaultViewportSizeOverride = size;
 
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 FloatSize FrameView::sizeForCSSDefaultViewportUnits() const
@@ -5764,7 +5764,7 @@ void FrameView::clearSizeOverrideForCSSSmallViewportUnits()
 
     m_smallViewportSizeOverride = std::nullopt;
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 void FrameView::setSizeForCSSSmallViewportUnits(FloatSize size)
@@ -5790,7 +5790,7 @@ void FrameView::setOverrideSizeForCSSSmallViewportUnits(OverrideViewportSize siz
     m_smallViewportSizeOverride = size;
 
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 FloatSize FrameView::sizeForCSSSmallViewportUnits() const
@@ -5805,7 +5805,7 @@ void FrameView::clearSizeOverrideForCSSLargeViewportUnits()
 
     m_largeViewportSizeOverride = std::nullopt;
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 void FrameView::setSizeForCSSLargeViewportUnits(FloatSize size)
@@ -5831,7 +5831,7 @@ void FrameView::setOverrideSizeForCSSLargeViewportUnits(OverrideViewportSize siz
     m_largeViewportSizeOverride = size;
 
     if (auto* document = frame().document())
-        document->styleScope().didChangeStyleSheetEnvironment();
+        document->updateViewportUnitsOnResize();
 }
 
 FloatSize FrameView::sizeForCSSLargeViewportUnits() const


### PR DESCRIPTION
#### 3f73c9df67940fbc43e8acd03c630ac487f61048
<pre>
REGRESSION(css-values-4 viewport units): Safari window resizing is glitchy on apple.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=243742">https://bugs.webkit.org/show_bug.cgi?id=243742</a>
&lt;rdar://problem/98155377&gt;

Reviewed by Tim Horton.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::clearSizeOverrideForCSSDefaultViewportUnits):
(WebCore::FrameView::setOverrideSizeForCSSDefaultViewportUnits):
(WebCore::FrameView::clearSizeOverrideForCSSSmallViewportUnits):
(WebCore::FrameView::setOverrideSizeForCSSSmallViewportUnits):
(WebCore::FrameView::clearSizeOverrideForCSSLargeViewportUnits):
(WebCore::FrameView::setOverrideSizeForCSSLargeViewportUnits):
Replace `didChangeStyleSheetEnvironment` with `updateViewportUnitsOnResize` as the latter only
affects styles/nodes that actually use viewport units, whereas the former recalculates everything.

Canonical link: <a href="https://commits.webkit.org/253277@main">https://commits.webkit.org/253277@main</a>
</pre>
