### PR TITLE
[Gardening]: REBASELINE: [ iOS ] imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3703,5 +3703,3 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 webkit.org/b/243828 fast/text-autosizing/ios/idempotentmode/idempotent-autosizing-after-changing-initial-scale.html [ Pass Failure ]
 
 webkit.org/b/243836 imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html [ Pass Failure ]
-
-webkit.org/b/243946 imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt
@@ -2,6 +2,8 @@
 
 
 
+
 FAIL Submit event with a submit button promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'event.bubbles')"
 FAIL Submit event with no submit button promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'event.bubbles')"
+PASS Submit event with disabled submit button
 


### PR DESCRIPTION
#### eed65a3854e1421d3a820d1e9e98187502d8b878
<pre>
[Gardening]: REBASELINE: [ iOS ] imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243946">https://bugs.webkit.org/show_bug.cgi?id=243946</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional-expected.txt:

Canonical link: <a href="https://commits.webkit.org/253436@main">https://commits.webkit.org/253436@main</a>
</pre>
