### PR TITLE
Unreviewed non-unified build fix following 253447@main

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingObserver.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### 15b69b7614a088a3a87cc875918c18887454f6b7
<pre>
Unreviewed non-unified build fix following 253447@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=243965">https://bugs.webkit.org/show_bug.cgi?id=243965</a>

* Source/WebCore/Modules/reporting/ReportingObserver.h: Add missing include.

Canonical link: <a href="https://commits.webkit.org/253448@main">https://commits.webkit.org/253448@main</a>
</pre>
