### PR TITLE
[GStreamer] REGRESSION(253289@main): Broke debug builds

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
@@ -187,7 +187,7 @@ RefPtr<VideoFrame> RealtimeVideoSource::adaptVideoFrame(VideoFrame& videoFrame)
 
     auto newVideoFrame = m_imageTransferSession->convertVideoFrame(videoFrame, size());
 #elif USE(GSTREAMER)
-    auto newVideoFrame = reinterpret_cast<VideoFrameGStreamer&>(videoFrame).resizeTo(size());
+    RefPtr<VideoFrameGStreamer> newVideoFrame = reinterpret_cast<VideoFrameGStreamer&>(videoFrame).resizeTo(size());
 #else
     notImplemented();
     return nullptr;


### PR DESCRIPTION
#### 764278b2e156410c58371a42692600b255882966
<pre>
[GStreamer] REGRESSION(253289@main): Broke debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=243781">https://bugs.webkit.org/show_bug.cgi?id=243781</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp:
(WebCore::RealtimeVideoSource::adaptVideoFrame): Explicitly use
RefPtr&lt;VideoFrameGStreamer&gt; instead of letting the compiler guess.
</pre>