### PR TITLE
Change the argument type of HTMLSlotElement.assign() into (Element or Text)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt
@@ -14,4 +14,5 @@ PASS Assignment with the same node in parameters should be ignored, first one wi
 PASS Removing a slot from DOM resets its slottable's slot assignment.
 PASS Nodes can be assigned even if slots or nodes aren't in the same tree.
 PASS Removing a node from the document does not break manually assigned slot linkage.
+PASS throw TypeError if the passed values are neither Element nor Text
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api.html
@@ -285,4 +285,19 @@ test(() => {
   assert_equals(tTree.c2.assignedSlot, tTree.s1);
 }, 'Removing a node from the document does not break manually assigned slot linkage.');
 
+test(() => {
+  const inputValues = [
+    ['Attr', document.createAttribute('bar')],
+    ['Comment', document.createComment('bar')],
+    ['DocumentFragment', document.createDocumentFragment()],
+    ['DocumentType', document.implementation.createDocumentType('html', '', '')]
+  ];
+  for (const [label, input] of inputValues) {
+    assert_throws_js(TypeError, () => {
+      const slot = document.createElement('slot');
+      slot.assign(input);
+    }, label);
+  }
+}, 'throw TypeError if the passed values are neither Element nor Text');
+
 </script>

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -32,6 +32,8 @@ namespace WebCore {
 class HTMLSlotElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLSlotElement);
 public:
+    using ElementOrText = std::variant<RefPtr<Element>, RefPtr<Text>>;
+
     static Ref<HTMLSlotElement> create(const QualifiedName&, Document&);
 
     const Vector<WeakPtr<Node>>* assignedNodes() const;
@@ -41,7 +43,7 @@ public:
     Vector<Ref<Node>> assignedNodes(const AssignedNodesOptions&) const;
     Vector<Ref<Element>> assignedElements(const AssignedNodesOptions&) const;
 
-    void assign(FixedVector<std::reference_wrapper<Node>>&&);
+    void assign(FixedVector<ElementOrText>&&);
     const Vector<WeakPtr<Node>>& manuallyAssignedNodes() const { return m_manuallyAssignedNodes; }
     void removeManuallyAssignedNode(Node&);
 

--- a/Source/WebCore/html/HTMLSlotElement.idl
+++ b/Source/WebCore/html/HTMLSlotElement.idl
@@ -30,7 +30,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     sequence<Node> assignedNodes(optional AssignedNodesOptions options);
     sequence<Element> assignedElements(optional AssignedNodesOptions options);
-    [EnabledBySetting=ImperativeSlotAPIEnabled] undefined assign(Node... nodes); // FIXME: This should be (Element or Text) instead of Node.
+    [EnabledBySetting=ImperativeSlotAPIEnabled] undefined assign((Element or Text)... nodes);
 };
 
 dictionary AssignedNodesOptions {


### PR DESCRIPTION
#### 48034229ee50a9abebeb9837701560cb2ad448a4
<pre>
Change the argument type of HTMLSlotElement.assign() into (Element or Text)
<a href="https://bugs.webkit.org/show_bug.cgi?id=243815">https://bugs.webkit.org/show_bug.cgi?id=243815</a>

Reviewed by Ryosuke Niwa.

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/imperative-slot-api.html:
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::assign):
* Source/WebCore/html/HTMLSlotElement.h:
* Source/WebCore/html/HTMLSlotElement.idl:

Canonical link: <a href="https://commits.webkit.org/253396@main">https://commits.webkit.org/253396@main</a>
</pre>
