### PR TITLE
Unreviewed, rebaseline some more tests after 253424@main

### DIFF
--- a/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt
@@ -51,15 +51,15 @@ layer at (0,0) size 800x600
             RenderBlock (anonymous) at (8,2) size 116x13
               RenderText at (0,0) size 116x13
                 text run at (0,0) width 116: "1. Set outline property"
-          RenderText {#text} at (132,0) size 4x18
-            text run at (132,0) width 4: " "
-          RenderButton {INPUT} at (136,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0]
-            RenderBlock (anonymous) at (8,2) size 120x13
-              RenderText at (0,0) size 120x13
-                text run at (0,0) width 120: "2. Set display property"
-          RenderText {#text} at (271,0) size 5x18
-            text run at (271,0) width 5: " "
-          RenderButton {INPUT} at (275,1) size 147x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderText {#text} at (131,0) size 5x18
+            text run at (131,0) width 5: " "
+          RenderButton {INPUT} at (135,1) size 136x18 [color=#000000D8] [bgcolor=#C0C0C0]
+            RenderBlock (anonymous) at (8,2) size 119x13
+              RenderText at (0,0) size 119x13
+                text run at (0,0) width 119: "2. Set display property"
+          RenderText {#text} at (270,0) size 5x18
+            text run at (270,0) width 5: " "
+          RenderButton {INPUT} at (274,1) size 148x18 [color=#000000D8] [bgcolor=#C0C0C0]
             RenderBlock (anonymous) at (8,2) size 131x13
               RenderText at (0,0) size 131x13
                 text run at (0,0) width 131: "3. Replace span-element"

--- a/LayoutTests/platform/mac/fast/forms/button-sizes-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/button-sizes-expected.txt
@@ -105,8 +105,8 @@ layer at (0,0) size 800x600
             text run at (0,0) width 100: "Test Button"
       RenderText {#text} at (747,28) size 5x18
         text run at (747,28) width 5: " "
-      RenderButton {BUTTON} at (0,49) size 121x29 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
-        RenderBlock (anonymous) at (8,2) size 105x24
-          RenderText {#text} at (0,0) size 105x24
-            text run at (0,0) width 105: "Test Button"
+      RenderButton {BUTTON} at (0,49) size 120x29 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
+        RenderBlock (anonymous) at (8,2) size 104x24
+          RenderText {#text} at (0,0) size 104x24
+            text run at (0,0) width 104: "Test Button"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (8,3) size 141x13
           RenderBlock {DIV} at (148,0) size 20x19
       RenderText {#text} at (0,0) size 0x0
-layer at (19,65) size 141x13 scrollWidth 272
+layer at (19,65) size 141x13 scrollWidth 271
   RenderBlock {DIV} at (0,0) size 141x13
     RenderText {#text} at (0,0) size 271x13
       text run at (0,0) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac/fast/forms/input-appearance-spinbutton-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/input-appearance-spinbutton-expected.txt
@@ -169,9 +169,9 @@ layer at (209,376) size 268x26
   RenderBlock {DIV} at (3,3) size 268x26
 layer at (209,408) size 249x26
   RenderBlock {DIV} at (0,0) size 249x26
-layer at (209,440) size 282x27
+layer at (209,440) size 281x27
   RenderBlock {DIV} at (3,3) size 282x27
-layer at (209,473) size 263x27
+layer at (209,473) size 262x27
   RenderBlock {DIV} at (0,0) size 263x27
 layer at (107,131) size 13x15
   RenderBlock (relative positioned) {DIV} at (92,0) size 14x15

--- a/LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt
@@ -8,19 +8,19 @@ layer at (0,0) size 800x600
           text run at (0,0) width 762: "Test appearances of spin buttons. Disabled state and read-only state should have appearances different from the normal"
           text run at (0,18) width 34: "state."
       RenderBlock {DIV} at (0,52) size 784x29
-        RenderInline {LABEL} at (0,0) size 335x18
+        RenderInline {LABEL} at (0,0) size 334x18
           RenderTextControl {INPUT} at (0,0) size 248x29 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderFlexibleBox {DIV} at (3,0) size 242x29
               RenderBlock {DIV} at (0,3) size 223x23
-          RenderText {#text} at (247,8) size 88x18
-            text run at (247,8) width 88: " Normal state"
+          RenderText {#text} at (247,8) size 87x18
+            text run at (247,8) width 87: " Normal state"
       RenderBlock {DIV} at (0,81) size 784x29
-        RenderInline {LABEL} at (0,0) size 342x18
+        RenderInline {LABEL} at (0,0) size 341x18
           RenderTextControl {INPUT} at (0,0) size 247x29 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
             RenderFlexibleBox {DIV} at (3,0) size 241x29
               RenderBlock {DIV} at (0,3) size 222x23
-          RenderText {#text} at (246,8) size 96x18
-            text run at (246,8) width 96: " Disabled state"
+          RenderText {#text} at (246,8) size 95x18
+            text run at (246,8) width 95: " Disabled state"
       RenderBlock {DIV} at (0,110) size 784x29
         RenderInline {LABEL} at (0,0) size 351x18
           RenderTextControl {INPUT} at (0,0) size 247x29 [bgcolor=#FFFFFF] [border: (2px inset #000000)]

--- a/LayoutTests/platform/mac/fast/forms/select-list-box-with-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select-list-box-with-height-expected.txt
@@ -7,5 +7,5 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 372x18
           text run at (0,0) width 372: "The select below has a size of 3, but a much larger height."
       RenderBlock (anonymous) at (0,34) size 784x250
-        RenderListBox {SELECT} at (0,0) size 59x250 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderListBox {SELECT} at (0,0) size 58x250 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt
@@ -4,10 +4,10 @@ layer at (0,0) size 800x316
   RenderBlock {HTML} at (0,0) size 800x316
     RenderBody {BODY} at (8,8) size 784x300
       RenderBlock {FORM} at (0,0) size 784x300
-        RenderListBox {SELECT} at (0,0) size 70x281 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
-        RenderText {#text} at (70,260) size 4x18
-          text run at (70,260) width 4: " "
-        RenderBR {BR} at (74,260) size 0x18
+        RenderListBox {SELECT} at (0,0) size 69x281 [bgcolor=#FFFFFF] [border: (1px inset #808080)]
+        RenderText {#text} at (69,260) size 4x18
+          text run at (69,260) width 4: " "
+        RenderBR {BR} at (73,260) size 0x18
         RenderMenuList {SELECT} at (0,282) size 74x18 [bgcolor=#FFFFFF]
           RenderBlock (anonymous) at (0,0) size 74x18
             RenderText at (8,2) size 31x13

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -66,16 +66,16 @@ layer at (0,0) size 785x678
         RenderBlock {P} at (0,0) size 769x38
           RenderText {#text} at (0,0) size 267x18
             text run at (0,0) width 267: "How does your browser fare on this test? "
-          RenderMenuList {SELECT} at (266,1) size 243x18 [bgcolor=#FFFFFF]
-            RenderBlock (anonymous) at (0,0) size 242x18
+          RenderMenuList {SELECT} at (266,1) size 242x18 [bgcolor=#FFFFFF]
+            RenderBlock (anonymous) at (0,0) size 241x18
               RenderText at (8,2) size 139x13
                 text run at (8,2) width 139: "The test renders correctly."
-          RenderText {#text} at (508,0) size 5x18
-            text run at (508,0) width 5: " "
+          RenderText {#text} at (507,0) size 5x18
+            text run at (507,0) width 5: " "
           RenderInline {LABEL} at (0,0) size 220x18
-            RenderText {#text} at (512,0) size 73x18
-              text run at (512,0) width 73: "Comment: "
-            RenderTextControl {INPUT} at (584,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
+            RenderText {#text} at (511,0) size 73x18
+              text run at (511,0) width 73: "Comment: "
+            RenderTextControl {INPUT} at (583,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderText {#text} at (0,0) size 0x0
           RenderButton {INPUT} at (0,20) size 53x18 [color=#000000D8] [bgcolor=#C0C0C0]
             RenderBlock (anonymous) at (8,2) size 37x13
@@ -115,5 +115,5 @@ layer at (0,0) size 785x678
       RenderBlock {P} at (0,622) size 769x19
         RenderText {#text} at (0,0) size 185x18
           text run at (0,0) width 185: "Last updated in March 1999."
-layer at (595,473) size 141x13
+layer at (594,473) size 141x13
   RenderBlock {DIV} at (3,3) size 141x13

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt
@@ -15,8 +15,8 @@ layer at (0,0) size 800x600
               RenderText {#text} at (1,1) size 59x18
                 text run at (1,1) width 59: "First row"
       RenderBlock {FORM} at (0,46) size 784x18
-        RenderButton {INPUT} at (0,0) size 47x18 [color=#000000D8] [bgcolor=#C0C0C0]
-          RenderBlock (anonymous) at (8,2) size 31x13
-            RenderText at (0,0) size 31x13
-              text run at (0,0) width 31: "insert"
+        RenderButton {INPUT} at (0,0) size 46x18 [color=#000000D8] [bgcolor=#C0C0C0]
+          RenderBlock (anonymous) at (8,2) size 30x13
+            RenderText at (0,0) size 30x13
+              text run at (0,0) width 30: "insert"
         RenderText {#text} at (0,0) size 0x0


### PR DESCRIPTION
#### c9b6f8603f3a8b3c57d1e82ce189f73348d7cd94
<pre>
Unreviewed, rebaseline some more tests after 253424@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243941">https://bugs.webkit.org/show_bug.cgi?id=243941</a>

* LayoutTests/platform/mac/fast/css/continuationCrash-expected.txt:
* LayoutTests/platform/mac/fast/forms/button-sizes-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/input-appearance-spinbutton-expected.txt:
* LayoutTests/platform/mac/fast/forms/number/number-appearance-spinbutton-disabled-readonly-expected.txt:
* LayoutTests/platform/mac/fast/forms/select-list-box-with-height-expected.txt:
* LayoutTests/platform/mac/fast/forms/select/optgroup-rendering-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug26178-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253427@main">https://commits.webkit.org/253427@main</a>
</pre>
