### PR TITLE
[FileReader] No progress event should be dispatched when reading an empty file / blob

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL events are dispatched in the correct order for an empty blob assert_equals: Expected load event, but got progress event instead expected "load" but got "progress"
+PASS events are dispatched in the correct order for an empty blob
 PASS events are dispatched in the correct order for a non-empty blob
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL events are dispatched in the correct order for an empty blob assert_equals: Expected load event, but got progress event instead expected "load" but got "progress"
+PASS events are dispatched in the correct order for an empty blob
 PASS events are dispatched in the correct order for a non-empty blob
 

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -180,7 +180,8 @@ void FileReader::didFinishLoading()
         if (m_state == DONE)
             return;
         m_finishedLoading = true;
-        fireEvent(eventNames().progressEvent);
+        if (m_loader->bytesLoaded())
+            fireEvent(eventNames().progressEvent);
         if (m_state == DONE)
             return;
         m_state = DONE;


### PR DESCRIPTION
#### 0021badc80b69f70869bf9d14420cfd673b0e02d
<pre>
[FileReader] No progress event should be dispatched when reading an empty file / blob
<a href="https://bugs.webkit.org/show_bug.cgi?id=243892">https://bugs.webkit.org/show_bug.cgi?id=243892</a>

Reviewed by Geoffrey Garen.

No progress event should be dispatched on FileReader when reading an empty file / blob:
- <a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a>

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_events.any.worker-expected.txt:
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::didFinishLoading):

Canonical link: <a href="https://commits.webkit.org/253425@main">https://commits.webkit.org/253425@main</a>
</pre>
