### PR TITLE
Add rudimentary implementation of imperative slot API

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -535,9 +535,6 @@ fast/history/page-cache-active-fetch-response-blobReadAsBlob.html [ DumpJSConsol
 fast/dom/navigator-detached-no-crash.html [ DumpJSConsoleLogInStdErr ]
 webaudio/audioworket-out-of-memory.html [ DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/242376 imported/w3c/web-platform-tests/shadow-dom/imperative-slot-layout-invalidation-001.html [ ImageOnlyFailure ]
-webkit.org/b/243460 imported/w3c/web-platform-tests/shadow-dom/slot-fallback-content-006.html [ ImageOnlyFailure ]
-
 # Newly imported WPT tests that are timing out.
 imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-read/clipboard-read-disabled-by-feature-policy.tentative.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-read/clipboard-read-enabled-by-feature-policy-attribute-cross-origin-tentative.https.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -1,3 +1,7 @@
+CONSOLE MESSAGE: [blocked] The page at https://localhost:9443/html/dom/idlharness.https.html was not allowed to display insecure content from http://invalid/.
+
+CONSOLE MESSAGE: Not allowed to request resource
+CONSOLE MESSAGE: EventSource cannot load http://invalid/ due to access control checks.
 HTML IDL tests
 
 
@@ -3898,7 +3902,7 @@ PASS HTMLSlotElement interface: existence and properties of interface prototype 
 PASS HTMLSlotElement interface: attribute name
 PASS HTMLSlotElement interface: operation assignedNodes(optional AssignedNodesOptions)
 PASS HTMLSlotElement interface: operation assignedElements(optional AssignedNodesOptions)
-FAIL HTMLSlotElement interface: operation assign((Element or Text)...) assert_own_property: interface prototype object missing non-static operation expected property "assign" missing
+PASS HTMLSlotElement interface: operation assign((Element or Text)...)
 PASS HTMLSlotElement must be primary interface of document.createElement("slot")
 PASS Stringification of document.createElement("slot")
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "name" with the proper type
@@ -3906,8 +3910,8 @@ PASS HTMLSlotElement interface: document.createElement("slot") must inherit prop
 PASS HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assignedElements(optional AssignedNodesOptions)" with the proper type
 PASS HTMLSlotElement interface: calling assignedElements(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
-FAIL HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type assert_inherits: property "assign" not found in prototype chain
-FAIL HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError assert_inherits: property "assign" not found in prototype chain
+PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type
+PASS HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLCanvasElement interface: existence and properties of interface object
 PASS HTMLCanvasElement interface object length
 PASS HTMLCanvasElement interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt
@@ -1,17 +1,17 @@
 
 PASS attachShadow can take slotAssignment parameter.
-FAIL slot.attach() should take variadic not sequence. tTree.s1.assign is not a function. (In 'tTree.s1.assign(c1,c2)', 'tTree.s1.assign' is undefined)
-FAIL Imperative slot API can assign nodes in manual slot assignment. assert_equals: expected null but got Element node <slot id="s1"></slot>
-FAIL Order of slottables is preserved in manual slot assignment. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c2, tTree.c3, tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Previously assigned slottable is moved to new slot when it's reassigned. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c2, tTree.c3, tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Order and assignment of nodes are preserved during multiple assignment in a row. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Assigning invalid nodes should be allowed. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c4, tTree.c2)', 'tTree.s1.assign' is undefined)
-FAIL Moving a slot to a new host, the slot loses its previously assigned slottables. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2, tTree.c3)', 'tTree.s1.assign' is undefined)
-FAIL Moving a slot's tree order position within a shadow host has no impact on its assigned slottables. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2, tTree.c3)', 'tTree.s1.assign' is undefined)
-FAIL Appending slottable to different host, it loses slot assignment. It can be re-assigned within a new host. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2, tTree.c3)', 'tTree.s1.assign' is undefined)
-FAIL Previously assigned node should not be assigned if slot moved to a new shadow root. The node is re-assigned when moved back. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Assignment with the same node in parameters should be ignored, first one wins. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c1, tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Removing a slot from DOM resets its slottable's slot assignment. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2, tTree.c3)', 'tTree.s1.assign' is undefined)
-FAIL Nodes can be assigned even if slots or nodes aren't in the same tree. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2)', 'tTree.s1.assign' is undefined)
-FAIL Removing a node from the document does not break manually assigned slot linkage. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2)', 'tTree.s1.assign' is undefined)
+PASS slot.attach() should take variadic not sequence.
+PASS Imperative slot API can assign nodes in manual slot assignment.
+PASS Order of slottables is preserved in manual slot assignment.
+PASS Previously assigned slottable is moved to new slot when it's reassigned.
+PASS Order and assignment of nodes are preserved during multiple assignment in a row.
+PASS Assigning invalid nodes should be allowed.
+PASS Moving a slot to a new host, the slot loses its previously assigned slottables.
+PASS Moving a slot's tree order position within a shadow host has no impact on its assigned slottables.
+PASS Appending slottable to different host, it loses slot assignment. It can be re-assigned within a new host.
+PASS Previously assigned node should not be assigned if slot moved to a new shadow root. The node is re-assigned when moved back.
+PASS Assignment with the same node in parameters should be ignored, first one wins.
+PASS Removing a slot from DOM resets its slottable's slot assignment.
+FAIL Nodes can be assigned even if slots or nodes aren't in the same tree. assert_equals: expected Element node <slot id="s1"></slot> but got null
+PASS Removing a node from the document does not break manually assigned slot linkage.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-slotchange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-slotchange-expected.txt
@@ -1,15 +1,17 @@
 
