### PR TITLE
Include image matches in find-in-page results on iOS Safari

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -337,6 +337,8 @@ public:
     virtual WebCore::IntRect rootViewToScreen(const WebCore::IntRect&) = 0;
     virtual WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&) = 0;
     virtual WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&) = 0;
+
+    virtual void updateFindResults() { }
 #if PLATFORM(MAC)
     virtual WebCore::IntRect rootViewToWindow(const WebCore::IntRect&) = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4476,6 +4476,11 @@ void WebPageProxy::removeLayerForFindOverlay(CompletionHandler<void()>&& callbac
     sendWithAsyncReply(Messages::WebPage::RemoveLayerForFindOverlay(), WTFMove(callbackFunction));
 }
 
+void WebPageProxy::updateFindResults()
+{
+    pageClient().updateFindResults();
+}
+
 void WebPageProxy::getImageForFindMatch(int32_t matchIndex)
 {
     send(Messages::WebPage::GetImageForFindMatch(matchIndex));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1264,6 +1264,8 @@ public:
     void addLayerForFindOverlay(CompletionHandler<void(WebCore::GraphicsLayer::PlatformLayerID)>&&);
     void removeLayerForFindOverlay(CompletionHandler<void()>&&);
 
+    void updateFindResults();
+
     void getContentsAsString(ContentAsStringIncludesChildFrames, CompletionHandler<void(const String&)>&&);
 #if PLATFORM(COCOA)
     void getContentsAsAttributedString(CompletionHandler<void(const WebCore::AttributedString&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -245,6 +245,7 @@ messages -> WebPageProxy {
     DidFailToFindString(String string)
     DidFindStringMatches(String string, Vector<Vector<WebCore::IntRect>> matches, int32_t firstIndexAfterSelection)
     DidGetImageForFindMatch(struct WebCore::ImageBufferBackend::Parameters parameters, WebKit::ShareableBitmap::Handle contentImageHandle, uint32_t matchIndex)
+    UpdateFindResults()
 
     # PopupMenu messages
     ShowPopupMenu(WebCore::IntRect rect, uint64_t textDirection, Vector<WebKit::WebPopupItem> items, int32_t selectedIndex, struct WebKit::PlatformPopupMenuData data)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -193,6 +193,8 @@ private:
     void showPlaybackTargetPicker(bool hasVideo, const WebCore::IntRect& elementRect, WebCore::RouteSharingPolicy, const String&) override;
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) override;
 
+    void updateFindResults() override;
+
     bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) override;
     bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void(bool)>&&) override;
     void showContactPicker(const WebCore::ContactsRequestData&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -636,6 +636,14 @@ void PageClientImpl::elementDidFocus(const FocusedElementInformation& nodeInform
     [m_contentView _elementDidFocus:nodeInformation userIsInteracting:userIsInteracting blurPreviousNode:blurPreviousNode activityStateChanges:activityStateChanges userObject:userObject];
 }
 
+void PageClientImpl::updateFindResults()
+{
+#if HAVE(UIFINDINTERACTION)
+    auto findInteraction = [m_webView findInteraction];
+    [findInteraction presentFindNavigatorShowingReplace:NO];
+#endif
+}
+
 void PageClientImpl::updateInputContextAfterBlurringAndRefocusingElement()
 {
     [m_contentView _updateInputContextAfterBlurringAndRefocusingElement];

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -117,6 +117,7 @@ private:
     WebCore::FloatRect convertToUserSpace(const WebCore::FloatRect&) override;
     WebCore::IntPoint screenToRootView(const WebCore::IntPoint&) override;
     WebCore::IntRect rootViewToScreen(const WebCore::IntRect&) override;
+
 #if PLATFORM(MAC)
     WebCore::IntRect rootViewToWindow(const WebCore::IntRect&) override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -52,8 +52,20 @@ WebFoundTextRangeController::WebFoundTextRangeController(WebPage& webPage)
 {
 }
 
+void WebFoundTextRangeController::updateFindResults()
+{
+    m_webPage->updateFindResults();
+}
+
 void WebFoundTextRangeController::findTextRangesForStringMatches(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(Vector<WebFoundTextRange>&&)>&& completionHandler)
 {
+#if ENABLE(IMAGE_ANALYSIS)
+    m_webPage->corePage()->analyzeImagesForFindInPage([weakThis = WeakPtr { *this }] {
+        if (weakThis)
+            weakThis->updateFindResults();
+    });
+#endif
+
     auto result = m_webPage->corePage()->findTextMatches(string, core(options), maxMatchCount, false);
     Vector<WebCore::SimpleRange> findMatches = WTFMove(result.ranges);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -46,7 +46,7 @@ namespace WebKit {
 
 class WebPage;
 
-class WebFoundTextRangeController : private WebCore::PageOverlay::Client {
+class WebFoundTextRangeController : private WebCore::PageOverlay::Client, public CanMakeWeakPtr<WebFoundTextRangeController> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WebFoundTextRangeController);
 
@@ -85,6 +85,8 @@ private:
 
     WebCore::Document* documentForFoundTextRange(const WebFoundTextRange&) const;
     std::optional<WebCore::SimpleRange> simpleRangeFromFoundTextRange(WebFoundTextRange);
+
+    void updateFindResults();
 
     WeakPtr<WebPage> m_webPage;
     RefPtr<WebCore::PageOverlay> m_findPageOverlay;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4931,6 +4931,11 @@ void WebPage::removeLayerForFindOverlay(CompletionHandler<void()>&& completionHa
     completionHandler();
 }
 
+void WebPage::updateFindResults()
+{
+    send(Messages::WebPageProxy::UpdateFindResults());
+}
+
 void WebPage::getImageForFindMatch(uint32_t matchIndex)
 {
     findController().getImageForFindMatch(matchIndex);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -384,6 +384,8 @@ public:
 
     DrawingArea* drawingArea() const { return m_drawingArea.get(); }
 
+    void updateFindResults();
+
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
 #endif


### PR DESCRIPTION
#### 7bdaa877929166c898c7d2d221249ea2d0ef0ef9
<pre>
Include image matches in find-in-page results on iOS Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=243948">https://bugs.webkit.org/show_bug.cgi?id=243948</a>
rdar://problem/98681935

Reviewed by NOBODY (OOPS!).

No tests yet.

This patch improves the internal setting ImageAnalysisForFindInPage, which
Currently only supports macOS Safari. With this patch, iOS Safari find-in-page
follows the same behavior as macOS Safari, where all images on the page are
enqueued, and when the queue empties, the most recent find-in-page is repeated
to include any matches from the most recently analyzed images.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::updateFindResults): Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateFindResults): Added.
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:

(WebKit::WebFoundTextRangeController::updateFindResults): Added.

Initiates IPC that eventually calls [findInteraction presentFindNavigatorShowingReplace:NO],
Which triggers the most recent search to repeat.

(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):

Calls Page::analyzeImagesForFindInPage with WebFoundTextRangeController::updateFindResults as a callback to be called when the image queue empties.

* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateFindResults): Added.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre>