### PR TITLE
Make shouldApplyContainment methods more flexible

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2285,7 +2285,7 @@ void RenderBlock::offsetForContents(LayoutPoint& offset) const
 void RenderBlock::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
     ASSERT(!childrenInline());
-    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (!shouldIgnoreDescendantContentForLogicalWidth)
         computeBlockPreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -346,7 +346,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
 
 void RenderBlockFlow::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
-    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreDescendantContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (!shouldIgnoreDescendantContentForLogicalWidth) {
         if (childrenInline())
             computeInlinePreferredLogicalWidths(minLogicalWidth, maxLogicalWidth);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -98,7 +98,7 @@ void RenderFlexibleBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
         minLogicalWidth += scrollbarWidth;
     };
 
-    auto shouldIgnoreFlexItemContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+    auto shouldIgnoreFlexItemContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
     if (shouldIgnoreFlexItemContentForLogicalWidth) {
         addScrollbarWidth();
         return;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -293,7 +293,7 @@ void RenderGrid::layoutBlock(bool relayoutChildren, LayoutUnit)
         // logical width is always definite as the above call to updateLogicalWidth() properly resolves intrinsic 
         // sizes. We cannot do the same for heights though because many code paths inside updateLogicalHeight() require 
         // a previous call to setLogicalHeight() to resolve heights properly (like for positioned items for example).
-        auto shouldIgnoreGridItemContentForLogicalWidth = shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize });
+        auto shouldIgnoreGridItemContentForLogicalWidth = shouldApplySizeOrInlineSizeContainment();
         if (shouldIgnoreGridItemContentForLogicalWidth)
             computeTrackSizesForIndefiniteSize(m_trackSizingAlgorithm, ForColumns);
         else
@@ -637,7 +637,7 @@ std::unique_ptr<OrderedTrackIndexSet> RenderGrid::computeEmptyTracksForAutoRepea
     unsigned firstAutoRepeatTrack = insertionPoint + grid.explicitGridStart(direction);
     unsigned lastAutoRepeatTrack = firstAutoRepeatTrack + grid.autoRepeatTracks(direction);
 
-    if (!grid.hasGridItems() || shouldApplySizeOrStyleContainment({ Containment::Size, Containment::InlineSize })) {
+    if (!grid.hasGridItems() || shouldApplySizeOrInlineSizeContainment()) {
         emptyTrackIndexes = makeUnique<OrderedTrackIndexSet>();
         for (unsigned trackIndex = firstAutoRepeatTrack; trackIndex < lastAutoRepeatTrack; ++trackIndex)
             emptyTrackIndexes->add(trackIndex);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -540,8 +540,11 @@ public:
     OptionSet<Containment> effectiveContainment() const { return m_rareNonInheritedData->effectiveContainment(); }
     bool containsLayout() const { return effectiveContainment().contains(Containment::Layout); }
     bool containsSize() const { return effectiveContainment().contains(Containment::Size); }
+    bool containsInlineSize() const { return effectiveContainment().contains(Containment::InlineSize); }
+    bool containsSizeOrInlineSize() const { return effectiveContainment().containsAny({ Containment::Size, Containment::InlineSize }); }
     bool containsStyle() const { return effectiveContainment().contains(Containment::Style); }
     bool containsPaint() const { return effectiveContainment().contains(Containment::Paint); }
+    bool containsLayoutOrPaint() const { return effectiveContainment().containsAny({ Containment::Layout, Containment::Paint }); }
     ContainerType containerType() const { return static_cast<ContainerType>(m_rareNonInheritedData->containerType); }
     const Vector<AtomString>& containerNames() const { return m_rareNonInheritedData->containerNames; }
 


### PR DESCRIPTION
#### 6c79952a8e996748546ce0be7ce628f297f07297
<pre>
Make shouldApplyContainment methods more flexible
<a href="https://bugs.webkit.org/show_bug.cgi?id=240906">https://bugs.webkit.org/show_bug.cgi?id=240906</a>

Reviewed by Simon Fraser.

In r293943 some shouldApplyContainment methods were optimised, however
they are not flexible enough to deal with the content-visibility feature,
which in certain cases can influence containment. So to be flexible use
boolean parameters instead of relying on effectiveContainment() directly.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::canContainFixedPositionObjects const):
(WebCore::RenderElement::canContainAbsolutelyPositionedObjects const):
(WebCore::RenderElement::shouldApplyLayoutOrPaintContainment const):
(WebCore::RenderElement::shouldApplySizeOrStyleContainment const):
(WebCore::RenderElement::shouldApplyLayoutContainment const):
(WebCore::RenderElement::shouldApplyPaintContainment const):
(WebCore::RenderElement::shouldApplySizeContainment const):
(WebCore::RenderElement::shouldApplyInlineSizeContainment const):
(WebCore::RenderElement::shouldApplySizeOrInlineSizeContainment const):
(WebCore::RenderElement::shouldApplyStyleContainment const):
(WebCore::RenderElement::shouldApplyAnyContainment const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::computeEmptyTracksForAutoRepeat const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::containsInlineSize const):
(WebCore::RenderStyle::containsSizeOrInlineSize const):
(WebCore::RenderStyle::containsLayoutOrPaint const):

Canonical link: <a href="https://commits.webkit.org/253324@main">https://commits.webkit.org/253324@main</a>
</pre>
