### PR TITLE
Drop obsolete event handler attributes from HTMLMarqueeElement.idl

### DIFF
--- a/Source/WebCore/html/HTMLMarqueeElement.idl
+++ b/Source/WebCore/html/HTMLMarqueeElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 Apple Inc. All rights reserved
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -23,7 +23,7 @@
 ] interface HTMLMarqueeElement : HTMLElement {
     undefined start();
     undefined stop();
-    
+
     [CEReactions=NotNeeded, Reflect] attribute DOMString behavior;
     [CEReactions=NotNeeded, Reflect] attribute DOMString bgColor;
     [CEReactions=NotNeeded, Reflect] attribute DOMString direction;
@@ -35,10 +35,4 @@
     [CEReactions=NotNeeded, Reflect] attribute boolean trueSpeed;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long vspace;
     [CEReactions=NotNeeded, Reflect] attribute DOMString width;
-
-    // FIXME: Implement the following event handler attributes
-    // https://bugs.webkit.org/show_bug.cgi?id=49788
-    // attribute EventHandler onbounce;
-    // attribute EventHandler onfinish;
-    // attribute EventHandler onstart;
 };


### PR DESCRIPTION
#### 2435ca3d84c973af19e7ba34069ed8206ecffc73
<pre>
Drop obsolete event handler attributes from HTMLMarqueeElement.idl
<a href="https://bugs.webkit.org/show_bug.cgi?id=49788">https://bugs.webkit.org/show_bug.cgi?id=49788</a>

Reviewed by Darin Adler.

Removed the obsolete event handlers FIXMEs from HTMLMarqueeElement.idl
since these event handlers are no longer defined in the HTML5 specification.

* Source/WebCore/html/HTMLMarqueeElement.idl:

Canonical link: <a href="https://commits.webkit.org/253300@main">https://commits.webkit.org/253300@main</a>
</pre>
