### PR TITLE
[Gardening]: [ iOS ] Run tests in fast/forms/ios by default in EWS

### DIFF
--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -114,3 +114,5 @@ webkit.org/b/292090 media/video-canvas-createPattern.html [ Failure ]
 # Failure only on iPad simulator
 webkit.org/b/178588 fast/css/button-height.html [ Failure ]
 webkit.org/b/214465 imported/w3c/web-platform-tests/css/mediaqueries/mq-gamut-002.html [ ImageOnlyFailure ]
+
+webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass Timeout ]


### PR DESCRIPTION
#### 4c0133ab31ceeb53fad57eb74aaa850ac703b6e6
<pre>
[Gardening]: [ iOS ] Run tests in fast/forms/ios by default in EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=229656">https://bugs.webkit.org/show_bug.cgi?id=229656</a>

Unreviewed test gardening.

* LayoutTests/platform/ipad/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253444@main">https://commits.webkit.org/253444@main</a>
</pre>