-FAIL slotchange event must not fire synchronously. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL slotchange event should not fire when assignments do not change assignedNodes. tTree.s1.assign is not a function. (In 'tTree.s1.assign()', 'tTree.s1.assign' is undefined)
-FAIL slotchange event should not fire when same node is assigned. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event when slot's assigned nodes changes. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event on previous slot and new slot when node is reassigned. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event on node assignment and when assigned node is removed. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event when order of assigned nodes changes. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1, tTree.c2)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event when assigned node is removed. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL Fire slotchange event when removing a slot from Shadows Root that changes its assigned nodes. tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)
-FAIL No slotchange event when adding or removing an empty slot. assert_equals: expected 0 but got 1
-FAIL No slotchange event when adding another slotable. assert_equals: expected 0 but got 1
-FAIL Fire slotchange event when assign node to nested slot, ensure event bubbles ups. tTree.s3.assign is not a function. (In 'tTree.s3.assign(tTree.s1)', 'tTree.s3.assign' is undefined)
-FAIL Signal a slot change should be done in tree order. promise_test: Unhandled rejection with value: object "TypeError: tTree.s1.assign is not a function. (In 'tTree.s1.assign(tTree.c1)', 'tTree.s1.assign' is undefined)"
+Harness Error (TIMEOUT), message = null
+
+PASS slotchange event must not fire synchronously.
+PASS slotchange event should not fire when assignments do not change assignedNodes.
+PASS slotchange event should not fire when same node is assigned.
+PASS Fire slotchange event when slot's assigned nodes changes.
+PASS Fire slotchange event on previous slot and new slot when node is reassigned.
+PASS Fire slotchange event on node assignment and when assigned node is removed.
+PASS Fire slotchange event when order of assigned nodes changes.
+TIMEOUT Fire slotchange event when assigned node is removed. Test timed out
+NOTRUN Fire slotchange event when removing a slot from Shadows Root that changes its assigned nodes.
+PASS No slotchange event when adding or removing an empty slot.
+PASS No slotchange event when adding another slotable.
+PASS Fire slotchange event when assign node to nested slot, ensure event bubbles ups.
+NOTRUN Signal a slot change should be done in tree order.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-fallback-clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-fallback-clear-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Text node fallback should be cleared in a subsequently layout slot.assign is not a function. (In 'slot.assign(host.firstChild)', 'slot.assign' is undefined)
-FAIL Element fallback should be cleared in a subsequent layout slot.assign is not a function. (In 'slot.assign(host.firstChild)', 'slot.assign' is undefined)
+PASS Text node fallback should be cleared in a subsequently layout
+PASS Element fallback should be cleared in a subsequent layout
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3898,7 +3898,7 @@ PASS HTMLSlotElement interface: existence and properties of interface prototype 
 PASS HTMLSlotElement interface: attribute name
 PASS HTMLSlotElement interface: operation assignedNodes(optional AssignedNodesOptions)
 PASS HTMLSlotElement interface: operation assignedElements(optional AssignedNodesOptions)
