### PR TITLE
getClientRects returning wrong values on empty selection

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -41,10 +41,28 @@ TextBoxIterator TextBox::nextTextBox() const
 
 LayoutRect TextBox::selectionRect(unsigned rangeStart, unsigned rangeEnd) const
 {
+    bool isCaretCase = rangeStart == rangeEnd;
+
     auto [clampedStart, clampedEnd] = selectableRange().clamp(rangeStart, rangeEnd);
 
-    if (clampedStart >= clampedEnd && !(rangeStart == rangeEnd && rangeStart >= start() && rangeStart <= end()))
-        return { };
+    if (clampedStart >= clampedEnd) {
+        if (isCaretCase) {
+            // handle unitary range, e.g.: representing caret position
+            bool isCaretWithinTextBox = rangeStart >= start() && rangeStart < end();
+            // For last text box in a InlineTextBox chain, we allow the caret to move to a position 'after' the end of the last text box.
+            bool isCaretWithinLastTextBox = rangeStart >= start() && rangeStart <= end();
+
+            auto itEnd = TextBoxRange(TextBoxIterator(*this)).end();
+            auto isLastTextBox = nextTextBox() == itEnd;
+
+            if ((isLastTextBox && !isCaretWithinLastTextBox) || (!isLastTextBox && !isCaretWithinTextBox))
+                return { };
+        } else {
+            bool isRangeWithinTextBox = (rangeStart >= start() && rangeStart <= end());
+            if (!isRangeWithinTextBox)
+                return { };
+        }
+    }
 
     auto lineSelectionRect = LineSelection::logicalRect(*lineBox());
     auto selectionRect = LayoutRect { logicalLeft(), lineSelectionRect.y(), logicalWidth(), lineSelectionRect.height() };

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -465,8 +465,7 @@ void RenderText::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
 
 static FloatRect localQuadForTextRun(const InlineIterator::TextBox& run, unsigned start, unsigned end, bool useSelectionHeight)
 {
-    unsigned realEnd = std::min(run.end(), end);
-    LayoutRect boxSelectionRect = run.selectionRect(start, realEnd);
+    LayoutRect boxSelectionRect = run.selectionRect(start, end);
     if (!boxSelectionRect.height())
         return { };
     if (useSelectionHeight)


### PR DESCRIPTION
#### b9508a969a49f752996bd8d3dd86fd29339e004d
<pre>
getClientRects returning wrong values on empty selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=148532">https://bugs.webkit.org/show_bug.cgi?id=148532</a>
&lt;rdar://22634654&gt;

Reviewed by Antti Koivisto.

* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::selectionRect const):

getClientRects should return only the rect at the caret position when selection is empty (or unitary range).
In this PR we changed the way to evaluate if the caret is within the text box regarding its upper limit.
If the caret position is equal the end of the text box, the caret should be considered in the range of the
text box only for the last text box in the chain. This is because we allow the caret to move to a position after
the last text box in the chain.

For the non-caret case we keep calculating if range is within the text box as before.

* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::selectionRect const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::localQuadForTextRun):

We are now passing the real offset limits (start, end) of the range to TextBox::selectionRect so
it can identify a caret case. This seems to be unnecessary since we are clamping the range limits in relation
to the textbox inside selectionRect. Also, without that we can&apos;t differ between a caret case and a case in which the text box
has just 1 position overlapping with.

Canonical link: <a href="https://commits.webkit.org/253536@main">https://commits.webkit.org/253536@main</a>
</pre>
