### PR TITLE
Incorrect behavior of "cursor: auto" over links

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
@@ -2,5 +2,5 @@
 An unclickable (non-link) area should not show the link cursor when hovered.
 
 
-FAIL Only clickable areas should show the link cursor. assert_equals: expected "pointer" but got "auto"
+PASS Only clickable areas should show the link cursor.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/no-help-cursor-on-links.historical-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Unvisited help links must have pointer cursor, not help cursor assert_equals: expected "pointer" but got "auto"
-FAIL Visited help links must have pointer cursor, not help cursor assert_equals: expected "pointer" but got "auto"
+PASS Unvisited help links must have pointer cursor, not help cursor
+PASS Visited help links must have pointer cursor, not help cursor
 unvisited will be visited

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1290,11 +1290,19 @@ input[type="file"]:focus::file-selector-button {
 a:any-link {
     color: -webkit-link;
     text-decoration: underline;
-    cursor: auto;
+    cursor: pointer;
 }
 
 a:any-link:active {
     color: -webkit-activelink;
+}
+
+a:any-link:read-write {
+    cursor: text;
+}
+
+area:any-link {
+    cursor: pointer;
 }
 
 /* HTML5 ruby elements */

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1420,18 +1420,18 @@ void EventHandler::updateCursor()
     HitTestResult result(view->windowToContents(*m_lastKnownMousePosition));
     document->hitTest(hitType, result);
 
-    updateCursor(*view, result, shiftKey);
+    updateCursor(*view, result);
 }
 
