### PR TITLE
[WPE] Cannot build with USE_SYSTEM_MALLOC enabled

### DIFF
--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -116,8 +116,11 @@ set(TestJSC_LIBRARIES
 set(TestJSC_FRAMEWORKS
     JavaScriptCore
     WTF
-    bmalloc
 )
+
+if (NOT USE_SYSTEM_MALLOC)
+    list(APPEND TestJSC_FRAMEWORKS bmalloc)
+endif ()
 
 set(TestJSC_DEFINITIONS
     WEBKIT_SRC_DIR="${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
#### 2999a68ccc3b85463dec63e4b7b9406a8101740e
<pre>
[WPE] Cannot build with USE_SYSTEM_MALLOC enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=243868">https://bugs.webkit.org/show_bug.cgi?id=243868</a>

Reviewed by Yusuke Suzuki and Adrian Perez de Castro.

* Tools/TestWebKitAPI/PlatformWPE.cmake: Add bmalloc to
  TestJSC_FRAMEWORKS only if USE_SYSTEM_MALLOC is not defined.

Canonical link: <a href="https://commits.webkit.org/253375@main">https://commits.webkit.org/253375@main</a>
</pre>
