### PR TITLE
HTML parser should ignore head start tags in "in head noscript" state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS When the scripting flag is disabled, a head start tag in "in head noscript" mode should be ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Test that when the scripting flag is disabled, a head start tag in "in head noscript" mode is ignored</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+promise_test(async function(t) {
+    let iframe = document.createElement("iframe");
+    iframe.srcdoc = "<!DOCTYPE html><head><noscript><head><style></style>";
+    iframe.sandbox = "allow-same-origin";
+    let loaded = new Promise(resolve => iframe.onload = resolve);
+    document.body.append(iframe);
+    await loaded;
+    assert_equals(String(iframe.contentDocument.querySelector("noscript").firstChild), "[object HTMLStyleElement]");
+}, "When the scripting flag is disabled, a head start tag in \"in head noscript\" mode should be ignored");
+</script>

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1226,7 +1226,7 @@ void HTMLTreeBuilder::processStartTag(AtomHTMLToken&& token)
             ASSERT_UNUSED(didProcess, didProcess);
             return;
         }
-        if (token.name() == htmlTag || token.name() == noscriptTag) {
+        if (token.name() == headTag || token.name() == noscriptTag) {
             parseError(token);
             return;
         }


### PR DESCRIPTION
#### 174fe130c08322d49b2c6c6e55f1bab04faee1df
<pre>
HTML parser should ignore head start tags in &quot;in head noscript&quot; state
<a href="https://bugs.webkit.org/show_bug.cgi?id=243976">https://bugs.webkit.org/show_bug.cgi?id=243976</a>

Reviewed by Ryosuke Niwa.

<a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inheadnoscript">https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inheadnoscript</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/inhead-noscript-head.html: Added.
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processStartTag):

Canonical link: <a href="https://commits.webkit.org/253489@main">https://commits.webkit.org/253489@main</a>
</pre>
