### PR TITLE
REGRESSION (250414@main): Placeholder text is vertically off center on mail.163.com

### DIFF
--- a/LayoutTests/fast/forms/placeholder-content-center.html
+++ b/LayoutTests/fast/forms/placeholder-content-center.html
@@ -11,6 +11,8 @@ input {
 ::placeholder {
   color: black;
   font-size: 22px;
+  height: 40px;
+  padding: 40px 0px;
 }
 </style>
 <input placeholder="PASS if placeholder text is fully visible">

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -221,6 +221,8 @@ std::optional<Style::ElementStyle> TextControlPlaceholderElement::resolveCustomS
     if (is<HTMLInputElement>(controlElement)) {
         auto& inputElement = downcast<HTMLInputElement>(controlElement);
         style.renderStyle->setTextOverflow(inputElement.shouldTruncateText(*shadowHostStyle) ? TextOverflow::Ellipsis : TextOverflow::Clip);
+        style.renderStyle->setPaddingTop(Length { 0, LengthType::Fixed });
+        style.renderStyle->setPaddingBottom(Length { 0, LengthType::Fixed });
     }
     return style;
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -63,6 +63,7 @@ public:
     float contentLogicalLeft() const;
     float contentLogicalRight() const;
     float contentLogicalWidth() const;
+    float contentLogicalHeight() const;
 
     float contentLogicalTopAdjustedForPrecedingLineBox() const;
     float contentLogicalBottomAdjustedForFollowingLineBox() const;
@@ -214,6 +215,11 @@ inline float LineBox::contentLogicalRight() const
 inline float LineBox::contentLogicalWidth() const
 {
     return contentLogicalRight() - contentLogicalLeft();
+}
+
+inline float LineBox::contentLogicalHeight() const
+{
+    return contentLogicalBottom() - contentLogicalTop();
 }
 
 inline bool LineBox::isHorizontal() const

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -32,6 +32,7 @@
 #include "FrameView.h"
 #include "HTMLNames.h"
 #include "HitTestResult.h"
+#include "InlineIteratorLineBox.h"
 #include "LocalizedStrings.h"
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
@@ -198,7 +199,9 @@ void RenderTextControlSingleLine::layout()
         auto* containerBox = innerTextRenderer ? innerTextRenderer : innerBlockRenderer ? innerBlockRenderer : containerRenderer;
         if (containerBox) {
             // Center vertical align the placeholder content.
-            auto logicalTop = placeholderTopLeft.y() + (containerBox->logicalHeight() / 2 - placeholderBox->logicalHeight() / 2);
+            auto placeholderLineBox = InlineIterator::firstLineBoxFor(downcast<RenderBlockFlow>(*placeholderBox));
+            auto placeholderLineLogicalHeight = LayoutUnit { placeholderLineBox->contentLogicalHeight() };
+            auto logicalTop = placeholderTopLeft.y() + (containerBox->logicalHeight() / 2 - placeholderLineLogicalHeight / 2);
             placeholderBox->setLogicalTop(logicalTop);
         }
         if (!placeholderBoxHadLayout && placeholderBox->checkForRepaintDuringLayout()) {


### PR DESCRIPTION
#### 0f760ccf1c9e695d6ecf5d6a215a07adc08dcd7f
<pre>
REGRESSION (250414@main): Placeholder text is vertically off center on mail.163.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=243966">https://bugs.webkit.org/show_bug.cgi?id=243966</a>
rdar://96399025

Reviewed by Ryosuke Niwa.

mail.163.com sets a height and equivalent line-height on `::placeholder`.
Following 250414@main, the line-height property cannot be set by the author,
matching the behavior of other browsers. However, this change exposed a flaw in
the logic that vertically centers `::placeholder`.

As of 222311@main, `::placeholder` is centered using its box&apos;s logical height.
However, if the height is larger than the height of content in the first line
box, and the line height does not match the logical height, the placeholder
text will appear vertically off center, even though the box itself is center
aligned.

To fix, use the height of the content in the placeholder&apos;s first line box to
determine its position. This approach works as the placeholder in input elements
is restricted to a single line. Additionally, prevent authors from changing the
vertical padding on `::placeholder`. This behavior matches other browsers, and
ensures the line box height approach keeps the placeholder text centered.

* LayoutTests/fast/forms/placeholder-content-center.html:

Augmented an existing reference test to verify that the placeholder text remains
centered when height and vertical padding are specified.

* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlPlaceholderElement::resolveCustomStyle):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::contentLogicalHeight const):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):

Canonical link: <a href="https://commits.webkit.org/253500@main">https://commits.webkit.org/253500@main</a>
</pre>
