### PR TITLE
REGRESSION (238684@main, 985de701a): Add back fault logs when WebKit process calls exit()

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -75,7 +75,7 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: Received unexpected XPC event type: %{public}s", xpc_type_get_name(type));
             if (type == XPC_TYPE_ERROR) {
                 if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_TERMINATION_IMMINENT) {
-                    RELEASE_LOG_ERROR(IPC, "Exiting: Received XPC event type: %{public}s", event == XPC_ERROR_CONNECTION_INVALID ? "XPC_ERROR_CONNECTION_INVALID" : "XPC_ERROR_TERMINATION_IMMINENT");
+                    RELEASE_LOG_FAULT(IPC, "Exiting: Received XPC event type: %{public}s", event == XPC_ERROR_CONNECTION_INVALID ? "XPC_ERROR_CONNECTION_INVALID" : "XPC_ERROR_TERMINATION_IMMINENT");
                     // FIXME: Handle this case more gracefully.
                     [[NSRunLoop mainRunLoop] performBlock:^{
                         exit(EXIT_FAILURE);


### PR DESCRIPTION
#### 5738533dfc4f2b50a9a2c4896302f178f0b66244
<pre>
REGRESSION (238684@main, 985de701a): Add back fault logs when WebKit process calls exit()
<a href="https://bugs.webkit.org/show_bug.cgi?id=243955">https://bugs.webkit.org/show_bug.cgi?id=243955</a>
&lt;rdar://98689492&gt;

Reviewed by Chris Dumez.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
- Change RELEASE_LOG_ERROR() back to RELEASE_LOG_FAULT() when
  the WebKit process is about to call exit().

Canonical link: <a href="https://commits.webkit.org/253479@main">https://commits.webkit.org/253479@main</a>
</pre>