-FAIL HTMLSlotElement interface: operation assign((Element or Text)...) assert_own_property: interface prototype object missing non-static operation expected property "assign" missing
+PASS HTMLSlotElement interface: operation assign((Element or Text)...)
 PASS HTMLSlotElement must be primary interface of document.createElement("slot")
 PASS Stringification of document.createElement("slot")
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "name" with the proper type
@@ -3906,8 +3906,8 @@ PASS HTMLSlotElement interface: document.createElement("slot") must inherit prop
 PASS HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assignedElements(optional AssignedNodesOptions)" with the proper type
 PASS HTMLSlotElement interface: calling assignedElements(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
-FAIL HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type assert_inherits: property "assign" not found in prototype chain
-FAIL HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError assert_inherits: property "assign" not found in prototype chain
+PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type
+PASS HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLCanvasElement interface: existence and properties of interface object
 PASS HTMLCanvasElement interface object length
 PASS HTMLCanvasElement interface object name
@@ -5901,4 +5901,3 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
-

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3888,7 +3888,7 @@ PASS HTMLSlotElement interface: existence and properties of interface prototype 
 PASS HTMLSlotElement interface: attribute name
 PASS HTMLSlotElement interface: operation assignedNodes(optional AssignedNodesOptions)
 PASS HTMLSlotElement interface: operation assignedElements(optional AssignedNodesOptions)
-FAIL HTMLSlotElement interface: operation assign((Element or Text)...) assert_own_property: interface prototype object missing non-static operation expected property "assign" missing
+PASS HTMLSlotElement interface: operation assign((Element or Text)...)
 PASS HTMLSlotElement must be primary interface of document.createElement("slot")
 PASS Stringification of document.createElement("slot")
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "name" with the proper type
@@ -3896,8 +3896,8 @@ PASS HTMLSlotElement interface: document.createElement("slot") must inherit prop
 PASS HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assignedElements(optional AssignedNodesOptions)" with the proper type
 PASS HTMLSlotElement interface: calling assignedElements(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
-FAIL HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type assert_inherits: property "assign" not found in prototype chain
-FAIL HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError assert_inherits: property "assign" not found in prototype chain
+PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type
+PASS HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLCanvasElement interface: existence and properties of interface object
 PASS HTMLCanvasElement interface object length
 PASS HTMLCanvasElement interface object name
@@ -5891,4 +5891,3 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
-

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3874,7 +3874,7 @@ PASS HTMLSlotElement interface: existence and properties of interface prototype 
 PASS HTMLSlotElement interface: attribute name
 PASS HTMLSlotElement interface: operation assignedNodes(optional AssignedNodesOptions)
 PASS HTMLSlotElement interface: operation assignedElements(optional AssignedNodesOptions)
-FAIL HTMLSlotElement interface: operation assign((Element or Text)...) assert_own_property: interface prototype object missing non-static operation expected property "assign" missing
+PASS HTMLSlotElement interface: operation assign((Element or Text)...)
 PASS HTMLSlotElement must be primary interface of document.createElement("slot")
 PASS Stringification of document.createElement("slot")
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "name" with the proper type
@@ -3882,8 +3882,8 @@ PASS HTMLSlotElement interface: document.createElement("slot") must inherit prop
 PASS HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assignedElements(optional AssignedNodesOptions)" with the proper type
 PASS HTMLSlotElement interface: calling assignedElements(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
-FAIL HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type assert_inherits: property "assign" not found in prototype chain
-FAIL HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError assert_inherits: property "assign" not found in prototype chain
+PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type
+PASS HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLCanvasElement interface: existence and properties of interface object
 PASS HTMLCanvasElement interface object length
 PASS HTMLCanvasElement interface object name
@@ -5890,4 +5890,3 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3898,7 +3898,7 @@ PASS HTMLSlotElement interface: existence and properties of interface prototype 
 PASS HTMLSlotElement interface: attribute name
 PASS HTMLSlotElement interface: operation assignedNodes(optional AssignedNodesOptions)
 PASS HTMLSlotElement interface: operation assignedElements(optional AssignedNodesOptions)
-FAIL HTMLSlotElement interface: operation assign((Element or Text)...) assert_own_property: interface prototype object missing non-static operation expected property "assign" missing
+PASS HTMLSlotElement interface: operation assign((Element or Text)...)
 PASS HTMLSlotElement must be primary interface of document.createElement("slot")
 PASS Stringification of document.createElement("slot")
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "name" with the proper type
@@ -3906,8 +3906,8 @@ PASS HTMLSlotElement interface: document.createElement("slot") must inherit prop
 PASS HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assignedElements(optional AssignedNodesOptions)" with the proper type
 PASS HTMLSlotElement interface: calling assignedElements(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError
-FAIL HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type assert_inherits: property "assign" not found in prototype chain
-FAIL HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError assert_inherits: property "assign" not found in prototype chain
+PASS HTMLSlotElement interface: document.createElement("slot") must inherit property "assign((Element or Text)...)" with the proper type
+PASS HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError
 PASS HTMLCanvasElement interface: existence and properties of interface object
 PASS HTMLCanvasElement interface object length
 PASS HTMLCanvasElement interface object name

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -115,10 +115,10 @@ static const char* stringForRareDataUseType(NodeRareData::UseType useType)
         return "NodeList";
     case NodeRareData::UseType::MutationObserver:
         return "MutationObserver";
+    case NodeRareData::UseType::ManuallyAssignedSlot:
+        return "ManuallyAssignedSlot";
     case NodeRareData::UseType::TabIndex:
         return "TabIndex";
-    case NodeRareData::UseType::MinimumSize:
-        return "MinimumSize";
     case NodeRareData::UseType::ScrollingPosition:
         return "ScrollingPosition";
     case NodeRareData::UseType::ComputedStyle:
@@ -147,6 +147,8 @@ static const char* stringForRareDataUseType(NodeRareData::UseType useType)
         return "PartList";
     case NodeRareData::UseType::PartNames:
         return "PartNames";
+    case NodeRareData::UseType::Nonce:
+        return "Nonce";
     case NodeRareData::UseType::ExplicitlySetAttrElementsMap:
         return "ExplicitlySetAttrElementsMap";
     }
@@ -1210,6 +1212,18 @@ HTMLSlotElement* Node::assignedSlotForBindings() const
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::Open)
         return shadowRoot->findAssignedSlot(*this);
     return nullptr;
+}
+
+HTMLSlotElement* Node::manuallyAssignedSlot() const
+{
+    if (!hasRareData())
+        return nullptr;
+    return rareData()->manuallyAssignedSlot();
+}
+
+void Node::setManuallyAssignedSlot(HTMLSlotElement* slotElement)
+{
+    ensureRareData().setManuallyAssignedSlot(slotElement);
 }
 
 ContainerNode* Node::parentInComposedTree() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -246,6 +246,8 @@ public:
 
     HTMLSlotElement* assignedSlot() const;
     HTMLSlotElement* assignedSlotForBindings() const;
+    HTMLSlotElement* manuallyAssignedSlot() const;
+    void setManuallyAssignedSlot(HTMLSlotElement*);
 
     bool isUncustomizedCustomElement() const { return customElementState() == CustomElementState::Uncustomized; }
     bool isCustomElementUpgradeCandidate() const { return customElementState() == CustomElementState::Undefined; }

--- a/Source/WebCore/dom/NodeRareData.cpp
+++ b/Source/WebCore/dom/NodeRareData.cpp
@@ -39,6 +39,7 @@ struct SameSizeAsNodeRareData {
     uint32_t m_tabIndex;
     uint32_t m_childIndexAndIsElementRareDataFlag;
     void* m_pointer[2];
+    WeakPtr<Node> m_weakPointer;
 };
 
 static_assert(sizeof(NodeRareData) == sizeof(SameSizeAsNodeRareData), "NodeRareData should stay small");

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -24,11 +24,13 @@
 #include "ChildNodeList.h"
 #include "CommonAtomStrings.h"
 #include "HTMLCollection.h"
+#include "HTMLSlotElement.h"
 #include "MutationObserverRegistration.h"
 #include "QualifiedName.h"
 #include "TagCollection.h"
 #include <wtf/HashSet.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -248,24 +250,25 @@ public:
     enum class UseType : uint32_t {
         NodeList = 1 << 0,
         MutationObserver = 1 << 1,
-        TabIndex = 1 << 2,
-        ScrollingPosition = 1 << 3,
-        ComputedStyle = 1 << 4,
-        Dataset = 1 << 5,
-        ClassList = 1 << 6,
-        ShadowRoot = 1 << 7,
-        CustomElementQueue = 1 << 8,
-        AttributeMap = 1 << 9,
-        InteractionObserver = 1 << 10,
-        ResizeObserver = 1 << 11,
-        Animations = 1 << 12,
-        PseudoElements = 1 << 13,
-        StyleMap = 1 << 14,
-        PartList = 1 << 15,
-        PartNames = 1 << 16,
-        Nonce = 1 << 17,
-        ComputedStyleMap = 1 << 18,
-        ExplicitlySetAttrElementsMap = 1 << 19,
+        ManuallyAssignedSlot = 1 << 2,
+        TabIndex = 1 << 3,
+        ScrollingPosition = 1 << 4,
+        ComputedStyle = 1 << 5,
+        Dataset = 1 << 6,
+        ClassList = 1 << 7,
+        ShadowRoot = 1 << 8,
+        CustomElementQueue = 1 << 9,
+        AttributeMap = 1 << 10,
+        InteractionObserver = 1 << 11,
+        ResizeObserver = 1 << 12,
+        Animations = 1 << 13,
+        PseudoElements = 1 << 14,
+        StyleMap = 1 << 15,
+        PartList = 1 << 16,
+        PartNames = 1 << 17,
+        Nonce = 1 << 18,
+        ComputedStyleMap = 1 << 19,
+        ExplicitlySetAttrElementsMap = 1 << 20,
     };
 #endif
 
@@ -295,6 +298,10 @@ public:
         return *m_mutationObserverData;
     }
 
