### PR TITLE
Enable imperative slot API by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -750,11 +750,11 @@ ImperativeSlotAPIEnabled:
   humanReadableDescription: "Imperative Shadow DOM Distribution API"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely.
 InProcessCookieCacheEnabled:

--- a/Source/WebCore/features.json
+++ b/Source/WebCore/features.json
@@ -1594,8 +1594,7 @@
     {
         "name": "Imperative Slot API",
         "status": {
-            "status": "In Development",
-            "enabled-by-default": false
+            "status": "Supported"
         },
         "specification": "Web Components",
         "category": "webapps",


### PR DESCRIPTION
#### 80742bc96322e3782179e9b2afecf546b7870c4d
<pre>
Enable imperative slot API by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=218692">https://bugs.webkit.org/show_bug.cgi?id=218692</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/features.json:

Canonical link: <a href="https://commits.webkit.org/253402@main">https://commits.webkit.org/253402@main</a>
</pre>
