### PR TITLE
[Gardening]: REGRESSION (252720@main): [iOS] imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 394
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 394
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for element outside the flat tree assert_equals: expected 0 but got 393
+FAIL getComputedStyle returns no style for descendant outside the flat tree assert_equals: expected 0 but got 393
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 


### PR DESCRIPTION
#### dd1aff2d3b6ee525d412bdcc6cbbe9df111339b7
<pre>
[Gardening]: REGRESSION (252720@main): [iOS] imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243787">https://bugs.webkit.org/show_bug.cgi?id=243787</a>
&lt;rdar://98454629&gt;

Re-baseline

Unreviewed test gardening.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253333@main">https://commits.webkit.org/253333@main</a>
</pre>
