### PR TITLE
Darwin specific IPC encoding primitives are implemented in WebKit/Shared but used in WebKit/Platform/IPC

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -40,6 +40,10 @@
 #include <wtf/Unexpected.h>
 #include <wtf/WallTime.h>
 
+#if OS(DARWIN)
+#include "ArgumentCodersDarwin.h"
+#endif
+
 namespace IPC {
 
 // An argument coder works on POD types
@@ -1010,13 +1014,6 @@ template<> struct ArgumentCoder<SHA1::Digest> {
     static void encode(Encoder&, const SHA1::Digest&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, SHA1::Digest&);
 };
-
-#if HAVE(AUDIT_TOKEN)
-template<> struct ArgumentCoder<audit_token_t> {
-    static void encode(Encoder&, const audit_token_t&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, audit_token_t&);
-};
-#endif
 
 template<> struct ArgumentCoder<std::monostate> {
     template<typename Encoder>

--- a/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h
+++ b/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoder.h"
+
+#if HAVE(AUDIT_TOKEN)
+#include <mach/mach.h>
+#endif
+
+namespace WTF {
+class MachSendRight;
+}
+
+namespace IPC {
+
+template<> struct ArgumentCoder<WTF::MachSendRight> {
+    static void encode(Encoder&, const WTF::MachSendRight&);
+    static void encode(Encoder&, WTF::MachSendRight&&);
+    static WARN_UNUSED_RETURN bool decode(Decoder&, WTF::MachSendRight&);
+};
+
+#if HAVE(AUDIT_TOKEN)
+template<> struct ArgumentCoder<audit_token_t> {
+    static void encode(Encoder&, const audit_token_t&);
+    static WARN_UNUSED_RETURN bool decode(Decoder&, audit_token_t&);
+};
+#endif
+
+}

--- a/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.mm
+++ b/Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.mm
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ArgumentCodersDarwin.h"
+
+#import <wtf/MachSendRight.h>
+
+namespace IPC {
+
+void ArgumentCoder<MachSendRight>::encode(Encoder& encoder, const MachSendRight& sendRight)
+{
+    encoder << Attachment { sendRight };
+}
+
+void ArgumentCoder<MachSendRight>::encode(Encoder& encoder, MachSendRight&& sendRight)
+{
+    encoder << Attachment { WTFMove(sendRight) };
+}
+
+bool ArgumentCoder<MachSendRight>::decode(Decoder& decoder, MachSendRight& sendRight)
+{
+    Attachment attachment;
+    if (!decoder.decode(attachment))
+        return false;
+
+    sendRight = WTFMove(attachment);
+    return true;
+}
+
+}

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -675,6 +675,7 @@ def argument_coder_headers_for_type(type):
 
     special_cases = {
         'String': '"ArgumentCoders.h"',
+        'MachSendRight': '"ArgumentCodersDarwin.h"',
         'WebKit::ScriptMessageHandlerHandle': '"WebScriptMessageHandler.h"',
     }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -27,6 +27,9 @@
 #include "TestWithLegacyReceiver.h"
 
 #include "ArgumentCoders.h" // NOLINT
+#if PLATFORM(MAC)
+#include "ArgumentCodersDarwin.h" // NOLINT
+#endif
 #include "Connection.h" // NOLINT
 #include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -26,6 +26,9 @@
 #include "TestWithStream.h"
 
 #include "ArgumentCoders.h" // NOLINT
+#if PLATFORM(COCOA)
+#include "ArgumentCodersDarwin.h" // NOLINT
+#endif
 #include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
 #include "TestWithStreamMessages.h" // NOLINT

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -27,6 +27,9 @@
 #include "TestWithoutAttributes.h"
 
 #include "ArgumentCoders.h" // NOLINT
+#if PLATFORM(MAC)
+#include "ArgumentCodersDarwin.h" // NOLINT
+#endif
 #include "Connection.h" // NOLINT
 #include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -99,10 +99,6 @@
 
 #if PLATFORM(COCOA)
 #include "ArgumentCodersCF.h"
-
-namespace WTF {
-class MachSendRight;
-}
 #endif
 
 #if USE(UNIX_DOMAIN_SOCKETS)
@@ -438,12 +434,6 @@ template<> struct ArgumentCoder<WebCore::DragData> {
 #endif
 
 #if PLATFORM(COCOA)
-
-template<> struct ArgumentCoder<WTF::MachSendRight> {
-    static void encode(Encoder&, const WTF::MachSendRight&);
-    static void encode(Encoder&, WTF::MachSendRight&&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WTF::MachSendRight&);
-};
 
 template<> struct ArgumentCoder<WebCore::KeypressCommand> {
     static void encode(Encoder&, const WebCore::KeypressCommand&);

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -275,26 +275,6 @@ bool ArgumentCoder<WebCore::Credential>::decodePlatformData(Decoder& decoder, We
     return true;
 }
 
-void ArgumentCoder<MachSendRight>::encode(Encoder& encoder, const MachSendRight& sendRight)
-{
-    encoder << Attachment { sendRight };
-}
-
-void ArgumentCoder<MachSendRight>::encode(Encoder& encoder, MachSendRight&& sendRight)
-{
-    encoder << Attachment { WTFMove(sendRight) };
-}
-
-bool ArgumentCoder<MachSendRight>::decode(Decoder& decoder, MachSendRight& sendRight)
-{
-    Attachment attachment;
-    if (!decoder.decode(attachment))
-        return false;
-
-    sendRight = WTFMove(attachment);
-    return true;
-}
-
 void ArgumentCoder<WebCore::KeypressCommand>::encode(Encoder& encoder, const WebCore::KeypressCommand& keypressCommand)
 {
     encoder << keypressCommand.commandName << keypressCommand.text;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -101,6 +101,7 @@ Platform/IPC/cocoa/ConnectionCocoa.mm
 Platform/IPC/cocoa/DaemonConnectionCocoa.mm
 Platform/IPC/cocoa/MachMessage.cpp
 
+Platform/IPC/darwin/ArgumentCodersDarwin.mm
 Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
 
 Platform/mac/MachUtilities.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5479,6 +5479,8 @@
 		7B90416D2550108C006EEB8C /* RemoteGraphicsContextGLFunctionsGenerated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLFunctionsGenerated.h; sourceTree = "<group>"; };
 		7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCUtilities.h; sourceTree = "<group>"; };
 		7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCUtilities.cpp; sourceTree = "<group>"; };
+		7B9FC5E128A54BCC007570E7 /* ArgumentCodersDarwin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArgumentCodersDarwin.h; sourceTree = "<group>"; };
+		7B9FC5E228A54BCC007570E7 /* ArgumentCodersDarwin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ArgumentCodersDarwin.mm; sourceTree = "<group>"; };
 		7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedActiveMessageReceiveQueue.h; sourceTree = "<group>"; };
 		7BBA63DC280E93B500B04823 /* IPCConnectionTesterIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCConnectionTesterIdentifier.h; sourceTree = "<group>"; };
 		7BBA63DD280E93B600B04823 /* IPCConnectionTester.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCConnectionTester.cpp; sourceTree = "<group>"; };
@@ -10949,6 +10951,8 @@
 		7B73122C25CA67AE003B2796 /* darwin */ = {
 			isa = PBXGroup;
 			children = (
+				7B9FC5E128A54BCC007570E7 /* ArgumentCodersDarwin.h */,
+				7B9FC5E228A54BCC007570E7 /* ArgumentCodersDarwin.mm */,
 				A31F60A625CC7DCF00AF14F4 /* IPCSemaphoreDarwin.cpp */,
 			);
 			path = darwin;


### PR DESCRIPTION
#### d509234209c030b6fd02ececa22b4f53ae9b0d83
<pre>
Darwin specific IPC encoding primitives are implemented in WebKit/Shared but used in WebKit/Platform/IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=243870">https://bugs.webkit.org/show_bug.cgi?id=243870</a>
rdar://problem/98551932

Reviewed by Sam Weinig.

The base IPC implementation depends on stdlib, OS libraries, WTF.
Move MachSendRight serialization code from the client, WebKit/Shared,
to WebKit/Platform/IPC platform specific serialization headers.

This way WebKit/Platform/IPC is easier to compile in isolation, for
unit test purposes.

Also move audit_token_t to Darwin specific serialization headers.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.h: Added.
* Source/WebKit/Platform/IPC/darwin/ArgumentCodersDarwin.mm: Added.
Add the platform specific serialization header and implementation.

(IPC::ArgumentCoder&lt;MachSendRight&gt;::encode):
(IPC::ArgumentCoder&lt;MachSendRight&gt;::decode):
* Source/WebKit/Scripts/webkit/messages.py:
(argument_coder_headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;MachSendRight&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;MachSendRight&gt;::decode): Deleted.
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/253422@main">https://commits.webkit.org/253422@main</a>
</pre>
