### PR TITLE
html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html WPT test is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document-expected.txt
@@ -1,4 +1,4 @@
-This is a dialog
 
-FAIL Test that removing dialog unblocks the document. assert_equals: expected false but got true
+
+PASS Test that removing dialog unblocks the document.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9219,6 +9219,16 @@ bool Document::isSameSiteForCookies(const URL& url) const
     return domain.matches(url);
 }
 
+HTMLDialogElement* Document::blockedByDialogElement() const
+{
+    return m_blockedByDialogElement.get();
+}
+
+void Document::setBlockedByDialogElement(HTMLDialogElement* dialog)
+{
+    m_blockedByDialogElement = dialog;
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -465,6 +465,10 @@ public:
 
     void setContent(const String&);
 
+    // https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog
+    HTMLDialogElement* blockedByDialogElement() const;
+    void setBlockedByDialogElement(HTMLDialogElement*);
+
     String suggestedMIMEType() const;
 
     void overrideMIMEType(const String&);
@@ -2287,6 +2291,7 @@ private:
     Vector<Function<void()>> m_whenIsVisibleHandlers;
 
     WeakHashSet<Element> m_elementsWithPendingUserAgentShadowTreeUpdates;
+    WeakPtr<HTMLDialogElement> m_blockedByDialogElement; // https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog
 };
 
 Element* eventTargetElementForDocument(Document*);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -745,9 +745,27 @@ Vector<String> Element::getAttributeNames() const
     return attributesVector;
 }
 
+bool Element::isInert() const
+{
+    // FIXME: The inert attribute should also be taken into account.
+    // https://html.spec.whatwg.org/multipage/interaction.html#the-inert-attribute
+
+    if (!isConnected())
+        return false;
+
+    auto* blockedByDialogElement = document().blockedByDialogElement();
+    if (LIKELY(!blockedByDialogElement))
+        return false;
+
+    return blockedByDialogElement != this && !isDescendantOrShadowDescendantOf(*blockedByDialogElement);
+}
+
 bool Element::isFocusable() const
 {
     if (!isConnected() || !supportsFocus())
+        return false;
+
+    if (isInert())
         return false;
 
     if (!renderer()) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -352,6 +352,7 @@ public:
     bool isBeingDragged() const { return isUserActionElement() && isUserActionElementDragged(); }
     bool hasFocusVisible() const { return isUserActionElement() && isUserActionElementHasFocusVisible(); }
     bool hasFocusWithin() const { return isUserActionElement() && isUserActionElementHasFocusWithin(); };
+    bool isInert() const;
 
     virtual void setActive(bool = true, Style::InvalidationScope = Style::InvalidationScope::All);
     virtual void setHovered(bool = true, Style::InvalidationScope = Style::InvalidationScope::All, HitTestRequest = {});

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -79,6 +79,8 @@ ExceptionOr<void> HTMLDialogElement::showModal()
 
     setIsModal(true);
 
+    document().setBlockedByDialogElement(this);
+
     if (!isInTopLayer())
         addToTopLayer();
 
@@ -97,6 +99,9 @@ void HTMLDialogElement::close(const String& result)
     setBooleanAttribute(openAttr, false);
 
     setIsModal(false);
+
+    if (document().blockedByDialogElement() == this)
+        document().setBlockedByDialogElement(nullptr);
 
     if (!result.isNull())
         m_returnValue = result;
@@ -148,6 +153,8 @@ void HTMLDialogElement::removedFromAncestor(RemovalType removalType, ContainerNo
 {
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     setIsModal(false);
+    if (document().blockedByDialogElement() == this)
+        document().setBlockedByDialogElement(nullptr);
 }
 
 void HTMLDialogElement::setIsModal(bool newValue)


### PR DESCRIPTION
#### a19a09f8035ea5841ccbdb61957b4c84c87d4e90
<pre>
html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document.html WPT test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243798">https://bugs.webkit.org/show_bug.cgi?id=243798</a>

Reviewed by NOBODY (OOPS!).

Add missing step in HTMLDialogElement::showModal() to mark the Document as blocked
by the dialog element:
- <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal">https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal</a> (step 6)

When a document is blocked by a dialog element, its nodes are marked as inert unless they
are a flat-tree descendant of the dialog element:
- <a href="https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog">https://html.spec.whatwg.org/multipage/interaction.html#blocked-by-a-modal-dialog</a>

When inert, an element should not be focusable:
- <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a> (step 4)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/remove-dialog-should-unblock-document-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::blockedByDialogElement const):
(WebCore::Document::setBlockedByDialogElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isInert const):
(WebCore::Element::isFocusable const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::close):
(WebCore::HTMLDialogElement::removedFromAncestor):
</pre>