### PR TITLE
Make the MarkedBlock Footer a Header instead.

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@ inline unsigned MarkedBlock::Handle::cellsPerBlock()
 
 inline bool MarkedBlock::isNewlyAllocatedStale() const
 {
-    return footer().m_newlyAllocatedVersion != space()->newlyAllocatedVersion();
+    return header().m_newlyAllocatedVersion != space()->newlyAllocatedVersion();
 }
 
 inline bool MarkedBlock::hasAnyNewlyAllocated()
@@ -67,7 +67,7 @@ inline MarkedSpace* MarkedBlock::Handle::space() const
 
 inline bool MarkedBlock::marksConveyLivenessDuringMarking(HeapVersion markingVersion)
 {
-    return marksConveyLivenessDuringMarking(footer().m_markingVersion, markingVersion);
+    return marksConveyLivenessDuringMarking(header().m_markingVersion, markingVersion);
 }
 
 inline bool MarkedBlock::marksConveyLivenessDuringMarking(HeapVersion myMarkingVersion, HeapVersion markingVersion)
@@ -138,41 +138,41 @@ ALWAYS_INLINE bool MarkedBlock::Handle::isLive(HeapVersion markingVersion, HeapV
     // impact on perf - around 2% on splay if you get it wrong.
 
     MarkedBlock& block = this->block();
-    MarkedBlock::Footer& footer = block.footer();
+    MarkedBlock::Header& header = block.header();
     
-    auto count = footer.m_lock.tryOptimisticFencelessRead();
+    auto count = header.m_lock.tryOptimisticFencelessRead();
     if (count.value) {
         Dependency fenceBefore = Dependency::fence(count.input);
         MarkedBlock& fencedBlock = *fenceBefore.consume(&block);
-        MarkedBlock::Footer& fencedFooter = fencedBlock.footer();
+        MarkedBlock::Header& fencedHeader = fencedBlock.header();
         MarkedBlock::Handle* fencedThis = fenceBefore.consume(this);
         
         ASSERT_UNUSED(fencedThis, !fencedThis->isFreeListed());
         
-        HeapVersion myNewlyAllocatedVersion = fencedFooter.m_newlyAllocatedVersion;
+        HeapVersion myNewlyAllocatedVersion = fencedHeader.m_newlyAllocatedVersion;
         if (myNewlyAllocatedVersion == newlyAllocatedVersion) {
             bool result = fencedBlock.isNewlyAllocated(cell);
-            if (footer.m_lock.fencelessValidate(count.value, Dependency::fence(result)))
+            if (header.m_lock.fencelessValidate(count.value, Dependency::fence(result)))
                 return result;
         } else {
-            HeapVersion myMarkingVersion = fencedFooter.m_markingVersion;
+            HeapVersion myMarkingVersion = fencedHeader.m_markingVersion;
             if (myMarkingVersion != markingVersion
                 && (!isMarking || !fencedBlock.marksConveyLivenessDuringMarking(myMarkingVersion, markingVersion))) {
-                if (footer.m_lock.fencelessValidate(count.value, Dependency::fence(myMarkingVersion)))
+                if (header.m_lock.fencelessValidate(count.value, Dependency::fence(myMarkingVersion)))
                     return false;
             } else {
-                bool result = fencedFooter.m_marks.get(block.atomNumber(cell));
-                if (footer.m_lock.fencelessValidate(count.value, Dependency::fence(result)))
+                bool result = fencedHeader.m_marks.get(block.atomNumber(cell));
+                if (header.m_lock.fencelessValidate(count.value, Dependency::fence(result)))
                     return result;
             }
         }
     }
     
-    Locker locker { footer.m_lock };
+    Locker locker { header.m_lock };
 
     ASSERT(!isFreeListed());
     
-    HeapVersion myNewlyAllocatedVersion = footer.m_newlyAllocatedVersion;
+    HeapVersion myNewlyAllocatedVersion = header.m_newlyAllocatedVersion;
     if (myNewlyAllocatedVersion == newlyAllocatedVersion)
         return block.isNewlyAllocated(cell);
     
@@ -183,7 +183,7 @@ ALWAYS_INLINE bool MarkedBlock::Handle::isLive(HeapVersion markingVersion, HeapV
             return false;
     }
     
-    return footer.m_marks.get(block.atomNumber(cell));
+    return header.m_marks.get(block.atomNumber(cell));
 }
 
 inline bool MarkedBlock::Handle::isLiveCell(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const void* p)
