### PR TITLE
Fetch Request object should keep its Blob URL alive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any-expected.txt
@@ -12,6 +12,7 @@ PASS fetch with method "OPTIONS" should fail
 PASS fetch with method "PUT" should fail
 PASS fetch with method "CUSTOM" should fail
 PASS fetch should return Content-Type from Blob
-FAIL Revoke blob URL after creating Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Revoke blob URL after creating Request, will fetch
+PASS Revoke blob URL after creating Request, then clone Request, will fetch
 PASS Revoke blob URL after calling fetch, fetch should succeed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.js
@@ -1,5 +1,26 @@
 // META: script=resources/fetch-tests.js
 
+async function garbageCollect() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    var gcRec = function (n) {
+      if (n < 1)
+        return {};
+      var temp = {i: "ab" + i + (i / 100000)};
+      temp += "foo";
+      gcRec(n-1);
+    };
+    for (var i = 0; i < 1000; i++)
+      gcRec(10);
+  }
+}
+
 function fetch_should_succeed(test, request) {
   return fetch(request).then(response => response.text());
 }
@@ -36,6 +57,24 @@ promise_test(t => {
     assert_equals(text, blob_contents);
   });
 }, 'Revoke blob URL after creating Request, will fetch');
+
+promise_test(async t => {
+  const blob_contents = 'test blob contents';
+  const blob = new Blob([blob_contents]);
+  const url = URL.createObjectURL(blob);
+  let request = new Request(url);
+
+  // Revoke the object URL.  Request should take a reference to the blob as
+  // soon as it receives it in open(), so the request succeeds even though we
+  // revoke the URL before calling fetch().
+  URL.revokeObjectURL(url);
+
+  request = request.clone();
+  await garbageCollect();
+
+  const text = await fetch_should_succeed(t, request);
+  assert_equals(text, blob_contents);
+}, 'Revoke blob URL after creating Request, then clone Request, will fetch');
 
 promise_test(function(t) {
   const blob_contents = 'test blob contents';

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.worker-expected.txt
@@ -12,6 +12,7 @@ PASS fetch with method "OPTIONS" should fail
 PASS fetch with method "PUT" should fail
 PASS fetch with method "CUSTOM" should fail
 PASS fetch should return Content-Type from Blob
-FAIL Revoke blob URL after creating Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Revoke blob URL after creating Request, will fetch
+PASS Revoke blob URL after creating Request, then clone Request, will fetch
 PASS Revoke blob URL after calling fetch, fetch should succeed
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any-expected.txt
@@ -12,6 +12,6 @@ PASS fetch with method "OPTIONS" should fail
 PASS fetch with method "PUT" should fail
 PASS fetch with method "CUSTOM" should fail
 PASS fetch should return Content-Type from Blob
-FAIL Revoke blob URL after creating Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Revoke blob URL after creating Request, will fetch
 PASS Revoke blob URL after calling fetch, fetch should succeed
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.worker-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.worker-expected.txt
@@ -12,6 +12,6 @@ PASS fetch with method "OPTIONS" should fail
 PASS fetch with method "PUT" should fail
 PASS fetch with method "CUSTOM" should fail
 PASS fetch should return Content-Type from Blob
-FAIL Revoke blob URL after creating Request, will fetch promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Revoke blob URL after creating Request, will fetch
 PASS Revoke blob URL after calling fetch, fetch should succeed
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -198,6 +198,9 @@ ExceptionOr<void> FetchRequest::initializeWith(const String& url, Init&& init)
             return setBodyResult.releaseException();
     }
 
+    if (requestURL.protocolIsBlob())
+        m_requestBlobURLLifetimeExtender = requestURL;
+
     updateContentType();
     return { };
 }
@@ -235,6 +238,9 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     auto setBodyResult = init.body ? setBody(WTFMove(*init.body)) : setBody(input);
     if (setBodyResult.hasException())
         return setBodyResult;
+
+    if (m_request.url().protocolIsBlob())
+        m_requestBlobURLLifetimeExtender = m_request.url();
 
     updateContentType();
     return { };
@@ -338,6 +344,12 @@ ExceptionOr<Ref<FetchRequest>> FetchRequest::clone()
     clone->setNavigationPreloadIdentifier(m_navigationPreloadIdentifier);
     clone->m_signal->signalFollow(m_signal);
     return clone;
+}
+
+void FetchRequest::stop()
+{
+    m_requestBlobURLLifetimeExtender.clear();
+    FetchBodyOwner::stop();
 }
 
 const char* FetchRequest::activeDOMObjectName() const

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "AbortSignal.h"
+#include "BlobURL.h"
 #include "ExceptionOr.h"
 #include "FetchBodyOwner.h"
 #include "FetchIdentifier.h"
@@ -94,12 +95,14 @@ private:
     ExceptionOr<void> setBody(FetchBody::Init&&);
     ExceptionOr<void> setBody(FetchRequest&);
 
+    void stop() final;
     const char* activeDOMObjectName() const final;
 
     ResourceRequest m_request;
     FetchOptions m_options;
     String m_referrer;
     mutable String m_requestURL;
+    BlobURLHandle m_requestBlobURLLifetimeExtender;
     Ref<AbortSignal> m_signal;
     FetchIdentifier m_navigationPreloadIdentifier;
 };
@@ -112,6 +115,8 @@ inline FetchRequest::FetchRequest(ScriptExecutionContext* context, std::optional
     , m_signal(AbortSignal::create(context))
 {
     m_request.setRequester(ResourceRequest::Requester::Fetch);
+    if (m_request.url().protocolIsBlob())
+        m_requestBlobURLLifetimeExtender = m_request.url();
     updateContentType();
 }
 


### PR DESCRIPTION
#### 046f56da695a0c509934ddcda16212a26f37cd2b
<pre>
Fetch Request object should keep its Blob URL alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=243935">https://bugs.webkit.org/show_bug.cgi?id=243935</a>

Reviewed by Geoffrey Garen.

Fetch Request object should keep its Blob URL alive. This means that creating a
Fetch Request from a Blob URL, then revoking said Blob URL then triggering a
fetch() for this request should succeed, like it does in Blink.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-with-fetch.any.worker-expected.txt:
Rebaseline tests that are now passing.

* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):
(WebCore::FetchRequest::stop):
* Source/WebCore/Modules/fetch/FetchRequest.h:
(WebCore::FetchRequest::FetchRequest):

Canonical link: <a href="https://commits.webkit.org/253469@main">https://commits.webkit.org/253469@main</a>
</pre>
