### PR TITLE
Adopt CGDisplayList resource cache

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -957,10 +957,10 @@ UseARKitForModel:
     WebKit:
       default: true
 
-UseCGDisplayListOutOfLineSurfaces:
+UseCGDisplayListImageCache:
   type: bool
-  humanReadableName: "CG Display Lists: Out-of-line Surfaces"
-  humanReadableDescription: "Encode surfaces out-of-line for CG Display List image buffers."
+  humanReadableName: "CG Display Lists: Image Cache"
+  humanReadableDescription: "Cache and transmit surfaces out-of-line for CG Display List image buffers."
   webcoreBinding: none
   condition: ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
   exposed: [ WebKit ]

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -59,9 +59,9 @@ public:
 #endif
         bool avoidIOSurfaceSizeCheckInWebProcessForTesting = false;
 
-        enum class UseOutOfLineSurfaces : bool { No, Yes };
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-        UseOutOfLineSurfaces useOutOfLineSurfacesForCGDisplayLists;
+        enum class UseCGDisplayListImageCache : bool { No, Yes };
+        UseCGDisplayListImageCache useCGDisplayListImageCache;
 #endif
 
         CreationContext(HostWindow* window = nullptr
@@ -70,7 +70,7 @@ public:
 #endif
             , bool avoidCheck = false
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-            , UseOutOfLineSurfaces useOutOfLineSurfacesForCGDisplayLists = UseOutOfLineSurfaces::No
+            , UseCGDisplayListImageCache useCGDisplayListImageCache = UseCGDisplayListImageCache::No
 #endif
         )
             : hostWindow(window)
@@ -79,7 +79,7 @@ public:
 #endif
             , avoidIOSurfaceSizeCheckInWebProcessForTesting(avoidCheck)
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-            , useOutOfLineSurfacesForCGDisplayLists(useOutOfLineSurfacesForCGDisplayLists)
+            , useCGDisplayListImageCache(useCGDisplayListImageCache)
 #endif
         { }
     };

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-using UseOutOfLineSurfaces = WebCore::ImageBuffer::CreationContext::UseOutOfLineSurfaces;
+using UseCGDisplayListImageCache = WebCore::ImageBuffer::CreationContext::UseCGDisplayListImageCache;
 
 class CGDisplayListImageBufferBackend final : public WebCore::ImageBufferCGBackend, public ImageBufferBackendHandleSharing {
     WTF_MAKE_ISO_ALLOCATED(CGDisplayListImageBufferBackend);
@@ -56,7 +56,7 @@ public:
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
 protected:
-    CGDisplayListImageBufferBackend(const Parameters&, UseOutOfLineSurfaces);
+    CGDisplayListImageBufferBackend(const Parameters&, const WebCore::ImageBuffer::CreationContext&);
 
     unsigned bytesPerRow() const final;
 
@@ -64,7 +64,7 @@ protected:
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
     mutable std::unique_ptr<WebCore::GraphicsContext> m_context;
-    UseOutOfLineSurfaces m_useOutOfLineSurfaces;
+    RetainPtr<id> m_resourceCache;
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -87,18 +87,12 @@ RemoteLayerBackingStoreCollection* RemoteLayerBackingStore::backingStoreCollecti
     return nullptr;
 }
 
