### PR TITLE
WebProcessProxy should keep WebsiteDataStore alive

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -168,7 +168,7 @@ public:
     void enableRemoteWorkers(RemoteWorkerType, const UserContentControllerIdentifier&);
     void disableRemoteWorkers(RemoteWorkerType);
 
-    WebsiteDataStore* websiteDataStore() const;
+    WebsiteDataStore* websiteDataStore() const { ASSERT(m_websiteDataStore); return m_websiteDataStore.get(); }
     void setWebsiteDataStore(WebsiteDataStore&);
     
     PAL::SessionID sessionID() const;
@@ -620,7 +620,7 @@ private:
     Vector<CompletionHandler<void(bool webProcessIsResponsive)>> m_isResponsiveCallbacks;
 
     VisibleWebPageCounter m_visiblePageCounter;
-    std::optional<PAL::SessionID> m_sessionID;
+    RefPtr<WebsiteDataStore> m_websiteDataStore;
 
     bool m_isUnderMemoryPressure { false };
 


### PR DESCRIPTION
#### 2cd7eec58eff04dacbc4466941627d044f901adf
<pre>
WebProcessProxy should keep WebsiteDataStore alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=243960">https://bugs.webkit.org/show_bug.cgi?id=243960</a>
&lt;rdar://98313174&gt;

Reviewed by Chris Dumez.

This effectively reverts bug 238892 because it caused rdar://98313174
Tasks such as the one scheduled in WorkerSWClientConnection::unregisterServiceWorkerClient
need a connection to the network process, and if the network process has crashed
then they need a WebsiteDataStore to restart that network process, so a WebProcessProxy
needs to keep a WebsiteDataStore alive.

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::m_webPermissionController):
(WebKit::WebProcessProxy::setWebsiteDataStore):
(WebKit::WebProcessProxy::isDummyProcessProxy const):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::getNetworkProcessConnection):
(WebKit::WebProcessProxy::sessionID const):
(WebKit::WebProcessProxy::websiteDataStore const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::websiteDataStore const):

Canonical link: <a href="https://commits.webkit.org/253449@main">https://commits.webkit.org/253449@main</a>
</pre>
