### PR TITLE
[Filters] Move the static createEffect functions to the FilterOperation classes

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -24,6 +24,7 @@
 
 #include "DestinationColorSpace.h"
 #include "FilterEffectApplier.h"
+#include "FilterEffectGeometry.h"
 #include "FilterFunction.h"
 #include "FilterImageVector.h"
 

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -25,11 +25,8 @@
 
 #pragma once
 
-#include "FilterEffectGeometry.h"
 #include "FilterImage.h"
-#include "FilterImageVector.h"
 #include "FloatRect.h"
-#include "LengthBox.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/AtomString.h>
 

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -26,12 +26,11 @@
 #pragma once
 
 #include "FloatRect.h"
+#include "ImageBuffer.h"
 #include "IntRect.h"
 #include "PixelBuffer.h"
 #include "RenderingMode.h"
-#include <JavaScriptCore/Forward.h>
 #include <wtf/RefCounted.h>
-#include <wtf/Vector.h>
 
 #if USE(CORE_IMAGE)
 OBJC_CLASS CIImage;
@@ -40,8 +39,6 @@ OBJC_CLASS CIImage;
 namespace WebCore {
 
 class Filter;
-class FloatRect;
-class ImageBuffer;
 class ImageBufferAllocator;
 
 class FilterImage : public RefCounted<FilterImage> {

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Color.h"
+#include "FilterFunction.h"
 #include "LayoutSize.h"
 #include "LengthBox.h"
 #include <wtf/EnumTraits.h>
@@ -45,7 +46,6 @@ namespace WebCore {
 struct BlendingContext;
 class CachedResourceLoader;
 class CachedSVGDocumentReference;
-class FilterEffect;
 struct ResourceLoaderOptions;
 
 class FilterOperation : public ThreadSafeRefCounted<FilterOperation> {
@@ -98,6 +98,8 @@ public:
     bool isSameType(const FilterOperation& o) const { return o.type() == m_type; }
 
     virtual bool isIdentity() const { return false; }
+    
+    virtual RefPtr<FilterFunction> createFilterFunction(const Filter&) const { return nullptr; }
 
     virtual IntOutsets outsets() const { return { }; }
 
@@ -202,6 +204,8 @@ private:
     bool isIdentity() const override;
     IntOutsets outsets() const override;
 
+    RefPtr<FilterFunction> createFilterFunction(const Filter&) const override;
+
     String m_url;
     AtomString m_fragment;
     std::unique_ptr<CachedSVGDocumentReference> m_cachedSVGDocumentReference;
@@ -237,6 +241,8 @@ private:
     }
 
     bool isIdentity() const override;
+    RefPtr<FilterFunction> createFilterFunction(const Filter&) const override;
+
     bool transformColor(SRGBA<float>&) const override;
 
     double m_amount;
@@ -273,6 +279,8 @@ private:
     }
 
     bool isIdentity() const override;
+    RefPtr<FilterFunction> createFilterFunction(const Filter&) const override;
+
     bool transformColor(SRGBA<float>&) const override;
 
     double m_amount;
@@ -335,6 +343,8 @@ private:
     bool isIdentity() const override;
     IntOutsets outsets() const override;
 
+    RefPtr<FilterFunction> createFilterFunction(const Filter&) const override;
+
     Length m_stdDeviation;
 };
 
@@ -374,6 +384,8 @@ private:
 
     bool isIdentity() const override;
     IntOutsets outsets() const override;
+
+    RefPtr<FilterFunction> createFilterFunction(const Filter&) const override;
 
     IntPoint m_location; // FIXME: should location be in Lengths?
     int m_stdDeviation;


### PR DESCRIPTION
#### 543580ddc47bec3c192071142bdd2762d9f65d47
<pre>
[Filters] Move the static createEffect functions to the FilterOperation classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243748">https://bugs.webkit.org/show_bug.cgi?id=243748</a>

Reviewed by NOBODY (OOPS!).

The CSS FilterOperations have a hierarchy of base and super classes. Instead of
having static createEffect functions in CSSFilter.cpp for every FilterOperation
we can make them virtual functions and make CSSFilter::buildFilterFunctions()
call them through the base class FilterOperation.

* Source/WebCore/platform/graphics/filters/FilterEffect.h:
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::ReferenceFilterOperation::createFilterEffect const):
(WebCore::createGrayScaleEffect):
(WebCore::createSepiaEffect):
(WebCore::createSaturateEffect):
(WebCore::createHueRotateEffect):
(WebCore::BasicColorMatrixFilterOperation::createFilterEffect const):
(WebCore::createInvertEffect):
(WebCore::createOpacityEffect):
(WebCore::createBrightnessEffect):
(WebCore::createContrastEffect):
(WebCore::BasicComponentTransferFilterOperation::createFilterEffect const):
(WebCore::BlurFilterOperation::createFilterEffect const):
(WebCore::DropShadowFilterOperation::createFilterEffect const):
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
(WebCore::FilterOperation::createFilterEffect const):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::buildFilterFunctions):
(WebCore::createBlurEffect): Deleted.
(WebCore::createBrightnessEffect): Deleted.
(WebCore::createContrastEffect): Deleted.
(WebCore::createDropShadowEffect): Deleted.
(WebCore::createGrayScaleEffect): Deleted.
(WebCore::createHueRotateEffect): Deleted.
(WebCore::createInvertEffect): Deleted.
(WebCore::createOpacityEffect): Deleted.
(WebCore::createSaturateEffect): Deleted.
(WebCore::createSepiaEffect): Deleted.
</pre>