### PR TITLE
Test share-url-invalid.https.html should be enabled on iOS-wk2

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1783,7 +1783,6 @@ imported/w3c/web-platform-tests/web-share/share-url-pathonly-manual.https.html [
 imported/w3c/web-platform-tests/web-share/share-url-relative-manual.https.html [ Skip ]
 
 imported/w3c/web-platform-tests/web-share/share-sharePromise-internal-slot.https.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/web-share/share-url-invalid.https.html [ Skip ]
 
 # rdar://problem/59595496
 quicklook/keynote-09.html [ Failure ]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-url-invalid.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-url-invalid.https-expected.txt
@@ -1,3 +1,10 @@
 
-PASS share with an invalid URL
+PASS share() rejects when URL is invalid
+PASS share() rejects file:// URLs
+PASS share() rejects wss: URLs
+PASS share() rejects about: URLs
+PASS share() rejects chrome: URLs
+PASS share() rejects javascript: URLs
+PASS share() rejects blob: URLs
+PASS share() rejects data: URLs
 


### PR DESCRIPTION
#### 2c61b57a64a84466864cb999083296bd5cb2e167
<pre>
Test share-url-invalid.https.html should be enabled on iOS-wk2
<a href="https://bugs.webkit.org/show_bug.cgi?id=243769">https://bugs.webkit.org/show_bug.cgi?id=243769</a>

Reviewed by Chris Dumez.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/web-share/share-url-invalid.https-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253319@main">https://commits.webkit.org/253319@main</a>
</pre>
