### PR TITLE
[QtWPE] Don't try to load unversioned libWPEBackend-fdo-1.0.so

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp
@@ -74,7 +74,7 @@ WPEQtViewBackend::WPEQtViewBackend(const QSizeF& size, EGLDisplay display, EGLCo
     , m_view(view)
     , m_size(size)
 {
-    wpe_loader_init("libWPEBackend-fdo-1.0.so");
+    wpe_loader_init("libWPEBackend-fdo-1.0.so.1");
 
     imageTargetTexture2DOES = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(eglGetProcAddress("glEGLImageTargetTexture2DOES"));
 


### PR DESCRIPTION
#### 2a881ad3aa451fa6c8dbff45ab37379dab95c5e4
<pre>
[QtWPE] Don&apos;t try to load unversioned libWPEBackend-fdo-1.0.so
<a href="https://bugs.webkit.org/show_bug.cgi?id=243877">https://bugs.webkit.org/show_bug.cgi?id=243877</a>

Reviewed by Philippe Normand.

* Source/WebKit/UIProcess/API/wpe/qt/WPEQtViewBackend.cpp:
(WPEQtViewBackend::WPEQtViewBackend):

Canonical link: <a href="https://commits.webkit.org/253380@main">https://commits.webkit.org/253380@main</a>
</pre>
