### PR TITLE
[GTK][WPE] Add support for showing notification icon

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/notifications/instance-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/notifications/instance-expected.txt
@@ -1,0 +1,16 @@
+Blocked access to external URL http://example.com/icon.png
+CONSOLE MESSAGE: Cannot load http://example.com/icon.png due to access control checks.
+
+PASS Notification instance exists.
+PASS Attribute exists: close
+PASS Attribute exists: onclick
+PASS Attribute exists: onshow
+PASS Attribute exists: onerror
+PASS Attribute exists: onclose
+PASS Attribute exists with expected value: title
+PASS Attribute exists with expected value: dir
+PASS Attribute exists with expected value: lang
+PASS Attribute exists with expected value: body
+PASS Attribute exists with expected value: tag
+PASS Attribute exists with expected value: icon
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -298,6 +298,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/notifications/NotificationEventType.h
     Modules/notifications/NotificationPermission.h
     Modules/notifications/NotificationPermissionCallback.h
+    Modules/notifications/NotificationResources.h
 
     Modules/permissions/PermissionController.h
     Modules/permissions/PermissionDescriptor.h

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -37,6 +37,7 @@
 #include "EventTarget.h"
 #include "NotificationDirection.h"
 #include "NotificationPermission.h"
+#include "NotificationResources.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "SerializedScriptValue.h"
 #include <wtf/CompletionHandler.h>
@@ -50,6 +51,7 @@ class DeferredPromise;
 class Document;
 class NotificationClient;
 class NotificationPermissionCallback;
+class NotificationResourcesLoader;
 
 struct NotificationData;
 
@@ -101,6 +103,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     WEBCORE_EXPORT NotificationData data() const;
+    RefPtr<NotificationResources> resources() const { return m_resources; }
 
     using ThreadSafeRefCounted::ref;
     using ThreadSafeRefCounted::deref;
@@ -117,6 +120,8 @@ private:
 
     NotificationClient* clientFromContext();
     EventTargetInterface eventTargetInterface() const final { return NotificationEventTargetInterfaceType; }
+
+    void stopResourcesLoader();
 
     // ActiveDOMObject
     const char* activeDOMObjectName() const final;
@@ -150,6 +155,8 @@ private:
     NotificationSource m_notificationSource;
     ScriptExecutionContextIdentifier m_contextIdentifier;
     URL m_serviceWorkerRegistrationURL;
