### PR TITLE
REGRESSION(249632@main): wpt /service-workers/service-worker/claim-worker-fetch.https.html

### DIFF
--- a/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetch() in Worker should be intercepted after the client is claimed.
+PASS fetch() in blob URL Worker should be intercepted after the client is claimed.
+

--- a/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html
+++ b/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<body>
+<script>
+
+// Copy of the service-workers/service-worker/claim-worker-fetch.https.html upstream WPT without the Worker nesting subtests
+// since WebKit doesn't support that.
+
+promise_test((t) => {
+  return runTest(t, '/service-workers/service-worker/resources/claim-worker-fetch-iframe.html');
+}, 'fetch() in Worker should be intercepted after the client is claimed.');
+
+promise_test((t) => {
+  return runTest(t, '/service-workers/service-worker/resources/claim-blob-url-worker-fetch-iframe.html');
+}, 'fetch() in blob URL Worker should be intercepted after the client is claimed.');
+
+async function runTest(t, iframe_url) {
+  const resource = 'simple.txt';
+  const scope = '/service-workers/service-worker/resources/';
+  const script = '/service-workers/service-worker/resources/claim-worker.js';
+
+  // Create the test iframe with a dedicated worker.
+  const frame = await with_iframe(iframe_url);
+  t.add_cleanup(_ => frame.remove());
+
+  // Check the controller and test with fetch in the worker.
+  assert_equals(frame.contentWindow.navigator.controller,
+                undefined, 'Should have no controller.');
+  {
+    const response_text = await frame.contentWindow.fetch_in_worker(resource);
+    assert_equals(response_text, 'a simple text file\n',
+                  'fetch() should not be intercepted.');
+  }
+
+  // Register a service worker.
+  const reg = await service_worker_unregister_and_register(t, script, scope);
+  t.add_cleanup(_ => reg.unregister());
+  await wait_for_state(t, reg.installing, 'activated');
+
+  // Let the service worker claim the iframe and the worker.
+  const channel = new MessageChannel();
+  const saw_message = new Promise(function(resolve) {
+    channel.port1.onmessage = t.step_func(function(e) {
+      assert_equals(e.data, 'PASS', 'Worker call to claim() should fulfill.');
+      resolve();
+    });
+  });
+  reg.active.postMessage({port: channel.port2}, [channel.port2]);
+  await saw_message;
+
+  // Check the controller and test with fetch in the worker.
+  const reg2 =
+    await frame.contentWindow.navigator.serviceWorker.getRegistration(scope);
+  assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
+                reg2.active, 'Test iframe should be claimed.');
+
+  {
+    // TODO(horo): Check the worker's navigator.seviceWorker.controller.
+    const response_text = await frame.contentWindow.fetch_in_worker(resource);
+    assert_equals(response_text, 'Intercepted!',
+                  'fetch() in the worker should be intercepted.');
+  }
+}
+
+</script>
+</body>

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -95,6 +95,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WorkerGlobalScope);
 WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, WorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider)
     : WorkerOrWorkletGlobalScope(type, params.sessionID, isMainThread() ? Ref { commonVM() } : JSC::VM::create(), &thread, params.clientIdentifier)
     , m_url(params.scriptURL)
+    , m_ownerURL(params.ownerURL)
     , m_inspectorIdentifier(params.inspectorIdentifier)
     , m_userAgent(params.userAgent)
     , m_isOnline(params.isOnline)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -82,6 +82,7 @@ public:
     virtual Type type() const = 0;
 
     const URL& url() const final { return m_url; }
+    const URL& ownerURL() const { return m_ownerURL; }
     String origin() const;
     const String& inspectorIdentifier() const { return m_inspectorIdentifier; }
 
@@ -198,6 +199,7 @@ private:
     void stopIndexedDatabase();
 
     URL m_url;
+    URL m_ownerURL;
     String m_inspectorIdentifier;
     String m_userAgent;
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -125,7 +125,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
 
     SocketProvider* socketProvider = document.socketProvider();
 
