### PR TITLE
[GTK] Fix build on macOS

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -29,6 +29,10 @@
 #include <string.h>
 #include <wtf/CheckedArithmetic.h>
 
+#if OS(DARWIN)
+#include <malloc/malloc.h>
+#endif
+
 #if OS(WINDOWS)
 #include <windows.h>
 #else

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -24,6 +24,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     )
 elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     list(APPEND WTF_PUBLIC_HEADERS
+        spi/darwin/OSVariantSPI.h
         spi/darwin/ProcessMemoryFootprint.h
     )
 endif ()

--- a/Source/WTF/wtf/RandomDevice.cpp
+++ b/Source/WTF/wtf/RandomDevice.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #if OS(DARWIN)
+#include <CommonCrypto/CommonCryptor.h>
 #include <CommonCrypto/CommonRandom.h>
 #endif
 

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -30,7 +30,7 @@
 #include <wtf/Lock.h>
 #include <wtf/StdLibExtras.h>
 
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
 #include <wtf/spi/cocoa/MachVMSPI.h>
 #include <mach/mach.h>
 #elif OS(LINUX)
@@ -62,7 +62,7 @@ namespace WTF {
 #if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 void setPermissionsOfConfigPage()
 {
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         mach_vm_address_t addr = bitwise_cast<uintptr_t>(static_cast<void*>(WebConfig::g_config));
@@ -86,7 +86,7 @@ void setPermissionsOfConfigPage()
 
         RELEASE_ASSERT(result == KERN_SUCCESS);
     });
-#endif // OS(DARWIN)
+#endif // PLATFORM(COCOA)
 }
 #endif // ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
 
@@ -107,7 +107,7 @@ void Config::permanentlyFreeze()
     int result = 0;
 
 #if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
     enum {
         AllowPermissionChangesAfterThis = false,
         DisallowPermissionChangesAfterThis = true

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -44,7 +44,7 @@
 #endif // OS(DARWIN)
 #endif // ENABLE(JIT_CAGE)
 
-#if OS(DARWIN)
+#if PLATFORM(COCOA)
 #include <wtf/spi/cocoa/MachVMSPI.h>
 #endif
 


### PR DESCRIPTION
#### 6bb3f1342f342358061b525c7b8f077b7b5ed15b
<pre>
[GTK] Fix build on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243759">https://bugs.webkit.org/show_bug.cgi?id=243759</a>

Reviewed by Yusuke Suzuki.

This attempts to fix the WebKitGTK build on macOS. The patch is
contributed by echassiers.09-regards@icloud.com.

* Source/WTF/wtf/FastMalloc.cpp:
* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/RandomDevice.cpp:
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::setPermissionsOfConfigPage):
(WTF::Config::permanentlyFreeze):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:

Canonical link: <a href="https://commits.webkit.org/253367@main">https://commits.webkit.org/253367@main</a>
</pre>
