### PR TITLE
[WTF] Optimize tryGetUtf8ForRange by introducing SIMD find8NonASCII

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TestWTF_SOURCES
     Tests/WTF/Span.cpp
     Tests/WTF/StdLibExtras.cpp
     Tests/WTF/StringBuilder.cpp
+    Tests/WTF/StringCommon.cpp
     Tests/WTF/StringConcatenate.cpp
     Tests/WTF/StringHasher.cpp
     Tests/WTF/StringImpl.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1019,6 +1019,7 @@
 		E3A1E78221B25B7A008C6007 /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A1E78021B25B79008C6007 /* URL.cpp */; };
 		E3A1E78521B25B91008C6007 /* URLParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A1E78421B25B91008C6007 /* URLParser.cpp */; };
 		E3C21A7C21B25CA2003B31A3 /* URLExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3C21A7B21B25CA2003B31A3 /* URLExtras.mm */; };
+		E3DE273C28A8D67800873DF2 /* StringCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DE273B28A8D67700873DF2 /* StringCommon.cpp */; };
 		E3DEA8111F0A589000CBC2E8 /* ThreadGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DEA8101F0A588000CBC2E8 /* ThreadGroup.cpp */; };
 		E3EFB02F25506503003C2F96 /* SystemBeep.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3EFB02E25506503003C2F96 /* SystemBeep.mm */; };
 		E3F8AB92241AB9CE003E2A7E /* AccessibilityRemoteUIApp.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3F8AB91241AB9CE003E2A7E /* AccessibilityRemoteUIApp.mm */; };
@@ -3132,6 +3133,7 @@
 		E3A1E78021B25B79008C6007 /* URL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URL.cpp; sourceTree = "<group>"; };
 		E3A1E78421B25B91008C6007 /* URLParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLParser.cpp; sourceTree = "<group>"; };
 		E3C21A7B21B25CA2003B31A3 /* URLExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = URLExtras.mm; sourceTree = "<group>"; };
+		E3DE273B28A8D67700873DF2 /* StringCommon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringCommon.cpp; sourceTree = "<group>"; };
 		E3DEA8101F0A588000CBC2E8 /* ThreadGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadGroup.cpp; sourceTree = "<group>"; };
 		E3EFB02E25506503003C2F96 /* SystemBeep.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemBeep.mm; sourceTree = "<group>"; };
 		E3F8AB91241AB9CE003E2A7E /* AccessibilityRemoteUIApp.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityRemoteUIApp.mm; sourceTree = "<group>"; };
@@ -4858,6 +4860,7 @@
 				BCA30C7D266D2F43000D230C /* Span.cpp */,
 				FE2BCDC62470FC7000DEC33B /* StdLibExtras.cpp */,
 				81B50192140F232300D9EB58 /* StringBuilder.cpp */,
+				E3DE273B28A8D67700873DF2 /* StringCommon.cpp */,
 				7CD4C26C1E2C0E6E00929470 /* StringConcatenate.cpp */,
 				93ABA80816DDAB91002DB2FA /* StringHasher.cpp */,
 				26F1B44315CA434F00D1E4BF /* StringImpl.cpp */,
@@ -5739,6 +5742,7 @@
 				BCA30C7E266D2F43000D230C /* Span.cpp in Sources */,
 				FE2BCDC72470FDA300DEC33B /* StdLibExtras.cpp in Sources */,
 				7C83DF321D0A590C00FEBCF3 /* StringBuilder.cpp in Sources */,
+				E3DE273C28A8D67800873DF2 /* StringCommon.cpp in Sources */,
 				7CD4C26E1E2C0E6E00929470 /* StringConcatenate.cpp in Sources */,
 				7C83DF361D0A590C00FEBCF3 /* StringHasher.cpp in Sources */,
 				7C83DF371D0A590C00FEBCF3 /* StringImpl.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WTFStringUtilities.h"
+#include <wtf/Vector.h>
+#include <wtf/text/StringCommon.h>
+
+namespace TestWebKitAPI {
+
+#if CPU(ARM64)
+TEST(WTF_StringCommon, Find8NonASCII)
+{
+    Vector<LChar> vector(4096);
+    vector.fill('a');
+
+    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 4096));
+
+    vector[4095] = 0x80;
+    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    for (unsigned i = 0; i < 16; ++i)
+        EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 4095 - i));
+
+    vector[1024] = 0x80;
+    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 1023));
+
+    vector[1024] = 0xff;
+    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 1023));
+
+    vector[1024] = 0x7f;
+    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 4095);
+
+    vector[0] = 0xff;
+    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 0);
+    for (int i = 0; i < 16; ++i) {
+        vector[i] = 0xff;
+        EXPECT_EQ(WTF::find8NonASCII(vector.data() + i, 4096 - i) - vector.data(), i);
+    }
+}
+
+TEST(WTF_StringCommon, Find16NonASCII)
+{
+    Vector<UChar> vector(4096);
+    vector.fill('a');
+
+    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 4096));
+
+    vector[4095] = 0x80;
+    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    for (unsigned i = 0; i < 16; ++i)
+        EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 4095 - i));
+
+    vector[1024] = 0x80;
+    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 1023));
+
+    vector[1024] = 0xff;
+    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 1023));
+
+    vector[1024] = 0x7f;
+    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 4095);
+
+    vector[0] = 0xff;
+    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 0);
+    for (int i = 0; i < 16; ++i) {
+        vector[i] = 0xff;
+        EXPECT_EQ(WTF::find16NonASCII(vector.data() + i, 4096 - i) - vector.data(), i);
+    }
+}
+#endif
+
+} // namespace


### PR DESCRIPTION
#### 1b93c3178bdb088707ca358225f7dcf0f58ea5f4
<pre>
[WTF] Optimize tryGetUtf8ForRange by introducing SIMD find8NonASCII
<a href="https://bugs.webkit.org/show_bug.cgi?id=243925">https://bugs.webkit.org/show_bug.cgi?id=243925</a>

Reviewed by Darin Adler.

This patch introduces find8NonASCII and find16NonASCII. Later, both can be used in isAllASCII implementation.
We use it for tryGetUtf8ForRange improvement by avoiding allocating temporary Vector. We also extract it as
a template so that we can avoid allocating temporary CString in TextEncoder#encode.
The microbenchmark showed TextEncoder#encode improvement by 15%.

* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::find8NonASCIIAlignedImpl):
(WTF::find16NonASCIIAlignedImpl):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::find8NonASCII):
(WTF::find16NonASCII):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharacters):
(WTF::StringImpl::tryGetUtf8ForRange const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUtf8ForRange const):
* Source/WebCore/dom/TextEncoder.cpp:
(WebCore::TextEncoder::encode const):

Canonical link: <a href="https://commits.webkit.org/253410@main">https://commits.webkit.org/253410@main</a>
</pre>
