### PR TITLE
REGRESSION (15.4.x): Status bar loses its color after PDF download

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -59,6 +59,7 @@ enum class TapHandlingResult : uint8_t;
 - (void)_processWillSwap;
 - (void)_didRelaunchProcess;
 
+- (WKScrollView *)_wkScrollView;
 - (UIView *)_currentContentView;
 
 - (void)_didCommitLoadForMainFrame;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -440,6 +440,11 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
     return CGSizeMake(floorToDevicePixel(contentSize.width, deviceScaleFactor), floorToDevicePixel(contentSize.height, deviceScaleFactor));
 }
 
+- (WKScrollView *)_wkScrollView
+{
+    return _scrollView.get();
+}
+
 - (UIView *)_currentContentView
 {
     return _customContentView ? [_customContentView web_contentView] : _contentView.get();
@@ -609,8 +614,8 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 {
     auto newScrollViewBackgroundColor = scrollViewBackgroundColor(self, AllowPageBackgroundColorOverride::Yes);
     if (_scrollViewBackgroundColor != newScrollViewBackgroundColor) {
-        _scrollViewBackgroundColor = newScrollViewBackgroundColor;
         [_scrollView _setBackgroundColorInternal:cocoaColor(newScrollViewBackgroundColor).get()];
+        _scrollViewBackgroundColor = newScrollViewBackgroundColor;
     }
 
     [self _updateScrollViewIndicatorStyle];

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -34,6 +34,7 @@
 #import "UIKitSPI.h"
 #import "WKActionSheetAssistant.h"
 #import "WKKeyboardScrollingAnimator.h"
+#import "WKScrollView.h"
 #import "WKUIDelegatePrivate.h"
 #import "WKWebEvent.h"
 #import "WKWebViewIOS.h"
@@ -192,7 +193,7 @@
 
     UIColor *backgroundColor = PDFHostViewController.backgroundColor;
     self.backgroundColor = backgroundColor;
-    webView.scrollView.backgroundColor = backgroundColor;
+    [webView._wkScrollView _setBackgroundColorInternal:backgroundColor];
 
     _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:webView.scrollView]);
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -245,6 +245,8 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
         return;
 
     super.backgroundColor = backgroundColor;
+
+    [_internalDelegate _resetCachedScrollViewBackgroundColor];
 }
 
 - (void)setIndicatorStyle:(UIScrollViewIndicatorStyle)indicatorStyle

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -790,6 +790,7 @@
 		93F56DA71E5F9174003EDE84 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0331D0A5F2700FEBCF3 /* libicucore.dylib */; };
 		93F7E86F14DC8E5C00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F7E86E14DC8E5B00C84A99 /* NewFirstVisuallyNonEmptyLayoutFrames_Bundle.cpp */; };
 		93FCDB34263631560046DD7D /* SortedArrayMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93FCDB33263631560046DD7D /* SortedArrayMap.cpp */; };
+		95194CC028A5811F00343FDE /* red.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 95194CBF28A580E900343FDE /* red.html */; };
 		9528E5FD279A0341008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */; };
 		952F7167270BD9CB00D00DCC /* CSSViewportUnits.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCC /* CSSViewportUnits.html */; };
 		952F7167270BD9CB00D00DCD /* CSSViewportUnits.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 952F7166270BD99700D00DCD /* CSSViewportUnits.svg */; };
@@ -1661,6 +1662,7 @@
 				F41AB9A81EF4696B0083FA08 /* prevent-operation.html in Copy Resources */,
 				F41AB9A91EF4696B0083FA08 /* prevent-start.html in Copy Resources */,
 				F6FDDDD614241C6F004F1729 /* push-state.html in Copy Resources */,
+				95194CC028A5811F00343FDE /* red.html in Copy Resources */,
 				F4476F4B279082F900931786 /* remove-node-on-drop.html in Copy Resources */,
 				A12DDC001E8373E700CF6CAE /* rendered-image-excluding-overflow.html in Copy Resources */,
 				498D030A26376B34009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */,
@@ -2726,6 +2728,7 @@
 		93FCDB33263631560046DD7D /* SortedArrayMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SortedArrayMap.cpp; sourceTree = "<group>"; };
 		95095F1F262FFFA50000D920 /* SampledPageTopColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SampledPageTopColor.mm; sourceTree = "<group>"; };
 		950E4CC0252E75230071659F /* iOSStylusSupport.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = iOSStylusSupport.mm; sourceTree = "<group>"; };
+		95194CBF28A580E900343FDE /* red.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = red.html; sourceTree = "<group>"; };
 		9528E5FA279A0337008ADFEF /* BundleCSSStyleDeclarationHandleProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BundleCSSStyleDeclarationHandleProtocol.h; sourceTree = "<group>"; };
 		9528E5FB279A0337008ADFEF /* BundleCSSStyleDeclarationHandle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleCSSStyleDeclarationHandle.mm; sourceTree = "<group>"; };
 		9528E5FC279A0338008ADFEF /* BundleCSSStyleDeclarationHandlePlugIn.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleCSSStyleDeclarationHandlePlugIn.mm; sourceTree = "<group>"; };
@@ -4974,6 +4977,7 @@
 				83148B08202AC76800BADE99 /* override-builtins-test.html */,
 				0EBBCC651FFF9DCE00FA42AB /* pop-up-check.html */,
 				F6FDDDD514241C48004F1729 /* push-state.html */,
+				95194CBF28A580E900343FDE /* red.html */,
 				F4476F4A279082EB00931786 /* remove-node-on-drop.html */,
 				0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */,
 				7A66BDB71EAF150100CCC924 /* set-long-title.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/red.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/red.html
@@ -1,0 +1,1 @@
+<body style="background-color: red"></body>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
@@ -28,7 +28,7 @@
 #import "ClassMethodSwizzler.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
-#import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
 #import "TestURLSchemeHandler.h"
@@ -171,6 +171,23 @@ TEST(WebKit, WKPDFViewFindActions)
 }
 
 #endif
+
+TEST(WKPDFView, BackgroundColor)
+{
+    auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"red" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]]];
+    EXPECT_TRUE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, redColor.get()));
+
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]]];
+    EXPECT_FALSE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, redColor.get()));
+
+    [webView synchronouslyGoBack];
+    EXPECT_TRUE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, redColor.get()));
+}
 
 #endif
 


### PR DESCRIPTION
#### 89cbb8ee6ca0ac4237096199725f10e09e785386
<pre>
REGRESSION (15.4.x): Status bar loses its color after PDF download
<a href="https://bugs.webkit.org/show_bug.cgi?id=239898">https://bugs.webkit.org/show_bug.cgi?id=239898</a>
&lt;rdar://problem/92544725&gt;

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_initWithFrame:webView:mimeType:]):
243980@main changed `WKScrollView` to have a `-[WKScrollView _setBackgroundColorInternal:]` in order
to know whether the `backgroundColor` is being set by WebKit or by the owner of the `WKWebView`. The
former allows for WebKit to continue automatically updating the `backgroundColor` based on the page
content, whereas the latter means WebKit should not as the client explicitly asked for that color.
Since `WKPDFView` is an internal implementation detail of WebKit, it should fall into the former.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _wkScrollView]): Added.
(-[WKWebView _updateScrollViewBackground]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _setBackgroundColorInternal:]):
Expose a way for internal logic to access the `WKScrollView` from the `WKWebView`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm:
(TEST.WKPDFView.BackgroundColor): Added.
* Tools/TestWebKitAPI/Tests/WebKit/red.html: Added.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/253372@main">https://commits.webkit.org/253372@main</a>
</pre>
