### PR TITLE
Scheduling a navigation to a Blob URL should keep the URL alive until the navigation actually occurs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window-expected.txt
@@ -1,10 +1,8 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Fetching a blob URL immediately before revoking it works in an iframe.
-TIMEOUT Fetching a blob URL immediately before revoking it works in an iframe navigation. Test timed out
+PASS Fetching a blob URL immediately before revoking it works in an iframe navigation.
 PASS Opening a blob URL in a new window immediately before revoking it works.
-TIMEOUT Opening a blob URL in a noopener about:blank window immediately before revoking it works. Test timed out
+PASS Opening a blob URL in a noopener about:blank window immediately before revoking it works.
 PASS Fetching a blob URL immediately before revoking it works in <script> tags.
 PASS Opening a blob URL in a new window by clicking an <a> tag works immediately before revoking the URL.
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -127,6 +127,8 @@ protected:
         , m_url { url }
         , m_referrer { referrer }
     {
+        if (m_url.protocolIsBlob())
+            m_blobURLLifetimeExtender = m_url;
     }
 
     void didStartTimer(Frame& frame, Timer& timer) override
@@ -163,6 +165,7 @@ private:
     Ref<Document> m_initiatingDocument;
     RefPtr<SecurityOrigin> m_securityOrigin;
     URL m_url;
+    BlobURLHandle m_blobURLLifetimeExtender;
     String m_referrer;
     bool m_haveToldClient { false };
 };


### PR DESCRIPTION
#### 568ffc6e49bac0233128a6f4ef332868d4d58712
<pre>
Scheduling a navigation to a Blob URL should keep the URL alive until the navigation actually occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=243936">https://bugs.webkit.org/show_bug.cgi?id=243936</a>

Reviewed by Geoffrey Garen.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:

Canonical link: <a href="https://commits.webkit.org/253435@main">https://commits.webkit.org/253435@main</a>
</pre>
