### PR TITLE
[WebGL] Calculate correct image transfer size from ArrayBufferView

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3938,6 +3938,8 @@ webgl/2.0.0/conformance/programs/program-test.html [ Skip ]
 webgl/1.0.x/conformance/textures/misc/texture-corner-case-videos.html [ Failure ]
 webgl/2.0.y/conformance/textures/misc/texture-corner-case-videos.html [ Failure ]
 
+webkit.org/b/243819 webgl/2.0.y/deqp/functional/gles3/negativetextureapi.html [ Pass ]
+
 # pre-wrap progression. Other rendering engines agree with the result.
 webkit.org/b/206168 [ Debug ] fast/dom/insert-span-into-long-text-bug-28245.html [ Skip ]
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -933,13 +933,10 @@ protected:
 
     ExceptionOr<void> texImageSourceHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& sourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, TexImageSource&&);
     // Helper function for tex(Sub)Image2D && texSubImage3D.
-    bool computeImageSizeInBytes(TexImageDimension texDim, GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, unsigned* imageSizeInBytes);
     void texImageArrayBufferViewHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition, GCGLuint srcOffset);
     void texImageImpl(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLenum format, GCGLenum type, Image*, GraphicsContextGL::DOMSource, bool flipY, bool premultiplyAlpha, bool ignoreNativeImageAlphaPremultiplication, const IntRect&, GCGLsizei depth, GCGLint unpackImageHeight);
-    void texImage2DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLsizei byteLength, const void* pixels);
-    void texImage3DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLsizei byteLength, const void* pixels);
-    void texSubImage2DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum internalFormat, GCGLenum format, GCGLenum type, GCGLsizei byteLength, const void* pixels);
-    void texSubImage3DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum internalFormat, GCGLenum format, GCGLenum type, GCGLsizei byteLength, const void* pixels);
+    void texImage2DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels);
+    void texSubImage2DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum internalFormat, GCGLenum format, GCGLenum type, GCGLSpan<const GCGLvoid> pixels);
     static const char* getTexImageFunctionName(TexImageFunctionID);
     using PixelStoreParams = GraphicsContextGL::PixelStoreParams;
     virtual PixelStoreParams getPackPixelStoreParams() const;
@@ -1025,7 +1022,7 @@ protected:
     // Helper function to validate that the given ArrayBufferView
     // is of the correct type and contains enough data for the texImage call.
     // Generates GL error and returns false if parameters are invalid.
-    bool validateTexFuncData(const char* functionName, TexImageDimension,
+    std::optional<GCGLSpan<const GCGLvoid>> validateTexFuncData(const char* functionName, TexImageDimension,
         GCGLsizei width, GCGLsizei height, GCGLsizei depth,
         GCGLenum format, GCGLenum type,
         ArrayBufferView* pixels,

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -576,7 +576,7 @@ bool GraphicsContextGL::extractPixelBuffer(const PixelBuffer& pixelBuffer, DataF
     return true;
 }
 
-bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, const void* pixels, Vector<uint8_t>& data)
+bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, GCGLSpan<const GCGLvoid> pixels, Vector<uint8_t>& data)
 {
     // Assumes format, type, etc. have already been validated.
     DataFormat sourceDataFormat = getDataFormat(format, type);
@@ -591,7 +591,7 @@ bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGL
 
     unsigned imageSizeInBytes, skipSizeInBytes;
     computeImageSizeInBytes(format, type, width, height, 1, unpackParams, &imageSizeInBytes, nullptr, &skipSizeInBytes);
-    const uint8_t* srcData = static_cast<const uint8_t*>(pixels);
+    const uint8_t* srcData = static_cast<const uint8_t*>(pixels.data);
     if (skipSizeInBytes)
         srcData += skipSizeInBytes;
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1532,7 +1532,7 @@ public:
     // If the data is not tightly packed according to the passed
     // unpackParams, the output data will be tightly packed.
     // Returns true if successful, false if any error occurred.
-    static bool extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, const void* pixels, Vector<uint8_t>& data);
+    static bool extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, GCGLSpan<const GCGLvoid> pixels, Vector<uint8_t>& data);
 
     // Packs the contents of the given Image which is passed in |pixels| into the passed Vector
     // according to the given format and type, and obeying the flipY and AlphaOp flags.


### PR DESCRIPTION
#### 592cd219941fef52e1429c31038b2d0c920af544
<pre>
[WebGL] Calculate correct image transfer size from ArrayBufferView
<a href="https://bugs.webkit.org/show_bug.cgi?id=243819">https://bugs.webkit.org/show_bug.cgi?id=243819</a>
rdar://98347913

Reviewed by Kimmo Kinnunen.

Validation was being skipped when pixels was null, which is an optimization
instead of passing a sufficiently large array of all zeroes. Remove the two step
approach to calculating the required bytes and instead return the value from
`validateTexFuncData()` and pass this size to base helper functions.

* LayoutTests/TestExpectations: Enable failing test.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
Unify passing image data span as GCGLSpan&lt;&gt; instead of as separate base ptr +
length.
(WebCore::WebGLRenderingContextBase::computeImageSizeInBytes): Deleted.
(WebCore::WebGLRenderingContextBase::texImageArrayBufferViewHelper):
Unify passing validated image data span as GCGLSpan&lt;&gt; instead of as separate
base ptr + length. Adjustment due to srcOffset moved to validateTexFuncData.
(WebCore::WebGLRenderingContextBase::texImageImpl):
Unify passing image data span as GCGLSpan&lt;&gt; instead of as separate base ptr +
length.
(WebCore::WebGLRenderingContextBase::texImage2DBase):
When using ANGLE, remove extra image size checks as this is handled in
validateTexFuncData.
(WebCore::WebGLRenderingContextBase::texImage3DBase): Deleted
(WebCore::WebGLRenderingContextBase::texSubImage2DBase):
When using ANGLE, remove extra image size checks as this is handled in
validateTexFuncData.
(WebCore::WebGLRenderingContextBase::texSubImage3DBase): Deleted
(WebCore::WebGLRenderingContextBase::validateTexFuncData):
Consolidate calculation of image byte size and don&apos;t skip required checks if
pixels is null. Returns validated span of the data that will be read by texture
specification functions.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
- Remove unneeded texImage helper functions
- Change validateTexFuncData to return optional validated span of image bytes
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
* Source/WebCore/platform/graphics/GrpahicsContextGL.h:
(WebCore::GraphicsContextGL::extractTextureData):
Change pixels to span of pixels instead of ptr.

Canonical link: <a href="https://commits.webkit.org/253543@main">https://commits.webkit.org/253543@main</a>
</pre>
