### PR TITLE
Make SQLite use libpas for malloc in NetworkProcess

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -562,17 +562,26 @@ void fastFree(void* object)
 #endif
 }
 
-size_t fastMallocSize(const void*)
+size_t fastMallocSize(const void* p)
 {
+#if BENABLE(MALLOC_SIZE)
+    return bmalloc::api::mallocSize(p);
+#else
     // FIXME: This is incorrect; best fix is probably to remove this function.
     // Caller currently are all using this for assertion, not to actually check
     // the size of the allocation, so maybe we can come up with something for that.
+    UNUSED_PARAM(p);
     return 1;
+#endif
 }
 
 size_t fastMallocGoodSize(size_t size)
 {
+#if BENABLE(MALLOC_GOOD_SIZE)
+    return bmalloc::api::mallocGoodSize(size);
+#else
     return size;
+#endif
 }
 
 void* fastAlignedMalloc(size_t alignment, size_t size)

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -36,12 +36,18 @@
 #include <mutex>
 #include <sqlite3.h>
 #include <thread>
+#include <wtf/FastMalloc.h>
 #include <wtf/FileSystem.h>
 #include <wtf/Lock.h>
 #include <wtf/Scope.h>
 #include <wtf/Threading.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringConcatenateNumbers.h>
+
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#define ENABLE_SQLITE_FAST_MALLOC (BENABLE(MALLOC_SIZE) && BENABLE(MALLOC_GOOD_SIZE))
+#endif
 
 namespace WebCore {
 
@@ -75,6 +81,28 @@ static void initializeSQLiteIfNecessary()
 
 static Lock isDatabaseOpeningForbiddenLock;
 static bool isDatabaseOpeningForbidden WTF_GUARDED_BY_LOCK(isDatabaseOpeningForbiddenLock) { false };
+
+void SQLiteDatabase::useFastMalloc()
+{
+#if ENABLE(SQLITE_FAST_MALLOC)
+    int returnCode = sqlite3_config(SQLITE_CONFIG_LOOKASIDE, 0, 0);
+    RELEASE_LOG_ERROR_IF(returnCode != SQLITE_OK, SQLDatabase, "Unable to reduce lookaside buffer size: %d", returnCode);
+
+    static sqlite3_mem_methods fastMallocMethods = {
+        [](int n) { return fastMalloc(n); },
+        fastFree,
+        [](void *p, int n) { return fastRealloc(p, n); },
+        [](void *p) { return static_cast<int>(fastMallocSize(p)); },
+        [](int n) { return static_cast<int>(fastMallocGoodSize(n)); },
+        [](void*) { return SQLITE_OK; },
+        [](void*) { },
+        nullptr
+    };
+
+    returnCode = sqlite3_config(SQLITE_CONFIG_MALLOC, &fastMallocMethods);
+    RELEASE_LOG_ERROR_IF(returnCode != SQLITE_OK, SQLDatabase, "Unable to replace SQLite malloc: %d", returnCode);
+#endif
+}
 
 void SQLiteDatabase::setIsDatabaseOpeningForbidden(bool isForbidden)
 {

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -157,6 +157,8 @@ public:
     void disableThreadingChecks() { }
 #endif
 
+    WEBCORE_EXPORT static void useFastMalloc();
+
     WEBCORE_EXPORT static void setIsDatabaseOpeningForbidden(bool);
 
     WEBCORE_EXPORT void releaseMemory();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -80,6 +80,7 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/RuntimeApplicationChecks.h>
+#include <WebCore/SQLiteDatabase.h>
 #include <WebCore/SWServer.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
@@ -314,6 +315,7 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 #else
     WTF::setProcessPrivileges({ ProcessPrivilege::CanAccessRawCookies, ProcessPrivilege::CanAccessCredentials });
 #endif
+    WebCore::SQLiteDatabase::useFastMalloc();
     WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);
     platformInitializeNetworkProcess(parameters);
 

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -368,3 +368,12 @@
 #else
 #define BENABLE_UNIFIED_AND_FREEZABLE_CONFIG_RECORD 1
 #endif
+
+/* We only export the mallocSize and mallocGoodSize APIs if they're supported by the DebugHeap allocator (currently only Darwin) and the current bmalloc allocator (currently only libpas). */
+#if BUSE(LIBPAS) && BOS(DARWIN)
+#define BENABLE_MALLOC_SIZE 1
+#define BENABLE_MALLOC_GOOD_SIZE 1
+#else
+#define BENABLE_MALLOC_SIZE 0
+#define BENABLE_MALLOC_GOOD_SIZE 0
+#endif

--- a/Source/bmalloc/bmalloc/DebugHeap.h
+++ b/Source/bmalloc/bmalloc/DebugHeap.h
@@ -50,6 +50,14 @@ public:
     void* memalignLarge(size_t alignment, size_t);
     void freeLarge(void* base);
 
+#if BENABLE(MALLOC_SIZE)
+    size_t mallocSize(const void* object) { return malloc_size(object); }
+#endif
+
+#if BENABLE(MALLOC_GOOD_SIZE)
+    size_t mallocGoodSize(size_t size) { return malloc_good_size(size); }
+#endif
+
     void scavenge();
     void dump();
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -189,5 +189,23 @@ BEXPORT void enableMiniMode();
 // Used for debugging only.
 BEXPORT void disableScavenger();
 
+#if BENABLE(MALLOC_SIZE)
+inline size_t mallocSize(const void* object)
+{
+    if (auto* debugHeap = DebugHeap::tryGet())
+        return debugHeap->mallocSize(object);
+    return bmalloc_get_allocation_size(const_cast<void*>(object));
+}
+#endif
+
+#if BENABLE(MALLOC_GOOD_SIZE)
+inline size_t mallocGoodSize(size_t size)
+{
+    if (auto* debugHeap = DebugHeap::tryGet())
+        return debugHeap->mallocGoodSize(size);
+    return size;
+}
+#endif
+
 } // namespace api
 } // namespace bmalloc


### PR DESCRIPTION
#### 36909d0439c25c259e6fa2bf8ac99fd6d924e221
<pre>
Make SQLite use libpas for malloc in NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=243642">https://bugs.webkit.org/show_bug.cgi?id=243642</a>
&lt;rdar://problem/98288137&gt;

Reviewed by Yusuke Suzuki.

This makes SQLite use libpas instead of system malloc in NetworkProcess. It seems to be a ~0.5% win
in Membuster. The wins come from:

1. libpas being more aggressive at returning memory to the OS via MADV_FREE.
2. libpas being fast enough that we can disable the lookaside allocator, which was dirtying 128KB of
   memory per connection. I tested this by running various IDB benchmarks which seemed neutral after
   this making this change.

This requires exporting libpas&apos;s implementation of malloc_size to WTF, since the current
implementation of that function in WTF doesn&apos;t do anything.

We also have to implement malloc_size and malloc_good_size in DebugHeap and pass that through to WTF
so that these databases continue to work when Malloc=1 is specified.

* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastMallocSize):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::useFastMalloc):
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::mallocSize):
* Source/bmalloc/bmalloc/bmalloc.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastMallocSize):
(WTF::fastMallocGoodSize):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::useFastMalloc):
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/DebugHeap.h:
(bmalloc::DebugHeap::mallocSize):
(bmalloc::DebugHeap::mallocGoodSize):
* Source/bmalloc/bmalloc/bmalloc.h:
(bmalloc::api::mallocSize):
(bmalloc::api::mallocGoodSize):

Canonical link: <a href="https://commits.webkit.org/253338@main">https://commits.webkit.org/253338@main</a>
</pre>
