### PR TITLE
Add some style invalidation tests for imperative slot API

### DIFF
--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-1-expected.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-1-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="box"></div>
+<style>
+div { width: 100px; height: 100px; background: green; }
+</style>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-1.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-1.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="host"><div class="fail">FAIL</div><div class="pass">PASS</div></div>
+<style>
+#host > div { width: 100px; height: 100px; }
+.fail { background: red; }
+.pass { color: green; background: green; }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+const shadowRoot = host.attachShadow({mode: 'closed', slotAssignment: 'manual'});
+const slot = document.createElement('slot');
+shadowRoot.appendChild(slot);
+slot.assign(document.querySelector('.fail'));
+
+requestAnimationFrame(() => {
+    setTimeout(() => {
+        slot.assign(document.querySelector('.pass'), document.querySelector('.pass'));
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-2-expected.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-2-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="box"></div>
+<style>
+div { width: 100px; height: 100px; background: green; }
+</style>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-2.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-2.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="host"><div class="fail">FAIL</div><div class="pass">PASS</div><div class="fail">FAIL</div></div>
+<style>
+#host > div { width: 50px; height: 50px; }
+.fail { background: red; }
+.pass { color: green; background: green; }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+const shadowRoot = host.attachShadow({mode: 'closed', slotAssignment: 'manual'});
+shadowRoot.innerHTML = '<style> slot::slotted(.pass) { display: block; border: solid 25px green; } </style>'
+const slot = document.createElement('slot');
+shadowRoot.appendChild(slot);
+slot.assign(...host.children);
+
+requestAnimationFrame(() => {
+    setTimeout(() => {
+        document.createElement('slot').assign(...host.querySelectorAll('.fail'));
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+});
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-3-expected.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-3-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="box"></div>
+<style>
+div { width: 100px; height: 100px; background: green; }
+</style>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/imperative-slot-update-3.html
+++ b/LayoutTests/fast/shadow-dom/imperative-slot-update-3.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="host"><div class="fail"></div><div class="pass"></div><div class="fail"></div><div class="pass"></div></div>
+<style>
+#host > div { width: 100px; height: 50px; }
+.fail { background: red; }
+.pass { color: green; background: green; }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+const shadowRoot = host.attachShadow({mode: 'closed', slotAssignment: 'manual'});
+shadowRoot.innerHTML = '<style> slot::slotted(.fail:first-child) { display: none; } </style>'
+const slot = document.createElement('slot');
+shadowRoot.appendChild(slot);
+slot.assign(...host.children);
+
+requestAnimationFrame(() => {
+    setTimeout(() => {
+        shadowRoot.querySelector('style').sheet.insertRule('::slotted(.fail:nth-child(3)) { display: none; }', 0);
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### c10d6b1a2919f1a4e8c882afe3e71008acf158bc
<pre>
Add some style invalidation tests for imperative slot API
<a href="https://bugs.webkit.org/show_bug.cgi?id=243923">https://bugs.webkit.org/show_bug.cgi?id=243923</a>

Reviewed by Simon Fraser.

Added style invalidation tests for the imperative slot API.

* LayoutTests/fast/shadow-dom/imperative-slot-update-1-expected.html: Added.
* LayoutTests/fast/shadow-dom/imperative-slot-update-1.html: Added.
* LayoutTests/fast/shadow-dom/imperative-slot-update-2-expected.html: Added.
* LayoutTests/fast/shadow-dom/imperative-slot-update-2.html: Added.
* LayoutTests/fast/shadow-dom/imperative-slot-update-3-expected.html: Added.
* LayoutTests/fast/shadow-dom/imperative-slot-update-3.html: Added.

Canonical link: <a href="https://commits.webkit.org/253456@main">https://commits.webkit.org/253456@main</a>
</pre>
