### PR TITLE
[Gardening]: REGRESSION(253327@main): [ iOS ] 2X imported/w3c/web-platform-tests/css/css-pseudo/(Layout Tests) are almost constant failures

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3705,3 +3705,6 @@ webkit.org/b/243828 fast/text-autosizing/ios/idempotentmode/idempotent-autosizin
 webkit.org/b/243836 imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html [ Pass Failure ]
 
 webkit.org/b/243946 imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/implicit-submission.optional.html [ Pass Failure ]
+
+webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/target-text-008.html [ Pass ImageOnlyFailure ]
+webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/highlight-paired-cascade-005.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### d95feca639ce98a8198d50535151b8ff4eb9e417
<pre>
[Gardening]: REGRESSION(253327@main): [ iOS ] 2X imported/w3c/web-platform-tests/css/css-pseudo/(Layout Tests) are almost constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=243962">https://bugs.webkit.org/show_bug.cgi?id=243962</a>

Unreviewed test gardening.

* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/253446@main">https://commits.webkit.org/253446@main</a>
</pre>
