### PR TITLE
iframe srcdoc with quirky doctype should be no-quirks mode

### DIFF
--- a/LayoutTests/fast/frames/srcdoc/srcdoc-can-be-in-qurks-mode-expected.txt
+++ b/LayoutTests/fast/frames/srcdoc/srcdoc-can-be-in-qurks-mode-expected.txt
@@ -1,2 +1,2 @@
-ALERT: BackCompat
+ALERT: CSS1Compat
 Normally srcdoc documents default to standards mode, but they can end up in quirks mode with a sufficiently nutty DocType.

--- a/LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype-expected.txt
+++ b/LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype-expected.txt
@@ -1,0 +1,13 @@
+This tests that the documents in srcdoc are always in strict mode
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS frame1.contentDocument.compatMode is "CSS1Compat"
+PASS frame2.contentDocument.compatMode is "CSS1Compat"
+PASS frame3.contentDocument.compatMode is "CSS1Compat"
+PASS frame4.contentDocument.compatMode is "CSS1Compat"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype.html
+++ b/LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src='../../resources/js-test.js'></script>
+<iframe id="frame1" srcdoc='<!doctype x>'></iframe>
+<iframe id="frame2" srcdoc='<!doctype html public "-//w3c//dtd html 3.2//en">'></iframe>
+<iframe id="frame3" srcdoc='<!doctype "-//w3c//dtd html 3.2//en">'></iframe>
+<iframe id="frame4" srcdoc='<!doctype html -//w3c//dtd xhtml 1.0 frameset//">'></iframe>
+<script>
+
+description('This tests that the documents in srcdoc are always in strict mode');
+
+onload = () => {
+    shouldBeEqualToString('frame1.contentDocument.compatMode', 'CSS1Compat');
+    shouldBeEqualToString('frame2.contentDocument.compatMode', 'CSS1Compat');
+    shouldBeEqualToString('frame3.contentDocument.compatMode', 'CSS1Compat');
+    shouldBeEqualToString('frame4.contentDocument.compatMode', 'CSS1Compat');
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -342,6 +342,11 @@ void HTMLConstructionSite::setCompatibilityModeFromDoctype(const String& name, c
     // Limited Quirks - This mode is identical to no-quirks mode except for its treatment of line-height in the inline box model.  
     // No Quirks - no quirks apply. Web pages will obey the specifications to the letter.
 
+    if (m_document.isSrcdocDocument()) {
+        setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
+        return;
+    }
+
     // Check for Quirks Mode.
     if (name != "html"_s
         || startsWithLettersIgnoringASCIICase(publicId, "+//silmaril//dtd html pro v0r11 19970101//"_s)
@@ -445,7 +450,7 @@ void HTMLConstructionSite::insertDoctype(AtomHTMLToken&& token)
     if (m_isParsingFragment)
         return;
 
-    if (token.forceQuirks())
+    if (token.forceQuirks() && !m_document.isSrcdocDocument())
         setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
     else
         setCompatibilityModeFromDoctype(token.name(), publicId, systemId);


### PR DESCRIPTION
#### 4401d4e5b5d9e430acd08167d20557dfcc20a569
<pre>
iframe srcdoc with quirky doctype should be no-quirks mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=159489">https://bugs.webkit.org/show_bug.cgi?id=159489</a>

Reviewed by Chris Dumez.

This patch addresses the bug that a document in srcdoc can be in quirks mode due to DOCTYPE.
New behavior of WebKit matches the spec, Gecko, and Blink.

* LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype-expected.txt: Added.
* LayoutTests/fast/parser/strict-mode-in-srcdoc-with-quirks-doctype.html: Added.
* LayoutTests/fast/frames/srcdoc/srcdoc-can-be-in-qurks-mode-expected.txt:

* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::setCompatibilityModeFromDoctype):
(WebCore::HTMLConstructionSite::insertDoctype):

Canonical link: <a href="https://commits.webkit.org/253326@main">https://commits.webkit.org/253326@main</a>
</pre>
