### PR TITLE
[ews-build.webkit.org] Ignore base commit when rebasing

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -991,7 +991,6 @@ class CheckOutPullRequest(steps.ShellSequence, ShellMixin):
         remote = self.getProperty('github.head.repo.full_name', 'origin').split('/')[0]
         project = self.getProperty('github.head.repo.full_name', self.getProperty('project'))
         pr_branch = self.getProperty('github.head.ref', DEFAULT_BRANCH)
-        base_hash = self.getProperty('github.base.sha')
         rebase_target_hash = self.getProperty('ews_revision') or self.getProperty('got_revision')
 
         commands = [
@@ -1001,12 +1000,9 @@ class CheckOutPullRequest(steps.ShellSequence, ShellMixin):
             ['git', 'fetch', remote, '--prune'],
             ['git', 'branch', '-f', pr_branch, 'remotes/{}/{}'.format(remote, pr_branch)],
             ['git', 'checkout', pr_branch],
+            ['git', 'config', 'merge.changelog.driver', 'perl Tools/Scripts/resolve-ChangeLogs --merge-driver -c %O %A %B'],
+            ['git', 'rebase', rebase_target_hash],
         ]
-        if rebase_target_hash and base_hash and rebase_target_hash != base_hash:
-            commands += [
-                ['git', 'config', 'merge.changelog.driver', 'perl Tools/Scripts/resolve-ChangeLogs --merge-driver -c %O %A %B'],
-                ['git', 'rebase', '--onto', rebase_target_hash, base_hash, pr_branch],
-            ]
         for command in commands:
             self.commands.append(util.ShellArg(command=command, logname='stdio', haltOnFailure=True))
 


### PR DESCRIPTION
#### 6099c7d8ae7c2cd81314f0a9afeaaebe3283d688
<pre>
[ews-build.webkit.org] Ignore base commit when rebasing
<a href="https://bugs.webkit.org/show_bug.cgi?id=243979">https://bugs.webkit.org/show_bug.cgi?id=243979</a>
&lt;rdar://problem/99019798&gt;

Reviewed by NOBODY (OOPS!).

The base commit as reported by GitHub isn&apos;t reliable.

* Tools/CISupport/ews-build/master.cfg: Remove github.base.sha.
* Tools/CISupport/ews-build/steps.py:
(CheckOutPullRequest.run): Remove reliance on github.base.sha.
* Tools/CISupport/ews-build/steps_unittest.py:
</pre>