### PR TITLE
iOS 7 Element.querySelectorAll does not obey element scope with ID

### DIFF
--- a/LayoutTests/fast/selectors/querySelector-scoped-by-element-expected.txt
+++ b/LayoutTests/fast/selectors/querySelector-scoped-by-element-expected.txt
@@ -1,0 +1,44 @@
+Verify that querySelector only returns elements in the subtree of the element on which the function was called..
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Simple query on #id rooted on 'parent1'.
+PASS document.getElementById("parent1").querySelectorAll("#myDiv").length is 1
+PASS document.getElementById("parent1").querySelectorAll("#myDiv")[0].hasAttribute("data-target1") is true
+
+Simple query on .class rooted on 'parent1'.
+PASS document.getElementById("parent1").querySelectorAll(".myDiv").length is 1
+PASS document.getElementById("parent1").querySelectorAll(".myDiv")[0].hasAttribute("data-target2") is true
+
+Scoped query on #id rooted on 'parent1'.
+PASS document.getElementById("parent1").querySelectorAll(":scope > #myDiv").length is 1
+PASS document.getElementById("parent1").querySelectorAll(":scope > #myDiv")[0].hasAttribute("data-target1") is true
+PASS document.getElementById("parent1").querySelectorAll(":scope > * >  #myDiv").length is 0
+
+Scoped query on .class rooted on 'parent1'.
+PASS document.getElementById("parent1").querySelectorAll(":scope > .myDiv").length is 1
+PASS document.getElementById("parent1").querySelectorAll(":scope > .myDiv")[0].hasAttribute("data-target2") is true
+PASS document.getElementById("parent1").querySelectorAll(":scope > * >  .myDiv").length is 0
+
+Simple query on #id rooted on 'parent2'. The id we are looking for is duplicated in the document.
+PASS document.getElementById("parent2").querySelectorAll("#myDiv").length is 1
+PASS document.getElementById("parent2").querySelectorAll("#myDiv")[0].hasAttribute("data-target3") is true
+
+Simple query on .class rooted on 'parent2'. The id we are looking for is duplicated in the document.
+PASS document.getElementById("parent2").querySelectorAll(".myDiv").length is 1
+PASS document.getElementById("parent2").querySelectorAll(".myDiv")[0].hasAttribute("data-target4") is true
+
+Scoped query on #id rooted on 'parent2'.
+PASS document.getElementById("parent2").querySelectorAll(":scope > #myDiv").length is 1
+PASS document.getElementById("parent2").querySelectorAll(":scope > #myDiv")[0].hasAttribute("data-target3") is true
+PASS document.getElementById("parent2").querySelectorAll(":scope > * >  #myDiv").length is 0
+
+Scoped query on .class rooted on 'parent2'.
+PASS document.getElementById("parent2").querySelectorAll(":scope > .myDiv").length is 1
+PASS document.getElementById("parent2").querySelectorAll(":scope > .myDiv")[0].hasAttribute("data-target4") is true
+PASS document.getElementById("parent2").querySelectorAll(":scope > * >  .myDiv").length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/selectors/querySelector-scoped-by-element.html
+++ b/LayoutTests/fast/selectors/querySelector-scoped-by-element.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<div style="display:none">
+    <div id="parent1">
+        <div id="myDiv" data-target1>ID Div 1</div>
+        <div class="myDiv" data-target2>Class Div 1</div>
+    </div>
+    <div id="parent2">
+        <div id="myDiv" data-target3>ID Div 2</div>
+        <div class="myDiv" data-target4>Class Div 2</div>
+    </div>
+</body>
+<script>
+description('Verify that querySelector only returns elements in the subtree of the element on which the function was called..');
+
+debug("Simple query on #id rooted on 'parent1'.");
+shouldBe('document.getElementById("parent1").querySelectorAll("#myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent1").querySelectorAll("#myDiv")[0].hasAttribute("data-target1")');
+debug("");
+
+debug("Simple query on .class rooted on 'parent1'.");
+shouldBe('document.getElementById("parent1").querySelectorAll(".myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent1").querySelectorAll(".myDiv")[0].hasAttribute("data-target2")');
+debug("");
+
+debug("Scoped query on #id rooted on 'parent1'.");
+shouldBe('document.getElementById("parent1").querySelectorAll(":scope > #myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent1").querySelectorAll(":scope > #myDiv")[0].hasAttribute("data-target1")');
+
+shouldBe('document.getElementById("parent1").querySelectorAll(":scope > * >  #myDiv").length', '0');
+debug("");
+
+debug("Scoped query on .class rooted on 'parent1'.");
+shouldBe('document.getElementById("parent1").querySelectorAll(":scope > .myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent1").querySelectorAll(":scope > .myDiv")[0].hasAttribute("data-target2")');
+
+shouldBe('document.getElementById("parent1").querySelectorAll(":scope > * >  .myDiv").length', '0');
+debug("");
+
+debug("Simple query on #id rooted on 'parent2'. The id we are looking for is duplicated in the document.");
+shouldBe('document.getElementById("parent2").querySelectorAll("#myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent2").querySelectorAll("#myDiv")[0].hasAttribute("data-target3")');
+debug("");
+
+debug("Simple query on .class rooted on 'parent2'. The id we are looking for is duplicated in the document.");
+shouldBe('document.getElementById("parent2").querySelectorAll(".myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent2").querySelectorAll(".myDiv")[0].hasAttribute("data-target4")');
+debug("");
+
+debug("Scoped query on #id rooted on 'parent2'.");
+shouldBe('document.getElementById("parent2").querySelectorAll(":scope > #myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent2").querySelectorAll(":scope > #myDiv")[0].hasAttribute("data-target3")');
+
+shouldBe('document.getElementById("parent2").querySelectorAll(":scope > * >  #myDiv").length', '0');
+debug("");
+
+debug("Scoped query on .class rooted on 'parent2'.");
+shouldBe('document.getElementById("parent2").querySelectorAll(":scope > .myDiv").length', '1');
+shouldBeTrue('document.getElementById("parent2").querySelectorAll(":scope > .myDiv")[0].hasAttribute("data-target4")');
+
+shouldBe('document.getElementById("parent2").querySelectorAll(":scope > * >  .myDiv").length', '0');
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</html>


### PR DESCRIPTION
#### 09386b2b402bd9bfbf79c3ab416e75bf51b78c83
<pre>
iOS 7 Element.querySelectorAll does not obey element scope with ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=123538">https://bugs.webkit.org/show_bug.cgi?id=123538</a>

Reviewed by Chris Dumez.

Based on a patch authored by Benjamin Poulain.

Adding a regression test since they&apos;re passing now.

* LayoutTests/fast/selectors/querySelector-scoped-by-element-expected.txt: Added.
* LayoutTests/fast/selectors/querySelector-scoped-by-element.html: Added.

Canonical link: <a href="https://commits.webkit.org/253315@main">https://commits.webkit.org/253315@main</a>
</pre>
