### PR TITLE
WebKit build failure: Use of undeclared identifier 'InspectorFrontendAPIDispatcher'; did you mean 'WebCore::InspectorFrontendAPIDispatcher'?

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -385,7 +385,7 @@ void WebInspectorUIExtensionController::navigateTabForExtension(const Inspector:
         JSON::Value::create(extensionTabIdentifier),
         JSON::Value::create(sourceURL.string()),
     };
-    m_frontendClient->frontendAPIDispatcher().dispatchCommandWithResultAsync("navigateTabForExtension"_s, WTFMove(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
+    m_frontendClient->frontendAPIDispatcher().dispatchCommandWithResultAsync("navigateTabForExtension"_s, WTFMove(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
         if (!weakThis) {
             completionHandler(Inspector::ExtensionError::ContextDestroyed);
             return;


### PR DESCRIPTION
#### 6e3353ec6e21038020dbf6d968163e7b88be2fc4
<pre>
WebKit build failure: Use of undeclared identifier &apos;InspectorFrontendAPIDispatcher&apos;; did you mean &apos;WebCore::InspectorFrontendAPIDispatcher&apos;?
<a href="https://bugs.webkit.org/show_bug.cgi?id=243827">https://bugs.webkit.org/show_bug.cgi?id=243827</a>
rdar://98489955

Unreviewed build fix.

* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::navigateTabForExtension): Add WebCore namespace.

Canonical link: <a href="https://commits.webkit.org/253340@main">https://commits.webkit.org/253340@main</a>
</pre>
