### PR TITLE
[GLIB] Unreviewed, build fix for Ubuntu LTS/Debian after 253304@main

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "InlineIteratorBox.h"
 
+#include "InlineIteratorInlineBox.h"
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBox.h"
 #include "LayoutIntegrationLineLayout.h"


### PR DESCRIPTION
#### 238f5fda7c241143e77e18c60208b8f8545a929b
<pre>
[GLIB] Unreviewed, build fix for Ubuntu LTS/Debian after 253304@main

* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp: Add
  missing header &apos;InlineIteratorInlineBox.h&apos;.

Canonical link: <a href="https://commits.webkit.org/253322@main">https://commits.webkit.org/253322@main</a>
</pre>