+    // https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes
+    HTMLSlotElement* manuallyAssignedSlot() { return m_manuallyAssignedSlot.get(); }
+    void setManuallyAssignedSlot(HTMLSlotElement* slot) { m_manuallyAssignedSlot = slot; }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {
@@ -303,6 +310,8 @@ public:
             result.add(UseType::NodeList);
         if (m_mutationObserverData)
             result.add(UseType::MutationObserver);
+        if (m_manuallyAssignedSlot)
+            result.add(UseType::ManuallyAssignedSlot);
         return result;
     }
 #endif
@@ -317,6 +326,7 @@ private:
 
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
+    WeakPtr<HTMLSlotElement> m_manuallyAssignedSlot;
 };
 
 template<> struct NodeListTypeIdentifier<NameNodeList> {

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -250,8 +250,12 @@ void ShadowRoot::renameSlotElement(HTMLSlotElement& slot, const AtomString& oldN
 void ShadowRoot::addSlotElementByName(const AtomString& name, HTMLSlotElement& slot)
 {
     ASSERT(&slot.rootNode() == this);
-    if (!m_slotAssignment)
-        m_slotAssignment = makeUnique<NamedSlotAssignment>();
+    if (!m_slotAssignment) {
+        if (m_slotAssignmentMode == SlotAssignmentMode::Named)
+            m_slotAssignment = makeUnique<NamedSlotAssignment>();
+        else
+            m_slotAssignment = makeUnique<ManualSlotAssignment>();
+    }
 
     return m_slotAssignment->addSlotElementByName(name, slot, *this);
 }
@@ -260,6 +264,12 @@ void ShadowRoot::removeSlotElementByName(const AtomString& name, HTMLSlotElement
 {
     ASSERT(m_slotAssignment);
     return m_slotAssignment->removeSlotElementByName(name, slot, &oldParentOfRemovedTree, *this);
+}
+
+void ShadowRoot::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current)
+{
+    ASSERT(m_slotAssignment);
+    m_slotAssignment->slotManualAssignmentDidChange(slot, previous, current, *this);
 }
 
 void ShadowRoot::slotFallbackDidChange(HTMLSlotElement& slot)

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -98,6 +98,7 @@ public:
     void renameSlotElement(HTMLSlotElement&, const AtomString& oldName, const AtomString& newName);
     void addSlotElementByName(const AtomString&, HTMLSlotElement&);
     void removeSlotElementByName(const AtomString&, HTMLSlotElement&, ContainerNode& oldParentOfRemovedTree);
+    void slotManualAssignmentDidChange(HTMLSlotElement&, Vector<WeakPtr<Node>>& previous, Vector<WeakPtr<Node>>& current);
     void slotFallbackDidChange(HTMLSlotElement&);
     void resolveSlotsBeforeNodeInsertionOrRemoval();
     void willRemoveAllChildren(ContainerNode&);

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-
 #include "HTMLElement.h"
 
 namespace WebCore {
@@ -41,6 +40,10 @@ public:
     };
     Vector<Ref<Node>> assignedNodes(const AssignedNodesOptions&) const;
     Vector<Ref<Element>> assignedElements(const AssignedNodesOptions&) const;
+
+    void assign(FixedVector<std::reference_wrapper<Node>>&&);
+    const Vector<WeakPtr<Node>>& manuallyAssignedNodes() const { return m_manuallyAssignedNodes; }
+    void removeManuallyAssignedNode(Node&);
 
     void enqueueSlotChangeEvent();
     void didRemoveFromSignalSlotList() { m_inSignalSlotList = false; }
@@ -59,6 +62,7 @@ private:
 
     bool m_inSignalSlotList { false };
     bool m_isInInsertedIntoAncestor { false };
+    Vector<WeakPtr<Node>> m_manuallyAssignedNodes;
 };
 
 }

--- a/Source/WebCore/html/HTMLSlotElement.idl
+++ b/Source/WebCore/html/HTMLSlotElement.idl
@@ -30,6 +30,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     sequence<Node> assignedNodes(optional AssignedNodesOptions options);
     sequence<Element> assignedElements(optional AssignedNodesOptions options);
+    [EnabledBySetting=ImperativeSlotAPIEnabled] undefined assign(Node... nodes); // FIXME: This should be (Element or Text) instead of Node.
 };
 
 dictionary AssignedNodesOptions {


### PR DESCRIPTION
#### b3a5c931e34b75897600609a07df70e3dc0924cc
<pre>
Add rudimentary implementation of imperative slot API
<a href="https://bugs.webkit.org/show_bug.cgi?id=243772">https://bugs.webkit.org/show_bug.cgi?id=243772</a>

Reviewed by Antti Koivisto.

Add a very basic implementation of imperative slot API.

NodeRareData now contains a back reference to the slot element to which the node is manually assigned.
Each slot element remembers which nodes were last manually assigned.

These two states are updated by ManualSlotAssignment.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-slotchange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-fallback-clear-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:

* Source/WebCore/dom/Node.cpp:
(WebCore::stringForRareDataUseType):
(WebCore::Node::manuallyAssignedSlot const): Added.
(WebCore::Node::setManuallyAssignedSlot): Added.
* Source/WebCore/dom/Node.h:

* Source/WebCore/dom/NodeRareData.cpp:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeRareData::manuallyAssignedSlot): Added.
(WebCore::NodeRareData::setManuallyAssignedSlot): Added.
(WebCore::NodeRareData::useTypes const):

* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::addSlotElementByName): Construct ManualSlotAssignment as needed.
(WebCore::ShadowRoot::slotManualAssignmentDidChange):
* Source/WebCore/dom/ShadowRoot.h:

* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::slotManualAssignmentDidChange): Added. No-op.
(WebCore::ManualSlotAssignment::findAssignedSlot): Ditto.
(WebCore::effectiveAssignedNodes): Ditto.
(WebCore::ManualSlotAssignment::assignedNodesForSlot): Ditto.
(WebCore::ManualSlotAssignment::renameSlotElement): Added. No-op.
(WebCore::ManualSlotAssignment::addSlotElementByName): Ditto.
(WebCore::ManualSlotAssignment::removeSlotElementByName): Ditto.
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange): Added. This implements the main logic
for updating manually assigned nodes. First, we clear slot-back references in the previous assignment,
and destroy any renderer created for the previous assignment. Second, we go through the current assignment
and find any slot in the same shadow tree from which we&apos;re taking nodes away. Finally, we visit each
slot which got affected by this assignment in the tree order and enqueue slotchange events as needed.
(WebCore::ManualSlotAssignment::slotFallbackDidChange): Added.
(WebCore::ManualSlotAssignment::hostChildElementDidChange): Ditto.
(WebCore::ManualSlotAssignment::hostChildElementDidChangeSlotAttribute): Ditto.
(WebCore::ManualSlotAssignment::willRemoveAssignedNode): Ditto.
(WebCore::ManualSlotAssignment::didRemoveAllChildrenOfShadowHost): Ditto.
(WebCore::ManualSlotAssignment::didMutateTextNodesOfShadowHost): Ditto.
* Source/WebCore/dom/SlotAssignment.h:
(WebCore::ManualSlotAssignment): Added.
(WebCore::ManualSlotAssignment::Slot): Added.

* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::assign): Added.
(WebCore::HTMLSlotElement::removeManuallyAssignedNode): Added.
* Source/WebCore/html/HTMLSlotElement.h:

* Source/WebCore/html/HTMLSlotElement.idl:

Canonical link: <a href="https://commits.webkit.org/253320@main">https://commits.webkit.org/253320@main</a>
</pre>