@@ -246,7 +246,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
     SuperSamplerScope superSamplerScope(false);
 
     MarkedBlock& block = this->block();
-    MarkedBlock::Footer& footer = block.footer();
+    MarkedBlock::Header& header = block.header();
     
     if (false)
         dataLog(RawPointer(this), "/", RawPointer(&block), ": MarkedBlock::Handle::specializedSweep!\n");
@@ -269,26 +269,25 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         && newlyAllocatedMode == DoesNotHaveNewlyAllocated) {
         
         // This is an incredibly powerful assertion that checks the sanity of our block bits.
-        if (marksMode == MarksNotStale && !footer.m_marks.isEmpty()) {
+        if (marksMode == MarksNotStale && !header.m_marks.isEmpty()) {
             WTF::dataFile().atomically(
                 [&] (PrintStream& out) {
                     out.print("Block ", RawPointer(&block), ": marks not empty!\n");
-                    out.print("Block lock is held: ", footer.m_lock.isHeld(), "\n");
-                    out.print("Marking version of block: ", footer.m_markingVersion, "\n");
+                    out.print("Block lock is held: ", header.m_lock.isHeld(), "\n");
+                    out.print("Marking version of block: ", header.m_markingVersion, "\n");
                     out.print("Marking version of heap: ", space()->markingVersion(), "\n");
                     UNREACHABLE_FOR_PLATFORM();
                 });
         }
-        
-        char* startOfLastCell = static_cast<char*>(cellAlign(block.atoms() + m_endAtom - 1));
-        char* payloadEnd = startOfLastCell + cellSize;
-        char* payloadBegin = bitwise_cast<char*>(block.atoms());
-        RELEASE_ASSERT(payloadEnd - MarkedBlock::blockSize <= bitwise_cast<char*>(&block), payloadBegin, payloadEnd, &block, cellSize, m_endAtom);
+
+        char* payloadEnd = bitwise_cast<char*>(block.atoms() + numberOfAtoms);
+        char* payloadBegin = bitwise_cast<char*>(block.atoms() + m_startAtom);
+        RELEASE_ASSERT(static_cast<size_t>(payloadEnd - payloadBegin) <= payloadSize, payloadBegin, payloadEnd, &block, cellSize, m_startAtom);
         
         if (sweepMode == SweepToFreeList)
             setIsFreeListed();
         if (space()->isMarking())
-            footer.m_lock.unlock();
+            header.m_lock.unlock();
         if (destructionMode != BlockHasNoDestructors) {
             for (char* cell = payloadBegin; cell < payloadEnd; cell += cellSize)
                 destroy(cell);
@@ -326,10 +325,10 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
             ++count;
         }
     };
-    for (size_t i = 0; i < m_endAtom; i += m_atomsPerCell) {
+    for (size_t i = m_startAtom; i < endAtom; i += m_atomsPerCell) {
         if (emptyMode == NotEmpty
-            && ((marksMode == MarksNotStale && footer.m_marks.get(i))
-                || (newlyAllocatedMode == HasNewlyAllocated && footer.m_newlyAllocated.get(i)))) {
+            && ((marksMode == MarksNotStale && header.m_marks.get(i))
+                || (newlyAllocatedMode == HasNewlyAllocated && header.m_newlyAllocated.get(i)))) {
             isEmpty = false;
             continue;
         }
@@ -343,10 +342,10 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
     // We only want to discard the newlyAllocated bits if we're creating a FreeList,
     // otherwise we would lose information on what's currently alive.
     if (sweepMode == SweepToFreeList && newlyAllocatedMode == HasNewlyAllocated)
-        footer.m_newlyAllocatedVersion = MarkedSpace::nullVersion;
+        header.m_newlyAllocatedVersion = MarkedSpace::nullVersion;
     
     if (space()->isMarking())
-        footer.m_lock.unlock();
+        header.m_lock.unlock();
     
     if (destructionMode == BlockHasDestructorsAndCollectorIsRunning) {
         for (size_t i : deadCells)
@@ -507,7 +506,7 @@ inline IterationStatus MarkedBlock::Handle::forEachLiveCell(const Functor& funct
     // https://bugs.webkit.org/show_bug.cgi?id=180315
     
     HeapCell::Kind kind = m_attributes.cellKind;
-    for (size_t i = 0; i < m_endAtom; i += m_atomsPerCell) {
+    for (size_t i = m_startAtom; i < endAtom; i += m_atomsPerCell) {
         HeapCell* cell = reinterpret_cast_ptr<HeapCell*>(&m_block->atoms()[i]);
         if (!isLive(cell))
             continue;
@@ -522,7 +521,7 @@ template <typename Functor>
 inline IterationStatus MarkedBlock::Handle::forEachDeadCell(const Functor& functor)
 {
     HeapCell::Kind kind = m_attributes.cellKind;
-    for (size_t i = 0; i < m_endAtom; i += m_atomsPerCell) {
+    for (size_t i = m_startAtom; i < endAtom; i += m_atomsPerCell) {
         HeapCell* cell = reinterpret_cast_ptr<HeapCell*>(&m_block->atoms()[i]);
         if (isLive(cell))
             continue;
@@ -542,8 +541,8 @@ inline IterationStatus MarkedBlock::Handle::forEachMarkedCell(const Functor& fun
     WTF::loadLoadFence();
     if (areMarksStale)
         return IterationStatus::Continue;
-    for (size_t i = 0; i < m_endAtom; i += m_atomsPerCell) {
-        if (!block.footer().m_marks.get(i))
+    for (size_t i = m_startAtom; i < endAtom; i += m_atomsPerCell) {
+        if (!block.header().m_marks.get(i))
             continue;
 
         HeapCell* cell = reinterpret_cast_ptr<HeapCell*>(&m_block->atoms()[i]);

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2018 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  *
  *  This library is free software; you can redistribute it and/or
@@ -41,7 +41,7 @@ static Vector<size_t> sizeClasses()
 
     if (UNLIKELY(Options::dumpSizeClasses())) {
         dataLog("Block size: ", MarkedBlock::blockSize, "\n");
-        dataLog("Footer size: ", sizeof(MarkedBlock::Footer), "\n");
+        dataLog("Header size: ", sizeof(MarkedBlock::Header), "\n");
     }
     
     auto add = [&] (size_t sizeClass) {

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -225,7 +225,7 @@ MacroAssemblerCodeRef<JSEntryPtrTag> getHostCallReturnValueThunk()
 
         auto preciseAllocationCase = jit.branchTestPtr(CCallHelpers::NonZero, GPRInfo::regT0, CCallHelpers::TrustedImm32(PreciseAllocation::halfAlignment));
         jit.andPtr(CCallHelpers::TrustedImmPtr(MarkedBlock::blockMask), GPRInfo::regT0);
-        jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, MarkedBlock::offsetOfFooter + MarkedBlock::Footer::offsetOfVM()), GPRInfo::regT0);
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, MarkedBlock::offsetOfHeader + MarkedBlock::Header::offsetOfVM()), GPRInfo::regT0);
         auto loadedCase = jit.jump();
 
         preciseAllocationCase.link(&jit);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -640,7 +640,7 @@ const NotInitialization = constexpr InitializationMode::NotInitialization
 
 const MarkedBlockSize = constexpr MarkedBlock::blockSize
 const MarkedBlockMask = ~(MarkedBlockSize - 1)
-const MarkedBlockFooterOffset = constexpr MarkedBlock::offsetOfFooter
+const MarkedBlockHeaderOffset = constexpr MarkedBlock::offsetOfHeader
 const PreciseAllocationHeaderSize = constexpr (PreciseAllocation::headerSize())
 const PreciseAllocationVMOffset = (PreciseAllocation::m_weakSet + WeakSet::m_vm - PreciseAllocationHeaderSize)
 
@@ -1507,7 +1507,7 @@ end
 macro convertCalleeToVM(callee)
     btpnz callee, (constexpr PreciseAllocation::halfAlignment), .preciseAllocation
     andp MarkedBlockMask, callee
-    loadp MarkedBlockFooterOffset + MarkedBlock::Footer::m_vm[callee], callee
+    loadp MarkedBlockHeaderOffset + MarkedBlock::Header::m_vm[callee], callee
     jmp .done
 .preciseAllocation:
     loadp PreciseAllocationVMOffset[callee], callee

--- a/Source/JavaScriptCore/tools/Integrity.h
+++ b/Source/JavaScriptCore/tools/Integrity.h
@@ -173,7 +173,7 @@ ALWAYS_INLINE void auditCell(VM&, JSValue);
 ALWAYS_INLINE void auditStructureID(StructureID);
 
 #if ENABLE(EXTRA_INTEGRITY_CHECKS) && USE(JSVALUE64)
-template<typename T> ALWAYS_INLINE T audit(T value) { return doAudit(value); }
+template<typename T> ALWAYS_INLINE T audit(T value) { return bitwise_cast<T>(doAudit(value)); }
 #else
 template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
 #endif

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -116,7 +116,7 @@ static inline void emitRethrowImpl(CCallHelpers& jit)
     {
         auto preciseAllocationCase = jit.branchTestPtr(CCallHelpers::NonZero, scratch, CCallHelpers::TrustedImm32(PreciseAllocation::halfAlignment));
         jit.andPtr(CCallHelpers::TrustedImmPtr(MarkedBlock::blockMask), scratch);
-        jit.loadPtr(CCallHelpers::Address(scratch, MarkedBlock::offsetOfFooter + MarkedBlock::Footer::offsetOfVM()), scratch);
+        jit.loadPtr(CCallHelpers::Address(scratch, MarkedBlock::offsetOfHeader + MarkedBlock::Header::offsetOfVM()), scratch);
         auto loadedCase = jit.jump();
 
         preciseAllocationCase.link(&jit);
@@ -144,7 +144,7 @@ static inline void emitThrowImpl(CCallHelpers& jit, unsigned exceptionIndex)
     {
         auto preciseAllocationCase = jit.branchTestPtr(CCallHelpers::NonZero, scratch, CCallHelpers::TrustedImm32(PreciseAllocation::halfAlignment));
         jit.andPtr(CCallHelpers::TrustedImmPtr(MarkedBlock::blockMask), scratch);
-        jit.loadPtr(CCallHelpers::Address(scratch, MarkedBlock::offsetOfFooter + MarkedBlock::Footer::offsetOfVM()), scratch);
+        jit.loadPtr(CCallHelpers::Address(scratch, MarkedBlock::offsetOfHeader + MarkedBlock::Header::offsetOfVM()), scratch);
         auto loadedCase = jit.jump();
 
         preciseAllocationCase.link(&jit);
@@ -184,7 +184,7 @@ static inline void emitCatchPrologueShared(B3::Air::Code& code, CCallHelpers& ji
         // https://bugs.webkit.org/show_bug.cgi?id=231213
         auto preciseAllocationCase = jit.branchTestPtr(CCallHelpers::NonZero, GPRInfo::regT0, CCallHelpers::TrustedImm32(PreciseAllocation::halfAlignment));
         jit.andPtr(CCallHelpers::TrustedImmPtr(MarkedBlock::blockMask), GPRInfo::regT0);
-        jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, MarkedBlock::offsetOfFooter + MarkedBlock::Footer::offsetOfVM()), GPRInfo::regT0);
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::regT0, MarkedBlock::offsetOfHeader + MarkedBlock::Header::offsetOfVM()), GPRInfo::regT0);
         auto loadedCase = jit.jump();
 
         preciseAllocationCase.link(&jit);


### PR DESCRIPTION
#### 6af7334a69e50ad413b84ee79f81309f7b6bc213
<pre>
Make the MarkedBlock Footer a Header instead.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243932">https://bugs.webkit.org/show_bug.cgi?id=243932</a>
&lt;rdar://problem/98709256&gt;

Reviewed by Yusuke Suzuki.

This opens up an opportunity for potentially making PreciseAllocations polymorphic with MarkedBlocks.

The main difference is that instead of computing an m_endAtom, we now compute a m_startAtom.
m_startAtom is chosen so that increments of m_atomsPerCell added to m_startAtom will always end
up at the end of the MarkedBlock (as denoted by endAtom).  This simplifies the iteration of cells
in the MarkedBlock.

* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::MarkedBlock):
(JSC::MarkedBlock::~MarkedBlock):
(JSC::MarkedBlock::Header::Header):
(JSC::MarkedBlock::Header::~Header):
(JSC::MarkedBlock::Handle::stopAllocating):
(JSC::MarkedBlock::Handle::lastChanceToFinalize):
(JSC::MarkedBlock::Handle::resumeAllocating):
(JSC::MarkedBlock::aboutToMarkSlow):
(JSC::MarkedBlock::resetAllocated):
(JSC::MarkedBlock::resetMarks):
(JSC::MarkedBlock::assertMarksNotStale):
(JSC::MarkedBlock::Handle::didConsumeFreeList):
(JSC::MarkedBlock::markCount):
(JSC::MarkedBlock::clearHasAnyMarked):
(JSC::MarkedBlock::Handle::didAddToDirectory):
(JSC::MarkedBlock::Handle::didRemoveFromDirectory):
(JSC::MarkedBlock::Handle::sweep):
(JSC::MarkedBlock::Footer::Footer): Deleted.
(JSC::MarkedBlock::Footer::~Footer): Deleted.
* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::Handle::start const):
(JSC::MarkedBlock::Handle::end const):
(JSC::MarkedBlock::Header::offsetOfVM):
(JSC::MarkedBlock::newlyAllocatedVersion const):
(JSC::MarkedBlock::markingVersion const):
(JSC::MarkedBlock::lock):
(JSC::MarkedBlock::subspace const):
(JSC::MarkedBlock::populatePage const):
(JSC::MarkedBlock::header):
(JSC::MarkedBlock::header const):
(JSC::MarkedBlock::handle):
(JSC::MarkedBlock::Handle::blockHeader):
(JSC::MarkedBlock::Handle::cellAlign):
(JSC::MarkedBlock::vm const):
(JSC::MarkedBlock::atomNumber):
(JSC::MarkedBlock::areMarksStale):
(JSC::MarkedBlock::aboutToMark):
(JSC::MarkedBlock::isMarkedRaw):
(JSC::MarkedBlock::isMarked):
(JSC::MarkedBlock::testAndSetMarked):
(JSC::MarkedBlock::marks const):
(JSC::MarkedBlock::isNewlyAllocated):
(JSC::MarkedBlock::setNewlyAllocated):
(JSC::MarkedBlock::clearNewlyAllocated):
(JSC::MarkedBlock::newlyAllocated const):
(JSC::MarkedBlock::isAtom):
(JSC::MarkedBlock::Handle::forEachCell):
(JSC::MarkedBlock::hasAnyMarked const):
(JSC::MarkedBlock::noteMarked):
(JSC::MarkedBlock::setVerifierMemo):
(JSC::MarkedBlock::verifierMemo const):
(JSC::MarkedBlock::Footer::offsetOfVM): Deleted.
(JSC::MarkedBlock::footer): Deleted.
(JSC::MarkedBlock::footer const): Deleted.
(JSC::MarkedBlock::Handle::blockFooter): Deleted.
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::isNewlyAllocatedStale const):
(JSC::MarkedBlock::marksConveyLivenessDuringMarking):
(JSC::MarkedBlock::Handle::isLive):
(JSC::MarkedBlock::Handle::specializedSweep):
(JSC::MarkedBlock::Handle::forEachLiveCell):
(JSC::MarkedBlock::Handle::forEachDeadCell):
(JSC::MarkedBlock::Handle::forEachMarkedCell):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::getHostCallReturnValueThunk):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/tools/Integrity.h:
(JSC::Integrity::audit):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::emitRethrowImpl):
(JSC::Wasm::emitThrowImpl):
(JSC::Wasm::emitCatchPrologueShared):

Canonical link: <a href="https://commits.webkit.org/253482@main">https://commits.webkit.org/253482@main</a>
</pre>
