### PR TITLE
[GStreamer] REGRESSION(253289@main): Broke debug builds

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -129,7 +129,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
 {
 }
 
-Ref<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
+RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
 {
     auto* caps = gst_sample_get_caps(m_sample.get());
 
@@ -165,7 +165,7 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinatio
     auto presentationTime = this->presentationTime();
     setBufferFields(outputBuffer.get(), presentationTime, frameRate);
     auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
-    return adoptRef(*new VideoFrameGStreamer(WTFMove(sample), presentationTime, rotation()));
+    return VideoFrameGStreamer::create(WTFMove(sample), destinationSize, presentationTime, rotation(), isMirrored());
 }
 
 RefPtr<JSC::Uint8ClampedArray> VideoFrameGStreamer::computeRGBAImageData() const

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -53,7 +53,7 @@ public:
     static Ref<VideoFrameGStreamer> createFromPixelBuffer(Ref<PixelBuffer>&&, CanvasContentType canvasContentType, Rotation videoRotation, const MediaTime& presentationTime = MediaTime::invalidTime(), const IntSize& destinationSize = { }, double frameRate = 1, bool videoMirrored = false, std::optional<VideoFrameTimeMetadata>&& metadata = std::nullopt);
 
 
-    Ref<VideoFrameGStreamer> resizeTo(const IntSize&);
+    RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GstSample* sample() const { return m_sample.get(); }
     RefPtr<JSC::Uint8ClampedArray> computeRGBAImageData() const;


### PR DESCRIPTION
#### ec1e02abd6f96d5aa790e6f969a2e3e3738c8ec5
<pre>
[GStreamer] REGRESSION(253289@main): Broke debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=243781">https://bugs.webkit.org/show_bug.cgi?id=243781</a>

Reviewed by Adrian Perez de Castro.

The return type for the resizeTo() method was changed to RefPtr&lt;&gt;, which is more consistent with the
mac ImageTransferSessionVT::convertVideoFrame() signature.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::resizeTo):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/253296@main">https://commits.webkit.org/253296@main</a>
</pre>
