### PR TITLE
Disable UseCGDisplayListOutOfLineSurfaces internal setting by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -966,7 +966,7 @@ UseCGDisplayListOutOfLineSurfaces:
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
-      default: true
+      default: false
 
 UseCGDisplayListsForDOMRendering:
   type: bool


### PR DESCRIPTION
#### 0fc83cbac749dad9f4a6fe0f25320a41e18f7546
<pre>
Disable UseCGDisplayListOutOfLineSurfaces internal setting by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=243745">https://bugs.webkit.org/show_bug.cgi?id=243745</a>
&lt;rdar://98338212&gt;

Reviewed by Megan Gardner.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
Disable this preference.

Canonical link: <a href="https://commits.webkit.org/253270@main">https://commits.webkit.org/253270@main</a>
</pre>
