### PR TITLE
[Cocoa] Establish AVCapture server connection when capturing audio or video

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -375,6 +375,10 @@ void GPUProcess::setOrientationForMediaCapture(uint64_t orientation)
 
 void GPUProcess::updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier processID, CompletionHandler<void()>&& completionHandler)
 {
+#if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
+    ensureAVCaptureServerConnection();
+#endif
+
     if (auto* connection = webProcessConnection(processID)) {
         connection->updateCaptureAccess(allowAudioCapture, allowVideoCapture, allowDisplayCapture);
         return completionHandler();
@@ -398,10 +402,6 @@ void GPUProcess::updateSandboxAccess(const Vector<SandboxExtension::Handle>& ext
 {
     for (auto& extension : extensions)
         SandboxExtension::consumePermanently(extension);
-
-#if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
-    sandboxWasUpatedForCapture();
-#endif
 }
 
 void GPUProcess::addMockMediaDevice(const WebCore::MockMediaDevice& device)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,8 +95,9 @@ public:
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     WorkQueue& videoMediaStreamTrackRendererQueue();
-    void sandboxWasUpatedForCapture();
+    void ensureAVCaptureServerConnection();
 #endif
+
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
     WorkQueue& libWebRTCCodecsQueue();
 #endif

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,10 +78,13 @@ void GPUProcess::dispatchSimulatedNotificationsForPreferenceChange(const String&
 #endif // ENABLE(CFPREFS_DIRECT_MODE)
 
 #if ENABLE(MEDIA_STREAM)
-void GPUProcess::sandboxWasUpatedForCapture()
+void GPUProcess::ensureAVCaptureServerConnection()
 {
-    if ([PAL::getAVCaptureDeviceClass() respondsToSelector:@selector(ensureServerConnection)])
-        [PAL::getAVCaptureDeviceClass() ensureServerConnection];
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        if ([PAL::getAVCaptureDeviceClass() respondsToSelector:@selector(ensureServerConnection)])
+            [PAL::getAVCaptureDeviceClass() ensureServerConnection];
+    });
 }
 #endif
 


### PR DESCRIPTION
#### 4fcb3683e6a4ff65761babde0f4f2358a1bc8a58
<pre>
[Cocoa] Establish AVCapture server connection when capturing audio or video
<a href="https://bugs.webkit.org/show_bug.cgi?id=243826">https://bugs.webkit.org/show_bug.cgi?id=243826</a>
&lt;rdar://97391073&gt;

Reviewed by Jer Noble.

+[AVCaptureDevice ensureServerConnection] should be called before capture begins so
call it from GPUProcess::updateCaptureAccess instead of from GPUProcess::updateSandboxAccess
because we don&apos;t currently extend the GPU process sandbox when capturing only audio on
macOS.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateCaptureAccess): Call ensureAVCaptureServerConnection.
(WebKit::GPUProcess::updateSandboxAccess): Remove call to sandboxWasUpatedForCapture.
* Source/WebKit/GPUProcess/GPUProcess.h:

* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::ensureAVCaptureServerConnection): Renamed from sandboxWasUpatedForCapture.
(WebKit::GPUProcess::sandboxWasUpatedForCapture): Deleted.

Canonical link: <a href="https://commits.webkit.org/253570@main">https://commits.webkit.org/253570@main</a>
</pre>
