### PR TITLE
REGRESSION(252541@main): [ iOS ] platform/ios/ios/plugin/youtube-flash-plugin-iframe.html is a constant timeout

### DIFF
--- a/LayoutTests/platform/ios/ios/plugin/youtube-flash-plugin-iframe.html
+++ b/LayoutTests/platform/ios/ios/plugin/youtube-flash-plugin-iframe.html
@@ -26,7 +26,7 @@ function testEmbedYouTubeVideoInsideIframe()
         '<body>',
         '<p>Normal Embed:<br><embed id="normal-embed" src="http://www.youtube.com/v/N0gb9v4LI4o" type="application/x-shockwave-flash" width="425" height="350"></p>',
         '<script>',
-        'window.setTimeout(window.parent.checkEmbeddedYouTubeVideoInsideIframe, 0);',
+        'onload = () => setTimeout(window.parent.checkEmbeddedYouTubeVideoInsideIframe, 0);',
         '</' + 'script>',
         '</body>',
     ];


### PR DESCRIPTION
#### 8fd86461c8c1ec85118233768713fc4e7a301257
<pre>
REGRESSION(252541@main): [ iOS ] platform/ios/ios/plugin/youtube-flash-plugin-iframe.html is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=243904">https://bugs.webkit.org/show_bug.cgi?id=243904</a>

Reviewed by Wenson Hsieh.

Fix the test by waiting until 0s timer fires after load event.

* LayoutTests/platform/ios/ios/plugin/youtube-flash-plugin-iframe.html:

Canonical link: <a href="https://commits.webkit.org/253408@main">https://commits.webkit.org/253408@main</a>
</pre>
