### PR TITLE
[iOS] Audio session is never activated again after first deactivation

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -90,8 +90,10 @@ void RemoteAudioSessionProxy::setPreferredBufferSize(uint64_t size)
 
 void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& completion)
 {
-    m_active = audioSessionManager().tryToSetActiveForProcess(*this, active);
-    completion(m_active);
+    auto success = audioSessionManager().tryToSetActiveForProcess(*this, active);
+    if (success)
+        m_active = active;
+    completion(success);
 
     audioSessionManager().updatePresentingProcesses();
 }


### PR DESCRIPTION
#### c7f6fbf083feff1cd7109229661946ba2a6f5d1e
<pre>
[iOS] Audio session is never activated again after first deactivation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243797">https://bugs.webkit.org/show_bug.cgi?id=243797</a>
&lt;rdar://98062901&gt;

Reviewed by Eric Carlson.

In the original implementation of RemoteAudioSessionProxy in 221567@main,
the return value of tryToSetActive() was saved to the ivar m_active. However
the return value is whether or not the call succeeded, not whether or not the
session is active. The fallout of this is that only the first request to
activate the audio session actually occurs; all subsequent requests fail
because we think the session is already active.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::tryToSetActive):

Canonical link: <a href="https://commits.webkit.org/253335@main">https://commits.webkit.org/253335@main</a>
</pre>
