### PR TITLE
[Xcode] Avoid building libwebrtc for watchOS/tvOS

### DIFF
--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
@@ -84,20 +84,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FB39D0D01200F0E300088E69"
-               BuildableName = "libwebrtc.dylib"
-               BlueprintName = "libwebrtc"
-               ReferencedContainer = "container:Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "41816F7913859C550057AAA4"
                BuildableName = "All"
                BlueprintName = "All"


### PR DESCRIPTION
#### a7782f59ecbe6c2bf04a059289dd5cd71aa2c390
<pre>
[Xcode] Avoid building libwebrtc for watchOS/tvOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243907">https://bugs.webkit.org/show_bug.cgi?id=243907</a>

Reviewed by Alexey Proskuryakov.

Remove libwebrtc from the required targets in &quot;Everything up to WebKit +
Tools&quot; (it&apos;s already not listed in &quot;Everything up to WebKit&quot;). It will
only be built when it&apos;s needed, which is determined by when WebCore
conditionally links against it.

* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:

Canonical link: <a href="https://commits.webkit.org/253400@main">https://commits.webkit.org/253400@main</a>
</pre>
