### PR TITLE
Improve handling of build RETRY and EXCEPTION cases in GitHub Status-bubbles

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -219,7 +219,12 @@ class GitHubEWS(GitHub):
             if re.search(r'Pull request .* doesn\'t have relevant changes', build.state_string):
                 return u'| '
             name = u'~~{}~~'.format(name)
-        # FIXME: Handle other cases like EXCEPTION, RETRY etc.
+        elif build.result == Buildbot.RETRY:
+            hover_over_text = 'Build is being retried.'
+            status = GitHubEWS.ICON_BUILD_ONGOING
+        elif build.result == Buildbot.EXCEPTION:
+            hover_over_text = 'An unexpected error occured.'
+            status = GitHubEWS.ICON_BUILD_ERROR
         else:
             status = GitHubEWS.ICON_BUILD_ERROR
 


### PR DESCRIPTION
#### 57d18151e833f2c099814f8382af44befa79a79c
<pre>
Improve handling of build RETRY and EXCEPTION cases in GitHub Status-bubbles
<a href="https://bugs.webkit.org/show_bug.cgi?id=243845">https://bugs.webkit.org/show_bug.cgi?id=243845</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.github_status_for_queue):

Canonical link: <a href="https://commits.webkit.org/253376@main">https://commits.webkit.org/253376@main</a>
</pre>
