### PR TITLE
Fix build error with release build

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
@@ -28,6 +28,12 @@
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
 
 #include <WebCore/SharedBuffer.h>
+#include <wtf/MachSendRight.h>
+
+namespace IPC {
+class Encoder;
+class Decoder;
+}
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
@@ -30,6 +30,10 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
+namespace WebKit {
+class CGDisplayList;
+}
+
 @interface WKCompositingLayer : CALayer
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)


### PR DESCRIPTION
#### bef51cdb6b04dc5f945e93d08cf7eb9ef57a9687
<pre>
Fix build error with release build
<a href="https://bugs.webkit.org/show_bug.cgi?id=243954">https://bugs.webkit.org/show_bug.cgi?id=243954</a>

Reviewed by Simon Fraser.

Release build was not successful when ENABLE_CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER=1

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h:
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h:

Canonical link: <a href="https://commits.webkit.org/253437@main">https://commits.webkit.org/253437@main</a>
</pre>
