### PR TITLE
Web Inspector: Elements Tab: add a navigation item to control what badges are shown

### DIFF
--- a/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
@@ -142,6 +142,8 @@ PASS: toggleIncludes of an existing item with force true should have no effect.
 PASS: toggleIncludes of an existing item with force false should remove the item.
 PASS: toggleIncludes of a nonexistent item with force true should add the item.
 PASS: toggleIncludes of a nonexistent item with force false should have no effect.
+PASS: toggleIncludes with no 'force' should add the item if it's not present.
+PASS: toggleIncludes with no 'force' should remove the item if it's present.
 
 -- Running test case: Array.prototype.insertAtIndex
 PASS: insertAtIndex with index unspecified should insert at the beginning.

--- a/LayoutTests/inspector/unit-tests/array-utilities.html
+++ b/LayoutTests/inspector/unit-tests/array-utilities.html
@@ -309,6 +309,12 @@ function test()
             arr4.toggleIncludes(4, false);
             InspectorTest.expectShallowEqual(arr4, [1, 2, 3], "toggleIncludes of a nonexistent item with force false should have no effect.");
 
+            let arr5 = [1, 2, 3];
+            arr5.toggleIncludes(4);
+            InspectorTest.expectShallowEqual(arr5, [1, 2, 3, 4], "toggleIncludes with no 'force' should add the item if it's not present.");
+            arr5.toggleIncludes(4);
+            InspectorTest.expectShallowEqual(arr5, [1, 2, 3], "toggleIncludes with no 'force' should remove the item if it's present.");
+
             return true;
         }
     });

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -232,6 +232,8 @@ localizedStrings["Average: %s"] = "Average: %s";
 localizedStrings["BMP"] = "BMP";
 localizedStrings["Back (%s)"] = "Back (%s)";
 localizedStrings["Backtrace"] = "Backtrace";
+/* Label for navigation item that controls what badges are shown in the main DOM tree. */
+localizedStrings["Badges @ Elements Tab"] = "Badges";
 localizedStrings["Basic"] = "Basic";
 /* Section title for basic font properties. */
 localizedStrings["Basic Properties @ Font Details Sidebar Section"] = "Basic Properties";
@@ -321,6 +323,7 @@ localizedStrings["Child"] = "Child";
 localizedStrings["Child Layers"] = "Child Layers";
 localizedStrings["Child added to "] = "Child added to ";
 localizedStrings["Children"] = "Children";
+localizedStrings["Choose which badges are shown in the DOM tree"] = "Choose which badges are shown in the DOM tree";
 localizedStrings["Cipher"] = "Cipher";
 localizedStrings["Clamp to sRGB"] = "Clamp to sRGB";
 localizedStrings["Classes"] = "Classes";
@@ -629,6 +632,8 @@ localizedStrings["Enable paint flashing"] = "Enable paint flashing";
 localizedStrings["Enable source maps"] = "Enable source maps";
 localizedStrings["Enable:"] = "Enable:";
 localizedStrings["Enabled"] = "Enabled";
