### PR TITLE
[JSC] Drop alignas for "JSC::JIT" class

### DIFF
--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -27,14 +27,6 @@
 
 #if ENABLE(JIT)
 
-// We've run into some problems where changing the size of the class JIT leads to
-// performance fluctuations. Try forcing alignment in an attempt to stabilize this.
-#if COMPILER(GCC_COMPATIBLE)
-#define JIT_CLASS_ALIGNMENT alignas(32)
-#else
-#define JIT_CLASS_ALIGNMENT
-#endif
-
 #define ASSERT_JIT_OFFSET(actual, expected) ASSERT_WITH_MESSAGE(actual == expected, "JIT Offset \"%s\" should be %d, not %d.\n", #expected, static_cast<int>(expected), static_cast<int>(actual));
 
 #include "BaselineJITCode.h"
@@ -158,7 +150,7 @@ namespace JSC {
 
     void ctiPatchCallByReturnAddress(ReturnAddressPtr, FunctionPtr<CFunctionPtrTag> newCalleeFunction);
 
-    class JIT_CLASS_ALIGNMENT JIT : public JSInterfaceJIT {
+    class JIT final : public JSInterfaceJIT {
         friend class JITSlowPathCall;
         friend class JITStubCall;
         friend class JITThunks;


### PR DESCRIPTION
#### cb15632c5a01f6aa09274ecb5cd13522cd1ae42e
<pre>
[JSC] Drop alignas for &quot;JSC::JIT&quot; class
<a href="https://bugs.webkit.org/show_bug.cgi?id=243898">https://bugs.webkit.org/show_bug.cgi?id=243898</a>

Reviewed by Mark Lam.

We are already putting JSC::JIT class on BaselineJITPlan (heap allocated class), thus, this alignment requirement is not longer guaranteed,
and we are not seeing performance problems. Plus, if clang generates code based on this alignment, it does not work (in particular on x64),
if SIMD requires 32byte alignment[1]. This patch removes this alignment requirement.

[1]: <a href="https://github.com/oven-sh/bun/issues/1055">https://github.com/oven-sh/bun/issues/1055</a>

* Source/JavaScriptCore/jit/JIT.h:

Canonical link: <a href="https://commits.webkit.org/253398@main">https://commits.webkit.org/253398@main</a>
</pre>
