### PR TITLE
[Flatpak SDK] Update Mold to version 1.4.0

### DIFF
--- a/Tools/buildstream/elements/sdk/hwloc.bst
+++ b/Tools/buildstream/elements/sdk/hwloc.bst
@@ -13,5 +13,5 @@ variables:
 
 sources:
 - kind: tar
-  url: https://www.open-mpi.org/software/hwloc/v2.7/downloads/hwloc-2.7.1.tar.bz2
-  ref: 0d4e1d36c3a72c5d61901bfd477337f5a4c7e0a975da57165237d00e35ef528d
+  url: https://download.open-mpi.org/release/hwloc/v2.8/hwloc-2.8.0.tar.bz2
+  ref: 348a72fcd48c32a823ee1da149ae992203e7ad033549e64aed6ea6eeb01f42c1

--- a/Tools/buildstream/elements/sdk/mold.bst
+++ b/Tools/buildstream/elements/sdk/mold.bst
@@ -13,4 +13,4 @@ sources:
   checkout-submodules: false
   track-tags: true
   track: main
-  ref: v1.3.1-0-g7f7d10cc896e0c7513d09723d5ca3d8346bdea49
+  ref: v1.4.0-0-g7177f7442bc18210a1cf67092e80511818b473b0


### PR DESCRIPTION
#### 6394c9b3472050821e9373a5864cf108cdfc3b0e
<pre>
[Flatpak SDK] Update Mold to version 1.4.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=243823">https://bugs.webkit.org/show_bug.cgi?id=243823</a>

Reviewed by Philippe Normand.

While at it, update hwloc, which is a dependency of TBB, which in turn
is a dependency of Mold itself.

* Tools/buildstream/elements/sdk/hwloc.bst: Update to version 2.8.0
* Tools/buildstream/elements/sdk/mold.bst: Update to version 1.4.0

Canonical link: <a href="https://commits.webkit.org/253373@main">https://commits.webkit.org/253373@main</a>
</pre>
