### PR TITLE
[Gardening] Remove unknown file paths from TestExpectations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4112,11 +4112,6 @@ webkit.org/b/207262 imported/w3c/web-platform-tests/web-animations/timing-model/
 webkit.org/b/210963 imported/w3c/web-platform-tests/css/css-animations/animation-important-002.html [ ImageOnlyFailure ]
 webkit.org/b/235110 imported/w3c/web-platform-tests/css/css-animations/flip-running-animation-via-variable.html [ ImageOnlyFailure ]
 
-# These are references
-imported/w3c/web-platform-tests/css/css-transforms/transform-compound-notref-1.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-transforms/transform-compound-notref-2.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-001.ref.html [ Skip ]
-
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-transformed-tbody-contains-fixed-position.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-transformed-tfoot-contains-fixed-position.html [ ImageOnlyFailure ]
 webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform-transformed-thead-contains-fixed-position.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 9e04387dd1f4c191a5502f4474ad4ea6718f6c17
<pre>
[Gardening] Remove unknown file paths from TestExpectations

Unreviewed test gardening.

* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253404@main">https://commits.webkit.org/253404@main</a>
</pre>
