### PR TITLE
Resync html/semantics/forms/form-submission-0/implicit-submission.optional.html from upstream WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt
@@ -2,6 +2,8 @@
 
 
 
+
 PASS Submit event with a submit button
 PASS Submit event with no submit button
+PASS Submit event with disabled submit button
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html
@@ -35,5 +35,13 @@ promise_test(async () => {
   assert_equals(event.submitter, null);
   assert_true(event instanceof SubmitEvent);
 }, 'Submit event with no submit button');
+
+promise_test(async (test) => {
+  let form = populateForm('<input name=text value=abc><input name=submitButton type=submit disabled>');
+  form.text.focus();
+  form.addEventListener('submit', test.unreached_func('submit event should not be dispatched'));
+  await test_driver.send_keys(form.text, ENTER);
+}, 'Submit event with disabled submit button');
+
 </script>
 </body>


### PR DESCRIPTION
#### 37fdb87d9457ba7968f49624d9d5e643ae177fef
<pre>
Resync html/semantics/forms/form-submission-0/implicit-submission.optional.html from upstream WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=243794">https://bugs.webkit.org/show_bug.cgi?id=243794</a>

Reviewed by Tim Nguyen.

Resync html/semantics/forms/form-submission-0/implicit-submission.optional.html from upstream WPT
a33a5d46cb7bce1f63.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html:

Canonical link: <a href="https://commits.webkit.org/253309@main">https://commits.webkit.org/253309@main</a>
</pre>
