### PR TITLE
Non-unified build fixes, almost mid August 2022 edition

### DIFF
--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ElementInternals.h"
 
+#include "ShadowRoot.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -29,6 +29,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -112,6 +112,7 @@
 #include "Settings.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include "TextIndicator.h"
 #include "TextIterator.h"
 #include "TextResourceDecoder.h"
 #include "TiledBacking.h"


### PR DESCRIPTION
#### 9638d1e2db0f41c2fbb4eada3b6ebb09a2e35b7f
<pre>
Non-unified build fixes, almost mid August 2022 edition

Unreviewed non-unified build fixes.

* Source/WebCore/dom/ElementInternals.cpp: Add missing ShadowRoot.h
  header inclusion.
* Source/WebCore/dom/SlotAssignment.h: Add missing wtf/WeakHashMap.h
  header inclusion.
* Source/WebCore/page/FrameView.cpp: Add missing TextIndicator.h header
  inclusion.

Canonical link: <a href="https://commits.webkit.org/253362@main">https://commits.webkit.org/253362@main</a>
</pre>
