### PR TITLE
Default HSTS storage directory is not set

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -736,7 +736,7 @@ const gchar* webkit_website_data_manager_get_hsts_cache_directory(WebKitWebsiteD
         return nullptr;
 
     if (!priv->hstsCacheDirectory)
-        priv->hstsCacheDirectory.reset(g_strdup(WebKit::WebsiteDataStore::defaultHSTSDirectory().utf8().data()));
+        priv->hstsCacheDirectory.reset(g_strdup(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory().utf8().data()));
     return priv->hstsCacheDirectory.get();
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -298,6 +298,11 @@ String WebsiteDataStore::defaultAlternativeServicesDirectory()
     return cacheDirectoryFileSystemRepresentation("AlternativeServices"_s, ShouldCreateDirectory::No);
 }
 
+String WebsiteDataStore::defaultHSTSStorageDirectory()
+{
+    return cacheDirectoryFileSystemRepresentation("HSTS"_s);
+}
+
 String WebsiteDataStore::defaultMediaCacheDirectory()
 {
     return tempDirectoryFileSystemRepresentation("MediaCache"_s);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -348,8 +348,8 @@ public:
     static WTF::String defaultAlternativeServicesDirectory();
     static WTF::String defaultApplicationCacheDirectory();
     static WTF::String defaultWebSQLDatabaseDirectory();
-#if USE(GLIB)
-    static WTF::String defaultHSTSDirectory();
+#if USE(GLIB) || PLATFORM(COCOA)
+    static WTF::String defaultHSTSStorageDirectory();
 #endif
 #if ENABLE(ARKIT_INLINE_PREVIEW)
     static WTF::String defaultModelElementCacheDirectory();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -41,6 +41,9 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPers
         setCacheStorageDirectory(WebsiteDataStore::defaultCacheStorageDirectory());
         setGeneralStorageDirectory(WebsiteDataStore::defaultGeneralStorageDirectory());
         setNetworkCacheDirectory(WebsiteDataStore::defaultNetworkCacheDirectory());
+#if USE(GLIB) || PLATFORM(COCOA)
+        setHSTSStorageDirectory(WebsiteDataStore::defaultHSTSStorageDirectory());
+#endif
         setAlternativeServicesDirectory(WebsiteDataStore::defaultAlternativeServicesDirectory());
         setMediaCacheDirectory(WebsiteDataStore::defaultMediaCacheDirectory());
         setIndexedDBDatabaseDirectory(WebsiteDataStore::defaultIndexedDBDatabaseDirectory());

--- a/Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp
@@ -89,7 +89,7 @@ WTF::String WebsiteDataStore::defaultWebSQLDatabaseDirectory()
     return websiteDataDirectoryFileSystemRepresentation(BASE_DIRECTORY G_DIR_SEPARATOR_S "databases");
 }
 
-WTF::String WebsiteDataStore::defaultHSTSDirectory()
+WTF::String WebsiteDataStore::defaultHSTSStorageDirectory()
 {
     return websiteDataDirectoryFileSystemRepresentation(BASE_DIRECTORY G_DIR_SEPARATOR_S);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -448,4 +448,11 @@ TEST(WKWebsiteDataStore, DoNotCreateDefaultDataStore)
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
 
+TEST(WebKit, DefaultHSTSStorageDirectory)
+{
+    auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    EXPECT_FALSE(configuration.get().hstsStorageDirectory == nil);
+    EXPECT_GT(configuration.get().hstsStorageDirectory.absoluteString.length, 0U);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 96a8ca8ed98d7e3f55a6c47e2f46f9aaf1f5dcac
<pre>
Default HSTS storage directory is not set
<a href="https://bugs.webkit.org/show_bug.cgi?id=243770">https://bugs.webkit.org/show_bug.cgi?id=243770</a>
&lt;rdar://problem/98432266&gt;

Reviewed by Sihui Liu.

We should provide a default HSTS storage directory in case the client is not. Reading and
writing of HSTS data will fail due to sandbox restrictions when the HSTS directory is not
set. When a default HSTS is being provided, a sandbox extension will be sent to the
WebContent process, fixing this issue. When the HSTS directory is not set, CFNetwork will
fall back to use a default path for HSTS storage. The sandbox violation is caused by the
Network process not having access to the default path.

* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkit_website_data_manager_get_hsts_cache_directory):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration):
* Source/WebKit/UIProcess/glib/WebsiteDataStoreGLib.cpp:
(WebKit::WebsiteDataStore::defaultHSTSStorageDirectory):
(WebKit::WebsiteDataStore::defaultHSTSDirectory): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/253331@main">https://commits.webkit.org/253331@main</a>
</pre>
