### PR TITLE
html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html WPT test fails to run with our infrastructure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -644,7 +644,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-elemen
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigate_history_go_forward.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/srcdoc_change_hash.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/natural-size-orientation.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-submit-remove-children.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popups/popup-animated-hide-display.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popups/popup-animated-hide-finishes.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame-expected.txt
@@ -1,10 +1,10 @@
+CONSOLE MESSAGE: Blocked a frame with origin "http://localhost:8800" from accessing a frame with origin "http://127.0.0.1:8800". Protocols, domains, and ports must match.
+CONSOLE MESSAGE: Blocked a frame with origin "http://localhost:8800" from accessing a frame with origin "http://127.0.0.1:8800". Protocols, domains, and ports must match.
 This frame should stay blank
 
 This frame should navigate (to 404)
 
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT default submit action should supersede onclick submit() for cross-origin iframes Test timed out
+PASS default submit action should supersede onclick submit() for cross-origin iframes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <!-- The onclick submit() should get superseded by the default
      action submit(), which isn't preventDefaulted by onclick here.
@@ -35,8 +36,7 @@ promise_test(async () => {
 
   const frame1LoadPromise = getLoadPromise(frame1);
   let frame2LoadPromise = getLoadPromise(frame2);
-  const subframeScheme = window.location.protocol === 'https:' ? 'http://' : 'https://';
-  const subframeUrl = subframeScheme + window.location.host;
+  const subframeUrl = get_host_info().REMOTE_ORIGIN;
   frame1.src = subframeUrl;
   frame2.src = subframeUrl;
   await frame1LoadPromise;


### PR DESCRIPTION
#### d883156c3539a453b1f2f903d0da1bfda5ac306a
<pre>
html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html WPT test fails to run with our infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243843">https://bugs.webkit.org/show_bug.cgi?id=243843</a>

Reviewed by Tim Nguyen.

The test relies on switching a URL cross-origin by switching its scheme from http to https. However,
when running WPT tests on an HTTP server that uses non-default ports, this doesn&apos;t result in a valid
URL since the port wasn&apos;t updated to the HTTPS port.

To address the issue, rely on get_host_info().REMOTE_ORIGIN to get a remote origin URL.

Upstream PR: <a href="https://github.com/web-platform-tests/wpt/pull/35441">https://github.com/web-platform-tests/wpt/pull/35441</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-to-different-origin-frame.html:

Canonical link: <a href="https://commits.webkit.org/253357@main">https://commits.webkit.org/253357@main</a>
</pre>
