### PR TITLE
[Gardening]: REBASELINE: [ iOS macOS wk2 Release ] imported/w3c/web-platform-tests/html/dom/idlharness.https.html is a constant failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: [blocked] The page at https://localhost:9443/html/dom/idlharness.https.html was not allowed to display insecure content from http://invalid/.
-
-CONSOLE MESSAGE: Not allowed to request resource
-CONSOLE MESSAGE: EventSource cannot load http://invalid/ due to access control checks.
 HTML IDL tests
 
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -5901,3 +5901,4 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
+

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2307,5 +2307,3 @@ webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/se
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/registration-updateviacache.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/service-worker-header.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html [ Pass Crash ]
-
-webkit.org/b/243841 [ Release ] imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Pass Failure ]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -5891,3 +5891,4 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
+

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -95,8 +95,6 @@ media/remove-video-element-in-pip-from-document.html [ Pass ]
 
 webkit.org/b/228622 [ Debug ] accessibility/ios-simulator/scroll-in-overflow-div.html [ Crash ]
 
-webkit.org/b/197960 imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Pass Failure ]
-
 webkit.org/b/228663 fast/canvas/canvas-color-space-display-p3.html [ ImageOnlyFailure ]
 
 webkit.org/b/231611 [ Debug ] imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html [ Pass Failure ]

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -5890,3 +5890,4 @@ PASS Document interface: documentWithHandlers must inherit property "oncut" with
 PASS Document interface: documentWithHandlers must inherit property "onpaste" with the proper type
 PASS Document interface: documentWithHandlers must inherit property "activeElement" with the proper type
 PASS ShadowRoot interface: attribute activeElement
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1721,5 +1721,3 @@ webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/se
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/registration-updateviacache.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/service-worker-header.https.html [ Pass Crash ]
 webkit.org/b/243589 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html [ Pass Crash ]
-
-webkit.org/b/243841 [ Release ] imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Pass Failure ]


### PR DESCRIPTION
#### 09c2c778f76ac8604bc7a997646d32f5a64fdfb3
<pre>
[Gardening]: REBASELINE: [ iOS macOS wk2 Release ] imported/w3c/web-platform-tests/html/dom/idlharness.https.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243852">https://bugs.webkit.org/show_bug.cgi?id=243852</a>

Unreviewed test gardening.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253351@main">https://commits.webkit.org/253351@main</a>
</pre>