+    std::unique_ptr<NotificationResourcesLoader> m_resourcesLoader;
+    RefPtr<NotificationResources> m_resources;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationResources.h
+++ b/Source/WebCore/Modules/notifications/NotificationResources.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Image.h"
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class NotificationResources : public ThreadSafeRefCounted<NotificationResources> {
+public:
+    static Ref<NotificationResources> create()
+    {
+        return adoptRef(*new NotificationResources());
+    }
+
+    void setIcon(RefPtr<Image>&& icon) { m_icon = WTFMove(icon); }
+    const RefPtr<Image>& icon() const { return m_icon; }
+
+private:
+    RefPtr<Image> m_icon;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NotificationResourcesLoader.h"
+
+#if ENABLE(NOTIFICATIONS)
+
+#include "BitmapImage.h"
+#include "GraphicsContext.h"
+#include "NotificationResources.h"
+#include "ResourceRequest.h"
+#include "ResourceResponse.h"
+#include <wtf/URL.h>
+
+namespace WebCore {
+
+// 2.5. Resources
+// https://notifications.spec.whatwg.org/#resources
+
+NotificationResourcesLoader::NotificationResourcesLoader(Notification& notification)
+    : m_notification(notification)
+{
+}
+
+bool NotificationResourcesLoader::resourceIsSupportedInPlatform(Resource resource)
+{
+    switch (resource) {
+    case Resource::Icon:
+#if PLATFORM(GTK) || PLATFORM(WPE)
+        return true;
+#else
+        return false;
+#endif
+    case Resource::Image:
+    case Resource::Badge:
+    case Resource::ActionIcon:
+        // FIXME: Implement other resources.
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+void NotificationResourcesLoader::start(CompletionHandler<void(RefPtr<NotificationResources>&&)>&& completionHandler)
+{
+    m_completionHandler = WTFMove(completionHandler);
+
+    // If the notification platform supports icons, fetch notification’s icon URL, if icon URL is set.
+    if (resourceIsSupportedInPlatform(Resource::Icon)) {
+        const URL& iconURL = m_notification.icon();
+        if (!iconURL.isEmpty()) {
+            if (!m_resources)
+                m_resources = NotificationResources::create();
+            m_loaders.add(makeUnique<ResourceLoader>(*m_notification.scriptExecutionContext(), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
+                if (!m_resources)
+                    return;
+
+                m_resources->setIcon(WTFMove(image));
+                didFinishLoadingResource(loader);
+            }));
+        }
+    }
+
+    // FIXME: Implement other resources.
+
+    if (m_loaders.isEmpty())
+        m_completionHandler(nullptr);
+}
+
+void NotificationResourcesLoader::stop()
+{
+    m_resources = nullptr;
+    auto completionHandler = std::exchange(m_completionHandler, nullptr);
+
+    while (!m_loaders.isEmpty()) {
+        auto loader = m_loaders.takeAny();
+        loader->cancel();
+    }
+
+    if (completionHandler)
+        completionHandler(nullptr);
+}
+
+void NotificationResourcesLoader::didFinishLoadingResource(ResourceLoader* loader)
+{
+    m_loaders.remove(loader);
+    if (m_loaders.isEmpty() && m_completionHandler)
+        m_completionHandler(WTFMove(m_resources));
+}
+
+NotificationResourcesLoader::ResourceLoader::ResourceLoader(ScriptExecutionContext& context, const URL& url, CompletionHandler<void(ResourceLoader*, RefPtr<BitmapImage>&&)>&& completionHandler)
+    : m_completionHandler(WTFMove(completionHandler))
+{
+    ThreadableLoaderOptions options;
+    options.mode = FetchOptions::Mode::Cors;
+    options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
+    options.dataBufferingPolicy = DataBufferingPolicy::DoNotBufferData;
+    options.contentSecurityPolicyEnforcement = context.shouldBypassMainWorldContentSecurityPolicy() ? ContentSecurityPolicyEnforcement::DoNotEnforce : ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective;
+    m_loader = ThreadableLoader::create(context, *this, ResourceRequest(url), options);
+}
+
+NotificationResourcesLoader::ResourceLoader::~ResourceLoader()
+{
+}
+
+void NotificationResourcesLoader::ResourceLoader::cancel()
+{
+    auto completionHandler = std::exchange(m_completionHandler, nullptr);
+    m_loader->cancel();
+    m_loader = nullptr;
+    if (completionHandler)
+        completionHandler(this, nullptr);
+}
+
+void NotificationResourcesLoader::ResourceLoader::didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse& response)
+{
+    // If the response's internal response's type is "default", then attempt to decode the resource as image.
+    if (response.type() == ResourceResponse::Type::Default)
+        m_image = BitmapImage::create();
+}
+
+void NotificationResourcesLoader::ResourceLoader::didReceiveData(const SharedBuffer& buffer)
+{
+    if (m_image) {
+        m_buffer.append(buffer);
+        m_image->setData(m_buffer.get(), false);
+    }
+}
+
+void NotificationResourcesLoader::ResourceLoader::didFinishLoading(ResourceLoaderIdentifier, const NetworkLoadMetrics&)
+{
+    if (m_image)
+        m_image->setData(m_buffer.take(), true);
+
+    if (m_completionHandler)
+        m_completionHandler(this, WTFMove(m_image));
+}
+
+void NotificationResourcesLoader::ResourceLoader::didFail(const ResourceError&)
+{
+    if (m_completionHandler)
+        m_completionHandler(this, nullptr);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(NOTIFICATIONS)
+
+#include "Notification.h"
+#include "SharedBuffer.h"
+#include "ThreadableLoader.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashSet.h>
+
+namespace WebCore {
+
+class BitmapImage;
+class NetworkLoadMetrics;
+class NotificationResources;
+class ResourceError;
+class ResourceResponse;
+
+class NotificationResourcesLoader {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit NotificationResourcesLoader(Notification&);
+
+    void start(CompletionHandler<void(RefPtr<NotificationResources>&&)>&&);
+    void stop();
+
+private:
+    enum class Resource { Image, Icon, Badge, ActionIcon };
+    static bool resourceIsSupportedInPlatform(Resource);
+
+    class ResourceLoader final : public ThreadableLoaderClient {
+    public:
+        ResourceLoader(ScriptExecutionContext&, const URL&, CompletionHandler<void(ResourceLoader*, RefPtr<BitmapImage>&&)>&&);
+        ~ResourceLoader();
+
+        void cancel();
+
+    private:
+        // ThreadableLoaderClient API.
+        void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) final;
+        void didReceiveData(const SharedBuffer&) final;
+        void didFinishLoading(ResourceLoaderIdentifier, const NetworkLoadMetrics&) final;
+        void didFail(const ResourceError&) final;
+
+        SharedBufferBuilder m_buffer;
+        RefPtr<BitmapImage> m_image;
+        RefPtr<ThreadableLoader> m_loader;
+        CompletionHandler<void(ResourceLoader*, RefPtr<BitmapImage>&&)> m_completionHandler;
+    };
+
+    void didFinishLoadingResource(ResourceLoader*);
+
+    Notification& m_notification;
+    CompletionHandler<void(RefPtr<NotificationResources>&&)> m_completionHandler;
+    HashSet<std::unique_ptr<ResourceLoader>> m_loaders;
+    RefPtr<NotificationResources> m_resources;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -247,6 +247,7 @@ Modules/notifications/Notification.cpp
 Modules/notifications/NotificationController.cpp
 Modules/notifications/NotificationData.cpp
 Modules/notifications/NotificationEvent.cpp
+Modules/notifications/NotificationResourcesLoader.cpp
 Modules/paymentrequest/MerchantValidationEvent.cpp
 Modules/paymentrequest/PaymentAddress.cpp
 Modules/paymentrequest/PaymentHandler.cpp

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -117,7 +117,7 @@ void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(c
     sendMessageWithReply<WebPushD::MessageType::GetPendingPushMessages>(WTFMove(replyHandler));
 }
 
-void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCore::NotificationData&, CompletionHandler<void()>&& callback)
+void NetworkNotificationManager::showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<NotificationResources>&&, CompletionHandler<void()>&& callback)
 {
     callback();
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -37,6 +37,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+class NotificationResources;
 struct SecurityOriginData;
 }
 
@@ -72,7 +73,7 @@ private:
     NetworkNotificationManager(NetworkSession&, const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&);
 
     void requestSystemNotificationPermission(const String& originString, CompletionHandler<void(bool)>&&) final;
-    void showNotification(IPC::Connection&, const WebCore::NotificationData&, CompletionHandler<void()>&&) final;
+    void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -31,6 +31,7 @@
 #include <wtf/UUID.h>
 
 namespace WebCore {
+class NotificationResources;
 struct NotificationData;
 }
 
@@ -41,7 +42,7 @@ public:
     virtual ~NotificationManagerMessageHandler() = default;
 
     virtual void requestSystemNotificationPermission(const String& securityOrigin, CompletionHandler<void(bool)>&&) = 0;
-    virtual void showNotification(IPC::Connection&, const WebCore::NotificationData&, CompletionHandler<void()>&&) = 0;
+    virtual void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) = 0;
     virtual void cancelNotification(const UUID& notificationID) = 0;
     virtual void clearNotifications(const Vector<UUID>& notificationIDs) = 0;
     virtual void didDestroyNotification(const UUID& notificationID) = 0;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -22,7 +22,7 @@
 
 messages -> NotificationManagerMessageHandler NotRefCounted {
     RequestSystemNotificationPermission(String originIdentifier) -> (bool allowed)
-    ShowNotification(struct WebCore::NotificationData notificationData) -> () WantsConnection
+    ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> () WantsConnection
     CancelNotification(UUID notificationID)
     ClearNotifications(Vector<UUID> notificationIDs)
     DidDestroyNotification(UUID notificationID)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -66,6 +66,7 @@
 #include <WebCore/Length.h>
 #include <WebCore/LengthBox.h>
 #include <WebCore/MediaSelectionOption.h>
+#include <WebCore/NotificationResources.h>
 #include <WebCore/Pasteboard.h>
 #include <WebCore/PluginData.h>
 #include <WebCore/PromisedAttachmentInfo.h>
@@ -3079,6 +3080,25 @@ std::optional<Ref<SystemImage>> ArgumentCoder<SystemImage>::decode(Decoder& deco
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
+}
+
+void ArgumentCoder<WebCore::NotificationResources>::encode(Encoder& encoder, const WebCore::NotificationResources& resources)
+{
+    encodeOptionalImage(encoder, resources.icon().get());
+}
+
+std::optional<RefPtr<WebCore::NotificationResources>> ArgumentCoder<WebCore::NotificationResources>::decode(Decoder& decoder)
+{
+    RefPtr<Image> icon;
+    if (!decodeOptionalImage(decoder, icon))
+        return std::nullopt;
+
+    if (!icon)
+        return nullptr;
+
+    auto resources = WebCore::NotificationResources::create();
+    resources->setIcon(WTFMove(icon));
+    return resources;
 }
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -135,6 +135,7 @@ class HTTPHeaderMap;
 class KeyframeValueList;
 class LinearTimingFunction;
 class Notification;
+class NotificationResources;
 class PasteboardCustomData;
 class PaymentInstallmentConfiguration;
 class ProtectionSpace;
@@ -761,6 +762,11 @@ template<> struct ArgumentCoder<WebCore::SystemImage> {
     template<typename Encoder>
     static void encode(Encoder&, const WebCore::SystemImage&);
     static std::optional<Ref<WebCore::SystemImage>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::NotificationResources> {
+    static void encode(Encoder&, const WebCore::NotificationResources&);
+    static std::optional<RefPtr<WebCore::NotificationResources>> decode(Decoder&);
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/API/APINotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/APINotificationProvider.h
@@ -35,6 +35,10 @@ class WebNotificationManagerProxy;
 class WebPageProxy;
 }
 
+namespace WebCore {
+class NotificationResources;
+}
+
 namespace API {
 
 class NotificationProvider {
@@ -42,7 +46,7 @@ class NotificationProvider {
 public:
     virtual ~NotificationProvider() = default;
 
-    virtual void show(WebKit::WebPageProxy*, WebKit::WebNotification&) { }
+    virtual void show(WebKit::WebPageProxy*, WebKit::WebNotification&, RefPtr<WebCore::NotificationResources>&&) { }
     virtual void cancel(WebKit::WebNotification&) { }
     virtual void didDestroyNotification(WebKit::WebNotification&) { }
     virtual void clearNotifications(const Vector<uint64_t>& /*notificationIDs*/) { }

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
@@ -48,9 +48,9 @@ public:
     }
 
 private:
-    void show(WebPageProxy* page, WebNotification& notification) override
+    void show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&& resources) override
     {
-        m_provider.show(page, notification);
+        m_provider.show(page, notification, WTFMove(resources));
     }
 
     void cancel(WebNotification& notification) override
@@ -125,11 +125,11 @@ void WebKitNotificationProvider::withdrawAnyPreviousAPINotificationMatchingTag(c
 #endif
 }
 
-void WebKitNotificationProvider::show(WebPageProxy* page, WebNotification& webNotification)
+void WebKitNotificationProvider::show(WebPageProxy* page, WebNotification& webNotification, RefPtr<WebCore::NotificationResources>&& resources)
 {
     if (!page || !m_webContext) {
         // FIXME: glib API needs to find their own solution to handling pageless notifications.
-        show(webNotification);
+        show(webNotification, resources);
         return;
     }
 
@@ -149,18 +149,18 @@ void WebKitNotificationProvider::show(WebPageProxy* page, WebNotification& webNo
         m_notificationManager->providerDidShowNotification(webNotification.notificationID());
     else {
         g_signal_handlers_disconnect_by_data(notification.get(), this);
-        show(webNotification);
+        show(webNotification, resources);
     }
 }
 
-void WebKitNotificationProvider::show(WebNotification& webNotification)
+void WebKitNotificationProvider::show(WebNotification& webNotification, const RefPtr<WebCore::NotificationResources>& resources)
 {
     if (!m_observerRegistered) {
         NotificationService::singleton().addObserver(*this);
         m_observerRegistered = true;
     }
 
-    if (NotificationService::singleton().showNotification(webNotification))
+    if (NotificationService::singleton().showNotification(webNotification, resources))
         m_notificationManager->providerDidShowNotification(webNotification.notificationID());
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h
@@ -27,6 +27,10 @@
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/text/StringHash.h>
 
+namespace WebCore {
+class NotificationResources;
+}
+
 namespace WebKit {
 class WebNotificationManagerProxy;
 class WebNotification;
@@ -38,7 +42,7 @@ public:
     WebKitNotificationProvider(WebNotificationManagerProxy*, WebKitWebContext*);
     ~WebKitNotificationProvider();
 
-    void show(WebPageProxy*, WebNotification&);
+    void show(WebPageProxy*, WebNotification&, RefPtr<WebCore::NotificationResources>&&);
     void cancel(const WebNotification&);
     void clearNotifications(const Vector<uint64_t>&);
 
@@ -57,7 +61,7 @@ private:
 
     void withdrawAnyPreviousAPINotificationMatchingTag(const CString&);
 
-    void show(WebNotification&);
+    void show(WebNotification&, const RefPtr<WebCore::NotificationResources>&);
 
     // NotificationService
     void didClickNotification(uint64_t) final;

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -53,7 +53,7 @@ WebsiteDataStore* ServiceWorkerNotificationHandler::dataStoreForNotificationID(c
     return WebsiteDataStore::existingDataStoreForSessionID(iterator->value);
 }
 
-void ServiceWorkerNotificationHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, CompletionHandler<void()>&& callback)
+void ServiceWorkerNotificationHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&& callback)
 {
     auto scope = makeScopeExit([&callback] { callback(); });
 

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -38,7 +38,7 @@ class ServiceWorkerNotificationHandler final : public NotificationManagerMessage
 public:
     static ServiceWorkerNotificationHandler& singleton();
 
-    void showNotification(IPC::Connection&, const WebCore::NotificationData&, CompletionHandler<void()>&&) final;
+    void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -41,13 +41,13 @@ void WebNotificationManagerMessageHandler::requestSystemNotificationPermission(c
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, CompletionHandler<void()>&& callback)
+void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, RefPtr<WebCore::NotificationResources>&& resources, CompletionHandler<void()>&& callback)
 {
     if (!data.serviceWorkerRegistrationURL.isEmpty()) {
-        ServiceWorkerNotificationHandler::singleton().showNotification(connection, data, WTFMove(callback));
+        ServiceWorkerNotificationHandler::singleton().showNotification(connection, data, WTFMove(resources), WTFMove(callback));
         return;
     }
-    m_webPageProxy.showNotification(connection, data);
+    m_webPageProxy.showNotification(connection, data, WTFMove(resources));
     callback();
 }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -37,7 +37,7 @@ private:
     explicit WebNotificationManagerMessageHandler(WebPageProxy&);
 
     void requestSystemNotificationPermission(const String&, CompletionHandler<void(bool)>&&) final;
-    void showNotification(IPC::Connection&, const WebCore::NotificationData&, CompletionHandler<void()>&&) final;
+    void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&) final;
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -103,14 +103,14 @@ static WebPageProxyIdentifier identifierForPagePointer(WebPageProxy* webPage)
     return webPage ? webPage->identifier() : WebPageProxyIdentifier();
 }
 
-void WebNotificationManagerProxy::show(WebPageProxy* webPage, IPC::Connection& connection, const WebCore::NotificationData& notificationData)
+void WebNotificationManagerProxy::show(WebPageProxy* webPage, IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     LOG(Notifications, "WebPageProxy (%p) asking to show notification (%s)", webPage, notificationData.notificationID.toString().utf8().data());
 
     auto notification = WebNotification::create(notificationData, identifierForPagePointer(webPage), connection);
     m_globalNotificationMap.set(notification->notificationID(), notification->coreNotificationID());
     m_notifications.set(notification->coreNotificationID(), notification);
-    m_provider->show(webPage, notification.get());
+    m_provider->show(webPage, notification.get(), WTFMove(notificationResources));
 }
 
 void WebNotificationManagerProxy::cancel(WebPageProxy* page, const UUID& pageNotificationID)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -36,6 +36,7 @@
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
+class NotificationResources;
 struct NotificationData;
 }
 
@@ -63,7 +64,7 @@ public:
     void setProvider(std::unique_ptr<API::NotificationProvider>&&);
     HashMap<String, bool> notificationPermissions();
 
-    void show(WebPageProxy*, IPC::Connection&, const WebCore::NotificationData&);
+    void show(WebPageProxy*, IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
     void cancel(WebPageProxy*, const UUID& pageNotificationID);
     void clearNotifications(WebPageProxy*);
     void clearNotifications(WebPageProxy*, const Vector<UUID>& pageNotificationIDs);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
@@ -42,7 +42,7 @@ WebNotificationProvider::WebNotificationProvider(const WKNotificationProviderBas
     initialize(provider);
 }
 
-void WebNotificationProvider::show(WebPageProxy* page, WebNotification& notification)
+void WebNotificationProvider::show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&&)
 {
     if (!m_client.show)
         return;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
@@ -48,7 +48,7 @@ class WebNotificationProvider : public API::NotificationProvider, public API::Cl
 public:
     explicit WebNotificationProvider(const WKNotificationProviderBase*);
 
-    void show(WebPageProxy*, WebNotification&) override;
+    void show(WebPageProxy*, WebNotification&, RefPtr<WebCore::NotificationResources>&&) override;
     void cancel(WebNotification&) override;
     void didDestroyNotification(WebNotification&) override;
     void clearNotifications(const Vector<uint64_t>& notificationIDs) override;

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.h
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.h
@@ -34,6 +34,10 @@
 typedef struct _GDBusProxy GDBusProxy;
 typedef struct _GVariant GVariant;
 
+namespace WebCore {
+class NotificationResources;
+}
+
 namespace WebKit {
 
 class WebNotification;
@@ -45,7 +49,7 @@ class NotificationService {
 public:
     static NotificationService& singleton();
 
-    bool showNotification(const WebNotification&);
+    bool showNotification(const WebNotification&, const RefPtr<WebCore::NotificationResources>&);
     void cancelNotification(uint64_t);
 
     class Observer {
@@ -63,6 +67,7 @@ private:
         uint32_t id { 0 };
         String portalID;
         String tag;
+        String iconURL;
     };
 
     enum class Capabilities : uint16_t {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9101,9 +9101,9 @@ void WebPageProxy::requestNotificationPermission(const String& originString, Com
     m_uiClient->decidePolicyForNotificationPermissionRequest(*this, origin.get(), WTFMove(completionHandler));
 }
 
-void WebPageProxy::showNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData)
+void WebPageProxy::showNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
-    m_process->processPool().supplement<WebNotificationManagerProxy>()->show(this, connection, notificationData);
+    m_process->processPool().supplement<WebNotificationManagerProxy>()->show(this, connection, notificationData, WTFMove(notificationResources));
 }
 
 void WebPageProxy::cancelNotification(const UUID& notificationID)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2102,7 +2102,7 @@ public:
     bool isQuarantinedAndNotUserApproved(const String&);
 #endif
 
-    void showNotification(IPC::Connection&, const WebCore::NotificationData&);
+    void showNotification(IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
     void cancelNotification(const UUID& notificationID);
     void clearNotifications(const Vector<UUID>& notificationIDs);
     void didDestroyNotification(const UUID& notificationID);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -54,6 +54,7 @@
 #include <WebCore/DatabaseTracker.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/NetworkStorageSession.h>
+#include <WebCore/NotificationResources.h>
 #include <WebCore/OriginLock.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/SecurityOrigin.h>
@@ -2044,7 +2045,7 @@ bool WebsiteDataStore::shouldMakeNextNetworkProcessLaunchFailForTesting()
 
 void WebsiteDataStore::showServiceWorkerNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData)
 {
-    WebNotificationManagerProxy::sharedServiceWorkerManager().show(nullptr, connection, notificationData);
+    WebNotificationManagerProxy::sharedServiceWorkerManager().show(nullptr, connection, notificationData, nullptr);
 }
 
 void WebsiteDataStore::cancelServiceWorkerNotification(const UUID& notificationID)

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -170,7 +170,7 @@ bool WebNotificationManager::show(Notification& notification, WebPage* page, Com
     if (page && !page->corePage()->settings().notificationsEnabled())
         return false;
 
-    if (!sendNotificationMessageWithAsyncReply(Messages::NotificationManagerMessageHandler::ShowNotification(notification.data()), notification, page, WTFMove(callback)))
+    if (!sendNotificationMessageWithAsyncReply(Messages::NotificationManagerMessageHandler::ShowNotification(notification.data(), notification.resources()), notification, page, WTFMove(callback)))
         return false;
 
     if (!notification.isPersistent()) {


### PR DESCRIPTION
#### abb92629ba7294891e342d8a00304d0bd005fff7
<pre>
[GTK][WPE] Add support for showing notification icon
<a href="https://bugs.webkit.org/show_bug.cgi?id=243786">https://bugs.webkit.org/show_bug.cgi?id=243786</a>

Reviewed by Michael Catanzaro.

Add NotificationResourcesLoader to load the notification resources
following the spec (<a href="https://notifications.spec.whatwg.org/#resources).">https://notifications.spec.whatwg.org/#resources).</a>
For now only the icon image is loaded since it&apos;s the only one actually
used. Resources are passed to the UI process as an extra parameter to
ShowNotification message. This patch only adds suport for notification
icon in the default notifications implementation, but it should also be
exposed in the public API in a follow up.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::show):
(WebCore::Notification::close):
(WebCore::Notification::stop):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/NotificationResources.h: Added.
(WebCore::NotificationResources::create):
(WebCore::NotificationResources::setIcon):
(WebCore::NotificationResources::icon const):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp: Added.
(WebCore::NotificationResourcesLoader::NotificationResourcesLoader):
(WebCore::NotificationResourcesLoader::resourceIsSupportedInPlatform):
(WebCore::NotificationResourcesLoader::start):
(WebCore::NotificationResourcesLoader::stop):
(WebCore::NotificationResourcesLoader::didFinishLoadingResource):
(WebCore::NotificationResourcesLoader::ResourceLoader::ResourceLoader):
(WebCore::NotificationResourcesLoader::ResourceLoader::~ResourceLoader):
(WebCore::NotificationResourcesLoader::ResourceLoader::cancel):
(WebCore::NotificationResourcesLoader::ResourceLoader::didReceiveResponse):
(WebCore::NotificationResourcesLoader::ResourceLoader::didReceiveData):
(WebCore::NotificationResourcesLoader::ResourceLoader::didFinishLoading):
(WebCore::NotificationResourcesLoader::ResourceLoader::didFail):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::NotificationResources&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::NotificationResources&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/UIProcess/API/APINotificationProvider.h:
(API::NotificationProvider::show):
* Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp:
(WebKitNotificationProvider::show):
* Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.h:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::showNotification):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::showNotification):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::show):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp:
(WebKit::WebNotificationProvider::show):
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h:
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
(WebKit::IconCache::IconCache):
(WebKit::IconCache::~IconCache):
(WebKit::IconCache::iconPath):
(WebKit::IconCache::iconBytes):
(WebKit::IconCache::unuseIcon):
(WebKit::IconCache::removeUnusedIcons):
(WebKit::IconCache::timerFired):
(WebKit::iconCache):
(WebKit::NotificationService::showNotification):
(WebKit::NotificationService::didCloseNotification):
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showNotification):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::showServiceWorkerNotification):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::show):

Canonical link: <a href="https://commits.webkit.org/253460@main">https://commits.webkit.org/253460@main</a>
</pre>
