### PR TITLE
[Gardening]: [ iOS ] imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3700,3 +3700,5 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-so.https.html [ Pass Failure ]
 
 webkit.org/b/243828 fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html [ Pass Failure ]
+
+webkit.org/b/243836 imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html [ Pass Failure ]


### PR DESCRIPTION
#### daef9fc001b84a1ae06f49c29de8fdcab1b7ba8c
<pre>
[Gardening]: [ iOS ] imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243836">https://bugs.webkit.org/show_bug.cgi?id=243836</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253344@main">https://commits.webkit.org/253344@main</a>
</pre>
