### PR TITLE
Web Inspector: REGRESSION(252653@main): nodes should not be greyscaled when outside of the DOM tree

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -87,13 +87,13 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
     color: var(--selected-secondary-text-color);
 }
 
-.tree-outline.dom li:not(.rendered) > span > *:not(.html-comment) {
+.content-view.dom-tree .tree-outline.dom li:not(.rendered) > span > *:not(.html-comment) {
     filter: grayscale();
 }
 
-.tree-outline.dom li:not(.rendered, .selected) > span > *:not(.html-comment),
-.tree-outline.dom:not(:focus-within) li.selected:not(.rendered) > span > *:not(.html-comment),
-body:is(.window-inactive, .window-docked-inactive) .tree-outline.dom li.selected:not(.rendered) > span > *:not(.html-comment) {
+.content-view.dom-tree .tree-outline.dom li:not(.rendered, .selected) > span > *:not(.html-comment),
+.content-view.dom-tree .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) > span > *:not(.html-comment),
+body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom li.selected:not(.rendered) > span > *:not(.html-comment) {
     opacity: 0.7;
 }
 


### PR DESCRIPTION
#### 370c3d084c697b819722460126a48f6ca2708b82
<pre>
Web Inspector: REGRESSION(252653@main): nodes should not be greyscaled when outside of the DOM tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=243839">https://bugs.webkit.org/show_bug.cgi?id=243839</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.content-view.dom-tree .tree-outline.dom li:not(.rendered) &gt; span &gt; *:not(.html-comment)): Renamed from `.tree-outline.dom li:not(.rendered) &gt; span &gt; *:not(.html-comment)`.
(.content-view.dom-tree .tree-outline.dom li:not(.rendered, .selected) &gt; span &gt; *:not(.html-comment), .content-view.dom-tree .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment), body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree .tree-outline.dom li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment)): Renamed from `.tree-outline.dom li:not(.rendered, .selected) &gt; span &gt; *:not(.html-comment), .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment), body:is(.window-inactive, .window-docked-inactive) .tree-outline.dom li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment)`.

Canonical link: <a href="https://commits.webkit.org/253346@main">https://commits.webkit.org/253346@main</a>
</pre>
