### PR TITLE
dom/xslt/transformToFragment.tentative.window.html WPT test is failing in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/transformToFragment.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/xslt/transformToFragment.tentative.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL internal script assert_true: script element from XSLTProcessor.transformToFragment() is evaluated expected true got undefined
-FAIL external script assert_true: script element from XSLTProcessor.transformToFragment() is evaluated expected true got undefined
+PASS internal script
+PASS external script
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1283,11 +1283,11 @@ RefPtr<DocumentFragment> createFragmentForTransformToFragment(Document& outputDo
         // Unfortunately, that's an implementation detail of the parser.
         // We achieve that effect here by passing in a fake body element as context for the fragment.
         auto fakeBody = HTMLBodyElement::create(outputDoc);
-        fragment->parseHTML(WTFMove(sourceString), fakeBody.ptr());
+        fragment->parseHTML(WTFMove(sourceString), fakeBody.ptr(), AllowScriptingContentAndDoNotMarkAlreadyStarted);
     } else if (sourceMIMEType == textPlainContentTypeAtom())
         fragment->parserAppendChild(Text::create(outputDoc, WTFMove(sourceString)));
     else {
-        bool successfulParse = fragment->parseXML(WTFMove(sourceString), 0);
+        bool successfulParse = fragment->parseXML(WTFMove(sourceString), nullptr, AllowScriptingContentAndDoNotMarkAlreadyStarted);
         if (!successfulParse)
             return nullptr;
     }


### PR DESCRIPTION
#### cafdf878d51c209e354d49e24f682dcb591ffb7c
<pre>
dom/xslt/transformToFragment.tentative.window.html WPT test is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243849">https://bugs.webkit.org/show_bug.cgi?id=243849</a>

Reviewed by Geoffrey Garen.

Per <a href="https://html.spec.whatwg.org/multipage/scripting.html#scriptTagXSLT">https://html.spec.whatwg.org/multipage/scripting.html#scriptTagXSLT</a>, XSLTProcessor transformToFragment()
should allow script elements and set their &quot;already started&quot; flag to false so that they will execute when
the fragment is inserted into a document.

This aligns our behavior with Blink and Gecko as they pass this WPT test.

* LayoutTests/imported/w3c/web-platform-tests/dom/xslt/transformToFragment.tentative.window-expected.txt:
* Source/WebCore/editing/markup.cpp:
(WebCore::createFragmentForTransformToFragment):

Canonical link: <a href="https://commits.webkit.org/253369@main">https://commits.webkit.org/253369@main</a>
</pre>
