### PR TITLE
Rename WebCore::findHTMLTag to findTag and extend it to find SVG and MathML tags

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/cross-global-revoke.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/cross-global-revoke.sub-expected.txt
@@ -1,8 +1,5 @@
-Blocked access to external URL http://www1.localhost:8800/FileAPI/url/resources/revoke-helper.html
 
-Harness Error (TIMEOUT), message = null
-
-FAIL It is possible to revoke same-origin blob URLs from different frames. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL It is possible to revoke same-origin blob URLs from a different worker global. assert_unreached: Should have rejected: undefined Reached unreachable code
-TIMEOUT It is not possible to revoke cross-origin blob URLs. Test timed out
+PASS It is possible to revoke same-origin blob URLs from different frames.
+PASS It is possible to revoke same-origin blob URLs from a different worker global.
+PASS It is not possible to revoke cross-origin blob URLs.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/cross-global-revoke.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/cross-global-revoke.sub.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <body>
 <script>
 async_test(t => {
@@ -42,7 +43,7 @@ async_test(t => {
   const url = URL.createObjectURL(blob);
   const frame = document.createElement('iframe');
   frame.setAttribute('style', 'display:none;');
-  frame.src = '//{{domains[www1]}}:{{location[port]}}/FileAPI/url/resources/revoke-helper.html';
+  frame.src = get_host_info().HTTP_REMOTE_ORIGIN + '/FileAPI/url/resources/revoke-helper.html';
   document.body.appendChild(frame);
 
   frame.onload = t.step_func(e => {

--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
@@ -47,13 +47,15 @@ public:
     static MediaSourceRegistry& registry();
 
     // Registers a blob URL referring to the specified media source.
-    void registerURL(ScriptExecutionContext&, const URL&, URLRegistrable&)final;
+    void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) final;
     void unregisterURL(const URL&) final;
+    void unregisterURLsForContext(const ScriptExecutionContext&) final;
     URLRegistrable* lookup(const String&) const final;
 
 private:
     MediaSourceRegistry();
-    MemoryCompactRobinHoodHashMap<String, RefPtr<MediaSource>> m_mediaSources;
+    MemoryCompactRobinHoodHashMap<String, std::pair<RefPtr<MediaSource>, ScriptExecutionContextIdentifier>> m_mediaSources;
+    HashMap<ScriptExecutionContextIdentifier, HashSet<String>> m_urlsPerContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1349,6 +1349,7 @@ html/TimeRanges.cpp
 html/TypeAhead.cpp
 html/URLDecomposition.cpp
 html/URLInputType.cpp
+html/URLRegistry.cpp
 html/URLSearchParams.cpp
 html/ValidationMessage.cpp
 html/WeekInputType.cpp

--- a/Source/WebCore/html/PublicURLManager.h
+++ b/Source/WebCore/html/PublicURLManager.h
@@ -52,10 +52,7 @@ private:
     void stop() override;
     const char* activeDOMObjectName() const override;
     
-    typedef HashSet<String> URLSet;
-    typedef HashMap<URLRegistry*, URLSet > RegistryURLMap;
-    RegistryURLMap m_registryToURL;
-    bool m_isStopped;
+    bool m_isStopped { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/URLRegistry.cpp
+++ b/Source/WebCore/html/URLRegistry.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "URLRegistry.h"
+
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+static Lock allRegistriesLock;
+static Vector<URLRegistry*>& allRegistries() WTF_REQUIRES_LOCK(allRegistriesLock)
+{
+    static NeverDestroyed<Vector<URLRegistry*>> list;
+    return list;
+}
+
+void URLRegistry::forEach(const Function<void(URLRegistry&)>& apply)
+{
+    Vector<URLRegistry*> registries;
+    {
+        Locker locker { allRegistriesLock };
+        registries = allRegistries();
+    }
+    for (auto* registry : registries)
+        apply(*registry);
+}
+
+URLRegistry::URLRegistry()
+{
+    Locker locker { allRegistriesLock };
+    allRegistries().append(this);
+}
+
+URLRegistry::~URLRegistry()
+{
+    RELEASE_ASSERT_NOT_REACHED(); // All our registries are singleton objects.
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/URLRegistry.h
+++ b/Source/WebCore/html/URLRegistry.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -46,9 +47,14 @@ public:
 class URLRegistry {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    virtual ~URLRegistry() = default;
-    virtual void registerURL(ScriptExecutionContext&, const URL&, URLRegistrable&) = 0;
+    static void forEach(const Function<void(URLRegistry&)>&);
+
+    URLRegistry();
+
+    virtual ~URLRegistry();
+    virtual void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) = 0;
     virtual void unregisterURL(const URL&) = 0;
+    virtual void unregisterURLsForContext(const ScriptExecutionContext&) = 0;
 
     // This is an optional API
     virtual URLRegistrable* lookup(const String&) const { ASSERT_NOT_REACHED(); return 0; }


### PR DESCRIPTION
#### 67070d4e441692ab2cda8a9fe5257006742ff0da
<pre>
Rename WebCore::findHTMLTag to findTag and extend it to find SVG and MathML tags
<a href="https://bugs.webkit.org/show_bug.cgi?id=244020">https://bugs.webkit.org/show_bug.cgi?id=244020</a>
rdar://problem/98767683

Reviewed by NOBODY (OOPS!).

We currently generate the WebCore::findHTMLTag function and use this in the
AtomHTMLToken constructor. We can extend this to look for any known tag name
(HTML, SVG, or MathML) by reworking make-names.pl a bit.

This isn&apos;t helpful for Speedometer performance, since parsing non-HTML tags is
rare, but local testing shows it to be a neutral change. Handling all known tag
names will set the stage for a later patch that does improve Speedometer
performance.

We generate a new pair of files, KnownTag.h and KnownTag.cpp, move the
old findHTMLTag function there, and rename it to findTag.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCoreMacros.cmake:

Build system changes to invoke make_names.pl to generate
KnownTag.{h,cpp}.

* Source/WebCore/dom/make_names.pl:
(readKnownTags):

Read a list of tag name files. Any duplicate tag name found in a
subsequent file is ignored (e.g. the SVG script tag will be ignored if
the HTML tag name file is parsed first). Since the %parameters hash
doesn&apos;t make much sense when parsing multiple files, it&apos;s cleared out
by the end of the function, but the namespace for each tag (which comes
from the parameters object) is recorded on the tag object.

(printNamesHeaderFile):
(printNamesCppFile):

Remove the findHTMLTag generation from generated HTMLNames.{h,cpp} etc.

(printKnownTagsHeaderFile):
(printKnownTagsCppFile):

Generated findTag in KnownTag.{h,cpp}. Use the namespace stored on the
tag object to decide the QualifiedName on which to look up the local
name.

(findMaxTagLength): Just refer to the global %allTags variable, like other
functions do.

(tagsWithLength): Simplify.

(generateFindTagForLength): We need to replace &quot;_&quot;s with &quot;-&quot;s when generating
the big switch statement, since the tag names it&apos;s operating on have already
been converted into identifiers.

* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::AtomHTMLToken):

Call the new findTag function.
</pre>