+/* Label for column showing the list of enabled timelines. */
+localizedStrings["Enabled Timelines @ Timelines Tab"] = "Enabled Timelines";
 localizedStrings["Encoded"] = "Encoded";
 localizedStrings["Encoding"] = "Encoding";
 localizedStrings["Energy Impact"] = "Energy Impact";

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -759,7 +759,8 @@ Object.defineProperty(Array.prototype, "toggleIncludes",
     value(value, force)
     {
         let exists = this.includes(value);
-        if (exists === !!force)
+
+        if (force !== undefined && exists === !!force)
             return;
 
         if (exists)

--- a/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css
@@ -58,10 +58,6 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.content-view.audit .message-text-view .navigation-item-help:is(.start-editing-audits, .stop-editing-audits) .navigation-bar {
-    --navigation-item-help-navigation-bar-vertical-align: 0.5px;
-}
-
 .content-view.tab.audit .content-view > .audit-version {
     position: absolute;
     right: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.js
@@ -59,7 +59,7 @@ WI.AuditNavigationSidebarPanel = class AuditNavigationSidebarPanel extends WI.Na
             createAuditHelpElement.classList.add("create-audit");
             contentPlaceholder.appendChild(createAuditHelpElement);
 
-            let stopEditingAuditsNavigationItem = new WI.ButtonNavigationItem("stop-editing-audits", WI.UIString("Done"));
+            let stopEditingAuditsNavigationItem = new WI.ButtonNavigationItem("stop-editing-audits", WI.UIString("Done"), "Images/Pencil.svg", 16, 16);
             stopEditingAuditsNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleEditButtonNavigationItemClicked, this);
 
             let stopEditingAuditsHelpElement = WI.createNavigationItemHelp(WI.UIString("Press %s to stop editing audits."), stopEditingAuditsNavigationItem);
@@ -86,7 +86,7 @@ WI.AuditNavigationSidebarPanel = class AuditNavigationSidebarPanel extends WI.Na
             importAuditHelpElement.classList.add("import-audit");
             contentPlaceholder.appendChild(importAuditHelpElement);
 
-            let startEditingAuditsNavigationItem = new WI.ButtonNavigationItem("start-editing-audits", WI.UIString("Edit"));
+            let startEditingAuditsNavigationItem = new WI.ButtonNavigationItem("start-editing-audits", WI.UIString("Edit"), "Images/Pencil.svg", 16, 16);
             startEditingAuditsNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleEditButtonNavigationItemClicked, this);
 
             let startEditingAuditsHelpElement = WI.createNavigationItemHelp(hasEnabledAudit ? WI.UIString("Press %s to start editing audits.") : WI.UIString("Press %s to enable audits."), startEditingAuditsNavigationItem);
@@ -154,7 +154,7 @@ WI.AuditNavigationSidebarPanel = class AuditNavigationSidebarPanel extends WI.Na
 
         this.addSubview(controlsNavigationBar);
 
-        this._editButtonNavigationItem = new WI.ActivateButtonNavigationItem("edit-audits", WI.UIString("Edit"), WI.UIString("Done"));
+        this._editButtonNavigationItem = new WI.ActivateButtonNavigationItem("edit-audits", WI.UIString("Edit"), WI.UIString("Done"), "Images/Pencil.svg", 16, 16);
         this._editButtonNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleEditButtonNavigationItemClicked, this);
         this.filterBar.addFilterNavigationItem(this._editButtonNavigationItem);
 

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
@@ -55,8 +55,8 @@
 }
 
 .navigation-bar .item.button.text-only {
-    padding: 1px 8px 3px;
-    margin: 0 2px; /* WI.ButtonNavigationItem.prototype.get totalMargin */
+    padding: 1px 4px 3px;
+    margin: 0 2px; /* WI.ButtonNavigationItem.prototype.get textMargin */
 
     height: initial;
     line-height: 11px;

--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js
@@ -163,10 +163,14 @@ WI.ButtonNavigationItem = class ButtonNavigationItem extends WI.NavigationItem
 
     get totalMargin()
     {
-        let totalMargin = super.totalMargin;
+        return super.totalMargin + this.textMargin;
+    }
+
+    get textMargin()
+    {
         if (this._buttonStyle === ButtonNavigationItem.Style.Text)
-            return totalMargin + 4; /* .navigation-bar .item.button.text-only */
-        return totalMargin;
+            return 4; /* .navigation-bar .item.button.text-only */
+        return 0;
     }
 
     get additionalClassNames()

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css
@@ -23,6 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.item.button.text-only.configure-dom-tree-badges {
+    border-color: var(--border-color);
+}
+
+.item.button.text-only.configure-dom-tree-badges:hover {
+    background-color: var(--background-color-alternate);
+}
+
 .content-view.dom-tree {
     overflow: auto;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -31,6 +31,14 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
 
         super(representedObject);
 
+        // COMPATIBILITY (macOS 12.0, iOS 15.0): CSS.nodeLayoutContextTypeChanged did not exist yet.
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): CSS.nodeLayoutContextTypeChanged was renamed/expanded to CSS.nodeLayoutFlagsChanged.
+        this._configureDOMTreeBadgesNavigationItem = new WI.ButtonNavigationItem("configure-dom-tree-badges", WI.UIString("Badges", "Badges @ Elements Tab", "Label for navigation item that controls what badges are shown in the main DOM tree."));
+        this._configureDOMTreeBadgesNavigationItem.tooltip = WI.UIString("Choose which badges are shown in the DOM tree");
+        this._configureDOMTreeBadgesNavigationItem.enabled = InspectorBackend.hasEvent("CSS.nodeLayoutFlagsChanged") || InspectorBackend.hasEvent("CSS.nodeLayoutContextTypeChanged");
+        this._configureDOMTreeBadgesNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
+        WI.addMouseDownContextMenuHandlers(this._configureDOMTreeBadgesNavigationItem.element, this._populateConfigureDOMTreeBadgesNavigationItemContextMenu.bind(this));
+
         // COMPATIBILITY (iOS 12)
         WI.settings.showRulers.addEventListener(WI.Setting.Event.Changed, this._showRulersChanged, this);
         this._showRulersButtonNavigationItem = new WI.ActivateButtonNavigationItem("show-rulers", WI.UIString("Show rulers"), WI.UIString("Hide rulers"), "Images/Rulers.svg", 16, 16);
@@ -63,7 +71,7 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
         this.element.classList.add("dom-tree");
         this.element.addEventListener("click", this._mouseWasClicked.bind(this), false);
 
-        this._domTreeOutline = new WI.DOMTreeOutline({omitRootDOMNode: true, excludeRevealElementContextMenu: true, showInspectedNode: true});
+        this._domTreeOutline = new WI.DOMTreeOutline({omitRootDOMNode: true, excludeRevealElementContextMenu: true, showInspectedNode: true, showBadges: true});
         this._domTreeOutline.allowsEmptySelection = false;
         this._domTreeOutline.allowsMultipleSelection = true;
         this._domTreeOutline.addEventListener(WI.TreeOutline.Event.ElementAdded, this._domTreeElementAdded, this);
@@ -108,6 +116,7 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
     get navigationItems()
     {
         return [
+            this._configureDOMTreeBadgesNavigationItem,
             this._showRulersButtonNavigationItem,
             this._showPrintStylesButtonNavigationItem,
             this._forceAppearanceButtonNavigationItem,
@@ -490,6 +499,28 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
             WI.domManager.pushNodeByPathToFrontend(this._lastSelectedNodePathSetting.value.path, selectLastSelectedNode.bind(this));
         else
             selectNode.call(this);
+    }
+
+    _populateConfigureDOMTreeBadgesNavigationItemContextMenu(contextMenu)
+    {
+        if (!this._configureDOMTreeBadgesNavigationItem.enabled)
+            return;
+
+        // COMPATIBILITY (iOS 14.5): `DOM.showGridOverlay` did not exist yet.
+        if (InspectorBackend.hasCommand("DOM.showGridOverlay")) {
+            contextMenu.appendCheckboxItem(WI.unlocalizedString("grid"), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.Grid);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Grid));
+        }
+
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): `DOM.showFlexOverlay` did not exist yet.
+        if (InspectorBackend.hasCommand("DOM.showFlexOverlay")) {
+            contextMenu.appendCheckboxItem(WI.unlocalizedString("flex"), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.Flex);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Flex));
+        }
     }
 
     _domTreeElementAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.tree-outline.dom .layout-badge {
+.tree-outline.dom .badge {
     /* Using sans-serif San Francisco font here creates a badge 1px taller than the selected
     area. Use the same monospace font as the rest of the DOM tree outline. */
 
@@ -38,19 +38,19 @@
     box-shadow: 0 0 1px hsla(0, 0%, 0%, 0.5);
 }
 
-.tree-outline.dom .layout-badge.activated {
+.tree-outline.dom .badge.activated {
     background: var(--glyph-color-active);
     color: white;
 }
 
-body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.selected .layout-badge {
+body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.selected .badge {
     /* Override `li.selected * {color: inherited}` from DOMTreeOutline.css */
     color: var(--text-color);
 }
 
 
 @media (prefers-color-scheme: dark) {
-    .tree-outline.dom .layout-badge {
+    .tree-outline.dom .badge {
         background: hsla(0, 0%, 30%, 0.8);
         border-color: hsla(0, 0%, 100%, 0.1);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -30,7 +30,7 @@
 
 WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 {
-    constructor(node, elementCloseTag)
+    constructor(node, elementCloseTag, {showBadges} = {})
     {
         super("", node);
 
@@ -51,7 +51,9 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         this._highlightedAttributes = new Set;
         this._recentlyModifiedAttributes = new Map;
         this._closeTagTreeElement = null;
-        this._layoutBadgeElement = null;
+
+        this._showBadges = !!showBadges;
+        this._elementForBadgeType = new Map;
 
         node.addEventListener(WI.DOMNode.Event.EnabledPseudoClassesChanged, this._updatePseudoClassIndicator, this);
 
@@ -444,19 +446,21 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             this.listItemElement.addEventListener("dragstart", this);
         }
 
+        WI.settings.enabledDOMTreeBadgeTypes.addEventListener(WI.Setting.Event.Changed, this._handleShownDOMTreeBadgesChanged, this);
+
         this.representedObject.addEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
         this._handleLayoutFlagsChanged();
-
-        this._updateLayoutBadge();
     }
 
     ondetach()
     {
-        if (this.representedObject.layoutContextType && !this._elementCloseTag) {
-            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
+        if (this._elementForBadgeType.size) {
+            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateBadges, this);
+            this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateBadges, this);
         }
         this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutFlagsChanged, this._handleLayoutFlagsChanged, this);
+
+        WI.settings.enabledDOMTreeBadgeTypes.removeEventListener(WI.Setting.Event.Changed, this._handleShownDOMTreeBadgesChanged, this);
     }
 
     onpopulate()
@@ -482,7 +486,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     insertChildElement(child, index, closingTag)
     {
-        var newElement = new WI.DOMTreeElement(child, closingTag);
+        var newElement = new WI.DOMTreeElement(child, closingTag, {showBadges: this._showBadges});
         newElement.selectable = this.treeOutline.selectable;
         this.insertChild(newElement, index);
         return newElement;
@@ -1331,7 +1335,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             this.title.appendChild(this._nodeTitleInfo().titleDOM);
             this._highlightResult = undefined;
         }
-        this._updateLayoutBadge();
+        this._createBadges();
 
         // Setting this.title will implicitly remove all children. Clear the
         // selection element so that we properly recreate it if necessary.
@@ -2007,52 +2011,77 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         this._animatingHighlight = false;
     }
 
-    _updateLayoutBadge()
+    _createBadge(badgeType)
     {
-        if (!this.listItemElement || this._elementCloseTag)
+        console.assert(!this._elementForBadgeType.has(badgeType), badgeType);
+
+        if (!badgeType || !WI.settings.enabledDOMTreeBadgeTypes.value.includes(badgeType))
             return;
 
-        let hadLayoutBadge = !!this._layoutBadgeElement;
+        let text = "";
+        let handleClick = null;
 
-        if (this._layoutBadgeElement) {
-            this._layoutBadgeElement.remove();
-            this._layoutBadgeElement = null;
+        switch (badgeType) {
+        case WI.DOMTreeElement.BadgeType.Flex:
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Grid));
+            text = WI.unlocalizedString("flex");
+            handleClick = this._layoutBadgeClicked.bind(this);
+            break;
+
+        case WI.DOMTreeElement.BadgeType.Grid:
+            console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Flex));
+            text = WI.unlocalizedString("grid");
+            handleClick = this._layoutBadgeClicked.bind(this);
+            break;
         }
 
-        if (!this.representedObject.layoutContextType) {
-            if (hadLayoutBadge) {
-                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
+        let badgeElement = this.title.appendChild(document.createElement("span"));
+        badgeElement.className = "badge";
+        badgeElement.textContent = text;
+        if (handleClick) {
+            badgeElement.addEventListener("click", handleClick, true);
+            badgeElement.addEventListener("dblclick", this._layoutBadgeDoubleClicked, true);
+        }
+        this._elementForBadgeType.set(badgeType, badgeElement);
+    }
+
+    _createBadges()
+    {
+        if (!this._showBadges || !this.listItemElement || this._elementCloseTag)
+            return;
+
+        let hadBadge = this._elementForBadgeType.size;
+
+        for (let badgeElement of this._elementForBadgeType.values())
+            badgeElement.remove();
+        this._elementForBadgeType.clear();
+
+        for (let layoutFlag of this.representedObject.layoutFlags) {
+            switch (layoutFlag) {
+            case WI.DOMNode.LayoutFlag.Grid:
+                this._createBadge(WI.DOMTreeElement.BadgeType.Grid);
+                break;
+
+            case WI.DOMNode.LayoutFlag.Flex:
+                this._createBadge(WI.DOMTreeElement.BadgeType.Flex);
+                break;
+            }
+        }
+
+        if (!this._elementForBadgeType.size) {
+            if (hadBadge) {
+                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateBadges, this);
+                this.representedObject.removeEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateBadges, this);
             }
             return;
         }
 
-        if (!hadLayoutBadge) {
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateLayoutBadgeStatus, this);
-            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateLayoutBadgeStatus, this);
+        if (!hadBadge) {
+            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayShown, this._updateBadges, this);
+            this.representedObject.addEventListener(WI.DOMNode.Event.LayoutOverlayHidden, this._updateBadges, this);
         }
 
