### PR TITLE
imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination-worker.https.html is a flaky crash

### DIFF
--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -84,11 +84,13 @@ void KeepaliveRequestTracker::notifyFinished(CachedResource& resource, const Net
 void KeepaliveRequestTracker::unregisterRequest(CachedResource& resource)
 {
     ASSERT(resource.options().keepAlive);
-    resource.removeClient(*this);
-    bool wasRemoved = m_inflightKeepaliveRequests.removeFirst(&resource);
-    ASSERT_UNUSED(wasRemoved, wasRemoved);
+
     m_inflightKeepaliveBytes -= resource.resourceRequest().httpBody()->lengthInBytes();
     ASSERT(m_inflightKeepaliveBytes <= maxInflightKeepaliveBytes);
+
+    resource.removeClient(*this);
+    bool wasRemoved = m_inflightKeepaliveRequests.removeFirst(&resource); // May destroy |resource|.
+    ASSERT_UNUSED(wasRemoved, wasRemoved);
 }
 
 }


### PR DESCRIPTION
#### d4e3f52de7d8755b261845aa50a8a742f61d3a38
<pre>
imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination-worker.https.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=243761">https://bugs.webkit.org/show_bug.cgi?id=243761</a>
&lt;rdar://98408390&gt;

Reviewed by Alex Christensen.

Make sure we don&apos;t use |resource| after it&apos;s been removed from the m_inflightKeepaliveRequests
Vector.

* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::unregisterRequest):

Canonical link: <a href="https://commits.webkit.org/253280@main">https://commits.webkit.org/253280@main</a>
</pre>
