### PR TITLE
[ iOS ] fast/canvas/image-object-in-canvas.html is a flaky timeout on iOS (243558)

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3610,7 +3610,7 @@ webkit.org/b/240489 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html [ ImageOnlyFailure ]
 
-webkit.org/b/243558 fast/canvas/image-object-in-canvas.html [ Slow ]
+webkit.org/b/243558 fast/canvas/image-object-in-canvas.html [ Pass Timeout ]
 
 #  Correction to guard in Platform file removing iOS - Skip tests
 webkit.org/b/240579 http/tests/workers/service/shownotification-allowed-document.html [ Skip ]


### PR DESCRIPTION
#### 1c7756c916af7112b23cd95208c12a1874bbdc7e
<pre>
[ iOS ] fast/canvas/image-object-in-canvas.html is a flaky timeout on iOS (243558)
&lt;rdar://98147510&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=243558">https://bugs.webkit.org/show_bug.cgi?id=243558</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253438@main">https://commits.webkit.org/253438@main</a>
</pre>
