### PR TITLE
imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt
@@ -15,7 +15,7 @@ PASS textarea: selectionEnd disconnected node
 PASS textarea: selectionEnd event queue
 PASS textarea: selectionEnd twice in disconnected node (must fire select only once)
 PASS textarea: selectionDirection
-FAIL textarea: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS textarea: selectionDirection a second time (must not fire select)
 PASS textarea: selectionDirection disconnected node
 PASS textarea: selectionDirection event queue
 PASS textarea: selectionDirection twice in disconnected node (must fire select only once)
@@ -60,7 +60,7 @@ PASS input type text: selectionEnd disconnected node
 PASS input type text: selectionEnd event queue
 PASS input type text: selectionEnd twice in disconnected node (must fire select only once)
 PASS input type text: selectionDirection
-FAIL input type text: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS input type text: selectionDirection a second time (must not fire select)
 PASS input type text: selectionDirection disconnected node
 PASS input type text: selectionDirection event queue
 PASS input type text: selectionDirection twice in disconnected node (must fire select only once)
@@ -105,7 +105,7 @@ PASS input type search: selectionEnd disconnected node
 PASS input type search: selectionEnd event queue
 PASS input type search: selectionEnd twice in disconnected node (must fire select only once)
 PASS input type search: selectionDirection
-FAIL input type search: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS input type search: selectionDirection a second time (must not fire select)
 PASS input type search: selectionDirection disconnected node
 PASS input type search: selectionDirection event queue
 PASS input type search: selectionDirection twice in disconnected node (must fire select only once)
@@ -150,7 +150,7 @@ PASS input type tel: selectionEnd disconnected node
 PASS input type tel: selectionEnd event queue
 PASS input type tel: selectionEnd twice in disconnected node (must fire select only once)
 PASS input type tel: selectionDirection
-FAIL input type tel: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS input type tel: selectionDirection a second time (must not fire select)
 PASS input type tel: selectionDirection disconnected node
 PASS input type tel: selectionDirection event queue
 PASS input type tel: selectionDirection twice in disconnected node (must fire select only once)
@@ -195,7 +195,7 @@ PASS input type url: selectionEnd disconnected node
 PASS input type url: selectionEnd event queue
 PASS input type url: selectionEnd twice in disconnected node (must fire select only once)
 PASS input type url: selectionDirection
-FAIL input type url: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS input type url: selectionDirection a second time (must not fire select)
 PASS input type url: selectionDirection disconnected node
 PASS input type url: selectionDirection event queue
 PASS input type url: selectionDirection twice in disconnected node (must fire select only once)
@@ -240,7 +240,7 @@ PASS input type password: selectionEnd disconnected node
 PASS input type password: selectionEnd event queue
 PASS input type password: selectionEnd twice in disconnected node (must fire select only once)
 PASS input type password: selectionDirection
-FAIL input type password: selectionDirection a second time (must not fire select) assert_unreached: the select event must not fire the second time Reached unreachable code
+PASS input type password: selectionDirection a second time (must not fire select)
 PASS input type password: selectionDirection disconnected node
 PASS input type password: selectionDirection event queue
 PASS input type password: selectionDirection twice in disconnected node (must fire select only once)

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -348,7 +348,11 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
         }
     }
 
-    bool didChange = cacheSelection(start, end, direction);
+    auto previousSelectionStart = m_cachedSelectionStart;
+    auto previousSelectionEnd = m_cachedSelectionEnd;
+    auto previousSelectionDirection = m_cachedSelectionDirection;
+
+    cacheSelection(start, end, direction);
     Position startPosition = positionForIndex(innerText.get(), start);
     Position endPosition;
     if (start == end)
@@ -364,7 +368,7 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
     if (RefPtr<Frame> frame = document().frame())
         frame->selection().moveWithoutValidationTo(startPosition, endPosition, direction != SelectionHasNoDirection, !hasFocus, revealMode, intent);
 
-    return didChange;
+    return m_cachedSelectionStart != previousSelectionStart || m_cachedSelectionEnd != previousSelectionEnd || m_cachedSelectionDirection != previousSelectionDirection;
 }
 
 bool HTMLTextFormControlElement::cacheSelection(unsigned start, unsigned end, TextFieldSelectionDirection direction)


### PR DESCRIPTION
#### 2d1d35c1930c27764d839904590aee9a270f42a6
<pre>
imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243791">https://bugs.webkit.org/show_bug.cgi?id=243791</a>

Reviewed by Ryosuke Niwa.

Per the specification [1], we should not fire a select event if setting the selection range
doesn&apos;t result in a selection change. The issue was that setSelectionRange() could update
the selection in 2 places:
1. The first time when explicitly calling cacheSelection() explicitly
2. The second time indirectly by calling frame-&gt;selection().moveWithoutValidationTo()

Our `didChange` variable could be inaccurate because it only accounted for step 1 and not
step 2.

[1] <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#set-the-selection-range">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#set-the-selection-range</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/textfieldselection/select-event-expected.txt:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setSelectionRange):

Canonical link: <a href="https://commits.webkit.org/253342@main">https://commits.webkit.org/253342@main</a>
</pre>
