### PR TITLE
[filter-build-webkit] Remove new build warnings

### DIFF
--- a/Tools/Scripts/filter-build-webkit
+++ b/Tools/Scripts/filter-build-webkit
@@ -392,6 +392,9 @@ sub shouldIgnoreLine($$)
     return 1 if $line =~ /^Finished adding entitlements\.$/;
     return 1 if $line =~ /^.* will not be code signed because its settings don't specify a development team.$/;
     return 1 if $line =~ /^Initializing Plist...$/;
+    return 1 if $line =~ /^.* Run script build phase '/;
+    return 1 if $line =~ /^.* Traditional headermap style is no longer supported;/;
+    return 1 if $line =~ /^.* Skipping duplicate build file in/;
 
     if ($platform eq "win") {
         return 1 if $line =~ /^\s*(touch|perl|cat|rm -f|del|python|\/usr\/bin\/g\+\+|gperf|echo|sed|if \[ \-f|WebCore\/generate-export-file) /;


### PR DESCRIPTION
#### 2ee999b7196f8c9660976b27054997b8aa71c66c
<pre>
[filter-build-webkit] Remove new build warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=243891">https://bugs.webkit.org/show_bug.cgi?id=243891</a>
&lt;rdar://98580146&gt;

Reviewed by Simon Fraser.

After the switch to using workspace builds by default, new build warnings
have popped up which clutter up the build log.

* Tools/Scripts/filter-build-webkit:
(shouldIgnoreLine):

Canonical link: <a href="https://commits.webkit.org/253388@main">https://commits.webkit.org/253388@main</a>
</pre>
