### PR TITLE
WebKit::terminateWithReason() is declared in WebKit/Platform/spi, but defined in WebKit/Shared

### DIFF
--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -32,8 +32,8 @@
 #import "Logging.h"
 #import "MachMessage.h"
 #import "MachUtilities.h"
-#import "ReasonSPI.h"
 #import "WKCrashReporter.h"
+#import "XPCUtilities.h"
 #import <WebCore/AXObjectCache.h>
 #import <mach/mach_error.h>
 #import <mach/vm_map.h>

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,29 +25,16 @@
 
 #pragma once
 
-#if USE(APPLE_INTERNAL_SDK)
+#include <wtf/spi/darwin/XPCSPI.h>
 
-#include <sys/reason.h>
+namespace WebKit {
 
-// FIXME: Remove this ifndef once rdar://75717715 is available on bots.
-#ifndef OS_REASON_WEBKIT
-#define OS_REASON_WEBKIT 31
-#endif
+enum class ReasonCode : uint64_t {
+    WatchdogTimerFired,
+    Invalidation,
+    ConnectionKilled,
+};
 
-#else
+void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int terminate_with_reason(int pid, uint32_t reasonNamespace, uint64_t reasonCode, const char *reasonString, uint64_t reasonFlags);
-
-#ifdef __cplusplus
 }
-#endif
-
-#define OS_REASON_FLAG_NO_CRASH_REPORT 0x1
-
-#define OS_REASON_WEBKIT 31
-
-#endif

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,31 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "XPCUtilities.h"
 
-#if USE(APPLE_INTERNAL_SDK)
+namespace WebKit {
 
-#include <sys/reason.h>
-
-// FIXME: Remove this ifndef once rdar://75717715 is available on bots.
-#ifndef OS_REASON_WEBKIT
-#define OS_REASON_WEBKIT 31
-#endif
-
-#else
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int terminate_with_reason(int pid, uint32_t reasonNamespace, uint64_t reasonCode, const char *reasonString, uint64_t reasonFlags);
-
-#ifdef __cplusplus
+void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
+{
+    // This could use ReasonSPI.h, but currently does not as the SPI is blocked by the sandbox.
+    // See https://bugs.webkit.org/show_bug.cgi?id=224499 rdar://76396241
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    xpc_connection_kill(connection, SIGKILL);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
-#endif
 
-#define OS_REASON_FLAG_NO_CRASH_REPORT 0x1
-
-#define OS_REASON_WEBKIT 31
-
-#endif
+}

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -91,6 +91,7 @@ Platform/cocoa/SharedMemoryCocoa.cpp
 Platform/cocoa/WKCrashReporter.mm
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Platform/cocoa/WebKitAdditions.mm @no-unify
+Platform/cocoa/XPCUtilities.mm
 
 Platform/foundation/LoggingFoundation.mm
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -27,8 +27,8 @@
 #import "ProcessLauncher.h"
 
 #import "Logging.h"
-#import "ReasonSPI.h"
 #import "WebPreferencesDefaultValues.h"
+#import "XPCUtilities.h"
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <crt_externs.h>
 #import <mach-o/dyld.h>
@@ -339,13 +339,6 @@ void ProcessLauncher::terminateXPCConnection()
     xpc_connection_cancel(m_xpcConnection.get());
     terminateWithReason(m_xpcConnection.get(), WebKit::ReasonCode::Invalidation, "ProcessLauncher::platformInvalidate");
     m_xpcConnection = nullptr;
-}
-
-void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
-{
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    xpc_connection_kill(connection, SIGKILL);
-    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5481,6 +5481,8 @@
 		7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCUtilities.cpp; sourceTree = "<group>"; };
 		7B9FC5E128A54BCC007570E7 /* ArgumentCodersDarwin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArgumentCodersDarwin.h; sourceTree = "<group>"; };
 		7B9FC5E228A54BCC007570E7 /* ArgumentCodersDarwin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ArgumentCodersDarwin.mm; sourceTree = "<group>"; };
+		7B9FC5DF28A54373007570E7 /* XPCUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XPCUtilities.h; sourceTree = "<group>"; };
+		7B9FC5E028A54373007570E7 /* XPCUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XPCUtilities.cpp; sourceTree = "<group>"; };
 		7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedActiveMessageReceiveQueue.h; sourceTree = "<group>"; };
 		7BBA63DC280E93B500B04823 /* IPCConnectionTesterIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCConnectionTesterIdentifier.h; sourceTree = "<group>"; };
 		7BBA63DD280E93B600B04823 /* IPCConnectionTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCConnectionTester.cpp; sourceTree = "<group>"; };
@@ -10019,6 +10021,8 @@
 				A1FB68231F6E518200C43F9F /* WKCrashReporter.mm */,
 				A1798B47222E530A000764BD /* WKPaymentAuthorizationDelegate.h */,
 				A1798B48222E530A000764BD /* WKPaymentAuthorizationDelegate.mm */,
+				7B9FC5E028A54373007570E7 /* XPCUtilities.cpp */,
+				7B9FC5DF28A54373007570E7 /* XPCUtilities.h */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### 7e6b014c2242b524f3b8c9687047f4e18380a34f
<pre>
WebKit::terminateWithReason() is declared in WebKit/Platform/spi, but defined in WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=243824">https://bugs.webkit.org/show_bug.cgi?id=243824</a>
rdar://problem/98506618

Reviewed by Chris Dumez.

Move the WebKit function declaration to WebKit/Platform header and add a implementation file.
This way the SPI header only declares the SPI.
This way the WebKit function declaration and implementation are in consistent files.
This way the function implementation is logically part of WebKit/Platform, where it is also used.

This is a work to be able to compile Source/WebKit/Platform without the rest of Source/WebKit/
for unit testing purposes.

* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
* Source/WebKit/Platform/cocoa/XPCUtilities.cpp: Copied from Source/WebKit/Platform/spi/Cocoa/ReasonSPI.h.
(WebKit::terminateWithReason):
* Source/WebKit/Platform/cocoa/XPCUtilities.h: Copied from Source/WebKit/Platform/spi/Cocoa/ReasonSPI.h.
* Source/WebKit/Platform/spi/Cocoa/ReasonSPI.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::terminateWithReason): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/253461@main">https://commits.webkit.org/253461@main</a>
</pre>
