### PR TITLE
[ews] Fix commit rebasing issue

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1005,7 +1005,7 @@ class CheckOutPullRequest(steps.ShellSequence, ShellMixin):
         if rebase_target_hash and base_hash and rebase_target_hash != base_hash:
             commands += [
                 ['git', 'config', 'merge.changelog.driver', 'perl Tools/Scripts/resolve-ChangeLogs --merge-driver -c %O %A %B'],
-                ['git', 'rebase', '--onto', rebase_target_hash, base_hash, pr_branch],
+                ['git', 'rebase', '--onto', rebase_target_hash, '{}^'.format(pr_branch)],
             ]
         for command in commands:
             self.commands.append(util.ShellArg(command=command, logname='stdio', haltOnFailure=True))

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -3316,7 +3316,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 logEnviron=False,
                 env=self.ENV,
-                command=['git', 'rebase', '--onto', '59dab0396721db221c264aad3c0cea37ef0d297b', 'aaebef7312238f3ad1d25e8894916a1aaea45ba1', 'eng/pull-request-branch'],
+                command=['git', 'rebase', '--onto', '59dab0396721db221c264aad3c0cea37ef0d297b', 'eng/pull-request-branch^'],
             ) + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Checked out pull request')
@@ -3380,7 +3380,7 @@ class TestCheckOutPullRequest(BuildStepMixinAdditions, unittest.TestCase):
                 timeout=600,
                 logEnviron=False,
                 env=self.ENV,
-                command=['git', 'rebase', '--onto', '59dab0396721db221c264aad3c0cea37ef0d297b', 'aaebef7312238f3ad1d25e8894916a1aaea45ba1', 'eng/pull-request-branch'],
+                command=['git', 'rebase', '--onto', '59dab0396721db221c264aad3c0cea37ef0d297b', 'eng/pull-request-branch^'],
             ) + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Checked out pull request')


### PR DESCRIPTION
#### c8b3341786be652541c0933a16ec0648207ff78c
<pre>
[ews] Fix commit rebasing issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=243862">https://bugs.webkit.org/show_bug.cgi?id=243862</a>
&lt;rdar://98541779&gt;

Reviewed by NOBODY (OOPS!).

The EWS bot incorrectly attempts to rebase everything from the fork/main
branch to the fork/feature branch onto origin/main which can cause merge
conflicts with outdated fork/main branches.

Instead, we can just rebase the latest feature branch commit and ignore
everything else.

* Tools/CISupport/ews-build/steps.py:
(CheckOutPullRequest.run):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre>