### PR TITLE
[GTK][WPE] Support asynchronously returning values from user script messages

### DIFF
--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -76,6 +76,7 @@ public:
     static JSCContext* sharedJSCContext();
     static GRefPtr<JSCValue> deserialize(WebCore::SerializedScriptValue&);
     static RefPtr<SerializedScriptValue> createFromGVariant(GVariant*);
+    static RefPtr<SerializedScriptValue> createFromJSCValue(JSCValue*);
 #endif
 
     IPC::DataReference dataReference() const { return m_serializedScriptValue->wireBytes(); }

--- a/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
+++ b/Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp
@@ -168,4 +168,10 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::createFromGVariant(GVariant
     return create(coreValue.releaseNonNull());
 }
 
+RefPtr<SerializedScriptValue> SerializedScriptValue::createFromJSCValue(JSCValue* value)
+{
+    ASSERT(jsc_value_get_context(value) == sharedJSCContext());
+    return create(jscContextGetJSContext(jsc_value_get_context(value)), jscValueGetJSValue(value), nullptr);
+}
+
 }; // namespace API

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -28,6 +28,7 @@
 #include "WebKitUserContentPrivate.h"
 #include "WebKitWebContextPrivate.h"
 #include "WebScriptMessageHandler.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -71,6 +72,7 @@ WEBKIT_DEFINE_TYPE(WebKitUserContentManager, webkit_user_content_manager, G_TYPE
 
 enum {
     SCRIPT_MESSAGE_RECEIVED,
+    SCRIPT_MESSAGE_WITH_REPLY_RECEIVED,
 
     LAST_SIGNAL
 };
@@ -104,6 +106,41 @@ static void webkit_user_content_manager_class_init(WebKitUserContentManagerClass
             g_cclosure_marshal_VOID__BOXED,
             G_TYPE_NONE, 1,
             WEBKIT_TYPE_JAVASCRIPT_RESULT);
