### PR TITLE
Use align-content when calculating the static position of absolutely-positioned flexbox children.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4407,7 +4407,6 @@ webkit.org/b/233196 imported/w3c/web-platform-tests/css/css-flexbox/percentage-h
 
 # Static position alignment in Flexbox.
 webkit.org/b/221472 imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-safe-001.html [ ImageOnlyFailure ]
-webkit.org/b/221472 imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-fallback-align-content-001.html [ ImageOnlyFailure ]
 
 # Tables as flex items.
 webkit.org/b/221473 imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-min-height-1.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-001-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-002-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-003-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-004-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-005-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+offsetLeft expected 10 but got 2
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+offsetLeft expected -2 but got 2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-006-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+offsetLeft expected 10 but got 2
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+offsetLeft expected -2 but got 2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-007-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
+offsetLeft expected 10 but got 2
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
+offsetLeft expected -2 but got 2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-008-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
+offsetLeft expected 10 but got 2
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="5"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
+offsetLeft expected -2 but got 2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="-3"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-001-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-002-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+offsetLeft expected 2 but got 10
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+offsetLeft expected 2 but got -2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-001-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
+offsetLeft expected 2 but got 10
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetLeft expected 10 but got 6
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 6
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
+offsetLeft expected 2 but got -2
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetLeft expected -2 but got 0
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="2" data-offset-y="1"></div></div>
-offsetLeft expected 2 but got 0
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-002-expected.txt
@@ -10,55 +10,31 @@
 
 
 PASS .container > div 1
-FAIL .container > div 2 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+PASS .container > div 2
 FAIL .container > div 3 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 4 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
+offsetTop expected 5 but got 1
+PASS .container > div 4
 PASS .container > div 5
 PASS .container > div 6
 PASS .container > div 7
 PASS .container > div 8
-FAIL .container > div 9 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 10 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
-FAIL .container > div 11 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="10" data-offset-y="1"></div></div>
-offsetTop expected 1 but got 3
-FAIL .container > div 12 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="10" data-offset-y="5"></div></div>
-offsetTop expected 5 but got 3
+PASS .container > div 9
+PASS .container > div 10
+PASS .container > div 11
+PASS .container > div 12
 PASS .container > div 13
-FAIL .container > div 14 assert_equals:
-<div class="container" style="align-content: baseline"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+PASS .container > div 14
 FAIL .container > div 15 assert_equals:
 <div class="container" style="align-content: last baseline"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 16 assert_equals:
-<div class="container" style="align-content: space-between"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
+offsetTop expected -3 but got 1
+PASS .container > div 16
 PASS .container > div 17
 PASS .container > div 18
 PASS .container > div 19
 PASS .container > div 20
-FAIL .container > div 21 assert_equals:
-<div class="container" style="align-content: start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 22 assert_equals:
-<div class="container" style="align-content: end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
-FAIL .container > div 23 assert_equals:
-<div class="container" style="align-content: flex-start"><div data-offset-x="-2" data-offset-y="1"></div></div>
-offsetTop expected 1 but got -1
-FAIL .container > div 24 assert_equals:
-<div class="container" style="align-content: flex-end"><div data-offset-x="-2" data-offset-y="-3"></div></div>
-offsetTop expected -3 but got -1
+PASS .container > div 21
+PASS .container > div 22
+PASS .container > div 23
+PASS .container > div 24
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1271,7 +1271,7 @@ bool RenderFlexibleBox::hasAutoMarginsInCrossAxis(const RenderBox& child) const
     return child.style().marginLeft().isAuto() || child.style().marginRight().isAuto();
 }
 
-LayoutUnit RenderFlexibleBox::availableAlignmentSpaceForChild(LayoutUnit lineCrossAxisExtent, const RenderBox& child)
+LayoutUnit RenderFlexibleBox::availableAlignmentSpaceForChild(const LayoutUnit lineCrossAxisExtent, const RenderBox& child) const
 {
     LayoutUnit childCrossExtent = crossAxisMarginExtentForChild(child) + crossAxisExtentForChild(child);
     return lineCrossAxisExtent - childCrossExtent;
@@ -1731,10 +1731,42 @@ LayoutUnit RenderFlexibleBox::staticMainAxisPositionForPositionedChild(const Ren
     return offset;
 }
 
-LayoutUnit RenderFlexibleBox::staticCrossAxisPositionForPositionedChild(const RenderBox& child)
+LayoutUnit RenderFlexibleBox::staticCrossAxisPositionForPositionedChild(const RenderBox& child) const
 {
     auto availableSpace = availableAlignmentSpaceForChild(crossAxisContentExtent(), child);
-    return alignmentOffset(availableSpace, alignmentForChild(child), 0_lu, 0_lu, style().flexWrap() == FlexWrap::Reverse);
+    auto alignContentDistribution = style().resolvedAlignContentDistribution(contentAlignmentNormalBehavior());
+    bool isReversed = style().flexWrap() == FlexWrap::Reverse;
+
+    // This computes static positioning given a flex container's align-content property except for the case
+    // of align-content: stretch.
+    // https://drafts.csswg.org/css-flexbox-1/#align-content-property
+    const auto alignContentOffset = [&] {
+        auto alignContentPosition = style().resolvedAlignContentPosition(contentAlignmentNormalBehavior());
+
+        if (alignContentPosition == ContentPosition::FlexStart
+            || alignContentDistribution == ContentDistribution::SpaceBetween)
+            return isReversed ? availableSpace : 0_lu;
+
+        if (alignContentPosition == ContentPosition::FlexEnd)
+            return isReversed ? 0_lu : availableSpace;
+
+        if (alignContentPosition == ContentPosition::End)
+            return availableSpace;
+
+        if (alignContentPosition == ContentPosition::Center
+            || alignContentDistribution == ContentDistribution::SpaceEvenly
+            || alignContentDistribution == ContentDistribution::SpaceAround)
+            return availableSpace / 2;
+
+        return 0_lu;
+    };
+
+    if (isMultiline() && alignContentDistribution != ContentDistribution::Stretch)
+        return alignContentOffset();
+
+    // For the align-content: stretch case, this leads to unspecified but web compatible behavior.
+    // https://bugs.webkit.org/show_bug.cgi?id=243882
+    return alignmentOffset(availableSpace, alignmentForChild(child), 0_lu, 0_lu, isReversed);
 }
 
 LayoutUnit RenderFlexibleBox::staticInlinePositionForPositionedChild(const RenderBox& child)
@@ -2108,7 +2140,7 @@ void RenderFlexibleBox::layoutColumnReverse(const Vector<FlexItem>& children, La
         }
     }
 }
-    
+
 static LayoutUnit initialAlignContentOffset(LayoutUnit availableFreeSpace, ContentPosition alignContent, ContentDistribution alignContentDistribution, unsigned numberOfLines, bool isReversed)
 {
     if (alignContent == ContentPosition::FlexEnd

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -78,7 +78,7 @@ public:
     void clearCachedChildIntrinsicContentLogicalHeight(const RenderBox& child);
 
     LayoutUnit staticMainAxisPositionForPositionedChild(const RenderBox&);
-    LayoutUnit staticCrossAxisPositionForPositionedChild(const RenderBox&);
+    LayoutUnit staticCrossAxisPositionForPositionedChild(const RenderBox&) const;
     
     LayoutUnit staticInlinePositionForPositionedChild(const RenderBox&);
     LayoutUnit staticBlockPositionForPositionedChild(const RenderBox&);
@@ -179,7 +179,7 @@ private:
     bool updateAutoMarginsInCrossAxis(RenderBox& child, LayoutUnit availableAlignmentSpace);
     void repositionLogicalHeightDependentFlexItems(Vector<LineContext>&, LayoutUnit gapBetweenLines);
     
-    LayoutUnit availableAlignmentSpaceForChild(LayoutUnit lineCrossAxisExtent, const RenderBox& child);
+    LayoutUnit availableAlignmentSpaceForChild(const LayoutUnit lineCrossAxisExtent, const RenderBox& child) const;
     LayoutUnit marginBoxAscentForChild(const RenderBox& child);
     
     LayoutUnit computeChildMarginValue(Length margin);


### PR DESCRIPTION
#### 62e012dfc64a13172b55d9115d77119ec8dbe794
<pre>
Use align-content when calculating the static position of absolutely-positioned flexbox children.
<a href="https://bugs.webkit.org/show_bug.cgi?id=221472">https://bugs.webkit.org/show_bug.cgi?id=221472</a>
rdar://74278896

Reviewed by Sergio Villar Senin.

Absolutely-positioned children of multi-line flex containers were not taking into account
the value of align-content. Since abspos children are statically positioned as if they
were the only flex item, we must compute the alignment of the hypothetical flex line that
they would be on.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::staticCrossAxisPositionForPositionedChild const):
    Added a lambda for computing the alignment offset of the hypothetical flex line that
    an abspos child of a flex container lives on. We don&apos;t fully implement the spec
    at this time since there is a webcompat issue for fallback behavior for
    align-content: stretch. We maintain our current behavior and compatibility with all other
    engines and we compute position as if the hypothetical flex line stretches to fill the container.

(WebCore::RenderFlexibleBox::availableAlignmentSpaceForChild const):
(WebCore::RenderFlexibleBox::availableAlignmentSpaceForChild): Deleted.
    Made into a const member function.
(WebCore::RenderFlexibleBox::staticCrossAxisPositionForPositionedChild): Deleted.
    Made into a const member function.
* Source/WebCore/rendering/RenderFlexibleBox.h:

LayoutTests:
    Rebaseline css/css-flexbox/abspos tests.
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-rtl-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-content-vertWM-002-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253389@main">https://commits.webkit.org/253389@main</a>
</pre>
