### PR TITLE
Rename localOriginStorageManager to originStorageManager

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -107,7 +107,7 @@ private:
     ~NetworkStorageManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
-    OriginStorageManager& localOriginStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
+    OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
 
     void forEachOriginDirectory(const Function<void(const String&)>&);
@@ -183,7 +183,7 @@ private:
     String m_path;
     FileSystem::Salt m_salt;
     bool m_closed { false };
-    HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_localOriginStorageManagers;
+    HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers;
     WeakHashSet<IPC::Connection> m_connections; // Main thread only.
     std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;


### PR DESCRIPTION
#### ef8e12d96f600932a286b7c4db783cb518b03097
<pre>
Rename localOriginStorageManager to originStorageManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=243830">https://bugs.webkit.org/show_bug.cgi?id=243830</a>

Reviewed by Ryosuke Niwa.

The name &quot;localOriginStorageManager&quot; was used because we used to have &quot;sessionOriginStorageManager&quot; and we need to
distinguish between two types of OriginStorageManager. Since each origin only has one OriginStorageManager now, it can
be confusing to still keep the prefix &quot;local&quot;, as OriginStorageManager actually manages both &quot;local&quot; and &quot;session&quot;
storage types.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::close):
(WebKit::NetworkStorageManager::stopReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::removeOriginStorageManagerIfPossible):
(WebKit::NetworkStorageManager::persisted):
(WebKit::NetworkStorageManager::persist):
(WebKit::NetworkStorageManager::clearStorageForTesting):
(WebKit::NetworkStorageManager::clearStorageForWebPage):
(WebKit::NetworkStorageManager::didIncreaseQuota):
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::getAllOrigins):
(WebKit::NetworkStorageManager::fetchDataFromDisk):
(WebKit::NetworkStorageManager::deleteDataOnDisk):
(WebKit::NetworkStorageManager::moveData):
(WebKit::NetworkStorageManager::getOriginDirectory):
(WebKit::NetworkStorageManager::suspend):
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
(WebKit::NetworkStorageManager::requestSpace):
(WebKit::NetworkStorageManager::resetQuotaForTesting):
(WebKit::NetworkStorageManager::resetQuotaUpdatedBasedOnUsageForTesting):
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::cancelConnectToStorageArea):
(WebKit::NetworkStorageManager::disconnectFromStorageArea):
(WebKit::NetworkStorageManager::cloneSessionStorageNamespace):
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::openDBRequestCancelled):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
(WebKit::NetworkStorageManager::localOriginStorageManager): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/253432@main">https://commits.webkit.org/253432@main</a>
</pre>
