### PR TITLE
Safari v14.1 CSP Violation - Usage of "element.removeAttribute("style")" causes style-src CSP Violation.

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Refused to apply a stylesheet because its hash, its nonce, or 'unsafe-inline' does not appear in the style-src directive of the Content Security Policy.
+CONSOLE MESSAGE: PASS: style attribute successfully removed.
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'none';
+        connect-src 'self';
+        script-src 'self' 'sha256-kSyfQ4joIKFsQ/vuAU0PsTihY+jZ6waGXCmEWp6wMf4=';
+        style-src 'self' 'sha256-abBtF99/+bWrkA5qp1+WvGjHjqVlNpUWZD8/uEg8wKA=';
+        " />
+    <style>
+        .section {
+            height: 50vh;
+            width: 100vw;
+            background: paleturquoise;
+            display: flex;
+            flex-direction: COLUMN;
+            justify-content: center;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="section" id="section">
+        </div>
+    </div>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        let section = document.getElementById("section");
+        section.style.backgroundColor = "#2196f3";
+        section.setAttribute("style", "background-color: #2196f3");
+        section.removeAttribute("style");
+
+        if (section.style.backgroundColor == "rgb(33, 150, 243)") {
+            console.log("FAIL: style attribute was not removed.");
+        }
+        else {
+            console.log("PASS: style attribute successfully removed.");
+        }
+        testRunner.notifyDone();
+    </script>
+</body>
+
+</html>

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -230,7 +230,9 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
     if (document().scriptableDocumentParser() && !document().isInDocumentWrite())
         startLineNumber = document().scriptableDocumentParser()->textPosition().m_line;
 
-    if (reason == ModifiedByCloning || document().contentSecurityPolicy()->allowInlineStyle(document().url().string(), startLineNumber, newStyleString.string(), CheckUnsafeHashes::Yes, *this, nonce(), isInUserAgentShadowTree()))
+    if (newStyleString.isNull())
+        ensureMutableInlineStyle().clear();
+    else if (reason == ModifiedByCloning || document().contentSecurityPolicy()->allowInlineStyle(document().url().string(), startLineNumber, newStyleString.string(), CheckUnsafeHashes::Yes, *this, nonce(), isInUserAgentShadowTree()))
         setInlineStyleFromString(newStyleString);
 
     elementData()->setStyleAttributeIsDirty(false);


### PR DESCRIPTION
#### 572f10393126fefe8d887573d2644b27931a2516
<pre>
Safari v14.1 CSP Violation - Usage of &quot;element.removeAttribute(&quot;style&quot;)&quot; causes style-src CSP Violation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=227349">https://bugs.webkit.org/show_bug.cgi?id=227349</a>
&lt;rdar://80020346&gt;

Reviewed by Brent Fulgham.

If the new style string is null, clear the inline style without checking if the element&apos;s inline type should be blocked by CSP. This behavior matches Chrome and Firefox.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::styleAttributeChanged):
* LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/allow-inline-remove-attribute.html: Added.

Canonical link: <a href="https://commits.webkit.org/254409@main">https://commits.webkit.org/254409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba35e2f377a514369ed9d28e68527b53b65a17c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95293 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/149003 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/90435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28767 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25351 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90536 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/92063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23348 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/73416 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23396 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/78357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/78745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66400 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26679 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/12595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3086 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/36488 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32890 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->