-void EventHandler::updateCursor(FrameView& view, const HitTestResult& result, bool shiftKey)
+void EventHandler::updateCursor(FrameView& view, const HitTestResult& result)
 {
-    if (auto optionalCursor = selectCursor(result, shiftKey)) {
+    if (auto optionalCursor = selectCursor(result)) {
         m_currentMouseCursor = WTFMove(optionalCursor.value());
         view.setCursor(m_currentMouseCursor);
     }
 }
 
-std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bool shiftKey)
+std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result)
 {
     if (m_resizeLayer && m_resizeLayer->inResizeMode())
         return std::nullopt;
@@ -1458,8 +1458,8 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
     if (!node)
         return std::nullopt;
 
-    auto renderer = node->renderer();
-    auto* style = renderer ? &renderer->style() : nullptr;
+    // We are using the node's computed style instead of renderer()->style because we need style info for nodes without a renderer, e.g.: <area>
+    auto* style = node->computedStyle();
     bool horizontalText = !style || style->isHorizontalWritingMode();
     const Cursor& iBeam = horizontalText ? iBeamCursor() : verticalTextCursor();
 
@@ -1470,6 +1470,7 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
         cancelAutoHideCursorTimer();
 #endif
 
+    auto* renderer = node->renderer();
     if (renderer) {
         Cursor overrideCursor;
         switch (renderer->getCursor(roundedIntPoint(result.localPoint()), overrideCursor)) {
@@ -1536,9 +1537,6 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
         }
 
         bool editable = node->hasEditableStyle();
-
-        if (useHandCursor(node.get(), result.isOverLink(), shiftKey))
-            return handCursor();
 
         bool inResizer = false;
         if (renderer && renderer->hasLayer()) {
@@ -2044,7 +2042,7 @@ bool EventHandler::handleMouseMoveEvent(const PlatformMouseEvent& platformMouseE
 
     if (!newSubframe || mouseEvent.scrollbar()) {
         if (RefPtr view = m_frame.view())
-            updateCursor(*view, mouseEvent.hitTestResult(), platformMouseEvent.shiftKey());
+            updateCursor(*view, mouseEvent.hitTestResult());
     }
 
     m_lastMouseMoveEventSubframe = newSubframe;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -343,7 +343,7 @@ public:
     WEBCORE_EXPORT void cancelSelectionAutoscroll();
 #endif
 
-    WEBCORE_EXPORT std::optional<Cursor> selectCursor(const HitTestResult&, bool shiftKey);
+    WEBCORE_EXPORT std::optional<Cursor> selectCursor(const HitTestResult&);
 
 #if ENABLE(KINETIC_SCROLLING)
     std::optional<WheelScrollGestureState> wheelScrollGestureState() const { return m_wheelScrollGestureState; }
@@ -403,7 +403,7 @@ private:
 
     bool internalKeyEvent(const PlatformKeyboardEvent&);
 
-    void updateCursor(FrameView&, const HitTestResult&, bool shiftKey);
+    void updateCursor(FrameView&, const HitTestResult&);
 
     void hoverTimerFired();
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3245,7 +3245,7 @@ InteractionInformationAtPosition WebPage::positionInformation(const InteractionI
 
     auto hitTestResult = eventHandler.hitTestResultAtPoint(request.point, hitTestRequestTypes);
     if (auto* hitFrame = hitTestResult.innerNodeFrame()) {
-        info.cursor = hitFrame->eventHandler().selectCursor(hitTestResult, false);
+        info.cursor = hitFrame->eventHandler().selectCursor(hitTestResult);
         if (request.includeCaretContext)
             populateCaretContext(hitTestResult, request, info);
     }


### PR DESCRIPTION
#### b5d767e418f3d45709b214a545d9a04076954823
<pre>
Incorrect behavior of &quot;cursor: auto&quot; over links
<a href="https://bugs.webkit.org/show_bug.cgi?id=173909">https://bugs.webkit.org/show_bug.cgi?id=173909</a>
rdar://99495893

Reviewed by NOBODY (OOPS!).

The initial attempt to fix this bug and comply to spec was made
at <a href="https://commits.webkit.org/253685@main">https://commits.webkit.org/253685@main</a>

After that, a:any-link no longer depends on &apos;cursor: auto&apos;
for achieving &quot;Hand&quot; (css: pointer) cursor. This is because, according to spec,
&apos;cursor: auto&apos; can only result in default or text cursor. Therefore, 253685@main
sets &apos;cursor: pointer&apos; in the UA stylesheet (html.css).

Because of that, a test case for cursor types for recognized text (live-text)
was broken. There, we were testing a &lt;img&gt; nested in a &lt;a href=&quot;&quot;&gt;. Since,
this &lt;a&gt; is now selected to have &apos;cursor: pointer&apos;, its nested &lt;img&gt;
has no longer &apos;cursor: auto&apos;, which is required for resulting in IBeam (text)
cursor for the overlay installed in the img (see EventHandler::selectCursor).

Therefore, we are updating the test case here. A &lt;img&gt; inside a &lt;a href=&quot;...&quot;&gt;
is by default styled with cursor: pointer, and therefore hovering over
its overlay doesn&apos;t show IBeam (text) cursor, unless user styles its cursor to auto.

* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text-expected.txt:
* LayoutTests/fast/images/text-recognition/mac/cursor-types-for-recognized-text.html:
Updating tests. Note that one of the test cases is commented out. As stated in the comment,
this would fail due to <a href="https://bugs.webkit.org/show_bug.cgi?id=244944">https://bugs.webkit.org/show_bug.cgi?id=244944</a> (radar: 99495849).
In short, EventHandler::selectCursor will select an IBeam cursor although it shouldn&apos;t.
This is because Node::canStartSelection() is not false for user-select: none.
* LayoutTests/platform/mac-wk2/TestExpectations:
Reseting TextExpectations for this test, before set as failure.
* Source/WebCore/html/shadow/imageOverlay.css:
(div#image-overlay):
We should not style cursor for the live-text overlay that is installed
on top of images with text. Doing that would disable user to control which
cursor is displayed for the text portion of the image, since the overlay
is in the shadow tree, hosted by the image element. I.e.: user&apos;s cursor style
for the image would not be propagated to the overlay.
</pre>