### PR TITLE
Web Inspector: Show "Scroll" labels in the element tree for scrollable elements

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
@@ -1,0 +1,32 @@
+Tests for the CSS.nodeLayoutFlagsChanged event with the Scrollable enum.
+
+
+
+== Running test suite: CSS.nodeLayoutFlagsChanged.Scrollable
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyScrollable
+PASS: Should be scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowHidden
+Changing to `overflow: scroll`...
+PASS: Should render nodes changed to `display: block`.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowVisible
+Changing to `overflow: scroll`...
+PASS: Should have become scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.ContentShrunk
+Changing content length
+PASS: Should have become non-scrollable
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents
+PASS: iframe element should not be scrollable.
+PASS: iframe's #document node should not be scrollable
+PASS: Iframe <html> element should be scrollable.
+PASS: Iframe <body> element should not be scrollable.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.IFrameWithScrollableBody
+PASS: iframe element should not be scrollable.
+PASS: iframe's #document node should not be scrollable
+PASS: Iframe <html> element should not be scrollable.
+PASS: Iframe <body> element should be scrollable.
+

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .scroller {
+        height: 200px;
+        width: 200px;
+        border: 1px solid black;
+    }
+
+    .scroller .contents {
+        height: 200%;
+        width: 100%;
+    }
+
+    #scroller {
+        overflow: scroll;
+    }
+    
+    #overflow-hidden {
+        overflow: hidden;
+    }
+
+    #overflow-visible {
+        overflow: visible;
+    }
+    
+    #content-shrinking {
+        overflow: scroll;
+    }
+
+    #content-shrinking.shrunk .contents {
+        height: 80%;
+    }
+</style>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let documentNode;
+
+    let suite = InspectorTest.createAsyncSuite("CSS.nodeLayoutFlagsChanged.Scrollable");
+
+    function addTestCase({name, description, selector, setup, domNodeHandler})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            setup,
+            async test() {
+                let nodeId = await documentNode.querySelector(selector);
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '${selector}'.`);
+                await domNodeHandler(domNode);
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyScrollable",
+        description: "Test that an element with overflow:scroll and scrollable contents is scrollable",
+        selector: "#scroller",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should be scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowHidden",
+        description: "Test that nodes changed to `display: none` are not rendered.",
+        selector: "#overflow-hidden",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should not be initially scrollable.");
+
+            InspectorTest.log("Changing to `overflow: scroll`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "overflow: scroll"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Rendered), "Should render nodes changed to `display: block`.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.InitiallyOverflowVisible",
+        description: "Test that nodes that change from having visible overflow to `overflow:scroll` are scrollable",
+        selector: "#overflow-visible",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should not be initially scrollable.");
+
+            InspectorTest.log("Changing to `overflow: scroll`...");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("style", "overflow: scroll"),
+            ]);
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should have become scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.ContentShrunk",
+        description: "Test that nodes whose content shrinks are no longer scrollable",
+        selector: "#content-shrinking",
+        async domNodeHandler(domNode) {
+            InspectorTest.assert(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should be initially scrollable.");
+
+            InspectorTest.log("Changing content length");
+            await Promise.all([
+                domNode.awaitEvent(WI.DOMNode.Event.LayoutFlagsChanged),
+                domNode.setAttributeValue("class", "shrunk scroller"),
+            ]);
+            InspectorTest.expectTrue(!domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Should have become non-scrollable");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents",
+        description: "Test scrollability of document nodes in an iframe",
+        selector: "#iframe",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe element should not be scrollable.");
+
+            let iframeDocumentNode = domNode.children[0];
+            InspectorTest.expectFalse(iframeDocumentNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe's #document node should not be scrollable");
+
+            let iframeHTMLNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("html"));
+            InspectorTest.expectTrue(iframeHTMLNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <html> element should be scrollable.");
+
+            let iframeBodyNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("body"));
+            InspectorTest.expectFalse(iframeBodyNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <body> element should not be scrollable.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.IFrameWithScrollableBody",
+        description: "Test scrollability of the body node in an iframe ",
+        selector: "#iframe-with-scrollable-body",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe element should not be scrollable.");
+
+            let iframeDocumentNode = domNode.children[0];
+            InspectorTest.expectFalse(iframeDocumentNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "iframe's #document node should not be scrollable");
+
+            let iframeHTMLNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("html"));
+            InspectorTest.expectFalse(iframeHTMLNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <html> element should not be scrollable.");
+
+            let iframeBodyNode = WI.domManager.nodeForId(await iframeDocumentNode.querySelector("body"));
+            InspectorTest.expectTrue(iframeBodyNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "Iframe <body> element should be scrollable.");
+        },
+    });
+
+    WI.domManager.requestDocument().then((doc) => {
+        documentNode = doc;
+        suite.runTestCasesAndFinish();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.nodeLayoutFlagsChanged event with the Scrollable enum.</p>
+
+    <div class="scroller" id="scroller">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="overflow-hidden">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="overflow-visible">
+        <div class="contents"></div>
+    </div>
+
+    <div class="scroller" id="content-shrinking">
+        <div class="contents"></div>
+    </div>
+
+    <iframe id="iframe" srcdoc="
+    <html><style>body { height: 3000px; }</style><body>iframe document</body></html>
+    "></iframe>
+
+    <iframe id="iframe-with-scrollable-body" srcdoc="
+    <!DOCTYPE html><html><style>html { height: 100%; overflow: hidden; } body { height: 100%; overflow: scroll; } div { height: 1000px; }</style><body><div>contents</div></body></html>
+    "></iframe>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -273,6 +273,7 @@
             "type": "string",
             "enum": [
                 "rendered",
+                "scrollable",
                 "flex",
                 "grid",
                 "event"

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -185,6 +185,23 @@ void InspectorInstrumentation::didChangeRendererForDOMNodeImpl(InstrumentingAgen
         cssAgent->didChangeRendererForDOMNode(node);
 }
 
+void InspectorInstrumentation::didAddOrRemoveScrollbarsImpl(InstrumentingAgents& instrumentingAgents, FrameView& frameView)
+{
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent()) {
+        auto* document = frameView.frame().document();
+        if (auto* documentElement = document ? document->documentElement() : nullptr)
+            cssAgent->didChangeRendererForDOMNode(*documentElement);
+    }
+}
+
+void InspectorInstrumentation::didAddOrRemoveScrollbarsImpl(InstrumentingAgents& instrumentingAgents, RenderObject& renderer)
+{
+    if (auto* cssAgent = instrumentingAgents.enabledCSSAgent()) {
+        if (auto* node = renderer.node())
+            cssAgent->didChangeRendererForDOMNode(*node);
+    }
+}
+
 void InspectorInstrumentation::willModifyDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& oldValue, const AtomString& newValue)
 {
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -42,6 +42,7 @@
 #include "EventTarget.h"
 #include "FormData.h"
 #include "Frame.h"
+#include "FrameView.h"
 #include "HitTestResult.h"
 #include "InspectorInstrumentationPublic.h"
 #include "Page.h"
@@ -124,6 +125,8 @@ public:
     static void didRemoveDOMNode(Document&, Node&);
     static void willDestroyDOMNode(Node&);
     static void didChangeRendererForDOMNode(Node&);
+    static void didAddOrRemoveScrollbars(FrameView&);
+    static void didAddOrRemoveScrollbars(RenderObject&);
     static void willModifyDOMAttr(Document&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttr(Document&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttr(Document&, Element&, const AtomString& name);
@@ -346,6 +349,8 @@ private:
     static void didRemoveDOMNodeImpl(InstrumentingAgents&, Node&);
     static void willDestroyDOMNodeImpl(InstrumentingAgents&, Node&);
     static void didChangeRendererForDOMNodeImpl(InstrumentingAgents&, Node&);
+    static void didAddOrRemoveScrollbarsImpl(InstrumentingAgents&, FrameView&);
+    static void didAddOrRemoveScrollbarsImpl(InstrumentingAgents&, RenderObject&);
     static void willModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& oldValue, const AtomString& newValue);
     static void didModifyDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name, const AtomString& value);
     static void didRemoveDOMAttrImpl(InstrumentingAgents&, Element&, const AtomString& name);
@@ -603,6 +608,20 @@ inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
     if (auto* agents = instrumentingAgents(node.document()))
         didChangeRendererForDOMNodeImpl(*agents, node);
+}
+
+inline void InspectorInstrumentation::didAddOrRemoveScrollbars(FrameView& frameView)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(frameView.frame().document()))
+        didAddOrRemoveScrollbarsImpl(*agents, frameView);
+}
+
+inline void InspectorInstrumentation::didAddOrRemoveScrollbars(RenderObject& renderer)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(renderer))
+        didAddOrRemoveScrollbarsImpl(*agents, renderer);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -51,6 +51,7 @@
 #include "FontPlatformData.h"
 #include "Frame.h"
 #include "HTMLHeadElement.h"
+#include "HTMLHtmlElement.h"
 #include "HTMLStyleElement.h"
 #include "InspectorDOMAgent.h"
 #include "InspectorHistory.h"
@@ -980,8 +981,21 @@ OptionSet<InspectorCSSAgent::LayoutFlag> InspectorCSSAgent::layoutFlagsForNode(N
 
     OptionSet<LayoutFlag> layoutFlags;
 
-    if (renderer)
+    if (renderer) {
         layoutFlags.add(InspectorCSSAgent::LayoutFlag::Rendered);
+
+        if (is<Document>(node)) {
+            // We display document scrollability on the document element's node in the frontend. Other browsers show
+            // scrollability on document.scrollingElement(), but that makes it impossible to see when both the document
+            // and the <body> are scrollable in quirks mode.
+        } else if (is<HTMLHtmlElement>(node)) {
+            if (auto* frameView = node.document().view()) {
+                if (frameView->isScrollable())
+                    layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
+            }
+        } else if (is<RenderBox>(*renderer) && downcast<RenderBox>(*renderer).canBeScrolledAndHasScrollableArea())
+            layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
+    }
 
     if (auto contextType = layoutFlagContextType(renderer))
         layoutFlags.add(*contextType);
@@ -1000,6 +1014,8 @@ static RefPtr<JSON::ArrayOf<String /* Protocol::CSS::LayoutFlag */>> toProtocol(
     auto protocolLayoutFlags = JSON::ArrayOf<String /* Protocol::CSS::LayoutFlag */>::create();
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Rendered))
         protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Rendered));
+    if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Scrollable))
+        protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Scrollable));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Flex))
         protocolLayoutFlags->addItem(Protocol::Helpers::getEnumConstantValue(Protocol::CSS::LayoutFlag::Flex));
     if (layoutFlags.contains(InspectorCSSAgent::LayoutFlag::Grid))

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -136,6 +136,7 @@ public:
         Flex = 1 << 1,
         Grid = 1 << 2,
         Event = 1 << 3,
+        Scrollable = 1 << 4,
     };
     OptionSet<LayoutFlag> layoutFlagsForNode(Node&);
     RefPtr<JSON::ArrayOf<String /* Inspector::Protocol::CSS::LayoutFlag */>> protocolLayoutFlagsForNode(Node&);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -573,7 +573,7 @@ void FrameView::setContentsSize(const IntSize& size)
 
     ScrollView::setContentsSize(size);
     contentsResized();
-    
+
     Page* page = frame().page();
     if (!page)
         return;
@@ -3032,6 +3032,8 @@ void FrameView::addedOrRemovedScrollbar()
     }
 
     updateTiledBackingAdaptiveSizing();
+
+    InspectorInstrumentation::didAddOrRemoveScrollbars(*this);
 }
 
 TiledBacking::Scrollability FrameView::computeScrollability() const

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -124,8 +124,10 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
     RenderElement::styleDidChange(diff, oldStyle);
     updateFromStyle();
 
+    bool gainedOrLostLayer = false;
     if (requiresLayer()) {
         if (!layer() && layerCreationAllowedForSubtree()) {
+            gainedOrLostLayer = true;
             if (s_wasFloating && isFloating())
                 setChildNeedsLayout();
             createLayer();
@@ -133,6 +135,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
                 layer()->setRepaintStatus(NeedsFullRepaint);
         }
     } else if (layer() && layer()->parent()) {
+        gainedOrLostLayer = true;
 #if ENABLE(CSS_COMPOSITING)
         if (oldStyle && oldStyle->hasBlendMode())
             layer()->willRemoveChildWithBlendMode();
@@ -153,6 +156,9 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
         if (s_hadTransform)
             setNeedsLayoutAndPrefWidthsRecalc();
     }
+
+    if (gainedOrLostLayer)
+        InspectorInstrumentation::didAddOrRemoveScrollbars(*this);
 
     if (layer()) {
         layer()->styleChanged(diff, oldStyle);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1287,6 +1287,8 @@ void RenderLayerScrollableArea::updateScrollInfoAfterLayout()
         m_layer.setNeedsPostLayoutCompositingUpdate();
 
     resnapAfterLayout();
+
+    InspectorInstrumentation::didAddOrRemoveScrollbars(m_layer.renderer());
 }
 
 bool RenderLayerScrollableArea::overflowControlsIntersectRect(const IntRect& localRect) const

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1357,6 +1357,8 @@ localizedStrings["Script ignored due to blackbox"] = "Script ignored due to blac
 localizedStrings["Script ignored when debugging due to URL pattern blackbox"] = "Script ignored when debugging due to URL pattern blackbox";
 localizedStrings["Scripts"] = "Scripts";
 localizedStrings["Scripts can also be individually blackboxed by clicking on the %s icon that is shown on hover."] = "Scripts can also be individually blackboxed by clicking on the %s icon that is shown on hover.";
+/* Title for a badge applied to DOM nodes that are a scrollable container. */
+localizedStrings["Scroll"] = "Scroll";
 /* Scroll selected DOM node into view on the inspected web page */
 localizedStrings["Scroll into View"] = "Scroll into View";
 localizedStrings["Search"] = "Search";

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -274,7 +274,7 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(Array.isArray(layoutFlags), layoutFlags);
         console.assert(layoutFlags.every((layoutFlag) => Object.values(WI.DOMNode.LayoutFlag).includes(layoutFlag)), layoutFlags);
         console.assert(layoutFlags.filter((layoutFlag) => WI.DOMNode._LayoutContextTypes.includes(layoutFlag)).length <= 1, layoutFlags);
-        console.assert(layoutFlags.length && !Array.shallowEqual(layoutFlags, this._layoutFlags), layoutFlags);
+        console.assert(!layoutFlags.length || !Array.shallowEqual(layoutFlags, this._layoutFlags), layoutFlags);
 
         let oldLayoutContextType = this.layoutContextType;
 
@@ -1357,6 +1357,7 @@ WI.DOMNode.CustomElementState = {
 WI.DOMNode.LayoutFlag = {
     Rendered: "rendered",
     Event: "event",
+    Scrollable: "scrollable",
 
     // These are mutually exclusive.
     Flex: "flex",

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -534,6 +534,14 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
                 WI.settings.enabledDOMTreeBadgeTypes.save();
             }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Event));
         }
+
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): `Scrollable` value for `CSS.LayoutFlag` did not exist yet.
+        if (InspectorBackend.Enum.CSS?.LayoutFlag?.Scrollable) {
+            contextMenu.appendCheckboxItem(WI.UIString("Scroll", "Title for a badge applied to DOM nodes that are a scrollable container."), () => {
+                WI.settings.enabledDOMTreeBadgeTypes.value.toggleIncludes(WI.DOMTreeElement.BadgeType.Scrollable);
+                WI.settings.enabledDOMTreeBadgeTypes.save();
+            }, WI.settings.enabledDOMTreeBadgeTypes.value.includes(WI.DOMTreeElement.BadgeType.Scrollable));
+        }
     }
 
     _domTreeElementAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -2022,6 +2022,11 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         let handleClick = null;
 
         switch (badgeType) {
+        case WI.DOMTreeElement.BadgeType.Scrollable:
+            text = WI.UIString("Scroll", "Title for a badge applied to DOM nodes that are a scrollable container.");
+            handleClick = this._handleScrollableBadgeClicked.bind(this);
+            break;
+
         case WI.DOMTreeElement.BadgeType.Flex:
             console.assert(!this._elementForBadgeType.has(WI.DOMTreeElement.BadgeType.Grid));
             text = WI.unlocalizedString("flex");
@@ -2063,6 +2068,10 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         for (let layoutFlag of this.representedObject.layoutFlags) {
             switch (layoutFlag) {
+            case WI.DOMNode.LayoutFlag.Scrollable:
+                this._createBadge(WI.DOMTreeElement.BadgeType.Scrollable);
+                break;
+
             case WI.DOMNode.LayoutFlag.Grid:
                 this._createBadge(WI.DOMTreeElement.BadgeType.Grid);
                 break;
@@ -2137,7 +2146,12 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         contentElement.className = "event-badge-popover-content";
         contentElement.appendChild(detailsSection.element);
 
-        popover.presentNewContentWithFrame(contentElement, calculateTargetFrame(), preferredEdges)
+        popover.presentNewContentWithFrame(contentElement, calculateTargetFrame(), preferredEdges);
+    }
+
+    _handleScrollableBadgeClicked(event)
+    {
+        this.representedObject.scrollIntoView();
     }
 
     _handleBadgeDoubleClicked(event)
@@ -2203,11 +2217,12 @@ WI.DOMTreeElement.BreakpointStatus = {
 };
 
 WI.DOMTreeElement.BadgeType = {
+    Scrollable: "scrollable",
     Flex: "flex",
     Grid: "grid",
     Event: "event",
 };
-WI.settings.enabledDOMTreeBadgeTypes = new WI.Setting("enabled-dom-tree-badge-types", [WI.DOMTreeElement.BadgeType.Flex, WI.DOMTreeElement.BadgeType.Grid, WI.DOMTreeElement.BadgeType.Event]);
+WI.settings.enabledDOMTreeBadgeTypes = new WI.Setting("enabled-dom-tree-badge-types", [WI.DOMTreeElement.BadgeType.Flex, WI.DOMTreeElement.BadgeType.Grid, WI.DOMTreeElement.BadgeType.Event, WI.DOMTreeElement.BadgeType.Scrollable]);
 
 WI.DOMTreeElement.HighlightStyleClassName = "highlight";
 WI.DOMTreeElement.SearchHighlightStyleClassName = "search-highlight";


### PR DESCRIPTION
#### 5c6c14b2bd5558c1f301edd06c18de5e89e1b346
<pre>
Web Inspector: Show &quot;Scroll&quot; labels in the element tree for scrollable elements
<a href="https://webkit.org/b/243550">https://webkit.org/b/243550</a>
rdar://98519174

Reviewed by Devin Rousso.

Patch by Simon Fraser, with some rearranging by Patrick Angle.

Show &quot;Scroll&quot; labels on the document, and on scrollable elements in the Elements tab. We indicate document scrollability
on the `&lt;html&gt;` node, even in quirks mode where `document.scrollingElement()` is the `&lt;body&gt;`, unlike other browsers,
because otherwise you can&apos;t distinguish a scrollable document from a scrollable `&lt;body&gt;` on pages where the body is
independently scrollable.

&quot;Scrollable&quot; is a renderer flag just like &quot;Rendered&quot;, and DOMTreeElement.js makes a new badge for it just like &quot;flex&quot;
and &quot;grid&quot; badges.

Scrollable overflow depends on both style and layout, but doing invalidation at this level is tricky, so instead do
invalidation further downstream, when a renderer gains or loses a RenderLayer, and when a RenderLayerScrollableArea
updates its scrolling state after layout. For the FrameView, we invalidate when its scrollbars change.

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt: Added.
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html: Added.
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbarsImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbars):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
(WebCore::toProtocol):
(WebCore::InspectorCSSAgent::didAddOrRemoveScrollbars):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::setContentsSize):
(WebCore::FrameView::addedOrRemovedScrollbar):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollInfoAfterLayout):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype._populateConfigureDOMTreeBadgesNavigationItemContextMenu):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.updateTitle):
(WI.DOMTreeElement.prototype._createBadge):
(WI.DOMTreeElement.prototype._createBadges):

Canonical link: <a href="https://commits.webkit.org/254061@main">https://commits.webkit.org/254061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7129d2f3d4b6ce65b47f7afb04f5be8549cb1976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/87827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/31920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/18546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/97006 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/151501 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/91795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/30282 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/26342 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/79917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/91750 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/93442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/24452 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/74549 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/24428 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/79410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/79557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/67275 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/79611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/27950 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/13375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/73347 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/27933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/14390 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/26073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/29625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/37302 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/76180 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/29514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/33666 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/16892 "Passed tests") | 
<!--EWS-Status-Bubble-End-->