### PR TITLE
[Gardening]: REGRESSION(253277@main): [ iOS ] fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3698,3 +3698,5 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-unsafe-none-to-same-origin.https.html [ Pass Failure ]
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/javascript-url.https.html [ Pass Failure ]
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-so.https.html [ Pass Failure ]
+
+webkit.org/b/243828 fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html [ Pass Failure ]


### PR DESCRIPTION
#### e2c82db70f58dd87ed59beb5d0879b48b952a3c1
<pre>
[Gardening]: REGRESSION(253277@main): [ iOS ] fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243828">https://bugs.webkit.org/show_bug.cgi?id=243828</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253336@main">https://commits.webkit.org/253336@main</a>
</pre>
