### PR TITLE
Non-unified build fixes, mid August 2022 edition

### DIFF
--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ElementInternals.h"
 
+#include "ElementRareData.h"
 #include "ShadowRoot.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -29,6 +29,7 @@
 #include "ElementTraversal.h"
 #include "NodeRenderStyle.h"
 #include "PseudoClassChangeInvalidation.h"
+#include "RenderElement.h"
 #include "ShadowRoot.h"
 #include "SlotAssignment.h"
 #include "StyleResolver.h"


### PR DESCRIPTION
#### ae62826f4735
<pre>
 Non-unified build fixes, mid August 2022 edition

Unreviewed non-unified build fixes.

* Source/WebCore/dom/ElementInternals.cpp: Add header defining
  Element::shadowRoot()
* Source/WebCore/style/ChildChangeInvalidation.cpp: Add header defining
  RenderObject::style()
</pre>