### PR TITLE
Run-benchmarks runs fast when run remotely

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from webkitpy.benchmark_runner.utils import get_driver_binary_path
+from contextlib import contextmanager
 
 
 class BrowserDriver(object):
@@ -42,6 +43,10 @@ class BrowserDriver(object):
 
     def diagnose_test_failure(self, debug_directory, error):
         pass
+
+    @contextmanager
+    def prevent_sleep(self, timeout):
+        yield
 
     @property
     def webdriver_binary_path(self):

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -52,7 +52,8 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
             self._http_server_driver.serve(web_root)
             url = urljoin(self._http_server_driver.base_url(), self._plan_name + '/' + test_file)
             self._browser_driver.launch_url(url, self._plan['options'], self._build_dir, self._browser_path)
-            with Timeout(self._plan['timeout']):
+            timeout = self._plan['timeout']
+            with Timeout(timeout), self._browser_driver.prevent_sleep(timeout):
                 result = self._get_result(url)
         except Exception as error:
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)


### PR DESCRIPTION
#### 09d15752c8fa09ebe355c3c1c3d8830b7ea359ec
<pre>
Run-benchmarks runs fast when run remotely
<a href="https://bugs.webkit.org/show_bug.cgi?id=243977">https://bugs.webkit.org/show_bug.cgi?id=243977</a>

Reviewed by Dewei Zhu.

Partial fix.  Running the test with non-default Safari will still have the same issue
To support non default builds  we launch Safari via the binary.
This means Safari inherits the session env instead of the full login env.
We can workarount this problem by using open to escape the ssh context.

Instead of using caffeinate to launch Safari set a timeout for it that matches the test timeout.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.take_sleep_assertion):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py:
(OSXBrowserDriver._launch_process):
(OSXBrowserDriver._terminate_processes):
(OSXBrowserDriver.take_sleep_assertion):
(OSXBrowserDriver._launch_process_with_caffeinate): Deleted.
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver.launch_url):
(OSXSafariDriver):
(OSXSafariDriver._launch_url_with_custom_path):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/253495@main">https://commits.webkit.org/253495@main</a>
</pre>
