### PR TITLE
Avoid unnecessary UTF-8 string generation

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1315,7 +1315,7 @@ JSObject* GlobalObject::moduleLoaderCreateImportMetaProperties(JSGlobalObject* g
 template <typename T>
 static CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, T& string)
 {
-    Expected<CString, UTF8ConversionError> expectedString = string.tryGetUtf8();
+    Expected<CString, UTF8ConversionError> expectedString = string.tryGetUTF8();
     if (expectedString)
         return expectedString.value();
     switch (expectedString.error()) {
@@ -3209,7 +3209,7 @@ static void dumpException(GlobalObject* globalObject, JSValue exception)
 
     auto exceptionString = exception.toWTFString(globalObject);
     CHECK_EXCEPTION();
-    Expected<CString, UTF8ConversionError> expectedCString = exceptionString.tryGetUtf8();
+    Expected<CString, UTF8ConversionError> expectedCString = exceptionString.tryGetUTF8();
     if (expectedCString)
         printf("Exception: %s\n", expectedCString.value().data());
     else
@@ -3474,9 +3474,9 @@ static void runInteractive(GlobalObject* globalObject)
         Expected<CString, UTF8ConversionError> utf8;
         if (evaluationException) {
             fputs("Exception: ", stdout);
-            utf8 = evaluationException->value().toWTFString(globalObject).tryGetUtf8();
+            utf8 = evaluationException->value().toWTFString(globalObject).tryGetUTF8();
         } else
-            utf8 = returnValue.toWTFStringForConsole(globalObject).tryGetUtf8();
+            utf8 = returnValue.toWTFStringForConsole(globalObject).tryGetUTF8();
 
         CString result;
         if (utf8)

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -317,7 +317,7 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
 
     if (date == m_cachedDateString)
         return m_cachedDateStringValue;
-    auto expectedString = date.tryGetUtf8();
+    auto expectedString = date.tryGetUTF8();
     if (!expectedString) {
         if (expectedString.error() == UTF8ConversionError::OutOfMemory)
             throwOutOfMemoryError(globalObject, scope);
@@ -339,8 +339,8 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         return value;
     };
 
-    auto dateUtf8 = expectedString.value();
-    double value = parseDateImpl(dateUtf8.data());
+    auto dateUTF8 = expectedString.value();
+    double value = parseDateImpl(dateUTF8.data());
     m_cachedDateString = date;
     m_cachedDateStringValue = value;
     return value;

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -92,7 +92,7 @@ static void printExpectedCStringHelper(PrintStream& out, const char* type, Expec
 
 void printInternal(PrintStream& out, StringView string)
 {
-    printExpectedCStringHelper(out, "StringView", string.tryGetUtf8());
+    printExpectedCStringHelper(out, "StringView", string.tryGetUTF8());
 }
 
 void printInternal(PrintStream& out, const CString& string)
@@ -102,12 +102,12 @@ void printInternal(PrintStream& out, const CString& string)
 
 void printInternal(PrintStream& out, const String& string)
 {
-    printExpectedCStringHelper(out, "String", string.tryGetUtf8());
+    printExpectedCStringHelper(out, "String", string.tryGetUTF8());
 }
 
 void printInternal(PrintStream& out, const AtomString& string)
 {
-    printExpectedCStringHelper(out, "String", string.string().tryGetUtf8());
+    printExpectedCStringHelper(out, "String", string.string().tryGetUTF8());
 }
 
 void printInternal(PrintStream& out, const StringImpl* string)
@@ -116,7 +116,7 @@ void printInternal(PrintStream& out, const StringImpl* string)
         printInternal(out, "(null StringImpl*)");
         return;
     }
-    printExpectedCStringHelper(out, "StringImpl*", string->tryGetUtf8());
+    printExpectedCStringHelper(out, "StringImpl*", string->tryGetUTF8());
 }
 
 void printInternal(PrintStream& out, bool value)

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -88,7 +88,7 @@ bool StringView::endsWithIgnoringASCIICase(StringView suffix) const
     return ::WTF::endsWithIgnoringASCIICase(*this, suffix);
 }
 
