### PR TITLE
REGRESSION(251714@main): iPhone: espn.com: Entering full screen on videos exits automatically

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -301,7 +301,9 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
     FloatRect videoLayerFrame = FloatRect(0, 0, videoRect.width(), videoRect.height());
 
 #if PLATFORM(IOS)
-    if (!allowLayeredFullscreenVideos)
+    if (allowLayeredFullscreenVideos)
+        interface->setTargetIsFullscreen(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
+    else
 #endif
         setCurrentlyInFullscreen(*interface, mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 


### PR DESCRIPTION
#### c6bc44db9d3d248c14c2230d9955b80b42da4aeb
<pre>
REGRESSION(251714@main): iPhone: espn.com: Entering full screen on videos exits automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=243834">https://bugs.webkit.org/show_bug.cgi?id=243834</a>
&lt;rdar://97978553&gt;

Reviewed by Eric Carlson.

If a page has the fullscreen quirk, we never set the fullscreen state of
the underlying VideoFullscreenInterfaceContext when fullscreen is entered.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/253355@main">https://commits.webkit.org/253355@main</a>
</pre>
