### PR TITLE
[Gardening]: REGRESSION (253132@main): fast/events/touch/ios/tap-with-active-touch-end-listener.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/events/touch/ios/tap-with-active-touch-end-listener-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/tap-with-active-touch-end-listener-expected.txt
@@ -13,7 +13,7 @@ Tap on Target1 (green)
   (max layout viewport origin (0,0))
   (synchronous event dispatch region for event touchend
     at (0,0) size 300x100)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 Listener target1 received cancelable event touchend targetting eventTarget1
 Done
@@ -32,7 +32,7 @@ Tap on Target2 (red)
   (max layout viewport origin (0,0))
   (synchronous event dispatch region for event touchend
     at (0,0) size 300x100)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 Listener target1 received cancelable event touchend targetting eventTarget2
 Done
@@ -51,7 +51,7 @@ Tap on Target3 (blue)
   (max layout viewport origin (0,0))
   (synchronous event dispatch region for event touchend
     at (0,0) size 300x100)
-  (behavior for fixed 0)
+  (behavior for fixed 1)
 )
 Listener target1 received cancelable event touchend targetting eventTarget3
 


### PR DESCRIPTION
#### fe63f72fa61fa7e1b42c5bfe5e24b7cdbc1747c7
<pre>
[Gardening]: REGRESSION (253132@main): fast/events/touch/ios/tap-with-active-touch-end-listener.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243784">https://bugs.webkit.org/show_bug.cgi?id=243784</a>
&lt;rdar://98450454&gt;

Re-baseline.

Unreviewed test gardening.

* LayoutTests/fast/events/touch/ios/tap-with-active-touch-end-listener-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253295@main">https://commits.webkit.org/253295@main</a>
</pre>
