### PR TITLE
Web Inspector: Elements Tab: add a reference page link

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
+++ b/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
@@ -79,6 +79,9 @@ WI.ReferencePage.DOMBreakpoints.Configuration = new WI.ReferencePage(WI.Referenc
 WI.ReferencePage.DeviceSettings = new WI.ReferencePage("device-settings");
 WI.ReferencePage.DeviceSettings.Configuration = new WI.ReferencePage(WI.ReferencePage.DeviceSettings, {topic: "configuration"});
 
+WI.ReferencePage.ElementsTab = new WI.ReferencePage("elements-tab");
+WI.ReferencePage.ElementsTab.DOMTree = new WI.ReferencePage(WI.ReferencePage.ElementsTab, {topic: "dom-tree"});
+
 WI.ReferencePage.EventBreakpoints = new WI.ReferencePage("event-breakpoints");
 WI.ReferencePage.EventBreakpoints.Configuration = new WI.ReferencePage(WI.ReferencePage.EventBreakpoints, {topic: "configuration"});
 

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -108,6 +108,7 @@
     <link rel="stylesheet" href="Views/DividerNavigationItem.css">
     <link rel="stylesheet" href="Views/DropZoneView.css">
     <link rel="stylesheet" href="Views/Editing.css">
+    <link rel="stylesheet" href="Views/ElementsTabContentView.css">
     <link rel="stylesheet" href="Views/ErrorObjectView.css">
     <link rel="stylesheet" href="Views/EventBreakpointPopover.css">
     <link rel="stylesheet" href="Views/EventBreakpointTreeElement.css">

--- a/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.content-view.elements > .reference-page-link-container {
+    position: absolute;
+    bottom: 6px;
+    inset-inline-end: 6px;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
@@ -117,6 +117,13 @@ WI.ElementsTabContentView = class ElementsTabContentView extends WI.ContentBrows
         super.detached();
     }
 
+    initialLayout()
+    {
+        super.initialLayout();
+
+        this.element.appendChild(WI.ReferencePage.ElementsTab.DOMTree.createLinkElement());
+    }
+
     closed()
     {
         super.closed();


### PR DESCRIPTION
#### 3f4be94a72fd9c08abf05456f42c2856d74ffd5a
<pre>
Web Inspector: Elements Tab: add a reference page link
<a href="https://bugs.webkit.org/show_bug.cgi?id=243842">https://bugs.webkit.org/show_bug.cgi?id=243842</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Base/ReferencePage.js:
Create a `WI.ReferencePage.ElementsTab` and `WI.ReferencePage.ElementsTab.DOMTree`.

* Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js:
(WI.ElementsTabContentView.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.css: Added.
(.content-view.elements &gt; .reference-page-link-container):
Add a button linking to `WI.ReferencePage.ElementsTab.DOMTree` to the `element` of the Elements Tab.
This is done so &quot;high&quot; up because the container is not scrollable, unlike the `WI.ContentViewContainer`.

* Source/WebInspectorUI/UserInterface/Main.html:

Canonical link: <a href="https://commits.webkit.org/253356@main">https://commits.webkit.org/253356@main</a>
</pre>