-Expected<CString, UTF8ConversionError> StringView::tryGetUtf8(ConversionMode mode) const
+Expected<CString, UTF8ConversionError> StringView::tryGetUTF8(ConversionMode mode) const
 {
     if (isNull())
         return CString("", 0);
@@ -99,7 +99,7 @@ Expected<CString, UTF8ConversionError> StringView::tryGetUtf8(ConversionMode mod
 
 CString StringView::utf8(ConversionMode mode) const
 {
-    auto expectedString = tryGetUtf8(mode);
+    auto expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);
     return expectedString.value();
 }

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -459,19 +459,19 @@ CString String::latin1() const
     return result;
 }
 
-Expected<CString, UTF8ConversionError> String::tryGetUtf8(ConversionMode mode) const
+Expected<CString, UTF8ConversionError> String::tryGetUTF8(ConversionMode mode) const
 {
-    return m_impl ? m_impl->tryGetUtf8(mode) : CString { "", 0 };
+    return m_impl ? m_impl->tryGetUTF8(mode) : CString { "", 0 };
 }
 
-Expected<CString, UTF8ConversionError> String::tryGetUtf8() const
+Expected<CString, UTF8ConversionError> String::tryGetUTF8() const
 {
-    return tryGetUtf8(LenientConversion);
+    return tryGetUTF8(LenientConversion);
 }
 
 CString String::utf8(ConversionMode mode) const
 {
-    Expected<CString, UTF8ConversionError> expectedString = tryGetUtf8(mode);
+    Expected<CString, UTF8ConversionError> expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);
     return expectedString.value();
 }

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -52,8 +52,8 @@ Vector<uint8_t> convertArrayBufferToVector(ArrayBuffer* buffer)
 Vector<uint8_t> produceRpIdHash(const String& rpId)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    auto rpIdUtf8 = rpId.utf8();
-    crypto->addBytes(rpIdUtf8.data(), rpIdUtf8.length());
+    auto rpIdUTF8 = rpId.utf8();
+    crypto->addBytes(rpIdUTF8.data(), rpIdUTF8.length());
     return crypto->computeHash();
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -240,7 +240,7 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
 
     // 5. Sort animation properties in ascending order by the Unicode codepoints that define each property name.
     std::sort(animationProperties.begin(), animationProperties.end(), [](auto& lhs, auto& rhs) {
-        return lhs.string().string().utf8() < rhs.string().string().utf8();
+        return codePointCompareLessThan(lhs.string().string(), rhs.string().string());
     });
 
     // 6. For each property name in animation properties,

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -109,7 +109,7 @@ static bool compareCSSTransitions(const CSSTransition& a, const CSSTransition& b
 
     // Otherwise, sort A and B in ascending order by the Unicode codepoints that make up the expanded transition property name of each transition
     // (i.e. without attempting case conversion and such that ‘-moz-column-width’ sorts before ‘column-width’).
-    return a.transitionProperty().utf8() < b.transitionProperty().utf8();
+    return codePointCompareLessThan(a.transitionProperty(), b.transitionProperty());
 }
 
 static bool compareCSSAnimations(const CSSAnimation& a, const CSSAnimation& b)

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1035,8 +1035,8 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
                     // FIXME: Converting to JS just to JSON-Stringify seems inefficient. We should find a way to go directly from the struct to JSON.
                     auto jwk = toJS<IDLDictionary<JsonWebKey>>(*(promise->globalObject()), *(promise->globalObject()), WTFMove(std::get<JsonWebKey>(key)));
                     String jwkString = JSONStringify(promise->globalObject(), jwk, 0);