+
+    /**
+     * WebKitUserContentManager::script-message-with-reply-received:
+     * @manager: the #WebKitUserContentManager
+     * @js_result: the #WebKitJavascriptResult holding the value received from the JavaScript world.
+     * @reply: the #WebKitScriptMessageReply to send the reply to the script message.
+     *
+     * This signal is emitted when JavaScript in a web view calls
+     * <code>window.webkit.messageHandlers.<name>.postMessage()</code>, after registering
+     * <code><name></code> using
+     * webkit_user_content_manager_register_script_message_handler_with_reply()
+     *
+     * The given @reply can be used to send a return value with
+     * webkit_script_message_reply_return_value() or an error message with
+     * webkit_script_message_reply_return_error_message(). If none of them are
+     * called, an automatic reply with an undefined value will be sent.
+     *
+     * It is possible to handle the reply asynchronously, by simply calling
+     * g_object_ref() on the @reply and returning %TRUE.
+     *
+     * Returns: %TRUE to stop other handlers from being invoked for the event.
+     *    %FALSE to propagate the event further.
+     *
+     * Since: 2.40
+     */
+    signals[SCRIPT_MESSAGE_WITH_REPLY_RECEIVED] =
+        g_signal_new(
+            "script-message-with-reply-received",
+            G_TYPE_FROM_CLASS(gObjectClass),
+            static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED),
+            0, g_signal_accumulator_true_handled, nullptr,
+            g_cclosure_marshal_generic,
+            G_TYPE_BOOLEAN, 2,
+            WEBKIT_TYPE_JAVASCRIPT_RESULT,
+            WEBKIT_TYPE_SCRIPT_MESSAGE_REPLY);
 }
 
 /**
@@ -224,12 +261,138 @@ void webkit_user_content_manager_remove_all_scripts(WebKitUserContentManager* ma
     manager->priv->userContentController->removeAllUserScripts();
 }
 
+/**
+ * WebKitScriptMessageReply: (ref-func webkit_script_message_reply_ref) (unref-func webkit_script_message_reply_unref)
+ *
+ * A reply for a script message received.
+ * If no reply has been sent by the user, an automatically generated reply with
+ * undefined value with be sent.
+ *
+ * Since: 2.40
+ */
+struct _WebKitScriptMessageReply {
+    _WebKitScriptMessageReply(WTF::Function<void(API::SerializedScriptValue*, const String&)>&& completionHandler)
+        : completionHandler(WTFMove(completionHandler))
+        , referenceCount(1)
+    {
+    }
+
+    void sendValue(JSCValue* value)
+    {
+        auto serializedValue = API::SerializedScriptValue::createFromJSCValue(value);
+        completionHandler(serializedValue.get(), { });
+    }
+
+    void sendErrorMessage(const char* errorMessage)
+    {
+        completionHandler(nullptr, String::fromUTF8(errorMessage));
+    }
+
+    ~_WebKitScriptMessageReply()
+    {
+        if (completionHandler) {
+            auto value = adoptGRef(jsc_value_new_undefined(API::SerializedScriptValue::sharedJSCContext()));
+            sendValue(value.get());
+        }
+    }
+
+    WTF::CompletionHandler<void(API::SerializedScriptValue*, const String&)> completionHandler;
+    int referenceCount;
+};
+
+G_DEFINE_BOXED_TYPE(WebKitScriptMessageReply, webkit_script_message_reply, webkit_script_message_reply_ref, webkit_script_message_reply_unref)
+
+/**
+ * webkit_script_message_reply_ref:
+ * @script_message_reply: A #WebKitScriptMessageReply
+ *
+ * Atomically increments the reference count of @script_message_reply by one.
+ *
+ * Returns: the @script_message_reply passed in.
+ *
+ * Since: 2.40
+ */
+WebKitScriptMessageReply*
+webkit_script_message_reply_ref(WebKitScriptMessageReply* scriptMessageReply)
+{
+    g_return_val_if_fail(scriptMessageReply, nullptr);
+    g_atomic_int_inc(&scriptMessageReply->referenceCount);
+    return scriptMessageReply;
+}
+
+/**
+ * webkit_script_message_reply_unref:
+ * @script_message_reply: A #WebKitScriptMessageReply
+ *
+ * Atomically decrements the reference count of @script_message_reply by one.
+ *
+ * If the reference count drops to 0, all the memory allocated by the
+ * #WebKitScriptMessageReply is released. This function is MT-safe and may
+ * be called from any thread.
+ *
+ * Since: 2.40
+ */
+void webkit_script_message_reply_unref(WebKitScriptMessageReply* scriptMessageReply)
+{
+    g_return_if_fail(scriptMessageReply);
+    if (g_atomic_int_dec_and_test(&scriptMessageReply->referenceCount)) {
+        scriptMessageReply->~WebKitScriptMessageReply();
+        fastFree(scriptMessageReply);
+    }
+}
+
+WebKitScriptMessageReply* webKitScriptMessageReplyCreate(WTF::Function<void(API::SerializedScriptValue*, const String&)>&& completionHandler)
+{
+    WebKitScriptMessageReply* scriptMessageReply = static_cast<WebKitScriptMessageReply*>(fastMalloc(sizeof(WebKitScriptMessageReply)));
+    new (scriptMessageReply) WebKitScriptMessageReply(WTFMove(completionHandler));
+    return scriptMessageReply;
+}
+
+/**
+ * webkit_script_message_reply_return_value:
+ * @script_message_reply: A #WebKitScriptMessageReply
+ * @reply_value: Reply value of the provided script message
+ *
+ * Reply to a script message with a value.
+ *
+ * This function can be called twice for passing the reply value in.
+ *
+ * Since: 2.40
+ */
+void webkit_script_message_reply_return_value(WebKitScriptMessageReply* message, JSCValue* replyValue)
+{
+    g_return_if_fail(message != nullptr);
+    g_return_if_fail(message->completionHandler);
+
+    message->sendValue(replyValue);
+}
+
+/**
+ * webkit_script_message_reply_return_error_message:
+ * @script_message_reply: A #WebKitScriptMessageReply
+ * @error_message: An error message to return as specified by the user's script message
+ *
+ * Reply to a script message with an error message.
+ *
+ * Since: 2.40
+ */
+void
+webkit_script_message_reply_return_error_message(WebKitScriptMessageReply* message, const char* errorMessage)
+{
+    g_return_if_fail(message != nullptr);
+    g_return_if_fail(errorMessage != nullptr);
+    g_return_if_fail(message->completionHandler);
+
+    message->sendErrorMessage(errorMessage);
+}
+
 class ScriptMessageClientGtk final : public WebScriptMessageHandler::Client {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ScriptMessageClientGtk(WebKitUserContentManager* manager, const char* handlerName)
+    ScriptMessageClientGtk(WebKitUserContentManager* manager, const char* handlerName, bool supportsAsyncReply)
         : m_handlerName(g_quark_from_string(handlerName))
         , m_manager(manager)
+        , m_supportsAsyncReply(supportsAsyncReply)
     {
     }
 
@@ -242,18 +405,25 @@ public:
 
     bool supportsAsyncReply() override
     {
-        return false;
+        return m_supportsAsyncReply;
     }
-    
-    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, WebCore::SerializedScriptValue&, WTF::Function<void(API::SerializedScriptValue*, const String&)>&&) override
+
+    void didPostMessageWithAsyncReply(WebPageProxy&, FrameInfoData&&, API::ContentWorld&, WebCore::SerializedScriptValue& serializedScriptValue, WTF::Function<void(API::SerializedScriptValue*, const String&)>&& completionHandler) override
     {
+        WebKitJavascriptResult* jsResult = webkitJavascriptResultCreate(serializedScriptValue);
+        WebKitScriptMessageReply* message = webKitScriptMessageReplyCreate(WTFMove(completionHandler));
+        gboolean returnValue;
+        g_signal_emit(m_manager, signals[SCRIPT_MESSAGE_WITH_REPLY_RECEIVED], m_handlerName, jsResult, message, &returnValue);
+        webkit_javascript_result_unref(jsResult);
+        webkit_script_message_reply_unref(message);
     }
