### PR TITLE
HistoryItem are sometimes skipped on back/forward navigation on GitHub.com

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7268,7 +7268,8 @@ bool Document::hasRecentUserInteractionForNavigationFromJS() const
     if (UserGestureIndicator::processingUserGesture(this))
         return true;
 
-    return (MonotonicTime::now() - lastHandledUserGestureTimestamp()) <= UserGestureToken::maximumIntervalForUserGestureForwarding;
+    static constexpr Seconds maximumItervalForUserGestureForwarding { 10_s };
+    return (MonotonicTime::now() - lastHandledUserGestureTimestamp()) <= maximumItervalForUserGestureForwarding;
 }
 
 void Document::startTrackingStyleRecalcs()


### PR DESCRIPTION
#### 165f03cc6003b24c3ddaf46517c3f72183c5f4fe
<pre>
HistoryItem are sometimes skipped on back/forward navigation on GitHub.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=243914">https://bugs.webkit.org/show_bug.cgi?id=243914</a>
&lt;rdar://98392025&gt;

Reviewed by Darin Adler.

In 252649@main, I relaxed the user gesture requirement for our back/forward list
hijacking prevention, by treating a navigation as having a user gesture if there
was user interaction within the last second. This seemed to address issues on
GitHub.com.

However, back/forward navigation on GitHub is still flaky because it sometimes
takes GitHub a little over 1 second to call history.pushState() after the user
has clicked a link. To address this, I am relaxing our heuristic even further
to 10 seconds instead.

Note that Chrome seems to only require having ever interacted with the page
so we&apos;re still stricter.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasRecentUserInteractionForNavigationFromJS const):

Canonical link: <a href="https://commits.webkit.org/253405@main">https://commits.webkit.org/253405@main</a>
</pre>
