### PR TITLE
instantiateStreaming / compileStreaming should accept FetchResponse with FormData

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_compile_test-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_compile_test-expected.txt
@@ -10,7 +10,5 @@ PASS compileStreaming raise error if no-cors
 PASS compileStreaming receive promise with response created from ArrayBuffer
 PASS compileStreaming receive response that deliver data by chunks as bufferArray
 PASS compileStreaming using blob
-FAIL compileStreaming using FormData promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function CompileError() {
-    [native code]
-}" ("CompileError")
+PASS compileStreaming using FormData
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_instantiate_test-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_instantiate_test-expected.txt
@@ -10,7 +10,5 @@ PASS instantiateStreaming raise error if no-cors
 PASS instantiateStreaming receive promise with response created from ArrayBuffer
 PASS instantiateStreaming receive response that deliver data by chunks as bufferArray
 PASS instantiateStreaming using blob
-FAIL instantiateStreaming using FormData promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function CompileError() {
-    [native code]
-}" ("CompileError")
+PASS instantiateStreaming using FormData
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_compile_test-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_compile_test-expected.txt
@@ -11,7 +11,5 @@ PASS compileStreaming receive promise with response created from ArrayBuffer
 PASS compileStreaming using ReadableStream with Uint8Array chunks
 FAIL compileStreaming using ReadableStream with ArrayBuffer chunk assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS compileStreaming using blob
-FAIL compileStreaming using FormData promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function CompileError() {
-    [native code]
-}" ("CompileError")
+PASS compileStreaming using FormData
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_instantiate_test-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_instantiate_test-expected.txt
@@ -11,7 +11,5 @@ PASS instantiateStreaming receive promise with response created from ArrayBuffer
 PASS instantiateStreaming using ReadableStream with Uint8Array chunks
 FAIL instantiateStreaming using ReadableStream with ArrayBuffer chunk assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS instantiateStreaming using blob
-FAIL instantiateStreaming using FormData promise_rejects_js: function "function () { throw e }" threw object "NotSupportedError: Not implemented" ("NotSupportedError") expected instance of function "function CompileError() {
-    [native code]
-}" ("CompileError")
+PASS instantiateStreaming using FormData
 


### PR DESCRIPTION
#### e2b279112b8dc0852fd89c5a063f910b17c5cc21
<pre>
instantiateStreaming / compileStreaming should accept FetchResponse with FormData
<a href="https://bugs.webkit.org/show_bug.cgi?id=221248">https://bugs.webkit.org/show_bug.cgi?id=221248</a>
rdar://problem/74132453

Reviewed by Darin Adler.

Load FormData through ReadableStream in WebAssembly.{instantiateStreaming,compileStreaming}.

* LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_compile_test-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/wasm_stream_instantiate_test-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_compile_test-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/wasm_stream_instantiate_test-expected.txt:
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):

Canonical link: <a href="https://commits.webkit.org/253395@main">https://commits.webkit.org/253395@main</a>
</pre>
