### PR TITLE
Cocoa IPC code depends on WebCore accessibility

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -686,8 +686,6 @@ std::unique_ptr<Decoder> Connection::waitForSyncReply(SyncRequestID syncRequestI
 {
     timeout = timeoutRespectingIgnoreTimeoutsForTesting(timeout);
 
-    willSendSyncMessage(sendSyncOptions);
-    
     bool timedOut = false;
     while (!timedOut) {
         // First, check if we have any messages that we need to process.
@@ -703,10 +701,8 @@ std::unique_ptr<Decoder> Connection::waitForSyncReply(SyncRequestID syncRequestI
             ASSERT_UNUSED(syncRequestID, pendingSyncReply.syncRequestID == syncRequestID);
             
             // We found the sync reply, or the connection was closed.
-            if (pendingSyncReply.didReceiveReply || !m_shouldWaitForSyncReplies) {
-                didReceiveSyncReply(sendSyncOptions);
+            if (pendingSyncReply.didReceiveReply || !m_shouldWaitForSyncReplies)
                 return WTFMove(pendingSyncReply.replyDecoder);
-            }
         }
 
         // Processing a sync message could cause the connection to be invalidated.
@@ -715,7 +711,6 @@ std::unique_ptr<Decoder> Connection::waitForSyncReply(SyncRequestID syncRequestI
         // any more incoming messages.
         if (!isValid()) {
             RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Connection no longer valid, id=%" PRIu64, syncRequestID.toUInt64());
-            didReceiveSyncReply(sendSyncOptions);
             return nullptr;
         }
 
@@ -730,9 +725,6 @@ std::unique_ptr<Decoder> Connection::waitForSyncReply(SyncRequestID syncRequestI
 #else
     RELEASE_LOG_ERROR(IPC, "Connection::waitForSyncReply: Timed-out while waiting for reply for %s, id=%" PRIu64, description(messageName), syncRequestID.toUInt64());
 #endif
-
-    didReceiveSyncReply(sendSyncOptions);
-
     return nullptr;
 }
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -69,11 +69,9 @@ enum class SendOption {
 };
 
 enum class SendSyncOption {
-    // Use this to inform that this sync call will suspend this process until the user responds with input.
-    InformPlatformProcessWillSuspend = 1 << 0,
-    UseFullySynchronousModeForTesting = 1 << 1,
-    ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply = 1 << 2,
-    MaintainOrderingWithAsyncMessages = 1 << 3,
+    UseFullySynchronousModeForTesting = 1 << 0,
+    ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply = 1 << 1,
+    MaintainOrderingWithAsyncMessages = 1 << 2,
 };
 
 enum class WaitForOption {
@@ -373,9 +371,6 @@ private:
     // Can be called on any thread.
     void enqueueIncomingMessage(std::unique_ptr<Decoder>) WTF_REQUIRES_LOCK(m_incomingMessagesLock);
     size_t incomingMessagesDispatchingBatchSize() const;
-
-    void willSendSyncMessage(OptionSet<SendSyncOption>);
-    void didReceiveSyncReply(OptionSet<SendSyncOption>);
 
     Timeout timeoutRespectingIgnoreTimeoutsForTesting(Timeout) const;
 

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -627,14 +627,6 @@ Connection::SocketPair Connection::createPlatformConnection(unsigned options)
     return socketPair;
 }
 
-void Connection::willSendSyncMessage(OptionSet<SendSyncOption>)
-{
-}
-
-void Connection::didReceiveSyncReply(OptionSet<SendSyncOption>)
-{
-}
-
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {
     Connection::SocketPair socketPair = Connection::createPlatformConnection();

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -313,14 +313,6 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
     return false;
 }
 
-void Connection::willSendSyncMessage(OptionSet<SendSyncOption>)
-{
-}
-
-void Connection::didReceiveSyncReply(OptionSet<SendSyncOption>)
-{
-}
-
 void Connection::EventListener::open(Function<void()>&& handler)
 {
     m_handler = WTFMove(handler);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8178,6 +8178,12 @@ void WebPage::clearNotificationPermissionState()
 }
 #endif
 
+#if !PLATFORM(MAC) && !PLATFORM(IOS_FAMILY)
+void WebPage::notifyProcessWillChangeSuspendState(bool)
+{
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1367,8 +1367,10 @@ public:
     SendSyncResult sendSyncWithDelayedReply(T&& message, typename T::Reply&& reply, OptionSet<IPC::SendSyncOption> sendSyncOptions = { })
     {
         cancelCurrentInteractionInformationRequest();
-        sendSyncOptions = sendSyncOptions | IPC::SendSyncOption::InformPlatformProcessWillSuspend;
-        return sendSync(WTFMove(message), WTFMove(reply), Seconds::infinity(), sendSyncOptions);
+        notifyProcessWillChangeSuspendState(true);
+        auto result = sendSync(WTFMove(message), WTFMove(reply), Seconds::infinity(), sendSyncOptions);
+        notifyProcessWillChangeSuspendState(false);
+        return result;
     }
 
     WebCore::DOMPasteAccessResponse requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const String& originIdentifier);
@@ -2028,6 +2030,7 @@ private:
 
     bool hasPendingEditorStateUpdate() const;
     bool shouldAvoidComputingPostLayoutDataForEditorState() const;
+    void notifyProcessWillChangeSuspendState(bool suspended);
 
     WebCore::PageIdentifier m_identifier;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ApplicationServicesSPI.h"
 #import "ContextMenuContextData.h"
 #import "DataReference.h"
 #import "EditingRange.h"
@@ -107,6 +108,8 @@
 #endif
 
 #import "PDFKitSoftLink.h"
+
+extern "C" AXError _AXUIElementNotifyProcessSuspendStatus(AXSuspendStatus);
 
 namespace WebKit {
 using namespace WebCore;
@@ -1123,6 +1126,13 @@ void WebPage::removePDFHUD(PDFPlugin& plugin)
 }
 
 #endif // ENABLE(UI_PROCESS_PDF_HUD)
+
+void WebPage::notifyProcessWillChangeSuspendState(bool suspended)
+{
+    if (!WebCore::AXObjectCache::accessibilityEnabled())
+        return;
+    _AXUIElementNotifyProcessSuspendStatus(suspended ? AXSuspendStatusSuspended : AXSuspendStatusRunning);
+}
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 332d45f32d2cbd9101612a7173d77544bde49597
<pre>
Cocoa IPC code depends on WebCore accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=243775">https://bugs.webkit.org/show_bug.cgi?id=243775</a>
rdar://problem/98435378

Reviewed by NOBODY (OOPS!).

Using IPC::SendSyncOption::InformPlatformProcessWillSuspend
would notify accessibility that the process is suspended
for the duration of the sync send and receive.
This specific feature was only used for WebPage.

Move the suspension logic to WebPage.

This way ConnectionCocoa does not depend on WebCore and
can be compiled only with WTF. This helps in compiling
the WebKit/Platform/IPC to a static library in the future,
enabling C++ unit testing for the code.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForSyncReply):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::AccessibilityProcessSuspendedNotification):
(IPC::Connection::willSendSyncMessage): Deleted.
(IPC::Connection::didReceiveSyncReply): Deleted.
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::willSendSyncMessage): Deleted.
(IPC::Connection::didReceiveSyncReply): Deleted.
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::Connection::willSendSyncMessage): Deleted.
(IPC::Connection::didReceiveSyncReply): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::notifyProcessWillChangeSuspendState):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::notifyProcessWillChangeSuspendState):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::notifyProcessWillChangeSuspendState):
</pre>