### PR TITLE
WebKit::isTestingIPC is used from IPC::, making IPC:: depend on WebKit::

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL) && PLATFORM(COCOA)
 
 #include "GPUConnectionToWebProcess.h"
-#include "IPCTester.h"
+#include "IPCUtilities.h"
 #include <WebCore/ProcessIdentity.h>
 #include <wtf/MachSendRight.h>
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -30,7 +30,7 @@
 
 #import "GPUConnectionToWebProcess.h"
 #import "GPUProcess.h"
-#import "IPCTester.h"
+#import "IPCUtilities.h"
 #import "LibWebRTCCodecsMessages.h"
 #import "LibWebRTCCodecsProxyMessages.h"
 #import "RemoteVideoFrameIdentifier.h"
@@ -111,7 +111,7 @@ void LibWebRTCCodecsProxy::createH264Decoder(RTCDecoderIdentifier identifier, bo
 {
     assertIsCurrent(workQueue());
     auto result = m_decoders.add(identifier, webrtc::createLocalH264Decoder(makeBlockPtr(createDecoderCallback(identifier, useRemoteFrames)).get()));
-    ASSERT_UNUSED(result, result.isNewEntry || isTestingIPC());
+    ASSERT_UNUSED(result, result.isNewEntry || IPC::isTestingIPC());
     m_hasEncodersOrDecoders = true;
 }
 
@@ -119,7 +119,7 @@ void LibWebRTCCodecsProxy::createH265Decoder(RTCDecoderIdentifier identifier, bo
 {
     assertIsCurrent(workQueue());
     auto result = m_decoders.add(identifier, webrtc::createLocalH265Decoder(makeBlockPtr(createDecoderCallback(identifier, useRemoteFrames)).get()));
-    ASSERT_UNUSED(result, result.isNewEntry || isTestingIPC());
+    ASSERT_UNUSED(result, result.isNewEntry || IPC::isTestingIPC());
     m_hasEncodersOrDecoders = true;
 }
 
@@ -127,7 +127,7 @@ void LibWebRTCCodecsProxy::createVP9Decoder(RTCDecoderIdentifier identifier, boo
 {
     assertIsCurrent(workQueue());
     auto result = m_decoders.add(identifier, webrtc::createLocalVP9Decoder(makeBlockPtr(createDecoderCallback(identifier, useRemoteFrames)).get()));
-    ASSERT_UNUSED(result, result.isNewEntry || isTestingIPC());
+    ASSERT_UNUSED(result, result.isNewEntry || IPC::isTestingIPC());
     m_hasEncodersOrDecoders = true;
 }
 
@@ -178,7 +178,7 @@ void LibWebRTCCodecsProxy::createEncoder(RTCEncoderIdentifier identifier, const 
     }).get());
     webrtc::setLocalEncoderLowLatency(encoder, useLowLatency);
     auto result = m_encoders.add(identifier, Encoder { encoder, makeUnique<SharedVideoFrameReader>(Ref { m_videoFrameObjectHeap }, m_resourceOwner) });
-    ASSERT_UNUSED(result, result.isNewEntry || isTestingIPC());
+    ASSERT_UNUSED(result, result.isNewEntry || IPC::isTestingIPC());
     m_hasEncodersOrDecoders = true;
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -29,7 +29,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 #include "GPUConnectionToWebProcess.h"
-#include "IPCTester.h"
+#include "IPCUtilities.h"
 #include "RemoteVideoFrameObjectHeap.h"
 #include "SampleBufferDisplayLayerMessages.h"
 #include <WebCore/ImageTransferSessionVT.h>

--- a/Source/WebKit/Platform/IPC/IPCUtilities.cpp
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IPCUtilities.h"
+
+#include <atomic>
+
+namespace IPC {
+
+#if ENABLE(IPC_TESTING_API)
+
+static std::atomic<unsigned> ongoingIPCTests { 0 };
+
+bool isTestingIPC()
+{
+    return ongoingIPCTests;
+}
+
+void startTestingIPC()
+{
+    ongoingIPCTests++;
+}
+
+void stopTestingIPC()
+{
+    ongoingIPCTests--;
+}
+
+#endif
+
+}

--- a/Source/WebKit/Platform/IPC/IPCUtilities.h
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#define ASSERT_IS_TESTING_IPC() ASSERT(IPC::isTestingIPC(), "Untrusted connection sent invalid data. Should only happen when testing IPC.")
+
+namespace IPC {
+
+// Function to check when asserting IPC-related failures, so that IPC testing skips the assertions
+// and exposes bugs underneath.
+bool isTestingIPC();
+
+#if ENABLE(IPC_TESTING_API)
+void startTestingIPC();
+void stopTestingIPC();
+#else
+inline bool isTestingIPC()
+{
+    return false;
+}
+#endif
+
+}

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -27,7 +27,7 @@
 #import "Connection.h"
 
 #import "DataReference.h"
-#import "IPCTester.h"
+#import "IPCUtilities.h"
 #import "ImportanceAssertion.h"
 #import "Logging.h"
 #import "MachMessage.h"

--- a/Source/WebKit/Shared/IPCConnectionTester.cpp
+++ b/Source/WebKit/Shared/IPCConnectionTester.cpp
@@ -28,7 +28,7 @@
 
 #if ENABLE(IPC_TESTING_API)
 #include "IPCConnectionTesterMessages.h"
-#include "IPCTester.h"
+#include "IPCUtilities.h"
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -30,7 +30,7 @@
 #include "Decoder.h"
 #include "IPCStreamTesterMessages.h"
 #include "IPCStreamTesterProxyMessages.h"
-#include "IPCTester.h"
+#include "IPCUtilities.h"
 #include "StreamConnectionWorkQueue.h"
 #include "StreamServerConnection.h"
 

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -45,13 +45,7 @@
 
 namespace WebKit {
 
-#define ASSERT_IS_TESTING_IPC() ASSERT(WebKit::isTestingIPC(), "Untrusted connection sent invalid data. Should only happen when testing IPC.")
-
 #if ENABLE(IPC_TESTING_API)
-
-// Function to check when asserting IPC-related failures, so that IPC testing skips the assertions
-// and exposes bugs underneath.
-bool isTestingIPC();
 
 class IPCConnectionTester;
 class IPCStreamTester;
@@ -88,13 +82,6 @@ private:
     using ConnectionTesterMap = HashMap<IPCConnectionTesterIdentifier, IPC::ScopedActiveMessageReceiveQueue<IPCConnectionTester>>;
     ConnectionTesterMap m_connectionTesters;
 };
-
-#else
-
-constexpr inline bool isTestingIPC()
-{
-    return false;
-}
 
 #endif
 

--- a/Source/WebKit/Shared/ThreadSafeObjectHeap.h
+++ b/Source/WebKit/Shared/ThreadSafeObjectHeap.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "IPCTester.h"
+#include "IPCUtilities.h"
 #include "ObjectIdentifierReferenceTracker.h"
 #include <wtf/Condition.h>
 #include <wtf/HashMap.h>

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -198,6 +198,7 @@ Platform/IPC/DaemonDecoder.cpp
 Platform/IPC/DaemonEncoder.cpp
 Platform/IPC/Decoder.cpp
 Platform/IPC/Encoder.cpp
+Platform/IPC/IPCUtilities.cpp
 Platform/IPC/JSIPCBinding.cpp
 Platform/IPC/MessageReceiveQueueMap.cpp
 Platform/IPC/MessageReceiverMap.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5477,6 +5477,8 @@
 		7B904169254AFEA7006EEB8C /* RemoteGraphicsContextGL.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGL.cpp; sourceTree = "<group>"; };
 		7B90416A254AFEA7006EEB8C /* RemoteGraphicsContextGL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGL.h; sourceTree = "<group>"; };
 		7B90416D2550108C006EEB8C /* RemoteGraphicsContextGLFunctionsGenerated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLFunctionsGenerated.h; sourceTree = "<group>"; };
+		7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCUtilities.h; sourceTree = "<group>"; };
+		7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCUtilities.cpp; sourceTree = "<group>"; };
 		7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedActiveMessageReceiveQueue.h; sourceTree = "<group>"; };
 		7BBA63DC280E93B500B04823 /* IPCConnectionTesterIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCConnectionTesterIdentifier.h; sourceTree = "<group>"; };
 		7BBA63DD280E93B600B04823 /* IPCConnectionTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCConnectionTester.cpp; sourceTree = "<group>"; };
@@ -8305,6 +8307,8 @@
 				4151E5C31FBB90A900E47E2D /* FormDataReference.h */,
 				C0CE72AC1247E78D00BC0EC4 /* HandleMessage.h */,
 				A31F60A225CC7DB800AF14F4 /* IPCSemaphore.h */,
+				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,
+				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,
 				9B47908E253151CC00EC11AB /* JSIPCBinding.h */,
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,


### PR DESCRIPTION
#### a997bf6b7a87abfdadf4c940a4fdcce024b8eab9
<pre>
WebKit::isTestingIPC is used from IPC::, making IPC:: depend on WebKit::
<a href="https://bugs.webkit.org/show_bug.cgi?id=243778">https://bugs.webkit.org/show_bug.cgi?id=243778</a>
rdar://problem/98441549

Reviewed by Antti Koivisto.

Move WebKit::isTestingIPC implementation to IPC:: in IPCUtilities.h

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createH264Decoder):
(WebKit::LibWebRTCCodecsProxy::createH265Decoder):
(WebKit::LibWebRTCCodecsProxy::createVP9Decoder):
(WebKit::LibWebRTCCodecsProxy::createEncoder):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
* Source/WebKit/Platform/IPC/IPCUtilities.cpp: Added.
(IPC::isTestingIPC):
(IPC::startTestingIPC):
(IPC::stopTestingIPC):
* Source/WebKit/Platform/IPC/IPCUtilities.h: Added.
(IPC::isTestingIPC):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
* Source/WebKit/Shared/IPCConnectionTester.cpp:
* Source/WebKit/Shared/IPCStreamTester.cpp:
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::startMessageTesting):
(WebKit::IPCTester::createStreamTester):
(WebKit::IPCTester::createConnectionTester):
(WebKit::isTestingIPC): Deleted.
* Source/WebKit/Shared/IPCTester.h:
(WebKit::isTestingIPC): Deleted.
* Source/WebKit/Shared/ThreadSafeObjectHeap.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/253421@main">https://commits.webkit.org/253421@main</a>
</pre>