-    WorkerParameters params { scriptURL, name, identifier, WTFMove(initializationData.userAgent), platformStrategies()->loaderStrategy()->isOnLine(), contentSecurityPolicyResponseHeaders, shouldBypassMainWorldContentSecurityPolicy, crossOriginEmbedderPolicy, timeOrigin, referrerPolicy, workerType, credentials, document.settingsValues(), WorkerThreadMode::CreateNewThread, sessionID,
+    WorkerParameters params { scriptURL, document.url(), name, identifier, WTFMove(initializationData.userAgent), platformStrategies()->loaderStrategy()->isOnLine(), contentSecurityPolicyResponseHeaders, shouldBypassMainWorldContentSecurityPolicy, crossOriginEmbedderPolicy, timeOrigin, referrerPolicy, workerType, credentials, document.settingsValues(), WorkerThreadMode::CreateNewThread, sessionID,
 #if ENABLE(SERVICE_WORKER)
         WTFMove(initializationData.serviceWorkerData),
 #endif

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -50,6 +50,7 @@ WorkerParameters WorkerParameters::isolatedCopy() const
 {
     return {
         scriptURL.isolatedCopy(),
+        ownerURL.isolatedCopy(),
         name.isolatedCopy(),
         inspectorIdentifier.isolatedCopy(),
         userAgent.isolatedCopy(),

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -64,6 +64,7 @@ struct WorkerThreadStartupData;
 struct WorkerParameters {
 public:
     URL scriptURL;
+    URL ownerURL;
     String name;
     String inspectorIdentifier;
     String userAgent;

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -61,12 +61,12 @@ static ServiceWorkerClientFrameType toServiceWorkerClientFrameType(ScriptExecuti
 
 ServiceWorkerClientData ServiceWorkerClientData::isolatedCopy() const &
 {
-    return { identifier, type, frameType, url.isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, isVisible, isFocused, focusOrder, crossThreadCopy(ancestorOrigins) };
+    return { identifier, type, frameType, url.isolatedCopy(), ownerURL.isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, isVisible, isFocused, focusOrder, crossThreadCopy(ancestorOrigins) };
 }
 
 ServiceWorkerClientData ServiceWorkerClientData::isolatedCopy() &&
 {
-    return { identifier, type, frameType, WTFMove(url).isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, isVisible, isFocused, focusOrder, crossThreadCopy(WTFMove(ancestorOrigins)) };
+    return { identifier, type, frameType, WTFMove(url).isolatedCopy(), WTFMove(ownerURL).isolatedCopy(), pageIdentifier, frameIdentifier, lastNavigationWasAppInitiated, isVisible, isFocused, focusOrder, crossThreadCopy(WTFMove(ancestorOrigins)) };
 }
 
 ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& context)
@@ -85,6 +85,7 @@ ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& co
             ServiceWorkerClientType::Window,
             toServiceWorkerClientFrameType(context),
             document->creationURL(),
+            URL(),
             document->pageID(),
             document->frameID(),
             lastNavigationWasAppInitiated,
@@ -102,6 +103,7 @@ ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& co
         scope.type() == WebCore::WorkerGlobalScope::Type::SharedWorker ? ServiceWorkerClientType::Sharedworker : ServiceWorkerClientType::Worker,
         ServiceWorkerClientFrameType::None,
         scope.url(),
+        scope.ownerURL(),
         { },
         { },
         LastNavigationWasAppInitiated::No,

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.h
@@ -49,6 +49,7 @@ struct ServiceWorkerClientData {
     ServiceWorkerClientType type;
     ServiceWorkerClientFrameType frameType;
     URL url;
+    URL ownerURL;
     std::optional<PageIdentifier> pageIdentifier;
     std::optional<FrameIdentifier> frameIdentifier;
     LastNavigationWasAppInitiated lastNavigationWasAppInitiated;
@@ -69,7 +70,7 @@ struct ServiceWorkerClientData {
 template<class Encoder>
 void ServiceWorkerClientData::encode(Encoder& encoder) const
 {
-    encoder << identifier << type << frameType << url << pageIdentifier << frameIdentifier << lastNavigationWasAppInitiated << isVisible << isFocused << focusOrder << ancestorOrigins;
+    encoder << identifier << type << frameType << url << ownerURL << pageIdentifier << frameIdentifier << lastNavigationWasAppInitiated << isVisible << isFocused << focusOrder << ancestorOrigins;
 }
 
 template<class Decoder>
@@ -93,6 +94,11 @@ std::optional<ServiceWorkerClientData> ServiceWorkerClientData::decode(Decoder& 
     std::optional<URL> url;
     decoder >> url;
     if (!url)
+        return std::nullopt;
+
+    std::optional<URL> ownerURL;
+    decoder >> ownerURL;
+    if (!ownerURL)
         return std::nullopt;
 
     std::optional<std::optional<PageIdentifier>> pageIdentifier;
@@ -130,7 +136,7 @@ std::optional<ServiceWorkerClientData> ServiceWorkerClientData::decode(Decoder& 
     if (!ancestorOrigins)
         return std::nullopt;
 
-    return { { WTFMove(*identifier), WTFMove(*type), WTFMove(*frameType), WTFMove(*url), WTFMove(*pageIdentifier), WTFMove(*frameIdentifier), WTFMove(*lastNavigationWasAppInitiated), WTFMove(*isVisible), WTFMove(*isFocused), WTFMove(*focusOrder), WTFMove(*ancestorOrigins) } };
+    return { { WTFMove(*identifier), WTFMove(*type), WTFMove(*frameType), WTFMove(*url), WTFMove(*ownerURL), WTFMove(*pageIdentifier), WTFMove(*frameIdentifier), WTFMove(*lastNavigationWasAppInitiated), WTFMove(*isVisible), WTFMove(*isFocused), WTFMove(*focusOrder), WTFMove(*ancestorOrigins) } };
 }
 
 using ServiceWorkerClientsMatchAllCallback = CompletionHandler<void(Vector<ServiceWorkerClientData>&&)>;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -83,6 +83,7 @@ static WorkerParameters generateWorkerParameters(const ServiceWorkerContextData&
 {
     return {
         contextData.scriptURL,
+        URL(), // FIXME: Should pass owner URL.
         emptyString(),
         "serviceworker:" + Inspector::IdentifiersFactory::createIdentifier(),
         WTFMove(userAgent),

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -61,6 +61,7 @@ static WorkerParameters generateWorkerParameters(const WorkerFetchResult& worker
     RELEASE_ASSERT(document.sessionID());
     return {
         workerFetchResult.lastRequestURL,
+        document.url(),
         workerOptions.name,
         "sharedworker:" + Inspector::IdentifiersFactory::createIdentifier(),
         WTFMove(initializationData.userAgent),

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -185,7 +185,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
     });
 
     auto ancestorOrigins = map(parameters.frameAncestorOrigins, [](auto& origin) { return origin->toString(); });
-    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, false, false, 0, WTFMove(ancestorOrigins) };
+    ServiceWorkerClientData data { clientIdentifier, clientType, ServiceWorkerClientFrameType::None, request.url(), URL(), parameters.webPageID, parameters.webFrameID, request.isAppInitiated() ? WebCore::LastNavigationWasAppInitiated::Yes : WebCore::LastNavigationWasAppInitiated::No, false, false, 0, WTFMove(ancestorOrigins) };
     registerServiceWorkerClient(ClientOrigin { registration.key().topOrigin(), SecurityOriginData::fromURL(request.url()) }, WTFMove(data), registration.identifier(), request.httpUserAgent());
 }
 


### PR DESCRIPTION
#### 497df5ae79f3827b5671806255e543cb43bf1fdb
<pre>
REGRESSION(249632@main): wpt /service-workers/service-worker/claim-worker-fetch.https.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=243409">https://bugs.webkit.org/show_bug.cgi?id=243409</a>
&lt;rdar://97919820&gt;

Reviewed by Brady Eidson.

249632@main added support for registering workers as service worker clients. However, there is an issue
in the specification (<a href="https://github.com/w3c/ServiceWorker/issues/1554)">https://github.com/w3c/ServiceWorker/issues/1554)</a> making it so that Blob URL
workers cannot be claimed by a service worker. This is because the service worker registration matching
relies on the client URL and matching will fail if the client URL is a Blob URL.

To address the issue, I updated SWServer::claim() to use the owner&apos;s URL was client URL for the purpose
of registration matching whenever the client URL is a Blob URL. This makes it so that Blob URL clients
can be claimed by a service worker whenever their owner can be.

* LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html: Added.
The upstream WPT test that regressed is skipped in WebKit because several of its subtests rely on
nested worker, which WebKit doesn&apos;t support, making the test time out. To improve test coverage, I
copied the upstream tests to http/wpt/service-workers/ and dropped the nested worker subtests.

* Source/WebCore/workers/WorkerGlobalScope.cpp:
* Source/WebCore/workers/WorkerGlobalScope.h:
(WebCore::WorkerGlobalScope::ownerURL const):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerParameters::isolatedCopy const):
* Source/WebCore/workers/WorkerThread.h:
* Source/WebCore/workers/service/ServiceWorkerClientData.cpp:
(WebCore::ServiceWorkerClientData::isolatedCopy const):
(WebCore::ServiceWorkerClientData::isolatedCopy):
(WebCore::ServiceWorkerClientData::from):
* Source/WebCore/workers/service/ServiceWorkerClientData.h:
(WebCore::ServiceWorkerClientData::encode const):
(WebCore::ServiceWorkerClientData::decode):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::generateWorkerParameters):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::claim):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::generateWorkerParameters):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):

Canonical link: <a href="https://commits.webkit.org/253345@main">https://commits.webkit.org/253345@main</a>
</pre>
