### PR TITLE
Fix internal build for "[macOS Ventura] Build fails when using public SDK"

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -172,12 +172,22 @@ NS_ASSUME_NONNULL_BEGIN
 @interface VKCTranslatedParagraph : NSObject
 @property (nonatomic, readonly) VKQuad *quad;
 @property (nonatomic, readonly) NSString *text;
+@property (nonatomic, readonly) BOOL isPassthrough;
 @end
 
 @interface VKCImageAnalysisTranslation : NSObject
 @property (nonatomic, readonly) NSArray<VKCTranslatedParagraph *> *paragraphs;
 @end
+
+NS_ASSUME_NONNULL_END
+
 #endif
+
+#if __has_include(<VisionKitCore/VKCImageAnalysis.h>)
+#import <VisionKitCore/VKCImageAnalysis.h>
+#else
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface VKCImageAnalysis : VKImageAnalysis
 - (NSAttributedString *)_attributedStringForRange:(NSRange)range;
@@ -185,11 +195,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)translateFrom:(NSString *)sourceLanguage to:(NSString *)targetLanguage withCompletion:(void (^)(VKCImageAnalysisTranslation *translation, NSError *))completion;
 @end
 
-@interface VKCTranslatedParagraph (Staging_93280734)
-@property (nonatomic, readonly) BOOL isPassthrough;
-@end
-
 NS_ASSUME_NONNULL_END
+
+#endif
 
 #if __has_include(<VisionKitCore/VKImageClass_Private.h>)
 #import <VisionKitCore/VKImageClass_Private.h>


### PR DESCRIPTION
#### c691e658c5c0e519e78f391bf8acad90066969ce
<pre>
Fix internal build for &quot;[macOS Ventura] Build fails when using public SDK&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=242429">https://bugs.webkit.org/show_bug.cgi?id=242429</a>

Unreviewed build fix. Need to check for VKCImageAnalysis.h and avoid
redeclarations.

* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:

Canonical link: <a href="https://commits.webkit.org/253311@main">https://commits.webkit.org/253311@main</a>
</pre>
