### PR TITLE
REGRESSION(253277@main): [ iOS ] fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html is a constant failure

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -5764,7 +5764,7 @@ void FrameView::clearSizeOverrideForCSSDefaultViewportUnits()
 
     m_defaultViewportSizeOverride = std::nullopt;
     if (auto* document = frame().document())
-        document->updateViewportUnitsOnResize();
+        document->styleScope().didChangeStyleSheetEnvironment();
 }
 
 void FrameView::setSizeForCSSDefaultViewportUnits(FloatSize size)
@@ -5790,7 +5790,7 @@ void FrameView::setOverrideSizeForCSSDefaultViewportUnits(OverrideViewportSize s
     m_defaultViewportSizeOverride = size;
 
     if (auto* document = frame().document())
-        document->updateViewportUnitsOnResize();
+        document->styleScope().didChangeStyleSheetEnvironment();
 }
 
 FloatSize FrameView::sizeForCSSDefaultViewportUnits() const


### PR DESCRIPTION
#### debb098c0323383b53f8a07901c55ee4762fcb20
<pre>
REGRESSION(253277@main): [ iOS ] fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243828">https://bugs.webkit.org/show_bug.cgi?id=243828</a>
&lt;rdar://problem/98512091&gt;

Reviewed by Tim Horton.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::clearSizeOverrideForCSSDefaultViewportUnits):
(WebCore::FrameView::setOverrideSizeForCSSDefaultViewportUnits):
Partially revert 253277@main to use `didChangeStyleSheetEnvironment` whenever the underlying value
of the CSS default viewport unit changes, as this only happens when the size of the view changes,
which is really a change in the environment (as opposed to CSS small/large/dynamic viewport units
only changing when other UI near the view changes, but not the view itself). This also matches the
behavior before any of the new CSS viewport units were implemented (243349@main).

Canonical link: <a href="https://commits.webkit.org/253371@main">https://commits.webkit.org/253371@main</a>
</pre>
