### PR TITLE
[ews] Prevent multiple Github status-bubble comments per commit

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -231,7 +231,7 @@ class GitHubEWS(GitHub):
         return u'| [{status} {name}]({url} "{hover_over_text}") '.format(status=status, name=name, url=url, hover_over_text=hover_over_text)
 
     @classmethod
-    def add_or_update_comment_for_change_id(self, sha, pr_id, pr_project=None):
+    def add_or_update_comment_for_change_id(self, sha, pr_id, pr_project=None, allow_new_comment=False):
         if not pr_id or pr_id == -1:
             _log.error('Invalid pr_id: {}'.format(pr_id))
             return -1
@@ -244,6 +244,9 @@ class GitHubEWS(GitHub):
         comment_text = gh.generate_comment_text_for_change(change)
         comment_id = change.comment_id
         if comment_id == -1:
+            if not allow_new_comment:
+                # FIXME: improve this logic to use locking instead
+                return -1
             _log.info('Adding comment for hash: {}, pr_id: {}, pr_id from db: {}.'.format(sha, pr_id, change.pr_id))
             new_comment_id = gh.update_or_leave_comment_on_pr(pr_id, comment_text)
             if new_comment_id != -1:

--- a/Tools/CISupport/ews-app/ews/views/results.py
+++ b/Tools/CISupport/ews-app/ews/views/results.py
@@ -76,7 +76,8 @@ class Results(View):
                    state_string=data['state_string'], started_at=data['started_at'], complete_at=data['complete_at'], pr_id=pr_id, pr_project=pr_project)
         if rc == SUCCESS and pr_id and pr_id != -1:
             # For PR builds leave comment on PR
-            GitHubEWS.add_or_update_comment_for_change_id(change_id, pr_id, pr_project)
+            allow_new_comment = (data['status'] == 'started' and data['builder_display_name'] in ['services', 'ios-wk2'])
+            GitHubEWS.add_or_update_comment_for_change_id(change_id, pr_id, pr_project, allow_new_comment)
         return HttpResponse("Saved data for change: {}.\n".format(change_id))
 
     def step_event(self, data):


### PR DESCRIPTION
#### 10816b77b5c3ffcc288173f31772810302b9e932
<pre>
[ews] Prevent multiple Github status-bubble comments per commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=243876">https://bugs.webkit.org/show_bug.cgi?id=243876</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS.add_or_update_comment_for_change_id):
* Tools/CISupport/ews-app/ews/views/results.py:
(Results.build_event):

Canonical link: <a href="https://commits.webkit.org/253390@main">https://commits.webkit.org/253390@main</a>
</pre>
