### PR TITLE
[Xcode] TestWTF not built by all schemes that build TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-               BuildableName = "TestWebKitAPI"
-               BlueprintName = "TestWebKitAPI"
+               BlueprintIdentifier = "7C83E02B1D0A5E1000FEBCF3"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:TestWebKitAPI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
@@ -70,9 +70,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DD76F960486AA7600D96B5E"
-               BuildableName = "TestWebKitAPI"
-               BlueprintName = "TestWebKitAPI"
+               BlueprintIdentifier = "7C83E02B1D0A5E1000FEBCF3"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>


### PR DESCRIPTION
#### 2e25cb073e4c57b6647577e8998bb319a6030a8c
<pre>
[Xcode] TestWTF not built by all schemes that build TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=243747">https://bugs.webkit.org/show_bug.cgi?id=243747</a>

Unreviewed build fix.

Ensure that the &quot;All&quot; aggregate for TestWebKitAPI is built, not just the
TestWebKitAPI executable.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:

Canonical link: <a href="https://commits.webkit.org/253273@main">https://commits.webkit.org/253273@main</a>
</pre>
