### PR TITLE
[JSC][32bit] ASSERTION FAILED: !initialBytes

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -386,11 +386,16 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     ASSERT(initial);
     RELEASE_ASSERT(!maximum || maximum >= initial); // This should be guaranteed by our caller.
 
-    const size_t initialBytes = initial.bytes();
-    const size_t maximumBytes = maximum ? maximum.bytes() : 0;
+    const uint64_t initialBytes = initial.bytes();
+    const uint64_t maximumBytes = maximum ? maximum.bytes() : 0;
 
     if (initialBytes > MAX_ARRAY_BUFFER_SIZE)
         return nullptr; // Client will throw OOMError.
+
+#if USE(JSVALUE32_64)
+    if (maximumBytes > MAX_ARRAY_BUFFER_SIZE)
+        return nullptr; // Client will throw OOMError.
+#endif
 
     if (maximum && !maximumBytes) {
         // User specified a zero maximum, initial size must also be zero.


### PR DESCRIPTION
#### 3866ba779bf1f21626f945d9003d005f1c78a3eb
<pre>
[JSC][32bit] ASSERTION FAILED: !initialBytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=243901">https://bugs.webkit.org/show_bug.cgi?id=243901</a>

Reviewed by Yusuke Suzuki.

This patch fixes a value being truncated in 32bits platforms, resulting
in a invalid maximum size.

The method bytes() returns a uint64_t but in Memory::tryCreate, it is
stored in size_t, which is fine in 64bit platforms but gets truncated in
32 bits ones.

In this patch both initialBytes and maximumBytes are now uint64_t and
there is an extra check if the maximum size is greater than what&apos;s
allowed in the platform.

* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):

Canonical link: <a href="https://commits.webkit.org/253399@main">https://commits.webkit.org/253399@main</a>
</pre>