-void RemoteLayerBackingStore::ensureBackingStore(Type type, FloatSize size, float scale, bool deepColor, bool isOpaque, IncludeDisplayList includeDisplayList, UseOutOfLineSurfaces useOutOfLineSurfaces)
+void RemoteLayerBackingStore::ensureBackingStore(const Parameters& parameters)
 {
-    if (m_type == type && m_size == size && m_scale == scale && m_deepColor == deepColor && m_isOpaque == isOpaque && m_includeDisplayList == includeDisplayList && m_useOutOfLineSurfaces == useOutOfLineSurfaces)
+    if (m_parameters == parameters)
         return;
 
-    m_type = type;
-    m_size = size;
-    m_scale = scale;
-    m_deepColor = deepColor;
-    m_isOpaque = isOpaque;
-    m_includeDisplayList = includeDisplayList;
-    m_useOutOfLineSurfaces = useOutOfLineSurfaces;
+    m_parameters = parameters;
 
     if (m_frontBuffer) {
         // If we have a valid backing store, we need to ensure that it gets completely
@@ -134,17 +128,13 @@ void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
         return std::nullopt;
     };
 
-    encoder << m_type;
-    encoder << m_size;
-    encoder << m_scale;
-    encoder << m_isOpaque;
-    encoder << m_includeDisplayList;
+    encoder << m_parameters;
 
     // FIXME: For simplicity this should be moved to the end of display() once the buffer handles can be created once
     // and stored in m_bufferHandle. http://webkit.org/b/234169
     std::optional<ImageBufferBackendHandle> handle;
     if (m_contentsBufferHandle) {
-        ASSERT(m_type == Type::IOSurface);
+        ASSERT(m_parameters.type == Type::IOSurface);
         handle = m_contentsBufferHandle;
     } else if (m_frontBuffer.imageBuffer)
         handle = handleFromBuffer(*m_frontBuffer.imageBuffer);
@@ -162,19 +152,7 @@ void RemoteLayerBackingStore::encode(IPC::Encoder& encoder) const
 
 bool RemoteLayerBackingStore::decode(IPC::Decoder& decoder, RemoteLayerBackingStore& result)
 {
-    if (!decoder.decode(result.m_type))
-        return false;
-
-    if (!decoder.decode(result.m_size))
-        return false;
-
-    if (!decoder.decode(result.m_scale))
-        return false;
-
-    if (!decoder.decode(result.m_isOpaque))
-        return false;
-
-    if (!decoder.decode(result.m_includeDisplayList))
+    if (!decoder.decode(result.m_parameters))
         return false;
 
     if (!decoder.decode(result.m_bufferHandle))
@@ -206,14 +184,14 @@ void RemoteLayerBackingStore::setNeedsDisplay(const IntRect rect)
 
 void RemoteLayerBackingStore::setNeedsDisplay()
 {
-    setNeedsDisplay(IntRect(IntPoint(), expandedIntSize(m_size)));
+    setNeedsDisplay(IntRect(IntPoint(), expandedIntSize(m_parameters.size)));
 }
 
 PixelFormat RemoteLayerBackingStore::pixelFormat() const
 {
 #if HAVE(IOSURFACE_RGB10)
-    if (m_type == Type::IOSurface && m_deepColor)
-        return m_isOpaque ? PixelFormat::RGB10 : PixelFormat::RGB10A8;
+    if (m_parameters.type == Type::IOSurface && m_parameters.deepColor)
+        return m_parameters.isOpaque ? PixelFormat::RGB10 : PixelFormat::RGB10A8;
 #endif
 
     return PixelFormat::BGRA8;
@@ -237,7 +215,7 @@ SetNonVolatileResult RemoteLayerBackingStore::swapToValidFrontBuffer()
     // Sometimes, we can get two swaps ahead of the render server.
     // If we're using shared IOSurfaces, we must wait to modify
     // a surface until it no longer has outstanding clients.
-    if (m_type == Type::IOSurface) {
+    if (m_parameters.type == Type::IOSurface) {
         if (!m_backBuffer.imageBuffer || m_backBuffer.imageBuffer->isInUse()) {
             std::swap(m_backBuffer, m_secondaryBackBuffer);
 
@@ -281,9 +259,13 @@ void RemoteLayerBackingStore::applySwappedBuffers(RefPtr<ImageBuffer>&& front, R
 
 bool RemoteLayerBackingStore::supportsPartialRepaint() const
 {
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     // FIXME: Find a way to support partial repaint for backing store that
     // includes a display list without allowing unbounded memory growth.
-    return m_includeDisplayList == IncludeDisplayList::No;
+    return m_parameters.includeDisplayList == IncludeDisplayList::No;
+#else
+    return true;
+#endif
 }
 
 void RemoteLayerBackingStore::setContents(WTF::MachSendRight&& contents)
@@ -375,10 +357,10 @@ void RemoteLayerBackingStore::ensureFrontBuffer()
     m_frontBuffer.imageBuffer = collection->allocateBufferForBackingStore(*this);
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-    if (!m_displayListBuffer && m_includeDisplayList == IncludeDisplayList::Yes) {
+    if (!m_displayListBuffer && m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
         ImageBuffer::CreationContext creationContext;
-        creationContext.useOutOfLineSurfacesForCGDisplayLists = m_useOutOfLineSurfaces;
-        m_displayListBuffer = ImageBuffer::create<CGDisplayListImageBufferBackend>(m_size, m_scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, WTFMove(creationContext));
+        creationContext.useCGDisplayListImageCache = m_parameters.useCGDisplayListImageCache;
+        m_displayListBuffer = ImageBuffer::create<CGDisplayListImageBufferBackend>(m_parameters.size, m_parameters.scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, WTFMove(creationContext));
     }
 #endif
 }
@@ -435,30 +417,16 @@ void RemoteLayerBackingStore::paintContents()
 
     m_lastDisplayTime = MonotonicTime::now();
 
-    if (m_includeDisplayList == IncludeDisplayList::Yes) {
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
         BifurcatedGraphicsContext context(m_frontBuffer.imageBuffer->context(), m_displayListBuffer->context());
-#else
-        GraphicsContext& context = m_frontBuffer.imageBuffer->context();
-#endif
         drawInContext(context);
-    } else {
-        GraphicsContext& context = m_frontBuffer.imageBuffer->context();
-        drawInContext(context);    
+        return;
     }
-
-    m_dirtyRegion = { };
-    m_paintingRects.clear();
-
-    m_layer->owner()->platformCALayerLayerDidDisplay(m_layer);
-
-    m_frontBuffer.imageBuffer->flushDrawingContextAsync();
-
-    m_frontBufferFlushers.append(m_frontBuffer.imageBuffer->createFlusher());
-#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-    if (m_includeDisplayList == IncludeDisplayList::Yes)
-        m_frontBufferFlushers.append(m_displayListBuffer->createFlusher());
 #endif
+
+    GraphicsContext& context = m_frontBuffer.imageBuffer->context();
+    drawInContext(context);
 }
 
 void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
@@ -479,13 +447,13 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
     // FIXME: find a consistent way to scale and snap dirty and CG clip rects.
     for (const auto& rect : dirtyRects) {
         FloatRect scaledRect(rect);
-        scaledRect.scale(m_scale);
+        scaledRect.scale(m_parameters.scale);
         scaledRect = enclosingIntRect(scaledRect);
-        scaledRect.scale(1 / m_scale);
+        scaledRect.scale(1 / m_parameters.scale);
         m_paintingRects.append(scaledRect);
     }
 
-    IntRect layerBounds(IntPoint(), expandedIntSize(m_size));
+    IntRect layerBounds(IntPoint(), expandedIntSize(m_parameters.size));
     if (!m_dirtyRegion.contains(layerBounds) && m_backBuffer.imageBuffer)
         context.drawImageBuffer(*m_backBuffer.imageBuffer, { 0, 0 }, { CompositeOperator::Copy });
 
@@ -498,11 +466,11 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
         context.clipPath(clipPath);
     }
 
-    if (!m_isOpaque)
+    if (!m_parameters.isOpaque)
         context.clearRect(layerBounds);
 
 #ifndef NDEBUG
-    if (m_isOpaque)
+    if (m_parameters.isOpaque)
         context.fillRect(layerBounds, SRGBA<uint8_t> { 255, 47, 146 });
 #endif
 
@@ -535,6 +503,21 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context)
         ASSERT_NOT_REACHED();
         break;
     };
+
+    stateSaver.restore();
+
+    m_dirtyRegion = { };
+    m_paintingRects.clear();
+
+    m_layer->owner()->platformCALayerLayerDidDisplay(m_layer);
+
+    m_frontBuffer.imageBuffer->flushDrawingContextAsync();
+
+    m_frontBufferFlushers.append(m_frontBuffer.imageBuffer->createFlusher());
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes)
+        m_frontBufferFlushers.append(m_displayListBuffer->createFlusher());
+#endif
 }
 
 void RemoteLayerBackingStore::enumerateRectsBeingDrawn(GraphicsContext& context, void (^block)(FloatRect))
@@ -543,8 +526,8 @@ void RemoteLayerBackingStore::enumerateRectsBeingDrawn(GraphicsContext& context,
 
     // We don't want to un-apply the flipping or contentsScale,
     // because they're not applied to repaint rects.
-    inverseTransform = CGAffineTransformScale(inverseTransform, m_scale, -m_scale);
-    inverseTransform = CGAffineTransformTranslate(inverseTransform, 0, -m_size.height());
+    inverseTransform = CGAffineTransformScale(inverseTransform, m_parameters.scale, -m_parameters.scale);
+    inverseTransform = CGAffineTransformTranslate(inverseTransform, 0, -m_parameters.size.height());
 
     for (const auto& rect : m_paintingRects) {
         CGRect rectToDraw = CGRectApplyAffineTransform(rect, inverseTransform);
@@ -554,19 +537,19 @@ void RemoteLayerBackingStore::enumerateRectsBeingDrawn(GraphicsContext& context,
 
 void RemoteLayerBackingStore::applyBackingStoreToLayer(CALayer *layer, LayerContentsType contentsType, bool replayCGDisplayListsIntoBackingStore)
 {
-    layer.contentsOpaque = m_isOpaque;
+    layer.contentsOpaque = m_parameters.isOpaque;
 
     RetainPtr<id> contents;
     // m_bufferHandle can be unset here if IPC with the GPU process timed out.
     if (m_bufferHandle) {
         WTF::switchOn(*m_bufferHandle,
             [&] (ShareableBitmap::Handle& handle) {
-                ASSERT(m_type == Type::Bitmap);
+                ASSERT(m_parameters.type == Type::Bitmap);
                 if (auto bitmap = ShareableBitmap::create(handle))
                     contents = bridge_id_cast(bitmap->makeCGImageCopy());
             },
             [&] (MachSendRight& machSendRight) {
-                ASSERT(m_type == Type::IOSurface);
+                ASSERT(m_parameters.type == Type::IOSurface);
                 switch (contentsType) {
                 case RemoteLayerBackingStore::LayerContentsType::IOSurface: {
                     auto surface = WebCore::IOSurface::createFromSendRight(WTFMove(machSendRight), DestinationColorSpace::SRGB());
@@ -596,7 +579,7 @@ void RemoteLayerBackingStore::applyBackingStoreToLayer(CALayer *layer, LayerCont
             [layer setValue:@1 forKeyPath:WKCGDisplayListEnabledKey];
             [layer setValue:@1 forKeyPath:WKCGDisplayListBifurcationEnabledKey];
         } else
-            layer.opaque = m_isOpaque;
+            layer.opaque = m_parameters.isOpaque;
         [(WKCompositingLayer *)layer _setWKContents:contents.get() withDisplayList:WTFMove(std::get<CGDisplayList>(*m_displayListBufferHandle)) replayForTesting:replayCGDisplayListsIntoBackingStore];
         return;
     }
@@ -637,7 +620,7 @@ SetNonVolatileResult RemoteLayerBackingStore::setBufferNonVolatile(Buffer& buffe
 
 bool RemoteLayerBackingStore::setBufferVolatile(BufferType bufferType)
 {
-    if (m_type != Type::IOSurface)
+    if (m_parameters.type != Type::IOSurface)
         return true;
 
     switch (bufferType) {
@@ -656,7 +639,7 @@ bool RemoteLayerBackingStore::setBufferVolatile(BufferType bufferType)
 
 SetNonVolatileResult RemoteLayerBackingStore::setFrontBufferNonVolatile()
 {
-    if (m_type != Type::IOSurface)
+    if (m_parameters.type != Type::IOSurface)
         return SetNonVolatileResult::Valid;
 
     return setBufferNonVolatile(m_frontBuffer);
@@ -678,6 +661,48 @@ RefPtr<ImageBuffer> RemoteLayerBackingStore::bufferForType(BufferType bufferType
 void RemoteLayerBackingStore::Buffer::discard()
 {
     imageBuffer = nullptr;
+}
+
+void RemoteLayerBackingStore::Parameters::encode(IPC::Encoder& encoder) const
+{
+    encoder << type;
+    encoder << size;
+    encoder << scale;
+    encoder << deepColor;
+    encoder << isOpaque;
+
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    encoder << includeDisplayList;
+    encoder << useCGDisplayListImageCache;
+#endif
+}
+
+bool RemoteLayerBackingStore::Parameters::decode(IPC::Decoder& decoder, RemoteLayerBackingStore::Parameters& result)
+{
+    if (!decoder.decode(result.type))
+        return false;
+
+    if (!decoder.decode(result.size))
+        return false;
+
+    if (!decoder.decode(result.scale))
+        return false;
+
+    if (!decoder.decode(result.deepColor))
+        return false;
+
+    if (!decoder.decode(result.isOpaque))
+        return false;
+
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+    if (!decoder.decode(result.includeDisplayList))
+        return false;
+
+    if (!decoder.decode(result.useCGDisplayListImageCache))
+        return false;
+#endif
+
+    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -235,16 +235,21 @@ void PlatformCALayerRemote::updateBackingStore()
 
     ASSERT(m_properties.backingStoreAttached);
 
-    auto type = m_acceleratesDrawing ? RemoteLayerBackingStore::Type::IOSurface : RemoteLayerBackingStore::Type::Bitmap;
-    auto includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::No;
-    auto useOutOfLineSurfaces = UseOutOfLineSurfaces::No;
+    RemoteLayerBackingStore::Parameters parameters;
+    parameters.type = m_acceleratesDrawing ? RemoteLayerBackingStore::Type::IOSurface : RemoteLayerBackingStore::Type::Bitmap;
+    parameters.size = m_properties.bounds.size();
+    parameters.scale = m_properties.contentsScale;
+    parameters.deepColor = m_wantsDeepColorBackingStore;
+    parameters.isOpaque = m_properties.opaque;
+
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     if (m_context->useCGDisplayListsForDOMRendering())
-        includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::Yes;
-    if (m_context->useCGDisplayListOutOfLineSurfaces())
-        useOutOfLineSurfaces = UseOutOfLineSurfaces::Yes;
+        parameters.includeDisplayList = RemoteLayerBackingStore::IncludeDisplayList::Yes;
+    if (m_context->useCGDisplayListImageCache())
+        parameters.useCGDisplayListImageCache = UseCGDisplayListImageCache::Yes;
 #endif
-    m_properties.backingStore->ensureBackingStore(type, m_properties.bounds.size(), m_properties.contentsScale, m_wantsDeepColorBackingStore, m_properties.opaque, includeDisplayList, useOutOfLineSurfaces);
+
+    m_properties.backingStore->ensureBackingStore(parameters);
 }
 
 void PlatformCALayerRemote::setNeedsDisplayInRect(const FloatRect& rect)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -80,8 +80,8 @@ public:
     bool useCGDisplayListsForDOMRendering() const { return m_useCGDisplayListsForDOMRendering; }
     void setUseCGDisplayListsForDOMRendering(bool useCGDisplayLists) { m_useCGDisplayListsForDOMRendering = useCGDisplayLists; }
 
-    bool useCGDisplayListOutOfLineSurfaces() const { return m_useCGDisplayListOutOfLineSurfaces; }
-    void setUseCGDisplayListOutOfLineSurfaces(bool useOutOfLineSurfaces) { m_useCGDisplayListOutOfLineSurfaces = useOutOfLineSurfaces; }
+    bool useCGDisplayListImageCache() const { return m_useCGDisplayListImageCache; }
+    void setUseCGDisplayListImageCache(bool useCGDisplayListImageCache) { m_useCGDisplayListImageCache = useCGDisplayListImageCache; }
     
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const;
@@ -109,7 +109,7 @@ private:
 
     bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };
     bool m_useCGDisplayListsForDOMRendering { false };
-    bool m_useCGDisplayListOutOfLineSurfaces { false };
+    bool m_useCGDisplayListImageCache { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -173,7 +173,7 @@ void RemoteLayerTreeDrawingArea::updatePreferences(const WebPreferencesStore& pr
     m_rootLayer->setShowDebugBorder(settings.showDebugBorders());
 
     m_remoteLayerTreeContext->setUseCGDisplayListsForDOMRendering(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListsForDOMRenderingKey()));
-    m_remoteLayerTreeContext->setUseCGDisplayListOutOfLineSurfaces(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListOutOfLineSurfacesKey()) && !preferences.getBoolValueForKey(WebPreferencesKey::replayCGDisplayListsIntoBackingStoreKey()));
+    m_remoteLayerTreeContext->setUseCGDisplayListImageCache(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListImageCacheKey()) && !preferences.getBoolValueForKey(WebPreferencesKey::replayCGDisplayListsIntoBackingStoreKey()));
 
     DebugPageOverlays::settingsChanged(*m_webPage.corePage());
 }


### PR DESCRIPTION
#### 58147f715b43e70d85dfb439d544da19fb89f892
<pre>
Adopt CGDisplayList resource cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=243288">https://bugs.webkit.org/show_bug.cgi?id=243288</a>
&lt;rdar://problem/97614470&gt;

Reviewed by Simon Fraser.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
Rename the preference to be about the overall feature; it&apos;s not useful
to have separate toggles for out-of-line surfaces and the cache, so just merge them.

* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::CreationContext::CreationContext):
Plumb the new setting through ImageBuffer (removing the old one).

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::CGDisplayListImageBufferBackend::create):
If enabled, create a `WKCGCommandsCacheRef` and store it for the lifetime of the buffer.

(WebKit::CGDisplayListImageBufferBackend::CGDisplayListImageBufferBackend):
(WebKit::CGDisplayListImageBufferBackend::createBackendHandle const):
Vend the cache to the encoding method.
Adjust logging for the merged preference.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::RemoteLayerBackingStore::Parameters::operator== const):
(WebKit::RemoteLayerBackingStore::size const):
(WebKit::RemoteLayerBackingStore::scale const):
(WebKit::RemoteLayerBackingStore::type const):
(WebKit::RemoteLayerBackingStore::isOpaque const):
(WebKit::RemoteLayerBackingStore::hasEmptyDirtyRegion const):
Factor all of the properties that are passed to `ensureBackingStore` into a struct,
with its own operator== and encode/decode methods. This way, every RemoteLayerBackingStore
has all of its parameters, not a random subset, and it&apos;s neater to add conditional ones.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::ensureBackingStore):
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::decode):
(WebKit::RemoteLayerBackingStore::setNeedsDisplay):
(WebKit::RemoteLayerBackingStore::pixelFormat const):
(WebKit::RemoteLayerBackingStore::swapToValidFrontBuffer):
(WebKit::RemoteLayerBackingStore::supportsPartialRepaint const):
(WebKit::RemoteLayerBackingStore::ensureFrontBuffer):
Adopt Parameters everywhere.

(WebKit::RemoteLayerBackingStore::paintContents):
Move the post-painting code into drawInContext, so we can early-return here in
the display-list case, and don&apos;t have to duplicate the normal non-display-list case.

(WebKit::RemoteLayerBackingStore::drawInContext):
(WebKit::RemoteLayerBackingStore::enumerateRectsBeingDrawn):
(WebKit::RemoteLayerBackingStore::applyBackingStoreToLayer):
(WebKit::RemoteLayerBackingStore::setBufferVolatile):
(WebKit::RemoteLayerBackingStore::setFrontBufferNonVolatile):
More adoption of Parameters.

(WebKit::RemoteLayerBackingStore::Parameters::encode const):
(WebKit::RemoteLayerBackingStore::Parameters::decode):
Added: coders for Parameters.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::updateBackingStore):
Adopt Parameters at the only `ensureBackingStore` callsite.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::useCGDisplayListImageCache const):
(WebKit::RemoteLayerTreeContext::setUseCGDisplayListImageCache):
(WebKit::RemoteLayerTreeContext::useCGDisplayListOutOfLineSurfaces const): Deleted.
(WebKit::RemoteLayerTreeContext::setUseCGDisplayListOutOfLineSurfaces): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updatePreferences):
Adopt the new preference.

Canonical link: <a href="https://commits.webkit.org/253302@main">https://commits.webkit.org/253302@main</a>
</pre>
