### PR TITLE
[Gardening]: REGRESSION (253038@main): [macOS] inspector/dom/getAccessibilityPropertiesForNode.html is a consistent failure

### DIFF
--- a/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
+++ b/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
@@ -313,14 +313,12 @@ Total elements to be tested: 122.
     exists: true
     label:
     role: option
-    hidden: true
     parentNodeId: exists
 
 <option selected="">selected</option>
     exists: true
     label:
     role: option
-    hidden: true
     parentNodeId: exists
     selected: true
 


### PR DESCRIPTION
#### 8c90b961f4a08e9d59910e5e13180383bd577d46
<pre>
[Gardening]: REGRESSION (253038@main): [macOS] inspector/dom/getAccessibilityPropertiesForNode.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243804">https://bugs.webkit.org/show_bug.cgi?id=243804</a>
&lt;rdar://98479367&gt;

Re-baseline.

Unreviewed test gardening.

* LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253332@main">https://commits.webkit.org/253332@main</a>
</pre>
