### PR TITLE
[Gardening]: REGRESSION (253132@main): Three fast/events/touch/ios/block-without-overflow-scroll tests are a consistent failure

### DIFF
--- a/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-block-scrolling-state-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-block-scrolling-state-expected.txt
@@ -20,6 +20,6 @@ Verify that the block scrolling on overflow has touch event region with synchron
     at (8,8) size 784x200)
   (synchronous event dispatch region for event touchstart
     at (8,8) size 784x200)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 

--- a/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-document-scrolling-state-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-document-scrolling-state-expected.txt
@@ -22,6 +22,6 @@ Verify that the block scrolling on overflow has touch event region with synchron
     at (8,8) size 784x200)
   (synchronous event dispatch region for event touchstart
     at (8,8) size 784x200)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 

--- a/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-scrolling-state-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-scrolling-state-expected.txt
@@ -20,6 +20,6 @@ Verify that the block scrolling on overflow has touch event region with synchron
     at (0,0) size 800x200)
   (synchronous event dispatch region for event touchstart
     at (0,0) size 800x200)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 


### PR DESCRIPTION
#### 6efd100bcf84ca5c5eaf981b33d1e7dc4f9b7d1b
<pre>
[Gardening]: REGRESSION (253132@main): [SkyE][Sydney] Three fast/events/touch/ios/block-without-overflow-scroll tests are a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243758">https://bugs.webkit.org/show_bug.cgi?id=243758</a>

Re-baseline.

Unreviewed test gardening.

* LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-block-scrolling-state-expected.txt:
* LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-and-passive-observer-on-document-scrolling-state-expected.txt:
* LayoutTests/fast/events/touch/ios/block-without-overflow-scroll-scrolling-state-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253279@main">https://commits.webkit.org/253279@main</a>
</pre>
