### PR TITLE
Web Inspector: Network Tab: add reference page links

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
+++ b/Source/WebInspectorUI/UserInterface/Base/ReferencePage.js
@@ -93,6 +93,14 @@ WI.ReferencePage.LayersTab = new WI.ReferencePage("layers-tab");
 WI.ReferencePage.LocalOverrides = new WI.ReferencePage("local-overrides");
 WI.ReferencePage.LocalOverrides.ConfiguringLocalOverrides = new WI.ReferencePage(WI.ReferencePage.LocalOverrides, {topic: "configuring-local-overrides"});
 
+WI.ReferencePage.NetworkTab = new WI.ReferencePage("network-tab");
+WI.ReferencePage.NetworkTab.CookiesPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "cookies-pane"});
+WI.ReferencePage.NetworkTab.HeadersPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "headers-pane"});
+WI.ReferencePage.NetworkTab.PreviewPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "preview-pane"});
+WI.ReferencePage.NetworkTab.SecurityPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "security-pane"});
+WI.ReferencePage.NetworkTab.SizesPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "sizes-pane"});
+WI.ReferencePage.NetworkTab.TimingPane = new WI.ReferencePage(WI.ReferencePage.NetworkTab, {topic: "timing-pane"});
+
 WI.ReferencePage.SymbolicBreakpoints = new WI.ReferencePage("symbolic-breakpoints");
 WI.ReferencePage.SymbolicBreakpoints.Configuration = new WI.ReferencePage(WI.ReferencePage.SymbolicBreakpoints, {topic: "configuration"});
 

--- a/Source/WebInspectorUI/UserInterface/Views/CreateAuditPopover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CreateAuditPopover.css
@@ -34,7 +34,7 @@
     margin-top: 4px;
 }
 
-.popover .create-audit-content > .editor-wrapper > .reference-page-link {
+.popover .create-audit-content > .editor-wrapper > .reference-page-link-container {
     margin-bottom: 2px;
     margin-inline-start: 0.5em;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.js
@@ -86,6 +86,7 @@ WI.NetworkDetailView = class NetworkDetailView extends WI.View
 
         const element = null;
         this._contentBrowser = new WI.ContentBrowser(element, this, {hideBackForwardButtons: true, flexibleNavigationItem, contentViewNavigationItemGroup});
+        this._contentBrowser.addEventListener(WI.ContentBrowser.Event.CurrentContentViewDidChange, this._handleCurrentContentViewDidChange, this);
 
         // Insert all of our custom navigation items at the start of the ContentBrowser's NavigationBar.
         let index = 0;
@@ -142,6 +143,12 @@ WI.NetworkDetailView = class NetworkDetailView extends WI.View
 
         console.assert(firstNavigationItem, "Should have found at least one navigation item above");
         this._contentBrowser.navigationBar.selectedNavigationItem = firstNavigationItem;
+    }
+
+    _handleCurrentContentViewDidChange(event)
+    {
+        // Redispatch this event since this view is basically just a wrapper.
+        this.dispatchEventToListeners(event.type, event.data);
     }
 
     _navigationItemSelected(event)

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
@@ -43,6 +43,20 @@ WI.NetworkResourceDetailView = class NetworkResourceDetailView extends WI.Networ
 
     // Public
 
+    get referencePage()
+    {
+        let currentContentView = this._contentBrowser.currentContentView;
+        if (!currentContentView)
+            return null;
+
+        if (currentContentView === this._resourceContentView)
+            return WI.ReferencePage.NetworkTab.PreviewPane;
+
+        return currentContentView?.constructor.ReferencePage;
+    }
+
+    // Protected
+
     attached()
     {
         super.attached();

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -421,6 +421,11 @@ body[dir=rtl] .waterfall.network .block {
     font-variant-numeric: tabular-nums;
 }
 
+.network-table .reference-page-link-container {
+    position: absolute;
+    inset-inline-end: 6px;
+}
+
 @media (prefers-color-scheme: dark) {
     .content-view.tab.network > .content-browser > .navigation-bar .hierarchical-path .icon {
         filter: invert(88%);

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js
@@ -293,3 +293,5 @@ WI.ResourceCookiesContentView = class ResourceCookiesContentView extends WI.Cont
         this._refreshResponseCookiesSection();
     }
 };
+
+WI.ResourceCookiesContentView.ReferencePage = WI.ReferencePage.NetworkTab.CookiesPane;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js
@@ -564,3 +564,5 @@ WI.ResourceHeadersContentView = class ResourceHeadersContentView extends WI.Cont
         this.needsLayout();
     }
 };