-        this._layoutBadgeElement = this.title.appendChild(document.createElement("span"));
-        this._layoutBadgeElement.className = "layout-badge";
-
-        switch (this.representedObject.layoutContextType) {
-        case WI.DOMNode.LayoutFlag.Grid:
-            this._layoutBadgeElement.textContent = WI.unlocalizedString("grid");
-            break;
-
-        case WI.DOMNode.LayoutFlag.Flex:
-            this._layoutBadgeElement.textContent = WI.unlocalizedString("flex");
-            break;
-
-        default:
-            console.assert(false, this.representedObject.layoutContextType);
-            break;
-        }
-
-        this._updateLayoutBadgeStatus();
-
-        this._layoutBadgeElement.addEventListener("click", this._layoutBadgeClicked.bind(this), true);
-        this._layoutBadgeElement.addEventListener("dblclick", this._layoutBadgeDoubleClicked, true);
+        this._updateBadges();
     }
 
     _layoutBadgeClicked(event)
@@ -2074,29 +2103,38 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         event.stop();
     }
 
-    _updateLayoutBadgeStatus()
+    _updateBadges()
     {
-        if (!this._layoutBadgeElement)
-            return;
-
-        let hasVisibleOverlay = this.representedObject.layoutOverlayShowing;
-        this._layoutBadgeElement.classList.toggle("activated", hasVisibleOverlay);
-
-        if (hasVisibleOverlay) {
-            let color = this.representedObject.layoutOverlayColor;
-            let hue = color.hsl[0];
-            this._layoutBadgeElement.style.borderColor = color.toString();
-            this._layoutBadgeElement.style.backgroundColor = `hsl(${hue}, 90%, 95%)`;
-            this._layoutBadgeElement.style.setProperty("color", `hsl(${hue}, 55%, 40%)`);
-        } else
-            this._layoutBadgeElement.removeAttribute("style");
+        for (let [badgeType, badgeElement] of this._elementForBadgeType) {
+            switch (badgeType) {
+            case WI.DOMTreeElement.BadgeType.Grid:
+            case WI.DOMTreeElement.BadgeType.Flex: {
+                let layoutOverlayShowing = this.representedObject.layoutOverlayShowing;
+                badgeElement.classList.toggle("activated", layoutOverlayShowing);
+                if (layoutOverlayShowing) {
+                    let color = this.representedObject.layoutOverlayColor;
+                    let hue = color.hsl[0];
+                    badgeElement.style.borderColor = color.toString();
+                    badgeElement.style.backgroundColor = `hsl(${hue}, 90%, 95%)`;
+                    badgeElement.style.setProperty("color", `hsl(${hue}, 55%, 40%)`);
+                } else
+                    badgeElement.removeAttribute("style");
+                break;
+            }
+            }
+        }
     }
 
     _handleLayoutFlagsChanged(event)
     {
         this.listItemElement?.classList.toggle("rendered", this.representedObject.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered));
 
-        this._updateLayoutBadge();
+        this._createBadges();
+    }
+
+    _handleShownDOMTreeBadgesChanged(event)
+    {
+        this._createBadges();
     }
 };
 
@@ -2121,6 +2159,12 @@ WI.DOMTreeElement.BreakpointStatus = {
     Breakpoint: Symbol("breakpoint"),
     DisabledBreakpoint: Symbol("disabled-breakpoint"),
 };
+
+WI.DOMTreeElement.BadgeType = {
+    Flex: "flex",
+    Grid: "grid",
+};
+WI.settings.enabledDOMTreeBadgeTypes = new WI.Setting("enabled-dom-tree-badge-types", [WI.DOMTreeElement.BadgeType.Flex, WI.DOMTreeElement.BadgeType.Grid]);
 
 WI.DOMTreeElement.HighlightStyleClassName = "highlight";
 WI.DOMTreeElement.SearchHighlightStyleClassName = "search-highlight";

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -30,7 +30,7 @@
 
 WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 {
-    constructor({selectable, omitRootDOMNode, excludeRevealElementContextMenu, showInspectedNode} = {})
+    constructor({selectable, omitRootDOMNode, excludeRevealElementContextMenu, showInspectedNode, showBadges} = {})
     {
         super(selectable);
 
@@ -64,6 +64,8 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
         this._showInspectedNode = !!showInspectedNode;
         if (this._showInspectedNode)
             WI.domManager.addEventListener(WI.DOMManager.Event.InspectedNodeChanged, this._handleInspectedNodeChanged, this);
+
+        this._showBadges = !!showBadges;
     }
 
     // Public
@@ -171,16 +173,18 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 
         this.removeChildren();
 
+        const elementCloseTag = false;
+
         var treeElement;
         if (this._includeRootDOMNode) {
-            treeElement = new WI.DOMTreeElement(this.rootDOMNode);
+            treeElement = new WI.DOMTreeElement(this.rootDOMNode, elementCloseTag, {showBadges: this._showBadges});
             treeElement.selectable = this.selectable;
             this.appendChild(treeElement);
         } else {
             // FIXME: this could use findTreeElement to reuse a tree element if it already exists
             var node = this.rootDOMNode.firstChild;
             while (node) {
-                treeElement = new WI.DOMTreeElement(node);
+                treeElement = new WI.DOMTreeElement(node, elementCloseTag, {showBadges: this._showBadges});
                 treeElement.selectable = this.selectable;
                 this.appendChild(treeElement);
                 node = node.nextSibling;

--- a/Source/WebInspectorUI/UserInterface/Views/HierarchicalPathNavigationItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HierarchicalPathNavigationItem.js
@@ -140,7 +140,7 @@ WI.HierarchicalPathNavigationItem = class HierarchicalPathNavigationItem extends
             if (navigationBar.navigationItems[i] instanceof WI.FlexibleSpaceNavigationItem)
                 continue;
 
-            totalOtherItemsWidth += navigationBar.navigationItems[i].element.realOffsetWidth;
+            totalOtherItemsWidth += navigationBar.navigationItems[i].width;
         }
 
         // Calculate the width for all the components.

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -226,7 +226,7 @@ body.docked:matches(.right, .left) #navigation-sidebar.collapsed > .resizer {
     display: inline-flex;
     height: 20px;
     border-bottom: none;
-    vertical-align: var(--navigation-item-help-navigation-bar-vertical-align, sub);
+    vertical-align: sub;
 }
 
 .navigation-item-help > .navigation-bar > .item.button {

--- a/Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css
@@ -32,3 +32,11 @@
     color: hsl(0, 0%, 18%);
     text-align: center;
 }
+
+.navigation-bar .item:first-child.text {
+    padding-inline-start: 2px;
+}
+
+.navigation-bar .item:last-child.text {
+    padding-inline-end: 2px;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.css
@@ -27,8 +27,11 @@
     width: auto;
     height: 17px;
     margin: auto;
-    margin-left: 8px;
-    margin-right: 8px;
+    margin-inline: 5px; /* WI.TextToggleButtonNavigationItem.prototype.get textMargin */
+}
+
+.navigation-bar .item.text-toggle.button.text-only:not(:hover, .selected) {
+    border-color: var(--border-color);
 }
 
 .navigation-bar .item.text-toggle.button.text-only:hover {

--- a/Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.js
@@ -54,6 +54,11 @@
 
         // Protected
 
+        get textMargin()
+        {
+            return 10; /* .navigation-bar .item.text-toggle.button.text-only */
+        }
+
         get additionalClassNames()
         {
             return ["text-toggle", "button"];

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -48,6 +48,11 @@
     border-bottom: 1px solid var(--border-color);
 }
 
+.navigation-bar.timelines .item.text.enabled-timelines {
+    font-style: italic;
+    color: hsl(0, 0%, 50%);
+}
+
 .navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):matches(:focus, .activate.activated, .radio.selected) {
     color: var(--glyph-color-active);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js
@@ -55,13 +55,14 @@ WI.TimelineOverview = class TimelineOverview extends WI.View
         this._selectedTimelineRecord = null;
         this._overviewGraphsByTypeMap = new Map;
 
-        this._editInstrumentsButton = new WI.ActivateButtonNavigationItem("toggle-edit-instruments", WI.UIString("Edit configuration"), WI.UIString("Save configuration"));
+        this._editInstrumentsButton = new WI.ActivateButtonNavigationItem("toggle-edit-instruments", WI.UIString("Edit configuration"), WI.UIString("Save configuration"), "Images/Pencil.svg", 16, 16);
         this._editInstrumentsButton.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._toggleEditingInstruments, this);
         this._editingInstruments = false;
         this._updateEditInstrumentsButton();
 
         let instrumentsNavigationBar = new WI.NavigationBar;
         instrumentsNavigationBar.element.classList.add("timelines");
+        instrumentsNavigationBar.addNavigationItem(new WI.TextNavigationItem("enabled-timelines", WI.UIString("Enabled Timelines", "Enabled Timelines @ Timelines Tab", "Label for column showing the list of enabled timelines.")));
         instrumentsNavigationBar.addNavigationItem(new WI.FlexibleSpaceNavigationItem);
         instrumentsNavigationBar.addNavigationItem(this._editInstrumentsButton);
         this.addSubview(instrumentsNavigationBar);


### PR DESCRIPTION
#### 5c3f6f4a6d39f6ff0fd12999c8ba73abe94d0124
<pre>
Web Inspector: Elements Tab: add a navigation item to control what badges are shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=243858">https://bugs.webkit.org/show_bug.cgi?id=243858</a>

Reviewed by Patrick Angle.

This will allow us to add more badges (e.g. &quot;Scroll&quot;, &quot;Events&quot;, etc.) without overloading the DOM
tree with too many badges, as developers can turn off ones they do not find useful.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView):
(WI.DOMTreeContentView.prototype.get navigationItems):
(WI.DOMTreeContentView.prototype.attached):
(WI.DOMTreeContentView.prototype.detached):
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu): Added.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.css:
(.item.button.text-only.configure-dom-tree-badges): Added.
(.item.button.text-only.configure-dom-tree-badges:hover): Added.
The &quot;Badges&quot; navigation item will show a contextmenu containing checkbox items for each type of DOM
tree badge. If any badges are selected, the navigation item is considered activated. Currently there
are only two badges: &quot;flex&quot; and &quot;grid&quot;.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement):
(WI.DOMTreeElement.prototype.onattach):
(WI.DOMTreeElement.prototype.ondetach):
(WI.DOMTreeElement.prototype.insertChildElement):
(WI.DOMTreeElement.prototype.updateTitle):
(WI.DOMTreeElement.prototype._createBadge): Added.
(WI.DOMTreeElement.prototype._createBadges): Added.
(WI.DOMTreeElement.prototype._updateBadges): Added.
(WI.DOMTreeElement.prototype._handleLayoutFlagsChanged):
(WI.DOMTreeElement.prototype._handleShownDOMTreeBadgesChanged): Added.
(WI.DOMTreeElement.prototype._updateLayoutBadge): Deleted.
(WI.DOMTreeElement.prototype._updateLayoutBadgeStatus): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.css:
(.tree-outline.dom .badge): Renamed from `.tree-outline.dom .layout-badge`.
(.tree-outline.dom .badge.activated): Renamed from `.tree-outline.dom .layout-badge.activated`.
(body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.selected .badge): Renamed from `body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.selected .layout-badge`.
(@media (prefers-color-scheme: dark) .tree-outline.dom .badge): Renamed from `@media (prefers-color-scheme: dark) .tree-outline.dom .layout-badge`.
Rework how badges are created to first check that the desired badge is allowed based on the current
selections from the above navigation item. Also don&apos;t assume that there is only one badge.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype.update):
Add a `showBadges` constructor option that controls whether any child `WI.DOMTreeElement` will even
try to create a badge. This ensures that badges are only created in the DOM tree in the Elements Tab.

