### PR TITLE
HTML foster-parenting algorithm no longer requires foster parents to be elements

### DIFF
--- a/LayoutTests/fast/parser/foster-parent-expected.txt
+++ b/LayoutTests/fast/parser/foster-parent-expected.txt
@@ -1,3 +1,6 @@
-Otherwise, if there is a table element in the stack of open elements, but the last table element in the stack of open elements has no parent, or its parent node is not an element, then the foster parent element is the element before the last table element in the stack of open elements.
+PASS div.children.length is 0
+PASS docFragment.firstElementChild.tagName is "H1"
+PASS successfullyParsed is true
 
-success
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/foster-parent.html
+++ b/LayoutTests/fast/parser/foster-parent.html
@@ -1,10 +1,6 @@
 <html>
 <body>
-<script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-</script>
-
+<script src="../../resources/js-test.js"></script>
 <div id="div">
   <table id="table">
     <script>
@@ -13,18 +9,14 @@ if (window.testRunner)
       var docFragment = document.createDocumentFragment();
       docFragment.appendChild(table);
     </script>
-    <h1 id="h1">Otherwise, if there is a table element in the stack of open elements, but the last table element in the stack of open elements has no parent, or its parent node is not an element, then the foster parent element is the element before the last table element in the stack of open elements.</h1>
+    <h1></h1>
   </table>
 </div>
 
 <script>
 var div = document.getElementById('div');
-var h1 = document.getElementById('h1');
-
-if (h1 && h1 === div.firstElementChild)
-    document.write("success");
-else
-    document.write("failure");
+shouldBe("div.children.length", "0");
+shouldBeEqualToString("docFragment.firstElementChild.tagName", "H1");
 </script>
 </body>
 </html>

--- a/LayoutTests/html5lib/resources/template.dat
+++ b/LayoutTests/html5lib/resources/template.dat
@@ -1338,3 +1338,16 @@
 |   <body>
 |     <template>
 |       content
+
+#data
+<template><a><table><a>
+#errors
+#document
+| <html>
+|   <head>
+|     <template>
+|       content
+|         <a>
+|           <a>
+|           <table>
+|   <body>


### PR DESCRIPTION
#### 3363325609a1e42490d723fb454977c18e5009e1
<pre>
HTML foster-parenting algorithm no longer requires foster parents to be elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=137501">https://bugs.webkit.org/show_bug.cgi?id=137501</a>

Reviewed by Chris Dumez.

Merge <a href="https://src.chromium.org/viewvc/blink?revision=183370&amp">https://src.chromium.org/viewvc/blink?revision=183370&amp</a>;view=revision

This patch updates the foster parenting algorithm to match the spec and behavior of Blink.

* LayoutTests/fast/parser/foster-parent-expected.txt:
* LayoutTests/fast/parser/foster-parent.html:
* LayoutTests/html5lib/resources/template.dat:

* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::findFosterSite):

Canonical link: <a href="https://commits.webkit.org/253504@main">https://commits.webkit.org/253504@main</a>
</pre>
