### PR TITLE
[merge-queue] validate-commit-message step rejects reviewers if spelling isn't an exact match with contributors.json

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5061,14 +5061,12 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
         elif rc == SUCCESS:
             if reviewers and not self.contributors:
                 self.summary = "Failed to load contributors.json, can't validate reviewers"
-                rc = FAILURE
             elif reviewers and any([not self.is_reviewer(reviewer) for reviewer in reviewers]):
-                self.summary = "'{}' is not a reviewer"
+                self.summary = "'{}' is not a reviewer, still continuing"
                 for reviewer in reviewers:
                     if not self.is_reviewer(reviewer):
                         self.summary = self.summary.format(reviewer)
                         break
-                rc = FAILURE
             elif reviewers and author and any([author.startswith(reviewer) for reviewer in reviewers]):
                 self.summary = f"'{author}' cannot review their own change"
                 rc = FAILURE

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6115,7 +6115,7 @@ class TestValidateCommitMessage(BuildStepMixinAdditions, unittest.TestCase):
         self.setUpCommonProperties()
         expected_remote_command_output = '    Reviewed by WebKit Contributor.\n'
         self.expectCommonRemoteCommandsWithOutput(expected_remote_command_output)
-        self.expectOutcome(result=FAILURE, state_string="'WebKit Contributor' is not a reviewer")
+        self.expectOutcome(result=SUCCESS, state_string="'WebKit Contributor' is not a reviewer, still continuing")
         return self.runStep()
 
     def test_self_reviewer(self):


### PR DESCRIPTION
#### a25d41d0d20fdcb1e2553bf85370b7d7e96705e1
<pre>
[merge-queue] validate-commit-message step rejects reviewers if spelling isn&apos;t an exact match with contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=243750">https://bugs.webkit.org/show_bug.cgi?id=243750</a>

Reviewed by Chris Dumez.

Continue with merging even if reviewer name is not found in contributors.json. Will
still perform basic validation like checking like OOPS.
* Tools/CISupport/ews-build/steps.py:
(ValidateCommitMessage.run):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/253275@main">https://commits.webkit.org/253275@main</a>
</pre>
