### PR TITLE
[libpas] Use __thread keyword on Linux and FreeBSD

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -53,6 +53,10 @@
 
 PAS_BEGIN_EXTERN_C;
 
+#if PAS_HAVE_THREAD_KEYWORD
+__thread void* pas_thread_local_cache_pointer = NULL;
+#endif
+
 pas_fast_tls pas_thread_local_cache_fast_tls = PAS_FAST_TLS_INITIALIZER;
 
 size_t pas_thread_local_cache_size_for_allocator_index_capacity(unsigned allocator_index_capacity)
@@ -131,8 +135,11 @@ static void destructor(void* arg)
     static const bool verbose = false;
 
     pas_thread_local_cache* thread_local_cache;
-    
+
     thread_local_cache = (pas_thread_local_cache*)arg;
+
+    if (verbose)
+        pas_log("[%d] Destructor call for TLS %p\n", getpid(), thread_local_cache);
 
 #ifndef PAS_THREAD_LOCAL_CACHE_CAN_DETECT_THREAD_EXIT
     /* If pthread_self_is_exiting_np does not exist, we set PAS_THREAD_LOCAL_CACHE_DESTROYED in the TLS so that

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -97,7 +97,14 @@ struct pas_thread_local_cache {
 
 PAS_API extern pas_fast_tls pas_thread_local_cache_fast_tls;
 
+#if PAS_HAVE_PTHREAD_MACHDEP_H
 #define PAS_THREAD_LOCAL_KEY __PTK_FRAMEWORK_JAVASCRIPTCORE_KEY4
+#endif
+
+#if PAS_HAVE_THREAD_KEYWORD
+PAS_API extern __thread void* pas_thread_local_cache_pointer;
+#define PAS_THREAD_LOCAL_KEY pas_thread_local_cache_pointer
+#endif
 
 static PAS_ALWAYS_INLINE pas_thread_local_cache* pas_thread_local_cache_try_get_impl(void)
 {


### PR DESCRIPTION
#### 3d8b0c6d5f0aae9a197be0b2075b7a2625ac3d7d
<pre>
[libpas] Use __thread keyword on Linux and FreeBSD
<a href="https://bugs.webkit.org/show_bug.cgi?id=243975">https://bugs.webkit.org/show_bug.cgi?id=243975</a>

Reviewed by Mark Lam.

This patch adds a new handling of TLS in libpas: using __thread for Linux and FreeBSD.
The mechanism is that,

1. Declare __thread with initial value NULL.
2. Then, when setting a valid TLS value, we also call pthread_setspecific to schedule thread exit callback.
3. In thread exit callback, we clear __thread with PAS_THREAD_LOCAL_CACHE_DESTROYED.
4. So, we can check whether the thread is dying by looking at __thread&apos;s variable, if it is PAS_THREAD_LOCAL_CACHE_DESTROYED, then it is dying.

This offers better performance in Linux and FreeBSD since we can use ELF&apos;s TLS allocation for libpas TLC.
On OSS Darwin, we continue using repeated pthread_setspecific since __thread implementation does not work. This is because it can be cleared to the initial
value after the TLS clearing iteration. So we cannot use this value for pthread exiting detection.

* Source/bmalloc/libpas/src/libpas/pas_fast_tls.h:
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(destructor):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:
(pas_thread_local_cache_try_get):
(pas_thread_local_cache_can_set):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/253564@main">https://commits.webkit.org/253564@main</a>
</pre>









<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5223f471aeaec45a8f833ac92ffcc24a747b20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/86365 "failed 3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/69/builds/30285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/17334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/95209 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/148922 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/64/builds/28655 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/25297 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/78501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/90461 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/91965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/68/builds/23242 "Passed tests") | [✅ ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/73359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/23338 "Passed tests") | 
| | [✅ ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/78252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/78676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/66343 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/78309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/26604 "Built successfully") | [✅ ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/12525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/71936 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/26514 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/13539 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/25726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/2539 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/28191 "Built successfully") | [✅ ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/73359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/74717 "failed Failed to checkout and rebase branch from PR 3345") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/28131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/32820 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/74717 "failed Failed to checkout and rebase branch from PR 3345") | 
<!--EWS-Status-Bubble-End-->