### PR TITLE
[WPE] Fix runtime error while running 'test262-runner' in Flatpak

### DIFF
--- a/Tools/Scripts/test262-runner
+++ b/Tools/Scripts/test262-runner
@@ -34,6 +34,26 @@ use 5.8.8;
 use FindBin;
 use Config;
 
+sub build_flatpak_args
+{
+    my $type;
+    my $args = ();
+    for my $argv (@_) {
+       next if $argv eq "--no-flatpak-check";
+       next if $argv eq "--wpe" || $argv eq "--gtk";
+       if ($argv eq "--release" || $argv eq "--debug") {
+          $type = ucfirst(substr($argv, 2));
+          next;
+       }
+       $args->{$argv} = "";
+    }
+
+    if (!exists($args->{"--jsc"})) {
+       $args->{"--jsc"} = "/app/webkit/WebKitBuild/$type/bin/jsc";
+    }
+    return %$args;
+}
+
 BEGIN {
     use lib $FindBin::Bin;
     use File::Spec::Functions qw(catfile);
@@ -67,6 +87,10 @@ BEGIN {
     unshift @INC, "$FindBin::Bin/test262";
 
     $ENV{LOAD_ROUTES} = 1;
+}
+
+if (grep(/^--no-flatpak-check$/,  @ARGV)) {
+    @ARGV = build_flatpak_args(@ARGV);
 }
 
 use Runner;


### PR DESCRIPTION
#### bb263fe0c0b4e3d0df12bd4677a134b02539aec3
<pre>
[WPE] Fix runtime error while running &apos;test262-runner&apos; in Flatpak
<a href="https://bugs.webkit.org/show_bug.cgi?id=243755">https://bugs.webkit.org/show_bug.cgi?id=243755</a>

Reviewed by Philippe Normand.

* Tools/Scripts/test262-runner:
(build_flatpak_args): Build expected list of arguments for running
&apos;test262-runner&apos; inside Flatpak.

Canonical link: <a href="https://commits.webkit.org/253292@main">https://commits.webkit.org/253292@main</a>
</pre>
