### PR TITLE
Web Inspector: Network Tab: initiated resource should only be highlighted when a row is hovered

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -97,16 +97,16 @@
     cursor: pointer;
 }
 
-body.shift-key-pressed .network-table > .table:hover li:not(:hover, .selected, .initiated) .cell {
+.network-table.highlight-initiated > .table li:not(:hover, .selected, .initiated) .cell {
     color: var(--text-color-transparent);
 }
 
-body.shift-key-pressed .network-table > .table:hover li:not(:hover, .selected, .initiated) .cell > * {
+.network-table.highlight-initiated > .table li:not(:hover, .selected, .initiated) .cell > * {
     color: var(--text-color);
     opacity: 0.4;
 }
 
-body.shift-key-pressed .network-table > .table:hover li.initiated .cell.name::after {
+.network-table.highlight-initiated > .table li.initiated .cell.name::after {
     display: inline-block;
     float: right;
     width: 4px;

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -1587,9 +1587,12 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
 
     _highlightRelatedResourcesForHoveredResource()
     {
+        let highlightInitiated = !isNaN(this._hoveredRowIndex) && WI.modifierKeys.shiftKey;
+        this.element.classList.toggle("highlight-initiated", highlightInitiated);
+
         let needsRestyle = false;
 
-        if (isNaN(this._hoveredRowIndex) || !WI.modifierKeys.shiftKey) {
+        if (!highlightInitiated) {
             for (let entry of this._activeCollection.entries) {
                 if (entry.rowClassNames.length)
                     needsRestyle = true;
@@ -1994,7 +1997,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
 
         let rowClassNames = [];
 
-        if (this._hoveredRowIndex) {
+        if (!isNaN(this._hoveredRowIndex) && WI.modifierKeys.shiftKey) {
             let hoveredEntry = this._activeCollection.filteredEntries[this._hoveredRowIndex];
             if (hoveredEntry?.resource?.initiatedResources.includes(resource))
                 rowClassNames.push("initiated");


### PR DESCRIPTION
#### 06e6a494bd4c5d7af45af5eab181b56e4234b79b
<pre>
Web Inspector: Network Tab: initiated resource should only be highlighted when a row is hovered
<a href="https://bugs.webkit.org/show_bug.cgi?id=243866">https://bugs.webkit.org/show_bug.cgi?id=243866</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView.prototype._highlightRelatedResourcesForHoveredResource):
(WI.NetworkTableContentView.prototype._entryForResource):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(.network-table.highlight-initiated &gt; .table li:not(:hover, .selected, .initiated) .cell): Renamed from `body.shift-key-pressed .network-table &gt; .table:hover li:not(:hover, .selected, .initiated) .cell`.
(.network-table.highlight-initiated &gt; .table li:not(:hover, .selected, .initiated) .cell &gt; *): Renamed from `body.shift-key-pressed .network-table &gt; .table:hover li:not(:hover, .selected, .initiated) .cell &gt; *`.
(.network-table.highlight-initiated &gt; .table li.initiated .cell.name::after): Renamed from `body.shift-key-pressed .network-table &gt; .table:hover li.initiated .cell.name::after`.
Apply a CSS class manually instead of using the global `.shift-key-pressed`, as that is set whenever
the shift key is pressed regardless of where the mouse is on the screen. Doing it manually means we
can better control when it&apos;s set, such as only when there&apos;s a row underneath the cursor. This way,
errant presses of the shift key won&apos;t suddenly cause the entire table to dim.

Canonical link: <a href="https://commits.webkit.org/253476@main">https://commits.webkit.org/253476@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/145a3d64112163e2a984ba9588a70e112aef753b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/85814 "") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/29739 "") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/16903 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/93770 "") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148312 "") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28105 "") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/24891 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/77979 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/89928 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91393 "") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/22807 "") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/72919 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66054 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/77858 "") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78360 "") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26083 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12245 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/25986 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13240 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/941 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/27656 "") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36151 "") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/27586 "") | | | 
<!--EWS-Status-Bubble-End-->