### PR TITLE
Stop calling plugInViewWithArguments: to load legacy WebKit plug ins

### DIFF
--- a/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
@@ -103,60 +103,11 @@ static RetainPtr<NSMutableSet>& pluginViews()
     return pluginViews;
 }
 
-#if PLATFORM(IOS_FAMILY)
-static void initializeAudioSession()
-{
-    static bool wasAudioSessionInitialized;
-    if (wasAudioSessionInitialized)
-        return;
-
-    wasAudioSessionInitialized = true;
-    if (!WebCore::IOSApplication::isMobileSafari())
-        return;
-
-    WebCore::AudioSession::sharedSession().setCategory(WebCore::AudioSession::CategoryType::MediaPlayback, WebCore::RouteSharingPolicy::Default);
-}
-#endif
-
 @implementation WebPluginController
 
 - (NSView *)plugInViewWithArguments:(NSDictionary *)arguments fromPluginPackage:(WebPluginPackage *)pluginPackage
 {
-#if PLATFORM(IOS_FAMILY)
-    initializeAudioSession();
-#endif
-
-    [pluginPackage load];
-
-    NSView *view = nil;
-
-#if PLATFORM(IOS_FAMILY)
-    {
-        WebView *webView = [_documentView _webView];
-        JSC::JSLock::DropAllLocks dropAllLocks(WebCore::commonVM());
-        view = [[webView _UIKitDelegateForwarder] webView:webView plugInViewWithArguments:arguments fromPlugInPackage:pluginPackage];
-    }
-#else
-    Class viewFactory = [pluginPackage viewFactory];
-    if ([viewFactory respondsToSelector:@selector(plugInViewWithArguments:)]) {
-        JSC::JSLock::DropAllLocks dropAllLocks(WebCore::commonVM());
-        view = [viewFactory plugInViewWithArguments:arguments];
-    } else if ([viewFactory respondsToSelector:@selector(pluginViewWithArguments:)]) {
-        JSC::JSLock::DropAllLocks dropAllLocks(WebCore::commonVM());
-        view = [viewFactory pluginViewWithArguments:arguments];
-    }
-#endif
-
-    if (view == nil) {
-        return nil;
-    }
-    
-    auto& views = pluginViews();
-    if (!views)
-        views = adoptNS([[NSMutableSet alloc] init]);
-    [views addObject:view];
-
-    return view;
+    return nil;
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1704,8 +1704,9 @@ IGNORE_WARNINGS_END
         };
         LOG(Plugins, "arguments:\n%@", arguments);
     }
+    (void)arguments;
 
-    return [pluginController plugInViewWithArguments:arguments fromPluginPackage:pluginPackage];
+    return nil;
 }
 
 class PluginWidget : public WebCore::PluginViewBase {


### PR DESCRIPTION
#### ed8fb0f71e754c7f4146ad6f4378bcdcc4748f7d
<pre>
Stop calling plugInViewWithArguments: to load legacy WebKit plug ins
<a href="https://bugs.webkit.org/show_bug.cgi?id=243857">https://bugs.webkit.org/show_bug.cgi?id=243857</a>

Reviewed by Geoffrey Garen.

* Source/WebKitLegacy/mac/Plugins/WebPluginController.mm:
(-[WebPluginController plugInViewWithArguments:fromPluginPackage:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(pluginView):

Canonical link: <a href="https://commits.webkit.org/253366@main">https://commits.webkit.org/253366@main</a>
</pre>
