### PR TITLE
Fix rendererSyleHasScrollSnap typo

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -920,17 +920,17 @@ void FrameView::updateSnapOffsets()
     auto* documentElement = document.documentElement();
     RenderBox* bodyRenderer = document.bodyOrFrameset() ? document.bodyOrFrameset()->renderBox() : nullptr;
     RenderBox* rootRenderer = documentElement ? documentElement->renderBox() : nullptr;
-    auto rendererSyleHasScrollSnap = [](const RenderObject* renderer) {
+    auto hasScrollSnap = [](const RenderObject* renderer) {
         return renderer && renderer->style().scrollSnapType().strictness != ScrollSnapStrictness::None;
     };
 
     const RenderStyle* styleToUse = nullptr;
-    if (rendererSyleHasScrollSnap(bodyRenderer)) {
+    if (hasScrollSnap(bodyRenderer)) {
         //  The specification doesn't allow setting scroll-snap-type on the body, but
         //  we do this to ensure backwards compatibility with an earlier version of the
         //  specification: See webkit.org/b/200643.
         styleToUse = &bodyRenderer->style();
-    } else if (rendererSyleHasScrollSnap(rootRenderer))
+    } else if (hasScrollSnap(rootRenderer))
         styleToUse = &rootRenderer->style();
 
     if (!styleToUse || !documentElement) {


### PR DESCRIPTION
#### 9a90883b2863d368621b33f54099a0e8121753dc
<pre>
Fix rendererSyleHasScrollSnap typo
<a href="https://bugs.webkit.org/show_bug.cgi?id=243916">https://bugs.webkit.org/show_bug.cgi?id=243916</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::updateSnapOffsets):

Canonical link: <a href="https://commits.webkit.org/253401@main">https://commits.webkit.org/253401@main</a>
</pre>