-                    CString jwkUtf8String = jwkString.utf8(StrictConversion);
-                    bytes.append(jwkUtf8String.data(), jwkUtf8String.length());
+                    CString jwkUTF8String = jwkString.utf8(StrictConversion);
+                    bytes.append(jwkUTF8String.data(), jwkUTF8String.length());
                 }
                 }
 

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-TextDecoder::TextDecoder(const char* label, Options options)
+TextDecoder::TextDecoder(StringView label, Options options)
     : m_textEncoding(label)
     , m_options(options)
 {
@@ -45,7 +45,7 @@ ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options o
     const UChar nullCharacter = '\0';
     if (strippedLabel.contains(nullCharacter))
         return Exception { RangeError };
-    auto decoder = adoptRef(*new TextDecoder(strippedLabel.utf8().data(), options));
+    auto decoder = adoptRef(*new TextDecoder(strippedLabel, options));
     if (!decoder->m_textEncoding.isValid() || !strcmp(decoder->m_textEncoding.name(), "replacement"))
         return Exception { RangeError };
     return decoder;

--- a/Source/WebCore/dom/TextDecoder.h
+++ b/Source/WebCore/dom/TextDecoder.h
@@ -35,7 +35,7 @@ class TextCodec;
 
 namespace WebCore {
 
-class TextDecoder : public RefCounted<TextDecoder> {
+class TextDecoder final : public RefCounted<TextDecoder> {
 public:
     ~TextDecoder();
 
@@ -55,7 +55,7 @@ public:
     ExceptionOr<String> decode(std::optional<BufferSource::VariantType>, DecodeOptions);
 
 private:
-    TextDecoder(const char*, Options);
+    TextDecoder(StringView, Options);
 
     const PAL::TextEncoding m_textEncoding;
     const Options m_options;

--- a/Source/WebCore/dom/TextEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoder.cpp
@@ -38,13 +38,11 @@ String TextEncoder::encoding() const
 
 RefPtr<Uint8Array> TextEncoder::encode(String&& input) const
 {
-    if (StringImpl* impl = input.impl()) {
-        auto result = impl->tryGetUtf8ForRange([&](Span<const char> span) -> RefPtr<Uint8Array> {
-            return Uint8Array::tryCreate(reinterpret_cast<const uint8_t*>(span.data()), span.size());
-        }, 0, impl->length());
-        if (result)
-            return result.value();
-    }
+    auto result = input.tryGetUTF8ForRange([&](Span<const char> span) -> RefPtr<Uint8Array> {
+        return Uint8Array::tryCreate(reinterpret_cast<const uint8_t*>(span.data()), span.size());
+    }, 0, input.length());
+    if (result)
+        return result.value();
     return Uint8Array::tryCreate(nullptr, 0);
 }
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -695,7 +695,7 @@ template<typename T> void getStringData(IDataObject* data, FORMATETC* format, Ve
     ReleaseStgMedium(&store);
 }
 
-void getUtf8Data(IDataObject* data, FORMATETC* format, Vector<String>& dataStrings)
+void getUTF8Data(IDataObject* data, FORMATETC* format, Vector<String>& dataStrings)
 {
     STGMEDIUM store;
     if (FAILED(data->GetData(format, &store)))
@@ -741,7 +741,7 @@ void setUCharData(IDataObject* data, FORMATETC* format, const Vector<String>& da
     ::GlobalFree(medium.hGlobal);
 }
 
-void setUtf8Data(IDataObject* data, FORMATETC* format, const Vector<String>& dataStrings)
+void setUTF8Data(IDataObject* data, FORMATETC* format, const Vector<String>& dataStrings)
 {
     STGMEDIUM medium { };
     medium.tymed = TYMED_HGLOBAL;
@@ -783,14 +783,14 @@ static const ClipboardFormatMap& getClipboardMap()
 {
     static ClipboardFormatMap formatMap;
     if (formatMap.isEmpty()) {
-        formatMap.add(htmlFormat()->cfFormat, new ClipboardDataItem(htmlFormat(), getUtf8Data, setUtf8Data));
+        formatMap.add(htmlFormat()->cfFormat, new ClipboardDataItem(htmlFormat(), getUTF8Data, setUTF8Data));
         formatMap.add(texthtmlFormat()->cfFormat, new ClipboardDataItem(texthtmlFormat(), getStringData<UChar>, setUCharData));
-        formatMap.add(plainTextFormat()->cfFormat,  new ClipboardDataItem(plainTextFormat(), getStringData<char>, setUtf8Data));
+        formatMap.add(plainTextFormat()->cfFormat,  new ClipboardDataItem(plainTextFormat(), getStringData<char>, setUTF8Data));
         formatMap.add(plainTextWFormat()->cfFormat,  new ClipboardDataItem(plainTextWFormat(), getStringData<UChar>, setUCharData));
         formatMap.add(cfHDropFormat()->cfFormat,  new ClipboardDataItem(cfHDropFormat(), getHDropData, setHDropData));
-        formatMap.add(filenameFormat()->cfFormat,  new ClipboardDataItem(filenameFormat(), getStringData<char>, setUtf8Data));
+        formatMap.add(filenameFormat()->cfFormat,  new ClipboardDataItem(filenameFormat(), getStringData<char>, setUTF8Data));
         formatMap.add(filenameWFormat()->cfFormat,  new ClipboardDataItem(filenameWFormat(), getStringData<UChar>, setUCharData));
-        formatMap.add(urlFormat()->cfFormat,  new ClipboardDataItem(urlFormat(), getStringData<char>, setUtf8Data));
+        formatMap.add(urlFormat()->cfFormat,  new ClipboardDataItem(urlFormat(), getStringData<char>, setUTF8Data));
         formatMap.add(urlWFormat()->cfFormat,  new ClipboardDataItem(urlWFormat(), getStringData<UChar>, setUCharData));
     }
     return formatMap;

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -37,8 +37,7 @@ namespace WebCore {
 
 ScriptBuffer::ScriptBuffer(const String& string)
 {
-    auto utf8 = string.utf8();
-    m_buffer.append(utf8.data(), utf8.length());
+    append(string);
 }
 
 ScriptBuffer ScriptBuffer::empty()
@@ -65,8 +64,11 @@ bool ScriptBuffer::containsSingleFileMappedSegment() const
 
 void ScriptBuffer::append(const String& string)
 {
-    auto utf8 = string.utf8();
-    m_buffer.append(utf8.data(), utf8.length());
+    auto result = string.tryGetUTF8ForRange([&](Span<const char> span) -> bool {
+        m_buffer.append(span.data(), span.size());
+        return true;
+    }, 0, string.length());
+    RELEASE_ASSERT(result);
 }
 
 void ScriptBuffer::append(const FragmentedSharedBuffer& buffer)

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -53,8 +53,8 @@ String SWScriptStorage::sha2Hash(const String& input) const
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(m_salt.data(), m_salt.size());
-    auto inputUtf8 = input.utf8();
-    crypto->addBytes(inputUtf8.data(), inputUtf8.length());
+    auto inputUTF8 = input.utf8();
+    crypto->addBytes(inputUTF8.data(), inputUTF8.length());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1465,13 +1465,13 @@ bool XMLDocumentParser::appendFragmentSource(const String& chunk)
     ASSERT(!m_context);
     ASSERT(m_parsingFragment);
 
-    CString chunkAsUtf8 = chunk.utf8();
+    CString chunkAsUTF8 = chunk.utf8();
     
     // libxml2 takes an int for a length, and therefore can't handle XML chunks larger than 2 GiB.
-    if (chunkAsUtf8.length() > INT_MAX)
+    if (chunkAsUTF8.length() > INT_MAX)
         return false;
 
-    initializeParserContext(chunkAsUtf8);
+    initializeParserContext(chunkAsUTF8);
     xmlParseContent(context());
     endDocument(); // Close any open text nodes.
 
@@ -1479,10 +1479,10 @@ bool XMLDocumentParser::appendFragmentSource(const String& chunk)
     // XMLDocumentParserQt has a similar check (m_stream.error() == QXmlStreamReader::PrematureEndOfDocumentError) in doEnd().
     // Check if all the chunk has been processed.
     long bytesProcessed = xmlByteConsumed(context());
-    if (bytesProcessed == -1 || ((unsigned long)bytesProcessed) != chunkAsUtf8.length()) {
+    if (bytesProcessed == -1 || ((unsigned long)bytesProcessed) != chunkAsUTF8.length()) {
         // FIXME: I don't believe we can hit this case without also having seen an error or a null byte.
         // If we hit this ASSERT, we've found a test case which demonstrates the need for this code.
-        ASSERT(m_sawError || (bytesProcessed >= 0 && !chunkAsUtf8.data()[bytesProcessed]));
+        ASSERT(m_sawError || (bytesProcessed >= 0 && !chunkAsUTF8.data()[bytesProcessed]));
         return false;
     }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -307,15 +307,15 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
         return;
     }
 
-    auto pinUtf8 = pin::validateAndConvertToUTF8(pin);
-    if (!pinUtf8) {
+    auto pinUTF8 = pin::validateAndConvertToUTF8(pin);
+    if (!pinUTF8) {
         // Fake a pin invalid response from the authenticator such that clients could show some error to the user.
         if (auto* observer = this->observer())
             observer->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
         tryRestartPin(CtapDeviceResponseCode::kCtap2ErrPinInvalid);
         return;
     }
-    auto tokenRequest = pin::TokenRequest::tryCreate(*pinUtf8, peerKey);
+    auto tokenRequest = pin::TokenRequest::tryCreate(*pinUTF8, peerKey);
     if (!tokenRequest) {
         receiveRespond(ExceptionData { UnknownError, "Cannot create a TokenRequest."_s });
         return;

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1404,12 +1404,12 @@ static RetainPtr<NSString> dumpFramesAsText(WebFrame *frame)
 
     NSString *innerText = [documentElement innerText];
 
-    // We use WTF::String::tryGetUtf8 to convert innerText to a UTF8 buffer since
+    // We use WTF::String::tryGetUTF8 to convert innerText to a UTF8 buffer since
     // it can handle dangling surrogates and the NSString
     // conversion methods cannot. After the conversion to a buffer, we turn that buffer into
     // a CFString via fromUTF8WithLatin1Fallback().createCFString() which can be appended to
     // the result without any conversion.
-    if (auto utf8Result = WTF::String(innerText).tryGetUtf8()) {
+    if (auto utf8Result = WTF::String(innerText).tryGetUTF8()) {
         auto string = WTFMove(utf8Result.value());
         [result appendFormat:@"%@\n", String::fromUTF8WithLatin1Fallback(string.data(), string.length()).createCFString().get()];
     } else

--- a/Tools/DumpRenderTree/win/UIDelegate.cpp
+++ b/Tools/DumpRenderTree/win/UIDelegate.cpp
@@ -482,7 +482,7 @@ std::string toMessage(BSTR message)
         return "";
     // Return "(null)" for an invalid UTF-16 sequence to align with WebKitTestRunner.
     // FIXME: Could probably take advantage of WC_ERR_INVALID_CHARS and avoid converting to UTF-8 twice.
-    if (!StringView(ucharFrom(message), length).tryGetUtf8(StrictConversion))
+    if (!StringView(ucharFrom(message), length).tryGetUTF8(StrictConversion))
         return "(null)";
     return toUTF8(message);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -588,7 +588,7 @@ void InjectedBundle::dumpToStdErr(const String& output)
     if (output.isEmpty())
         return;
     // FIXME: Do we really have to convert to UTF-8 instead of using toWK?
-    auto string = output.tryGetUtf8();
+    auto string = output.tryGetUTF8();
     postPageMessage("DumpToStdErr", string ? string->data() : "Out of memory\n");
 }
 
@@ -599,7 +599,7 @@ void InjectedBundle::outputText(StringView output, IsFinalTestOutput isFinalTest
     if (output.isEmpty())
         return;
     // FIXME: Do we really have to convert to UTF-8 instead of using toWK?
-    auto string = output.tryGetUtf8();
+    auto string = output.tryGetUTF8();
     // We use WKBundlePagePostMessageIgnoringFullySynchronousMode() instead of WKBundlePagePostMessage() to make sure that all text output
     // is done via asynchronous IPC, even if the connection is in fully synchronous mode due to a WKBundlePagePostSynchronousMessageForTesting()
     // call. Otherwise, messages logged via sync and async IPC may end up out of order and cause flakiness.


### PR DESCRIPTION
#### 0e2f9b02c86cd64041171e370c18f4b262ea7505
<pre>
Avoid unnecessary UTF-8 string generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243931">https://bugs.webkit.org/show_bug.cgi?id=243931</a>

Reviewed by Darin Adler.

This patch removes unnecessary UTF-8 string generation by using tryGetUtf8ForRange.
We consolidate the implementation into StringImpl::tryGetUtf8ForCharacters and
implement the other functions by using that.

One of the important change is that we avoid unnecessary allocation in ScriptBuffer.
This is important since ScriptBuffer size tends to be very large.

* Source/JavaScriptCore/jsc.cpp:
(toCString):
(dumpException):
(runInteractive):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::parseDate):
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printInternal):
* Source/WTF/wtf/URL.cpp:
(WTF::percentEncodeCharacters):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharacters):
(WTF::StringImpl::tryGetUTF8ForRange const):
(WTF::StringImpl::tryGetUTF8 const):
(WTF::StringImpl::utf8 const):
(WTF::StringImpl::tryGetUtf8ForRange const): Deleted.
(WTF::StringImpl::tryGetUtf8 const): Deleted.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForRange const):
(WTF::StringImpl::tryGetUTF8ForCharacters):
(WTF::StringImpl::tryGetUtf8ForRange const): Deleted.
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::tryGetUTF8 const):
(WTF::StringView::utf8 const):
(WTF::StringView::tryGetUtf8 const): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::tryGetUTF8ForRange const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::tryGetUTF8 const):
(WTF::String::utf8 const):
(WTF::String::tryGetUtf8 const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::tryGetUTF8ForRange const):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::produceRpIdHash):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::processKeyframeLikeObject):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareCSSTransitions):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::wrapKey):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::TextDecoder):
(WebCore::TextDecoder::create):
* Source/WebCore/dom/TextDecoder.h:
(WebCore::TextDecoder::fatal const): Deleted.
(WebCore::TextDecoder::ignoreBOM const): Deleted.
* Source/WebCore/dom/TextEncoder.cpp:
(WebCore::TextEncoder::encode const):
* Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp:
(WebCore::KeyedEncoderGeneric::encodeString):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::getUTF8Data):
(WebCore::setUTF8Data):
(WebCore::getClipboardMap):
(WebCore::getUtf8Data): Deleted.
(WebCore::setUtf8Data): Deleted.
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::ScriptBuffer):
(WebCore::ScriptBuffer::append):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::appendFragmentSource):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueGetPinTokenAfterRequestPin):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(dumpFramesAsText):
* Tools/DumpRenderTree/win/UIDelegate.cpp:
(toMessage):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::dumpToStdErr):
(WTR::InjectedBundle::outputText):

Canonical link: <a href="https://commits.webkit.org/253642@main">https://commits.webkit.org/253642@main</a>
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5125abc6325ae90210b6ff97c1761d8ccf3dda46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95491 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149220 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/29078 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25514 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90734 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23499 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73572 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23566 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66572 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78583 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26864 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12707 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/72220 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26783 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13722 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2584 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36581 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/75003 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33001 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16589 "Passed tests") | 
<!--EWS-Status-Bubble-End-->