-    
+
     virtual ~ScriptMessageClientGtk() { }
 
 private:
     GQuark m_handlerName;
     WebKitUserContentManager* m_manager;
+    bool m_supportsAsyncReply;
 };
 
 /**
@@ -293,7 +463,7 @@ gboolean webkit_user_content_manager_register_script_message_handler(WebKitUserC
     g_return_val_if_fail(name, FALSE);
 
     Ref<WebScriptMessageHandler> handler =
-        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name), AtomString::fromUTF8(name), API::ContentWorld::pageContentWorld());
+        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), AtomString::fromUTF8(name), API::ContentWorld::pageContentWorld());
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 
@@ -321,6 +491,42 @@ void webkit_user_content_manager_unregister_script_message_handler(WebKitUserCon
 }
 
 /**
+ * webkit_user_content_manager_register_script_message_handler_with_reply:
+ * @manager: A #WebKitUserContentManager
+ * @name: Name of the script message channel
+ * @world_name (nullable): the name of a #WebKitScriptWorld
+ *
+ * Registers a new user script message handler in script world with name @world_name.
+ *
+ * Different from webkit_user_content_manager_register_script_message_handler(),
+ * when using this function to register the handler, the connected signal is
+ * script-message-with-reply-received, and a reply provided by the user is expected.
+ * Otherwise, the user will receive a default undefined value.
+ *
+ * If %NULL is passed as the @world_name, the default world will be used.
+ * See webkit_user_content_manager_register_script_message_handler() for full description.
+ *
+ * Registering a script message handler will fail if the requested
+ * name has been already registered before.
+ *
+ * The registered handler can be unregistered by using
+ * #webkit_user_content_manager_unregister_script_message_handler() and
+ * #webkit_user_content_manager_unregister_script_message_handler_in_world().
+ *
+ * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
+ *
+ * Since: 2.40
+ */
+gboolean webkit_user_content_manager_register_script_message_handler_with_reply(WebKitUserContentManager* manager, const char* name, const char* worldName)
+{
+    g_return_val_if_fail(WEBKIT_IS_USER_CONTENT_MANAGER(manager), FALSE);
+    g_return_val_if_fail(name, FALSE);
+
+    auto handler = WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, true), AtomString::fromUTF8(name), worldName ? webkitContentWorld(worldName) : API::ContentWorld::pageContentWorld());
+    return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
+}
+
+/**
  * webkit_user_content_manager_register_script_message_handler_in_world:
  * @manager: A #WebKitUserContentManager
  * @name: Name of the script message channel
@@ -345,7 +551,7 @@ gboolean webkit_user_content_manager_register_script_message_handler_in_world(We
     g_return_val_if_fail(worldName, FALSE);
 
     Ref<WebScriptMessageHandler> handler =
-        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name), AtomString::fromUTF8(name), webkitContentWorld(worldName));
+        WebScriptMessageHandler::create(makeUnique<ScriptMessageClientGtk>(manager, name, false), AtomString::fromUTF8(name), webkitContentWorld(worldName));
     return manager->priv->userContentController->addUserScriptMessageHandler(handler.get());
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
@@ -23,6 +23,7 @@
 #define WebKitUserContentManager_h
 
 #include <glib-object.h>
+#include <jsc/jsc.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 #include <@API_INCLUDE_PREFIX@/WebKitUserContent.h>
 
@@ -82,6 +83,11 @@ webkit_user_content_manager_unregister_script_message_handler          (WebKitUs
                                                                         const gchar              *name);
 
 WEBKIT_API gboolean
+webkit_user_content_manager_register_script_message_handler_with_reply (WebKitUserContentManager *manager,
+                                                                        const char               *name,
+                                                                        const char               *world_name);
+
+WEBKIT_API gboolean
 webkit_user_content_manager_register_script_message_handler_in_world   (WebKitUserContentManager *manager,
                                                                         const gchar              *name,
                                                                         const gchar              *world_name);
@@ -115,6 +121,27 @@ webkit_user_content_manager_remove_filter_by_id                        (WebKitUs
 
 WEBKIT_API void
 webkit_user_content_manager_remove_all_filters                         (WebKitUserContentManager *manager);
+
+#define WEBKIT_TYPE_SCRIPT_MESSAGE_REPLY                               (webkit_script_message_reply_get_type())
+
+typedef struct _WebKitScriptMessageReply WebKitScriptMessageReply;
+
+WEBKIT_API GType
+webkit_script_message_reply_get_type                                   (void);
+
+WEBKIT_API WebKitScriptMessageReply *
+webkit_script_message_reply_ref                                        (WebKitScriptMessageReply *script_message_reply);
+
+WEBKIT_API void
+webkit_script_message_reply_unref                                      (WebKitScriptMessageReply *script_message_reply);
+
+WEBKIT_API void
+webkit_script_message_reply_return_value                               (WebKitScriptMessageReply *script_message_reply,
+                                                                        JSCValue                 *reply_value);
+
+WEBKIT_API void
+webkit_script_message_reply_return_error_message                       (WebKitScriptMessageReply *script_message_reply,
+                                                                        const char               *error_message);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManagerPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManagerPrivate.h
@@ -20,9 +20,11 @@
 #ifndef WebKitUserContentManagerPrivate_h
 #define WebKitUserContentManagerPrivate_h
 
+#include "APISerializedScriptValue.h"
 #include "WebKitUserContentManager.h"
 #include "WebUserContentControllerProxy.h"
 
 WebKit::WebUserContentControllerProxy* webkitUserContentManagerGetUserContentControllerProxy(WebKitUserContentManager*);
+WebKitScriptMessageReply* webKitScriptMessageReplyCreate(WebCore::SerializedScriptValue&, WTF::Function<void(API::SerializedScriptValue*, const String&)>&&);
 
 #endif // WebKitUserContentManagerPrivate_h

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -267,18 +267,20 @@ public:
     MAKE_GLIB_TEST_FIXTURE(UserScriptMessageTest);
 
     UserScriptMessageTest()
-        : m_userScriptMessage(nullptr)
+        : m_scriptMessage(nullptr)
     {
     }
 
     ~UserScriptMessageTest()
     {
-        if (m_userScriptMessage)
-            webkit_javascript_result_unref(m_userScriptMessage);
+        if (m_scriptMessage)
+            webkit_javascript_result_unref(m_scriptMessage);
     }
 
-    bool registerHandler(const char* handlerName, const char* worldName = nullptr)
+    bool registerHandler(const char* handlerName, const char* worldName = nullptr, bool async = false)
     {
+        if (async)
+            return webkit_user_content_manager_register_script_message_handler_with_reply(m_userContentManager.get(), handlerName, worldName);
         return worldName ? webkit_user_content_manager_register_script_message_handler_in_world(m_userContentManager.get(), handlerName, worldName)
             : webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), handlerName);
     }
@@ -295,15 +297,15 @@ public:
         if (!test->m_waitForScriptRun)
             g_main_loop_quit(test->m_mainLoop);
 
-        g_assert_null(test->m_userScriptMessage);
-        test->m_userScriptMessage = webkit_javascript_result_ref(jsResult);
+        g_assert_null(test->m_scriptMessage);
+        test->m_scriptMessage = webkit_javascript_result_ref(jsResult);
     }
 
     WebKitJavascriptResult* waitUntilMessageReceived(const char* handlerName)
     {
-        if (m_userScriptMessage) {
-            webkit_javascript_result_unref(m_userScriptMessage);
-            m_userScriptMessage = nullptr;
+        if (m_scriptMessage) {
+            webkit_javascript_result_unref(m_scriptMessage);
+            m_scriptMessage = nullptr;
         }
 
         GUniquePtr<char> signalName(g_strdup_printf("script-message-received::%s", handlerName));
@@ -311,8 +313,8 @@ public:
 
         g_main_loop_run(m_mainLoop);
         g_assert_false(m_waitForScriptRun);
-        g_assert_nonnull(m_userScriptMessage);
-        return m_userScriptMessage;
+        g_assert_nonnull(m_scriptMessage);
+        return m_scriptMessage;
     }
 
     static void runJavaScriptFinished(GObject*, GAsyncResult* result, UserScriptMessageTest* test)
@@ -333,8 +335,68 @@ public:
         return waitUntilMessageReceived(handlerName);
     }
 
+    static gboolean asyncScriptMessageReceived(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* jsResult, WebKitScriptMessageReply* scriptMessageReply, UserScriptMessageTest* test)
+    {
+        g_signal_handlers_disconnect_by_func(userContentManager, reinterpret_cast<gpointer>(asyncScriptMessageReceived), test);
+        if (!test->m_waitForScriptRun)
+            g_main_loop_quit(test->m_mainLoop);
+
+        auto* jsValue = webkit_javascript_result_get_js_value(jsResult);
+        g_assert_true(JSC_IS_VALUE(jsValue));
+        g_assert_true(jsc_value_is_string(jsValue));
+        GUniquePtr<char> message(jsc_value_to_string(jsValue));
+        if (!g_strcmp0(message.get(), "DoNothing"))
+            return FALSE;
+
+        if (!g_strcmp0(message.get(), "Ping")) {
+            GRefPtr<JSCValue> reply = adoptGRef(jsc_value_new_string(jsc_value_get_context(jsValue), "Pong"));
+            webkit_script_message_reply_return_value(scriptMessageReply, reply.get());
+        } else if (!g_strcmp0(message.get(), "Fail"))
+            webkit_script_message_reply_return_error_message(scriptMessageReply, "Failed");
+        else
+            webkit_script_message_reply_return_value(scriptMessageReply, jsValue);
+
+        return TRUE;
+    }
+
+    WebKitJavascriptResult* waitUntilPromiseResolved(const char* handlerName, GUniquePtr<GError>& error)
+    {
+        if (m_scriptMessage) {
+            webkit_javascript_result_unref(m_scriptMessage);
+            m_scriptMessage = nullptr;
+        }
+
+        GUniquePtr<char> signalName(g_strdup_printf("script-message-with-reply-received::%s", handlerName));
+        g_signal_connect(m_userContentManager.get(), signalName.get(), G_CALLBACK(asyncScriptMessageReceived), this);
+
+        g_main_loop_run(m_mainLoop);
+        g_assert_false(m_waitForScriptRun);
+
+        error.reset(m_scriptError.release());
+        return m_scriptMessage;
+    }
+
+    static void runAsyncJavaScriptFinished(GObject* webView, GAsyncResult* result, UserScriptMessageTest* test)
+    {
+        g_assert_true(test->m_waitForScriptRun);
+        test->m_waitForScriptRun = false;
+        test->m_scriptMessage = webkit_web_view_run_javascript_in_world_finish(WEBKIT_WEB_VIEW(webView), result, &test->m_scriptError.outPtr());
+        g_main_loop_quit(test->m_mainLoop);
+    }
+
+    WebKitJavascriptResult* postMessageAndWaitForPromiseResolved(const char* handlerName, const char* javascriptValueAsText, const char* worldName, GUniquePtr<GError>& error)
+    {
+        GUniquePtr<char> javascriptSnippet(g_strdup_printf("var p = window.webkit.messageHandlers.%s.postMessage(%s); await p; return p;", handlerName, javascriptValueAsText));
+        m_waitForScriptRun = true;
+
+        webkit_web_view_run_async_javascript_function_in_world(m_webView, javascriptSnippet.get(), nullptr, worldName, nullptr, reinterpret_cast<GAsyncReadyCallback>(runAsyncJavaScriptFinished), this);
+
+        return waitUntilPromiseResolved(handlerName, error);
+    }
+
 private:
-    WebKitJavascriptResult* m_userScriptMessage;
+    WebKitJavascriptResult* m_scriptMessage;
+    GUniqueOutPtr<GError> m_scriptError;
     bool m_waitForScriptRun { false };
 };
 
@@ -429,6 +491,87 @@ static void testUserContentManagerScriptMessageInWorldReceived(UserScriptMessage
 
     valueString.reset(WebViewTest::javascriptResultToCString(test->postMessageAndWaitUntilReceived("msg", "'user message'", "WebExtensionTestScriptWorld")));
     g_assert_cmpstr(valueString.get(), ==, "user message");
+
+    // Post message in main world should fail.
+    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
+    g_assert_null(javascriptResult);
+    g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+
+    test->unregisterHandler("msg", "WebExtensionTestScriptWorld");
+}
+
+static void testUserContentManagerScriptMessageWithReplyReceived(UserScriptMessageTest* test, gconstpointer)
+{
+    g_assert_true(test->registerHandler("msg", nullptr, true));
+
+    // Trying to register the same handler a second time must fail.
+    g_assert_false(test->registerHandler("msg"));
+
+    test->loadHtml("<html></html>", nullptr);
+    test->waitUntilLoadFinished();
+
+    // Check that the "window.webkit.messageHandlers" namespace exists.
+    GUniqueOutPtr<GError> error;
+    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(error.get());
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    g_assert_cmpstr(valueString.get(), ==, "y");
+
+    // Check that the "document.webkit.messageHandlers.msg" namespace exists.
+    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(error.get());
+    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    g_assert_cmpstr(valueString.get(), ==, "y");
+
+    GUniquePtr<GError> scriptError;
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", nullptr, scriptError);
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(scriptError.get());
+    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    g_assert_cmpstr(valueString.get(), ==, "Pong");
+
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", nullptr, scriptError);
+    g_assert_null(javascriptResult);
+    g_assert_error(scriptError.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    g_assert_cmpstr(scriptError->message, ==, "Error: Failed");
+
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", nullptr, scriptError);
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(scriptError.get());
+    g_assert_true(WebViewTest::javascriptResultIsUndefined(javascriptResult));
+
+    // Check that the "window.webkit.messageHandlers" namespace doesn't exist in isolated worlds.
+    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", &error.outPtr());
+    g_assert_null(javascriptResult);
+    g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    test->unregisterHandler("msg", nullptr);
+
+    g_assert_true(test->registerHandler("msg", "WebExtensionTestScriptWorld", true));
+
+    // Check that the "window.webkit.messageHandlers" namespace exists in the world.
+    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", &error.outPtr());
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(error.get());
+    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    g_assert_cmpstr(valueString.get(), ==, "y");
+
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(scriptError.get());
+    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    g_assert_cmpstr(valueString.get(), ==, "Pong");
+
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_null(javascriptResult);
+    g_assert_error(scriptError.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    g_assert_cmpstr(scriptError->message, ==, "Error: Failed");
+
+    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_nonnull(javascriptResult);
+    g_assert_no_error(scriptError.get());
+    g_assert_true(WebViewTest::javascriptResultIsUndefined(javascriptResult));
 
     // Post message in main world should fail.
     javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
@@ -547,6 +690,7 @@ void beforeAll()
     WebViewTest::add("WebKitUserContentManager", "injected-script", testUserContentManagerInjectedScript);
     UserScriptMessageTest::add("WebKitUserContentManager", "script-message-received", testUserContentManagerScriptMessageReceived);
     UserScriptMessageTest::add("WebKitUserContentManager", "script-message-in-world-received", testUserContentManagerScriptMessageInWorldReceived);
+    UserScriptMessageTest::add("WebKitUserContentManager", "script-message-with-reply-received", testUserContentManagerScriptMessageWithReplyReceived);
 #if PLATFORM(GTK)
     UserScriptMessageTest::add("WebKitUserContentManager", "script-message-from-dom-bindings", testUserContentManagerScriptMessageFromDOMBindings);
 #endif


### PR DESCRIPTION
#### 9267215ef0d1b1b2f0233ff63940fa293eb51d30
<pre>
[GTK][WPE] Support asynchronously returning values from user script messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=243492">https://bugs.webkit.org/show_bug.cgi?id=243492</a>

Reviewed by Carlos Garcia Campos.

Expose WebKit&apos;s functionality of responding asynchronously
to user script messages in the public API, by means of a
returned Promise object.

A new helper class &quot;WebKitUserScriptMessgeReply&quot; is added to
Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp;
it holds the returned JS value or the error message from executing
the user script message, which will be sent to the user by the
&quot;didPostMessageWithAsyncReply()&quot; method in the &quot;ScriptMessageClientGtk&quot;
class.

If asynchronous handling is wished for, the new
&quot;webkit_user_content_manager_register_script_message_handler_with_reply()&quot;
method should be used to register the message handler, its associated signal
being &quot;WebKitUserContentManager::script-message-with-reply-received&quot;.
The user should ideally provide a callback reply in the script message,
otherwise an undefined value will be returned.

* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp:
(API::SerializedScriptValue::createFromJSCValue):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
(_WebKitScriptMessageReply::_WebKitScriptMessageReply):
(_WebKitScriptMessageReply::sendValue):
(_WebKitScriptMessageReply::sendErrorMessage):
(_WebKitScriptMessageReply::~_WebKitScriptMessageReply):
(webkit_script_message_reply_ref):
(webkit_script_message_reply_unref):
(webKitScriptMessageReplyCreate):
(webkit_script_message_reply_return_value):
(webkit_script_message_reply_return_error_message):
(webkit_user_content_manager_register_script_message_handler):
(webkit_user_content_manager_register_script_message_handler_with_reply):
(webkit_user_content_manager_register_script_message_handler_in_world):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManagerPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(UserScriptMessageTest::UserScriptMessageTest):
(UserScriptMessageTest::~UserScriptMessageTest):
(UserScriptMessageTest::registerHandler):
(UserScriptMessageTest::scriptMessageReceived):
(UserScriptMessageTest::waitUntilMessageReceived):
(UserScriptMessageTest::asyncScriptMessageReceived):
(UserScriptMessageTest::waitUntilPromiseResolved):
(UserScriptMessageTest::runAsyncJavaScriptFinished):
(UserScriptMessageTest::postMessageAndWaitForPromiseResolved):
(testUserContentManagerScriptMessageWithReplyReceived):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/257016@main">https://commits.webkit.org/257016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/619c995f05eee7ea061ff3e0a08ee32a7f860862

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107016 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167280 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7103 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35523 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103685 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5319 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84143 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32324 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75249 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/769 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5570 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44395 "Found 3 new test failures: fast/forms/file/entries-api/image-no-transcode-open-panel.html, fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41297 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->