### PR TITLE
WebViewImpl::isUsingUISideCompositing() should not rely on there being a DrawingAreaProxy

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 
+#include "DrawingAreaInfo.h"
 #include "ImageAnalysisUtilities.h"
 #include "PDFPluginIdentifier.h"
 #include "ShareableBitmap.h"
@@ -771,6 +772,8 @@ private:
     WeakObjCPtr<NSView<WebViewImplDelegate>> m_view;
     std::unique_ptr<PageClient> m_pageClient;
     Ref<WebPageProxy> m_page;
+
+    DrawingAreaType m_drawingAreaType { DrawingAreaType::TiledCoreAnimation };
 
     bool m_willBecomeFirstResponderAgain { false };
     bool m_inBecomeFirstResponder { false };


### PR DESCRIPTION
#### 1dfe5d397bd945c3de5590889ffa55d90b346f53
<pre>
WebViewImpl::isUsingUISideCompositing() should not rely on there being a DrawingAreaProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=243896">https://bugs.webkit.org/show_bug.cgi?id=243896</a>

Reviewed by Tim Horton.

WebViewImpl::isUsingUISideCompositing() gets called before we&apos;ve created a DrawingAreaProxy, so
returns false then. In order to use the new WKScrollView/WKContentView code path, we need it to give
an accurate result.

So instead store DrawingAreaType on WebViewImpl, which is initialized by reading from NSUserDefaults
in the constructor.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
(WebKit::WebViewImpl::createDrawingAreaProxy):
(WebKit::WebViewImpl::isUsingUISideCompositing const):

Canonical link: <a href="https://commits.webkit.org/253417@main">https://commits.webkit.org/253417@main</a>
</pre>
