### PR TITLE
Charset of blobs are incorrectly ignored

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-charset.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-charset.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Blob charset should override any auto-detected charset. assert_equals: expected "UTF-8" but got "windows-1252"
-FAIL Blob charset should override <meta charset>. assert_equals: expected "UTF-8" but got "windows-1252"
+PASS Blob charset should override any auto-detected charset.
+PASS Blob charset should override <meta charset>.
 

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -575,6 +575,7 @@ void BlobResourceHandle::notifyResponseOnSuccess()
     response.setHTTPStatusText(isRangeRequest ? httpPartialContentText : httpOKText);
 
     response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
     response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
     addCrossOriginOpenerPolicyHeaders(response, m_blobData->policyContainer().crossOriginOpenerPolicy);
     addCrossOriginEmbedderPolicyHeaders(response, m_blobData->policyContainer().crossOriginEmbedderPolicy);

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -81,7 +81,7 @@ bool isValidHTTPToken(StringView);
 std::optional<WallTime> parseHTTPDate(const String&);
 StringView filenameFromHTTPContentDisposition(StringView);
 WEBCORE_EXPORT String extractMIMETypeFromMediaType(const String&);
-StringView extractCharsetFromMediaType(StringView);
+WEBCORE_EXPORT StringView extractCharsetFromMediaType(StringView);
 XSSProtectionDisposition parseXSSProtectionHeader(const String& header, String& failureReason, unsigned& failurePosition, String& reportURL);
 AtomString extractReasonPhraseFromHTTPStatusLine(const String&);
 WEBCORE_EXPORT XFrameOptionsDisposition parseXFrameOptionsHeader(StringView);

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -266,6 +266,7 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse(Error errorCode)
         response.setHTTPStatusText(isRangeRequest ? httpPartialContentText : httpOKText);
 
         response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
+        response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
         response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
         addCrossOriginOpenerPolicyHeaders(response, m_blobData->policyContainer().crossOriginOpenerPolicy);
         addCrossOriginEmbedderPolicyHeaders(response, m_blobData->policyContainer().crossOriginEmbedderPolicy);


### PR DESCRIPTION
#### 0f75f96f0731509996eb756fc3266812e188c97a
<pre>
Charset of blobs are incorrectly ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=243953">https://bugs.webkit.org/show_bug.cgi?id=243953</a>

Reviewed by Geoffrey Garen.

We were failing to set the text encoding name on the ResourceResponse
based on the charset present in the Content-Type HTTP header.
Normally, it gets initialized lazily by ResourceResponse::textEncodingName()
based on the Content-Type header. However, this doesn&apos;t happen for Blobs
because there is no underlying NSURLRequest.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/url-charset.window-expected.txt:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/253458@main">https://commits.webkit.org/253458@main</a>
</pre>