+
+WI.ResourceHeadersContentView.ReferencePage = WI.ReferencePage.NetworkTab.HeadersPane;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.js
@@ -355,3 +355,5 @@ WI.ResourceSecurityContentView = class ResourceSecurityContentView extends WI.Co
         this.needsLayout();
     }
 };
+
+WI.ResourceSecurityContentView.ReferencePage = WI.ReferencePage.NetworkTab.SecurityPane;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.js
@@ -249,3 +249,5 @@ WI.ResourceSizesContentView = class ResourceSizesContentView extends WI.ContentV
         this.needsLayout();
     }
 };
+
+WI.ResourceSizesContentView.ReferencePage = WI.ReferencePage.NetworkTab.SizesPane;

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTimingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTimingContentView.js
@@ -110,3 +110,5 @@ WI.ResourceTimingContentView = class ResourceTimingContentView extends WI.Conten
         this.needsLayout();
     }
 };
+
+WI.ResourceTimingContentView.ReferencePage = WI.ReferencePage.NetworkTab.TimingPane;


### PR DESCRIPTION
#### cd4704109f52b55f39d24142444f64887531b448
<pre>
Web Inspector: Network Tab: add reference page links
<a href="https://bugs.webkit.org/show_bug.cgi?id=243861">https://bugs.webkit.org/show_bug.cgi?id=243861</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Base/ReferencePage.js:
* Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js:
(WI.NetworkResourceDetailView.prototype.get referencePage): Added.
* Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js:
* Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js:
* Source/WebInspectorUI/UserInterface/Views/ResourceSecurityContentView.js:
* Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.js:
* Source/WebInspectorUI/UserInterface/Views/ResourceTimingContentView.js:
Add a `ReferencePage` property to each class.

* Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.js:
(WI.NetworkDetailView.prototype.initialLayout):
(WI.NetworkDetailView.prototype._handleCurrentContentViewDidChange): Added.
Propagate `WI.ContentBrowser.Event.CurrentContentViewDidChange` so that callers can know to grab the
new `referencePage` value.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView.prototype.initialLayout):
(WI.NetworkTableContentView.prototype._hideDetailView):
(WI.NetworkTableContentView.prototype._showDetailView):
(WI.NetworkTableContentView.prototype._handleCurrentResourceDetailViewDidChange):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(.network-table .reference-page-link-container): Added.
Add a reference page link in the right of the statistics bar. Update it if the detail view changes.

* Source/WebInspectorUI/UserInterface/Views/CreateAuditPopover.css:
(.popover .create-audit-content &gt; .editor-wrapper &gt; .reference-page-link-container): Renamed from `.popover .create-audit-content &gt; .editor-wrapper &gt; .reference-page-link`.
Drive-by: I noticed this was wrong while searching for related styles.

Canonical link: <a href="https://commits.webkit.org/253477@main">https://commits.webkit.org/253477@main</a>
</pre>

































<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1c403ff274289516d23a7703769b3fcb9e55617

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30101 "Built successfully") | [✅ ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/17182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/95040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/148738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28473 "Built successfully") | [✅ ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/25161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/90308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/91759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/23108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/78316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/17182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/26437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/17182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26334 "Built successfully") | [✅ ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/17182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28010 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/27947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->