* Source/WebInspectorUI/UserInterface/Views/HierarchicalPathNavigationItem.js:
(WI.HierarchicalPathNavigationItem.prototype.update):
Drive-by: Use `.width` instead of `.element.realOffsetWidth` as the former includes any CSS margins.

* Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.js:
(WI.ButtonNavigationItem.prototype.get totalMargin):
(WI.ButtonNavigationItem.prototype.get textMargin): Added.
* Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css:
(.navigation-bar .item.button.text-only):
* Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.js:
(WI.TextToggleButtonNavigationItem.prototype.get textMargin): Added.
* Source/WebInspectorUI/UserInterface/Views/TextToggleButtonNavigationItem.css:
(.navigation-bar .item.text-toggle.button.text-only):
(.navigation-bar .item.text-toggle.button.text-only:not(:hover, .selected)): Added.
Drive-by: Decrease text toggle `margin` and `padding` to better match text button.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.js:
(WI.TimelineOverview):
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(.navigation-bar.timelines .item.text.enabled-timelines): Added.
* Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.js:
(WI.AuditNavigationSidebarPanel.prototype.showDefaultContentView):
(WI.AuditNavigationSidebarPanel.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css:
(.content-view.audit .message-text-view .navigation-item-help:is(.start-editing-audits, .stop-editing-audits) .navigation-bar): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(.navigation-item-help &gt; .navigation-bar):
Drive-by: Add an icon for all other text buttons.

* Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css:
(.navigation-bar .item:first-child.text): Added.
(.navigation-bar .item:last-child.text): Added.
Drive-by: Don&apos;t add so much padding if the text is at the beginning/end of the `WI.NavigationBar`.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(Array.prototype.toggleIncludes):
* LayoutTests/inspector/unit-tests/array-utilities.html:
* LayoutTests/inspector/unit-tests/array-utilities-expected.txt:
Drive-by: Allow not passing a `force`, which behaves like a flip-flop.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/253579@main">https://commits.webkit.org/253579@main</a>
</pre>






















<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ddef6f48509c021a045c35fb92b3a203a858116

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30380 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95304 "Built successfully") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/149015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28784 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90548 "failed Failed to checkout and rebase branch from PR 3251") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92075 "Passed tests") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/78613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26691 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26605 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28284 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/985 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28225 "Built successfully") | [✅ ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/17426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->