### PR TITLE
[GTK] Prefer EGL over X11 where available

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.h
@@ -122,7 +122,7 @@ private:
     static EGLSurface createWindowSurfaceWPE(EGLDisplay, EGLConfig, GLNativeWindowType);
 #endif
 
-    static bool getEGLConfig(EGLDisplay, EGLConfig*, EGLSurfaceType);
+    static bool getEGLConfig(EGLDisplay, EGLConfig*, EGLSurfaceType, Function<bool(int)>&& = nullptr);
 
     EGLContext m_context { nullptr };
     EGLSurface m_surface { nullptr };

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -141,39 +141,21 @@ static bool webGLEnabled(WebKitURISchemeRequest* request)
     return webkit_settings_get_enable_webgl(webkit_web_view_get_settings(webView));
 }
 
-static const char* openGLAPI()
+static const char* openGLAPI(bool isEGL)
 {
 #if USE(LIBEPOXY)
     if (epoxy_is_desktop_gl())
         return "OpenGL (libepoxy)";
     return "OpenGL ES 2 (libepoxy)";
 #else
-#if USE(GLX)
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11)
-        return "OpenGL";
-#endif
 #if USE(EGL)
+    if (isEGL) {
 #if USE(OPENGL_ES)
-    return "OpenGL ES 2";
-#else
+        return "OpenGL ES 2";
+#endif
+    }
+#endif
     return "OpenGL";
-#endif
-#endif
-#endif
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static const char* nativeInterface()
-{
-#if PLATFORM(GTK)
-#if USE(GLX)
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11)
-        return "GLX";
-#endif
-#endif
-
-#if USE(EGL)
-    return "EGL";
 #endif
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -370,23 +352,27 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
         "  <td>%s</td>"
         " </tbody></tr>",
         webGLEnabled(request) ? "Yes" : "No");
+#endif
 
+#if USE(EGL) || USE(GLX)
     auto glContext = GLContext::createOffscreenContext();
     glContext->makeContextCurrent();
+
+    bool isEGL = glContext->isEGLContext();
 
     g_string_append_printf(html,
         " <tbody><tr>"
         "  <td><div class=\"titlename\">API</div></td>"
         "  <td>%s</td>"
         " </tbody></tr>",
-        openGLAPI());
+        openGLAPI(isEGL));
 
     g_string_append_printf(html,
         " <tbody><tr>"
         "  <td><div class=\"titlename\">Native interface</div></td>"
         "  <td>%s</td>"
         " </tbody></tr>",
-        nativeInterface());
+        isEGL ? "EGL" : "GLX");
 
     g_string_append_printf(html,
         " <tbody><tr>"
@@ -441,10 +427,8 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     g_string_free(extensions, TRUE);
 #endif
 
-    bool isGLX = false;
 #if USE(GLX)
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11) {
-        isGLX = true;
+    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11 && !isEGL) {
         auto* x11Display = downcast<PlatformDisplayX11>(PlatformDisplay::sharedDisplay()).native();
 
         g_string_append_printf(html,
@@ -471,7 +455,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #endif
 
 #if USE(EGL)
-    if (!isGLX) {
+    if (isEGL) {
         auto eglDisplay = PlatformDisplay::sharedDisplay().eglDisplay();
 
         g_string_append_printf(html,
@@ -497,7 +481,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             eglQueryString(eglDisplay, EGL_EXTENSIONS));
     }
 #endif
-#endif // ENABLE(WEBGL)
+#endif // USE(EGL) || USE(GLX)
 
     g_string_append(html, "<table>");
 


### PR DESCRIPTION
#### 5948e8b03d0ca94615e87db2d3435717e36a510c
<pre>
[GTK] Prefer EGL over X11 where available
<a href="https://bugs.webkit.org/show_bug.cgi?id=236163">https://bugs.webkit.org/show_bug.cgi?id=236163</a>

Reviewed by Žan Doberšek.

Patch Authored by Carlos Garcia Campos &lt;cgarcia@igalia.com&gt; and Arcady Goldmints-Orlov.

* Source/WebCore/platform/graphics/GLContext.cpp:
(WebCore::GLContext::createContextForWindow): Create context from shared context if available. Then
create EGL context first and GLX later.
(WebCore::GLContext::createSharingContext): Create EGL shared context first and GLX later, if
WEBKIT_FORCE_GLX environment variable is not set.
* Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:
(WebCore::GLContextEGL::getEGLConfig): Select visual compatible with window one, if compatible
function is available.
(WebCore::GLContextEGL::createWindowContext): If platform is X11 get window attributes and
instantiates a function for compatible to later compare it with specified visual id.
* Source/WebCore/platform/graphics/egl/GLContextEGL.h:
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp: Move and guard GstGL
headers.
(createGstGLDisplay): Use GstGLPlatform to select the display type.
(PlatformDisplay::tryEnsureGstGLContext const): Get GstGLPlatform from shared context.
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::openGLAPI): Simplify the API string creation.
(WebKit::WebKitProtocolHandler::handleGPU): Unify detection if EGL is used, before it assumed always
GLX if X11.
(WebKit::nativeInterface): Deleted.

Canonical link: <a href="https://commits.webkit.org/254751@main">https://commits.webkit.org/254751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/068bc27c9b5b0f8cdeb278ec4bf5e3d1925bd00b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/90123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/34669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/20740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/99440 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/33161 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/28524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/82455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/94633 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/95773 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/68/builds/26369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/76951 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/26263 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/81215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/80999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/69262 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/81739 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/34322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/15076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/76639 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/32163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/16021 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3336 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/35907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/38989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/79225 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/37810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/35105 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/17360 "Passed tests") | 
<!--EWS-Status-Bubble-End-->