### PR TITLE
[MSE] Use detach method for HTMLMediaElement::m_mediasource

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1086,7 +1086,7 @@ void HTMLMediaElement::setSrcObject(MediaProvider&& mediaProvider)
     m_mediaStreamSrcObject = nullptr;
 #endif
 #if ENABLE(MEDIA_SOURCE)
-    m_mediaSource = nullptr;
+    detachMediaSource();
 #endif
     m_blob = nullptr;
 


### PR DESCRIPTION
#### da8084304e47a8b83b4c730bd320e3615cbd0f25
<pre>
[MSE] Use detach method for HTMLMediaElement::m_mediasource
<a href="https://bugs.webkit.org/show_bug.cgi?id=243796">https://bugs.webkit.org/show_bug.cgi?id=243796</a>
&lt;rdar://98471033&gt;

Reviewed by Eric Carlson.

We should be using the `detachMediaSource` method in `setSrcObject` in
order to be consistent with the rest of the `HTMLMediaElement` implementation.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSrcObject):

Canonical link: <a href="https://commits.webkit.org/253314@main">https://commits.webkit.org/253314@main</a>
</pre>
